### PR TITLE
fix multiple executions with the same contextValue in graphql

### DIFF
--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -26,14 +26,16 @@ function createWrapExecute (tracer, config, defaultFieldResolver, responsePathAs
         schema._datadog_patched = true
       }
 
-      Object.defineProperties(contextValue, {
-        _datadog_operation: {
-          value: {
-            span: createOperationSpan(tracer, config, operation, document._datadog_source)
-          }
-        },
-        _datadog_fields: { value: {} }
-      })
+      if (!contextValue._datadog_operation) {
+        Object.defineProperties(contextValue, {
+          _datadog_operation: {
+            value: {
+              span: createOperationSpan(tracer, config, operation, document._datadog_source)
+            }
+          },
+          _datadog_fields: { value: {} }
+        })
+      }
 
       return call(execute, this, [args], err => finishOperation(contextValue, err))
     }

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -644,6 +644,43 @@ describe('Plugin', () => {
 
         graphql.graphql({ schema, source, rootValue }).catch(done)
       })
+
+      it('should support multiple executions with the same contextValue', done => {
+        const error = new Error('test')
+
+        const schema = graphql.buildSchema(`
+          type Query {
+            hello: String
+          }
+        `)
+
+        const source = `{ hello }`
+
+        const rootValue = {
+          hello: () => {
+            return Promise.reject(error)
+          }
+        }
+
+        const contextValue = {}
+
+        agent
+          .use(traces => {
+            const spans = sort(traces[0])
+
+            expect(spans).to.have.length(3)
+            expect(spans[2]).to.have.property('error', 1)
+            expect(spans[2].meta).to.have.property('error.type', error.name)
+            expect(spans[2].meta).to.have.property('error.msg', error.message)
+            expect(spans[2].meta).to.have.property('error.stack', error.stack)
+          })
+          .then(done)
+          .catch(done)
+
+        graphql.graphql({ schema, source, rootValue, contextValue })
+          .then(() => graphql.graphql({ schema, source, rootValue, contextValue }))
+          .catch(done)
+      })
     })
 
     describe('with configuration', () => {


### PR DESCRIPTION
This PR fixes errors from the `graphql` plugin when `execute()` is called multiple times with the same contextValue. The assumption was that this cannot happen but when using schema stitching the same contextValue is used multiple times.

Note: This doesn't add full support for schema stitching. It only fixes the immediate issue with the error.

Related to #235