### PR TITLE
fix detection of aws signature when using array headers

### DIFF
--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -112,13 +112,20 @@ function hasAmazonSignature (options) {
         [next.toLowerCase()]: options.headers[next]
       }), {})
 
-    if (headers['x-amz-signature'] ||
-      (headers['authorization'] && headers['authorization'].startsWith('AWS4-HMAC-SHA256'))) {
+    if (headers['x-amz-signature']) {
+      return true
+    }
+
+    if ([].concat(headers['authorization']).some(startsWith('AWS4-HMAC-SHA256'))) {
       return true
     }
   }
 
   return options.path && options.path.toLowerCase().indexOf('x-amz-signature=') !== -1
+}
+
+function startsWith (searchString) {
+  return value => String(value).startsWith(searchString)
 }
 
 function unpatch (http) {

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -205,6 +205,36 @@ describe('Plugin', () => {
         })
       })
 
+      it('should skip injecting if one of the Authorization headers contains an AWS signature', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request({
+              port,
+              headers: {
+                Authorization: ['AWS4-HMAC-SHA256 ...']
+              }
+            })
+
+            req.end()
+          })
+        })
+      })
+
       it('should skip injecting if the X-Amz-Signature header is set', done => {
         const app = express()
 


### PR DESCRIPTION
This PR fixes the detection for AWS signature when using array headers. Before it was assuming headers were strings even though it's possible to use arrays to define multiple headers with the same name.

Fixes #219 