### PR TITLE
update express plugin to support nested router paths

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -8,6 +8,7 @@ require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk 2013-2014 TJ Holowaychuk
 require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,parent-module,MIT,Copyright Sindre Sorhus
+require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
 require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,read-pkg-up,MIT,Copyright Sindre Sorhus
 require,require-dir,MIT,Copyright 2012-2015 Aseem Kishore

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "msgpack-lite": "^0.1.26",
     "opentracing": "0.14.1",
     "parent-module": "^0.1.0",
+    "path-to-regexp": "^2.2.1",
     "performance-now": "^2.1.0",
     "read-pkg-up": "^3.0.0",
     "require-dir": "^1.0.0",

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -5,14 +5,11 @@ const Tags = opentracing.Tags
 const FORMAT_HTTP_HEADERS = opentracing.FORMAT_HTTP_HEADERS
 const shimmer = require('shimmer')
 const METHODS = require('methods').concat('use', 'route', 'param', 'all')
+const pathToRegExp = require('path-to-regexp')
 
 const OPERATION_NAME = 'express.request'
 
-function patch (express, tracer, config) {
-  METHODS.forEach((method) => {
-    shimmer.wrap(express.application, method, wrapper)
-  })
-
+function createWrapMethod (tracer, config) {
   function middleware (req, res, next) {
     const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`
     const childOf = tracer.extract(FORMAT_HTTP_HEADERS, req.headers)
@@ -30,9 +27,10 @@ function patch (express, tracer, config) {
       res.end = function () {
         res.end = originalEnd
         const returned = res.end.apply(this, arguments)
+        const paths = tracer._context.get('express.paths')
 
-        if (req.route && req.route.path) {
-          span.setTag('resource.name', req.route.path)
+        if (paths) {
+          span.setTag('resource.name', paths.join(' -> '))
         }
 
         span.setTag('service.name', config.service || tracer._service)
@@ -48,8 +46,8 @@ function patch (express, tracer, config) {
     })
   }
 
-  function wrapper (original) {
-    return function () {
+  return function wrapMethod (original) {
+    return function methodWithTrace () {
       if (!this._datadog_trace_patched && !this._router) {
         this._datadog_trace_patched = true
         this.use(middleware)
@@ -59,10 +57,82 @@ function patch (express, tracer, config) {
   }
 }
 
-function unpatch (express) {
-  METHODS.forEach((method) => {
-    shimmer.unwrap(express.application, method)
+function createWrapProcessParams (tracer, config) {
+  const context = tracer._context
+
+  return function wrapProcessParams (processParams) {
+    return function processParamsWithTrace (layer, called, req, res, done) {
+      const matchers = layer._datadog_matchers
+      let paths = context.get('express.paths') || []
+
+      if (matchers) {
+        // Try to guess which path actually matched
+        for (let i = 0; i < matchers.length; i++) {
+          if (matchers[i].test(layer.path)) {
+            paths = paths.concat(matchers[i].path)
+
+            context.run(() => {
+              context.set('express.paths', paths)
+              layer.handle = context.bind(layer.handle)
+            })
+
+            break
+          }
+        }
+      }
+
+      return processParams.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapRouterMethod () {
+  return function wrapRouterMethod (original) {
+    return function methodWithTrace (fn) {
+      const offset = this.stack.length
+      const router = original.apply(this, arguments)
+      const matchers = extractMatchers(fn)
+
+      this.stack.slice(offset).forEach(layer => {
+        layer._datadog_matchers = matchers
+      })
+
+      return router
+    }
+  }
+}
+
+function extractMatchers (fn) {
+  const arg = flatten([].concat(fn))
+
+  if (typeof arg[0] === 'function') {
+    return []
+  }
+
+  return arg.map(pattern => ({
+    path: pattern.toString(),
+    test: path => pathToRegExp(pattern).test(path)
+  }))
+}
+
+function flatten (arr) {
+  return arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flatten(val)) : acc.concat(val), [])
+}
+
+function patch (express, tracer, config) {
+  METHODS.forEach(method => {
+    shimmer.wrap(express.application, method, createWrapMethod(tracer, config))
   })
+  shimmer.wrap(express.Router, 'process_params', createWrapProcessParams(tracer, config))
+  shimmer.wrap(express.Router, 'use', createWrapRouterMethod(tracer, config))
+  shimmer.wrap(express.Router, 'route', createWrapRouterMethod(tracer, config))
+}
+
+function unpatch (express) {
+  METHODS.forEach(method => shimmer.unwrap(express.application, method))
+  shimmer.unwrap(express.Router, 'process_params')
+  shimmer.unwrap(express.Router, 'use')
+  shimmer.unwrap(express.Router, 'route')
 }
 
 module.exports = {

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -30,7 +30,7 @@ function createWrapMethod (tracer, config) {
         const paths = tracer._context.get('express.paths')
 
         if (paths) {
-          span.setTag('resource.name', paths.join(' -> '))
+          span.setTag('resource.name', paths.join(''))
         }
 
         span.setTag('service.name', config.service || tracer._service)
@@ -110,7 +110,7 @@ function extractMatchers (fn) {
   }
 
   return arg.map(pattern => ({
-    path: pattern.toString(),
+    path: pattern instanceof RegExp ? `(${pattern})` : pattern,
     test: path => pathToRegExp(pattern).test(path)
   }))
 }

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -69,11 +69,36 @@ describe('Plugin', () => {
           agent.use(traces => {
             expect(traces[0][0]).to.have.property('service', 'test')
             expect(traces[0][0]).to.have.property('type', 'web')
-            expect(traces[0][0]).to.have.property('resource', '/app -> /user/:id')
+            expect(traces[0][0]).to.have.property('resource', '/app/user/:id')
             expect(traces[0][0].meta).to.have.property('span.kind', 'server')
             expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/app/user/1`)
             expect(traces[0][0].meta).to.have.property('http.method', 'GET')
             expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
+          })
+        })
+      })
+
+      it('should surround matchers based on regular expressions', done => {
+        const app = express()
+        const router = express.Router()
+
+        router.get(/^\/user\/(\d)$/, (req, res) => {
+          res.status(200).send()
+        })
+
+        app.use('/app', router)
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('resource', '/app(/^\\/user\\/(\\d)$/)')
 
             done()
           })
