### PR TITLE
fix express res.end() handler not bound to tracer context

### DIFF
--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -240,6 +240,32 @@ describe('Plugin', () => {
         })
       })
 
+      it('should bind the response to the current context', done => {
+        const app = express()
+
+        context.run(() => {
+          const send = context.bind(res => res.status(200).send())
+
+          app.get('/user', (req, res) => {
+            send(res)
+          })
+        })
+
+        getPort().then(port => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('resource', '/user')
+            })
+            .then(done)
+            .catch(done)
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios.get(`http://localhost:${port}/user`)
+              .catch(done)
+          })
+        })
+      })
+
       it('should bind the next callback to the current context', done => {
         const app = express()
 


### PR DESCRIPTION
This PR binds the `res.end()` handler to the trace context. This prevents the handler from crashing or having incorrect data if the context is lost in a router handler.