### PR TITLE
Improve test services error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The easiest way to start all of them is to use the provided
 docker-compose configuration:
 
 ```sh
-$ docker-compose up -d
+$ docker-compose up -d -V --remove-orphans --force-recreate
 ```
 
 #### Unit Tests

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,6 +7,7 @@ const proxyquire = require('proxyquire')
 const nock = require('nock')
 const semver = require('semver')
 const retry = require('retry')
+const RetryOperation = require('retry/lib/retry_operation')
 const pg = require('pg')
 const mysql = require('mysql')
 const redis = require('redis')
@@ -61,7 +62,7 @@ function waitForServices () {
 
 function waitForPostgres () {
   return new Promise((resolve, reject) => {
-    const operation = retry.operation(retryOptions)
+    const operation = createOperation('postgres')
 
     operation.attempt(currentAttempt => {
       const client = new pg.Client({
@@ -72,15 +73,15 @@ function waitForPostgres () {
       })
 
       client.connect((err) => {
-        if (operation.retry(err)) return
+        if (retryOperation(operation, err)) return
         if (err) return reject(err)
 
         client.query('SELECT version()', (err, result) => {
-          if (operation.retry(err)) return
+          if (retryOperation(operation, err)) return
           if (err) return reject(err)
 
           client.end((err) => {
-            if (operation.retry(err)) return
+            if (retryOperation(operation, err)) return
             if (err) return reject(err)
 
             resolve()
@@ -93,7 +94,7 @@ function waitForPostgres () {
 
 function waitForMysql () {
   return new Promise((resolve, reject) => {
-    const operation = retry.operation(retryOptions)
+    const operation = createOperation('mysql')
 
     operation.attempt(currentAttempt => {
       const connection = mysql.createConnection({
@@ -103,7 +104,7 @@ function waitForMysql () {
       })
 
       connection.connect(err => {
-        if (operation.retry(err)) return
+        if (retryOperation(operation, err)) return
         if (err) reject(err)
 
         connection.end(() => resolve())
@@ -118,6 +119,8 @@ function waitForRedis () {
       retry_strategy: function (options) {
         if (options.attempt > retryOptions.retries) {
           return reject(options.error)
+        } else {
+          logAttempt('redis', options.attempt, 'failed to connect')
         }
 
         return retryOptions.maxTimeout
@@ -133,7 +136,7 @@ function waitForRedis () {
 
 function waitForMongo () {
   return new Promise((resolve, reject) => {
-    const operation = retry.operation(retryOptions)
+    const operation = createOperation('mongo')
 
     operation.attempt(currentAttempt => {
       const server = new mongo.Server({
@@ -148,7 +151,7 @@ function waitForMongo () {
       })
 
       server.on('error', err => {
-        if (!operation.retry(err)) {
+        if (!retryOperation(operation, err)) {
           reject(err)
         }
       })
@@ -160,7 +163,7 @@ function waitForMongo () {
 
 function waitForElasticsearch () {
   return new Promise((resolve, reject) => {
-    const operation = retry.operation(retryOptions)
+    const operation = createOperation('elasticsearch')
 
     operation.attempt(currentAttempt => {
       const client = new elasticsearch.Client({
@@ -168,7 +171,7 @@ function waitForElasticsearch () {
       })
 
       client.ping((err) => {
-        if (operation.retry(err)) return
+        if (retryOperation(operation, err)) return
         if (err) reject(err)
 
         resolve()
@@ -179,12 +182,12 @@ function waitForElasticsearch () {
 
 function waitForRabbitMQ () {
   return new Promise((resolve, reject) => {
-    const operation = retry.operation(retryOptions)
+    const operation = createOperation('rabbitmq')
 
     operation.attempt(currentAttempt => {
       amqplib
         .connect((err, conn) => {
-          if (operation.retry(err)) return
+          if (retryOperation(operation, err)) return
           if (err) reject(err)
 
           conn.close(() => resolve())
@@ -264,4 +267,24 @@ function withVersions (plugin, moduleName, range, cb) {
     .forEach(v => {
       describe(`with ${moduleName} ${v.range} (${v.version})`, () => cb(v.test))
     })
+}
+
+function createOperation (service) {
+  const timeouts = retry.timeouts(retryOptions)
+  return new RetryOperation(timeouts, Object.assign({ service }, retryOptions))
+}
+
+function retryOperation (operation, err) {
+  const shouldRetry = operation.retry(err)
+  if (shouldRetry) {
+    logAttempt(operation._options.service, operation._attempts, err.message)
+  }
+  return shouldRetry
+}
+
+function logAttempt (service, attempts, message) {
+  if (attempts > 2) {
+    // eslint-disable-next-line no-console
+    console.error(`[Retrying connection to ${service}] ${message}`)
+  }
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -120,7 +120,7 @@ function waitForRedis () {
         if (options.attempt > retryOptions.retries) {
           return reject(options.error)
         } else {
-          logAttempt('redis', options.attempt, 'failed to connect')
+          logAttempt('redis', 'failed to connect')
         }
 
         return retryOptions.maxTimeout
@@ -277,14 +277,12 @@ function createOperation (service) {
 function retryOperation (operation, err) {
   const shouldRetry = operation.retry(err)
   if (shouldRetry) {
-    logAttempt(operation._options.service, operation._attempts, err.message)
+    logAttempt(operation._options.service, err.message)
   }
   return shouldRetry
 }
 
-function logAttempt (service, attempts, message) {
-  if (attempts > 2) {
-    // eslint-disable-next-line no-console
-    console.error(`[Retrying connection to ${service}] ${message}`)
-  }
+function logAttempt (service, message) {
+  // eslint-disable-next-line no-console
+  console.error(`[Retrying connection to ${service}] ${message}`)
 }


### PR DESCRIPTION
As per https://github.com/DataDog/dd-trace-js/pull/243, I was running into hard to debug problems that caused the tests to seemingly not run at all.

The issue in my case ended up being unable to connect to MySQL without a password, but that error was never being logged until, presumably, the 60 retry attempts would have run out. However, that could take minutes, which is not typically something a user would wait for.

I ended up:
* Logging errors about connecting to services after the third attempt.
* Updating the Docker command in the README to ensure people not too familiar with Docker will definitely be using the latest configuration from `docker-compose.yml`.