### PR TITLE
add error handling for user input

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,21 +10,25 @@ class Config {
 
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
+    const service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), platform.service())
+    const env = coalesce(options.env, platform.env('DD_ENV'))
     const protocol = 'http'
     const hostname = coalesce(options.hostname, platform.env('DD_TRACE_AGENT_HOSTNAME'), 'localhost')
     const port = coalesce(options.port, platform.env('DD_TRACE_AGENT_PORT'), 8126)
+    const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
+    const plugins = coalesce(options.plugins, true)
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
-    this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), platform.service())
-    this.env = coalesce(options.env, platform.env('DD_ENV'))
+    this.service = String(service)
+    this.env = String(env)
     this.url = new URL(`${protocol}://${hostname}:${port}`)
-    this.tags = coalesce(options.tags, {})
-    this.flushInterval = coalesce(options.flushInterval, 2000)
+    this.tags = Object.assign({}, options.tags)
+    this.flushInterval = flushInterval
     this.bufferSize = 100000
     this.sampleRate = 1
     this.logger = options.logger
-    this.plugins = coalesce(options.plugins, true)
+    this.plugins = !!plugins
     this.experimental = {
       asyncHooks: isFlagEnabled(options.experimental, 'asyncHooks')
     }
@@ -32,7 +36,11 @@ class Config {
 }
 
 function isFlagEnabled (obj, prop) {
-  return obj === true || (typeof obj === 'object' && obj !== null && obj[prop])
+  return obj === true || (isObject(obj) && !!obj[prop])
+}
+
+function isObject (value) {
+  return typeof value === 'object' && value !== null
 }
 
 module.exports = Config

--- a/src/format.js
+++ b/src/format.js
@@ -25,8 +25,8 @@ function formatSpan (span) {
     trace_id: spanContext.traceId,
     span_id: spanContext.spanId,
     parent_id: spanContext.parentId,
-    name: span._operationName,
-    service: tracer._service,
+    name: String(span._operationName),
+    service: String(tracer._service),
     error: 0,
     meta: {},
     start: new Uint64BE(Math.round(span._startTime * 1e6)),
@@ -40,16 +40,16 @@ function extractTags (trace, tags) {
       case 'service.name':
       case 'span.type':
       case 'resource.name':
-        trace[map[tag]] = tags[tag]
+        trace[map[tag]] = String(tags[tag])
         break
       case 'error.type':
       case 'error.msg':
       case 'error.stack':
         trace.error = 1
-        trace.meta[tag] = tags[tag]
+        trace.meta[tag] = String(tags[tag])
         break
       default:
-        trace.meta[tag] = tags[tag]
+        trace.meta[tag] = String(tags[tag])
     }
   })
 }

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -4,6 +4,7 @@ const requireDir = require('require-dir')
 const path = require('path')
 const semver = require('semver')
 const hook = require('require-in-the-middle')
+const log = require('./log')
 
 // TODO: lazy load built-in plugins
 
@@ -49,8 +50,12 @@ class Instrumenter {
   }
 
   reload () {
-    const instrumentedModules = Array.from(this._plugins.keys()).map(plugin => plugin.name)
-    hook(instrumentedModules, this.hookModule.bind(this))
+    try {
+      const instrumentedModules = Array.from(this._plugins.keys()).map(plugin => plugin.name)
+      hook(instrumentedModules, this.hookModule.bind(this))
+    } catch (e) {
+      log.error(e)
+    }
   }
 
   hookModule (moduleExports, moduleName, moduleBaseDir) {

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -4,6 +4,7 @@ const opentracing = require('opentracing')
 const Span = opentracing.Span
 const SpanContext = require('./span_context')
 const platform = require('../platform')
+const log = require('../log')
 
 class DatadogSpan extends Span {
   constructor (tracer, fields) {
@@ -69,13 +70,17 @@ class DatadogSpan extends Span {
   }
 
   _addTags (keyValuePairs) {
-    Object.keys(keyValuePairs).forEach(key => {
-      this._tags[key] = String(keyValuePairs[key])
-    })
+    try {
+      Object.keys(keyValuePairs).forEach(key => {
+        this._tags[key] = String(keyValuePairs[key])
+      })
+    } catch (e) {
+      log.error(e)
+    }
   }
 
   _finish (finishTime) {
-    finishTime = finishTime || platform.now()
+    finishTime = parseInt(finishTime, 10) || platform.now()
 
     this._duration = finishTime - this._startTime
     this._spanContext.trace.finished.push(this)

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -94,5 +94,23 @@ describe('format', () => {
 
       expect(trace.error).to.equal(1)
     })
+
+    it('should sanitize the input', () => {
+      tracer._service = null
+      span._operationName = null
+      span._tags = {
+        'foo.bar': null
+      }
+      span._startTime = NaN
+      span._duration = NaN
+
+      trace = format(span)
+
+      expect(trace.name).to.equal('null')
+      expect(trace.service).to.equal('null')
+      expect(trace.meta['foo.bar']).to.equal('null')
+      expect(trace.start).to.be.instanceof(Uint64BE)
+      expect(trace.duration).to.be.instanceof(Uint64BE)
+    })
   })
 })

