### PR TITLE
add elasticsearch integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ jobs:
         image: redis:4.0-alpine
       - &mongo
         image: mongo:3.6
+      - &elasticsearch
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
     working_directory: ~/dd-trace-js
     steps:
       - checkout
@@ -54,6 +56,7 @@ jobs:
       - *mysql
       - *redis
       - *mongo
+      - *elasticsearch
   build-node-6:
     <<: *node-base
     docker:
@@ -62,6 +65,7 @@ jobs:
       - *mysql
       - *redis
       - *mongo
+      - *elasticsearch
   build-node-8:
     <<: *node-base
     docker:
@@ -70,6 +74,7 @@ jobs:
       - *mysql
       - *redis
       - *mongo
+      - *elasticsearch
   build-node-latest:
     <<: *node-base
     docker:
@@ -78,6 +83,7 @@ jobs:
       - *mysql
       - *redis
       - *mongo
+      - *elasticsearch
 
 workflows:
   version: 2

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -21,6 +21,7 @@ dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David D
 dev,bluebird,MIT,Copyright 2013-2018 Petka Antonov
 dev,body-parser,MIT,Copyright 2014 Jonathan Ong 2014-2015 Douglas Christopher Wilson
 dev,chai,MIT,Copyright 2017 Chai.js Assertion Library
