### PR TITLE
fix graphql integration wrapping resolvers multiple in some cases

### DIFF
--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -63,6 +63,9 @@ describe('Plugin', () => {
               return Promise.resolve({})
             }
           },
+          person: {
+            type: Human
+          },
           friends: {
             type: new graphql.GraphQLList(Human),
             resolve () {


### PR DESCRIPTION
This PR fixes the `graphql` integration wrapping resolvers multiple times for shared types. When a type would have a resolver, that resolver would be wrapped for every field using the type, thus resulting in recursion.