### PR TITLE
fix resource name not being the operation name by default

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -26,6 +26,7 @@ function formatSpan (span) {
     span_id: spanContext.spanId,
     parent_id: spanContext.parentId,
     name: String(span._operationName),
+    resource: String(span._operationName),
     service: String(tracer._service),
     error: 0,
     meta: {},

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -41,6 +41,7 @@ describe('format', () => {
       expect(trace.span_id).to.equal(span.context().spanId)
       expect(trace.parent_id).to.equal(span.context().parentId)
       expect(trace.name).to.equal(span._operationName)
+      expect(trace.resource).to.equal(span._operationName)
       expect(trace.service).to.equal(span.tracer()._service)
       expect(trace.error).to.equal(0)
       expect(trace.start).to.be.instanceof(Int64BE)
@@ -108,6 +109,7 @@ describe('format', () => {
 
       expect(trace.name).to.equal('null')
       expect(trace.service).to.equal('null')
+      expect(trace.resource).to.equal('null')
       expect(trace.meta['foo.bar']).to.equal('null')
       expect(trace.start).to.be.instanceof(Int64BE)
       expect(trace.duration).to.be.instanceof(Int64BE)


### PR DESCRIPTION
This PR fixes a bug where the resource name would not be set to the operation name by default if not explicitly set when using the OpenTracing API.