### PR TITLE
fix span type being set to undefined when not explicitly set

### DIFF
--- a/src/tracer.js
+++ b/src/tracer.js
@@ -18,13 +18,18 @@ class DatadogTracer extends Tracer {
 
     this._context.run(() => {
       const childOf = options.childOf !== undefined ? options.childOf : this._context.get('current')
-      const tags = Object.assign({
+      const defaultTags = {
         'service.name': options.service || this._service,
-        'resource.name': options.resource || name,
-        'span.type': options.type
-      }, options.tags)
+        'resource.name': options.resource || name
+      }
 
+      if (options.type) {
+        defaultTags['span.type'] = options.type
+      }
+
+      const tags = Object.assign(defaultTags, options.tags)
       const span = this.startSpan(name, { childOf, tags })
+
       this._context.set('current', span)
 
       callback(span)

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -73,6 +73,7 @@ describe('Tracer', () => {
       tracer.trace('name', current => {
         expect(current._tags).to.have.property('service.name', 'service')
         expect(current._tags).to.have.property('resource.name', 'name')
+        expect(current._tags).to.not.have.property('span.type')
         done()
       })
     })


### PR DESCRIPTION
This PR fixes the span type being set to the string `undefined` when not explicitly set. It is now correctly not set.