### PR TITLE
add id and now helpers in platform + cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "int64-buffer": "^0.1.9",
     "msgpack-lite": "^0.1.26",
     "opentracing": "^0.14.1",
+    "performance-now": "^2.1.0",
     "safe-buffer": "^5.1.1"
   },
   "devDependencies": {

--- a/src/platform/node/id.js
+++ b/src/platform/node/id.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const Uint64BE = require('int64-buffer').Uint64BE
+const randomBytes = require('crypto').randomBytes
+
+module.exports = () => new Uint64BE(randomBytes(8))

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -1,64 +1,13 @@
 'use strict'
 
-const http = require('http')
-const Buffer = require('safe-buffer').Buffer
+const id = require('./id')
+const now = require('./now')
+const request = require('./request')
+const msgpack = require('./msgpack')
 
 module.exports = {
-  request (options, callback) {
-    options = Object.assign({
-      headers: {},
-      data: [],
-      timeout: 2000
-    }, options)
-
-    const data = [].concat(options.data)
-
-    options.headers['Content-Length'] = byteLength(data)
-
-    return new Promise((resolve, reject) => {
-      const req = http.request(options, res => {
-        res.on('data', chunk => {})
-        res.on('end', () => {
-          if (res.statusCode >= 200 && res.statusCode <= 299) {
-            resolve()
-          } else {
-            const error = new Error(http.STATUS_CODES[res.statusCode])
-            error.status = res.statusCode
-
-            reject(error)
-          }
-        })
-      })
-
-      req.setTimeout(options.timeout, req.abort)
-      req.on('error', reject)
-
-      data.forEach(buffer => req.write(buffer))
-
-      req.end()
-    })
-  },
-
-  msgpackArrayPrefix (length) {
-    let buffer
-
-    if (length <= 0xf) { // fixarray
-      buffer = Buffer.alloc(1)
-      buffer.fill(0x90 + length)
-    } else if (length <= 0xffff) { // array 16
-      buffer = Buffer.alloc(3)
-      buffer.fill(0xdc, 0, 1)
-      buffer.writeUInt16BE(length, 1)
-    } else { // array 32
-      buffer = Buffer.alloc(5)
-      buffer.fill(0xdd, 0, 1)
-      buffer.writeUInt32BE(length, 1)
-    }
-
-    return buffer
-  }
-}
-
-function byteLength (data) {
-  return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
+  id,
+  now,
+  request,
+  msgpack
 }

--- a/src/platform/node/msgpack.js
+++ b/src/platform/node/msgpack.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const Buffer = require('safe-buffer').Buffer
+
+module.exports = {
+  prefix (array) {
+    let buffer
+
+    if (array.length <= 0xf) { // fixarray
+      buffer = Buffer.alloc(1)
+      buffer.fill(0x90 + array.length)
+    } else if (array.length <= 0xffff) { // array 16
+      buffer = Buffer.alloc(3)
+      buffer.fill(0xdc, 0, 1)
+      buffer.writeUInt16BE(array.length, 1)
+    } else { // array 32
+      buffer = Buffer.alloc(5)
+      buffer.fill(0xdd, 0, 1)
+      buffer.writeUInt32BE(array.length, 1)
+    }
+
+    return [buffer].concat(array)
+  }
+}

--- a/src/platform/node/now.js
+++ b/src/platform/node/now.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const now = require('performance-now')
+const loadNs = now()
+const loadMs = Date.now()
+
+module.exports = () => loadMs + now() - loadNs

--- a/src/platform/node/request.js
+++ b/src/platform/node/request.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const http = require('http')
+
+function request (options, callback) {
+  options = Object.assign({
+    headers: {},
+    data: [],
+    timeout: 2000
+  }, options)
+
+  const data = [].concat(options.data)
+
+  options.headers['Content-Length'] = byteLength(data)
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(options, res => {
+      res.on('data', chunk => {})
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode <= 299) {
+          resolve()
+        } else {
+          const error = new Error(http.STATUS_CODES[res.statusCode])
+          error.status = res.statusCode
+
+          reject(error)
+        }
+      })
+    })
+
+    req.setTimeout(options.timeout, req.abort)
+    req.on('error', reject)
+
+    data.forEach(buffer => req.write(buffer))
+
+    req.end()
+  })
+}
+
+function byteLength (data) {
+  return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
+}
+
+module.exports = request

