### PR TITLE
update to always use async_hooks/AsyncWrap instead of async-listener

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -318,7 +318,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | tags          |                              | {}        | Set global tags that should be applied to all spans. |
 | sampleRate    |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
-| experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Available experimental features: `asyncHooks`. |
+| experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 
 <h3 id="custom-logging">Custom Logging</h3>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=4"
+    "node": ">=4.7"
   },
   "dependencies": {
     "cls-bluebird": "^2.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,9 @@ class Config {
     const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
     const plugins = coalesce(options.plugins, true)
 
+    // Temporary safety net. Do not disable without contacting support.
+    const asyncHooks = coalesce(options.asyncHooks, true)
+
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.service = service
@@ -30,18 +33,8 @@ class Config {
     this.sampleRate = sampleRate
     this.logger = options.logger
     this.plugins = !!plugins
-    this.experimental = {
-      asyncHooks: isFlagEnabled(options.experimental, 'asyncHooks')
-    }
+    this.asyncHooks = !!asyncHooks
   }
-}
-
-function isFlagEnabled (obj, prop) {
-  return obj === true || (isObject(obj) && !!obj[prop])
-}
-
-function isObject (value) {
-  return typeof value === 'object' && value !== null
 }
 
 module.exports = Config

--- a/src/platform/node/context/index.js
+++ b/src/platform/node/context/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
-module.exports = config => {
+module.exports = function () {
   let namespace
 
-  if (config.experimental.asyncHooks) {
+  if (this._config.asyncHooks) {
     namespace = require('./cls_hooked')
   } else {
     namespace = require('./cls')

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -10,9 +10,13 @@ const context = require('./context')
 const msgpack = require('./msgpack')
 
 module.exports = {
+  _config: {},
   name: () => 'nodejs',
   version: () => process.version,
   engine: () => process.jsEngine || 'v8',
+  configure (config) {
+    this._config = config
+  },
   id,
   now,
   env,

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -35,7 +35,6 @@ class Tracer extends BaseTracer {
    * will submit traces to the agent.
    * @param {Object|boolean} [options.experimental={}] Experimental features can be enabled all at once
    * using boolean `true` or individually using key/value pairs.
-   * @param {boolean} [options.experimental.asyncHooks=false] Whether to use Node's experimental async hooks.
    * @param {boolean} [options.plugins=true] Whether to load all built-in plugins.
    * @returns {Tracer} Self
    */
@@ -44,6 +43,8 @@ class Tracer extends BaseTracer {
       platform.load()
 
       const config = new Config(options)
+
+      platform.configure(config)
 
       this._tracer = new DatadogTracer(config)
       this._instrumenter.patch(config)

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -9,7 +9,8 @@
     "expect": true,
     "sinon": true,
     "proxyquire": true,
-    "nock": true
+    "nock": true,
+    "wrapIt": true
   },
   "rules": {
     "no-unused-expressions": 0

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -106,28 +106,6 @@ describe('Config', () => {
     expect(config).to.have.property('env', 'development')
   })
 
-  it('should support global experimental flag', () => {
-    const config = new Config({
-      experimental: true
-    })
-
-    expect(config).to.have.deep.property('experimental', {
-      asyncHooks: true
-    })
-  })
-
-  it('should support experimental asyncHooks flag', () => {
-    const config = new Config({
-      experimental: {
-        asyncHooks: true
-      }
-    })
-
-    expect(config).to.have.deep.property('experimental', {
-      asyncHooks: true
-    })
-  })
-
   it('should sanitize the sample rate to be between 0 and 1', () => {
     expect(new Config({ sampleRate: -1 })).to.have.property('sampleRate', 0)
     expect(new Config({ sampleRate: 2 })).to.have.property('sampleRate', 1)

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -4,6 +4,8 @@ const EventEmitter = require('events')
 const Buffer = require('safe-buffer').Buffer
 const semver = require('semver')
 
+wrapIt()
+
 describe('Platform', () => {
   describe('Node', () => {
     let platform
@@ -321,7 +323,6 @@ describe('Platform', () => {
     })
 
     describe('context', () => {
-      let context
       let namespace
       let clsBluebird
       let config
@@ -329,7 +330,6 @@ describe('Platform', () => {
       beforeEach(() => {
         require('cls-bluebird')
         clsBluebird = sinon.spy(require.cache[require.resolve('cls-bluebird')], 'exports')
-        context = require('../../../src/platform/node/context')
       })
 
       afterEach(() => {
@@ -338,23 +338,21 @@ describe('Platform', () => {
 
       describe('continuation-local-storage', () => {
         beforeEach(() => {
-          config = { experimental: { asyncHooks: false } }
-          namespace = context(config)
+          platform.configure({ asyncHooks: false })
+          namespace = platform.context()
         })
 
         testContext('../../../src/platform/node/context/cls')
       })
 
-      if (semver.gte(semver.valid(process.version), '8.2.0')) {
-        describe('cls-hooked', () => {
-          beforeEach(() => {
-            config = { experimental: { asyncHooks: true } }
-            namespace = context(config)
-          })
-
-          testContext('../../../src/platform/node/context/cls_hooked')
+      describe('cls-hooked', () => {
+        beforeEach(() => {
+          platform.configure({ asyncHooks: true })
+          namespace = platform.context(config)
         })
-      }
+
+        testContext('../../../src/platform/node/context/cls_hooked')
+      })
 
       function testContext (modulePath) {
         it('should use the correct implementation from the experimental flag', () => {
@@ -456,7 +454,7 @@ describe('Platform', () => {
         })
 
         it('should only patch bluebird once', () => {
-          context(config)
+          platform.context()
           expect(clsBluebird).to.not.have.been.called
         })
 

--- a/test/plugins/amqplib.spec.js
+++ b/test/plugins/amqplib.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let context

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let elasticsearch

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -4,6 +4,8 @@ const axios = require('axios')
 const getPort = require('get-port')
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let context
@@ -14,7 +16,7 @@ describe('Plugin', () => {
     beforeEach(() => {
       plugin = require('../../src/plugins/express')
       express = require('express')
-      context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
+      context = require('../../src/platform').context()
     })
 
     afterEach(() => {

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let context
@@ -13,7 +15,7 @@ describe('Plugin', () => {
     beforeEach(() => {
       plugin = require('../../src/plugins/graphql')
       graphql = require('graphql')
-      context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
+      context = require('../../src/platform').context()
 
       schema = new graphql.GraphQLSchema({
         query: new graphql.GraphQLObjectType({

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -3,6 +3,8 @@
 const getPort = require('get-port')
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let express

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let mongo
@@ -44,7 +46,7 @@ describe('Plugin', () => {
       mongo = require('mongodb-core')
       plugin = require('../../src/plugins/mongodb-core')
       platform = require('../../src/platform')
-      context = platform.context({ experimental: { asyncHooks: false } })
+      context = platform.context()
 
       collection = platform.id().toString()
 

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let mysql
@@ -11,7 +13,7 @@ describe('Plugin', () => {
     beforeEach(() => {
       mysql = require('mysql')
       plugin = require('../../src/plugins/mysql')
-      context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
+      context = require('../../src/platform').context()
     })
 
     afterEach(() => {
@@ -115,7 +117,6 @@ describe('Plugin', () => {
 
         connection.query('INVALID', (err, results, fields) => {
           error = err
-          expect(error).to.be.an('error')
         })
       })
 

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let mysql2
@@ -10,7 +12,7 @@ describe('Plugin', () => {
   describe('mysql2', () => {
     beforeEach(() => {
       plugin = require('../../src/plugins/mysql2')
-      context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
+      context = require('../../src/platform').context()
     })
 
     afterEach(() => {
@@ -116,7 +118,6 @@ describe('Plugin', () => {
 
         connection.query('INVALID', (err, results, fields) => {
           error = err
-          expect(error).to.be.an('error')
         })
       })
 

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let pg

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -2,6 +2,8 @@
 
 const agent = require('./agent')
 
+wrapIt()
+
 describe('Plugin', () => {
   let plugin
   let redis
@@ -12,7 +14,7 @@ describe('Plugin', () => {
     beforeEach(() => {
       redis = require('redis')
       plugin = require('../../src/plugins/redis')
-      context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
+      context = require('../../src/platform').context()
     })
 
     afterEach(() => {


### PR DESCRIPTION
This PR updates the tracer to always use `cls-hooked` instead of `continuation-local-storage`. This was done because there are known issues with `continuation-local-storage` that have already impacted several users. The recommendation has so far always been to switch to `cls-hooked`.

Both have the same API and functionality. The main difference is that `cls-hooked` uses the native `async_hooks` or `AsyncWrap` depending on the Node version, whereas `continuation-local-storage` uses the `async-listener` library to monkey patch most of Node's API. This makes it far more stable in maintaining the context since it benefits from the guarantees of a native API. It also supports async/await, which is not possible to support properly without native APIs.

This change will also be helpful to ease the eventual transition to OpenTracing's ScopeManager.

An option to revert to the old behavior was kept as a hidden configuration option as a safety net in case a user experiences a regression.