### PR TITLE
update release script to support actual release process

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -5,9 +5,4 @@ const exec = require('child_process').execSync
 exec('npm whoami')
 exec('git checkout master')
 exec('git pull')
-
-const pkg = require('../package.json')
-
-exec(`git tag v${pkg.version}`)
-exec(`git push origin refs/tags/v${pkg.version}`)
 exec('npm publish')


### PR DESCRIPTION
Since tags/releases will be done directly from GitHub, tagging is no longer necessary in the release script.