+dev,elasticsearch,Apache-2.0,Copyright 2013 Elasticsearch BV
 dev,eslint,MIT,Copyright JS Foundation and other contributors https://js.foundation
 dev,eslint-config-standard,MIT,Copyright Feross Aboukhadijeh
 dev,eslint-plugin-import,MIT,Copyright 2015 Ben Mosher

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,7 @@ services:
     image: mongo:3.6
     ports:
       - "127.0.0.1:27017:27017"
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+    ports:
+      - "127.0.0.1:9200:9200"

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,27 @@ tracer.use('pg', {
 
 Each integration can be configured individually. See below for more information for every integration.
 
+<h3 id="elasticsearch">elasticsearch</h3>
+
+<h5 id="elasticsearch-tags">Tags</h5>
+
+| Tag                  | Description                                           |
+|----------------------|-------------------------------------------------------|
+| db.type              | Always set to `elasticsearch`.                        |
+| out.host             | The host of the Elasticsearch server.                 |
+| out.port             | The port of the Elasticsearch server.                 |
+| span.kind            | Always set to `client`.                               |
+| elasticsearch.method | The underlying HTTP request verb.                     |
+| elasticsearch.url    | The underlying HTTP request URL path.                 |
+| elasticsearch.body   | The body of the query.                                |
+| elasticsearch.params | The parameters of the query.                          |
+
+<h5 id="elasticsearch-config">Configuration Options</h5>
+
+| Option           | Default          | Description                            |
+|------------------|------------------|----------------------------------------|
+| service          | elasticsearch    | The service name for this integration. |
+
 <h3 id="express">express</h3>
 
 <h5 id="express-tags">Tags</h5>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "bluebird": "^3.5.1",
     "body-parser": "^1.18.2",
     "chai": "^4.1.2",
+    "elasticsearch": "^15.0.0",
     "eslint": "^4.15.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-import": "^2.8.0",

--- a/src/plugins/elasticsearch.js
+++ b/src/plugins/elasticsearch.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const Tags = require('opentracing').Tags
+const shimmer = require('shimmer')
+
+function createWrapRequest (tracer, config) {
+  return function wrapRequest (request) {
+    return function requestWithTrace (params, cb) {
+      let returnValue
+
+      tracer._context.run(() => {
+        let defer
+
+        if (typeof cb === 'function') {
+          cb = tracer.bind(cb)
+        } else {
+          defer = this.defer()
+
+          cb = tracer.bind((err, parsedBody, status) => {
+            if (err) {
+              err.body = parsedBody
+              err.status = status
+              defer.reject(err)
+            } else {
+              defer.resolve(parsedBody)
+            }
+          })
+        }
+
+        tracer.trace('elasticsearch.query', {
+          tags: {
+            [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+            [Tags.DB_TYPE]: 'elasticsearch'
+          }
+        }, span => {
+          span.addTags({
+            'service.name': config.service || 'elasticsearch',
+            'resource.name': `${params.method} ${quantizePath(params.path)}`,
+            'span.type': 'db',
+            'elasticsearch.url': params.path,
+            'elasticsearch.method': params.method,
+            'elasticsearch.params': JSON.stringify(params.query)
+          })
+
+          if (JSON.stringify(params.body)) {
+            span.setTag('elasticsearch.body', JSON.stringify(params.body))
+          }
+
+          if (!defer) {
+            returnValue = request.call(this, params, wrapCallback(tracer, span, cb))
+          } else {
+            const ret = request.call(this, params, wrapCallback(tracer, span, cb))
+
+            returnValue = defer.promise
+            returnValue.abort = ret.abort
+          }
+        })
+      })
+
+      return returnValue
+    }
+  }
+}
+
+function createWrapSelect (tracer, config) {
+  return function wrapSelect (select) {
+    return function selectWithTrace (cb) {
+      const span = tracer.currentSpan()
+
+      return select.call(this, function (_, conn) {
+        if (conn && conn.host) {
+          span.addTags({
+            'out.host': conn.host.host,
+            'out.port': conn.host.port
+          })
+        }
+
+        return cb.apply(null, arguments)
+      })
+    }
+  }
+}
+
+function wrapCallback (tracer, span, done) {
+  return function (err) {
+    finish(span, err)
+    done.apply(null, arguments)
+  }
+}
+
+function finish (span, err) {
+  if (err) {
+    span.addTags({
+      'error.type': err.name,
+      'error.msg': err.message,
+      'error.stack': err.stack
+    })
+  }
+
+  span.finish()
+}
+
+function quantizePath (path) {
+  return path.replace(/[0-9]+/g, '?')
+}
+
+module.exports = [
+  {
+    name: 'elasticsearch',
+    file: 'src/lib/connection_pool.js',
+    versions: ['15.x'],
+    patch (ConnectionPool, tracer, config) {
+      shimmer.wrap(ConnectionPool.prototype, 'select', createWrapSelect(tracer, config))
+    },
+    unpatch (ConnectionPool) {
+      shimmer.unwrap(ConnectionPool.prototype, 'select')
+    }
+  },
+  {
+    name: 'elasticsearch',
+    file: 'src/lib/transport.js',
+    versions: ['15.x'],
+    patch (Transport, tracer, config) {
+      shimmer.wrap(Transport.prototype, 'request', createWrapRequest(tracer, config))
+    },
+    unpatch (Transport) {
+      shimmer.unwrap(Transport.prototype, 'request')
+    }
+  }
+]

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -1,0 +1,250 @@
+'use strict'
+
+const agent = require('./agent')
+
+describe('Plugin', () => {
+  let plugin
+  let elasticsearch
+  let tracer
+
+  describe('elasticsearch', () => {
+    beforeEach(() => {
+      elasticsearch = require('elasticsearch')
+      plugin = require('../../src/plugins/elasticsearch')
+      tracer = require('../..')
+    })
+
+    afterEach(() => {
+      agent.close()
+    })
+
+    describe('without configuration', () => {
+      let client
+
+      beforeEach(() => {
+        client = new elasticsearch.Client({
+          host: 'localhost:9200'
+        })
+
+        return agent.load(plugin, 'elasticsearch')
+      })
+
+      it('should work without any living connection', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0].meta).to.not.have.property('out.host')
+            expect(traces[0][0].meta).to.not.have.property('out.port')
+          })
+          .then(done)
+          .catch(done)
+
+        client = new elasticsearch.Client({
+          hosts: [],
+          log: 'error'
+        })
+
+        client.ping(() => {})
+      })
+
+      it('should sanitize the resource name', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('resource', 'POST /logstash-?.?.?/_search')
+          })
+          .then(done)
+          .catch(done)
+
+        client.search({ index: 'logstash-2000.01.01' }, () => {})
+      })
+
+      it('should set the correct tags', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0].meta).to.have.property('db.type', 'elasticsearch')
+            expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
+            expect(traces[0][0].meta).to.have.property('out.port', '9200')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            expect(traces[0][0].meta).to.have.property('elasticsearch.method', 'POST')
+            expect(traces[0][0].meta).to.have.property('elasticsearch.url', '/docs/_search')
+            expect(traces[0][0].meta).to.have.property('elasticsearch.body', '{"query":{"match_all":{}}}')
+            expect(traces[0][0].meta).to.have.property('elasticsearch.params', '{"sort":"name","size":100}')
+          })
+          .then(done)
+          .catch(done)
+
+        client.search({
+          index: 'docs',
+          sort: 'name',
+          size: 100,
+          body: {
+            query: {
+              match_all: {}
+            }
+          }
+        }, () => {})
+      })
+
+      it('should skip tags for unavailable fields', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0].meta).to.not.have.property('elasticsearch.body')
+          })
+          .then(done)
+          .catch(done)
+
+        client.ping(err => err && done(err))
+      })
+
+      describe('when using a callback', () => {
+        it('should do automatic instrumentation', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'elasticsearch')
+              expect(traces[0][0]).to.have.property('resource', 'HEAD /')
+              expect(traces[0][0]).to.have.property('type', 'db')
+            })
+            .then(done)
+            .catch(done)
+
+          client.ping(err => err && done(err))
+        })
+
+        it('should propagate context', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('parent_id')
+              expect(traces[0][0].parent_id).to.not.be.null
+            })
+            .then(done)
+            .catch(done)
+
+          tracer.trace('test', span => {
+            client.ping(() => span.finish())
+          })
+        })
+
+        it('should run the callback in the parent context', done => {
+          client.ping(error => {
+            expect(tracer.currentSpan()).to.be.null
+            done(error)
+          })
+        })
+
+        it('should handle errors', done => {
+          let error
+
+          agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property('error.type', error.name)
+              expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+              expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+            })
+            .then(done)
+            .catch(done)
+
+          client.search({ index: 'invalid' }, err => {
+            error = err
+          })
+        })
+
+        it('should support aborting the query', () => {
+          expect(() => {
+            client.ping(() => {}).abort()
+          }).not.to.throw()
+        })
+      })
+
+      describe('when using a promise', () => {
+        it('should do automatic instrumentation', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'elasticsearch')
+              expect(traces[0][0]).to.have.property('resource', 'HEAD /')
+              expect(traces[0][0]).to.have.property('type', 'db')
+            })
+            .then(done)
+            .catch(done)
+
+          client.ping().catch(done)
+        })
+
+        it('should propagate context', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('parent_id')
+              expect(traces[0][0].parent_id).to.not.be.null
+            })
+            .then(done)
+            .catch(done)
+
+          tracer.trace('test', span => {
+            client.ping()
+              .then(() => span.finish())
+              .catch(done)
+          })
+        })
+
+        it('should run resolved promises in the parent context', () => {
+          return client.ping()
+            .then(() => {
+              expect(tracer.currentSpan()).to.be.null
+            })
+        })
+
+        it('should run rejected promises in the parent context', done => {
+          client.search({ index: 'invalid' })
+            .catch(() => {
+              expect(tracer.currentSpan()).to.be.null
+              done()
+            })
+        })
+
+        it('should handle errors', done => {
+          let error
+
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('error.type', error.name)
+            expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+            expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+          })
+            .then(done)
+            .catch(done)
+
+          client.search({ index: 'invalid' })
+            .catch(err => {
+              error = err
+            })
+        })
+
+        it('should support aborting the query', () => {
+          expect(() => {
+            client.ping().abort()
+          }).not.to.throw()
+        })
+      })
+    })
+
+    describe('with configuration', () => {
+      let client
+
+      beforeEach(() => {
+        client = new elasticsearch.Client({
+          host: 'localhost:9200'
+        })
+
+        return agent.load(plugin, 'elasticsearch', { service: 'test' })
+      })
+
+      it('should be configured with the correct values', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'test')
+          })
+          .then(done)
+          .catch(done)
+
+        client.ping(err => err && done(err))
+      })
+    })
+  })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -10,6 +10,7 @@ const pg = require('pg')
 const mysql = require('mysql')
 const redis = require('redis')
 const mongo = require('mongodb-core')
+const elasticsearch = require('elasticsearch')
 const platform = require('../src/platform')
 const node = require('../src/platform/node')
 
@@ -41,7 +42,8 @@ function waitForServices () {
     waitForPostgres(),
     waitForMysql(),
     waitForRedis(),
-    waitForMongo()
+    waitForMongo(),
+    waitForElasticsearch()
   ])
 }
 
@@ -141,6 +143,25 @@ function waitForMongo () {
       })
 
       server.connect()
+    })
+  })
+}
+
+function waitForElasticsearch () {
+  return new Promise((resolve, reject) => {
+    const operation = retry.operation(retryOptions)
+
+    operation.attempt(currentAttempt => {
+      const client = new elasticsearch.Client({
+        host: 'localhost:9200'
+      })
+
+      client.ping((err) => {
+        if (operation.retry(err)) return
+        if (err) reject(err)
+
+        resolve()
+      })
     })
   })
 }


### PR DESCRIPTION
This PR adds the Elasticsearch integration. Numbers are removed from the path in the resource name to reduce cardinality. The original path can be found in the `elasticsearch.url` tag.