### PR TITLE
fix context not bound when next is called with an error

### DIFF
--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -267,6 +267,37 @@ describe('Plugin', () => {
         })
       })
 
+      it('should bind the next callback to the current context on error', done => {
+        const app = express()
+
+        app.use((req, res, next) => {
+          next(new Error('boom'))
+        })
+
+        app.use((e, req, res, next) => {
+          context.run(() => {
+            context.set('foo', 'bar')
+            next()
+          })
+        })
+
+        app.use((req, res, next) => {
+          res.status(200).send(context.get('foo'))
+        })
+
+        getPort().then(port => {
+          appListener = app.listen(port, 'localhost', () => {
+            axios.get(`http://localhost:${port}/user`)
+              .then(res => {
+                expect(res.status).to.equal(200)
+                expect(res.data).to.be.empty
+                done()
+              })
+              .catch(done)
+          })
+        })
+      })
+
       it('should only include paths for routes that matched', done => {
         const app = express()
         const router = express.Router()


### PR DESCRIPTION
The PR binds the context of the `next()` callback for error handlers. Right now this is only done when there are no errors.