### PR TITLE
add HTTP verb to express resource name

### DIFF
--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -29,7 +29,7 @@ function createWrapMethod (tracer, config) {
         const paths = tracer.currentSpan().context()._express_paths
 
         if (paths) {
-          span.setTag('resource.name', paths.join(''))
+          span.setTag('resource.name', `${req.method} ${paths.join('')}`)
         }
 
         span.setTag('service.name', config.service || tracer._service)

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -39,7 +39,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0]).to.have.property('type', 'web')
-              expect(traces[0][0]).to.have.property('resource', '/user')
+              expect(traces[0][0]).to.have.property('resource', 'GET /user')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
               expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
               expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -71,7 +71,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0]).to.have.property('type', 'web')
-              expect(traces[0][0]).to.have.property('resource', '/app/user/:id')
+              expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
               expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/app/user/1`)
               expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -101,7 +101,7 @@ describe('Plugin', () => {
         getPort().then(port => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', '/app(/^\\/user\\/(\\d)$/)')
+              expect(traces[0][0]).to.have.property('resource', 'GET /app(/^\\/user\\/(\\d)$/)')
             })
             .then(done)
             .catch(done)
@@ -127,7 +127,7 @@ describe('Plugin', () => {
         getPort().then(port => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', '/app/user/:id')
+              expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
             })
             .then(done)
             .catch(done)
@@ -159,7 +159,7 @@ describe('Plugin', () => {
         getPort().then(port => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', '/foo/bar')
+              expect(traces[0][0]).to.have.property('resource', 'GET /foo/bar')
             })
             .then(done)
             .catch(done)
@@ -185,7 +185,7 @@ describe('Plugin', () => {
         getPort().then(port => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', '/app/user/:id')
+              expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
             })
             .then(done)
             .catch(done)
@@ -212,7 +212,7 @@ describe('Plugin', () => {
         getPort().then(port => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', '/app/user/:id')
+              expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
             })
             .then(done)
             .catch(done)
@@ -286,7 +286,7 @@ describe('Plugin', () => {
         getPort().then(port => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', '/user')
+              expect(traces[0][0]).to.have.property('resource', 'GET /user')
             })
             .then(done)
             .catch(done)
@@ -373,7 +373,7 @@ describe('Plugin', () => {
         getPort().then(port => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', '/app/user/:id')
+              expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
             })
             .then(done)
             .catch(done)


### PR DESCRIPTION
This PR updates the resource name of the express to contains the HTTP verb. For example, instead of `/api/users` the resource name will be `GET /api/users`. This will also make it consistent with the other tracer implementations.