### PR TITLE
add error handling in the instrumenter and in integrations

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -5,6 +5,7 @@ require,continuation-local-storage,BSD-2-Clause,Copyright 2013-2016 Forrest L No
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,lodash.kebabcase,MIT,Copyright JS Foundation and other contributors
+require,lodash.uniq,MIT,Copyright JS Foundation and other contributors
 require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk 2013-2014 TJ Holowaychuk
 require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -12,7 +12,6 @@ require,parent-module,MIT,Copyright Sindre Sorhus
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
 require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,read-pkg-up,MIT,Copyright Sindre Sorhus
-require,require-dir,MIT,Copyright 2012-2015 Aseem Kishore
 require,require-in-the-middle,MIT,Copyright 2016-2018 Thomas Watson Steen
 require,safe-buffer,MIT,Copyright Feross Aboukhadijeh
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "path-to-regexp": "^2.2.1",
     "performance-now": "^2.1.0",
     "read-pkg-up": "^3.0.0",
-    "require-dir": "^1.0.0",
     "require-in-the-middle": "^2.2.2",
     "safe-buffer": "^5.1.1",
     "semver": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "int64-buffer": "^0.1.9",
     "koalas": "^1.0.2",
     "lodash.kebabcase": "^4.1.1",
+    "lodash.uniq": "^4.5.0",
     "methods": "^1.1.2",
     "msgpack-lite": "^0.1.26",
     "opentracing": "0.14.1",

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -1,29 +1,26 @@
 'use strict'
 
-const requireDir = require('require-dir')
-const path = require('path')
 const semver = require('semver')
 const hook = require('require-in-the-middle')
+const shimmer = require('shimmer')
 const log = require('./log')
 
