### PR TITLE
downgrade opentracing to a fixed version that works

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "koalas": "^1.0.2",
     "methods": "^1.1.2",
     "msgpack-lite": "^0.1.26",
-    "opentracing": "^0.14.1",
+    "opentracing": "0.14.1",
     "performance-now": "^2.1.0",
     "require-dir": "^1.0.0",
     "require-in-the-middle": "^2.2.1",


### PR DESCRIPTION
The latest version uses `lodash` without depending on it which breaks dependant libraries.

See https://github.com/opentracing/opentracing-javascript/issues/95