### PR TITLE
add graphql integration

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -32,6 +32,7 @@ dev,eslint-plugin-promise,ISC,jden and other contributors
 dev,eslint-plugin-standard,MIT,Copyright 2015 Jamund Ferguson
 dev,express,MIT,Copyright 2009-2014 TJ Holowaychuk 2013-2014 Roman Shtylman 2014-2015 Douglas Christopher Wilson
 dev,get-port,MIT,Copyright Sindre Sorhus
+dev,graphql,MIT,Copyright 2015-present Facebook Inc.
 dev,gulp,MIT,Copyright 2013-2017 Blaine Bublitz Eric Schoffstall and other contributors
 dev,gulp-jsdoc3,Apache-2.0,Copyright Marc Udoff
 dev,jsdoc,Apache-2.0,Copyright 2011-present Michael Mathews and the contributors to JSDoc

--- a/docs/API.md
+++ b/docs/API.md
@@ -170,6 +170,32 @@ This limitation doesn't apply to other commands. We are working on improving thi
 |------------------|---------------------------|----------------------------------------|
 | service          | *Service name of the app* | The service name for this integration. |
 
+<h3 id="graphql">graphql</h3>
+
+The `graphql` integration uses the operation name as the span resource name. If no operation name is set, the resource name will always be just `query` or `mutation`.
+
+For example:
+
+```graphql
+# good, the resource name will be `query HelloWorld`
+query HelloWorld {
+  hello
+  world
+}
+
+# bad, the resource name will be `query`
+{
+  hello
+  world
+}
+```
+
+<h5 id="graphql-config">Configuration Options</h5>
+
+| Option  | Default                                          | Description                            |
+|---------|--------------------------------------------------|----------------------------------------|
+| service | *Service name of the app suffixed with -graphql* | The service name for this integration. |
+
 <h3 id="http">http / https</h3>
 
 <h5 id="http-tags">Tags</h5>

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,6 +190,12 @@ query HelloWorld {
 }
 ```
 
+<h5 id="graphql-tags">Tags</h5>
+
+| Tag            | Description                                                 |
+|----------------|-------------------------------------------------------------|
+| graphql.source | The original source of the operation in GraphQL syntax.     |
+
 <h5 id="graphql-config">Configuration Options</h5>
 
 | Option  | Default                                          | Description                            |

--- a/docs/API.md
+++ b/docs/API.md
@@ -192,9 +192,9 @@ query HelloWorld {
 
 <h5 id="graphql-tags">Tags</h5>
 
-| Tag            | Description                                                 |
-|----------------|-------------------------------------------------------------|
-| graphql.source | The original source of the operation in GraphQL syntax.     |
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| graphql.document | The original GraphQL document.                            |
 
 <h5 id="graphql-config">Configuration Options</h5>
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "express": "^4.16.2",
     "get-port": "^3.2.0",
+    "graphql": "^0.13.2",
     "gulp": "^3.9.1",
     "gulp-jsdoc3": "^2.0.0",
     "jsdoc": "^3.5.5",

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -1,0 +1,208 @@
+'use strict'
+
+const shimmer = require('shimmer')
+const platform = require('../platform')
+
+function createWrapExecute (tracer, config, defaultFieldResolver) {
+  return function wrapExecute (execute) {
+    return function executeWithTrace () {
+      const schema = arguments[0]
+      const contextValue = arguments[3] || {}
+      const fieldResolver = arguments[6] || defaultFieldResolver
+
+      arguments[6] = wrapResolve(fieldResolver, tracer, config)
+      arguments[3] = contextValue
+
+      if (!schema._datadog_patched) {
+        wrapFields(schema._queryType._fields, tracer, config, [])
+        schema._datadog_patched = true
+      }
+
+      Object.defineProperties(contextValue, {
+        _datadog_operation: { value: {} },
+        _datadog_fields: { value: {} }
+      })
+
+      return call(execute, this, arguments, defer(tracer), () => finishOperation(contextValue))
+    }
+  }
+}
+
+function wrapFields (fields, tracer, config) {
+  Object.keys(fields).forEach(key => {
+    const field = fields[key]
+
+    if (typeof field.resolve === 'function') {
+      field.resolve = wrapResolve(field.resolve, tracer, config)
+    }
+
+    if (field.type && field.type._fields) {
+      wrapFields(field.type._fields, tracer, config)
+    }
+  })
+}
+
+function wrapResolve (resolve, tracer, config) {
+  return function resolveWithTrace (source, args, contextValue, info) {
+    const path = getPath(info.path)
+    const fieldParent = getFieldParent(tracer, config, contextValue, info, path)
+    const childOf = createSpan('graphql.field', tracer, config, fieldParent, path)
+    const deferred = defer(tracer)
+
+    let result
+
+    contextValue._datadog_fields[path] = {
+      span: childOf,
+      parent: fieldParent
+    }
+
+    tracer.trace('graphql.resolve', { childOf }, span => {
+      addTags(span, tracer, config, path)
+
+      result = call(resolve, this, arguments, deferred, err => finish(span, contextValue, path, err))
+    })
+
+    return result
+  }
+}
+
+function call (fn, thisContext, args, deferred, callback) {
+  try {
+    let result = fn.apply(thisContext, args)
+
+    if (result && typeof result.then === 'function') {
+      result = result
+        .then(value => {
+          callback(null, value)
+          deferred.resolve(value)
+          return deferred.promise
+        })
+        .catch(err => {
+          callback(err)
+          deferred.reject(err)
+          return deferred.promise
+        })
+    } else {
+      callback(null, result)
+    }
+
+    return result
+  } catch (e) {
+    callback(e)
+    throw e
+  }
+}
+
+function defer (tracer) {
+  const deferred = {}
+
+  deferred.promise = new Promise((resolve, reject) => {
+    deferred.resolve = tracer.bind(resolve)
+    deferred.reject = tracer.bind(reject)
+  })
+
+  return deferred
+}
+
+function getFieldParent (tracer, config, contextValue, info, path) {
+  if (!contextValue._datadog_operation.span) {
+    contextValue._datadog_operation.span = createOperationSpan(tracer, config, info)
+  }
+
+  if (path.length === 1) {
+    return contextValue._datadog_operation.span
+  }
+
+  return contextValue._datadog_fields[path.slice(0, -1).join('.')].span
+}
+
+function createOperationSpan (tracer, config, info) {
+  const type = info.operation.operation
+  const name = info.operation.name && info.operation.name.value
+
+  let span
+
+  tracer.trace(`graphql.${info.operation.operation}`, parent => {
+    span = parent
+    span.addTags({
+      'service.name': getService(tracer, config),
+      'resource.name': [type, name].filter(val => val).join(' '),
+      'span.type': 'custom'
+    })
+  })
+
+  return span
+}
+
+function createSpan (name, tracer, config, childOf, path) {
+  let span
+
+  tracer.trace(name, { childOf }, parent => {
+    span = parent
+    addTags(span, tracer, config, path)
+  })
+
+  return span
+}
+
+function addTags (span, tracer, config, path) {
+  span.addTags({
+    'service.name': getService(tracer, config),
+    'resource.name': path.join('.'),
+    'span.type': 'custom'
+  })
+}
+
+function finish (span, contextValue, path, error) {
+  addError(span, error)
+
+  span.finish()
+
+  for (let i = path.length - 2; i >= 0; i--) {
+    contextValue._datadog_fields[path[i]].finishTime = platform.now()
+  }
+}
+
+function finishOperation (contextValue) {
+  for (const key in contextValue._datadog_fields) {
+    contextValue._datadog_fields[key].span.finish(contextValue._datadog_fields[key].finishTime)
+  }
+
+  contextValue._datadog_operation.span.finish()
+}
+
+function getService (tracer, config) {
+  return config.service || `${tracer._service}-graphql`
+}
+
+function getPath (path) {
+  if (path.prev) {
+    return getPath(path.prev).concat(path.key)
+  } else {
+    return [path.key]
+  }
+}
+
+function addError (span, error) {
+  if (error) {
+    span.addTags({
+      'error.type': error.name,
+      'error.msg': error.message,
+      'error.stack': error.stack
+    })
+  }
+
+  return error
+}
+
+module.exports = {
+  name: 'graphql',
+  file: 'execution/execute.js',
+  versions: ['0.13.x'],
+  patch (execute, tracer, config) {
+    shimmer.wrap(execute, 'execute', createWrapExecute(tracer, config, execute.defaultFieldResolver))
+  },
+  unpatch (execute) {
+    shimmer.unwrap(execute, 'execute')
+  }
+}

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -147,7 +147,7 @@ function createOperationSpan (tracer, config, contextValue, info) {
       'service.name': getService(tracer, config),
       'resource.name': [type, name].filter(val => val).join(' '),
       'span.type': 'custom',
-      'graphql.source': contextValue._datadog_source
+      'graphql.document': contextValue._datadog_source
     })
   })
 

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -3,11 +3,35 @@
 const shimmer = require('shimmer')
 const platform = require('../platform')
 
+function createWrapGraphql (tracer, config, defaultFieldResolver) {
+  return function wrapGraphql (graphql) {
+    return function graphqlWithTrace () {
+      const source = arguments[1] || arguments[0].source
+      const contextValue = arguments[3] || arguments[0].contextValue || {}
+
+      if (arguments.length === 1) {
+        arguments[0].contextValue = contextValue
+      } else {
+        arguments[3] = contextValue
+        arguments.length = Math.max(arguments.length, 4)
+      }
+
+      Object.defineProperties(contextValue, {
+        _datadog_operation: { value: {} },
+        _datadog_fields: { value: {} },
+        _datadog_source: { value: source }
+      })
+
+      return graphql.apply(this, arguments)
+    }
+  }
+}
+
 function createWrapExecute (tracer, config, defaultFieldResolver) {
   return function wrapExecute (execute) {
     return function executeWithTrace () {
       const schema = arguments[0]
-      const contextValue = arguments[3] || {}
+      const contextValue = arguments[3]
       const fieldResolver = arguments[6] || defaultFieldResolver
 
       arguments[6] = wrapResolve(fieldResolver, tracer, config)
@@ -17,11 +41,6 @@ function createWrapExecute (tracer, config, defaultFieldResolver) {
         wrapFields(schema._queryType._fields, tracer, config, [])
         schema._datadog_patched = true
       }
-
-      Object.defineProperties(contextValue, {
-        _datadog_operation: { value: {} },
-        _datadog_fields: { value: {} }
-      })
 
       return call(execute, this, arguments, defer(tracer), () => finishOperation(contextValue))
     }
@@ -106,7 +125,7 @@ function defer (tracer) {
 
 function getFieldParent (tracer, config, contextValue, info, path) {
   if (!contextValue._datadog_operation.span) {
-    contextValue._datadog_operation.span = createOperationSpan(tracer, config, info)
+    contextValue._datadog_operation.span = createOperationSpan(tracer, config, contextValue, info)
   }
 
   if (path.length === 1) {
@@ -116,7 +135,7 @@ function getFieldParent (tracer, config, contextValue, info, path) {
   return contextValue._datadog_fields[path.slice(0, -1).join('.')].span
 }
 
-function createOperationSpan (tracer, config, info) {
+function createOperationSpan (tracer, config, contextValue, info) {
   const type = info.operation.operation
   const name = info.operation.name && info.operation.name.value
 
@@ -127,7 +146,8 @@ function createOperationSpan (tracer, config, info) {
     span.addTags({
       'service.name': getService(tracer, config),
       'resource.name': [type, name].filter(val => val).join(' '),
-      'span.type': 'custom'
+      'span.type': 'custom',
+      'graphql.source': contextValue._datadog_source
     })
   })
 
@@ -195,14 +215,27 @@ function addError (span, error) {
   return error
 }
 
-module.exports = {
-  name: 'graphql',
-  file: 'execution/execute.js',
-  versions: ['0.13.x'],
-  patch (execute, tracer, config) {
-    shimmer.wrap(execute, 'execute', createWrapExecute(tracer, config, execute.defaultFieldResolver))
+module.exports = [
+  {
+    name: 'graphql',
+    file: 'graphql.js',
+    versions: ['0.13.x'],
+    patch (graphql, tracer, config) {
+      shimmer.wrap(graphql, 'graphql', createWrapGraphql(tracer, config))
+    },
+    unpatch (graphql) {
+      shimmer.unwrap(graphql, 'graphql')
+    }
   },
-  unpatch (execute) {
-    shimmer.unwrap(execute, 'execute')
+  {
+    name: 'graphql',
+    file: 'execution/execute.js',
+    versions: ['0.13.x'],
+    patch (execute, tracer, config) {
+      shimmer.wrap(execute, 'execute', createWrapExecute(tracer, config, execute.defaultFieldResolver))
+    },
+    unpatch (execute) {
+      shimmer.unwrap(execute, 'execute')
+    }
   }
-}
+]

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -73,7 +73,7 @@ describe('Plugin', () => {
             expect(spans[0]).to.have.property('service', 'test-graphql')
             expect(spans[0]).to.have.property('name', 'graphql.query')
             expect(spans[0]).to.have.property('resource', 'query MyQuery')
-            expect(spans[0].meta).to.have.property('graphql.source', source)
+            expect(spans[0].meta).to.have.property('graphql.document', source)
           })
           .then(done)
           .catch(done)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -1,0 +1,353 @@
+'use strict'
+
+const agent = require('./agent')
+
+describe('Plugin', () => {
+  let plugin
+  let context
+  let graphql
+  let schema
+  let sort
+
+  describe('graphql', () => {
+    beforeEach(() => {
+      plugin = require('../../src/plugins/graphql')
+      graphql = require('graphql')
+      context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
+
+      schema = new graphql.GraphQLSchema({
+        query: new graphql.GraphQLObjectType({
+          name: 'RootQueryType',
+          fields: {
+            hello: {
+              type: graphql.GraphQLString,
+              args: {
+                name: {
+                  type: graphql.GraphQLString
+                }
+              },
+              resolve (obj, args) {
+                return args.name
+              }
+            },
+            human: {
+              type: new graphql.GraphQLObjectType({
+                name: 'Human',
+                fields: {
+                  name: {
+                    type: graphql.GraphQLString,
+                    resolve (obj, args) {
+                      return obj
+                    }
+                  }
+                }
+              }),
+              resolve (obj, args) {
+                return Promise.resolve('test')
+              }
+            }
+          }
+        })
+      })
+
+      sort = spans => spans.sort((a, b) => a.start.toString() > b.start.toString() ? 1 : -1)
+    })
+
+    afterEach(() => {
+      agent.close()
+    })
+
+    describe('without configuration', () => {
+      beforeEach(() => {
+        return agent.load(plugin, 'graphql')
+      })
+
+      it('should instrument schema resolvers', done => {
+        const source = `{ hello(name: "world") }`
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[2]).to.have.property('service', 'test-graphql')
+            expect(spans[2]).to.have.property('resource', 'hello')
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql(schema, source).catch(done)
+      })
+
+      it('should instrument nested field resolvers', done => {
+        const source = `{ human { name } }`
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(5)
+
+            const query = spans[0]
+            const humanField = spans[1]
+            const humanResolve = spans[2]
+            const humanNameField = spans[3]
+            const humanNameResolve = spans[4]
+
+            expect(query).to.have.property('name', 'graphql.query')
+            expect(query).to.have.property('resource', 'query')
+
+            expect(humanField).to.have.property('name', 'graphql.field')
+            expect(humanField).to.have.property('resource', 'human')
+            expect(humanField.parent_id.toString()).to.equal(query.span_id.toString())
+
+            expect(humanResolve).to.have.property('name', 'graphql.resolve')
+            expect(humanResolve).to.have.property('resource', 'human')
+            expect(humanResolve.parent_id.toString()).to.equal(humanField.span_id.toString())
+
+            expect(humanNameField).to.have.property('name', 'graphql.field')
+            expect(humanNameField).to.have.property('resource', 'human.name')
+            expect(humanNameField.parent_id.toString()).to.equal(humanField.span_id.toString())
+
+            expect(humanNameResolve).to.have.property('name', 'graphql.resolve')
+            expect(humanNameResolve).to.have.property('resource', 'human.name')
+            expect(humanNameResolve.parent_id.toString()).to.equal(humanNameField.span_id.toString())
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql(schema, source).catch(done)
+      })
+
+      it('should instrument the default field resolver', done => {
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[2]).to.have.property('resource', 'hello')
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql(schema, source, { hello: 'world' }).catch(done)
+      })
+
+      it('should instrument a custom field resolver', done => {
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        const rootValue = { hello: 'world' }
+
+        const fieldResolver = (source, args, contextValue, info) => {
+          return source[info.fieldName]
+        }
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[2]).to.have.property('resource', 'hello')
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql({ schema, source, rootValue, fieldResolver }).catch(done)
+      })
+
+      it('should use the operation name for the query resource', done => {
+        const source = `query MyQuery { hello(name: "world") }`
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[0]).to.have.property('resource', 'query MyQuery')
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql(schema, source).catch(done)
+      })
+
+      it('should not instrument schema resolvers multiple times', done => {
+        const source = `{ hello(name: "world") }`
+
+        agent.use(() => { // skip first call
+          agent
+            .use(traces => {
+              const spans = sort(traces[0])
+
+              expect(spans).to.have.length(3)
+            })
+            .then(done)
+            .catch(done)
+
+          graphql.graphql(schema, source).catch(done)
+        })
+
+        graphql.graphql(schema, source).catch(done)
+      })
+
+      it('should run the field resolver in the trace context', done => {
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        const rootValue = { hello: 'world' }
+
+        const fieldResolver = (source, args, contextValue, info) => {
+          expect(context.get('current')).to.not.be.undefined
+          done()
+          return source[info.fieldName]
+        }
+
+        graphql.graphql({ schema, source, rootValue, fieldResolver }).catch(done)
+      })
+
+      it('should run resolvers in the current context', done => {
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        const rootValue = {
+          hello () {
+            expect(context.get('current')).to.not.be.undefined
+            done()
+          }
+        }
+
+        graphql.graphql({ schema, source, rootValue }).catch(done)
+      })
+
+      it('should run returned promise in the parent context', () => {
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        const rootValue = {
+          hello () {
+            return Promise.resolve('test')
+          }
+        }
+
+        return graphql.graphql({ schema, source, rootValue })
+          .then(value => {
+            expect(value).to.have.nested.property('data.hello', 'test')
+            expect(context.get('current')).to.be.undefined
+          })
+      })
+
+      it('should handle exceptions', done => {
+        const error = new Error('test')
+
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        const fieldResolver = (source, args, contextValue, info) => {
+          throw error
+        }
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[2]).to.have.property('error', 1)
+            expect(spans[2].meta).to.have.property('error.type', error.name)
+            expect(spans[2].meta).to.have.property('error.msg', error.message)
+            expect(spans[2].meta).to.have.property('error.stack', error.stack)
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql({ schema, source, fieldResolver }).catch(done)
+      })
+
+      it('should handle rejected promises', done => {
+        const error = new Error('test')
+
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        const fieldResolver = (source, args, contextValue, info) => {
+          return Promise.reject(error)
+        }
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[2]).to.have.property('error', 1)
+            expect(spans[2].meta).to.have.property('error.type', error.name)
+            expect(spans[2].meta).to.have.property('error.msg', error.message)
+            expect(spans[2].meta).to.have.property('error.stack', error.stack)
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql({ schema, source, fieldResolver }).catch(done)
+      })
+    })
+
+    describe('with configuration', () => {
+      beforeEach(() => {
+        return agent.load(plugin, 'graphql', { service: 'test' })
+      })
+
+      it('should be configured with the correct values', done => {
+        const source = `{ hello(name: "world") }`
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[2]).to.have.property('service', 'test')
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql(schema, source).catch(done)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for `graphql` with the following format:

* A `graphql.query` or `graphql.mutation` top level span for the operation
* `graphql.field` spans that are children of either the operation or a parent field and include the duration of all descendants
* `graphql.resolve` spans that are always direct children of their field and only include the resolver duration