### PR TITLE
add plugin configuration

### DIFF
--- a/src/noop.js
+++ b/src/noop.js
@@ -3,6 +3,10 @@
 const Tracer = require('opentracing').Tracer
 
 class NoopTracer extends Tracer {
+  use (plugin, config) {
+    return this
+  }
+
   trace (operationName, options, callback) {
     callback(this.startSpan())
   }

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -8,7 +8,7 @@ const METHODS = require('methods').concat('use', 'route', 'param', 'all')
 
 const OPERATION_NAME = 'express.request'
 
-function patch (express, tracer) {
+function patch (express, tracer, config) {
   METHODS.forEach((method) => {
     shimmer.wrap(express.application, method, wrapper)
   })
@@ -35,7 +35,7 @@ function patch (express, tracer) {
           span.setTag('resource.name', req.route.path)
         }
 
-        span.setTag('service.name', tracer._service)
+        span.setTag('service.name', config.service || tracer._service)
         span.setTag('span.type', 'web')
         span.setTag(Tags.HTTP_STATUS_CODE, res.statusCode)
 

--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -7,7 +7,7 @@ const shimmer = require('shimmer')
 const Tags = opentracing.Tags
 const FORMAT_HTTP_HEADERS = opentracing.FORMAT_HTTP_HEADERS
 
-function patch (http, tracer) {
+function patch (http, tracer, config) {
   shimmer.wrap(http, 'request', request => makeRequestTrace(request))
   shimmer.wrap(http, 'get', get => makeRequestTrace(get))
 
@@ -35,7 +35,7 @@ function patch (http, tracer) {
         options.headers = options.headers || {}
 
         span.addTags({
-          'service.name': 'http-client',
+          'service.name': config.service || 'http-client',
           'span.type': 'web',
           'resource.name': options.pathname
         })

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -5,7 +5,7 @@ const shimmer = require('shimmer')
 
 const OPERATION_NAME = 'pg.query'
 
-function patch (pg, tracer) {
+function patch (pg, tracer, config) {
   function queryWrap (query) {
     return function queryTrace () {
       const pgQuery = query.apply(this, arguments)
@@ -20,7 +20,7 @@ function patch (pg, tracer) {
             [Tags.DB_TYPE]: 'postgres'
           }
         }, span => {
-          span.setTag('service.name', 'postgres')
+          span.setTag('service.name', config.service || 'postgres')
           span.setTag('resource.name', statement)
           span.setTag('db.name', params.database)
           span.setTag('db.user', params.user)

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -25,6 +25,10 @@ class TracerProxy extends Tracer {
     return this
   }
 
+  use () {
+    return this._tracer.use.apply(this._tracer, arguments)
+  }
+
   trace () {
     return this._tracer.trace.apply(this._tracer, arguments)
   }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -13,6 +13,11 @@ class DatadogTracer extends Tracer {
     this._instrumenter.patch()
   }
 
+  use (plugin, config) {
+    this._instrumenter.use(plugin, config)
+    return this
+  }
+
   trace (name, options, callback) {
     if (!callback) {
       callback = options

--- a/test/instrumenter.spec.js
+++ b/test/instrumenter.spec.js
@@ -39,6 +39,28 @@ describe('Instrumenter', () => {
       instrumenter = new Instrumenter(tracer, { plugins: true })
     })
 
+    describe('use', () => {
+      it('should allow configuring a plugin', () => {
+        const config = { foo: 'bar' }
+
+        instrumenter.use('express', config)
+        instrumenter.patch()
+
+        const express = require('express')
+
+        expect(integrations.express.patch).to.have.been.calledWith(express, tracer, config)
+      })
+
+      it('should default to an empty plugin configuration', () => {
+        instrumenter.use('express')
+        instrumenter.patch()
+
+        const express = require('express')
+
+        expect(integrations.express.patch).to.have.been.calledWith(express, tracer, {})
+      })
+    })
+
     describe('patch', () => {
       it('should patch modules from node_modules when they are loaded', () => {
         instrumenter.patch()
@@ -62,6 +84,7 @@ describe('Instrumenter', () => {
 
         const http = require('http')
 
+        expect(integrations.http.patch).to.have.been.called
         expect(integrations.http.patch).to.have.been.calledWith(http, tracer)
       })
     })

--- a/test/noop.spec.js
+++ b/test/noop.spec.js
@@ -11,6 +11,12 @@ describe('NoopTracer', () => {
     tracer = new NoopTracer()
   })
 
+  describe('use', () => {
+    it('should return itself', () => {
+      expect(tracer.use()).to.equal(tracer)
+    })
+  })
+
   describe('trace', () => {
     it('should return a noop span', done => {
       tracer.trace('test', {}, span => {

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -12,7 +12,7 @@ let listener = null
 let tracer = null
 
 module.exports = {
-  load (plugin, moduleToPatch) {
+  load (plugin, moduleToPatch, config) {
     tracer = require('../..')
     agent = express()
     agent.use(bodyParser.raw({ type: 'application/msgpack' }))
@@ -36,7 +36,7 @@ module.exports = {
           plugins: false
         })
 
-        plugin.patch(moduleToPatch, tracer._tracer)
+        plugin.patch(moduleToPatch, tracer._tracer, config || {})
       })
     })
   },

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -15,8 +15,6 @@ describe('Plugin', () => {
       plugin = require('../../src/plugins/express')
       express = require('express')
       context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
-
-      return agent.load(plugin, express)
     })
 
     afterEach(() => {
@@ -24,108 +22,148 @@ describe('Plugin', () => {
       appListener.close()
     })
 
-    it('should do automatic instrumentation', done => {
-      const app = express()
-
-      app.get('/user', (req, res) => {
-        res.status(200).send()
+    describe('without configuration', () => {
+      beforeEach(() => {
+        return agent.load(plugin, express)
       })
 
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0]).to.have.property('service', 'test')
-          expect(traces[0][0]).to.have.property('type', 'web')
-          expect(traces[0][0]).to.have.property('resource', '/user')
-          expect(traces[0][0].meta).to.have.property('span.kind', 'server')
-          expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
-          expect(traces[0][0].meta).to.have.property('http.method', 'GET')
-          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+      it('should do automatic instrumentation', done => {
+        const app = express()
 
-          done()
+        app.get('/user', (req, res) => {
+          res.status(200).send()
         })
 
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}/user`)
-            .catch(done)
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('type', 'web')
+            expect(traces[0][0]).to.have.property('resource', '/user')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+            expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+            expect(traces[0][0].meta).to.have.property('http.method', 'GET')
+            expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
+          })
+        })
+      })
+
+      it('should support custom routers', done => {
+        const app = express()
+
+        app.use((req, res) => {
+          res.status(200).send()
+        })
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('resource', 'express.request')
+            expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}`)
+              .catch(done)
+          })
+        })
+      })
+
+      it('should support context propagation', done => {
+        const app = express()
+
+        app.use((req, res, next) => {
+          context.set('foo', 'bar')
+          next()
+        })
+
+        app.get('/user', (req, res) => {
+          res.status(200).send(context.get('foo'))
+        })
+
+        getPort().then(port => {
+          appListener = app.listen(port, 'localhost', () => {
+            axios.get(`http://localhost:${port}/user`)
+              .then(res => {
+                expect(res.status).to.equal(200)
+                expect(res.data).to.equal('bar')
+                done()
+              })
+              .catch(done)
+          })
+        })
+      })
+
+      it('should extract its parent span from the headers', done => {
+        const app = express()
+
+        app.get('/user', (req, res) => {
+          expect(agent.currentSpan().context().baggageItems).to.have.property('foo', 'bar')
+          res.status(200).send()
+        })
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0].trace_id.toString()).to.equal('1234')
+            expect(traces[0][0].parent_id.toString()).to.equal('5678')
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/user`, {
+                headers: {
+                  'x-datadog-trace-id': '1234',
+                  'x-datadog-parent-id': '5678',
+                  'ot-baggage-foo': 'bar'
+                }
+              })
+              .catch(done)
+          })
         })
       })
     })
 
-    it('should support custom routers', done => {
-      const app = express()
+    describe('with configuration', () => {
+      let config
 
-      app.use((req, res) => {
-        res.status(200).send()
+      beforeEach(() => {
+        config = {
+          service: 'custom'
+        }
+
+        return agent.load(plugin, express, config)
       })
 
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0]).to.have.property('resource', 'express.request')
-          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+      it('should be configured with the correct values', done => {
+        const app = express()
 
-          done()
+        app.get('/user', (req, res) => {
+          res.status(200).send()
         })
 
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}`)
-            .catch(done)
-        })
-      })
-    })
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'custom')
 
-    it('should support context propagation', done => {
-      const app = express()
+            done()
+          })
 
-      app.use((req, res, next) => {
-        context.set('foo', 'bar')
-        next()
-      })
-
-      app.get('/user', (req, res) => {
-        res.status(200).send(context.get('foo'))
-      })
-
-      getPort().then(port => {
-        appListener = app.listen(port, 'localhost', () => {
-          axios.get(`http://localhost:${port}/user`)
-            .then(res => {
-              expect(res.status).to.equal(200)
-              expect(res.data).to.equal('bar')
-              done()
-            })
-            .catch(done)
-        })
-      })
-    })
-
-    it('should extract its parent span from the headers', done => {
-      const app = express()
-
-      app.get('/user', (req, res) => {
-        expect(agent.currentSpan().context().baggageItems).to.have.property('foo', 'bar')
-        res.status(200).send()
-      })
-
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0].trace_id.toString()).to.equal('1234')
-          expect(traces[0][0].parent_id.toString()).to.equal('5678')
-
-          done()
-        })
-
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}/user`, {
-              headers: {
-                'x-datadog-trace-id': '1234',
-                'x-datadog-parent-id': '5678',
-                'ot-baggage-foo': 'bar'
-              }
-            })
-            .catch(done)
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
+          })
         })
       })
     })

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -14,8 +14,6 @@ describe('Plugin', () => {
       plugin = require('../../src/plugins/http')
       express = require('express')
       http = require('http')
-
-      return agent.load(plugin, http)
     })
 
     afterEach(() => {
@@ -23,156 +21,198 @@ describe('Plugin', () => {
       appListener.close()
     })
 
-    it('should do automatic instrumentation', done => {
-      const app = express()
-
-      app.get('/user', (req, res) => {
-        res.status(200).send()
+    describe('without configuration', () => {
+      beforeEach(() => {
+        return agent.load(plugin, http)
       })
 
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0]).to.have.property('service', 'http-client')
-          expect(traces[0][0]).to.have.property('type', 'web')
-          expect(traces[0][0]).to.have.property('resource', '/user')
-          expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-          expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
-          expect(traces[0][0].meta).to.have.property('http.method', 'GET')
-          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+      it('should do automatic instrumentation', done => {
+        const app = express()
 
-          done()
+        app.get('/user', (req, res) => {
+          res.status(200).send()
         })
 
-        appListener = app.listen(port, 'localhost', () => {
-          const req = http.request(`http://localhost:${port}/user`, res => {
-            res.on('data', () => {})
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'http-client')
+            expect(traces[0][0]).to.have.property('type', 'web')
+            expect(traces[0][0]).to.have.property('resource', '/user')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+            expect(traces[0][0].meta).to.have.property('http.method', 'GET')
+            expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+
+            done()
           })
+
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request(`http://localhost:${port}/user`, res => {
+              res.on('data', () => {})
+            })
+
+            req.end()
+          })
+        })
+      })
+
+      it('should also support http.get', done => {
+        const app = express()
+
+        app.get('/user', (req, res) => {
+          res.status(200).send()
+        })
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.not.be.undefined
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.get(`http://localhost:${port}/user`, res => {
+              res.on('data', () => {})
+            })
+
+            req.end()
+          })
+        })
+      })
+
+      it('should support configuration as an URL object', done => {
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+
+            done()
+          })
+
+          const uri = {
+            hostname: 'localhost',
+            port,
+            pathname: '/user'
+          }
+
+          const req = http.request(uri)
+
+          req.end()
+        })
+      })
+
+      it('should use the correct defaults when not specified', done => {
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/`)
+
+            done()
+          })
+
+          const req = http.request({
+            port
+          })
+
+          req.end()
+        })
+      })
+
+      it('should not require consuming the data', done => {
+        const app = express()
+
+        app.get('/user', (req, res) => {
+          res.status(200).send()
+        })
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.not.be.undefined
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request(`http://localhost:${port}/user`)
+
+            req.end()
+          })
+        })
+      })
+
+      it('should inject its parent span in the headers', done => {
+        const app = express()
+
+        app.get('/user', (req, res) => {
+          expect(req.get('x-datadog-trace-id')).to.be.a('string')
+          expect(req.get('x-datadog-parent-id')).to.be.a('string')
+
+          res.status(200).send()
+        })
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request(`http://localhost:${port}/user`)
+
+            req.end()
+          })
+        })
+      })
+
+      it('should handle errors', done => {
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('error.type', 'Error')
+            expect(traces[0][0].meta).to.have.property('error.msg', `connect ECONNREFUSED 127.0.0.1:${port}`)
+            expect(traces[0][0].meta).to.have.property('error.stack')
+
+            done()
+          })
+
+          const req = http.request(`http://localhost:${port}/user`)
 
           req.end()
         })
       })
     })
 
