### PR TITLE
add scripts to create and release new versions

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -27,7 +27,6 @@ dev,eslint-plugin-node,MIT,Copyright 2015 Toru Nagashima
 dev,eslint-plugin-promise,ISC,jden and other contributors
 dev,eslint-plugin-standard,MIT,Copyright 2015 Jamund Ferguson
 dev,express,MIT,Copyright 2009-2014 TJ Holowaychuk 2013-2014 Roman Shtylman 2014-2015 Douglas Christopher Wilson
-dev,genversion,MIT,Copyright 2017 Akseli Palén
 dev,get-port,MIT,Copyright Sindre Sorhus
 dev,mocha,MIT,Copyright 2011-2018 JS Foundation and contributors https://js.foundation
 dev,nock,MIT,Copyright 2017 Pedro Teixeira and other contributors

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "express": "^4.16.2",
-    "genversion": "^2.0.1",
     "get-port": "^3.2.0",
     "mocha": "^5.0.0",
     "nock": "^9.1.6",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "bench": "node benchmark",
     "lint": "eslint . && node scripts/check_licenses.js",
     "tdd": "mocha --watch",
-    "test": "nyc --reporter text --reporter lcov mocha",
-    "version": "genversion lib/version.js && git add lib/version.js"
+    "test": "nyc --reporter text --reporter lcov mocha"
   },
   "repository": {
     "type": "git",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const exec = require('child_process').execSync
+const pkg = require('../package.json')
+
+const version = pkg.version
+
+exec('npm whoami')
+exec('git checkout master')
+exec('git pull')
+exec(`git tag v${version}`)
+exec(`git push origin v${version}`)
+exec('npm publish')

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+const semver = require('semver')
+const exec = require('child_process').execSync
+const pkg = require('../package.json')
+
+const increment = getIncrement()
+const version = semver.inc(pkg.version, increment)
+
+pkg.version = `v${version}`
+
+exec(`git checkout master`)
+exec(`git checkout -b v${version}`)
+write('package.json', JSON.stringify(pkg, 2) + '\n')
+write('lib/version.js', `module.exports = '${version}'\n`)
+add('package.json')
+add('lib/version.js')
+exec(`git commit -m "v${version}"`)
+exec(`git push -u origin HEAD`)
+
+function getIncrement () {
+  const increments = ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease']
+  const index = increments.indexOf(process.argv[2])
+
+  if (index === -1) {
+    throw new Error(`increment must be one of ${increments.join(', ')}`)
+  }
+
+  return increments[index]
+}
+
+function filename (relativePath) {
+  return path.normalize(path.join(__dirname, '..', relativePath))
+}
+
+function write (file, data) {
+  fs.writeFileSync(filename(file), data)
+}
+
+function add (file) {
+  exec(`git add ${filename(file)}`)
+}


### PR DESCRIPTION
This PR adds scripts to create and release new version. We need this because we have a non-standard flow based on PRs instead of direct push to master. This is necessary to prevent all unwanted pushes to master. It will also allow us to automate releases eventually by automatically publishing new versions to npm based on tags.