### PR TITLE
support pg 6 and 7

### DIFF
--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -7,7 +7,11 @@ const OPERATION_NAME = 'pg.query'
 function patch (pg, tracer, config) {
   function queryWrap (query) {
     return function queryTrace () {
-      const pgQuery = query.apply(this, arguments)
+      const retval = query.apply(this, arguments)
+      const pgQuery = this.queryQueue[this.queryQueue.length - 1] || this.activeQuery;
+      if (!pgQuery) {
+        return retval;
+      }
       const originalCallback = pgQuery.callback
       const statement = pgQuery.text
       const params = this.connectionParameters
@@ -54,7 +58,7 @@ function patch (pg, tracer, config) {
         }
       }
 
-      return pgQuery
+      return retval;
     }
   }
 
@@ -67,7 +71,7 @@ function unpatch (pg) {
 
 module.exports = {
   name: 'pg',
-  versions: ['6.x'],
+  versions: ['6.x','7.x'],
   patch,
   unpatch
 }


### PR DESCRIPTION
The return values of pg.Client.query differs in pg 6 vs 7. So instead of relying on the return value, get the query object from the queryQueue