### PR TITLE
fix express path being lost when active scope is closed

### DIFF
--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -74,9 +74,8 @@ function createWrapProcessParams (tracer, config) {
   return function wrapProcessParams (processParams) {
     return function processParamsWithTrace (layer, called, req, res, done) {
       const matchers = layer._datadog_matchers
-      const scope = tracer.scopeManager().active()
 
-      if (matchers && scope) {
+      if (matchers) {
         const paths = req._datadog_paths || []
 
         // Try to guess which path actually matched
@@ -126,14 +125,10 @@ function wrapNext (tracer, layer, req, next) {
     const originalNext = next
 
     return function () {
-      const scope = tracer.scopeManager().active()
+      const paths = req._datadog_paths
 
-      if (scope) {
-        const paths = req._datadog_paths
-
-        if (paths && layer.path && !layer.regexp.fast_star) {
-          paths.pop()
-        }
+      if (paths && layer.path && !layer.regexp.fast_star) {
+        paths.pop()
       }
 
       originalNext.apply(null, arguments)

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -268,6 +268,40 @@ describe('Plugin', () => {
         })
       })
 
+      it('should not lose the current path without a scope', done => {
+        const app = express()
+        const router = express.Router()
+
+        router.use((req, res, next) => {
+          const scope = tracer.scopeManager().active()
+
+          scope.close()
+
+          next()
+        })
+
+        router.get('/user/:id', (req, res) => {
+          res.status(200).send()
+        })
+
+        app.use('/app', router)
+
+        getPort().then(port => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
+            })
+            .then(done)
+            .catch(done)
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/app/user/123`)
+              .catch(done)
+          })
+        })
+      })
+
       it('should fallback to the the verb if a path pattern could not be found', done => {
         const app = express()
 


### PR DESCRIPTION
This PR fixes the current path being lost in the `express` integrations when the active scope is closed by removing the check that a scope exists. It was an artifact of the previous context propagation implementation before 0.4.0 and is no longer necessary.