### PR TITLE
wait longer for services in tests

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -14,10 +14,10 @@ const platform = require('../src/platform')
 const node = require('../src/platform/node')
 
 const retryOptions = {
-  retries: 10,
+  retries: 60,
   factor: 1,
-  minTimeout: 3000,
-  maxTimeout: 3000,
+  minTimeout: 5000,
+  maxTimeout: 5000,
   randomize: false
 }
 


### PR DESCRIPTION
There have been some cases where the services take over a minute to start, which would randomly fail builds. This PR sets the total wait time for services to 5 minutes which should be more than enough.