### PR TITLE
update the test setup to wait longer for external services

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -15,8 +15,8 @@ const node = require('../src/platform/node')
 const retryOptions = {
   retries: 10,
   factor: 1,
-  minTimeout: 1000,
-  maxTimeout: 1000,
+  minTimeout: 3000,
+  maxTimeout: 3000,
   randomize: false
 }
 


### PR DESCRIPTION
Random failures from CI when the services can't be reached. It seems the original 10 seconds wait time may not have been enough in some cases. This PR attempts to address this.