### PR TITLE
fix span recorded multiple times if finish() is called more than once

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -80,6 +80,10 @@ class DatadogSpan extends Span {
   }
 
   _finish (finishTime) {
+    if (this._duration !== undefined) {
+      return
+    }
+
     finishTime = parseFloat(finishTime) || platform.now()
 
     this._duration = finishTime - this._startTime

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -150,5 +150,15 @@ describe('Span', () => {
 
       expect(tracer._record).to.not.have.been.called
     })
+
+    it('should not record the span if already finished', () => {
+      tracer._record.returns(Promise.resolve())
+
+      span = new Span(tracer, { operationName: 'operation' })
+      span.finish()
+      span.finish()
+
+      expect(tracer._record).to.have.been.calledOnce
+    })
   })
 })


### PR DESCRIPTION
This PR fixes spans being recorded multiple times if `finish()` is called more than once. This could lead to unexpected behaviors as it may cause a trace to be flushed before all spans are finished, or to not be flushed at all.