### PR TITLE
Fail span if error tag is true

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -43,6 +43,11 @@ function extractTags (trace, tags) {
       case 'resource.name':
         trace[map[tag]] = String(tags[tag])
         break
+      case 'error':
+        if (tags[tag]) {
+          trace.error = 1
+        }
+        break
       case 'error.type':
       case 'error.msg':
       case 'error.stack':

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -86,7 +86,33 @@ describe('format', () => {
       expect(trace.meta['error.stack']).to.equal(span._error.stack)
     })
 
-    it('should set the error flag when there is an error tag', () => {
+    describe('when there is an `error` tag ', () => {
+      it('should set the error flag when error tag is true', () => {
+        span._tags['error'] = true
+
+        trace = format(span)
+
+        expect(trace.error).to.equal(1)
+      })
+
+      it('should not set the error flag when error is false', () => {
+        span._tags['error'] = false
+
+        trace = format(span)
+
+        expect(trace.error).to.equal(0)
+      })
+
+      it('should not extract error to meta', () => {
+        span._tags['error'] = true
+
+        trace = format(span)
+
+        expect(trace.meta['error']).to.be.undefined
+      })
+    })
+
+    it('should set the error flag when there is an error-related tag', () => {
       span._tags['error.type'] = 'Error'
       span._tags['error.msg'] = 'boom'
       span._tags['error.stack'] = ''


### PR DESCRIPTION
### Context
From [opentracing spec](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#standard-span-tags-and-log-fields), `error` tag should be ~respected to "*decide if and only if the application considers the operation represented by the Span to have failed*".~ true if and only if the application considers the operation represented by the Span to have failed

Currently we are relying on those three tags instead: ['error.type', 'error.msg', 'error.stack'].
 [reference](https://github.com/DataDog/dd-trace-js/blob/master/src/format.js#L46-L49)

### Approach

Set error **flag** to 1 if error **tag** is true. Also, skip writing it to meta since the error **flag** (not the **tag**) is used to classify the error. 

TODO
- [ ] Squash the commits if necessary



Closes https://github.com/DataDog/dd-trace-js/issues/139