### PR TITLE
fix IDs being unsigned instead of signed

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -5,7 +5,7 @@ const Buffer = require('safe-buffer').Buffer
 const EventEmitter = require('events')
 const proxyquire = require('proxyquire')
 const semver = require('semver')
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 const platform = require('../src/platform')
 const node = require('../src/platform/node')
 const cls = require('../src/platform/node/context/cls')
@@ -64,8 +64,8 @@ suite
       propagator = new TextMapPropagator()
       carrier = {}
       spanContext = new DatadogSpanContext({
-        traceId: new Uint64BE(0x12345678, 0x12345678),
-        spanId: new Uint64BE(0x12345678, 0x12345678),
+        traceId: new Int64BE(0x12345678, 0x12345678),
+        spanId: new Int64BE(0x12345678, 0x12345678),
         baggageItems: { foo: 'bar' }
       })
     },

--- a/benchmark/stubs/span.js
+++ b/benchmark/stubs/span.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
-const id = new Uint64BE(0x12345678, 0x12345678)
+const Int64BE = require('int64-buffer').Int64BE
+const id = new Int64BE(0x12345678, 0x12345678)
 
 const span = {
   tracer: () => ({

--- a/benchmark/stubs/trace.js
+++ b/benchmark/stubs/trace.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 
 const trace = [
   {
-    trace_id: new Uint64BE(0x12345678, 0x9abcdef0),
-    span_id: new Uint64BE(0x12345678, 0x12345678),
+    trace_id: new Int64BE(0x12345678, 0x9abcdef0),
+    span_id: new Int64BE(0x12345678, 0x12345678),
     parent_id: null,
     name: 'root',
     resource: '/',
@@ -17,9 +17,9 @@ const trace = [
     duration: 100000000
   },
   {
-    trace_id: new Uint64BE(0x12345678, 0x9abcdef0),
-    span_id: new Uint64BE(0x9abcdef0, 0x9abcdef0),
-    parent_id: new Uint64BE(0x12345678, 0x12345678),
+    trace_id: new Int64BE(0x12345678, 0x9abcdef0),
+    span_id: new Int64BE(0x9abcdef0, 0x9abcdef0),
+    parent_id: new Int64BE(0x12345678, 0x12345678),
     name: 'child',
     resource: '/',
     service: 'benchmark',

--- a/src/format.js
+++ b/src/format.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 
 const map = {
   'service.name': 'service',
@@ -29,8 +29,8 @@ function formatSpan (span) {
     service: String(tracer._service),
     error: 0,
     meta: {},
-    start: new Uint64BE(Math.round(span._startTime * 1e6)),
-    duration: new Uint64BE(Math.round(span._duration * 1e6))
+    start: new Int64BE(Math.round(span._startTime * 1e6)),
+    duration: new Int64BE(Math.round(span._duration * 1e6))
   }
 }
 

--- a/src/opentracing/propagation/text_map.js
+++ b/src/opentracing/propagation/text_map.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 const DatadogSpanContext = require('../span_context')
 
 const traceKey = 'x-datadog-trace-id'
@@ -34,8 +34,8 @@ class TextMapPropagator {
     })
 
     return new DatadogSpanContext({
-      traceId: new Uint64BE(carrier[traceKey], 10),
-      spanId: new Uint64BE(carrier[spanKey], 10),
+      traceId: new Int64BE(carrier[traceKey], 10),
+      spanId: new Int64BE(carrier[spanKey], 10),
       baggageItems
     })
   }

--- a/src/platform/node/id.js
+++ b/src/platform/node/id.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 const randomBytes = require('crypto').randomBytes
 
-module.exports = () => new Uint64BE(randomBytes(8))
+module.exports = () => new Int64BE(randomBytes(8))

--- a/test/dd-trace.spec.js
+++ b/test/dd-trace.spec.js
@@ -3,7 +3,7 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const getPort = require('get-port')
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 const msgpack = require('msgpack-lite')
 const codec = msgpack.createCodec({ int64: true })
 
@@ -43,15 +43,15 @@ describe('dd-trace', () => {
     agent.put('/v0.3/traces', (req, res) => {
       const payload = msgpack.decode(req.body, { codec })
 
-      expect(payload[0][0].trace_id).to.be.instanceof(Uint64BE)
+      expect(payload[0][0].trace_id).to.be.instanceof(Int64BE)
       expect(payload[0][0].trace_id.toString()).to.equal(span.context().traceId.toString())
-      expect(payload[0][0].span_id).to.be.instanceof(Uint64BE)
+      expect(payload[0][0].span_id).to.be.instanceof(Int64BE)
       expect(payload[0][0].span_id.toString()).to.equal(span.context().spanId.toString())
       expect(payload[0][0].service).to.equal('test')
       expect(payload[0][0].name).to.equal('hello')
       expect(payload[0][0].resource).to.equal('/hello/:name')
-      expect(payload[0][0].start).to.be.instanceof(Uint64BE)
-      expect(payload[0][0].duration).to.be.instanceof(Uint64BE)
+      expect(payload[0][0].start).to.be.instanceof(Int64BE)
+      expect(payload[0][0].duration).to.be.instanceof(Int64BE)
 
       res.status(200).send('OK')
 

--- a/test/encode.spec.js
+++ b/test/encode.spec.js
@@ -2,7 +2,7 @@
 
 const msgpack = require('msgpack-lite')
 const codec = msgpack.createCodec({ int64: true })
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 
 describe('encode', () => {
   let encode
@@ -13,7 +13,7 @@ describe('encode', () => {
 
   it('should encode to msgpack', () => {
     const data = [{
-      id: new Uint64BE(0x12345678, 0x12345678),
+      id: new Int64BE(0x12345678, 0x12345678),
       name: 'test'
     }]
 

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
-const id = new Uint64BE(0x12345678, 0x12345678)
+const Int64BE = require('int64-buffer').Int64BE
+const id = new Int64BE(0x12345678, 0x12345678)
 
 describe('format', () => {
   let format
@@ -43,9 +43,9 @@ describe('format', () => {
       expect(trace.name).to.equal(span._operationName)
       expect(trace.service).to.equal(span.tracer()._service)
       expect(trace.error).to.equal(0)
-      expect(trace.start).to.be.instanceof(Uint64BE)
+      expect(trace.start).to.be.instanceof(Int64BE)
       expect(trace.start.toNumber()).to.equal(span._startTime * 1e6)
-      expect(trace.duration).to.be.instanceof(Uint64BE)
+      expect(trace.duration).to.be.instanceof(Int64BE)
       expect(trace.duration.toNumber()).to.equal(span._duration * 1e6)
     })
 
@@ -109,8 +109,8 @@ describe('format', () => {
       expect(trace.name).to.equal('null')
       expect(trace.service).to.equal('null')
       expect(trace.meta['foo.bar']).to.equal('null')
-      expect(trace.start).to.be.instanceof(Uint64BE)
-      expect(trace.duration).to.be.instanceof(Uint64BE)
+      expect(trace.start).to.be.instanceof(Int64BE)
+      expect(trace.duration).to.be.instanceof(Int64BE)
     })
   })
 })

--- a/test/opentracing/propagation/binary.spec.js
+++ b/test/opentracing/propagation/binary.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 const SpanContext = require('../../../src/opentracing/span_context')
 
 describe('BinaryPropagator', () => {
@@ -16,8 +16,8 @@ describe('BinaryPropagator', () => {
     it('should not be supported', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(0, 456)
+        traceId: new Int64BE(0, 123),
+        spanId: new Int64BE(0, 456)
       })
 
       propagator.inject(spanContext, carrier)

--- a/test/opentracing/propagation/text_map.spec.js
+++ b/test/opentracing/propagation/text_map.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 const SpanContext = require('../../../src/opentracing/span_context')
 
 describe('TextMapPropagator', () => {
@@ -26,8 +26,8 @@ describe('TextMapPropagator', () => {
     it('should inject the span context into the carrier', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(0, 456),
+        traceId: new Int64BE(0, 123),
+        spanId: new Int64BE(0, 456),
         baggageItems
       })
 
@@ -39,8 +39,8 @@ describe('TextMapPropagator', () => {
     it('should handle non-string values', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(0, 456),
+        traceId: new Int64BE(0, 123),
+        spanId: new Int64BE(0, 456),
         baggageItems: {
           number: 1.23,
           bool: true,
@@ -64,8 +64,8 @@ describe('TextMapPropagator', () => {
       const spanContext = propagator.extract(carrier)
 
       expect(spanContext).to.deep.equal(new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(0, 456),
+        traceId: new Int64BE(0, 123),
+        spanId: new Int64BE(0, 456),
         baggageItems
       }))
     })

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const Int64BE = require('int64-buffer').Int64BE
 
 describe('Span', () => {
   let Span
@@ -10,8 +10,8 @@ describe('Span', () => {
 
   beforeEach(() => {
     platform = { id: sinon.stub() }
-    platform.id.onFirstCall().returns(new Uint64BE(123, 123))
-    platform.id.onSecondCall().returns(new Uint64BE(456, 456))
+    platform.id.onFirstCall().returns(new Int64BE(123, 123))
+    platform.id.onSecondCall().returns(new Int64BE(456, 456))
 
     tracer = {
       _record: sinon.stub(),
@@ -26,8 +26,8 @@ describe('Span', () => {
   it('should have a default context', () => {
     span = new Span(tracer, { operationName: 'operation' })
 
-    expect(span.context().traceId).to.deep.equal(new Uint64BE(123, 123))
-    expect(span.context().spanId).to.deep.equal(new Uint64BE(123, 123))
+    expect(span.context().traceId).to.deep.equal(new Int64BE(123, 123))
+    expect(span.context().spanId).to.deep.equal(new Int64BE(123, 123))
   })
 
   it('should add itself to the context trace started spans', () => {
@@ -38,8 +38,8 @@ describe('Span', () => {
 
   it('should use a parent context', () => {
     const parent = {
-      traceId: new Uint64BE(123, 123),
-      spanId: new Uint64BE(456, 456),
+      traceId: new Int64BE(123, 123),
+      spanId: new Int64BE(456, 456),
       sampled: false,
       baggageItems: { foo: 'bar' },
       trace: {
@@ -50,8 +50,8 @@ describe('Span', () => {
 
     span = new Span(tracer, { operationName: 'operation', parent })
 
-    expect(span.context().traceId).to.deep.equal(new Uint64BE(123, 123))
-    expect(span.context().parentId).to.deep.equal(new Uint64BE(456, 456))
+    expect(span.context().traceId).to.deep.equal(new Int64BE(123, 123))
+    expect(span.context().parentId).to.deep.equal(new Int64BE(456, 456))
     expect(span.context().baggageItems).to.deep.equal({ foo: 'bar' })
     expect(span.context().trace.started).to.deep.equal(['span', span])
   })


### PR DESCRIPTION
This PR fixes the trace IDs and span IDs that are currently unsigned longs but should be signed longs, which breaks interoperability with other tracer implementations.

Fixes #115 