### PR TITLE
fix the formatting of the buffer in the writer debug log

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -27,7 +27,7 @@ class Writer {
 
       const buffer = encode(formattedTrace)
 
-      log.debug(() => `Adding encoded trace to buffer: ${buffer}`)
+      log.debug(() => `Adding encoded trace to buffer: ${buffer.inspect()}`)
 
       if (this.length < this._size) {
         this._queue.push(buffer)


### PR DESCRIPTION
This PR fixes the formatting of the buffer in the writer debug log to be more useful. With this fix it will output in the format `<Buffer 0a 0b 0c 0d>` instead of an unreadable string.