### PR TITLE
use absolute path when loading plugins

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -78,7 +78,7 @@ class Instrumenter {
 }
 
 function loadIntegrations () {
-  const integrations = requireDir('./plugins')
+  const integrations = requireDir(path.join(__dirname, './plugins'))
 
   return Object.keys(integrations)
     .map(key => integrations[key])

--- a/test/instrumenter.spec.js
+++ b/test/instrumenter.spec.js
@@ -65,7 +65,7 @@ describe('Instrumenter', () => {
     Pool = 'Pool'
 
     requireDir = sinon.stub()
-    requireDir.withArgs(path.join(__dirname, '../src', './plugins')).returns(integrations)
+    requireDir.withArgs(path.join(__dirname, '../src/plugins')).returns(integrations)
 
     Instrumenter = proxyquire('../src/instrumenter', {
       'require-dir': requireDir,

--- a/test/instrumenter.spec.js
+++ b/test/instrumenter.spec.js
@@ -65,7 +65,7 @@ describe('Instrumenter', () => {
     Pool = 'Pool'
 
     requireDir = sinon.stub()
-    requireDir.withArgs('./plugins').returns(integrations)
+    requireDir.withArgs(path.join(__dirname, '../src', './plugins')).returns(integrations)
 
     Instrumenter = proxyquire('../src/instrumenter', {
       'require-dir': requireDir,


### PR DESCRIPTION
There is an issue with jest and require-dir which causing relative path loading to fail while running tests in jest. See related issue here aseemk/requireDir#53. By forcing requireDir to load via absolute path this works around the issue.