### PR TITLE
fix spans created after a finished parent not being root

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -26,7 +26,7 @@ class DatadogSpan extends Span {
   _createContext (parent) {
     let spanContext
 
-    if (parent) {
+    if (parent && parent.trace.pending > 0) {
       spanContext = new SpanContext({
         traceId: parent.traceId,
         spanId: platform.id(),
@@ -45,6 +45,7 @@ class DatadogSpan extends Span {
     }
 
     spanContext.trace.started.push(this)
+    spanContext.trace.pending++
 
     return spanContext
   }
@@ -84,6 +85,7 @@ class DatadogSpan extends Span {
 
     this._duration = finishTime - this._startTime
     this._spanContext.trace.finished.push(this)
+    this._spanContext.trace.pending--
 
     if (this._spanContext.sampled) {
       this._parentTracer._record(this)

--- a/src/opentracing/span_context.js
+++ b/src/opentracing/span_context.js
@@ -13,7 +13,8 @@ class DatadogSpanContext extends SpanContext {
     this.baggageItems = props.baggageItems || {}
     this.trace = props.trace || {
       started: [],
-      finished: []
+      finished: [],
+      pending: 0
     }
   }
 }

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -44,7 +44,8 @@ describe('Span', () => {
       baggageItems: { foo: 'bar' },
       trace: {
         started: ['span'],
-        finished: []
+        finished: [],
+        pending: 1
       }
     }
 
@@ -54,6 +55,26 @@ describe('Span', () => {
     expect(span.context().parentId).to.deep.equal(new Int64BE(456, 456))
     expect(span.context().baggageItems).to.deep.equal({ foo: 'bar' })
     expect(span.context().trace.started).to.deep.equal(['span', span])
+  })
+
+  it('should not use a parent context when the parent trace is finished', () => {
+    const parent = {
+      traceId: new Int64BE(123, 123),
+      spanId: new Int64BE(456, 456),
+      sampled: false,
+      baggageItems: { foo: 'bar' },
+      trace: {
+        started: ['span'],
+        finished: ['span'],
+        pending: 0
+      }
+    }
+
+    span = new Span(tracer, { operationName: 'operation', parent })
+
+    expect(span.context().traceId).to.deep.equal(new Int64BE(123, 123))
+    expect(span.context().parentId).to.be.null
+    expect(span.context().trace.started).to.deep.equal([span])
   })
 
   describe('tracer', () => {

--- a/test/opentracing/span_context.spec.js
+++ b/test/opentracing/span_context.spec.js
@@ -16,7 +16,8 @@ describe('SpanContext', () => {
       baggageItems: { foo: 'bar' },
       trace: {
         started: ['span1', 'span2'],
-        finished: ['span1']
+        finished: ['span1'],
+        pending: 1
       }
     }
     const spanContext = new SpanContext(props)
@@ -33,7 +34,8 @@ describe('SpanContext', () => {
       baggageItems: {},
       trace: {
         started: [],
-        finished: []
+        finished: [],
+        pending: 0
       }
     }
 


### PR DESCRIPTION
This PR fixes an issue where new spans would be created a child span of the span in the current context even if the parent is already finished. New spans will now correctly be root spans if there is no suitable parent available.