### PR TITLE
remove no longer used dependencies

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,8 +1,5 @@
 Component,Origin,License,Copyright
 require,async-hook-jl,MIT,Copyright 2015 Andreas Madsen
-require,cls-bluebird,BSD-2-Clause,Copyright Tim Beyer
-require,cls-hooked,BSD-2-Clause,Copyright 2013-2016 Forrest L Norvell
-require,continuation-local-storage,BSD-2-Clause,Copyright 2013-2016 Forrest L Norvell
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,lodash.kebabcase,MIT,Copyright JS Foundation and other contributors

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
   },
   "dependencies": {
     "async-hook-jl": "^1.7.6",
-    "cls-bluebird": "^2.1.0",
-    "cls-hooked": "^4.2.2",
-    "continuation-local-storage": "^3.2.1",
     "int64-buffer": "^0.1.9",
     "koalas": "^1.0.2",
     "lodash.kebabcase": "^4.1.1",


### PR DESCRIPTION
Now that we have implemented the scope manager, these dependencies are no longer actively used.