-    it('should also support http.get', done => {
-      const app = express()
+    describe('with configuration', () => {
+      let config
 
-      app.get('/user', (req, res) => {
-        res.status(200).send()
-      })
-
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0]).to.not.be.undefined
-
-          done()
-        })
-
-        appListener = app.listen(port, 'localhost', () => {
-          const req = http.get(`http://localhost:${port}/user`, res => {
-            res.on('data', () => {})
-          })
-
-          req.end()
-        })
-      })
-    })
-
-    it('should support configuration as an URL object', done => {
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
-
-          done()
-        })
-
-        const uri = {
-          hostname: 'localhost',
-          port,
-          pathname: '/user'
+      beforeEach(() => {
+        config = {
+          service: 'custom'
         }
 
-        const req = http.request(uri)
-
-        req.end()
-      })
-    })
-
-    it('should use the correct defaults when not specified', done => {
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/`)
-
-          done()
-        })
-
-        const req = http.request({
-          port
-        })
-
-        req.end()
-      })
-    })
-
-    it('should not require consuming the data', done => {
-      const app = express()
-
-      app.get('/user', (req, res) => {
-        res.status(200).send()
+        return agent.load(plugin, http, config)
       })
 
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0]).to.not.be.undefined
+      it('should be configured with the correct values', done => {
+        const app = express()
 
-          done()
+        app.get('/user', (req, res) => {
+          res.status(200).send()
         })
 
-        appListener = app.listen(port, 'localhost', () => {
-          const req = http.request(`http://localhost:${port}/user`)
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'custom')
 
-          req.end()
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request(`http://localhost:${port}/user`, res => {
+              res.on('data', () => {})
+            })
+
+            req.end()
+          })
         })
