### PR TITLE
add tests to detect memory leaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: node:alpine
+      - image: node
     working_directory: ~/dd-trace-js
     steps:
       - checkout
@@ -15,9 +15,24 @@ jobs:
       - run:
           name: Lint
           command: npm run lint
+  test-memory-leaks:
+    docker:
+      - image: node:8
+    working_directory: ~/dd-trace-js
+    steps:
+      - checkout
+      - run:
+          name: Versions
+          command: npm version
+      - run:
+          name: Install dependencies
+          command: npm install
+      - run:
+          name: Test
+          command: npm run leak
   build-node-base: &node-base
     docker:
-      - image: node:alpine
+      - image: node
       - &postgres
         image: postgres:9.5
       - &mysql
@@ -53,7 +68,7 @@ jobs:
   build-node-4:
     <<: *node-base
     docker:
-      - image: node:4-alpine
+      - image: node:4
       - *postgres
       - *mysql
       - *redis
@@ -63,7 +78,7 @@ jobs:
   build-node-6:
     <<: *node-base
     docker:
-      - image: node:6-alpine
+      - image: node:6
       - *postgres
       - *mysql
       - *redis
@@ -73,7 +88,7 @@ jobs:
   build-node-8:
     <<: *node-base
     docker:
-      - image: node:8-alpine
+      - image: node:8
       - *postgres
       - *mysql
       - *redis
@@ -83,7 +98,7 @@ jobs:
   build-node-latest:
     <<: *node-base
     docker:
-      - image: node:alpine
+      - image: node
       - *postgres
       - *mysql
       - *redis
@@ -96,6 +111,7 @@ workflows:
   build:
     jobs:
       - lint
+      - test-memory-leaks
       - build-node-4
       - build-node-6
       - build-node-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,42 @@
 version: 2
+docker-base: &docker-base
+  docker:
+    - image: node:8
+    - &postgres
+      image: postgres:9.5
+    - &mysql
+      image: mysql:5.7
+      environment:
+        - MYSQL_ROOT_PASSWORD=rootpass
+        - MYSQL_PASSWORD=userpass
+        - MYSQL_USER=user
+        - MYSQL_DATABASE=db
+    - &redis
+      image: redis:4.0-alpine
+    - &mongo
+      image: mongo:3.6
+    - &elasticsearch
+      image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+    - &rabbitmq
+      image: rabbitmq:3.6-alpine
+build-node-base: &node-base
+  <<: *docker-base
+  working_directory: ~/dd-trace-js
+  steps:
+    - checkout
+    - run:
+        name: Versions
+        command: npm version
+    - run:
+        name: Install dependencies
+        command: npm install
+    - run:
+        name: Test
+        command: npm test
+    - run:
+        name: Benchmark
+        command: npm run bench
 jobs:
-  docker-base: &docker-base
-    docker:
-      - image: node:8
-      - &postgres
-        image: postgres:9.5
-      - &mysql
-        image: mysql:5.7
-        environment:
-          - MYSQL_ROOT_PASSWORD=rootpass
-          - MYSQL_PASSWORD=userpass
-          - MYSQL_USER=user
-          - MYSQL_DATABASE=db
-      - &redis
-        image: redis:4.0-alpine
-      - &mongo
-        image: mongo:3.6
-      - &elasticsearch
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
-      - &rabbitmq
-        image: rabbitmq:3.6-alpine
   lint:
     docker:
       - image: node
@@ -49,23 +66,6 @@ jobs:
       - run:
           name: Test
           command: npm run leak
-  build-node-base: &node-base
-    <<: *docker-base
-    working_directory: ~/dd-trace-js
-    steps:
-      - checkout
-      - run:
-          name: Versions
-          command: npm version
-      - run:
-          name: Install dependencies
-          command: npm install
-      - run:
-          name: Test
-          command: npm test
-      - run:
-          name: Benchmark
-          command: npm run bench
   build-node-4:
     <<: *node-base
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,8 @@
 version: 2
 jobs:
