### PR TITLE
fix http plugin resuming the stream before it can be consumed

### DIFF
--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -149,6 +149,26 @@ describe('Plugin', () => {
         })
       })
 
+      it('should wait for other listeners before resuming the response stream', done => {
+        const app = express()
+
+        app.get('/user', (req, res) => {
+          res.status(200).send('OK')
+        })
+
+        getPort().then(port => {
+          appListener = app.listen(port, 'localhost', () => {
+            const req = http.request(`http://localhost:${port}/user`, res => {
+              setTimeout(() => {
+                res.on('data', () => done())
+              })
+            })
+
+            req.end()
+          })
+        })
+      })
+
       it('should inject its parent span in the headers', done => {
         const app = express()
 


### PR DESCRIPTION
This PR fixes the `http` plugin resuming the stream before it can be consumed. When listeners are registered using `req.once`, the listener count doesn't include these listeners after they are done running. This means that the plugin would detect that no listener is registered and resume the stream, effectively discarding the data, even though there was a listener that has since been removed.

By doing the check just before the response is received, listeners have not yet run so the check is safe.