### PR TITLE
add default service name for integrations

### DIFF
--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -35,6 +35,7 @@ function patch (express, tracer) {
           span.setTag('resource.name', req.route.path)
         }
 
+        span.setTag('service.name', tracer._service)
         span.setTag('span.type', 'web')
         span.setTag(Tags.HTTP_STATUS_CODE, res.statusCode)
 

--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -16,7 +16,7 @@ function patch (http, tracer) {
       const uri = extractUrl(options)
       const method = options.method || 'GET'
 
-      if (uri === `${tracer._tracer._url.href}/v0.3/traces`) {
+      if (uri === `${tracer._url.href}/v0.3/traces`) {
         return request.apply(this, [options, callback])
       }
 
@@ -35,6 +35,7 @@ function patch (http, tracer) {
         options.headers = options.headers || {}
 
         span.addTags({
+          'service.name': 'http_client',
           'span.type': 'web',
           'resource.name': options.pathname
         })

--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -35,7 +35,7 @@ function patch (http, tracer) {
         options.headers = options.headers || {}
 
         span.addTags({
-          'service.name': 'http_client',
+          'service.name': 'http-client',
           'span.type': 'web',
           'resource.name': options.pathname
         })

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -20,6 +20,7 @@ function patch (pg, tracer) {
             [Tags.DB_TYPE]: 'postgres'
           }
         }, span => {
+          span.setTag('service.name', 'postgres')
           span.setTag('resource.name', statement)
           span.setTag('db.name', params.database)
           span.setTag('db.user', params.user)

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -29,14 +29,14 @@ module.exports = {
 
         server.on('close', () => plugin.unpatch(moduleToPatch))
 
-        plugin.patch(moduleToPatch, tracer)
-
         tracer.init({
           service: 'test',
           port,
           flushInterval: 10,
           plugins: false
         })
+
+        plugin.patch(moduleToPatch, tracer._tracer)
       })
     })
   },

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -33,6 +33,7 @@ describe('Plugin', () => {
 
       getPort().then(port => {
         agent.use(traces => {
+          expect(traces[0][0]).to.have.property('service', 'test')
           expect(traces[0][0]).to.have.property('type', 'web')
           expect(traces[0][0]).to.have.property('resource', '/user')
           expect(traces[0][0].meta).to.have.property('span.kind', 'server')

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -32,7 +32,7 @@ describe('Plugin', () => {
 
       getPort().then(port => {
         agent.use(traces => {
-          expect(traces[0][0]).to.have.property('service', 'http_client')
+          expect(traces[0][0]).to.have.property('service', 'http-client')
           expect(traces[0][0]).to.have.property('type', 'web')
           expect(traces[0][0]).to.have.property('resource', '/user')
           expect(traces[0][0].meta).to.have.property('span.kind', 'client')

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -32,6 +32,7 @@ describe('Plugin', () => {
 
       getPort().then(port => {
         agent.use(traces => {
+          expect(traces[0][0]).to.have.property('service', 'http_client')
           expect(traces[0][0]).to.have.property('type', 'web')
           expect(traces[0][0]).to.have.property('resource', '/user')
           expect(traces[0][0].meta).to.have.property('span.kind', 'client')

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -20,6 +20,7 @@ describe('Plugin', () => {
 
     it('should do automatic instrumentation when using callbacks', done => {
       agent.use(traces => {
+        expect(traces[0][0]).to.have.property('service', 'postgres')
         expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
         expect(traces[0][0]).to.have.property('type', 'db')
         expect(traces[0][0].meta).to.have.property('db.name', 'postgres')


### PR DESCRIPTION
This PR adds a default service name for integrations:
* `express` uses the service name of the tracer since the server is exposing the service directly.
* `http` uses `http_client` for now and could be improved in the future to use information from the remote URL.
* `postgres` simply uses `postgres`