### PR TITLE
add amqplib integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
         image: mongo:3.6
       - &elasticsearch
         image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+      - &rabbitmq
+        image: rabbitmq:3.6-alpine
     working_directory: ~/dd-trace-js
     steps:
       - checkout
@@ -57,6 +59,7 @@ jobs:
       - *redis
       - *mongo
       - *elasticsearch
+      - *rabbitmq
   build-node-6:
     <<: *node-base
     docker:
@@ -66,6 +69,7 @@ jobs:
       - *redis
       - *mongo
       - *elasticsearch
+      - *rabbitmq
   build-node-8:
     <<: *node-base
     docker:
@@ -75,6 +79,7 @@ jobs:
       - *redis
       - *mongo
       - *elasticsearch
+      - *rabbitmq
   build-node-latest:
     <<: *node-base
     docker:
@@ -84,6 +89,7 @@ jobs:
       - *redis
       - *mongo
       - *elasticsearch
+      - *rabbitmq
 
 workflows:
   version: 2

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,6 +4,7 @@ require,cls-hooked,BSD-2-Clause,Copyright 2013-2016 Forrest L Norvell
 require,continuation-local-storage,BSD-2-Clause,Copyright 2013-2016 Forrest L Norvell
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
+require,lodash.kebabcase,MIT,Copyright JS Foundation and other contributors
 require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk 2013-2014 TJ Holowaychuk
 require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
@@ -16,6 +17,7 @@ require,require-in-the-middle,MIT,Copyright 2016-2018 Thomas Watson Steen
 require,safe-buffer,MIT,Copyright Feross Aboukhadijeh
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,url-parse,MIT,Copyright 2015 Unshift.io Arnout Kazemier the Contributors
+dev,amqplib,MIT,Copyright 2013-2014 Michael Bridgen
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie
 dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David Dalton
 dev,bluebird,MIT,Copyright 2013-2018 Petka Antonov

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
     ports:
       - "127.0.0.1:9200:9200"