--- a/src/writer.js
+++ b/src/writer.js
@@ -20,8 +20,7 @@ class Writer {
 
   flush () {
     if (this._queue.length > 0) {
-      const prefix = platform.msgpackArrayPrefix(this._queue.length)
-      const data = [prefix].concat(this._queue)
+      const data = platform.msgpack.prefix(this._queue)
 
       platform.request({
         protocol: this._url.protocol,

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -2,132 +2,193 @@
 
 const Buffer = require('safe-buffer').Buffer
 
-describe('Node Platform', () => {
-  let platform
+describe('Platform', () => {
+  describe('Node', () => {
+    describe('id', () => {
+      let id
+      let randomBytes
 
-  beforeEach(() => {
-    platform = require('../../../src/platform/node')
-  })
-
-  describe('request', () => {
-    it('should send an http request with a buffer', () => {
-      nock('http://test:123', {
-        reqheaders: {
-          'content-type': 'application/octet-stream',
-          'content-length': '13'
-        }
+      beforeEach(() => {
+        randomBytes = sinon.stub()
+        id = proxyquire('../src/platform/node/id', {
+          'crypto': { randomBytes }
+        })
       })
-        .put('/path', { foo: 'bar' })
-        .reply(200)
 
-      return platform.request({
-        protocol: 'http:',
-        hostname: 'test',
-        port: 123,
-        path: '/path',
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/octet-stream'
-        },
-        data: Buffer.from(JSON.stringify({ foo: 'bar' }))
+      it('should return a random 64bit ID', () => {
+        const buffer = Buffer.alloc(8)
+        buffer.writeUInt32BE(0x12345678)
+        buffer.writeUInt32BE(0x87654321, 4)
+
+        randomBytes.returns(buffer)
+
+        expect(id().toString('16')).to.equal('1234567887654321')
       })
     })
 
-    it('should send an http request with a buffer array', () => {
-      nock('http://test:123', {
-        reqheaders: {
-          'content-type': 'application/octet-stream',
-          'content-length': '8'
-        }
-      })
-        .put('/path', 'fizzbuzz')
-        .reply(200)
+    describe('now', () => {
+      let now
+      let performanceNow
 
-      return platform.request({
-        protocol: 'http:',
-        hostname: 'test',
-        port: 123,
-        path: '/path',
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/octet-stream'
-        },
-        data: [Buffer.from('fizz', 'utf-8'), Buffer.from('buzz', 'utf-8')]
+      beforeEach(() => {
+        sinon.stub(Date, 'now').returns(1500000000000)
+        performanceNow = sinon.stub().returns(100.1111)
+        now = proxyquire('../src/platform/node/now', {
+          'performance-now': performanceNow
+        })
+      })
+
+      afterEach(() => {
+        Date.now.restore()
+      })
+
+      it('should return the current time in milliseconds with high resolution', () => {
+        performanceNow.returns(600.3333)
+
+        expect(now()).to.equal(1500000000500.2222)
       })
     })
 
-    it('should handle an http error', done => {
-      nock('http://localhost:80')
-        .put('/path')
-        .reply(400)
+    describe('request', () => {
+      let request
 
-      platform
-        .request({
+      beforeEach(() => {
+        request = require('../../../src/platform/node/request')
+      })
+
+      it('should send an http request with a buffer', () => {
+        nock('http://test:123', {
+          reqheaders: {
+            'content-type': 'application/octet-stream',
+            'content-length': '13'
+          }
+        })
+          .put('/path', { foo: 'bar' })
+          .reply(200)
+
+        return request({
+          protocol: 'http:',
+          hostname: 'test',
+          port: 123,
+          path: '/path',
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/octet-stream'
+          },
+          data: Buffer.from(JSON.stringify({ foo: 'bar' }))
+        })
+      })
+
+      it('should send an http request with a buffer array', () => {
+        nock('http://test:123', {
+          reqheaders: {
+            'content-type': 'application/octet-stream',
+            'content-length': '8'
+          }
+        })
+          .put('/path', 'fizzbuzz')
+          .reply(200)
+
+        return request({
+          protocol: 'http:',
+          hostname: 'test',
+          port: 123,
+          path: '/path',
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/octet-stream'
+          },
+          data: [Buffer.from('fizz', 'utf-8'), Buffer.from('buzz', 'utf-8')]
+        })
+      })
+
+      it('should handle an http error', done => {
+        nock('http://localhost:80')
+          .put('/path')
+          .reply(400)
+
+        request({
           path: '/path',
           method: 'PUT'
         })
-        .catch(err => {
-          expect(err).to.be.instanceof(Error)
-          expect(err.status).to.equal(400)
-          done()
-        })
-    })
+          .catch(err => {
+            expect(err).to.be.instanceof(Error)
+            expect(err.status).to.equal(400)
+            done()
+          })
+      })
 
-    it('should timeout after 5 seconds by default', done => {
-      nock('http://localhost:80')
-        .put('/path')
-        .socketDelay(5001)
-        .reply(200)
+      it('should timeout after 5 seconds by default', done => {
+        nock('http://localhost:80')
+          .put('/path')
+          .socketDelay(5001)
+          .reply(200)
 
-      platform
-        .request({
+        request({
           path: '/path',
           method: 'PUT'
         })
-        .catch(err => {
-          expect(err).to.be.instanceof(Error)
-          expect(err.code).to.equal('ECONNRESET')
-          done()
-        })
-    })
+          .catch(err => {
+            expect(err).to.be.instanceof(Error)
+            expect(err.code).to.equal('ECONNRESET')
+            done()
+          })
+      })
 
-    it('should have a configurable timeout', done => {
-      nock('http://localhost:80')
-        .put('/path')
-        .socketDelay(2001)
-        .reply(200)
+      it('should have a configurable timeout', done => {
+        nock('http://localhost:80')
+          .put('/path')
+          .socketDelay(2001)
+          .reply(200)
 
-      platform
-        .request({
+        request({
           path: '/path',
           method: 'PUT',
           timeout: 2000
         })
-        .catch(err => {
-          expect(err).to.be.instanceof(Error)
-          expect(err.code).to.equal('ECONNRESET')
-          done()
+          .catch(err => {
+            expect(err).to.be.instanceof(Error)
+            expect(err.code).to.equal('ECONNRESET')
+            done()
+          })
+      })
+    })
+
+    describe('msgpack', () => {
+      let msgpack
+
+      beforeEach(() => {
+        msgpack = require('../../../src/platform/node/msgpack')
+      })
+
+      describe('prefix', () => {
+        it('should support fixarray', () => {
+          const length = 0xf
+          const array = new Array(length)
+          const prefixed = msgpack.prefix(array)
+
+          expect(prefixed.length).to.equal(length + 1)
+          expect(prefixed[0]).to.deep.equal(Buffer.from([0x9f]))
         })
-    })
-  })
 
-  describe('msgpackArrayPrefix', () => {
-    it('should support fixarray', () => {
-      const prefix = platform.msgpackArrayPrefix(0xf)
+        it('should should support array 16', () => {
+          const length = 0xf + 1
+          const array = new Array(length)
+          const prefixed = msgpack.prefix(array)
 
-      expect(prefix).to.deep.equal(Buffer.from([0x9f]))
-    })
+          expect(prefixed.length).to.equal(length + 1)
+          expect(prefixed[0]).to.deep.equal(Buffer.from([0xdc, 0x00, 0x10]))
+        })
 
-    it('should should support array 16', () => {
-      const prefix = platform.msgpackArrayPrefix(0xffff)
+        it('should should support array 32', () => {
+          const length = 0xffff + 1
+          const array = new Array(length)
+          const prefixed = msgpack.prefix(array)
 
-      expect(prefix).to.deep.equal(Buffer.from([0xdc, 0xff, 0xff]))
-    })
-
-    it('should should support array 32', () => {
-      const prefix = platform.msgpackArrayPrefix(0xffffffff)
-
-      expect(prefix).to.deep.equal(Buffer.from([0xdd, 0xff, 0xff, 0xff, 0xff]))
+          expect(prefixed.length).to.equal(length + 1)
+          expect(prefixed[0]).to.deep.equal(Buffer.from([0xdd, 0x00, 0x01, 0x00, 0x00]))
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
This PR is add an `id` and `now` helpers to platform. It also refactors platform into multiple files and adds benchmarks which were not yet done for platform.