### PR TITLE
update http resource name to avoid reaching the resource quota

### DIFF
--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -14,7 +14,7 @@ function patch (http, tracer, config) {
   function makeRequestTrace (request) {
     return function requestTrace (options, callback) {
       const uri = extractUrl(options)
-      const method = options.method || 'GET'
+      const method = (options.method || 'GET').toUpperCase()
 
       if (uri === `${tracer._url.href}/v0.3/traces`) {
         return request.apply(this, [options, callback])
@@ -37,7 +37,7 @@ function patch (http, tracer, config) {
         span.addTags({
           'service.name': config.service || 'http-client',
           'span.type': 'web',
-          'resource.name': options.pathname
+          'resource.name': method
         })
 
         tracer.inject(span, FORMAT_HTTP_HEADERS, options.headers)

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
           agent.use(traces => {
             expect(traces[0][0]).to.have.property('service', 'http-client')
             expect(traces[0][0]).to.have.property('type', 'web')
-            expect(traces[0][0]).to.have.property('resource', '/user')
+            expect(traces[0][0]).to.have.property('resource', 'GET')
             expect(traces[0][0].meta).to.have.property('span.kind', 'client')
             expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
             expect(traces[0][0].meta).to.have.property('http.method', 'GET')


### PR DESCRIPTION
Right now the resource name for outbound HTTP requests is the URL path. Since the path can change a lot, this may lead to a lot of resources, which would be difficult to use and would reach the quota on the backend.

While not ideal, this PR changes the resource name to use the HTTP verb instead. This will prevent problems for the moment, and we can revisit this later to improve it.