### PR TITLE
update release script to also create the git tag

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -5,10 +5,13 @@ const title = require('./helpers/title')
 
 title(`Publishing package to the npm registry`)
 
-const pkg = require('../package.json')
-
 exec('npm whoami')
 exec('git checkout master')
 exec('git pull')
+
+const pkg = require('../package.json')
+
+exec(`git tag v${pkg.version}`)
+exec(`git push origin refs/tags/v${pkg.version}`)
 exec('npm publish')
 exec(`node scripts/publish_docs.js "v${pkg.version}"`)


### PR DESCRIPTION
This PR updates the release script to also create and push the git tag. It also fixes a possible race condition when loading `package.json`.