### PR TITLE
fix spans that should be root having a parent in some cases

### DIFF
--- a/src/tracer.js
+++ b/src/tracer.js
@@ -17,7 +17,7 @@ class DatadogTracer extends Tracer {
     }
 
     this._context.run(() => {
-      const childOf = options.childOf || this._context.get('current')
+      const childOf = options.childOf !== undefined ? options.childOf : this._context.get('current')
       const tags = Object.assign({
         'service.name': options.service || this._service,
         'resource.name': options.resource || name,

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -56,6 +56,17 @@ describe('Tracer', () => {
       })
     })
 
+    it('should support explicitly creating a root span', done => {
+      tracer = new Tracer(config)
+
+      tracer.trace('parent', parent => {
+        tracer.trace('child', { childOf: null }, child => {
+          expect(child.context()).to.have.property('parentId', null)
+          done()
+        })
+      })
+    })
+
     it('should set default tags', done => {
       tracer = new Tracer(config)
 


### PR DESCRIPTION
When using `tracer.extract()`, it is expected that this is the entry point and should thus create a root span. In some cases where a parent context exist with a span, the new span will be created as a child of this span.

This PR addresses this by using an explicit `childOf` of `null` to always create a root span. Since `tracer.extract()` already returns `null` when it cannot extract a parent from the propagator, it already works with this new behavior.