### PR TITLE
fix using tracer.trace() without options

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -39,11 +39,13 @@ class TracerProxy extends Tracer {
       return this._tracer.trace(operationName, options, callback)
     } else if (options instanceof Function) {
       return this._tracer.trace(operationName, options)
+    } else if (options) {
+      return new Promise((resolve, reject) => {
+        this._tracer.trace(operationName, options, span => resolve(span))
+      })
     } else {
       return new Promise((resolve, reject) => {
-        this._tracer.trace(operationName, options, span => {
-          resolve(span)
-        })
+        this._tracer.trace(operationName, span => resolve(span))
       })
     }
   }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -36,7 +36,9 @@ class TracerProxy extends Tracer {
 
   trace (operationName, options, callback) {
     if (callback) {
-      return this._tracer.trace.apply(this._tracer, arguments)
+      return this._tracer.trace(operationName, options, callback)
+    } else if (options instanceof Function) {
+      return this._tracer.trace(operationName, options)
     } else {
       return new Promise((resolve, reject) => {
         this._tracer.trace(operationName, options, span => {

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -123,12 +123,24 @@ describe('TracerProxy', () => {
         })
       })
 
-      it('should work without options', () => {
+      it('should work without options for callbacks', () => {
         const callback = () => {}
         const returnValue = proxy.trace('a', callback)
 
         expect(noop.trace).to.have.been.calledWith('a', callback)
         expect(returnValue).to.equal('span')
+      })
+
+      it('should work without options for promises', () => {
+        const promise = proxy.trace('a')
+
+        expect(noop.trace).to.have.been.calledWith('a')
+
+        noop.trace.firstCall.args[1]('span')
+
+        return promise.then(span => {
+          expect(span).to.equal('span')
+        })
       })
     })
 
@@ -226,6 +238,18 @@ describe('TracerProxy', () => {
 
         expect(tracer.trace).to.have.been.calledWith('a', callback)
         expect(returnValue).to.equal('span')
+      })
+
+      it('should work without options for promises', () => {
+        const promise = proxy.trace('a')
+
+        expect(tracer.trace).to.have.been.calledWith('a')
+
+        tracer.trace.firstCall.args[1]('span')
+
+        return promise.then(span => {
+          expect(span).to.equal('span')
+        })
       })
     })
 

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -122,6 +122,14 @@ describe('TracerProxy', () => {
           expect(span).to.equal('span')
         })
       })
+
+      it('should work without options', () => {
+        const callback = () => {}
+        const returnValue = proxy.trace('a', callback)
+
+        expect(noop.trace).to.have.been.calledWith('a', callback)
+        expect(returnValue).to.equal('span')
+      })
     })
 
     describe('startSpan', () => {
@@ -183,11 +191,6 @@ describe('TracerProxy', () => {
       proxy.init()
     })
 
-    // it('should setup automatic instrumentation', () => {
-    //   expect(Instrumenter).to.have.been.calledWith(tracer)
-    //   expect(instrumenter.patch).to.have.been.called
-    // })
-
     describe('use', () => {
       it('should call the underlying Instrumenter', () => {
         const returnValue = proxy.use('a', 'b', 'c')
@@ -215,6 +218,14 @@ describe('TracerProxy', () => {
         return promise.then(span => {
           expect(span).to.equal('span')
         })
+      })
+
+      it('should work without options', () => {
+        const callback = () => {}
+        const returnValue = proxy.trace('a', callback)
+
+        expect(tracer.trace).to.have.been.calledWith('a', callback)
+        expect(returnValue).to.equal('span')
       })
     })
 


### PR DESCRIPTION
Right now it is required to set options for `tracer.trace()` to work.