### PR TITLE
fix memory leak when destroy is called before after on context

### DIFF
--- a/src/scope/scope_manager.js
+++ b/src/scope/scope_manager.js
@@ -99,10 +99,9 @@ class ScopeManager {
   }
 
   _after (asyncId) {
-    const context = this._contexts.get(asyncId)
     const execution = this._executions.get(asyncId)
 
-    if (context && execution) {
+    if (execution) {
       execution.exit()
       execution.release()
 


### PR DESCRIPTION
This PR fixes memory leaks when the `destroy` hook is triggered before the `after` hook. My understanding was that this cannot be the case, but it seems it can happen in some cases (i.e. with promises).