### PR TITLE
fix pg parent scope not available in query callbacks

### DIFF
--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -13,8 +13,9 @@ function patch (pg, tracer, config) {
       const params = this.connectionParameters
 
       const parentScope = tracer.scopeManager().active()
+      const parent = parentScope && parentScope.span()
       const span = tracer.startSpan(OPERATION_NAME, {
-        childOf: parentScope && parentScope.span(),
+        childOf: parent,
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || 'postgres',
@@ -45,6 +46,10 @@ function patch (pg, tracer, config) {
         span.finish()
 
         if (originalCallback) {
+          if (parent) {
+            tracer.scopeManager().activate(parent)
+          }
+
           originalCallback(err, res)
         }
       }

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -120,9 +120,16 @@ describe('Plugin', () => {
               application_name: 'test'
             })
 
-            pool.connect(err => done(err))
+            pool.connect((err, c) => {
+              client = c
+              done(err)
+            })
           })
           .catch(done)
+      })
+
+      afterEach(() => {
+        client && client.release()
       })
 
       it('should run the callback in the parent context', done => {


### PR DESCRIPTION
This PR fixes the parent scope not being passed to the `pg` integration query callback properly.