### PR TITLE
fix context propagation in express plugin

### DIFF
--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -223,6 +223,7 @@ describe('Plugin', () => {
         })
 
         app.get('/user', (req, res) => {
+          expect(context.get('current')).to.not.be.undefined
           res.status(200).send(context.get('foo'))
         })
 


### PR DESCRIPTION
This PR fixes context propagation in the express plugin. The `next()` function was being bound to the wrong context, which stopped proper propagation of the trace context.