### PR TITLE
add api documentation and move user docs from README

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 coverage
+out

--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,5 @@ typings/
 
 package-lock.json
 yarn.lock
+out
 !test/node_modules

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -29,6 +29,9 @@ dev,eslint-plugin-promise,ISC,jden and other contributors
 dev,eslint-plugin-standard,MIT,Copyright 2015 Jamund Ferguson
 dev,express,MIT,Copyright 2009-2014 TJ Holowaychuk 2013-2014 Roman Shtylman 2014-2015 Douglas Christopher Wilson
 dev,get-port,MIT,Copyright Sindre Sorhus
+dev,gulp,MIT,Copyright 2013-2017 Blaine Bublitz Eric Schoffstall and other contributors
+dev,gulp-jsdoc3,Apache-2.0,Copyright Marc Udoff
+dev,jsdoc,Apache-2.0,Copyright 2011-present Michael Mathews and the contributors to JSDoc
 dev,mocha,MIT,Copyright 2011-2018 JS Foundation and contributors https://js.foundation
 dev,mysql,MIT,Copyright 2012 Felix Geisendörfer and contributors
 dev,mysql2,MIT,Copyright 2016 Andrey Sidorov and contributors

--- a/README.md
+++ b/README.md
@@ -7,103 +7,13 @@
 
 This project is **experimental** and under active development. Use it at your own risk.
 
-## Installation
+## Getting Started
 
