### PR TITLE
split the release script to publish the docs separately

### DIFF
--- a/scripts/publish_docs.js
+++ b/scripts/publish_docs.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const fs = require('fs')
+const exec = require('./helpers/exec')
+const title = require('./helpers/title')
+
+title(`Publishing API documentation to GitHub Pages`)
+
+const msg = process.argv[2]
+
+if (!msg) {
+  throw new Error('Please provide a reason for the change. Example: node scripts/publish_docs.js "fix typo"')
+}
+
+if (fs.existsSync('yarn.lock')) {
+  exec('yarn')
+} else {
+  exec('npm install')
+}
+
+exec('rm -rf ./out')
+exec('git clone -b gh-pages --single-branch git@github.com:DataDog/dd-trace-js.git out')
+exec('npm run jsdoc')
+exec('git add -A', { cwd: './out' })
+exec(`git commit -m "${msg}"`, { cwd: './out' })
+exec('git push', { cwd: './out' })

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,29 +1,14 @@
 'use strict'
 
-const fs = require('fs')
 const exec = require('./helpers/exec')
 const title = require('./helpers/title')
 
 title(`Publishing package to the npm registry`)
 
+const pkg = require('../package.json')
+
 exec('npm whoami')
 exec('git checkout master')
 exec('git pull')
 exec('npm publish')
-
-title(`Publishing API documentation to GitHub Pages`)
-
-const pkg = require('../package.json')
-
-if (fs.existsSync('yarn.lock')) {
-  exec('yarn')
-} else {
-  exec('npm install')
-}
-
-exec('rm -rf ./out')
-exec('git clone -b gh-pages --single-branch git@github.com:DataDog/dd-trace-js.git out')
-exec('npm run jsdoc')
-exec('git add -A', { cwd: './out' })
-exec(`git commit -m "v${pkg.version}"`, { cwd: './out' })
-exec('git push', { cwd: './out' })
+exec(`node scripts/publish_docs.js "v${pkg.version}"`)


### PR DESCRIPTION
The PR split the release script so that publishing the API documentation can be done separately. This is useful in cases where we want to update the docs without releasing a new version.