### PR TITLE
flush pending traces when the process exits gracefully

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -32,6 +32,7 @@ dev,eslint-plugin-import,MIT,Copyright 2015 Ben Mosher
 dev,eslint-plugin-node,MIT,Copyright 2015 Toru Nagashima
 dev,eslint-plugin-promise,ISC,jden and other contributors
 dev,eslint-plugin-standard,MIT,Copyright 2015 Jamund Ferguson
+dev,eventemitter3,MIT,Copyright 2014 Arnout Kazemier
 dev,express,MIT,Copyright 2009-2014 TJ Holowaychuk 2013-2014 Roman Shtylman 2014-2015 Douglas Christopher Wilson
 dev,get-port,MIT,Copyright Sindre Sorhus
 dev,graphql,MIT,Copyright 2015-present Facebook Inc.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
+    "eventemitter3": "^3.1.0",
     "express": "^4.16.2",
     "get-port": "^3.2.0",
     "graphql": "^0.13.2",

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const EventEmitter = require('events')
 const id = require('./id')
 const now = require('./now')
 const env = require('./env')
@@ -8,7 +9,9 @@ const service = require('./service')
 const request = require('./request')
 const msgpack = require('./msgpack')
 
-module.exports = {
+const emitter = new EventEmitter()
+
+const platform = {
   _config: {},
   name: () => 'nodejs',
   version: () => process.version,
@@ -22,5 +25,12 @@ module.exports = {
   load,
   service,
   request,
-  msgpack
+  msgpack,
+  on: emitter.on.bind(emitter),
+  once: emitter.once.bind(emitter),
+  off: emitter.removeListener.bind(emitter)
 }
+
+process.once('beforeExit', () => emitter.emit('exit'))
+
+module.exports = platform

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// TODO: flush on process exit
+const platform = require('./platform')
 
 class Scheduler {
   constructor (callback, interval) {
@@ -12,10 +12,14 @@ class Scheduler {
   start () {
     this._timer = setInterval(this._callback, this._interval)
     this._timer.unref && this._timer.unref()
+
+    platform.on('exit', this._callback)
   }
 
   stop () {
     clearInterval(this._timer)
+
+    platform.off('exit', this._callback)
   }
 
   reset () {


### PR DESCRIPTION
This PR updates the scheduler to flush pending traces when the process exits gracefully. This is to support use cases without a long-lived process.