### PR TITLE
add context propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+yarn.lock
 
 # Created by https://www.gitignore.io/api/node,macos,visualstudiocode
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node": ">=4"
   },
   "dependencies": {
+    "continuation-local-storage": "^3.2.1",
     "int64-buffer": "^0.1.9",
     "msgpack-lite": "^0.1.26",
     "opentracing": "^0.14.1",

--- a/src/platform/node/context/cls.js
+++ b/src/platform/node/context/cls.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const cls = require('continuation-local-storage')
+const namespace = cls.createNamespace('dd-trace')
+
+module.exports = namespace

--- a/src/platform/node/context/index.js
+++ b/src/platform/node/context/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const cls = require('./cls')
+
+module.exports = () => cls

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -3,11 +3,13 @@
 const id = require('./id')
 const now = require('./now')
 const request = require('./request')
+const context = require('./context')
 const msgpack = require('./msgpack')
 
 module.exports = {
   id,
   now,
   request,
+  context,
   msgpack
 }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const platform = require('./platform')
+const Tracer = require('./opentracing/tracer')
+
+class DatadogTracer extends Tracer {
+  constructor (config) {
+    super(config)
+
+    this._context = platform.context()
+  }
+
+  trace (name, options, callback) {
+    if (!callback) {
+      callback = options
+      options = {}
+    }
+
+    this._context.run(() => {
+      const childOf = this._context.get('current')
+      const tags = Object.assign({
+        'service.name': options.service || this._service,
+        'resource.name': options.resource || name,
+        'span.type': options.type
+      }, options.tags)
+
+      const span = this.startSpan(name, { childOf, tags })
+      this._context.set('current', span)
+
+      callback(span)
+    })
+  }
+
+  currentSpan () {
+    return this._context.get('current')
+  }
+
+  bind (callback) {
+    return this._context.bind(callback)
+  }
+
+  bindEmitter (emitter) {
+    this._context.bindEmitter(emitter)
+  }
+}
+
+module.exports = DatadogTracer

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const Span = require('../src/opentracing/span')
+const platform = require('../src/platform')
+
+describe('Tracer', () => {
+  let Tracer
+  let tracer
+  let context
+
+  beforeEach(() => {
+    context = platform.context()
+    sinon.stub(context, 'bind')
+    sinon.stub(context, 'bindEmitter')
+
+    Tracer = require('../src/tracer')
+  })
+
+  afterEach(() => {
+    context.bind.restore()
+    context.bindEmitter.restore()
+  })
+
+  describe('trace', () => {
+    it('should run the callback with the new span', done => {
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', current => {
+        expect(current).to.be.instanceof(Span)
+        done()
+      })
+    })
+
+    it('should use the parent context', done => {
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('parent', parent => {
+        tracer.trace('child', child => {
+          expect(child.context()).to.have.property('parentId', parent.context().spanId)
+          done()
+        })
+      })
+    })
+
+    it('should set default tags', done => {
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', current => {
+        expect(current._tags).to.have.property('service.name', 'service')
+        expect(current._tags).to.have.property('resource.name', 'name')
+        done()
+      })
+    })
+
+    it('should support service option', done => {
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', { service: 'test' }, current => {
+        expect(current._tags).to.have.property('service.name', 'test')
+        done()
+      })
+    })
+
+    it('should support resource option', done => {
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', { resource: 'test' }, current => {
+        expect(current._tags).to.have.property('resource.name', 'test')
+        done()
+      })
+    })
+
+    it('should support type option', done => {
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', { type: 'test' }, current => {
+        expect(current._tags).to.have.property('span.type', 'test')
+        done()
+      })
+    })
+
+    it('should support custom tags', done => {
+      const tags = {
+        'foo': 'bar'
+      }
+
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', { tags }, current => {
+        expect(current._tags).to.have.property('foo', 'bar')
+        done()
+      })
+    })
+  })
+
+  describe('currentSpan', () => {
+    it('should return the current span', done => {
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', current => {
+        expect(tracer.currentSpan()).to.equal(current)
+        done()
+      })
+    })
+  })
+
+  describe('bind', () => {
+    it('should bind a function to the context', done => {
+      const callback = () => {}
+
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', current => {
+        tracer.bind(callback)
+        expect(context.bind).to.have.been.calledWith(callback)
+        done()
+      })
+    })
+  })
+
+  describe('bindEmitter', () => {
+    it('should bind an emitter to the context', done => {
+      const emitter = 'emitter'
+
+      tracer = new Tracer({ service: 'service' })
+
+      tracer.trace('name', current => {
+        tracer.bindEmitter(emitter)
+        expect(context.bindEmitter).to.have.been.calledWith(emitter)
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds a `trace` method to the tracer that supports context propagation and Datadog specific options. It is implemented using CLS at the moment but other implementations can be supported as well.