### PR TITLE
update the logger to support toggling, chaining and resetting

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -1,24 +1,44 @@
 'use strict'
 
-let _logger = {
-  debug: () => {},
-  error: () => {}
+const _default = {
+  debug: message => console.log(message), /* eslint-disable-line no-console */
+  error: err => console.error(err) /* eslint-disable-line no-console */
 }
+
+let _logger = _default
+let _enabled = false
 
 module.exports = {
   use (logger) {
-    const isObject = logger && typeof logger === 'object'
-
-    if (isObject && logger.debug instanceof Function && logger.error instanceof Function) {
+    if (logger && logger.debug instanceof Function && logger.error instanceof Function) {
       _logger = logger
     }
+
+    return this
+  },
+
+  toggle (enabled) {
+    _enabled = enabled
+
+    return this
+  },
+
+  reset () {
+    _logger = _default
+    _enabled = false
+
+    return this
   },
 
   debug (message) {
-    _logger.debug(message)
+    _enabled && _logger.debug(message)
+
+    return this
   },
 
-  error (message) {
-    _logger.error(message)
+  error (err) {
+    _enabled && _logger.error(err)
+
+    return this
   }
 }

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -15,6 +15,7 @@ class DatadogTracer extends Tracer {
     super()
 
     log.use(config.logger)
+    log.toggle(config.debug)
 
     this._service = config.service
     this._url = config.url

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -1,59 +1,125 @@
 'use strict'
 
+/* eslint-disable no-console */
+
 describe('log', () => {
   let log
+  let logger
 
   beforeEach(() => {
+    sinon.stub(console, 'log')
+    sinon.stub(console, 'error')
+
+    logger = {
+      debug: sinon.spy(),
+      error: sinon.spy()
+    }
+
     log = require('../src/log')
+    log.toggle(true)
   })
 
-  describe('without a logger', () => {
-    it('should be a no op', () => {
-      expect(log.debug).to.not.throw()
-      expect(log.error).to.not.throw()
+  afterEach(() => {
+    log.reset()
+    console.log.restore()
+    console.error.restore()
+  })
+
+  it('should log debug to console by default', () => {
+    log.debug('debug')
+
+    expect(console.log).to.have.been.calledWith('debug')
+  })
+
+  it('should log errors to console by default', () => {
+    const err = new Error()
+
+    log.error(err)
+
+    expect(console.error).to.have.been.calledWith(err)
+  })
+
+  it('should support chaining', () => {
+    expect(() => {
+      log
+        .use(logger)
+        .toggle(true)
+        .error('error')
+        .debug('debug')
+        .reset()
+    }).to.not.throw()
+  })
+
+  describe('toggle', () => {
+    it('should disable the logger', () => {
+      log.toggle(false)
+      log.debug('debug')
+      log.error('error')
+
+      expect(console.log).to.not.have.been.called
+      expect(console.error).to.not.have.been.called
+    })
+
+    it('should enable the logger', () => {
+      log.toggle(false)
+      log.toggle(true)
+      log.debug('debug')
+      log.error('error')
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith('error')
     })
   })
 
-  describe('with an empty logger', () => {
-    beforeEach(() => {
-      log.use(null)
-    })
-
-    it('should be a no op', () => {
-      expect(log.debug).to.not.throw()
-      expect(log.error).to.not.throw()
-    })
-  })
-
-  describe('with an invalid logger', () => {
-    beforeEach(() => {
-      log.use('invalid')
-    })
-
-    it('should be a no op', () => {
-      expect(log.debug).to.not.throw()
-      expect(log.error).to.not.throw()
-    })
-  })
-
-  describe('with a valid logger', () => {
-    let logger
-
-    beforeEach(() => {
-      logger = {
-        debug: sinon.spy(),
-        error: sinon.spy()
-      }
-
+  describe('use', () => {
+    it('should set the underlying logger when valid', () => {
       log.use(logger)
-    })
-
-    it('should call the underlying logger', () => {
       log.debug('debug')
       log.error('error')
 
       expect(logger.debug).to.have.been.calledWith('debug')
       expect(logger.error).to.have.been.calledWith('error')
+    })
+
+    it('be a no op with an empty logger', () => {
+      log.use(null)
+      log.debug('debug')
+      log.error('error')
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith('error')
+    })
+
+    it('be a no op with an invalid logger', () => {
+      log.use('invalid')
+      log.debug('debug')
+      log.error('error')
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith('error')
+    })
+  })
+
+  describe('reset', () => {
+    it('should reset the logger', () => {
+      log.use(logger)
+      log.reset()
+      log.toggle(true)
+      log.debug('debug')
+      log.error('error')
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith('error')
+    })
+
+    it('should reset the toggle', () => {
+      log.use(logger)
+      log.reset()
+      log.debug('debug')
+      log.error('error')
+
+      expect(console.log).to.not.have.been.called
+      expect(console.error).to.not.have.been.called
     })
   })
 })

--- a/test/opentracing/tracer.spec.js
+++ b/test/opentracing/tracer.spec.js
@@ -49,11 +49,13 @@ describe('Tracer', () => {
       flushInterval: 2000,
       bufferSize: 1000,
       logger: 'logger',
-      tags: {}
+      tags: {},
+      debug: false
     }
 
     log = {
-      use: sinon.spy()
+      use: sinon.spy(),
+      toggle: sinon.spy()
     }
 
     Tracer = proxyquire('../src/opentracing/tracer', {
@@ -75,10 +77,11 @@ describe('Tracer', () => {
     expect(recorder.record).to.have.been.calledWith('span')
   })
 
-  it('should be support logging', () => {
+  it('should support logging', () => {
     tracer = new Tracer(config)
 
     expect(log.use).to.have.been.calledWith(config.logger)
+    expect(log.toggle).to.have.been.calledWith(config.debug)
   })
 
   describe('startSpan', () => {


### PR DESCRIPTION
This PR improves the logger by adding support for toggling, chaining and resetting. Toggling will allow users to use enable the logger when debugging, chaining makes it easier to work with in general and resetting allows to restore the default logger.