-### NodeJS
+For a basic product overview, check out our [setup documentation](https://docs.datadoghq.com/tracing/setup/javascript/).
 
-```sh
-npm install --save dd-trace
-```
+For installation, configuration, and details about using the API, check out our [API documentation](https://datadog.github.io/dd-trace-js).
 
-*Node >= 4 is required.*
-
-## Usage
-
-Simply require and initialize the tracer and all supported
-[libraries](#automatic-instrumentation) will automatically
-be instrumented.
-
-```js
-// The tracer must be initialized before other libraries
-const tracer = require('dd-trace').init()
-```
-
-### Available Options
-
-Options can be configured as a parameter to the `init()` method
-or as environment variables.
-
-| Config        | Environment Variable         | Default   | Description |
-| ------------- | ---------------------------- | --------- | ----------- |
-| debug         | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
-| service       | DD_SERVICE_NAME              |           | The service name to be used for this program. |
-| hostname      | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the trace agent that the tracer will submit to. |
-| port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
-| flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
-| experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Available experimental features: `asyncHooks`. |
-| plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
-
-### Automatic Instrumentation
-
-The following libraries are instrumented automatically by default:
-
-* [http](https://nodejs.org/api/http.html)
-* [express](https://expressjs.com/) (version 4)
-* [pg](https://node-postgres.com/) (version 6)
-
-### OpenTracing
-
-This library is OpenTracing compliant, so once the tracer is initialized
-it can be used as a global tracer.
-
-```js
-const tracer = require('dd-trace').init()
-const opentracing = require('opentracing')
-
-opentracing.initGlobalTracer(tracer)
-```
-
-Then the tracer will be available with `opentracing.globalTracer()`.
-
-See the OpenTracing JavaScript [documentation](https://github.com/opentracing/opentracing-javascript)
-and [API](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/) for more details.
-
-**NOTE: When using OpenTracing, context propagation is not handled
-automatically.**
-
-## Advanced Usage
-
-In some cases you may want to do manual instrumentation. For example
-if there is no built-in plugin covering a library you are using or if you want more control on how instrumentation is done.
-
-### Manual instrumentation
-
-```js
-const tracer = require('dd-trace').init()
-const http = require('http')
-
-const server = http.createServer((req, res) => {
-  const options = {
-    resource: '/hello/:name',
-    type: 'web',
-    tags: {
-      'span.kind': 'server',
-      'http.method': 'GET',
-      'http.url': req.url,
-      'http.status_code': '200'
-    }
-  }
-
-  tracer.trace('say_hello', options, span => {
-    res.write('Hello, World!')
-    span.finish()
-  })
-
-  res.end()
-})
-
-server.listen(8000)
-```
+For descriptions of terminology used in APM, take a look at the [official documentation](https://docs.datadoghq.com/tracing/visualization/).
 
 ## Development
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -208,6 +208,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
 | env           | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
 | tags          |                              | {}        | Set global tags that should be applied to all spans. |
+| sampleRate    |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Available experimental features: `asyncHooks`. |
 | plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,237 @@
+<h1 id="home">Datadog JavaScript Tracer API</h1>
+
+This is the API documentation for the Datadog JavaScript Tracer. If you are just looking to get started, check out the [tracing setup documentation](https://docs.datadoghq.com/tracing/setup/javascript/).
+
+<h2 id="overview">Overview</h2>
+
+The module exported by this library is an instance of the [Tracer](./Tracer.html) class.
+
+<h2 id="manual-instrumentation">Manual Instrumentation</h2>
+
+If you aren’t using supported library instrumentation (see [Compatibility](#compatibility)), you may want to manually instrument your code.
+
+This can be done using either the [Trace API](#trace-api) or [OpenTracing](#opentracing-api).
+
+<h3 id="trace-api">Trace API</h3>
+
+The following example initializes a Datadog Tracer and creates a Span called `web.request`:
+
+```javascript
+const tracer = require('dd-trace').init()
+
+tracer
+  .trace('web.request', {
+    service: 'my_service'
+  })
+  .then(span => {
+    span.setTag('my_tag', 'my_value')
+    span.finish()
+  })
+```
+
+An important aspect of the Tracer API is that it will automatically propagate context internally. In other words, there is no need to explicitly pass the parent in a child tracer.
+
+For example:
+
+```javascript
+const tracer = require('dd-trace').init()
+
+tracer
+  .trace('web.request', {
+    service: 'user-service'
+  })
+  .then(span => {
+    getUsers()
+      .then(() => span.finish())
+  })
+
+function getUsers () {
+  // The span created here is automatically a child of the `web.request` span above.
+  return tracer
+    .trace('db.query', {
+      service: 'user-db'
+    })
+    .then(span => {
+      return User.findAll()
+        .then(users => {
+          span.finish()
+          return users
+        })
+    })
+}
+```
+
+<h3 id="opentracing-api">OpenTracing API</h3>
+
+This library is OpenTracing compliant. Use the [OpenTracing API](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/) and the Datadog Tracer (dd-trace) library to measure execution times for specific pieces of code. In the following example, a Datadog Tracer is initialized and used as a global tracer:
+
+```javascript
+const tracer = require('dd-trace').init()
+const opentracing = require('opentracing')
+
+opentracing.initGlobalTracer(tracer)
+```
+
+**NOTE: When using OpenTracing, context propagation is not handled
+automatically.**
+
+<h2 id="integrations">Integrations</h2>
+
+APM provides out-of-the-box instrumentation for many popular frameworks and libraries by using a plugin system. By default all built-in plugins are enabled. This behavior can be changed by setting the `plugins` option to `false` in the [tracer settings](#tracer-settings).
+
+Built-in plugins can be enabled by name and configured individually:
+
+```javascript
+const tracer = require('dd-trace').init({ plugins: false })
+
+// enable express integration
+tracer.use('express')
+
+// enable and configure postgresql integration
+tracer.use('pg', {
+  service: 'pg-cluster'
+})
+```
+
+Each integration can be configured individually. See below for more information for every integration.
+
+<h3 id="express">express</h3>
+
+<h5 id="express-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| http.url         | The complete URL of the request.                          |
+| http.method      | The HTTP method of the request.                           |
+| http.status_code | The HTTP status code of the response.                     |
+
+<h5 id="express-config">Configuration Options</h5>
+
+| Option           | Default                   | Description                            |
+|------------------|---------------------------|----------------------------------------|
+| service          | *Service name of the app* | The service name for this integration. |
+
+<h3 id="http">http / https</h3>
+
+<h5 id="http-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| http.url         | The complete URL of the request.                          |
+| http.method      | The HTTP method of the request.                           |
+| http.status_code | The HTTP status code of the response.                     |
+
+<h5 id="http-config">Configuration Options</h5>
+
+| Option           | Default          | Description                            |
+|------------------|------------------|----------------------------------------|
+| service          | http-client      | The service name for this integration. |
+
+<h3 id="mysql">mysql</h3>
+
+<h5 id="mysql-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| db.name          | The name of the queried database.                         |
+| db.user          | The user who made the query.                              |
+| out.host         | The host of the MySQL server.                             |
+| out.port         | The port of the MySQL server.                             |
+
+<h5 id="mysql-config">Configuration Options</h5>
+
+| Option           | Default          | Description                            |
+|------------------|------------------|----------------------------------------|
+| service          | mysql            | The service name for this integration. |
+
+<h3 id="mysql2">mysql2</h3>
+
+<h5 id="mysql2-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| db.name          | The name of the queried database.                         |
+| db.user          | The user who made the query.                              |
+| out.host         | The host of the MySQL server.                             |
+| out.port         | The port of the MySQL server.                             |
+
+<h5 id="mysql2-config">Configuration Options</h5>
+
+| Option           | Default          | Description                            |
+|------------------|------------------|----------------------------------------|
+| service          | mysql            | The service name for this integration. |
+
+<h3 id="pg">pg</h3>
+
+<h5 id="pg-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| db.name          | The name of the queried database.                         |
+| db.user          | The user who made the query.                              |
+| out.host         | The host of the PostgreSQL server.                        |
+| out.port         | The port of the PostgreSQL server.                        |
+
+<h5 id="pg-config">Configuration Options</h5>
+
+| Option           | Default          | Description                            |
+|------------------|------------------|----------------------------------------|
+| service          | postgres         | The service name for this integration. |
+
+<h3 id="redis">redis</h3>
+
+<h5 id="redis-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| db.name          | The index of the queried database.                        |
+| out.host         | The host of the Redis server.                             |
+| out.port         | The port of the Redis server.                             |
+
+<h5 id="redis-config">Configuration Options</h5>
+
+| Option           | Default          | Description                            |
+|------------------|------------------|----------------------------------------|
+| service          | redis            | The service name for this integration. |
+
+<h2 id="advanced-configuration">Advanced Configuration</h2>
+
+<h3 id="tracer-settings">Tracer settings</h3>
+
+Options can be configured as a parameter to the [init()](https://datadog.github.io/dd-trace-js/Tracer.html#init__anchor) method or as environment variables.
+
+| Config        | Environment Variable         | Default   | Description |
+| ------------- | ---------------------------- | --------- | ----------- |
+| debug         | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
+| service       | DD_SERVICE_NAME              |           | The service name to be used for this program. |
+| hostname      | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the trace agent that the tracer will submit to. |
+| port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
+| env           | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
+| tags          |                              | {}        | Set global tags that should be applied to all spans. |
+| flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
+| experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Available experimental features: `asyncHooks`. |
+| plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
+
+<h3 id="custom-logging">Custom Logging</h3>
+
+By default, logging from this library is disabled. In order to get debbuging information and errors sent to logs, the `debug` options should be set to `true` in the [init()](https://datadog.github.io/dd-trace-js/Tracer.html#init__anchor) method.
+
+The tracer will then log debug information to `console.log()` and errors to `console.error()`. This behavior can be changed by passing a custom logger to the tracer. The logger should contain a `debug()` and `error()` methods that can handle messages and errors, respectively.
+
+For example:
+
+```javascript
+const bunyan = require('bunyan')
+const logger = bunyan.createLogger({
+  name: 'dd-trace',
+  level: 'debug'
+})
+
+const tracer = require('dd-trace').init({
+  logger: {
+    debug: message => logger.trace(message),
+    error: err => logger.error(err)
+  },
+  debug: true
+})
+```

--- a/docs/API.md
+++ b/docs/API.md
@@ -127,6 +127,23 @@ Each integration can be configured individually. See below for more information 
 |------------------|------------------|----------------------------------------|
 | service          | http-client      | The service name for this integration. |
 
+<h3 id="mongodb-core">mongodb-core</h3>
+
+<h5 id="mongodb-core-tags">Tags</h5>
+
+| Tag                  | Description                                           |
+|----------------------|-------------------------------------------------------|
+| db.name              | The qualified name of the queried collection.         |
+| out.host             | The host of the MongoDB server.                       |
+| out.port             | The port of the MongoDB server.                       |
+| mongodb.cursor.index | When using a cursor, the current index of the cursor. |
+
+<h5 id="mongodb-core-config">Configuration Options</h5>
+
+| Option           | Default          | Description                            |
+|------------------|------------------|----------------------------------------|
+| service          | mongodb          | The service name for this integration. |
+
 <h3 id="mysql">mysql</h3>
 
 <h5 id="mysql-tags">Tags</h5>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const gulp = require('gulp')
+const jsdoc = require('gulp-jsdoc3')
+const jsdocConfig = require('./jsdoc.json')
+const jsdocSource = ['docs/API.md', 'src/**/*.js']
+
+gulp.task('jsdoc:watch', ['jsdoc'], () => {
+  gulp.watch(jsdocSource, ['jsdoc'])
+})
+
+gulp.task('jsdoc', cb => {
+  gulp.src(jsdocSource, { read: false })
+    .pipe(jsdoc(jsdocConfig, cb))
+})

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,7 @@
+{
+  "templates": {
+    "default": {
+      "outputSourceFiles": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "bench": "node benchmark",
+    "jsdoc": "gulp jsdoc",
+    "jsdoc:watch": "gulp jsdoc:watch",
     "lint": "eslint . && node scripts/check_licenses.js",
     "tdd": "mocha --watch",
     "test": "nyc --reporter text --reporter lcov mocha"
@@ -63,6 +65,9 @@
     "eslint-plugin-standard": "^3.0.1",
     "express": "^4.16.2",
     "get-port": "^3.2.0",
+    "gulp": "^3.9.1",
+    "gulp-jsdoc3": "^2.0.0",
+    "jsdoc": "^3.5.5",
     "mocha": "^5.0.0",
     "mysql": "^2.15.0",
     "mysql2": "^1.5.3",

--- a/src/globals.js
+++ b/src/globals.js
@@ -1,0 +1,6 @@
+'use strict'
+
+/**
+ * @callback traceCallback
+ * @param {external:"opentracing.Span"} span The span that was created.
+ */

--- a/src/opentracing/externals.js
+++ b/src/opentracing/externals.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * The base Tracer class from OpenTracing.
+ *
+ * @external "opentracing.Tracer"
+ * @see {@link https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/
+ * tracer.js~Tracer.html}
+ */
+
+/**
+ * The base Span class from OpenTracing.
+ *
+ * @external "opentracing.Span"
+ * @see {@link https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/
+ * span.js~Span.html}
+ */
+
+/**
+ * The base SpanContext class from OpenTracing.
+ *
+ * @external "opentracing.SpanContext"
+ * @see {@link https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/
+ * span_context.js~SpanContext.html}
+ */

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -30,6 +30,7 @@ class Tracer extends BaseTracer {
    * @param {string} [options.service] The service name to be used for this program.
    * @param {string} [options.hostname=localhost] The address of the trace agent that the tracer will submit to.
    * @param {number|string} [options.port=8126] The port of the trace agent that the tracer will submit to.
+   * @param {number} [options.sampleRate=1] Percentage of spans to sample as a float between 0 and 1.
    * @param {number} [options.flushInterval=2000] Interval in milliseconds at which the tracer
    * will submit traces to the agent.
    * @param {Object|boolean} [options.experimental={}] Experimental features can be enabled all at once

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Tracer = require('opentracing').Tracer
+const BaseTracer = require('opentracing').Tracer
 const NoopTracer = require('./noop')
 const DatadogTracer = require('./tracer')
 const Config = require('./config')
@@ -9,13 +9,35 @@ const platform = require('./platform')
 
 const noop = new NoopTracer()
 
-class TracerProxy extends Tracer {
+/**
+ * The Datadog Tracer. An instance of this class is what is returned by the module.
+ *
+ * @extends external:"opentracing.Tracer"
+ * @hideconstructor
+ */
+class Tracer extends BaseTracer {
   constructor () {
     super()
     this._tracer = noop
     this._instrumenter = new Instrumenter(this)
   }
 
+  /**
+   * Initializes the tracer. This should be called before importing other libraries.
+   *
+   * @param {Object} [options] Configuration options.
+   * @param {boolean} [options.debug=false] Enable debug logging in the tracer.
+   * @param {string} [options.service] The service name to be used for this program.
+   * @param {string} [options.hostname=localhost] The address of the trace agent that the tracer will submit to.
+   * @param {number|string} [options.port=8126] The port of the trace agent that the tracer will submit to.
+   * @param {number} [options.flushInterval=2000] Interval in milliseconds at which the tracer
+   * will submit traces to the agent.
+   * @param {Object|boolean} [options.experimental={}] Experimental features can be enabled all at once
+   * using boolean `true` or individually using key/value pairs.
+   * @param {boolean} [options.experimental.asyncHooks=false] Whether to use Node's experimental async hooks.
+   * @param {boolean} [options.plugins=true] Whether to load all built-in plugins.
+   * @returns {Tracer} Self
+   */
   init (options) {
     if (this._tracer === noop) {
       platform.load()
@@ -29,11 +51,36 @@ class TracerProxy extends Tracer {
     return this
   }
 
+  /**
+   * Enable and optionally configure a plugin.
+   *
+   * @param {string} plugin The name of a built-in plugin.
+   * @param {Object} [config] Configuration options.
+   * @param {string} [config.service] The service name to be used for this plugin.
+   * @returns {Tracer} Self
+   */
   use () {
     this._instrumenter.use.apply(this._instrumenter, arguments)
     return this
   }
 
+  /**
+   * Initiate a trace and creates a new span.
+   *
+   * @param {string} name The operation name to be used for this span.
+   * @param {Object} [options] Configuration options. These will take precedence over environment variables.
+   * @param {string} [options.service] The service name to be used for this span.
+   * The service name from the tracer will be used if this is not provided.
+   * @param {string} [options.resource] The resource name to be used for this span.
+   * The operation name will be used if this is not provided.
+   * @param {string} [options.type] The span type to be used for this span.
+   * @param {?external:"opentracing.Span"|external:"opentracing.SpanContext"} [options.childOf]
+   * The parent span or span context for the new span. Generally this is not needed as it will be
+   * fetched from the current context.
+   * @param {string} [options.tags={}] Global tags that should be assigned to every span.
+   * @param {traceCallback} [callback] Optional callback. A promise will be returned instead if not set.
+   * @returns {Promise<external:"opentracing.Span">|undefined}
+   */
   trace (operationName, options, callback) {
     if (callback) {
       return this._tracer.trace(operationName, options, callback)
@@ -62,17 +109,33 @@ class TracerProxy extends Tracer {
     return this._tracer.extract.apply(this._tracer, arguments)
   }
 
+  /**
+   * Get the span from the current context.
+   *
+   * @returns {?external:"opentracing.Span"} The current span or null if outside a trace context.
+   */
   currentSpan () {
     return this._tracer.currentSpan.apply(this._tracer, arguments)
   }
 
+  /**
+   * Bind a function to the current trace context.
+   *
+   * @param {Function} callback The function to bind.
+   * @returns {Function} The callback wrapped up in a context closure.
+   */
   bind () {
     return this._tracer.bind.apply(this._tracer, arguments)
   }
 
+  /**
+   * Bind an EventEmitter to the current trace context.
+   *
+   * @param {Function} callback The function to bind.
+   */
   bindEmitter () {
-    return this._tracer.bindEmitter.apply(this._tracer, arguments)
+    this._tracer.bindEmitter.apply(this._tracer, arguments)
   }
 }
 
-module.exports = TracerProxy
+module.exports = Tracer


### PR DESCRIPTION
This PR adds the API documentation, and moves most of the user documentation to it. It also introduces `gulp` to provide the ability to run tasks in watch mode.

The API documentation is generated using `jsdoc` with the `docstrap/simplex` theme.

Preview: https://github.com/DataDog/dd-trace-js/blob/jsdoc/docs/API.md