### PR TITLE
[GraphQL] Include variables in metadata.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -166,15 +166,17 @@ query HelloWorld {
 
 <h5 id="graphql-tags">Tags</h5>
 
-| Tag              | Description                                               |
-|------------------|-----------------------------------------------------------|
-| graphql.document | The original GraphQL document.                            |
+| Tag               | Description                                               |
+|-------------------|-----------------------------------------------------------|
+| graphql.document  | The original GraphQL document.                            |
+| graphql.variables | The variables applied to the document.                    |
 
 <h5 id="graphql-config">Configuration Options</h5>
 
-| Option  | Default                                          | Description                            |
-|---------|--------------------------------------------------|----------------------------------------|
-| service | *Service name of the app suffixed with -graphql* | The service name for this integration. |
+| Option          | Default                                          | Description                                                      |
+|-----------------|--------------------------------------------------|------------------------------------------------------------------|
+| service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                           |
+| filterVariables | `variables => variables`                         | A callback that allows filtering of variables before submission. |
 
 <h3 id="http">http / https</h3>
 

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -10,6 +10,7 @@ function createWrapExecute (tracer, config, defaultFieldResolver, responsePathAs
       const document = args.document
       const contextValue = args.contextValue || {}
       const fieldResolver = args.fieldResolver || defaultFieldResolver
+      const variableValues = args.variableValues
       const operation = getOperation(document)
 
       if (!schema || !operation || typeof fieldResolver !== 'function') {
@@ -30,7 +31,7 @@ function createWrapExecute (tracer, config, defaultFieldResolver, responsePathAs
         Object.defineProperties(contextValue, {
           _datadog_operation: {
             value: {
-              span: createOperationSpan(tracer, config, operation, document._datadog_source)
+              span: createOperationSpan(tracer, config, operation, document._datadog_source, variableValues)
             }
           },
           _datadog_fields: { value: {} }
@@ -172,7 +173,7 @@ function normalizeArgs (args) {
   }
 }
 
-function createOperationSpan (tracer, config, operation, source) {
+function createOperationSpan (tracer, config, operation, source, variableValues) {
   const type = operation.operation
   const name = operation.name && operation.name.value
 
@@ -182,7 +183,9 @@ function createOperationSpan (tracer, config, operation, source) {
     tags: {
       'service.name': getService(tracer, config),
       'resource.name': [type, name].filter(val => val).join(' '),
-      'graphql.document': source
+      'graphql.document': source,
+      'graphql.variables': variableValues &&
+        JSON.stringify(config.filterVariables ? config.filterVariables(variableValues) : variableValues)
     }
   })
 


### PR DESCRIPTION
This allows one to identify problematic queries when specific variables are applied.

A filter callback is included so sensitive data can be redacted, which I _assume_ is why this wasn’t included yet.