### PR TITLE
fix memory leak when using scopes with recursive timers

### DIFF
--- a/src/scope/context.js
+++ b/src/scope/context.js
@@ -23,9 +23,12 @@ class Context {
   }
 
   link (parent) {
-    this.unlink()
+    const oldParent = this._parent
+
     this._parent = parent
     this._parent.attach(this)
+
+    oldParent && oldParent.detach(this)
   }
 
   unlink () {

--- a/src/scope/context_execution.js
+++ b/src/scope/context_execution.js
@@ -7,6 +7,7 @@ class ContextExecution {
     this._active = null
     this._count = 0
     this._set = []
+    this._executed = false
 
     if (context) {
       context.retain()
@@ -43,12 +44,15 @@ class ContextExecution {
 
     this._set.splice(index, 1)
     this._active = this._set[this._set.length - 1] || null
+
+    if (this._executed) {
+      this._bypass()
+    }
   }
 
   exit () {
-    if (this._context && !this._active) {
-      this._bypass()
-    }
+    this._executed = true
+    this._bypass()
   }
 
   attach (child) {
@@ -76,7 +80,9 @@ class ContextExecution {
   }
 
   _bypass () {
-    this._children.forEach(child => child.link(this._context.parent()))
+    if (this._context && !this._active) {
+      this._children.forEach(child => child.link(this._context.parent()))
+    }
   }
 }
 

--- a/test/leak/scope_manager.js
+++ b/test/leak/scope_manager.js
@@ -1,6 +1,6 @@
 'use strict'
 
-require('../..').init()
+const tracer = require('../..').init()
 
 const test = require('tape')
 const profile = require('../profile')
@@ -10,5 +10,19 @@ test('ScopeManager should destroy executions even if their context is already de
 
   function operation (done) {
     Promise.resolve().then(done)
+  }
+})
+
+test('ScopeManager should not leak when using scopes with recursive timers', t => {
+  profile(t, operation)
+
+  function operation (done) {
+    const active = tracer.scopeManager().active()
+
+    active && active.close()
+
+    tracer.scopeManager().activate({})
+
+    done()
   }
 })


### PR DESCRIPTION
This PR fixes a memory leak when using scopes with recursive timers.

The problem is that context executions are only completely removed from the linked list of the current context when no scope is created inside them. This works for most use cases, but not if scopes are created in recursive timers. Since every new context is always a child of the previous context, this creates an infinite number of nested contexts that are never cleaned up. The most common use case for this are task queues, which are used internally in a few libraries such as Bluebird.