### PR TITLE
fix graphql stability and only instrument custom resolvers

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -80,7 +80,7 @@ class DatadogSpan extends Span {
   }
 
   _finish (finishTime) {
-    finishTime = parseInt(finishTime, 10) || platform.now()
+    finishTime = parseFloat(finishTime) || platform.now()
 
     this._duration = finishTime - this._startTime
     this._spanContext.trace.finished.push(this)


### PR DESCRIPTION
This PR fixes the following stability issues with the `graphql` integration:

* List item resolvers would crash since the parent field would never be found. This is now safe as it loops through the ancestors instead of trying to access the parent directly.
* The span durations were incorrect because of a precision issue (int vs float).

The execution resolver is also no longer instrumented if there is no custom resolver for a field. Since the execution resolver only returns the object as is, it's not useful and only ends up cluttering the UI.