### PR TITLE
fix exponential slowdown in tests

### DIFF
--- a/src/recorder.js
+++ b/src/recorder.js
@@ -8,15 +8,22 @@ const Writer = require('./writer')
 class Recorder {
   constructor (url, interval, size) {
     this._writer = new Writer(url, size)
-    this._scheduler = new Scheduler(() => this._writer.flush(), interval)
+
+    if (interval > 0) {
+      this._scheduler = new Scheduler(() => this._writer.flush(), interval)
+    }
   }
 
   init () {
-    this._scheduler.start()
+    this._scheduler && this._scheduler.start()
   }
 
   record (span) {
     this._writer.append(span)
+
+    if (!this._scheduler) {
+      this._writer.flush()
+    }
   }
 }
 

--- a/test/dd-trace.spec.js
+++ b/test/dd-trace.spec.js
@@ -22,7 +22,7 @@ describe('dd-trace', () => {
       tracer.init({
         service: 'test',
         port: listener.address().port,
-        flushInterval: 10,
+        flushInterval: 0,
         plugins: false
       })
     })

--- a/test/opentracing/api.spec.js
+++ b/test/opentracing/api.spec.js
@@ -1,13 +1,12 @@
 'use strict'
 
 const apiCompatibilityChecks = require('opentracing/lib/test/api_compatibility').default
-const DatadogTracer = require('../../src/opentracing/tracer')
+const tracer = require('../..')
 
 apiCompatibilityChecks(() => {
-  const clock = sinon.useFakeTimers()
-  const tracer = new DatadogTracer({ service: 'test' })
-
-  clock.restore()
-
-  return tracer
+  return tracer.init({
+    service: 'test',
+    flushInterval: 0,
+    plugins: false
+  })
 })

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -32,7 +32,7 @@ module.exports = {
         tracer.init({
           service: 'test',
           port,
-          flushInterval: 10,
+          flushInterval: 0,
           plugins: false
         })
 

--- a/test/recorder.spec.js
+++ b/test/recorder.spec.js
@@ -7,8 +7,10 @@ describe('Recorder', () => {
   let Writer
   let writer
   let recorder
+  let span
 
   beforeEach(() => {
+    span = {}
     scheduler = {
       start: sinon.spy(),
       reset: sinon.spy()
@@ -23,33 +25,58 @@ describe('Recorder', () => {
       './scheduler': Scheduler,
       './writer': Writer
     })
-    recorder = new Recorder('http://test', 1000, 2)
   })
 
-  describe('init', () => {
-    it('should schedule flushing after the configured interval', () => {
-      writer.length = 0
-
-      recorder.init()
-      Scheduler.firstCall.args[0]()
-
-      expect(scheduler.start).to.have.been.called
-      expect(writer.flush).to.have.been.called
-    })
-  })
-
-  describe('record', () => {
-    let span
-
+  describe('when interval is set to a positive number', () => {
     beforeEach(() => {
-      span = {}
+      recorder = new Recorder('http://test', 1000, 2)
+
+      describe('init', () => {
+        it('should schedule flushing after the configured interval', () => {
+          writer.length = 0
+
+          recorder.init()
+          Scheduler.firstCall.args[0]()
+
+          expect(scheduler.start).to.have.been.called
+          expect(writer.flush).to.have.been.called
+        })
+      })
+
+      describe('record', () => {
+        beforeEach(() => {
+          span = {}
+        })
+
+        it('should record a span', () => {
+          writer.length = 0
+          recorder.record(span)
+
+          expect(writer.append).to.have.been.calledWith(span)
+        })
+      })
+    })
+  })
+
+  describe('when interval is set to 0', () => {
+    beforeEach(() => {
+      recorder = new Recorder('http://test', 0)
     })
 
-    it('should record a span', () => {
-      writer.length = 0
+    describe('init', () => {
+      it('should not schedule flushing', () => {
+        writer.length = 0
+
+        recorder.init()
+
+        expect(scheduler.start).to.not.have.been.called
+      })
+    })
+
+    it('should flush right away when interval is set to 0', () => {
       recorder.record(span)
 
-      expect(writer.append).to.have.been.calledWith(span)
+      expect(writer.flush).to.have.been.called
     })
   })
 })


### PR DESCRIPTION
This PR introduces a few fixes to reduce the slowdowns of tests when ran in watch mode. The problem is not 100% resolved, but its impact has been reduced to a level where in most cases it wouldn't be noticeable.