### PR TITLE
fix mongodb-core plugin not sanitizing buffers in resource name

### DIFF
--- a/src/plugins/mongodb-core.js
+++ b/src/plugins/mongodb-core.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
+
 // TODO: remove sanitization when implemented by the agent
 
 // Reference https://docs.mongodb.com/v3.6/reference/command/
@@ -279,7 +281,7 @@ function sanitize (input) {
   const output = {}
 
   for (const key in input) {
-    if (isObject(input[key])) {
+    if (isObject(input[key]) && !Buffer.isBuffer(input[key])) {
       output[key] = sanitize(input[key])
     } else {
       output[key] = '?'

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const agent = require('./agent')
+const Buffer = require('safe-buffer').Buffer
 
 wrapIt()
 
@@ -117,6 +118,25 @@ describe('Plugin', () => {
               bar: {
                 baz: [1, 2, 3]
               }
+            }
+          }, () => {})
+        })
+
+        it('should sanitize buffers as values and not as objects', done => {
+          agent
+            .use(traces => {
+              const span = traces[0][0]
+              const resource = `find test.${collection} {"_id":"?"}`
+
+              expect(span).to.have.property('resource', resource)
+            })
+            .then(done)
+            .catch(done)
+
+          server.command(`test.${collection}`, {
+            find: `test.${collection}`,
+            query: {
+              _id: Buffer.from('1234')
             }
           }, () => {})
         })


### PR DESCRIPTION
This PR fixes the `mongodb-core` plugin not sanitizing buffers in the resource name. Since the resource name is a serialized representation of the query, it would include any buffer as its own serialized representation instead of obfuscating them as values. Buffers are now properly considered values.

Reported in #221 