### PR TITLE
cleanup unused code in ScopeManager and ContextExecution

### DIFF
--- a/src/scope/context_execution.js
+++ b/src/scope/context_execution.js
@@ -6,7 +6,6 @@ class ContextExecution {
     this._children = new Set()
     this._active = null
     this._count = 0
-    this._exited = false
     this._set = []
 
     if (context) {

--- a/src/scope/scope_manager.js
+++ b/src/scope/scope_manager.js
@@ -20,13 +20,12 @@ class ScopeManager {
 
     singleton = this
 
-    const id = -1
     const execution = new ContextExecution()
 
     this._active = execution
     this._stack = []
     this._contexts = new Map()
-    this._executions = new Map([[ id, execution ]])
+    this._executions = new Map()
 
     this._hook = asyncHooks.createHook({
       init: this._init.bind(this),


### PR DESCRIPTION
This PR cleans up unused code in `ScopeManager` and `ContextExecution` that could be confusing since the `id` variable was set to a valid context ID that could be used by another context.