### PR TITLE
set db span types to sql

### DIFF
--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -22,7 +22,7 @@ function createWrapQuery (tracer, config) {
       span.setTag('resource.name', sequence.sql)
       span.setTag('out.host', this.config.host)
       span.setTag('out.port', String(this.config.port))
-      span.setTag('span.type', 'db')
+      span.setTag('span.type', 'sql')
       span.setTag('db.user', this.config.user)
 
       if (this.config.database) {

--- a/src/plugins/mysql2.js
+++ b/src/plugins/mysql2.js
@@ -22,7 +22,7 @@ function createWrapQuery (tracer, config) {
       span.setTag('resource.name', sequence.sql)
       span.setTag('out.host', this.config.host)
       span.setTag('out.port', String(this.config.port))
-      span.setTag('span.type', 'db')
+      span.setTag('span.type', 'sql')
       span.setTag('db.user', this.config.user)
 
       if (this.config.database) {

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -21,7 +21,7 @@ function patch (pg, tracer, config) {
         }, span => {
           span.setTag('service.name', config.service || 'postgres')
           span.setTag('resource.name', statement)
-          span.setTag('span.type', 'db')
+          span.setTag('span.type', 'sql')
 
           if (params) {
             span.setTag('db.name', params.database)

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -89,7 +89,7 @@ describe('Plugin', () => {
         agent.use(traces => {
           expect(traces[0][0]).to.have.property('service', 'mysql')
           expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-          expect(traces[0][0]).to.have.property('type', 'db')
+          expect(traces[0][0]).to.have.property('type', 'sql')
           expect(traces[0][0].meta).to.have.property('db.name', 'db')
           expect(traces[0][0].meta).to.have.property('db.user', 'user')
           expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
@@ -191,7 +191,7 @@ describe('Plugin', () => {
         agent.use(traces => {
           expect(traces[0][0]).to.have.property('service', 'mysql')
           expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-          expect(traces[0][0]).to.have.property('type', 'db')
+          expect(traces[0][0]).to.have.property('type', 'sql')
           expect(traces[0][0].meta).to.have.property('db.user', 'user')
           expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
           expect(traces[0][0].meta).to.have.property('span.kind', 'client')

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -90,7 +90,7 @@ describe('Plugin', () => {
           .use(traces => {
             expect(traces[0][0]).to.have.property('service', 'mysql')
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            expect(traces[0][0]).to.have.property('type', 'db')
+            expect(traces[0][0]).to.have.property('type', 'sql')
             expect(traces[0][0].meta).to.have.property('db.name', 'db')
             expect(traces[0][0].meta).to.have.property('db.user', 'user')
             expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
@@ -197,7 +197,7 @@ describe('Plugin', () => {
           .use(traces => {
             expect(traces[0][0]).to.have.property('service', 'mysql')
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            expect(traces[0][0]).to.have.property('type', 'db')
+            expect(traces[0][0]).to.have.property('type', 'sql')
             expect(traces[0][0].meta).to.have.property('db.user', 'user')
             expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
             expect(traces[0][0].meta).to.have.property('span.kind', 'client')

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -42,7 +42,7 @@ describe('Plugin', () => {
         agent.use(traces => {
           expect(traces[0][0]).to.have.property('service', 'postgres')
           expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
-          expect(traces[0][0]).to.have.property('type', 'db')
+          expect(traces[0][0]).to.have.property('type', 'sql')
           expect(traces[0][0].meta).to.have.property('db.name', 'postgres')
           expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
           expect(traces[0][0].meta).to.have.property('db.type', 'postgres')


### PR DESCRIPTION
SQL integrations are not currently quantizing their resources because the span type is set to `db` when it should be `sql`.

The tests are failing for apparently unrelated plugins.