### PR TITLE
add sample rate env variable

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,11 @@ class Config {
     const protocol = 'http'
     const hostname = coalesce(options.hostname, platform.env('DD_TRACE_AGENT_HOSTNAME'), 'localhost')
     const port = coalesce(options.port, platform.env('DD_TRACE_AGENT_PORT'), 8126)
-    const sampleRate = coalesce(Math.min(Math.max(options.sampleRate, 0), 1), 1)
+    const sampleRate = coalesce(
+      Math.min(Math.max(options.sampleRate, 0), 1),
+      Math.min(Math.max(platform.env('DD_TRACE_SAMPLE_RATE'), 0), 1),
+      1
+    )
     const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
     const plugins = coalesce(options.plugins, true)
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -57,7 +57,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
-    expect(config).to.have.property('sampleRate', '0.01')
+    expect(config).to.have.property('sampleRate', 0.01)
   })
 
   it('should initialize from the options', () => {
@@ -106,7 +106,7 @@ describe('Config', () => {
       port: 7777,
       service: 'test',
       env: 'development',
-      sampleRate: '0.05'
+      sampleRate: 0.05
     })
 
     expect(config).to.have.property('enabled', true)
@@ -115,7 +115,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.port', '7777')
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
-    expect(config).to.have.property('sampleRate', '0.05')
+    expect(config).to.have.property('sampleRate', 0.05)
   })
 
   it('should sanitize the sample rate to be between 0 and 1', () => {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -47,6 +47,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
     platform.env.withArgs('DD_ENV').returns('test')
+    platform.env.withArgs('DD_TRACE_SAMPLE_RATE').returns('0.01')
 
     const config = new Config()
 
@@ -56,6 +57,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
+    expect(config).to.have.property('sampleRate', '0.01')
   })
 
   it('should initialize from the options', () => {
@@ -95,6 +97,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
     platform.env.withArgs('DD_ENV').returns('test')
+    platform.env.withArgs('DD_TRACE_SAMPLE_RATE').returns('0.01')
 
     const config = new Config({
       enabled: true,
@@ -102,7 +105,8 @@ describe('Config', () => {
       hostname: 'server',
       port: 7777,
       service: 'test',
-      env: 'development'
+      env: 'development',
+      sampleRate: '0.05'
     })
 
     expect(config).to.have.property('enabled', true)
@@ -111,6 +115,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.port', '7777')
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
+    expect(config).to.have.property('sampleRate', '0.05')
   })
 
   it('should sanitize the sample rate to be between 0 and 1', () => {


### PR DESCRIPTION
This PR makes the `sampleRate` config option configurable via an environment variable.

Please note I was unable to run the tests as it required a connection to elastic search.

This PR closes #269.