### PR TITLE
increase default buffer size

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -21,7 +21,7 @@ class Config {
     this.url = new URL(`${protocol}://${hostname}:${port}`)
     this.tags = coalesce(options.tags, {})
     this.flushInterval = 2000
-    this.bufferSize = 1000
+    this.bufferSize = 100000
     this.sampleRate = 1
     this.logger = options.logger
   }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -23,7 +23,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.hostname', 'localhost')
     expect(config).to.have.nested.property('url.port', '8126')
     expect(config).to.have.property('flushInterval', 2000)
-    expect(config).to.have.property('bufferSize', 1000)
+    expect(config).to.have.property('bufferSize', 100000)
     expect(config).to.have.property('sampleRate', 1)
     expect(config).to.have.deep.property('tags', {})
   })


### PR DESCRIPTION
This PR increases the default buffer size. After a discussion with @palazzem about dropped traces, we decided to increase this value to mitigate the problem.

Also, there are possible optimizations to significantly reduce the memory footprint of a trace so that we can even keep this amount with very low impact on memory usage.