### PR TITLE
update tdd script to require passing the test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bench": "node benchmark",
     "lint": "eslint . && node scripts/check_licenses.js",
     "tdd": "mocha --watch",
-    "test": "nyc --reporter text --reporter lcov mocha"
+    "test": "nyc --reporter text --reporter lcov mocha 'test/**/*.spec.js'"
   },
   "repository": {
     "type": "git",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --delay
 test/setup.js
-test/**/*.spec.js


### PR DESCRIPTION
This PR updates the `tdd` script to require passing a file glob explicitly. This was done for 2 reasons:

* Tests are getting slow in watch mode since there are many integration tests.
* Some side effects are present and difficult to avoid at the moment, which affects subsequent runs.