### PR TITLE
improve logging performance and add writer logging

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -31,13 +31,21 @@ module.exports = {
   },
 
   debug (message) {
-    _enabled && _logger.debug(message)
+    if (_enabled) {
+      _logger.debug(message instanceof Function ? message() : message)
+    }
 
     return this
   },
 
   error (err) {
-    _enabled && _logger.error(err)
+    if (_enabled) {
+      if (err instanceof Function) {
+        err = err()
+      }
+
+      _logger.error(typeof err === 'string' ? new Error(err) : err)
+    }
 
     return this
   }

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -84,14 +84,14 @@ function getParent (references) {
       const ref = references[i]
 
       if (!(ref instanceof Reference)) {
-        log.error(new Error(`Expected ${ref} to be an instance of opentracing.Reference`))
+        log.error(() => `Expected ${ref} to be an instance of opentracing.Reference`)
         break
       }
 
       const spanContext = ref.referencedContext()
 
       if (!(spanContext instanceof SpanContext)) {
-        log.error(new Error(`Expected ${spanContext} to be an instance of SpanContext`))
+        log.error(() => `Expected ${spanContext} to be an instance of SpanContext`)
         break
       }
 

--- a/src/writer.js
+++ b/src/writer.js
@@ -21,7 +21,13 @@ class Writer {
     const trace = span.context().trace
 
     if (trace.started.length === trace.finished.length) {
-      const buffer = encode(trace.finished.map(format))
+      const formattedTrace = trace.finished.map(format)
+
+      log.debug(() => `Encoding trace: ${JSON.stringify(formattedTrace)}`)
+
+      const buffer = encode(formattedTrace)
+
+      log.debug(() => `Adding encoded trace to buffer: ${buffer}`)
 
       if (this.length < this._size) {
         this._queue.push(buffer)

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -5,10 +5,13 @@
 describe('log', () => {
   let log
   let logger
+  let error
 
   beforeEach(() => {
     sinon.stub(console, 'log')
     sinon.stub(console, 'error')
+
+    error = new Error()
 
     logger = {
       debug: sinon.spy(),
@@ -25,20 +28,6 @@ describe('log', () => {
     console.error.restore()
   })
 
-  it('should log debug to console by default', () => {
-    log.debug('debug')
-
-    expect(console.log).to.have.been.calledWith('debug')
-  })
-
-  it('should log errors to console by default', () => {
-    const err = new Error()
-
-    log.error(err)
-
-    expect(console.error).to.have.been.calledWith(err)
-  })
-
   it('should support chaining', () => {
     expect(() => {
       log
@@ -50,11 +39,55 @@ describe('log', () => {
     }).to.not.throw()
   })
 
+  describe('debug', () => {
+    it('should log to console by default', () => {
+      log.debug('debug')
+
+      expect(console.log).to.have.been.calledWith('debug')
+    })
+
+    it('should support callbacks that return a message', () => {
+      log.debug(() => 'debug')
+
+      expect(console.log).to.have.been.calledWith('debug')
+    })
+  })
+
+  describe('error', () => {
+    it('should log to console by default', () => {
+      log.error(error)
+
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should support callbacks that return a error', () => {
+      log.error(() => error)
+
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should convert strings to errors', () => {
+      log.error('error')
+
+      expect(console.error).to.have.been.called
+      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+      expect(console.error.firstCall.args[0]).to.have.property('message', 'error')
+    })
+
+    it('should convert messages from callbacks to errors', () => {
+      log.error(() => 'error')
+
+      expect(console.error).to.have.been.called
+      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+      expect(console.error.firstCall.args[0]).to.have.property('message', 'error')
+    })
+  })
+
   describe('toggle', () => {
     it('should disable the logger', () => {
       log.toggle(false)
       log.debug('debug')
-      log.error('error')
+      log.error(error)
 
       expect(console.log).to.not.have.been.called
       expect(console.error).to.not.have.been.called
@@ -64,10 +97,10 @@ describe('log', () => {
       log.toggle(false)
       log.toggle(true)
       log.debug('debug')
-      log.error('error')
+      log.error(error)
 
       expect(console.log).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith('error')
+      expect(console.error).to.have.been.calledWith(error)
     })
   })
 
@@ -75,28 +108,28 @@ describe('log', () => {
     it('should set the underlying logger when valid', () => {
       log.use(logger)
       log.debug('debug')
-      log.error('error')
+      log.error(error)
 
       expect(logger.debug).to.have.been.calledWith('debug')
-      expect(logger.error).to.have.been.calledWith('error')
+      expect(logger.error).to.have.been.calledWith(error)
     })
 
     it('be a no op with an empty logger', () => {
       log.use(null)
       log.debug('debug')
-      log.error('error')
+      log.error(error)
 
       expect(console.log).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith('error')
+      expect(console.error).to.have.been.calledWith(error)
     })
 
     it('be a no op with an invalid logger', () => {
       log.use('invalid')
       log.debug('debug')
-      log.error('error')
+      log.error(error)
 
       expect(console.log).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith('error')
+      expect(console.error).to.have.been.calledWith(error)
     })
   })
 
@@ -106,17 +139,17 @@ describe('log', () => {
       log.reset()
       log.toggle(true)
       log.debug('debug')
-      log.error('error')
+      log.error(error)
 
       expect(console.log).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith('error')
+      expect(console.error).to.have.been.calledWith(error)
     })
 
     it('should reset the toggle', () => {
       log.use(logger)
       log.reset()
       log.debug('debug')
-      log.error('error')
+      log.error(error)
 
       expect(console.log).to.not.have.been.called
       expect(console.error).to.not.have.been.called


### PR DESCRIPTION
This PR improves logging performance by using callbacks to only run the code to generate the message if debugging is enabled. It also adds logging before and after encoding in the writer.