@@ -98,7 +123,7 @@ describe('Plugin', () => {
 
         getPort().then(port => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('resource', '/app -> /user/:id')
+            expect(traces[0][0]).to.have.property('resource', '/app/user/:id')
 
             done()
           })

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -27,7 +27,7 @@ describe('Plugin', () => {
         return agent.load(plugin, 'express')
       })
 
-      it('should do automatic instrumentation', done => {
+      it('should do automatic instrumentation on app routes', done => {
         const app = express()
 
         app.get('/user', (req, res) => {
@@ -55,16 +55,24 @@ describe('Plugin', () => {
         })
       })
 
-      it('should support custom routers', done => {
+      it('should do automatic instrumentation on routers', done => {
         const app = express()
+        const router = express.Router()
 
-        app.use((req, res) => {
+        router.get('/user/:id', (req, res) => {
           res.status(200).send()
         })
 
+        app.use('/app', router)
+
         getPort().then(port => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('resource', 'express.request')
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('type', 'web')
+            expect(traces[0][0]).to.have.property('resource', '/app -> /user/:id')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+            expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/app/user/1`)
+            expect(traces[0][0].meta).to.have.property('http.method', 'GET')
             expect(traces[0][0].meta).to.have.property('http.status_code', '200')
 
             done()
@@ -72,7 +80,52 @@ describe('Plugin', () => {
 
           appListener = app.listen(port, 'localhost', () => {
             axios
-              .get(`http://localhost:${port}`)
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
+          })
+        })
+      })
+
+      it('should support a nested array of paths on the router', done => {
+        const app = express()
+        const router = express.Router()
+
+        router.get([['/user/:id'], '/users/:id'], (req, res) => {
+          res.status(200).send()
+        })
+
+        app.use('/app', router)
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('resource', '/app -> /user/:id')
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
+          })
+        })
+      })
+
+      it('should fallback to the default resource name if a path pattern could not be found', done => {
+        const app = express()
+
+        app.use((req, res, next) => res.status(200).send())
+
+        getPort().then(port => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('resource', 'express.request')
+
+            done()
+          })
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/app`)
               .catch(done)
           })
         })


### PR DESCRIPTION
Right now only the path of the last router is added to the resource name when using nested routers with the express plugin. This is because express doesn't expose the complete hierarchy of matched patterns in `req.route.path`.

This PR adds supports for nested routers. Now the plugin will set the resource name in the format `/first/router -> /second/router -> /third/router`. Regular expressions and wildcards are supported as well.

For example, given the following router hierarchy:

```js
const express = require('express')
const app = express()
const router = express.Router()

router.get('/users/:id', (req, res) => res.json(req.params.id))
app.use('/api', router)

app.listen(8080)
```

A call to `/api/users/123` would result in a resource name of `/api -> /users/:id`.