### PR TITLE
fix describe in beforeEach block

### DIFF
--- a/test/recorder.spec.js
+++ b/test/recorder.spec.js
@@ -30,30 +30,30 @@ describe('Recorder', () => {
   describe('when interval is set to a positive number', () => {
     beforeEach(() => {
       recorder = new Recorder('http://test', 1000, 2)
+    })
 
-      describe('init', () => {
-        it('should schedule flushing after the configured interval', () => {
-          writer.length = 0
+    describe('init', () => {
+      it('should schedule flushing after the configured interval', () => {
+        writer.length = 0
 
-          recorder.init()
-          Scheduler.firstCall.args[0]()
+        recorder.init()
+        Scheduler.firstCall.args[0]()
 
-          expect(scheduler.start).to.have.been.called
-          expect(writer.flush).to.have.been.called
-        })
+        expect(scheduler.start).to.have.been.called
+        expect(writer.flush).to.have.been.called
+      })
+    })
+
+    describe('record', () => {
+      beforeEach(() => {
+        span = {}
       })
 
-      describe('record', () => {
-        beforeEach(() => {
-          span = {}
-        })
+      it('should record a span', () => {
+        writer.length = 0
+        recorder.record(span)
 
-        it('should record a span', () => {
-          writer.length = 0
-          recorder.record(span)
-
-          expect(writer.append).to.have.been.calledWith(span)
-        })
+        expect(writer.append).to.have.been.calledWith(span)
       })
     })
   })


### PR DESCRIPTION
This PR simply moves a `describe` block out of a `beforeEach` block, which was done by mistake. This prevented these tests from running.