+  rabbitmq:
+    image: rabbitmq:3.6-alpine
+    ports:
+      - "127.0.0.1:5672:5672"

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,44 @@ tracer.use('pg', {
 
 Each integration can be configured individually. See below for more information for every integration.
 
+<h3 id="amqplib">amqplib</h3>
+
+<h5 id="amqplib-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| out.host         | The host of the AMQP server.                              |
+| out.port         | The port of the AMQP server.                              |
+| span.kind        | Set to either `producer` or `consumer` where it applies.  |
+| amqp.queue       | The queue targeted by the command (when available).       |
+| amqp.exchange    | The exchange targeted by the command (when available).    |
+| amqp.routingKey  | The routing key targeted by the command (when available). |
+| amqp.consumerTag | The consumer tag (when available).                        |
+| amqp.source      | The source exchange of the binding (when available).      |
+| amqp.destination | The destination exchange of the binding (when available). |
+
+<h5 id="amqplib-config">Configuration Options</h5>
+
+| Option           | Default                   | Description                            |
+|------------------|---------------------------|----------------------------------------|
+| service          | *Service name of the app* | The service name for this integration. |
+
+<h5 id="amqplib-limitations">Known Limitations</h5>
+
+When consuming messages, the current span will be immediately finished. This means that if any asynchronous operation is started in the message handler callback, its duration will be excluded from the span duration.
+
+For example:
+
+```js
+channel.consume('queue', msg => {
+  setTimeout(() => {
+    // The message span will not include the 1 second from this operation.
+  }, 1000)
+}, {}, () => {})
+```
+
+This limitation doesn't apply to other commands. We are working on improving this behavior in a future version.
+
 <h3 id="elasticsearch">elasticsearch</h3>
 
 <h5 id="elasticsearch-tags">Tags</h5>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "continuation-local-storage": "^3.2.1",
     "int64-buffer": "^0.1.9",
     "koalas": "^1.0.2",
+    "lodash.kebabcase": "^4.1.1",
     "methods": "^1.1.2",
     "msgpack-lite": "^0.1.26",
     "opentracing": "0.14.1",
@@ -52,6 +53,7 @@
     "url-parse": "^1.2.0"
   },
   "devDependencies": {
+    "amqplib": "^0.5.2",
     "axios": "^0.18.0",
     "benchmark": "^2.1.4",
     "bluebird": "^3.5.1",

--- a/src/plugins/amqplib.js
+++ b/src/plugins/amqplib.js
@@ -1,0 +1,166 @@
+'use strict'
+
+const shimmer = require('shimmer')
+const kebabCase = require('lodash.kebabcase')
+
+let methods = {}
+
+function createWrapSendOrEnqueue (tracer, config) {
+  return function wrapSendOrEnqueue (sendOrEnqueue) {
+    return function sendOrEnqueueWithTrace (method, fields, reply) {
+      return sendOrEnqueue.call(this, method, fields, tracer.bind(reply))
+    }
+  }
+}
+
+function createWrapSendImmediately (tracer, config) {
+  return function wrapSendImmediately (sendImmediately) {
+    return function sendImmediatelyWithTrace (method, fields) {
+      return sendWithTrace(sendImmediately, this, arguments, tracer, config, methods[method], fields)
+    }
+  }
+}
+
+function createWrapSendMessage (tracer, config) {
+  return function wrapSendMessage (sendMessage) {
+    return function sendMessageWithTrace (fields) {
+      return sendWithTrace(sendMessage, this, arguments, tracer, config, 'basic.publish', fields)
+    }
+  }
+}
+
+function createWrapDispatchMessage (tracer, config) {
+  return function wrapDispatchMessage (dispatchMessage) {
+    return function dispatchMessageWithTrace (fields, message) {
+      let returnValue
+
+      tracer.trace('amqp.command', span => {
+        addTags(this, config, span, 'basic.deliver', fields)
+
+        try {
+          returnValue = dispatchMessage.apply(this, arguments)
+        } catch (e) {
+          throw addError(span, e)
+        } finally {
+          // Do not use this without contacting support first
+          if (config.consumerAutoFinish !== false) {
+            span.finish()
+          }
+        }
+      })
+
+      return returnValue
+    }
+  }
+}
+
+function sendWithTrace (send, channel, args, tracer, config, method, fields) {
+  let span
+
+  tracer.trace('amqp.command', child => {
+    span = child
+  })
+
+  addTags(channel, config, span, method, fields)
+
+  try {
+    return send.apply(channel, args)
+  } catch (e) {
+    throw addError(span, e)
+  } finally {
+    span.finish()
+  }
+}
+
+function isCamelCase (str) {
+  return /([A-Z][a-z0-9]+)+/.test(str)
+}
+
+function getResourceName (method, fields) {
+  return [
+    method,
+    fields.exchange,
+    fields.routingKey,
+    fields.queue,
+    fields.source,
+    fields.destination
+  ].filter(val => val).join(' ')
+}
+
+function addError (span, error) {
+  span.addTags({
+    'error.type': error.name,
+    'error.msg': error.message,
+    'error.stack': error.stack
+  })
+
+  return error
+}
+
+function addTags (channel, config, span, method, fields) {
+  const fieldNames = [
+    'queue',
+    'exchange',
+    'routingKey',
+    'consumerTag',
+    'source',
+    'destination'
+  ]
+
+  span.addTags({
+    'service.name': config.service || 'amqp',
+    'resource.name': getResourceName(method, fields),
+    'span.type': 'worker',
+    'out.host': channel.connection.stream._host,
+    'out.port': channel.connection.stream.remotePort
+  })
+
+  switch (method) {
+    case 'basic.publish':
+      span.setTag('span.kind', 'producer')
+      break
+    case 'basic.consume':
+    case 'basic.get':
+    case 'basic.deliver':
+      span.setTag('span.kind', 'consumer')
+      break
+  }
+
+  fieldNames.forEach(field => {
+    fields[field] !== undefined && span.setTag(`amqp.${field}`, fields[field])
+  })
+}
+
+module.exports = [
+  {
+    name: 'amqplib',
+    file: 'lib/defs.js',
+    versions: ['0.5.x'],
+    patch (defs, tracer, config) {
+      methods = Object.keys(defs)
+        .filter(key => Number.isInteger(defs[key]))
+        .filter(key => isCamelCase(key))
+        .reduce((acc, key) => Object.assign(acc, { [defs[key]]: kebabCase(key).replace('-', '.') }), {})
+    },
+    unpatch (defs) {
+      methods = {}
+    }
+  },
+  {
+    name: 'amqplib',
+    file: 'lib/channel.js',
+    versions: ['0.5.x'],
+    patch (channel, tracer, config) {
+      shimmer.wrap(channel.Channel.prototype, 'sendOrEnqueue', createWrapSendOrEnqueue(tracer, config))
+      shimmer.wrap(channel.Channel.prototype, 'sendImmediately', createWrapSendImmediately(tracer, config))
+      shimmer.wrap(channel.Channel.prototype, 'sendMessage', createWrapSendMessage(tracer, config))
+      shimmer.wrap(channel.BaseChannel.prototype, 'dispatchMessage', createWrapDispatchMessage(tracer, config))
+    },
+    unpatch (channel) {
+      shimmer.unwrap(channel.Channel.prototype, 'sendOrEnqueue')
+      shimmer.unwrap(channel.Channel.prototype, 'sendImmediately')
+      shimmer.unwrap(channel.Channel.prototype, 'sendMessage')
+      shimmer.unwrap(channel.BaseChannel.prototype, 'dispatchMessage')
+    }
+  }
+]

--- a/test/plugins/amqplib.spec.js
+++ b/test/plugins/amqplib.spec.js
@@ -1,0 +1,273 @@
+'use strict'
+
+const agent = require('./agent')
+
+describe('Plugin', () => {
+  let plugin
+  let context
+  let connection
+  let channel
+
+  describe('amqplib', () => {
+    beforeEach(() => {
+      plugin = require('../../src/plugins/amqplib')
+      context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
+    })
+
+    afterEach(() => {
+      agent.close()
+      connection.close()
+    })
+
+    describe('without configuration', () => {
+      describe('when using a callback', () => {
+        beforeEach(done => {
+          agent.load(plugin, 'amqplib')
+            .then(() => {
+              require('amqplib/callback_api')
+                .connect((err, conn) => {
+                  connection = conn
+
+                  if (err != null) {
+                    return done(err)
+                  }
+
+                  conn.createChannel((err, ch) => {
+                    channel = ch
+                    done(err)
+                  })
+                })
+            })
+            .catch(done)
+        })
+
+        describe('when sending commands', () => {
+          it('should do automatic instrumentation for immediate commands', done => {
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+
+                expect(span).to.have.property('name', 'amqp.command')
+                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('resource', 'queue.declare test')
+                expect(span).to.have.property('type', 'worker')
+                expect(span.meta).to.have.property('out.host', 'localhost')
+                expect(span.meta).to.have.property('out.port', '5672')
+              }, 2)
+              .then(done)
+              .catch(done)
+
+            channel.assertQueue('test', {}, () => {})
+          })
+
+          it('should do automatic instrumentation for queued commands', done => {
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+
+                expect(span).to.have.property('name', 'amqp.command')
+                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('resource', 'queue.delete test')
+                expect(span).to.have.property('type', 'worker')
+                expect(span.meta).to.have.property('out.host', 'localhost')
+                expect(span.meta).to.have.property('out.port', '5672')
+              }, 3)
+              .then(done)
+              .catch(done)
+
+            channel.assertQueue('test', {}, () => {})
+            channel.deleteQueue('test', () => {})
+          })
+
+          it('should handle errors', done => {
+            let error
+
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+
+                expect(span).to.have.property('error', 1)
+                expect(span.meta).to.have.property('error.type', error.name)
+                expect(span.meta).to.have.property('error.msg', error.message)
+                expect(span.meta).to.have.property('error.stack', error.stack)
+              }, 2)
+              .then(done)
+              .catch(done)
+
+            try {
+              channel.deleteQueue(null, () => {})
+            } catch (e) {
+              error = e
+            }
+          })
+        })
+
+        describe('when publishing messages', () => {
+          it('should do automatic instrumentation', done => {
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+
+                expect(span).to.have.property('name', 'amqp.command')
+                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('resource', 'basic.publish exchange routingKey')
+                expect(span).to.have.property('type', 'worker')
+                expect(span.meta).to.have.property('out.host', 'localhost')
+                expect(span.meta).to.have.property('out.port', '5672')
+                expect(span.meta).to.have.property('span.kind', 'producer')
+                expect(span.meta).to.have.property('amqp.routingKey', 'routingKey')
+              }, 3)
+              .then(done)
+              .catch(done)
+
+            channel.assertExchange('exchange', 'direct', {}, () => {})
+            channel.publish('exchange', 'routingKey', Buffer.from('content'))
+          })
+
+          it('should handle errors', done => {
+            let error
+
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+
+                expect(span).to.have.property('error', 1)
+                expect(span.meta).to.have.property('error.type', error.name)
+                expect(span.meta).to.have.property('error.msg', error.message)
+                expect(span.meta).to.have.property('error.stack', error.stack)
+              }, 2)
+              .then(done)
+              .catch(done)
+
+            try {
+              channel.sendToQueue('test', 'invalid')
+            } catch (e) {
+              error = e
+            }
+          })
+        })
+
+        describe('when consuming messages', () => {
+          it('should do automatic instrumentation', done => {
+            let consumerTag
+            let queue
+
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+
+                expect(span).to.have.property('name', 'amqp.command')
+                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('resource', `basic.deliver ${queue}`)
+                expect(span).to.have.property('type', 'worker')
+                expect(span.meta).to.have.property('out.host', 'localhost')
+                expect(span.meta).to.have.property('out.port', '5672')
+                expect(span.meta).to.have.property('span.kind', 'consumer')
+                expect(span.meta).to.have.property('amqp.consumerTag', consumerTag)
+              }, 5)
+              .then(done)
+              .catch(done)
+
+            channel.assertQueue('', {}, (err, ok) => {
+              if (err) return done(err)
+
+              queue = ok.queue
+
+              channel.sendToQueue(ok.queue, Buffer.from('content'))
+              channel.consume(ok.queue, () => {}, {}, (err, ok) => {
+                if (err) return done(err)
+                consumerTag = ok.consumerTag
+              })
+            })
+          })
+
+          it('should run the command callback in the parent context', done => {
+            context.run(() => {
+              context.set('foo', 'bar')
+
+              channel.assertQueue('', {}, (err, ok) => {
+                if (err) return done(err)
+
+                channel.consume(ok.queue, () => {}, {}, () => {
+                  expect(context.get('current')).to.be.undefined
+                  expect(context.get('foo')).to.equal('bar')
+                  done()
+                })
+              })
+            })
+          })
+
+          it('should run the delivery callback in the current context', done => {
+            channel.assertQueue('', {}, (err, ok) => {
+              if (err) return done(err)
+
+              channel.sendToQueue(ok.queue, Buffer.from('content'))
+              channel.consume(ok.queue, () => {
+                expect(context.get('current')).to.not.be.undefined
+                done()
+              }, {}, err => err && done(err))
+            })
+          })
+        })
+      })
+
+      describe('when using a promise', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'amqplib')
+            .then(() => require('amqplib').connect())
+            .then(conn => (connection = conn))
+            .then(conn => conn.createChannel())
+            .then(ch => (channel = ch))
+        })
+
+        it('should run the callback in the parent context', done => {
+          context.run(() => {
+            context.set('foo', 'bar')
+
+            channel.assertQueue('test', {})
+              .then(() => {
+                expect(context.get('current')).to.be.undefined
+                expect(context.get('foo')).to.equal('bar')
+                done()
+              })
+              .catch(done)
+          })
+        })
+      })
+    })
+
+    describe('with configuration', () => {
+      beforeEach(done => {
+        agent.load(plugin, 'amqplib', { service: 'test' })
+          .then(() => {
+            require('amqplib/callback_api')
+              .connect((err, conn) => {
+                connection = conn
+
+                if (err !== null) {
+                  return done(err)
+                }
+
+                conn.createChannel((err, ch) => {
+                  channel = ch
+                  done(err)
+                })
+              })
+          })
+          .catch(done)
+      })
+
+      it('should be configured with the correct values', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('resource', 'queue.declare test')
+          }, 2)
+          .then(done)
+          .catch(done)
+
+        channel.assertQueue('test', {}, () => {})
+      })
+    })
+  })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -11,6 +11,7 @@ const mysql = require('mysql')
 const redis = require('redis')
 const mongo = require('mongodb-core')
 const elasticsearch = require('elasticsearch')
+const amqplib = require('amqplib/callback_api')
 const platform = require('../src/platform')
 const node = require('../src/platform/node')
 
@@ -43,7 +44,8 @@ function waitForServices () {
     waitForMysql(),
     waitForRedis(),
     waitForMongo(),
-    waitForElasticsearch()
+    waitForElasticsearch(),
+    waitForRabbitMQ()
   ])
 }
 
@@ -162,6 +164,22 @@ function waitForElasticsearch () {
 
         resolve()
       })
+    })
+  })
+}
+
+function waitForRabbitMQ () {
+  return new Promise((resolve, reject) => {
+    const operation = retry.operation(retryOptions)
+
+    operation.attempt(currentAttempt => {
+      amqplib
+        .connect((err, conn) => {
+          if (operation.retry(err)) return
+          if (err) reject(err)
+
+          conn.close(() => resolve())
+        })
     })
   })
 }


### PR DESCRIPTION
This PR adds the `amqplib` integration. This effectively adds support for RabbitMQ since it uses AMQP as its main protocol.