### PR TITLE
fix scope manager being instantiated multiple times

### DIFF
--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -6,8 +6,9 @@ function createWrapQuery (tracer, config) {
   return function wrapQuery (query) {
     return function queryWithTrace (sql, values, cb) {
       const parentScope = tracer.scopeManager().active()
+      const parent = parentScope && parentScope.span()
       const span = tracer.startSpan('mysql.query', {
-        childOf: parentScope && parentScope.span(),
+        childOf: parent,
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || 'mysql',
@@ -28,7 +29,7 @@ function createWrapQuery (tracer, config) {
       span.setTag('resource.name', sequence.sql)
 
       if (sequence._callback) {
-        sequence._callback = wrapCallback(tracer, span, sequence._callback)
+        sequence._callback = wrapCallback(tracer, span, parent, sequence._callback)
       } else {
         sequence.on('end', () => {
           span.finish()
@@ -40,7 +41,7 @@ function createWrapQuery (tracer, config) {
   }
 }
 
-function wrapCallback (tracer, span, done) {
+function wrapCallback (tracer, span, parent, done) {
   return (err, res) => {
     if (err) {
       span.addTags({
@@ -51,6 +52,10 @@ function wrapCallback (tracer, span, done) {
     }
 
     span.finish()
+
+    if (parent) {
+      tracer.scopeManager().activate(parent)
+    }
 
     done(err, res)
   }

--- a/src/scope/scope_manager.js
+++ b/src/scope/scope_manager.js
@@ -5,7 +5,7 @@ const Scope = require('./scope')
 const Context = require('./context')
 const ContextExecution = require('./context_execution')
 
-const singleton = null
+let singleton = null
 
 /**
  * The Datadog Scope Manager. This is used for context propagation.
@@ -17,6 +17,8 @@ class ScopeManager {
     if (singleton) {
       return singleton
     }
+
+    singleton = this
 
     const id = -1
     const execution = new ContextExecution()

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -49,7 +49,6 @@ module.exports = {
 
         server.on('close', () => {
           tracer._instrumenter.unpatch()
-          tracer.scopeManager()._disable()
           tracer = null
         })
 

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -48,8 +48,7 @@ describe('Plugin', () => {
 
         connection.query('SELECT 1 + 1 AS solution', () => {
           const active = tracer.scopeManager().active()
-          scope.close()
-          expect(active).to.equal(scope)
+          expect(active.span()).to.equal(scope.span())
           done()
         })
       })

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -48,8 +48,7 @@ describe('Plugin', () => {
 
         connection.query('SELECT 1 + 1 AS solution', () => {
           const active = tracer.scopeManager().active()
-          scope.close()
-          expect(active).to.equal(scope)
+          expect(active.span()).to.equal(scope.span())
           done()
         })
       })

--- a/test/scope/scope_manager.spec.js
+++ b/test/scope/scope_manager.spec.js
@@ -31,8 +31,8 @@ describe('ScopeManager', () => {
     scopeManager = new ScopeManager()
   })
 
-  afterEach(() => {
-    scopeManager._disable()
+  it('should be a singleton', () => {
+    expect(new ScopeManager()).to.equal(scopeManager)
   })
 
   it('should enable its hooks', () => {

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -29,10 +29,6 @@ describe('Tracer', () => {
     tracer = new Tracer(config)
   })
 
-  afterEach(() => {
-    tracer.scopeManager()._disable()
-  })
-
   describe('trace', () => {
     it('should run the callback with the new span', done => {
       tracer.trace('name', current => {


### PR DESCRIPTION
This PR fixes the scope manager being instantiated multiple times. Once a scope manager has been created, there should only ever be a single one to avoid attaching hooks multiple times.

It also fixes the `mysql` and `mysql2` integrations missing the parent scope in their respective callbacks. It seems the way tests were setup before the scope manager fix was hiding this bug.