### PR TITLE
fix wrong context in integration callbacks

### DIFF
--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -6,37 +6,39 @@ const shimmer = require('shimmer')
 function createWrapQuery (tracer, config) {
   return function wrapQuery (query) {
     return function queryWithTrace (sql, values, cb) {
-      let sequence
+      let span
 
       tracer.trace('mysql.query', {
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           [Tags.DB_TYPE]: 'mysql'
         }
-      }, span => {
-        sequence = query.call(this, sql, values, cb)
-
-        span.setTag('service.name', config.service || 'mysql')
-        span.setTag('resource.name', sequence.sql)
-        span.setTag('out.host', this.config.host)
-        span.setTag('out.port', String(this.config.port))
-        span.setTag('span.type', 'db')
-        span.setTag('db.user', this.config.user)
-
-        if (this.config.database) {
-          span.setTag('db.name', this.config.database)
-        }
-
-        tracer.bindEmitter(sequence)
-
-        if (sequence._callback) {
-          sequence._callback = wrapCallback(tracer, span, sequence._callback)
-        } else {
-          sequence.on('end', () => {
-            span.finish()
-          })
-        }
+      }, child => {
+        span = child
       })
+
+      const sequence = query.call(this, sql, values, cb)
+
+      span.setTag('service.name', config.service || 'mysql')
+      span.setTag('resource.name', sequence.sql)
+      span.setTag('out.host', this.config.host)
+      span.setTag('out.port', String(this.config.port))
+      span.setTag('span.type', 'db')
+      span.setTag('db.user', this.config.user)
+
+      if (this.config.database) {
+        span.setTag('db.name', this.config.database)
+      }
+
+      tracer.bindEmitter(sequence)
+
+      if (sequence._callback) {
+        sequence._callback = wrapCallback(tracer, span, sequence._callback)
+      } else {
+        sequence.on('end', () => {
+          span.finish()
+        })
+      }
 
       return sequence
     }

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -37,11 +37,11 @@ function patch (pg, tracer, config) {
           }
 
           span.finish()
-
-          if (originalCallback) {
-            originalCallback(err, res)
-          }
         })
+
+        if (originalCallback) {
+          originalCallback(err, res)
+        }
       }
 
       return pgQuery

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -161,6 +161,13 @@ describe('Plugin', () => {
           }
         })
 
+        it('should run the callback in the parent context', done => {
+          server.insert(`test.${collection}`, [{ a: 1 }], {}, () => {
+            expect(context.get('current')).to.be.undefined
+            done()
+          })
+        })
+
         it('should handle errors', done => {
           let error
 
@@ -272,6 +279,18 @@ describe('Plugin', () => {
             expect(context.get('foo')).to.equal('bar')
             done()
           }
+        })
+
+        it('should run the callback in the parent context', done => {
+          const cursor = server.cursor(`test.${collection}`, {
+            find: `test.${collection}`,
+            query: { a: 1 }
+          })
+
+          cursor.next(() => {
+            expect(context.get('current')).to.be.undefined
+            done()
+          })
         })
 
         it('should handle errors', done => {

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -50,6 +50,13 @@ describe('Plugin', () => {
         }
       })
 
+      it('should run the callback in the parent context', done => {
+        connection.query('SELECT 1 + 1 AS solution', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
+      })
+
       it('should propagate context to events', done => {
         let query
 
@@ -63,6 +70,15 @@ describe('Plugin', () => {
           expect(context.get('foo')).to.equal('bar')
           done()
         }
+      })
+
+      it('should run event listeners in the parent context', done => {
+        const query = connection.query('SELECT 1 + 1 AS solution')
+
+        query.on('result', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
       })
 
       it('should do automatic instrumentation', done => {
@@ -187,6 +203,13 @@ describe('Plugin', () => {
           expect(context.get('foo')).to.equal('bar')
           done()
         }
+      })
+
+      it('should run the callback in the parent context', done => {
+        pool.query('SELECT 1 + 1 AS solution', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
       })
     })
   })

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -50,6 +50,13 @@ describe('Plugin', () => {
         }
       })
 
+      it('should run the callback in the parent context', done => {
+        connection.query('SELECT 1 + 1 AS solution', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
+      })
+
       it('should propagate context to events', done => {
         let query
 
@@ -63,6 +70,15 @@ describe('Plugin', () => {
           expect(context.get('foo')).to.equal('bar')
           done()
         }
+      })
+
+      it('should run event listeners in the parent context', done => {
+        const query = connection.query('SELECT 1 + 1 AS solution')
+
+        query.on('result', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
       })
 
       it('should do automatic instrumentation', done => {
@@ -193,6 +209,13 @@ describe('Plugin', () => {
           expect(context.get('foo')).to.equal('bar')
           done()
         }
+      })
+
+      it('should run the callback in the parent context', done => {
+        pool.query('SELECT 1 + 1 AS solution', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
       })
     })
   })

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -62,6 +62,15 @@ describe('Plugin', () => {
         }
       })
 
+      it('should run the callback in the parent context', done => {
+        client.on('error', done)
+
+        client.get('foo', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
+      })
+
       it('should propagate context to client emitters', done => {
         client.on('error', done)
 
@@ -74,6 +83,15 @@ describe('Plugin', () => {
           expect(context.get('foo')).to.equal('bar')
           done()
         }
+      })
+
+      it('should run client emitter listeners in the parent context', done => {
+        client.on('error', done)
+
+        client.on('ready', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
       })
 
       it('should propagate context to stream emitters', done => {
@@ -90,6 +108,17 @@ describe('Plugin', () => {
           expect(context.get('foo')).to.equal('bar')
           done()
         }
+      })
+
+      it('should run stream emitter listeners in the parent context', done => {
+        client.on('error', done)
+
+        client.stream.on('close', () => {
+          expect(context.get('current')).to.be.undefined
+          done()
+        })
+
+        client.stream.destroy()
       })
 
       it('should handle errors', done => {


### PR DESCRIPTION
This PR fixes a context propagation issue that affects most integrations. Basically the callbacks after a request/query is finished would end up in the context of the request/query span. This would cause any span created thereafter to end up as a child of that span, even though the span is finished.

The expected behavior is that any span created after should be on the same level and not as a child, which this PR addresses.