-  lint:
-    docker:
-      - image: node
-    working_directory: ~/dd-trace-js
-    steps:
-      - checkout
-      - run:
-          name: Versions
-          command: npm version
-      - run:
-          name: Install dependencies
-          command: npm install
-      - run:
-          name: Lint
-          command: npm run lint
-  test-memory-leaks:
+  docker-base: &docker-base
     docker:
       - image: node:8
-    working_directory: ~/dd-trace-js
-    steps:
-      - checkout
-      - run:
-          name: Versions
-          command: npm version
-      - run:
-          name: Install dependencies
-          command: npm install
-      - run:
-          name: Test
-          command: npm run leak
-  build-node-base: &node-base
-    docker:
-      - image: node
       - &postgres
         image: postgres:9.5
       - &mysql
@@ -50,6 +20,37 @@ jobs:
         image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
       - &rabbitmq
         image: rabbitmq:3.6-alpine
+  lint:
+    docker:
+      - image: node
+    working_directory: ~/dd-trace-js
+    steps:
+      - checkout
+      - run:
+          name: Versions
+          command: npm version
+      - run:
+          name: Install dependencies
+          command: npm install
+      - run:
+          name: Lint
+          command: npm run lint
+  test-memory-leaks:
+    <<: *docker-base
+    working_directory: ~/dd-trace-js
+    steps:
+      - checkout
+      - run:
+          name: Versions
+          command: npm version
+      - run:
+          name: Install dependencies
+          command: npm install
+      - run:
+          name: Test
+          command: npm run leak
+  build-node-base: &node-base
+    <<: *docker-base
     working_directory: ~/dd-trace-js
     steps:
       - checkout

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -16,6 +16,7 @@ require,require-in-the-middle,MIT,Copyright 2016-2018 Thomas Watson Steen
 require,safe-buffer,MIT,Copyright Feross Aboukhadijeh
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,url-parse,MIT,Copyright 2015 Unshift.io Arnout Kazemier the Contributors
+dev,@airbnb/node-memwatch,WTFPL,Copyright Lloyd Hilaiel
 dev,amqplib,MIT,Copyright 2013-2014 Michael Bridgen
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie
 dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David Dalton
@@ -49,3 +50,4 @@ dev,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
 dev,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen
 dev,sinon-chai,WTFPL and BSD-2-Clause,Copyright 2004 Sam Hocevar 2012–2017 Domenic Denicola
+dev,tape,MIT,Copyright James Halliday

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ docker-compose configuration:
 $ docker-compose up -d
 ```
 
+#### Unit Tests
+
 To run the unit tests, use:
 
 ```sh
@@ -51,6 +53,16 @@ To run the unit tests continuously in watch mode while developing, use:
 ```sh
 $ npm run tdd
 ```
+
+#### Memory Leaks
+
+To run the memory leak tests, use:
+
+```sh
+$ npm run leak
+```
+
+Please note that memory leak tests only run on Node `>=8`.
 
 ### Linting
 
