### PR TITLE
fix express leaking scope on other requests when using task queues

### DIFF
--- a/test/leak/plugins/express.js
+++ b/test/leak/plugins/express.js
@@ -1,0 +1,29 @@
+'use strict'
+
+require('../../..')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('express')
+
+const test = require('tape')
+const express = require('express')
+const axios = require('axios')
+const getPort = require('get-port')
+const profile = require('../../profile')
+
+test('express plugin should not leak', t => {
+  getPort().then(port => {
+    const app = express()
+
+    app.use((req, res) => {
+      res.status(200).send()
+    })
+
+    const listener = app.listen(port, '127.0.0.1', () => {
+      profile(t, operation).then(() => listener.close())
+
+      function operation (done) {
+        axios.get(`http://localhost:${port}`).then(done)
+      }
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes the `express` integration that could leak the active scope of the current requests to other incoming requests when used with a task queue.

Task queues can schedule tasks to run synchronously. This means it's possible that multiple `next` handlers are queued one after the other from different requests. Since the task queue has its own asynchronous context, all concurrent requests would end up sharing their scopes in that context.