### PR TITLE
Support configuring processors to skip or modify traces

### DIFF
--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -71,7 +71,7 @@ suite
   })
   .add('Writer#append', {
     onStart () {
-      writer = new Writer({}, 1000000)
+      writer = new Writer({}, 1000000, [])
     },
     fn () {
       writer.append(spanStub)
@@ -79,7 +79,7 @@ suite
   })
   .add('Writer#flush (1000 items)', {
     onStart () {
-      writer = new Writer({}, 1001)
+      writer = new Writer({}, 1001, [])
 
       for (let i = 0; i < 1000; i++) {
         writer.append(spanStub)

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ class Config {
     const sampleRate = coalesce(Math.min(Math.max(options.sampleRate, 0), 1), 1)
     const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
     const plugins = coalesce(options.plugins, true)
+    const processors = coalesce(options.processors, [])
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
@@ -27,6 +28,7 @@ class Config {
     this.bufferSize = 100000
     this.sampleRate = sampleRate
     this.logger = options.logger
+    this.processors = processors
     this.plugins = !!plugins
 
     Object.defineProperty(this, 'service', {

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -23,7 +23,7 @@ class DatadogTracer extends Tracer {
     this._url = config.url
     this._env = config.env
     this._tags = config.tags
-    this._recorder = new Recorder(config.url, config.flushInterval, config.bufferSize)
+    this._recorder = new Recorder(config.url, config.flushInterval, config.bufferSize, config.processors)
     this._recorder.init()
     this._sampler = new Sampler(config.sampleRate)
     this._propagators = {

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -6,8 +6,8 @@ const Writer = require('./writer')
 // TODO: make calls to Writer#append asynchronous
 
 class Recorder {
-  constructor (url, interval, size) {
-    this._writer = new Writer(url, size)
+  constructor (url, interval, size, processors) {
+    this._writer = new Writer(url, size, processors)
 
     if (interval > 0) {
       this._scheduler = new Scheduler(() => this._writer.flush(), interval)

--- a/src/writer.js
+++ b/src/writer.js
@@ -7,32 +7,55 @@ const encode = require('./encode')
 const tracerVersion = require('../lib/version')
 
 class Writer {
-  constructor (url, size) {
+  constructor (url, size, processors) {
     this._queue = []
     this._url = url
     this._size = size
+    this._processors = processors
   }
 
   get length () {
     return this._queue.length
   }
 
+  // A trace is considered filtered out if it is undefined, or if it contains no spans
+  isTraceFilteredOut (trace) {
+    return trace === undefined || trace === []
+  }
+
+  applyProcessors (trace) {
+    return this._processors.reduce((currentTrace, processor) => {
+      // If the trace has been filtered out by a previous processor, we don't need
+      // to bother calling the rest
+      if (!this.isTraceFilteredOut(currentTrace)) {
+        return processor(currentTrace)
+      }
+    }, trace)
+  }
+
   append (span) {
     const trace = span.context().trace
 
     if (trace.started.length === trace.finished.length) {
+      log.debug(() => `Formatting original trace: ${JSON.stringify(trace.finished)}`)
+
       const formattedTrace = trace.finished.map(format)
 
-      log.debug(() => `Encoding trace: ${JSON.stringify(formattedTrace)}`)
+      log.debug(() => `Running formatted trace through any configured processors: ${JSON.stringify(formattedTrace)}`)
 
-      const buffer = encode(formattedTrace)
+      const processedTrace = this.applyProcessors(formattedTrace)
 
-      log.debug(() => `Adding encoded trace to buffer: ${buffer.toString('hex').match(/../g).join(' ')}`)
-
-      if (this.length < this._size) {
-        this._queue.push(buffer)
+      if (this.isTraceFilteredOut(processedTrace)) {
+        log.debug(() => 'Trace was filtered out by processors, nothing to append to queue')
       } else {
-        this._squeeze(buffer)
+        log.debug(() => `Encoding processed trace: ${JSON.stringify(processedTrace)}`)
+        const encodedTrace = encode(processedTrace)
+
+        if (this.length < this._size) {
+          this._queue.push(encodedTrace)
+        } else {
+          this._squeeze(encodedTrace)
+        }
       }
     }
   }
@@ -67,9 +90,9 @@ class Writer {
     }
   }
 
-  _squeeze (buffer) {
+  _squeeze (trace) {
     const index = Math.floor(Math.random() * this.length)
-    this._queue[index] = buffer
+    this._queue[index] = trace
   }
 }
 

--- a/test/dd-trace.spec.js
+++ b/test/dd-trace.spec.js
@@ -43,7 +43,6 @@ describe('dd-trace', () => {
     agent.use(bodyParser.raw({ type: 'application/msgpack' }))
     agent.put('/v0.3/traces', (req, res) => {
       const payload = msgpack.decode(req.body, { codec })
-
       expect(payload[0][0].trace_id).to.be.instanceof(Uint64BE)
       expect(payload[0][0].trace_id.toString()).to.equal(span.context().traceId.toString())
       expect(payload[0][0].span_id).to.be.instanceof(Uint64BE)


### PR DESCRIPTION
This change allows you to configure your tracer with a series of "processors" which can alter traces (for example redacting sensitive data that you don't want to send to the Datadog Agent) or even skip them entirely (for example if you only want to keep "interesting" traces, e.g. ones that were particularly slow).

A processor is a function which is passed a trace, and is expected to either return a trace (which may have been changed from what was passed in) or `undefined` (if you want to skip the trace entirely).

After a trace is formatted and before it is encoded, we will run it through your pipeline of processors until we reach a final result. We will stop part-way if any of your processors
returns `undefined`, in which case we will not append the trace to the queue and it will not be sent to the Agent.

This is inspired by functionality found in the Ruby and Python Datadog APM libraries.

An example, taken from the documentation, is probably useful for showing off this feature:

```javascript
// You can return a modified trace, for example redacting a sensitive URL
const redactPasswords = (trace) => {
  return trace.map((span) => {
    // If the span's resource is /super-secret-endpoint, change it /redacted
    if (span.resource === '/super-secret-endpoint') {
      return Object.assign(span, { resource: '/redacted' })
    else {
      return span
    }
  })
}

// ...or you could even skip certain traces entirely
const onlyKeepSlowTraces = (trace) => {
  // Only keep a trace if one of the spans was slow, taking more than 2 seconds
  if (trace.some((span) => span.duration >= 2 * 1e6))
    return trace
  } else {
    return
  }
}

const tracer = require('dd-trace').init({
  // If a trace is filtered out by the first processor (i.e. it returns `undefined`),
  // subsequent processors will not be invoked
  processors: [onlyKeepSlowTraces, redactPasswords]
})
```

Addresses #271.