### PR TITLE
fix env tag being the string undefined when empty

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -21,8 +21,8 @@ class Config {
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
-    this.service = String(service)
-    this.env = String(env)
+    this.service = service
+    this.env = env
     this.url = new URL(`${protocol}://${hostname}:${port}`)
     this.tags = Object.assign({}, options.tags)
     this.flushInterval = flushInterval

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -30,6 +30,7 @@ describe('Config', () => {
     expect(config).to.have.property('sampleRate', 1)
     expect(config).to.have.deep.property('tags', {})
     expect(config).to.have.property('plugins', true)
+    expect(config).to.have.property('env', undefined)
   })
 
   it('should initialize from environment variables', () => {


### PR DESCRIPTION
This was caused by redundant sanitization which would cast any value as string, including `null` and `undefined`.