### PR TITLE
fix race condition to read package.json in version script

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -4,14 +4,16 @@ const path = require('path')
 const fs = require('fs')
 const semver = require('semver')
 const exec = require('child_process').execSync
-const pkg = require('../package.json')
 
+exec(`git checkout master`)
+exec(`git pull`)
+
+const pkg = require('../package.json')
 const increment = getIncrement()
 const version = semver.inc(pkg.version, increment)
 
 pkg.version = version
 
-exec(`git checkout master`)
 exec(`git checkout -b v${version}`)
 write('package.json', JSON.stringify(pkg, null, 2) + '\n')
 write('lib/version.js', `module.exports = '${version}'\n`)


### PR DESCRIPTION
This PR fixes a race condition in the version script where `package.json` would be read before the master branch was pulled. This could lead to an inconsistent `package.json` if it was different on disk before the merge.