### PR TITLE
Add browser support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const platform = require('./src/platform')
+const browser = require('./src/platform/browser')
 const TracerProxy = require('./src/proxy')
+
+platform.use(browser)
 
 module.exports = new TracerProxy()

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const platform = require('./src/platform')
+const TracerProxy = require('./src/proxy')
+
+module.exports = new TracerProxy()

--- a/src/platform/browser/context.js
+++ b/src/platform/browser/context.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const context = new Map()
+
+module.exports = config => {
+  return {
+    get(...args) {
+      return context.get(...args);
+    },
+    set(...args) {
+      return context.set(...args);
+    },
+    bind(fn) {
+      return fn
+    },
+    bindEmitter() {},
+  };
+}

--- a/src/platform/browser/env.js
+++ b/src/platform/browser/env.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = name => process.env[name]

--- a/src/platform/browser/id.js
+++ b/src/platform/browser/id.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const Uint64BE = require('int64-buffer').Uint64BE
+const crypto = window.crypto || window.msCrypto;
+
+const buffer = new Uint32Array(2);
+module.exports = () => {
+  crypto.getRandomValues(buffer);
+  return new Uint64BE(buffer[0] | buffer[1] << 32)
+}

--- a/src/platform/browser/index.js
+++ b/src/platform/browser/index.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const id = require('./id')
+const now = require('./now')
+const env = require('./env')
+const request = require('./request')
+const context = require('./context')
+const msgpack = require('./msgpack')
+
+module.exports = {
+  name: () => 'browser',
+  version: () => navigator.userAgent,
+  engine: () => 'browser',
+  id,
+  now,
+  env,
+  request,
+  context,
+  msgpack
+}

--- a/src/platform/browser/msgpack.js
+++ b/src/platform/browser/msgpack.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const Buffer = require('safe-buffer').Buffer
+
+module.exports = {
+  prefix (array) {
+    let buffer
+
+    if (array.length <= 0xf) { // fixarray
+      buffer = Buffer.alloc(1)
+      buffer.fill(0x90 + array.length)
+    } else if (array.length <= 0xffff) { // array 16
+      buffer = Buffer.alloc(3)
+      buffer.fill(0xdc, 0, 1)
+      buffer.writeUInt16BE(array.length, 1)
+    } else { // array 32
+      buffer = Buffer.alloc(5)
+      buffer.fill(0xdd, 0, 1)
+      buffer.writeUInt32BE(array.length, 1)
+    }
+
+    return [buffer].concat(array)
+  }
+}

--- a/src/platform/browser/now.js
+++ b/src/platform/browser/now.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const loadNs = performance.now()
+const loadMs = Date.now()
+
+module.exports = () => loadMs + performance.now() - loadNs

--- a/src/platform/browser/request.js
+++ b/src/platform/browser/request.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const http = require('http')
+
+function request (options, callback) {
+  options = Object.assign({
+    headers: {}
+  }, options)
+
+  options.headers['Content-Type'] = 'application/json'
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    const url = `${options.protocol}//${options.hostname}:${options.port}${options.path}`
+
+    xhr.onload = function() {
+      if (this.status >= 200 && this.status <= 299) {
+        resolve()
+      }
+    }
+    xhr.onerror = () => reject(new TypeError('network request failed'))
+    xhr.ontimeout = () => reject(new TypeError('network request timed out'))
+
+    xhr.open(options.method, url, true)
+
+    Object.entries(options.headers).forEach(([k, v]) => {
+      xhr.setRequestHeader(k, v)
+    })
+
+    xhr.send(options.data)
+  })
+}
+
+module.exports = request

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -2,15 +2,12 @@
 
 const platform = require('./platform')
 const Tracer = require('./opentracing/tracer')
-const Instrumenter = require('./instrumenter')
 
 class DatadogTracer extends Tracer {
   constructor (config) {
     super(config)
 
     this._context = platform.context(config)
-    this._instrumenter = new Instrumenter(this, config)
-    this._instrumenter.patch()
   }
 
   trace (name, options, callback) {


### PR DESCRIPTION
This PR adds support for tracing from a browser/non-node context. It does this by:
- Adding a new entrypoint, `dd-trace/browser` that browser clients should import as a drop-in replacement.
- Adding browser-specific platform implementations in `src/platform/browser`
- Removing the `Instrumenter` class from the tracer, as it pulls in node specific APIs. I believe this change makes sense as instrumentation should be a separate concern from the tracer.

todo:
- customize flush?