### PR TITLE
update service names and span types to match the specification

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -191,6 +191,7 @@ query HelloWorld {
 | Option           | Default          | Description                            |
 |------------------|------------------|----------------------------------------|
 | service          | http-client      | The service name for this integration. |
+| splitByDomain    | false            | Use the remote endpoint host as the service name instead of the default. |
 
 <h3 id="mongodb-core">mongodb-core</h3>
 

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ class Config {
 
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
-    const service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), platform.service())
+    const service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), platform.service(), 'node')
     const env = coalesce(options.env, platform.env('DD_ENV'))
     const protocol = 'http'
     const hostname = coalesce(options.hostname, platform.env('DD_TRACE_AGENT_HOSTNAME'), 'localhost')

--- a/src/plugins/amqplib.js
+++ b/src/plugins/amqplib.js
@@ -25,7 +25,7 @@ function createWrapDispatchMessage (tracer, config) {
     return function dispatchMessageWithTrace (fields, message) {
       const span = tracer.startSpan('amqp.command')
 
-      addTags(this, config, span, 'basic.deliver', fields)
+      addTags(this, tracer, config, span, 'basic.deliver', fields)
 
       setImmediate(() => {
         tracer.scopeManager().activate(span, true)
@@ -46,7 +46,7 @@ function sendWithTrace (send, channel, args, tracer, config, method, fields) {
     childOf: parentScope && parentScope.span()
   })
 
-  addTags(channel, config, span, method, fields)
+  addTags(channel, tracer, config, span, method, fields)
 
   try {
     return send.apply(channel, args)
@@ -82,7 +82,7 @@ function addError (span, error) {
   return error
 }
 
-function addTags (channel, config, span, method, fields) {
+function addTags (channel, tracer, config, span, method, fields) {
   const fieldNames = [
     'queue',
     'exchange',
@@ -93,7 +93,7 @@ function addTags (channel, config, span, method, fields) {
   ]
 
   span.addTags({
-    'service.name': config.service || 'amqp',
+    'service.name': config.service || `${tracer._service}-amqp`,
     'resource.name': getResourceName(method, fields),
     'span.type': 'worker'
   })

--- a/src/plugins/elasticsearch.js
+++ b/src/plugins/elasticsearch.js
@@ -11,9 +11,9 @@ function createWrapRequest (tracer, config) {
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           [Tags.DB_TYPE]: 'elasticsearch',
-          'service.name': config.service || 'elasticsearch',
+          'service.name': config.service || `${tracer._service}-elasticsearch`,
           'resource.name': `${params.method} ${quantizePath(params.path)}`,
-          'span.type': 'db',
+          'span.type': 'elasticsearch',
           'elasticsearch.url': params.path,
           'elasticsearch.method': params.method,
           'elasticsearch.params': JSON.stringify(params.query)

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -41,7 +41,7 @@ function createWrapMethod (tracer, config) {
       }
 
       span.setTag('service.name', config.service || tracer._service)
-      span.setTag('span.type', 'web')
+      span.setTag('span.type', 'http')
       span.setTag(Tags.HTTP_STATUS_CODE, res.statusCode)
 
       if (!validateStatus(res.statusCode)) {

--- a/src/plugins/https.js
+++ b/src/plugins/https.js
@@ -1,9 +1,0 @@
-'use strict'
-
-const http = require('./http')
-
-module.exports = {
-  name: 'https',
-  patch: http.patch,
-  unpatch: http.unpatch
-}

--- a/src/plugins/mongodb-core.js
+++ b/src/plugins/mongodb-core.js
@@ -193,7 +193,7 @@ function createWrapOperation (tracer, config, operationName) {
         childOf: parentScope && parentScope.span()
       })
 
-      addTags(span, config, resource, ns, this)
+      addTags(span, tracer, config, resource, ns, this)
 
       if (typeof options === 'function') {
         return operation.call(this, ns, ops, wrapCallback(tracer, span, options))
@@ -214,7 +214,7 @@ function createWrapNext (tracer, config) {
         childOf: parentScope && parentScope.span()
       })
 
-      addTags(span, config, resource, this.ns, this.topology)
+      addTags(span, tracer, config, resource, this.ns, this.topology)
 
       if (this.cursorState) {
         span.addTags({
@@ -227,11 +227,11 @@ function createWrapNext (tracer, config) {
   }
 }
 
-function addTags (span, config, resource, ns, topology) {
+function addTags (span, tracer, config, resource, ns, topology) {
   span.addTags({
-    'service.name': config.service || 'mongodb',
+    'service.name': config.service || `${tracer._service}-mongodb`,
     'resource.name': resource,
-    'span.type': 'db',
+    'span.type': 'mongodb',
     'db.name': ns
   })
 

--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -11,7 +11,7 @@ function createWrapQuery (tracer, config) {
         childOf: parent,
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
-          'service.name': config.service || 'mysql',
+          'service.name': config.service || `${tracer._service}-mysql`,
           'span.type': 'sql',
           'db.type': 'mysql',
           'db.user': this.config.user,

--- a/src/plugins/mysql2.js
+++ b/src/plugins/mysql2.js
@@ -11,7 +11,7 @@ function createWrapQuery (tracer, config) {
         childOf: parent,
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
-          'service.name': config.service || 'mysql',
+          'service.name': config.service || `${tracer._service}-mysql`,
           'span.type': 'sql',
           'db.type': 'mysql',
           'db.user': this.config.user,

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -18,7 +18,7 @@ function patch (pg, tracer, config) {
         childOf: parent,
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
-          'service.name': config.service || 'postgres',
+          'service.name': config.service || `${tracer._service}-postgres`,
           'resource.name': statement,
           'span.type': 'sql',
           'db.type': 'postgres'

--- a/src/plugins/redis.js
+++ b/src/plugins/redis.js
@@ -11,9 +11,9 @@ function createWrapInternalSendCommand (tracer, config) {
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           [Tags.DB_TYPE]: 'redis',
-          'service.name': config.service || 'redis',
+          'service.name': config.service || `${tracer._service}-redis`,
           'resource.name': options.command,
-          'span.type': 'db',
+          'span.type': 'redis',
           'db.name': this.selected_db || '0'
         }
       })

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -9,7 +9,6 @@ describe('Config', () => {
       env: sinon.stub(),
       service: sinon.stub()
     }
-    platform.service.returns('test')
 
     Config = proxyquire('../src/config', {
       './platform': platform
@@ -19,7 +18,7 @@ describe('Config', () => {
   it('should initialize with the correct defaults', () => {
     const config = new Config()
 
-    expect(config).to.have.property('service', 'test')
+    expect(config).to.have.property('service', 'node')
     expect(config).to.have.property('enabled', true)
     expect(config).to.have.property('debug', false)
     expect(config).to.have.nested.property('url.protocol', 'http:')
@@ -31,6 +30,14 @@ describe('Config', () => {
     expect(config).to.have.deep.property('tags', {})
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
+  })
+
+  it('should initialize from the platform', () => {
+    platform.service.returns('test')
+
+    const config = new Config()
+
+    expect(config).to.have.property('service', 'test')
   })
 
   it('should initialize from environment variables', () => {

--- a/test/plugins/amqplib.spec.js
+++ b/test/plugins/amqplib.spec.js
@@ -50,7 +50,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
 
                 expect(span).to.have.property('name', 'amqp.command')
-                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('service', 'test-amqp')
                 expect(span).to.have.property('resource', 'queue.declare test')
                 expect(span).to.have.property('type', 'worker')
                 expect(span.meta).to.have.property('out.host', 'localhost')
@@ -68,7 +68,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
 
                 expect(span).to.have.property('name', 'amqp.command')
-                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('service', 'test-amqp')
                 expect(span).to.have.property('resource', 'queue.delete test')
                 expect(span).to.have.property('type', 'worker')
                 expect(span.meta).to.have.property('out.host', 'localhost')
@@ -111,7 +111,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
 
                 expect(span).to.have.property('name', 'amqp.command')
-                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('service', 'test-amqp')
                 expect(span).to.have.property('resource', 'basic.publish exchange routingKey')
                 expect(span).to.have.property('type', 'worker')
                 expect(span.meta).to.have.property('out.host', 'localhost')
@@ -159,7 +159,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
 
                 expect(span).to.have.property('name', 'amqp.command')
-                expect(span).to.have.property('service', 'amqp')
+                expect(span).to.have.property('service', 'test-amqp')
                 expect(span).to.have.property('resource', `basic.deliver ${queue}`)
                 expect(span).to.have.property('type', 'worker')
                 expect(span.meta).to.have.property('out.host', 'localhost')

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -83,9 +83,9 @@ describe('Plugin', () => {
         it('should do automatic instrumentation', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'elasticsearch')
+              expect(traces[0][0]).to.have.property('service', 'test-elasticsearch')
               expect(traces[0][0]).to.have.property('resource', 'HEAD /')
-              expect(traces[0][0]).to.have.property('type', 'db')
+              expect(traces[0][0]).to.have.property('type', 'elasticsearch')
             })
             .then(done)
             .catch(done)
@@ -142,9 +142,9 @@ describe('Plugin', () => {
         it('should do automatic instrumentation', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'elasticsearch')
+              expect(traces[0][0]).to.have.property('service', 'test-elasticsearch')
               expect(traces[0][0]).to.have.property('resource', 'HEAD /')
-              expect(traces[0][0]).to.have.property('type', 'db')
+              expect(traces[0][0]).to.have.property('type', 'elasticsearch')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -42,7 +42,7 @@ describe('Plugin', () => {
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
-              expect(traces[0][0]).to.have.property('type', 'web')
+              expect(traces[0][0]).to.have.property('type', 'http')
               expect(traces[0][0]).to.have.property('resource', 'GET /user')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
               expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
@@ -74,7 +74,7 @@ describe('Plugin', () => {
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
-              expect(traces[0][0]).to.have.property('type', 'web')
+              expect(traces[0][0]).to.have.property('type', 'http')
               expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
               expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/app/user/1`)

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -54,9 +54,9 @@ describe('Plugin', () => {
               const resource = `insert test.${collection}`
 
               expect(span).to.have.property('name', 'mongodb.query')
-              expect(span).to.have.property('service', 'mongodb')
+              expect(span).to.have.property('service', 'test-mongodb')
               expect(span).to.have.property('resource', resource)
-              expect(span).to.have.property('type', 'db')
+              expect(span).to.have.property('type', 'mongodb')
               expect(span.meta).to.have.property('db.name', `test.${collection}`)
               expect(span.meta).to.have.property('out.host', 'localhost')
             })
@@ -154,8 +154,8 @@ describe('Plugin', () => {
               const span = traces[0][0]
 
               expect(span).to.have.property('name', 'mongodb.query')
-              expect(span).to.have.property('service', 'mongodb')
-              expect(span).to.have.property('type', 'db')
+              expect(span).to.have.property('service', 'test-mongodb')
+              expect(span).to.have.property('type', 'mongodb')
               expect(span.meta).to.have.property('db.name', `test.${collection}`)
               expect(span.meta).to.have.property('out.host', 'localhost')
               expect(span.meta).to.have.property('out.port', '27017')

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -73,7 +73,7 @@ describe('Plugin', () => {
 
       it('should do automatic instrumentation', done => {
         agent.use(traces => {
-          expect(traces[0][0]).to.have.property('service', 'mysql')
+          expect(traces[0][0]).to.have.property('service', 'test-mysql')
           expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
           expect(traces[0][0]).to.have.property('type', 'sql')
           expect(traces[0][0].meta).to.have.property('db.name', 'db')
@@ -175,7 +175,7 @@ describe('Plugin', () => {
 
       it('should do automatic instrumentation', done => {
         agent.use(traces => {
-          expect(traces[0][0]).to.have.property('service', 'mysql')
+          expect(traces[0][0]).to.have.property('service', 'test-mysql')
           expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
           expect(traces[0][0]).to.have.property('type', 'sql')
           expect(traces[0][0].meta).to.have.property('db.user', 'user')

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -74,7 +74,7 @@ describe('Plugin', () => {
       it('should do automatic instrumentation', done => {
         agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'mysql')
+            expect(traces[0][0]).to.have.property('service', 'test-mysql')
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
             expect(traces[0][0]).to.have.property('type', 'sql')
             expect(traces[0][0].meta).to.have.property('db.name', 'db')
@@ -181,7 +181,7 @@ describe('Plugin', () => {
       it('should do automatic instrumentation', done => {
         agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'mysql')
+            expect(traces[0][0]).to.have.property('service', 'test-mysql')
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
             expect(traces[0][0]).to.have.property('type', 'sql')
             expect(traces[0][0].meta).to.have.property('db.user', 'user')

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
 
       it('should do automatic instrumentation when using callbacks', done => {
         agent.use(traces => {
-          expect(traces[0][0]).to.have.property('service', 'postgres')
+          expect(traces[0][0]).to.have.property('service', 'test-postgres')
           expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
           expect(traces[0][0]).to.have.property('type', 'sql')
           expect(traces[0][0].meta).to.have.property('db.name', 'postgres')

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -37,9 +37,9 @@ describe('Plugin', () => {
         agent
           .use(traces => {
             expect(traces[0][0]).to.have.property('name', 'redis.command')
-            expect(traces[0][0]).to.have.property('service', 'redis')
+            expect(traces[0][0]).to.have.property('service', 'test-redis')
             expect(traces[0][0]).to.have.property('resource', 'get')
-            expect(traces[0][0]).to.have.property('type', 'db')
+            expect(traces[0][0]).to.have.property('type', 'redis')
             expect(traces[0][0].meta).to.have.property('db.name', '0')
             expect(traces[0][0].meta).to.have.property('db.type', 'redis')
             expect(traces[0][0].meta).to.have.property('span.kind', 'client')


### PR DESCRIPTION
This PR updates the service names and span types to match the upcoming specification and to be consistent with other tracer implementations.

Closes #152 