### PR TITLE
fix 403 error from AWS when sending a signed request

### DIFF
--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -175,6 +175,94 @@ describe('Plugin', () => {
         })
       })
 
+      it('should skip injecting if the Authorization header contains an AWS signature', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request({
+              port,
+              headers: {
+                Authorization: 'AWS4-HMAC-SHA256 ...'
+              }
+            })
+
+            req.end()
+          })
+        })
+      })
+
+      it('should skip injecting if the X-Amz-Signature header is set', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request({
+              port,
+              headers: {
+                'X-Amz-Signature': 'abc123'
+              }
+            })
+
+            req.end()
+          })
+        })
+      })
+
+      it('should skip injecting if the X-Amz-Signature query param is set', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request({
+              port,
+              path: '/?X-Amz-Signature=abc123'
+            })
+
+            req.end()
+          })
+        })
+      })
+
       it('should run the callback in the parent context', done => {
         const app = express()
 


### PR DESCRIPTION
This PR fixes 403 errors from AWS when sending signed requests.

AWS uses the headers when signing, and since we are altering the headers when injecting the span context, the signature would become invalid. This is unnecessary for requests to AWS since it cannot propagate context, so this PR removes the injection for these requests.