### PR TITLE
fix memory leak in express when used with recursive timers

### DIFF
--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -323,31 +323,6 @@ describe('Plugin', () => {
         })
       })
 
-      it('should support context propagation', done => {
-        const app = express()
-        const span = tracer.startSpan('test')
-
-        let scope
-
-        app.use((req, res, next) => {
-          scope = tracer.scopeManager().activate(span)
-          next()
-        })
-
-        app.get('/user', (req, res) => {
-          res.status(200).send()
-          expect(tracer.scopeManager().active()).to.equal(scope)
-          done()
-        })
-
-        getPort().then(port => {
-          appListener = app.listen(port, 'localhost', () => {
-            axios.get(`http://localhost:${port}/user`)
-              .catch(done)
-          })
-        })
-      })
-
       it('should reactivate the span when the active scope is closed', done => {
         const app = express()
 


### PR DESCRIPTION
This PR fixes a memory leak in express when used with recursive timers. Basically it would be possible in some cases where `next()` is called within an external task queue that the scope would stay active forever or become available to other requests.

The test that was removed is actually a use case that was never officially supported for a behavior that shouldn't be relied upon.

Related to #227 