### PR TITLE
update the writer debug log to include the complete buffer

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -27,7 +27,7 @@ class Writer {
 
       const buffer = encode(formattedTrace)
 
-      log.debug(() => `Adding encoded trace to buffer: ${buffer.inspect()}`)
+      log.debug(() => `Adding encoded trace to buffer: ${buffer.toString('hex').match(/../g).join(' ')}`)
 
       if (this.length < this._size) {
         this._queue.push(buffer)


### PR DESCRIPTION
This PR updates the writer debug log to include the complete buffer. Since `buffer.inspect()` cuts the buffer string if the buffer is too large, it was insufficient for debugging purposes.