### PR TITLE
add config

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
   },
   "dependencies": {
     "int64-buffer": "^0.1.9",
+    "koalas": "^1.0.2",
     "msgpack-lite": "^0.1.26",
     "opentracing": "^0.14.1",
     "performance-now": "^2.1.0",
-    "safe-buffer": "^5.1.1"
+    "safe-buffer": "^5.1.1",
+    "url-parse": "^1.2.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const URL = require('url-parse')
+const platform = require('./platform')
+const coalesce = require('koalas')
+
+class Config {
+  constructor (options) {
+    options = options || {}
+
+    const enabled = coalesce(options.enabled, platform.env('DATADOG_TRACE_ENABLED'), true)
+    const debug = coalesce(options.debug, platform.env('DATADOG_TRACE_DEBUG'), false)
+    const protocol = 'http'
+    const hostname = coalesce(options.hostname, platform.env('DATADOG_TRACE_AGENT_HOSTNAME'), 'localhost')
+    const port = coalesce(options.port, platform.env('DATADOG_TRACE_AGENT_PORT'), 8126)
+
+    this.enabled = String(enabled) === 'true'
+    this.debug = String(debug) === 'true'
+    this.service = coalesce(options.service, platform.env('DATADOG_SERVICE_NAME'))
+    this.env = coalesce(options.env, platform.env('DATADOG_ENV'))
+    this.url = new URL(`${protocol}://${hostname}:${port}`)
+    this.tags = coalesce(options.tags, {})
+    this.flushInterval = 2000
+    this.bufferSize = 1000
+    this.sampleRate = 1
+    this.logger = options.logger
+  }
+}
+
+module.exports = Config

--- a/src/platform/node/env.js
+++ b/src/platform/node/env.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = name => process.env[name]

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -2,12 +2,14 @@
 
 const id = require('./id')
 const now = require('./now')
+const env = require('./env')
 const request = require('./request')
 const msgpack = require('./msgpack')
 
 module.exports = {
   id,
   now,
+  env,
   request,
   msgpack
 }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,0 +1,97 @@
+'use strict'
+
+describe('Config', () => {
+  let Config
+
+  beforeEach(() => {
+    delete process.env.DATADOG_TRACE_AGENT_HOSTNAME
+    delete process.env.DATADOG_TRACE_AGENT_PORT
+    delete process.env.DATADOG_TRACE_ENABLED
+    delete process.env.DATADOG_TRACE_DEBUG
+    delete process.env.DATADOG_SERVICE_NAME
+    delete process.env.DATADOG_ENV
+
+    Config = require('../src/config')
+  })
+
+  it('should initialize with the correct defaults', () => {
+    const config = new Config()
+
+    expect(config).to.have.property('enabled', true)
+    expect(config).to.have.property('debug', false)
+    expect(config).to.have.nested.property('url.protocol', 'http:')
+    expect(config).to.have.nested.property('url.hostname', 'localhost')
+    expect(config).to.have.nested.property('url.port', '8126')
+    expect(config).to.have.property('flushInterval', 2000)
+    expect(config).to.have.property('bufferSize', 1000)
+    expect(config).to.have.property('sampleRate', 1)
+    expect(config).to.have.deep.property('tags', {})
+  })
+
+  it('should initialize from environment variables', () => {
+    process.env.DATADOG_TRACE_AGENT_HOSTNAME = 'agent'
+    process.env.DATADOG_TRACE_AGENT_PORT = '6218'
+    process.env.DATADOG_TRACE_ENABLED = 'false'
+    process.env.DATADOG_TRACE_DEBUG = 'true'
+    process.env.DATADOG_SERVICE_NAME = 'service'
+    process.env.DATADOG_ENV = 'test'
+
+    const config = new Config()
+
+    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('debug', true)
+    expect(config).to.have.nested.property('url.hostname', 'agent')
+    expect(config).to.have.nested.property('url.port', '6218')
+    expect(config).to.have.property('service', 'service')
+    expect(config).to.have.property('env', 'test')
+  })
+
+  it('should initialize from the options', () => {
+    const logger = {}
+    const tags = { foo: 'bar' }
+    const config = new Config({
+      enabled: false,
+      debug: true,
+      hostname: 'agent',
+      port: 6218,
+      service: 'service',
+      env: 'test',
+      logger,
+      tags
+    })
+
+    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('debug', true)
+    expect(config).to.have.nested.property('url.hostname', 'agent')
+    expect(config).to.have.nested.property('url.port', '6218')
+    expect(config).to.have.property('service', 'service')
+    expect(config).to.have.property('env', 'test')
+    expect(config).to.have.property('logger', logger)
+    expect(config).to.have.deep.property('tags', tags)
+  })
+
+  it('should give priority to the options', () => {
+    process.env.DATADOG_TRACE_AGENT_HOSTNAME = 'agent'
+    process.env.DATADOG_TRACE_AGENT_PORT = '6218'
+    process.env.DATADOG_TRACE_ENABLED = 'false'
+    process.env.DATADOG_TRACE_DEBUG = 'true'
+    process.env.DATADOG_SERVICE_NAME = 'service'
+    process.env.DATADOG_ENV = 'test'
+
+    const config = new Config({
+      enabled: true,
+      debug: false,
+      hostname: 'server',
+      port: 7777,
+      service: 'test',
+      env: 'development'
+    })
+
+    expect(config).to.have.property('enabled', true)
+    expect(config).to.have.property('debug', false)
+    expect(config).to.have.nested.property('url.hostname', 'server')
+    expect(config).to.have.nested.property('url.port', '7777')
+    expect(config).to.have.property('service', 'test')
+    expect(config).to.have.property('env', 'development')
+  })
+})

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -49,6 +49,23 @@ describe('Platform', () => {
       })
     })
 
+    describe('env', () => {
+      let env
+
+      beforeEach(() => {
+        process.env.FOO = 'bar'
+        env = require('../../../src/platform/node/env')
+      })
+
+      afterEach(() => {
+        delete process.env.FOO
+      })
+
+      it('should return the value from the environment variables', () => {
+        expect(env('FOO')).to.equal('bar')
+      })
+    })
+
     describe('request', () => {
       let request
       let log


### PR DESCRIPTION
Adds a `Config` class that supports options from environment variables and from an `options` parameter. It will be used to replace the current configuration logic in the tracer.