### PR TITLE
Deeper GraphQL and Recursively nested schemas

### DIFF
--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -56,20 +56,25 @@ function wrapFields (fields, tracer, config, responsePathAsArray) {
   Object.keys(fields).forEach(key => {
     const field = fields[key]
 
-    if (typeof field.resolve === 'function') {
+    if (typeof field.resolve === 'function' && !field.resolve._datadog_patched) {
       field.resolve = wrapResolve(field.resolve, tracer, config, responsePathAsArray)
     }
 
-    if (field.type && field.type._fields) {
-      wrapFields(field.type._fields, tracer, config, responsePathAsArray)
+    if (field.type) {
+      if (field.type._fields) {
+        wrapFields(field.type._fields, tracer, config, responsePathAsArray)
+      } else if (field.type.ofType && field.type.ofType._fields) {
+        wrapFields(field.type.ofType._fields, tracer, config, responsePathAsArray)
+      }
     }
   })
 }
 
 function wrapResolve (resolve, tracer, config, responsePathAsArray) {
-  return function resolveWithTrace (source, args, contextValue, info) {
+  function resolveWithTrace (source, args, contextValue, info) {
     const path = responsePathAsArray(info.path)
     const fieldParent = getFieldParent(contextValue, path)
+
     const childOf = createSpan('graphql.field', tracer, config, fieldParent, path)
     const deferred = defer(tracer)
 
@@ -88,6 +93,10 @@ function wrapResolve (resolve, tracer, config, responsePathAsArray) {
 
     return result
   }
+
+  resolveWithTrace._datadog_patched = true
+
+  return resolveWithTrace
 }
 
 function wrapFieldResolver (fieldResolver, tracer, config, responsePathAsArray) {

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -53,7 +53,6 @@ function createWrapParse () {
 }
 
 function wrapFields (type, tracer, config, responsePathAsArray) {
-
   if (type._datadog_patched) {
     return
   }
@@ -67,8 +66,7 @@ function wrapFields (type, tracer, config, responsePathAsArray) {
       field.resolve = wrapResolve(field.resolve, tracer, config, responsePathAsArray)
     }
 
-
-    if (field.type && !field.type._datadog_patched) {
+    if (field.type) {
       if (field.type._fields) {
         wrapFields(field.type, tracer, config, responsePathAsArray)
       } else if (field.type.ofType && field.type.ofType._fields) {

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -42,7 +42,7 @@ describe('Plugin', () => {
         pets: {
           type: new graphql.GraphQLList(new graphql.GraphQLObjectType({
             name: 'Pet',
-            fields: {
+            fields: () => ({
               type: {
                 type: graphql.GraphQLString,
                 resolve: () => 'dog'
@@ -50,6 +50,10 @@ describe('Plugin', () => {
               name: {
                 type: graphql.GraphQLString,
                 resolve: () => 'foo bar'
+              },
+              owner: {
+                type: Human,
+                resolve: () => {}
               },
               colours: {
                 type: new graphql.GraphQLList(new graphql.GraphQLObjectType({
@@ -65,7 +69,7 @@ describe('Plugin', () => {
                   return [{}, {}]
                 }
               }
-            }
+            })
           })),
           resolve (obj, args) {
             return [{}, {}, {}]

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -53,7 +53,7 @@ describe('Plugin', () => {
               },
               owner: {
                 type: Human,
-                resolve: () => {}
+                resolve: () => ({})
               },
               colours: {
                 type: new graphql.GraphQLList(new graphql.GraphQLObjectType({
@@ -324,18 +324,15 @@ describe('Plugin', () => {
         graphql.graphql(schema, source).catch(done)
       })
 
-      it('should instrument nested lists', done => {
-        const source = `{ friends { name pets { name colours { code } } } }`
-
-        agent
-          .use(traces => {
-            const spans = sort(traces[0])
-            expect(spans.filter(span => span.name === 'graphql.field').map(span => span.resource)).to.have.length(29)
-          })
-          .then(done)
-          .catch(done)
+      it('should handle a circular schema', done => {
+        const source = `{ human { pets { owner { name } } } }`
 
         graphql.graphql(schema, source)
+          .then((result) => {
+            expect(result.data.human.pets[0].owner.name).to.equal('test')
+
+            done()
+          })
           .catch(done)
       })
 


### PR DESCRIPTION
This PR fixes the `graphql` integration stoping a type being instrumented more than once, for allowing recursive types and will now instrument resolvers on types within lists.