-      })
-    })
-
-    it('should inject its parent span in the headers', done => {
-      const app = express()
-
-      app.get('/user', (req, res) => {
-        expect(req.get('x-datadog-trace-id')).to.be.a('string')
-        expect(req.get('x-datadog-parent-id')).to.be.a('string')
-
-        res.status(200).send()
-      })
-
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
-
-          done()
-        })
-
-        appListener = app.listen(port, 'localhost', () => {
-          const req = http.request(`http://localhost:${port}/user`)
-
-          req.end()
-        })
-      })
-    })
-
-    it('should handle errors', done => {
-      getPort().then(port => {
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-          expect(traces[0][0].meta).to.have.property('error.msg', `connect ECONNREFUSED 127.0.0.1:${port}`)
-          expect(traces[0][0].meta).to.have.property('error.stack')
-
-          done()
-        })
-
-        const req = http.request(`http://localhost:${port}/user`)
-
-        req.end()
       })
     })
   })

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -13,6 +13,7 @@ describe('TracerProxy', () => {
 
   beforeEach(() => {
     tracer = {
+      use: sinon.stub().returns('tracer'),
       trace: sinon.stub().returns('span'),
       startSpan: sinon.stub().returns('span'),
       inject: sinon.stub().returns('tracer'),
@@ -23,6 +24,7 @@ describe('TracerProxy', () => {
     }
 
     noop = {
+      use: sinon.stub().returns('tracer'),
       trace: sinon.stub().returns('span'),
       startSpan: sinon.stub().returns('span'),
       inject: sinon.stub().returns('noop'),
@@ -80,6 +82,15 @@ describe('TracerProxy', () => {
         proxy.init()
 
         expect(DatadogTracer).to.have.been.calledOnce
+      })
+    })
+
+    describe('use', () => {
+      it('should call the underlying NoopTracer', () => {
+        const returnValue = proxy.use('a', 'b', 'c')
+
+        expect(noop.use).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('tracer')
       })
     })
 
@@ -149,6 +160,15 @@ describe('TracerProxy', () => {
   describe('initialized', () => {
     beforeEach(() => {
       proxy.init()
+    })
+
+    describe('use', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.use('a', 'b', 'c')
+
+        expect(tracer.use).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('tracer')
+      })
     })
 
     describe('trace', () => {

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -20,6 +20,7 @@ describe('Tracer', () => {
     sinon.stub(context, 'bindEmitter')
 
     instrumenter = {
+      use: sinon.spy(),
       patch: sinon.spy()
     }
     Instrumenter = sinon.stub().returns(instrumenter)
@@ -39,6 +40,15 @@ describe('Tracer', () => {
 
     expect(Instrumenter).to.have.been.calledWith(tracer)
     expect(instrumenter.patch).to.have.been.called
+  })
+
+  describe('use', () => {
+    it('should configure a plugin with the instrumenter', () => {
+      tracer = new Tracer(config)
+      tracer.use('plugin', 'config')
+
+      expect(instrumenter.use).to.have.been.calledWith('plugin', 'config')
+    })
   })
 
   describe('trace', () => {


### PR DESCRIPTION
This PR adds a plugin configuration system similar to middleware. This allows the user to reconfigure existing plugins. By using the middleware syntax, it will also allow them to register custom plugins as well in the future.