### PR TITLE
add a tracer proxy as the module export

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 const platform = require('./src/platform')
 const node = require('./src/platform/node')
+const TracerProxy = require('./src/proxy')
 
 platform.use(node)
 
-module.exports = {}
+module.exports = new TracerProxy()

--- a/src/noop.js
+++ b/src/noop.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const Tracer = require('opentracing').Tracer
+
+class NoopTracer extends Tracer {
+  trace () {
+    return this.startSpan()
+  }
+}
+
+module.exports = NoopTracer

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const Tracer = require('opentracing').Tracer
+const NoopTracer = require('./noop')
+const DatadogTracer = require('./tracer')
+
+const noop = new NoopTracer()
+let tracer = noop
+
+class TracerProxy extends Tracer {
+  init (config) {
+    if (tracer === noop) {
+      tracer = new DatadogTracer(config)
+    }
+
+    return this
+  }
+
+  trace () {
+    return tracer.trace.apply(tracer, arguments)
+  }
+
+  startSpan () {
+    return tracer.startSpan.apply(tracer, arguments)
+  }
+
+  inject () {
+    return tracer.inject.apply(tracer, arguments)
+  }
+
+  extract () {
+    return tracer.extract.apply(tracer, arguments)
+  }
+}
+
+module.exports = TracerProxy

--- a/test/noop.spec.js
+++ b/test/noop.spec.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const Span = require('opentracing').Span
+
+describe('NoopTracer', () => {
+  let NoopTracer
+  let tracer
+
+  beforeEach(() => {
+    NoopTracer = require('../src/noop')
+    tracer = new NoopTracer()
+  })
+
+  describe('trace', () => {
+    it('should return a noop span', () => {
+      const span = tracer.trace()
+
+      expect(span).to.be.instanceof(Span)
+    })
+  })
+})

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -1,0 +1,137 @@
+'use strict'
+
+describe('TracerProxy', () => {
+  let Proxy
+  let proxy
+  let DatadogTracer
+  let tracer
+  let NoopTracer
+  let noop
+
+  beforeEach(() => {
+    tracer = {
+      trace: sinon.stub().returns('span'),
+      startSpan: sinon.stub().returns('span'),
+      inject: sinon.stub().returns('tracer'),
+      extract: sinon.stub().returns('spanContext')
+    }
+
+    noop = {
+      trace: sinon.stub().returns('span'),
+      startSpan: sinon.stub().returns('span'),
+      inject: sinon.stub().returns('noop'),
+      extract: sinon.stub().returns('spanContext')
+    }
+
+    DatadogTracer = sinon.stub().returns(tracer)
+    NoopTracer = sinon.stub().returns(noop)
+
+    Proxy = proxyquire('../src/proxy', {
+      './tracer': DatadogTracer,
+      './noop': NoopTracer
+    })
+
+    proxy = new Proxy()
+  })
+
+  describe('uninitialized', () => {
+    describe('init', () => {
+      it('should return itself', () => {
+        expect(proxy.init()).to.equal(proxy)
+      })
+
+      it('should initialize an instance of DatadogTracer', () => {
+        const config = {}
+
+        proxy.init(config)
+
+        expect(DatadogTracer).to.have.been.calledWith(config)
+      })
+
+      it('should not initialize twice', () => {
+        proxy.init()
+        proxy.init()
+
+        expect(DatadogTracer).to.have.been.calledOnce
+      })
+    })
+
+    describe('trace', () => {
+      it('should call the underlying NoopTracer', () => {
+        const returnValue = proxy.trace('a', 'b', 'c')
+
+        expect(noop.trace).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('span')
+      })
+    })
+
+    describe('startSpan', () => {
+      it('should call the underlying NoopTracer', () => {
+        const returnValue = proxy.startSpan('a', 'b', 'c')
+
+        expect(noop.startSpan).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('span')
+      })
+    })
+
+    describe('inject', () => {
+      it('should call the underlying NoopTracer', () => {
+        const returnValue = proxy.inject('a', 'b', 'c')
+
+        expect(noop.inject).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('noop')
+      })
+    })
+
+    describe('extract', () => {
+      it('should call the underlying NoopTracer', () => {
+        const returnValue = proxy.extract('a', 'b', 'c')
+
+        expect(noop.extract).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('spanContext')
+      })
+    })
+  })
+
+  describe('initialized', () => {
+    beforeEach(() => {
+      proxy.init()
+    })
+
+    describe('trace', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.trace('a', 'b', 'c')
+
+        expect(tracer.trace).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('span')
+      })
+    })
+
+    describe('startSpan', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.startSpan('a', 'b', 'c')
+
+        expect(tracer.startSpan).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('span')
+      })
+    })
+
+    describe('inject', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.inject('a', 'b', 'c')
+
+        expect(tracer.inject).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('tracer')
+      })
+    })
+
+    describe('extract', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.extract('a', 'b', 'c')
+
+        expect(tracer.extract).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('spanContext')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds a proxy that is the default export of the module. It proxies to a noop proxy by default and to the actual implementation after initialization.