### PR TITLE
don't consume response data if we detect dynamodb crc32 headers

### DIFF
--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -49,7 +49,10 @@ function patch (http, tracer, config) {
 
         // empty the data stream when no other listener exists to consume it
         if (req.listenerCount('response') === 1) {
-          res.resume()
+          // unless aws-sdk is waiting to checksum a dynamodb payload
+          if (!('x-amz-crc32' in res.headers)) {
+            res.resume()
+          }
         }
       })
 


### PR DESCRIPTION
This PR fixes failures when querying DynamoDB via the aws-sdk module. The http plugin consumes the DynamoDB response body before aws-sdk can perform its CRC32 check, so requests fail and you see errors like this:
```
{ CRC32CheckFailed: CRC32 integrity check failed
    at Request.checkCrc32 (/private/tmp/node_modules/aws-sdk/lib/services/dynamodb.js:22:35)
const tracer = require('dd-trace').init({
    at Request.callListeners (/private/tmp/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/private/tmp/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/private/tmp/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/private/tmp/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/private/tmp/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /private/tmp/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/private/tmp/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/private/tmp/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/private/tmp/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
  message: 'CRC32 integrity check failed',
  code: 'CRC32CheckFailed',
  retryable: true,
  time: 2018-08-16T18:18:54.282Z,
  statusCode: 200 } 'CRC32CheckFailed: CRC32 integrity check failed\n    at Request.checkCrc32 (/private/tmp/node_modules/aws-sdk/lib/services/dynamodb.js:22:35)\n    at Request.callListeners (/private/tmp/node_modules/aws-sdk/lib/sequential_executor.js:105:20)\n    at Request.emit (/private/tmp/node_modules/aws-sdk/lib/sequential_executor.js:77:10)\n    at Request.emit (/private/tmp/node_modules/aws-sdk/lib/request.js:683:14)\n    at Request.transition (/private/tmp/node_modules/aws-sdk/lib/request.js:22:10)\n    at AcceptorStateMachine.runTo (/private/tmp/node_modules/aws-sdk/lib/state_machine.js:14:12)\n    at /private/tmp/node_modules/aws-sdk/lib/state_machine.js:26:10\n    at Request.<anonymous> (/private/tmp/node_modules/aws-sdk/lib/request.js:38:9)\n    at Request.<anonymous> (/private/tmp/node_modules/aws-sdk/lib/request.js:685:12)\n    at Request.callListeners (/private/tmp/node_modules/aws-sdk/lib/sequential_executor.js:115:18)'
```

The fix checks for the x-amz-crc32 response header and bypasses the resume() call if detected. AFAICT, DynamoDB is the only service that uses x-amz-crc32.

However, I've also noticed that adding a ```require('http')``` after initializing the tracer object also fixes the problem, so there may be a more elegant solution.