### PR TITLE
Making parentPath defensively fall back to callerPath

### DIFF
--- a/src/platform/node/load.js
+++ b/src/platform/node/load.js
@@ -18,7 +18,7 @@ function load () {
 
   const callerPath = parentModule()
   const parentPath = parentModule(callerPath)
-  const cwd = parentPath || callerPath;
+  const cwd = path.dirname(parentPath || callerPath)
   const pkg = readPkgUp.sync({ cwd }).pkg || {}
 
   this._service = pkg.name

--- a/src/platform/node/load.js
+++ b/src/platform/node/load.js
@@ -18,7 +18,8 @@ function load () {
 
   const callerPath = parentModule()
   const parentPath = parentModule(callerPath)
-  const pkg = readPkgUp.sync({ cwd: path.dirname(parentPath) }).pkg || {}
+  const cwd = parentPath || callerPath;
+  const pkg = readPkgUp.sync({ cwd }).pkg || {}
 
   this._service = pkg.name
 }


### PR DESCRIPTION
I've run into a problem where `parentModule(callerPath)` returns `undefined` and dd-trace-js crashes the app. By falling back to `callerPath` in this event, it works as intended.

This effectively implements `parentModule` as suggested in https://www.npmjs.com/package/parent-module#tip  