--- a/test/instrumenter.spec.js
+++ b/test/instrumenter.spec.js
@@ -138,6 +138,10 @@ describe('Instrumenter', () => {
 
         expect(plugins.other.patch).to.have.been.calledWith(other, 'tracer', {})
       })
+
+      it('should handle errors', () => {
+        expect(() => instrumenter.use()).not.to.throw()
+      })
     })
 
     describe('patch', () => {

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -114,6 +114,12 @@ describe('Span', () => {
 
       expect(span._tags).to.have.property('foo', '123')
     })
+
+    it('should handle errors', () => {
+      span = new Span(tracer, { operationName: 'operation' })
+
+      expect(() => span.addTags()).not.to.throw()
+    })
   })
 
   describe('finish', () => {

--- a/test/opentracing/tracer.spec.js
+++ b/test/opentracing/tracer.spec.js
@@ -10,6 +10,7 @@ describe('Tracer', () => {
   let span
   let Recorder
   let recorder
+  let SpanContext
   let spanContext
   let fields
   let carrier
@@ -22,6 +23,8 @@ describe('Tracer', () => {
 
   beforeEach(() => {
     fields = {}
+
+    SpanContext = sinon.spy()
 
     span = {}
     Span = sinon.stub().returns(span)
@@ -57,6 +60,7 @@ describe('Tracer', () => {
 
     Tracer = proxyquire('../src/opentracing/tracer', {
       './span': Span,
+      './span_context': SpanContext,
       '../recorder': Recorder,
       './propagation/text_map': TextMapPropagator,
       './propagation/http': HttpPropagator,
@@ -99,7 +103,7 @@ describe('Tracer', () => {
     })
 
     it('should start a span that is the child of a span', () => {
-      const parent = {}
+      const parent = new SpanContext()
 
       fields.references = [
         new Reference(opentracing.REFERENCE_CHILD_OF, parent)
@@ -115,7 +119,7 @@ describe('Tracer', () => {
     })
 
     it('should start a span that follows from a span', () => {
-      const parent = {}
+      const parent = new SpanContext()
 
       fields.references = [
         new Reference(opentracing.REFERENCE_FOLLOWS_FROM, parent)
@@ -131,11 +135,11 @@ describe('Tracer', () => {
     })
 
     it('should ignore additional follow references', () => {
-      const parent = {}
+      const parent = new SpanContext()
 
       fields.references = [
         new Reference(opentracing.REFERENCE_FOLLOWS_FROM, parent),
-        new Reference(opentracing.REFERENCE_FOLLOWS_FROM, {})
+        new Reference(opentracing.REFERENCE_FOLLOWS_FROM, new SpanContext())
       ]
 
       tracer = new Tracer(config)
@@ -148,8 +152,36 @@ describe('Tracer', () => {
     })
 
     it('should ignore unknown references', () => {
+      const parent = new SpanContext()
+
       fields.references = [
-        new Reference('test', {})
+        new Reference('test', parent)
+      ]
+
+      tracer = new Tracer(config)
+      tracer.startSpan('name', fields)
+
+      expect(Span).to.have.been.calledWithMatch(tracer, {
+        operationName: 'name',
+        parent: null
+      })
+    })
+
+    it('should ignore references that are not references', () => {
+      fields.references = [{}]
+
+      tracer = new Tracer(config)
+      tracer.startSpan('name', fields)
+
+      expect(Span).to.have.been.calledWithMatch(tracer, {
+        operationName: 'name',
+        parent: null
+      })
+    })
+
+    it('should ignore references to objects other than span contexts', () => {
+      fields.references = [
+        new Reference(opentracing.REFERENCE_CHILD_OF, {})
       ]
 
       tracer = new Tracer(config)
@@ -189,6 +221,12 @@ describe('Tracer', () => {
 
       expect(propagator.inject).to.have.been.calledWith(spanContext, carrier)
     })
+
+    it('should handle errors', () => {
+      tracer = new Tracer(config)
+
+      expect(() => tracer.inject()).not.to.throw()
+    })
   })
 
   describe('extract', () => {
@@ -220,6 +258,12 @@ describe('Tracer', () => {
       const spanContext = tracer.extract(opentracing.FORMAT_BINARY, carrier)
 
       expect(spanContext).to.equal('spanContext')
+    })
+
+    it('should handle errors', () => {
+      tracer = new Tracer(config)
+
+      expect(() => tracer.extract()).not.to.throw()
     })
   })
 })


### PR DESCRIPTION
This PR adds error handling in methods that are exposed to the user. This will prevent for example an incorrect parameter crashing the application. Instead the tracer will silently fail and log the error if the `debug` option is set to `true`.