### PR TITLE
add depth option to graphql plugin

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -175,6 +175,7 @@ query HelloWorld {
 | Option  | Default                                          | Description                            |
 |---------|--------------------------------------------------|----------------------------------------|
 | service | *Service name of the app suffixed with -graphql* | The service name for this integration. |
+| depth   | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
 
 <h3 id="http">http / https</h3>
 


### PR DESCRIPTION
This PR adds a `depth` option to control how deep the fields/resolvers will be instrumented. In some cases the default can result in a lot of spans even though in reality all resolvers result in a single outgoing request. One good example of this is when using DataLoader which handles parallel queries in bulk. In that case having many individual spans for each resolver is unnecessary as they will all have the same duration.

It can also be helpful in cases where there are a lot of resolvers and the overhead of instrumentation is too high.