### PR TITLE
fix wrong log level in custom logger example

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -242,7 +242,7 @@ For example:
 const bunyan = require('bunyan')
 const logger = bunyan.createLogger({
   name: 'dd-trace',
-  level: 'debug'
+  level: 'trace'
 })
 
 const tracer = require('dd-trace').init({


### PR DESCRIPTION
The example is calling `logger.trace()`, so the log level should be set to `trace` instead of `debug`.