### PR TITLE
fix pending test cases not working with it() wrapper

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -189,6 +189,10 @@ function wrapIt () {
   const it = global.it
 
   global.it = function (title, fn) {
+    if (!fn) {
+      return it.apply(this, arguments)
+    }
+
     if (fn.length > 0) {
       return it.call(this, title, function (done) {
         const context = platform.context()


### PR DESCRIPTION
This PR fixes pending test cases not working with `it()` wrapper because it expected a function to always be passed.