### PR TITLE
fix missing path on errors in express plugin

### DIFF
--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -129,8 +129,8 @@ function wrapNext (tracer, layer, req, next) {
   req._datadog.scope && req._datadog.scope.close()
   req._datadog.scope = tracer.scopeManager().activate(req._datadog.span)
 
-  return function () {
-    if (layer.path && !layer.regexp.fast_star) {
+  return function (error) {
+    if (!error && layer.path && !layer.regexp.fast_star) {
       req._datadog.paths.pop()
     }
 

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -302,6 +302,33 @@ describe('Plugin', () => {
         })
       })
 
+      it('should not lose the current path on error', done => {
+        const app = express()
+
+        app.get('/app', (req, res, next) => {
+          next(new Error())
+        })
+
+        app.use((error, req, res, next) => {
+          res.status(200).send(error.message)
+        })
+
+        getPort().then(port => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('resource', 'GET /app')
+            })
+            .then(done)
+            .catch(done)
+
+          appListener = app.listen(port, 'localhost', () => {
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
+          })
+        })
+      })
+
       it('should not leak the current scope to other requests when using a task queue', done => {
         const app = express()
 


### PR DESCRIPTION
This PR fixes `express.request` spans missing the path in the resource name when an error middleware is registered and an error is thrown.

The assumption was that if any given middleware is called from another middleware by calling `next()`, the previous middleware was not a router and didn't handle the request so its path parth should be removed from the full path. This is however not true for errors since these can be thrown from within routers as well and lead to another middleware being called with `next(error)`.

Fixes #236 