### PR TITLE
[GraphQL] Instrument document parsing & validation and include variables in metadata

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -166,10 +166,10 @@ query HelloWorld {
 
 <h5 id="graphql-tags">Tags</h5>
 
-| Tag               | Description                                               |
-|-------------------|-----------------------------------------------------------|
-| graphql.document  | The original GraphQL document.                            |
-| graphql.variables | The variables applied to the document.                    |
+| Tag                 | Description                                               |
+|---------------------|-----------------------------------------------------------|
+| graphql.document    | The original GraphQL document.                            |
+| graphql.variables.* | The variables applied to the document.                    |
 
 <h5 id="graphql-config">Configuration Options</h5>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -166,16 +166,18 @@ query HelloWorld {
 
 <h5 id="graphql-tags">Tags</h5>
 
-| Tag              | Description                                               |
-|------------------|-----------------------------------------------------------|
-| graphql.document | The original GraphQL document.                            |
+| Tag               | Description                                               |
+|-------------------|-----------------------------------------------------------|
+| graphql.document  | The original GraphQL document.                            |
+| graphql.variables | The variables applied to the document.                    |
 
 <h5 id="graphql-config">Configuration Options</h5>
 
-| Option  | Default                                          | Description                            |
-|---------|--------------------------------------------------|----------------------------------------|
-| service | *Service name of the app suffixed with -graphql* | The service name for this integration. |
-| depth   | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
+| Option          | Default                                          | Description                                                      |
+|-----------------|--------------------------------------------------|------------------------------------------------------------------|
+| service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                           |
+| filterVariables | `variables => variables`                         | A callback that allows filtering of variables before submission. |
+| depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
 
 <h3 id="http">http / https</h3>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -173,10 +173,10 @@ query HelloWorld {
 
 <h5 id="graphql-config">Configuration Options</h5>
 
-| Option          | Default                                          | Description                                                      |
-|-----------------|--------------------------------------------------|------------------------------------------------------------------|
-| service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                           |
-| filterVariables | `variables => variables`                         | A callback that allows filtering of variables before submission. |
+| Option          | Default                                          | Description                                                            |
+|-----------------|--------------------------------------------------|------------------------------------------------------------------------|
+| service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                                 |
+| filterVariables | `undefined` *No variables will be recorded*      | To enable recording provide a callback. E.g. `variables => variables`. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
 
 <h3 id="http">http / https</h3>

--- a/docs/API.md
+++ b/docs/API.md
@@ -176,7 +176,7 @@ query HelloWorld {
 | Option          | Default                                          | Description                                                            |
 |-----------------|--------------------------------------------------|------------------------------------------------------------------------|
 | service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                                 |
-| variables       | `undefined`                                      | A callback to enable recording of variables. By default, no variables are recorded. For example, using variables => variables would record all variables. |
+| variables       | `undefined`                                      | A callback to enable recording of variables. By default, no variables are recorded. For example, using `variables => variables` would record all variables. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
 
 <h3 id="http">http / https</h3>

--- a/docs/API.md
+++ b/docs/API.md
@@ -176,7 +176,7 @@ query HelloWorld {
 | Option          | Default                                          | Description                                                            |
 |-----------------|--------------------------------------------------|------------------------------------------------------------------------|
 | service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                                 |
-| filterVariables | `undefined` *No variables will be recorded*      | To enable recording provide a callback. E.g. `variables => variables`. |
+| variables       | `undefined` *No variables will be recorded*      | To enable recording provide a callback. E.g. `variables => variables`. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
 
 <h3 id="http">http / https</h3>

--- a/docs/API.md
+++ b/docs/API.md
@@ -176,7 +176,7 @@ query HelloWorld {
 | Option          | Default                                          | Description                                                            |
 |-----------------|--------------------------------------------------|------------------------------------------------------------------------|
 | service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                                 |
-| variables       | `undefined` *No variables will be recorded*      | To enable recording provide a callback. E.g. `variables => variables`. |
+| variables       | `undefined`                                      | A callback to enable recording of variables. By default, no variables are recorded. For example, using variables => variables would record all variables. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
 
 <h3 id="http">http / https</h3>

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -240,7 +240,10 @@ function createOperationSpan (tracer, config, operation, source, variableValues,
     'graphql.document': source
   }
   if (variableValues && config.variables) {
-    tags['graphql.variables'] = JSON.stringify(config.variables(variableValues))
+    const variables = config.variables(variableValues)
+    for (const param in variables) {
+      tags[`graphql.variables.${param}`] = variables[param]
+    }
   }
   const span = tracer.startSpan(`graphql.${operation.operation}`, {
     tags,

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -81,10 +81,10 @@ function createWrapExecute (tracer, config, defaultFieldResolver, responsePathAs
       )
 
       if (document._datadog_parse_time) {
-        createFinishedSpan(tracer, config, 'parse-document', document._datadog_parse_time, span)
+        createFinishedSpan(tracer, config, 'parse', document._datadog_parse_time, span)
       }
       if (document._datadog_validate_time) {
-        createFinishedSpan(tracer, config, 'validate-document', document._datadog_validate_time, span)
+        createFinishedSpan(tracer, config, 'validate', document._datadog_validate_time, span)
       }
 
       if (!contextValue._datadog_operation) {

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -34,30 +34,30 @@ function createWrapExecute (tracer, config, defaultFieldResolver, responsePathAs
         }
       }
 
-      const parseTime = document._datadog_parse_time
-      const validateTime = document._datadog_validate_time
-
-      const operationSpan = createOperationSpan(
-        tracer,
-        config,
-        operation,
-        document._datadog_source,
-        variableValues,
-        (parseTime && parseTime.start) || (validateTime && validateTime.start)
-      )
-
-      if (parseTime) {
-        const span = createSpan(tracer, config, 'parse', operationSpan, parseTime.start)
-        span.finish(parseTime.end)
-      }
-      if (validateTime) {
-        const span = createSpan(tracer, config, 'validate', operationSpan, validateTime.start)
-        span.finish(validateTime.end)
-      }
-
-      const executeSpan = createSpan(tracer, config, 'execute', operationSpan)
-
       if (!contextValue._datadog_spans) {
+        const parseTime = document._datadog_parse_time
+        const validateTime = document._datadog_validate_time
+
+        const operationSpan = createOperationSpan(
+          tracer,
+          config,
+          operation,
+          document._datadog_source,
+          variableValues,
+          (parseTime && parseTime.start) || (validateTime && validateTime.start)
+        )
+
+        if (parseTime) {
+          const span = createSpan(tracer, config, 'parse', operationSpan, parseTime.start)
+          span.finish(parseTime.end)
+        }
+        if (validateTime) {
+          const span = createSpan(tracer, config, 'validate', operationSpan, validateTime.start)
+          span.finish(validateTime.end)
+        }
+
+        const executeSpan = createSpan(tracer, config, 'execute', operationSpan)
+
         Object.defineProperties(contextValue, {
           _datadog_spans: {
             value: { executeSpan, operationSpan }
@@ -239,8 +239,8 @@ function createOperationSpan (tracer, config, operation, source, variableValues,
     'resource.name': [type, name].filter(val => val).join(' '),
     'graphql.document': source
   }
-  if (variableValues && config.filterVariables) {
-    tags['graphql.variables'] = JSON.stringify(config.filterVariables(variableValues))
+  if (variableValues && config.variables) {
+    tags['graphql.variables'] = JSON.stringify(config.variables(variableValues))
   }
   const span = tracer.startSpan(`graphql.${operation.operation}`, {
     tags,

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -809,10 +809,8 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans[0].meta).to.have.property(
-                'graphql.variables',
-                JSON.stringify({ title: 'planet', who: 'REDACTED' })
-              )
+              expect(spans[0].meta).to.have.property('graphql.variables.title', 'planet')
+              expect(spans[0].meta).to.have.property('graphql.variables.who', 'REDACTED')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -239,7 +239,7 @@ describe('Plugin', () => {
               const query = spans[0]
               const parse = spans[1]
               expect(parse).to.have.property('service', 'test-graphql')
-              expect(parse).to.have.property('name', 'graphql.parse-document')
+              expect(parse).to.have.property('name', 'graphql.parse')
               expect(parse.parent_id.toString()).to.equal(query.span_id.toString())
               expect(parse.start.toNumber()).to.be.gte(query.start.toNumber())
               expect(parse.duration.toNumber()).to.be.lte(query.duration.toNumber())
@@ -261,7 +261,7 @@ describe('Plugin', () => {
               const parse = spans[1]
               const validate = spans[2]
               expect(validate).to.have.property('service', 'test-graphql')
-              expect(validate).to.have.property('name', 'graphql.validate-document')
+              expect(validate).to.have.property('name', 'graphql.validate')
 
               expect(validate.parent_id.toString()).to.equal(query.span_id.toString())
               expect(validate.start.toNumber()).to.be.gte(parse.start.toNumber())

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -161,7 +161,7 @@ describe('Plugin', () => {
         })
 
         it('should instrument operations', done => {
-          const source = `query MyQuery($who: String!) { hello(name: $who) }`
+          const source = `query MyQuery { hello(name: "world") }`
 
           agent
             .use(traces => {
@@ -172,7 +172,20 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('name', 'graphql.query')
               expect(spans[0]).to.have.property('resource', 'query MyQuery')
               expect(spans[0].meta).to.have.property('graphql.document', source)
-              expect(spans[0].meta).to.have.property('graphql.variables', JSON.stringify({ who: 'world' }))
+            })
+            .then(done)
+            .catch(done)
+
+          graphql.graphql(schema, source, null, null, { who: 'world' }).catch(done)
+        })
+
+        it('should not include variables by default', done => {
+          const source = `query MyQuery($who: String!) { hello(name: $who) }`
+
+          agent
+            .use(traces => {
+              const spans = sort(traces[0])
+              expect(spans[0].meta).to.not.have.property('graphql.variables')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -457,7 +457,7 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans).to.have.length(3)
+              expect(spans).to.have.length(6)
               expect(spans[0]).to.have.property('name', 'graphql.subscription')
             })
             .then(done)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -775,7 +775,7 @@ describe('Plugin', () => {
         beforeEach(() => {
           return agent.load(plugin, 'graphql', {
             service: 'test',
-            filterVariables: variables => Object.assign({}, variables, { who: 'REDACTED' })
+            variables: variables => Object.assign({}, variables, { who: 'REDACTED' })
           }).then(() => {
             graphql = require(`./versions/graphql@${version}`).get()
             buildSchema()

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -845,8 +845,11 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans).to.have.length(1)
+              expect(spans).to.have.length(4)
               expect(spans[0]).to.have.property('name', 'graphql.query')
+              expect(spans[1]).to.have.property('name', 'graphql.parse')
+              expect(spans[2]).to.have.property('name', 'graphql.validate')
+              expect(spans[3]).to.have.property('name', 'graphql.execute')
             })
             .then(done)
             .catch(done)
@@ -891,7 +894,7 @@ describe('Plugin', () => {
                 ].indexOf(span.resource) !== -1
               })
 
-              expect(spans).to.have.length(13)
+              expect(spans).to.have.length(16)
               expect(ignored).to.have.length(0)
             })
             .then(done)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -87,6 +87,10 @@ describe('Plugin', () => {
             args: {
               name: {
                 type: graphql.GraphQLString
+              },
+              title: {
+                type: graphql.GraphQLString,
+                defaultValue: null
               }
             },
             resolve (obj, args) {
@@ -157,7 +161,7 @@ describe('Plugin', () => {
         })
 
         it('should instrument operations', done => {
-          const source = `query MyQuery { hello(name: "world") }`
+          const source = `query MyQuery($who: String!) { hello(name: $who) }`
 
           agent
             .use(traces => {
@@ -168,6 +172,7 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('name', 'graphql.query')
               expect(spans[0]).to.have.property('resource', 'query MyQuery')
               expect(spans[0].meta).to.have.property('graphql.document', source)
+              expect(spans[0].meta).to.have.property('graphql.variables', JSON.stringify({ who: 'world' }))
             })
             .then(done)
             .catch(done)
@@ -688,11 +693,13 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'graphql', { service: 'test' })
-            .then(() => {
-              graphql = require(`./versions/graphql@${version}`).get()
-              buildSchema()
-            })
+          return agent.load(plugin, 'graphql', {
+            service: 'test',
+            filterVariables: variables => Object.assign({}, variables, { who: 'REDACTED' })
+          }).then(() => {
+            graphql = require(`./versions/graphql@${version}`).get()
+            buildSchema()
+          })
         })
 
         it('should be configured with the correct values', done => {
@@ -709,6 +716,28 @@ describe('Plugin', () => {
             .catch(done)
 
           graphql.graphql(schema, source).catch(done)
+        })
+
+        it('should apply the filter callback to the variables', done => {
+          const source = `
+            query MyQuery($title: String!, $who: String!) {
+              hello(title: $title, name: $who)
+            }
+          `
+
+          agent
+            .use(traces => {
+              const spans = sort(traces[0])
+
+              expect(spans[0].meta).to.have.property(
+                'graphql.variables',
+                JSON.stringify({ title: 'planet', who: 'REDACTED' })
+              )
+            })
+            .then(done)
+            .catch(done)
+
+          graphql.graphql(schema, source, null, null, { title: 'planet', who: 'world' }).catch(done)
         })
       })
 


### PR DESCRIPTION
So the logic in this PR may seem a little unintuitive at first, but my understanding of the existing code is that we really want the operation span to be the parent of all GraphQL related spans and we want to use the operation name as its name.

This means we can’t create the parse and validation spans _until_ the operation span has been created (otherwise we don’t have access to the parsed operation name), which is why my changes only record the timing but defer creation of the spans until the operation span is created.

I also ended up simplifying the tests a little, because they were a bit cumbersome to work with when adding new spans. Rather than assuming spans exist at a certain index, I added a helper function (`findSpan`) to find the spans based on data that the test previously asserted on. Additionally, most tests don’t really seem to need a total span count assertion, so I only left those in 2 places, which would make updating those a lot easier in the future.