### PR TITLE
only load required plugins + version support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "opentracing": "^0.14.1",
     "performance-now": "^2.1.0",
     "require-dir": "^1.0.0",
+    "require-in-the-middle": "^2.2.1",
     "safe-buffer": "^5.1.1",
+    "semver": "^5.5.0",
     "shimmer": "^1.2.0",
     "url-parse": "^1.2.0"
   },
@@ -62,7 +64,6 @@
     "nock": "^9.1.6",
     "nyc": "^11.4.1",
     "proxyquire": "^1.8.0",
-    "semver": "^5.5.0",
     "sinon": "^4.2.1",
     "sinon-chai": "^2.14.0"
   }

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -1,22 +1,40 @@
 'use strict'
 
 const requireDir = require('require-dir')
+const path = require('path')
+const semver = require('semver')
+const hook = require('require-in-the-middle')
 
 class Instrumenter {
-  constructor (config) {
+  constructor (tracer, config) {
+    this._tracer = tracer
     this._plugins = loadPlugins(config)
+    this._instrumented = new Map()
   }
 
-  patch (tracer) {
-    this._plugins.forEach(plugin => {
-      plugin.patch(require(plugin.name), tracer)
+  patch () {
+    const instrumentedModules = this._plugins.map(plugin => plugin.name)
+    hook(instrumentedModules, this.hookModule.bind(this))
+  }
+
+  unpatch () {
+    this._instrumented.forEach((instrumentation, moduleExports) => {
+      instrumentation.unpatch(moduleExports)
     })
   }
 
-  unpatch (tracer) {
-    this._plugins.forEach(plugin => {
-      plugin.unpatch(require(plugin.name), tracer)
-    })
+  hookModule (moduleExports, moduleName, moduleBaseDir) {
+    const moduleVersion = getVersion(moduleBaseDir)
+
+    this._plugins
+      .filter(plugin => plugin.name === moduleName)
+      .filter(plugin => matchVersion(moduleVersion, plugin.versions))
+      .forEach(plugin => {
+        plugin.patch(moduleExports, this._tracer)
+        this._instrumented.set(moduleExports, plugin)
+      })
+
+    return moduleExports
   }
 }
 
@@ -33,6 +51,17 @@ function loadPlugins (config) {
   })
 
   return plugins
+}
+
+function matchVersion (version, ranges) {
+  return !version || (ranges && ranges.some(range => semver.satisfies(version, range)))
+}
+
+function getVersion (moduleBaseDir) {
+  if (moduleBaseDir) {
+    const packageJSON = path.join(moduleBaseDir, 'package.json')
+    return require(packageJSON).version
+  }
 }
 
 module.exports = Instrumenter

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -70,6 +70,7 @@ function unpatch (express) {
 
 module.exports = {
   name: 'express',
+  versions: ['4.x'],
   patch,
   unpatch
 }


### PR DESCRIPTION
This PR adds support for specifying supported module versions in plugins. It also updates the instrumenter to only load the plugins for modules that are explicitly required.