### PR TITLE
fix reference to https plugin that no longer exists

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -6,7 +6,6 @@ module.exports = {
   'express': require('./express'),
   'graphql': require('./graphql'),
   'http': require('./http'),
-  'https': require('./https'),
   'mongodb-core': require('./mongodb-core'),
   'mysql': require('./mysql'),
   'mysql2': require('./mysql2'),


### PR DESCRIPTION
This PR removes a reference to the `https` plugin that was removed in favor of keeping only the `http` plugin to address both the `http` and `https` modules.

Fixes #198 