### PR TITLE
fix express resource with multiple middlewares matching the route

### DIFF
--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -104,7 +104,7 @@ function createWrapRouterMethod (tracer) {
             next = context.bind(function () {
               const paths = context.get('express.paths')
 
-              if (paths && layer.path) {
+              if (paths && layer.path && !layer.regexp.fast_star) {
                 paths.pop()
               }
 

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -99,7 +99,17 @@ function createWrapRouterMethod (tracer) {
 
         layer.handle_request = (req, res, next) => {
           if (req._datadog_trace_patched) {
-            next = context.bind(next)
+            const originalNext = next
+
+            next = context.bind(function () {
+              const paths = context.get('express.paths')
+
+              if (paths && layer.path) {
+                paths.pop()
+              }
+
+              originalNext.apply(null, arguments)
+            })
           }
 
           return handle.call(layer, req, res, next)

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -144,16 +144,17 @@ describe('Plugin', () => {
         const app = express()
         const router = express.Router()
 
+        router.use('/', (req, res, next) => next())
+        router.use('*', (req, res, next) => next())
         router.use('/bar', (req, res, next) => next())
+        router.use('/bar', (req, res, next) => {
+          res.status(200).send()
+        })
 
         app.use('/', (req, res, next) => next())
         app.use('*', (req, res, next) => next())
-        app.use('/*', (req, res, next) => next())
         app.use('/foo/bar', (req, res, next) => next())
         app.use('/foo', router)
-        app.use('/foo/bar', (req, res, next) => {
-          res.status(200).send()
-        })
 
         getPort().then(port => {
           agent


### PR DESCRIPTION
This PR fixes an issue where if there are multiple subsequent middlewares matching a route, the path for each of them would be added to the resource name, and not just the one of the actual handler.