-// TODO: lazy load built-in plugins
+shimmer({ logger: () => {} })
 
 class Instrumenter {
   constructor (tracer) {
     this._tracer = tracer
-    this._integrations = loadIntegrations()
     this._plugins = new Map()
     this._instrumented = new Map()
   }
 
   use (name, config) {
-    if (typeof name === 'string') {
-      this._integrations
-        .filter(plugin => plugin.name === name)
-        .forEach(plugin => this._set(plugin, config))
-    } else if (name) {
-      [].concat(name)
-        .forEach(plugin => this._set(plugin, config))
+    config = config || {}
+
+    try {
+      this._set(require(`./plugins/${name}`), { name, config })
+    } catch (e) {
+      log.debug(`Could not find a plugin named "${name}".`)
     }
 
     this.reload()
@@ -33,67 +30,118 @@ class Instrumenter {
     config = config || {}
 
     if (config.plugins !== false) {
-      this._integrations.forEach(integration => {
-        this._plugins.has(integration) || this._set(integration, {})
-      })
+      const plugins = require('./plugins')
+
+      Object.keys(plugins)
+        .forEach(name => {
+          this._plugins.has(plugins[name]) || this._set(plugins[name], { name, config: {} })
+        })
     }
 
     this.reload()
   }
 
   unpatch () {
-    this._instrumented.forEach((instrumentation, moduleExports) => {
-      instrumentation.unpatch(moduleExports)
+    this._instrumented.forEach((moduleExports, instrumentation) => {
+      this._unpatch(instrumentation)
     })
+
+    this._plugins.clear()
   }
 
   reload () {
-    try {
-      const instrumentedModules = Array.from(this._plugins.keys()).map(plugin => plugin.name)
-      hook(instrumentedModules, this.hookModule.bind(this))
-    } catch (e) {
-      log.error(e)
+    const instrumentedModules = Array.from(this._plugins.keys())
+      .reduce((prev, current) => prev.concat(current), [])
+      .map(instrumentation => instrumentation.name)
+
+    hook(instrumentedModules, { internals: true }, this.hookModule.bind(this))
+  }
+
+  wrap (nodule, name) {
+    if (typeof nodule[name] !== 'function') {
+      throw new Error(`Expected object ${nodule} to contain method ${name}.`)
     }
+
+    return shimmer.wrap.apply(this, arguments)
+  }
+
+  unwrap () {
+    return shimmer.unwrap.apply(this, arguments)
   }
 
   hookModule (moduleExports, moduleName, moduleBaseDir) {
     const moduleVersion = getVersion(moduleBaseDir)
 
     Array.from(this._plugins.keys())
-      .filter(plugin => plugin.name === moduleName)
-      .filter(plugin => matchVersion(moduleVersion, plugin.versions))
-      .forEach(plugin => {
-        let moduleToPatch = moduleExports
-        if (plugin.file) {
-          moduleToPatch = require(path.join(moduleBaseDir, plugin.file))
+      .filter(plugin => [].concat(plugin).some(instrumentation => filename(instrumentation) === moduleName))
+      .forEach(plugin => this._validate(plugin, moduleBaseDir))
+
+    this._plugins
+      .forEach((meta, plugin) => {
+        try {
+          [].concat(plugin)
+            .filter(instrumentation => moduleName === filename(instrumentation))
+            .filter(instrumentation => matchVersion(moduleVersion, instrumentation.versions))
+            .forEach(instrumentation => {
+              const modulePath = [moduleBaseDir, instrumentation.file].filter(val => val).join('/')
+
+              if (require.cache[modulePath]) {
+                log.debug([
+                  `Instrumented module "${moduleName}" was imported before calling tracer.init().`,
+                  `Please make sure to initialize the tracer before importing any instrumented module.`
+                ].join(' '))
+              }
+
+              this._instrumented.set(instrumentation, moduleExports)
+              instrumentation.patch.call(this, moduleExports, this._tracer._tracer, this._plugins.get(plugin).config)
+            })
+        } catch (e) {
+          log.error(e)
+          this._fail(plugin)
+          log.debug(`Error while trying to patch ${meta.name}. The plugin has been disabled.`)
         }
-        plugin.patch(moduleToPatch, this._tracer._tracer, this._plugins.get(plugin))
-        this._instrumented.set(moduleToPatch, plugin)
       })
 
     return moduleExports
   }
 
-  _set (plugin, config) {
-    config = config || {}
+  _set (plugin, meta) {
+    this._plugins.set(plugin, Object.assign({ config: {} }, meta))
+  }
 
-    this._plugins.set(plugin, config)
+  _validate (plugin, moduleBaseDir) {
+    const meta = this._plugins.get(plugin)
+    const instrumentations = [].concat(plugin)
 
-    if (require.cache[plugin.name]) {
-      log.debug([
-        `Instrumented module "${plugin.name}" was imported before calling tracer.init().`,
-        `Please make sure to initialize the tracer before importing any instrumented module.`
-      ].join(' '))
+    for (let i = 0; i < instrumentations.length; i++) {
+      if (instrumentations[i].file && !exists(moduleBaseDir, instrumentations[i].file)) {
+        this._fail(plugin)
+        log.debug([
+          `Plugin "${meta.name}" requires "${instrumentations[i].file}" which was not found.`,
+          `The plugin was disabled.`
+        ].join(' '))
+        break
+      }
     }
   }
-}
 
-function loadIntegrations () {
-  const integrations = requireDir(path.join(__dirname, './plugins'))
+  _fail (plugin) {
+    [].concat(plugin)
+      .forEach(instrumentation => {
+        this._unpatch(instrumentation)
+        this._instrumented.delete(instrumentation)
+      })
 
-  return Object.keys(integrations)
-    .map(key => integrations[key])
-    .reduce((previous, current) => previous.concat(current), [])
+    this._plugins.delete(plugin)
+  }
+
+  _unpatch (instrumentation) {
+    try {
+      instrumentation.unpatch.call(this, this._instrumented.get(instrumentation))
+    } catch (e) {
+      log.error(e)
+    }
+  }
 }
 
 function matchVersion (version, ranges) {
@@ -102,8 +150,21 @@ function matchVersion (version, ranges) {
 
 function getVersion (moduleBaseDir) {
   if (moduleBaseDir) {
-    const packageJSON = path.join(moduleBaseDir, 'package.json')
+    const packageJSON = `${moduleBaseDir}/package.json`
     return require(packageJSON).version
+  }
+}
+
+function filename (plugin) {
+  return [plugin.name, plugin.file].filter(val => val).join('/')
+}
+
+function exists (basedir, file) {
+  try {
+    require.resolve(`${basedir}/${file}`)
+    return true
+  } catch (e) {
+    return false
   }
 }
 

--- a/src/plugins/elasticsearch.js
+++ b/src/plugins/elasticsearch.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Tags = require('opentracing').Tags
-const shimmer = require('shimmer')
 
 function createWrapRequest (tracer, config) {
   return function wrapRequest (request) {
@@ -110,10 +109,10 @@ module.exports = [
     file: 'src/lib/connection_pool.js',
     versions: ['15.x'],
     patch (ConnectionPool, tracer, config) {
-      shimmer.wrap(ConnectionPool.prototype, 'select', createWrapSelect(tracer, config))
+      this.wrap(ConnectionPool.prototype, 'select', createWrapSelect(tracer, config))
     },
     unpatch (ConnectionPool) {
-      shimmer.unwrap(ConnectionPool.prototype, 'select')
+      this.unwrap(ConnectionPool.prototype, 'select')
     }
   },
   {
@@ -121,10 +120,10 @@ module.exports = [
     file: 'src/lib/transport.js',
     versions: ['15.x'],
     patch (Transport, tracer, config) {
-      shimmer.wrap(Transport.prototype, 'request', createWrapRequest(tracer, config))
+      this.wrap(Transport.prototype, 'request', createWrapRequest(tracer, config))
     },
     unpatch (Transport) {
-      shimmer.unwrap(Transport.prototype, 'request')
+      this.unwrap(Transport.prototype, 'request')
     }
   }
 ]

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -3,7 +3,6 @@
 const opentracing = require('opentracing')
 const Tags = opentracing.Tags
 const FORMAT_HTTP_HEADERS = opentracing.FORMAT_HTTP_HEADERS
-const shimmer = require('shimmer')
 const METHODS = require('methods').concat('use', 'route', 'param', 'all')
 const pathToRegExp = require('path-to-regexp')
 
@@ -149,18 +148,18 @@ function flatten (arr) {
 
 function patch (express, tracer, config) {
   METHODS.forEach(method => {
-    shimmer.wrap(express.application, method, createWrapMethod(tracer, config))
+    this.wrap(express.application, method, createWrapMethod(tracer, config))
   })
-  shimmer.wrap(express.Router, 'process_params', createWrapProcessParams(tracer, config))
-  shimmer.wrap(express.Router, 'use', createWrapRouterMethod(tracer, config))
-  shimmer.wrap(express.Router, 'route', createWrapRouterMethod(tracer, config))
+  this.wrap(express.Router, 'process_params', createWrapProcessParams(tracer, config))
+  this.wrap(express.Router, 'use', createWrapRouterMethod(tracer, config))
+  this.wrap(express.Router, 'route', createWrapRouterMethod(tracer, config))
 }
 
 function unpatch (express) {
-  METHODS.forEach(method => shimmer.unwrap(express.application, method))
-  shimmer.unwrap(express.Router, 'process_params')
-  shimmer.unwrap(express.Router, 'use')
-  shimmer.unwrap(express.Router, 'route')
+  METHODS.forEach(method => this.unwrap(express.application, method))
+  this.unwrap(express.Router, 'process_params')
+  this.unwrap(express.Router, 'use')
+  this.unwrap(express.Router, 'route')
 }
 
 module.exports = {

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const shimmer = require('shimmer')
 const platform = require('../platform')
 
 function createWrapExecute (tracer, config, defaultFieldResolver) {
@@ -239,10 +238,10 @@ module.exports = [
     file: 'execution/execute.js',
     versions: ['0.13.x'],
     patch (execute, tracer, config) {
-      shimmer.wrap(execute, 'execute', createWrapExecute(tracer, config, execute.defaultFieldResolver))
+      this.wrap(execute, 'execute', createWrapExecute(tracer, config, execute.defaultFieldResolver))
     },
     unpatch (execute) {
-      shimmer.unwrap(execute, 'execute')
+      this.unwrap(execute, 'execute')
     }
   },
   {
@@ -250,10 +249,10 @@ module.exports = [
     file: 'language/parser.js',
     versions: ['0.13.x'],
     patch (parser, tracer, config) {
-      shimmer.wrap(parser, 'parse', createWrapParse(tracer, config))
+      this.wrap(parser, 'parse', createWrapParse(tracer, config))
     },
     unpatch (parser) {
-      shimmer.unwrap(parser, 'parse')
+      this.unwrap(parser, 'parse')
     }
   }
 ]

--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -2,14 +2,13 @@
 
 const url = require('url')
 const opentracing = require('opentracing')
-const shimmer = require('shimmer')
 
 const Tags = opentracing.Tags
 const FORMAT_HTTP_HEADERS = opentracing.FORMAT_HTTP_HEADERS
 
 function patch (http, tracer, config) {
-  shimmer.wrap(http, 'request', request => makeRequestTrace(request))
-  shimmer.wrap(http, 'get', get => makeRequestTrace(get))
+  this.wrap(http, 'request', request => makeRequestTrace(request))
+  this.wrap(http, 'get', get => makeRequestTrace(get))
 
   function makeRequestTrace (request) {
     return function requestTrace (options, callback) {
@@ -89,8 +88,8 @@ function patch (http, tracer, config) {
 }
 
 function unpatch (http) {
-  shimmer.unwrap(http, 'request')
-  shimmer.unwrap(http, 'get')
+  this.unwrap(http, 'request')
+  this.unwrap(http, 'get')
 }
 
 module.exports = {

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  'amqplib': require('./amqplib'),
+  'elasticsearch': require('./elasticsearch'),
+  'express': require('./express'),
+  'graphql': require('./graphql'),
+  'http': require('./http'),
+  'https': require('./https'),
+  'mongodb-core': require('./mongodb-core'),
+  'mysql': require('./mysql'),
+  'mysql2': require('./mysql2'),
+  'pg': require('./pg'),
+  'redis': require('./redis')
+}

--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Tags = require('opentracing').Tags
-const shimmer = require('shimmer')
 
 function createWrapQuery (tracer, config) {
   return function wrapQuery (query) {
@@ -62,11 +61,11 @@ function wrapCallback (tracer, span, done) {
 }
 
 function patchConnection (Connection, tracer, config) {
-  shimmer.wrap(Connection.prototype, 'query', createWrapQuery(tracer, config))
+  this.wrap(Connection.prototype, 'query', createWrapQuery(tracer, config))
 }
 
 function unpatchConnection (Connection) {
-  shimmer.unwrap(Connection.prototype, 'query')
+  this.unwrap(Connection.prototype, 'query')
 }
 
 module.exports = [

--- a/src/plugins/mysql2.js
+++ b/src/plugins/mysql2.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Tags = require('opentracing').Tags
-const shimmer = require('shimmer')
 
 function createWrapQuery (tracer, config) {
   return function wrapQuery (query) {
@@ -62,11 +61,11 @@ function wrapCallback (tracer, span, done) {
 }
 
 function patchConnection (Connection, tracer, config) {
-  shimmer.wrap(Connection.prototype, 'query', createWrapQuery(tracer, config))
+  this.wrap(Connection.prototype, 'query', createWrapQuery(tracer, config))
 }
 
 function unpatchConnection (Connection) {
-  shimmer.unwrap(Connection.prototype, 'query')
+  this.unwrap(Connection.prototype, 'query')
 }
 
 module.exports = [

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Tags = require('opentracing').Tags
-const shimmer = require('shimmer')
 
 const OPERATION_NAME = 'pg.query'
 
@@ -22,11 +21,14 @@ function patch (pg, tracer, config) {
         }, span => {
           span.setTag('service.name', config.service || 'postgres')
           span.setTag('resource.name', statement)
-          span.setTag('db.name', params.database)
-          span.setTag('db.user', params.user)
-          span.setTag('out.host', params.host)
-          span.setTag('out.port', String(params.port))
           span.setTag('span.type', 'db')
+
+          if (params) {
+            span.setTag('db.name', params.database)
+            span.setTag('db.user', params.user)
+            span.setTag('out.host', params.host)
+            span.setTag('out.port', String(params.port))
+          }
 
           if (err) {
             span.addTags({
@@ -48,11 +50,11 @@ function patch (pg, tracer, config) {
     }
   }
 
-  shimmer.wrap(pg.Client.prototype, 'query', queryWrap)
+  this.wrap(pg.Client.prototype, 'query', queryWrap)
 }
 
 function unpatch (pg) {
-  shimmer.unwrap(pg.Client.prototype, 'query')
+  this.unwrap(pg.Client.prototype, 'query')
 }
 
 module.exports = {

--- a/test/node_modules/mysql-mock/index.js
+++ b/test/node_modules/mysql-mock/index.js
@@ -1,3 +1,6 @@
+require('./lib/connection')
+require('./lib/pool')
+
 module.exports = {
-  foo: 'bar'
+  name: 'mysql'
 }

--- a/test/node_modules/mysql-mock/lib/connection.js
+++ b/test/node_modules/mysql-mock/lib/connection.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'Connection'
+}

--- a/test/node_modules/mysql-mock/lib/pool.js
+++ b/test/node_modules/mysql-mock/lib/pool.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'Pool'
+}

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -11,7 +11,6 @@ describe('Plugin', () => {
 
   describe('elasticsearch', () => {
     beforeEach(() => {
-      elasticsearch = require('elasticsearch')
       plugin = require('../../src/plugins/elasticsearch')
       tracer = require('../..')
     })
@@ -24,11 +23,13 @@ describe('Plugin', () => {
       let client
 
       beforeEach(() => {
-        client = new elasticsearch.Client({
-          host: 'localhost:9200'
-        })
-
         return agent.load(plugin, 'elasticsearch')
+          .then(() => {
+            elasticsearch = require('elasticsearch')
+            client = new elasticsearch.Client({
+              host: 'localhost:9200'
+            })
+          })
       })
 
       it('should work without any living connection', done => {
@@ -230,11 +231,13 @@ describe('Plugin', () => {
       let client
 
       beforeEach(() => {
-        client = new elasticsearch.Client({
-          host: 'localhost:9200'
-        })
-
         return agent.load(plugin, 'elasticsearch', { service: 'test' })
+          .then(() => {
+            elasticsearch = require('elasticsearch')
+            client = new elasticsearch.Client({
+              host: 'localhost:9200'
+            })
+          })
       })
 
       it('should be configured with the correct values', done => {

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -15,7 +15,6 @@ describe('Plugin', () => {
   describe('express', () => {
     beforeEach(() => {
       plugin = require('../../src/plugins/express')
-      express = require('express')
       context = require('../../src/platform').context()
     })
 
@@ -27,6 +26,9 @@ describe('Plugin', () => {
     describe('without configuration', () => {
       beforeEach(() => {
         return agent.load(plugin, 'express')
+          .then(() => {
+            express = require('express')
+          })
       })
 
       it('should do automatic instrumentation on app routes', done => {
@@ -431,6 +433,9 @@ describe('Plugin', () => {
         }
 
         return agent.load(plugin, 'express', config)
+          .then(() => {
+            express = require('express')
+          })
       })
 
       it('should be configured with the correct values', done => {

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -11,46 +11,47 @@ describe('Plugin', () => {
   let schema
   let sort
 
+  function buildSchema () {
+    schema = new graphql.GraphQLSchema({
+      query: new graphql.GraphQLObjectType({
+        name: 'RootQueryType',
+        fields: {
+          hello: {
+            type: graphql.GraphQLString,
+            args: {
+              name: {
+                type: graphql.GraphQLString
+              }
+            },
+            resolve (obj, args) {
+              return args.name
+            }
+          },
+          human: {
+            type: new graphql.GraphQLObjectType({
+              name: 'Human',
+              fields: {
+                name: {
+                  type: graphql.GraphQLString,
+                  resolve (obj, args) {
+                    return obj
+                  }
+                }
+              }
+            }),
+            resolve (obj, args) {
+              return Promise.resolve('test')
+            }
+          }
+        }
+      })
+    })
+  }
+
   describe('graphql', () => {
     beforeEach(() => {
       plugin = require('../../src/plugins/graphql')
-      graphql = require('graphql')
       context = require('../../src/platform').context()
-
-      schema = new graphql.GraphQLSchema({
-        query: new graphql.GraphQLObjectType({
-          name: 'RootQueryType',
-          fields: {
-            hello: {
-              type: graphql.GraphQLString,
-              args: {
-                name: {
-                  type: graphql.GraphQLString
-                }
-              },
-              resolve (obj, args) {
-                return args.name
-              }
-            },
-            human: {
-              type: new graphql.GraphQLObjectType({
-                name: 'Human',
-                fields: {
-                  name: {
-                    type: graphql.GraphQLString,
-                    resolve (obj, args) {
-                      return obj
-                    }
-                  }
-                }
-              }),
-              resolve (obj, args) {
-                return Promise.resolve('test')
-              }
-            }
-          }
-        })
-      })
 
       sort = spans => spans.sort((a, b) => a.start.toString() > b.start.toString() ? 1 : -1)
     })
@@ -62,6 +63,10 @@ describe('Plugin', () => {
     describe('without configuration', () => {
       beforeEach(() => {
         return agent.load(plugin, 'graphql')
+          .then(() => {
+            graphql = require('graphql')
+            buildSchema()
+          })
       })
 
       it('should instrument operations', done => {
@@ -375,6 +380,10 @@ describe('Plugin', () => {
     describe('with configuration', () => {
       beforeEach(() => {
         return agent.load(plugin, 'graphql', { service: 'test' })
+          .then(() => {
+            graphql = require('graphql')
+            buildSchema()
+          })
       })
 
       it('should be configured with the correct values', done => {

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -15,8 +15,6 @@ describe('Plugin', () => {
   describe('http', () => {
     beforeEach(() => {
       plugin = require('../../src/plugins/http')
-      express = require('express')
-      http = require('http')
       context = require('../../src/platform').context({ experimental: {} })
     })
 
@@ -28,6 +26,10 @@ describe('Plugin', () => {
     describe('without configuration', () => {
       beforeEach(() => {
         return agent.load(plugin, 'http')
+          .then(() => {
+            http = require('http')
+            express = require('express')
+          })
       })
 
       it('should do automatic instrumentation', done => {
@@ -241,6 +243,10 @@ describe('Plugin', () => {
         }
 
         return agent.load(plugin, 'http', config)
+          .then(() => {
+            http = require('http')
+            express = require('express')
+          })
       })
 
       it('should be configured with the correct values', done => {

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -12,45 +12,13 @@ describe('Plugin', () => {
   let context
   let collection
 
-  function setupMongo () {
-    return new Promise((resolve, reject) => {
-      server = new mongo.Server({
-        host: 'localhost',
-        port: 27017,
-        reconnect: false
-      })
-
-      server.on('connect', server => {
-        server.command('test', {
-          create: collection
-        }, {}, (err, result) => {
-          server.destroy()
-          server = null
-
-          if (err) {
-            reject(err)
-          } else {
-            resolve()
-          }
-        })
-      })
-
-      server.on('error', reject)
-
-      server.connect()
-    })
-  }
-
   describe('mongodb-core', () => {
     beforeEach(() => {
-      mongo = require('mongodb-core')
       plugin = require('../../src/plugins/mongodb-core')
       platform = require('../../src/platform')
       context = platform.context()
 
       collection = platform.id().toString()
-
-      return setupMongo()
     })
 
     afterEach(() => {
@@ -62,6 +30,8 @@ describe('Plugin', () => {
       beforeEach(done => {
         agent.load(plugin, 'mongodb-core')
           .then(() => {
+            mongo = require('mongodb-core')
+
             server = new mongo.Server({
               host: 'localhost',
               port: 27017,
@@ -329,6 +299,8 @@ describe('Plugin', () => {
 
         agent.load(plugin, 'mongodb-core', config)
           .then(() => {
+            mongo = require('mongodb-core')
+
             server = new mongo.Server({
               host: 'localhost',
               port: 27017,

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -11,7 +11,6 @@ describe('Plugin', () => {
 
   describe('mysql', () => {
     beforeEach(() => {
-      mysql = require('mysql')
       plugin = require('../../src/plugins/mysql')
       context = require('../../src/platform').context()
     })

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -12,8 +12,7 @@ describe('Plugin', () => {
 
   describe('pg', () => {
     beforeEach(() => {
-      pg = require('pg')
-      plugin = proxyquire('../src/plugins/pg', { 'pg': pg })
+      plugin = require('../../src/plugins/pg')
       context = require('../../src/platform').context({ experimental: { asyncHooks: false } })
     })
 
@@ -25,6 +24,8 @@ describe('Plugin', () => {
       beforeEach(done => {
         agent.load(plugin, 'pg')
           .then(() => {
+            pg = require('pg')
+
             client = new pg.Client({
               user: 'postgres',
               password: 'postgres',
@@ -110,6 +111,8 @@ describe('Plugin', () => {
 
         agent.load(plugin, 'pg', config)
           .then(() => {
+            pg = require('pg')
+
             client = new pg.Client({
               user: 'postgres',
               password: 'postgres',

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -12,7 +12,6 @@ describe('Plugin', () => {
 
   describe('redis', () => {
     beforeEach(() => {
-      redis = require('redis')
       plugin = require('../../src/plugins/redis')
       context = require('../../src/platform').context()
     })
@@ -26,6 +25,7 @@ describe('Plugin', () => {
       beforeEach(() => {
         return agent.load(plugin, 'redis')
           .then(() => {
+            redis = require('redis')
             client = redis.createClient()
           })
       })
@@ -155,6 +155,7 @@ describe('Plugin', () => {
 
         return agent.load(plugin, 'redis', config)
           .then(() => {
+            redis = require('redis')
             client = redis.createClient()
           })
       })


### PR DESCRIPTION
This PR adds error handling in the instrumenter and in integrations.

The instrumenter will now try to catch faulty plugins early and disable them. For the integrations I added several checks to prevent errors instead, since catching errors can be tricky (was the error caused by the plugin or the underlying module?).

These changes will make the tracer more robust and future-proof.

Closes #142 