@@ -73,6 +85,7 @@ After installing the `circleci` CLI, simply run one of the following:
 
 ```sh
 $ circleci build --job lint
+$ circleci build --job test-memory-leaks
 $ circleci build --job build-node-4
 $ circleci build --job build-node-6
 $ circleci build --job build-node-8

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "jsdoc:watch": "gulp jsdoc:watch",
     "lint": "eslint . && node scripts/check_licenses.js",
     "tdd": "mocha --watch",
-    "test": "nyc --reporter text --reporter lcov mocha 'test/**/*.spec.js'"
+    "test": "nyc --reporter text --reporter lcov mocha 'test/**/*.spec.js'",
+    "leak": "node --no-warnings ./node_modules/.bin/tape 'test/leak/**/*.js'"
   },
   "repository": {
     "type": "git",
@@ -83,6 +84,10 @@
     "redis": "^2.8.0",
     "retry": "^0.10.1",
     "sinon": "^4.2.1",
-    "sinon-chai": "^2.14.0"
+    "sinon-chai": "^2.14.0",
+    "tape": "^4.9.1"
+  },
+  "optionalDependencies": {
+    "@airbnb/node-memwatch": "^1.0.2"
   }
 }

--- a/scripts/check_licenses.js
+++ b/scripts/check_licenses.js
@@ -8,6 +8,7 @@ const pkg = require(path.join(__dirname, '..', '/package.json'))
 const filePath = path.join(__dirname, '..', '/LICENSE-3rdparty.csv')
 const deps = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.devDependencies))
+  .concat(Object.keys(pkg.optionalDependencies))
   .sort()
 
 let index = 0

--- a/test/leak/plugins/amqplib.js
+++ b/test/leak/plugins/amqplib.js
@@ -1,0 +1,40 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('amqplib')
+
+const test = require('tape')
+const profile = require('../../profile')
+
+test('amqplib plugin should not leak when using callbacks', t => {
+  require('amqplib/callback_api')
+    .connect((err, conn) => {
+      if (err) return t.fail(err)
+
+      conn.createChannel((err, ch) => {
+        if (err) return t.fail(err)
+
+        profile(t, operation).then(() => conn.close())
+
+        function operation (done) {
+          ch.assertQueue('test', {}, done)
+        }
+      })
+    })
+})
+
+test('amqplib plugin should not leak when using promises', t => {
+  require('amqplib').connect()
+    .then(conn => {
+      return conn.createChannel()
+        .then(ch => {
+          profile(t, operation).then(() => conn.close())
+
+          function operation (done) {
+            ch.assertQueue('test', {}).then(done)
+          }
+        })
+    })
+    .catch(t.fail)
+})

--- a/test/leak/plugins/graphql.js
+++ b/test/leak/plugins/graphql.js
@@ -1,0 +1,25 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('graphql')
+
+const test = require('tape')
+const graphql = require('graphql')
+const profile = require('../../profile')
+
+test('graphql plugin should not leak', t => {
+  const schema = graphql.buildSchema(`
+    type Query {
+      hello: String
+    }
+  `)
+
+  const source = `{ hello }`
+
+  profile(t, operation)
+
+  function operation (done) {
+    graphql.graphql(schema, source).then(done)
+  }
+})

--- a/test/leak/plugins/mongodb-core.js
+++ b/test/leak/plugins/mongodb-core.js
@@ -1,0 +1,29 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('mongodb-core')
+
+const test = require('tape')
+const mongo = require('mongodb-core')
+const profile = require('../../profile')
+
+test('mongodb-core plugin should not leak', t => {
+  const server = new mongo.Server({
+    host: 'localhost',
+    port: 27017,
+    reconnect: false
+  })
+
+  server.on('connect', () => {
+    profile(t, operation).then(() => server.destroy())
+  })
+
+  server.on('error', t.fail)
+
+  server.connect()
+
+  function operation (done) {
+    server.insert(`test.1234`, [{ a: 1 }], {}, done)
+  }
+})

--- a/test/leak/plugins/mysql.js
+++ b/test/leak/plugins/mysql.js
@@ -1,0 +1,28 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('mysql')
+
+const test = require('tape')
+const mysql = require('mysql')
+const profile = require('../../profile')
+
+test('mysql plugin should not leak', t => {
+  const connection = mysql.createConnection({
+    host: 'localhost',
+    user: 'user',
+    password: 'userpass',
+    database: 'db'
+  })
+
+  connection.connect(err => {
+    if (err) return t.fail(err)
+
+    profile(t, operation).then(() => connection.end())
+  })
+
+  function operation (done) {
+    connection.query('SELECT 1 + 1 AS solution', done)
+  }
+})

--- a/test/leak/plugins/mysql2.js
+++ b/test/leak/plugins/mysql2.js
@@ -1,0 +1,28 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('mysql2')
+
+const test = require('tape')
+const mysql2 = require('mysql2')
+const profile = require('../../profile')
+
+test('mysql2 plugin should not leak', t => {
+  const connection = mysql2.createConnection({
+    host: 'localhost',
+    user: 'user',
+    password: 'userpass',
+    database: 'db'
+  })
+
+  connection.connect(err => {
+    if (err) return t.fail(err)
+
+    profile(t, operation).then(() => connection.end())
+  })
+
+  function operation (done) {
+    connection.query('SELECT 1 + 1 AS solution', done)
+  }
+})

--- a/test/leak/plugins/pg.js
+++ b/test/leak/plugins/pg.js
@@ -1,0 +1,28 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('pg')
+
+const test = require('tape')
+const pg = require('pg')
+const profile = require('../../profile')
+
+test('pg plugin should not leak', t => {
+  const client = new pg.Client({
+    user: 'postgres',
+    password: 'postgres',
+    database: 'postgres',
+    application_name: 'test'
+  })
+
+  client.connect(err => {
+    if (err) return t.fail(err)
+
+    profile(t, operation).then(() => client.end())
+  })
+
+  function operation (done) {
+    client.query('SELECT 1 + 1 AS solution', done)
+  }
+})

--- a/test/leak/plugins/redis.js
+++ b/test/leak/plugins/redis.js
@@ -1,0 +1,19 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('redis')
+
+const test = require('tape')
+const redis = require('redis')
+const profile = require('../../profile')
+
+test('redis plugin should not leak', t => {
+  const client = redis.createClient()
+
+  profile(t, operation).then(() => client.quit())
+
+  function operation (done) {
+    client.get('foo', done)
+  }
+})

--- a/test/leak/scope_manager.js
+++ b/test/leak/scope_manager.js
@@ -1,0 +1,14 @@
+'use strict'
+
+require('../..').init()
+
+const test = require('tape')
+const profile = require('../profile')
+
+test('ScopeManager should destroy executions even if their context is already destroyed', t => {
+  profile(t, operation)
+
+  function operation (done) {
+    Promise.resolve().then(done)
+  }
+})

--- a/test/leak/tracer.js
+++ b/test/leak/tracer.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const tracer = require('../..').init()
+
+const test = require('tape')
+const profile = require('../profile')
+
+test('Tracer should not keep unfinished spans in memory if they are no longer needed', t => {
+  profile(t, operation)
+
+  function operation (done) {
+    tracer.startSpan('test')
+    done()
+  }
+})

--- a/test/profile.js
+++ b/test/profile.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const memwatch = require('@airbnb/node-memwatch')
+
+function profile (t, operation, iterations, concurrency) {
+  t.plan(1)
+
+  iterations = iterations || 1000
+  concurrency = concurrency || 5
+
+  let error = null
+
+  const handleWarning = e => {
+    if (e.name === 'MaxListenersExceededWarning') {
+      error = error || e
+    }
+  }
+
+  process.on('warning', handleWarning)
+
+  const promises = []
+  const hd = new memwatch.HeapDiff()
+
+  for (let i = 0; i < concurrency; i++) {
+    const promise = new Promise((resolve, reject) => {
+      start(0)
+
+      function start (count) {
+        if (count === iterations || error) {
+          return resolve()
+        }
+
+        operation(() => {
+          setImmediate(() => start(count + 1))
+        })
+      }
+    })
+
+    promises.push(promise)
+  }
+
+  return Promise.all(promises)
+    .then(() => {
+      if (error) {
+        log(t, error.stack)
+        t.fail('event listener leak detected')
+        return
+      }
+
+      const diff = hd.end()
+      const leaks = diff.change.details.filter(change => {
+        const max = iterations * concurrency
+
+        return change['+'] >= max
+      })
+
+      process.removeListener('warning', handleWarning)
+
+      if (leaks.length > 0) {
+        log(t, JSON.stringify(diff, null, 2))
+        t.fail('memory leak detected')
+      } else {
+        t.pass('no memory leak detected')
+      }
+    })
+}
+
+function log (t, message) {
+  message.split('\n').forEach(line => {
+    t.emit('result', line)
+  })
+}
+
+module.exports = profile


### PR DESCRIPTION
This PR adds tests to detect memory leaks. It uses a single heap diff of several thousands iterations and assumes that if any object type has more instances in memory than the number of iterations there is a leak.

Right now only components that don't interact with `http` are tested, since there is a [bug](https://github.com/nodejs/node/issues/19859) in Node where calling the `http` module in quick successions always results in a memory leak.