### PR TITLE
update require-in-the-middle

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "performance-now": "^2.1.0",
     "read-pkg-up": "^3.0.0",
     "require-dir": "^1.0.0",
-    "require-in-the-middle": "^2.2.1",
+    "require-in-the-middle": "^2.2.2",
     "safe-buffer": "^5.1.1",
     "semver": "^5.5.0",
     "shimmer": "^1.2.0",


### PR DESCRIPTION
This PR updates `require-in-the-middle` to the latest version that includes a fix for circular dependencies. Since we had a problem with this in the `mysql` and `mysql2` integrations in the past, we should definitely update.