### PR TITLE
add logging for request/response to the agent

### DIFF
--- a/src/platform/node/request.js
+++ b/src/platform/node/request.js
@@ -15,10 +15,12 @@ function request (options, callback) {
 
   return new Promise((resolve, reject) => {
     const req = http.request(options, res => {
-      res.on('data', chunk => {})
+      let data = ''
+
+      res.on('data', chunk => { data += chunk })
       res.on('end', () => {
         if (res.statusCode >= 200 && res.statusCode <= 299) {
-          resolve()
+          resolve(data)
         } else {
           const error = new Error(http.STATUS_CODES[res.statusCode])
           error.status = res.statusCode

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -189,7 +189,7 @@ describe('Platform', () => {
           }
         })
           .put('/path', { foo: 'bar' })
-          .reply(200)
+          .reply(200, 'OK')
 
         return request({
           protocol: 'http:',
@@ -201,6 +201,8 @@ describe('Platform', () => {
             'Content-Type': 'application/octet-stream'
           },
           data: Buffer.from(JSON.stringify({ foo: 'bar' }))
+        }).then(res => {
+          expect(res).to.equal('OK')
         })
       })
 
@@ -212,7 +214,7 @@ describe('Platform', () => {
           }
         })
           .put('/path', 'fizzbuzz')
-          .reply(200)
+          .reply(200, 'OK')
 
         return request({
           protocol: 'http:',
@@ -224,6 +226,8 @@ describe('Platform', () => {
             'Content-Type': 'application/octet-stream'
           },
           data: [Buffer.from('fizz', 'utf-8'), Buffer.from('buzz', 'utf-8')]
+        }).then(res => {
+          expect(res).to.equal('OK')
         })
       })
 


### PR DESCRIPTION
This PR adds logging from and to the agent. This will help in cases where the user is unsure if the request was actually sent to the agent when the agent didn't receive anything.