### PR TITLE
add an environment variable to disable context propagation

### DIFF
--- a/src/noop.js
+++ b/src/noop.js
@@ -1,11 +1,18 @@
 'use strict'
 
 const Tracer = require('opentracing').Tracer
-const ScopeManager = require('./scope/scope_manager')
 
 class NoopTracer extends Tracer {
   constructor (config) {
     super(config)
+
+    let ScopeManager
+
+    if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
+      ScopeManager = require('./scope/noop/scope_manager')
+    } else {
+      ScopeManager = require('./scope/scope_manager')
+    }
 
     this._scopeManager = new ScopeManager()
   }

--- a/src/plugins/amqp10.js
+++ b/src/plugins/amqp10.js
@@ -27,8 +27,15 @@ function createWrapMessageReceived (tracer, config) {
       const span = startReceiveSpan(tracer, config, this)
 
       process.nextTick(() => {
-        tracer.scopeManager().activate(span, true)
-        messageReceived.apply(this, arguments)
+        const scope = tracer.scopeManager().activate(span, true)
+
+        try {
+          messageReceived.apply(this, arguments)
+        } finally {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
+            scope.close()
+          }
+        }
       })
     }
   }

--- a/src/plugins/amqplib.js
+++ b/src/plugins/amqplib.js
@@ -28,12 +28,16 @@ function createWrapDispatchMessage (tracer, config) {
       addTags(this, tracer, config, span, 'basic.deliver', fields)
 
       setImmediate(() => {
-        tracer.scopeManager().activate(span, true)
+        tracer.scopeManager().activate(span, process.env.DD_CONTEXT_PROPAGATION !== 'false')
 
         try {
           dispatchMessage.apply(this, arguments)
         } catch (e) {
           throw addError(span, e)
+        } finally {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
+            span.finish()
+          }
         }
       })
     }

--- a/src/plugins/amqplib.js
+++ b/src/plugins/amqplib.js
@@ -28,7 +28,7 @@ function createWrapDispatchMessage (tracer, config) {
       addTags(this, tracer, config, span, 'basic.deliver', fields)
 
       setImmediate(() => {
-        tracer.scopeManager().activate(span, process.env.DD_CONTEXT_PROPAGATION !== 'false')
+        const scope = tracer.scopeManager().activate(span, true)
 
         try {
           dispatchMessage.apply(this, arguments)
@@ -36,7 +36,7 @@ function createWrapDispatchMessage (tracer, config) {
           throw addError(span, e)
         } finally {
           if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
-            span.finish()
+            scope.close()
           }
         }
       })

--- a/src/scope/noop/scope.js
+++ b/src/scope/noop/scope.js
@@ -1,0 +1,20 @@
+'use strict'
+
+class Scope {
+  constructor (span, finishSpanOnClose) {
+    this._span = span
+    this._finishSpanOnClose = finishSpanOnClose
+  }
+
+  span () {
+    return this._span
+  }
+
+  close () {
+    if (this._finishSpanOnClose) {
+      this._span.finish()
+    }
+  }
+}
+
+module.exports = Scope

--- a/src/scope/noop/scope_manager.js
+++ b/src/scope/noop/scope_manager.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const Scope = require('./scope')
+
+let singleton = null
+
+class ScopeManager {
+  constructor () {
+    if (!singleton) {
+      singleton = this
+    }
+
+    return singleton
+  }
+
+  active () {
+    return null
+  }
+
+  activate (span, finishSpanOnClose) {
+    return new Scope(span, finishSpanOnClose)
+  }
+}
+
+module.exports = ScopeManager

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,11 +1,18 @@
 'use strict'
 
 const Tracer = require('./opentracing/tracer')
-const ScopeManager = require('./scope/scope_manager')
 
 class DatadogTracer extends Tracer {
   constructor (config) {
     super(config)
+
+    let ScopeManager
+
+    if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
+      ScopeManager = require('./scope/noop/scope_manager')
+    } else {
+      ScopeManager = require('./scope/scope_manager')
+    }
 
     this._scopeManager = new ScopeManager()
   }

--- a/test/plugins/amqp10.spec.js
+++ b/test/plugins/amqp10.spec.js
@@ -144,6 +144,8 @@ describe('Plugin', () => {
           })
 
           it('should run the message event listener in the AMQP span scope', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             const parent = tracer.scopeManager().active()
 
             receiver.on('message', message => {

--- a/test/plugins/amqplib.spec.js
+++ b/test/plugins/amqplib.spec.js
@@ -185,6 +185,8 @@ describe('Plugin', () => {
             })
 
             it('should run the command callback in the parent context', done => {
+              if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
               channel.assertQueue('', {}, (err, ok) => {
                 if (err) return done(err)
 
@@ -196,6 +198,8 @@ describe('Plugin', () => {
             })
 
             it('should run the delivery callback in the current context', done => {
+              if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
               channel.assertQueue('', {}, (err, ok) => {
                 if (err) return done(err)
 
@@ -219,6 +223,8 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             channel.assertQueue('test', {})
               .then(() => {
                 expect(tracer.scopeManager().active()).to.be.null

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -95,6 +95,8 @@ describe('Plugin', () => {
           })
 
           it('should propagate context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('parent_id')
@@ -109,6 +111,8 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             client.ping(error => {
               expect(tracer.scopeManager().active()).to.be.null
               done(error)
@@ -154,6 +158,8 @@ describe('Plugin', () => {
           })
 
           it('should propagate context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('parent_id')
@@ -170,6 +176,8 @@ describe('Plugin', () => {
           })
 
           it('should run resolved promises in the parent context', () => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
             return client.ping()
               .then(() => {
                 expect(tracer.scopeManager().active()).to.be.null
@@ -177,6 +185,8 @@ describe('Plugin', () => {
           })
 
           it('should run rejected promises in the parent context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             client.search({ index: 'invalid' })
               .catch(() => {
                 expect(tracer.scopeManager().active()).to.be.null

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -257,6 +257,8 @@ describe('Plugin', () => {
         })
 
         it('should not lose the current path when changing scope', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const app = express()
           const router = express.Router()
 
@@ -296,6 +298,8 @@ describe('Plugin', () => {
         })
 
         it('should not lose the current path without a scope', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const app = express()
           const router = express.Router()
 
@@ -412,6 +416,8 @@ describe('Plugin', () => {
         })
 
         it('should reactivate the span when the active scope is closed', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const app = express()
 
           let span

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -465,6 +465,8 @@ describe('Plugin', () => {
         })
 
         it('should run rootValue resolvers in the current context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const schema = graphql.buildSchema(`
             type Query {
               hello: String
@@ -484,6 +486,8 @@ describe('Plugin', () => {
         })
 
         it('should run returned promise in the parent context', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
           const schema = graphql.buildSchema(`
             type Query {
               hello: String

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -314,6 +314,8 @@ describe('Plugin', () => {
       })
 
       it('should run the callback in the parent context', done => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
         const app = express()
 
         app.get('/user', (req, res) => {
@@ -333,6 +335,8 @@ describe('Plugin', () => {
       })
 
       it('should run the event listeners in the parent context', done => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
         const app = express()
 
         app.get('/user', (req, res) => {

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -142,6 +142,8 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             server.insert(`test.${collection}`, [{ a: 1 }], {}, () => {
               expect(tracer.scopeManager().active()).to.be.null
               done()
@@ -245,6 +247,8 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
             const cursor = server.cursor(`test.${collection}`, {
               find: `test.${collection}`,
               query: { a: 1 }

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -43,6 +43,8 @@ describe('Plugin', () => {
         })
 
         it('should propagate context to callbacks', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const span = tracer.startSpan('test')
           const scope = tracer.scopeManager().activate(span)
 
@@ -54,6 +56,8 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           connection.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()
             expect(active).to.be.null
@@ -62,6 +66,8 @@ describe('Plugin', () => {
         })
 
         it('should run event listeners in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const query = connection.query('SELECT 1 + 1 AS solution')
 
           query.on('result', () => {
@@ -188,6 +194,8 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           pool.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()
             expect(active).to.be.null

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -43,6 +43,8 @@ describe('Plugin', () => {
         })
 
         it('should propagate context to callbacks', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const span = tracer.startSpan('test')
           const scope = tracer.scopeManager().activate(span)
 
@@ -54,6 +56,8 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           connection.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()
             expect(active).to.be.null
@@ -62,6 +66,8 @@ describe('Plugin', () => {
         })
 
         it('should run event listeners in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const query = connection.query('SELECT 1 + 1 AS solution')
 
           query.on('result', () => {
@@ -193,6 +199,8 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           pool.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()
             expect(active).to.be.null

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -97,6 +97,8 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const span = {}
           const scope = tracer.scopeManager().activate(span)
 
@@ -140,6 +142,8 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           const span = {}
           const scope = tracer.scopeManager().activate(span)
 

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -51,6 +51,8 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           client.on('error', done)
 
           client.get('foo', () => {
@@ -60,6 +62,8 @@ describe('Plugin', () => {
         })
 
         it('should run client emitter listeners in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           client.on('error', done)
 
           client.on('ready', () => {
@@ -69,6 +73,8 @@ describe('Plugin', () => {
         })
 
         it('should run stream emitter listeners in the parent context', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
           client.on('error', done)
 
           client.stream.on('close', () => {


### PR DESCRIPTION
This PR adds an environment variable to disable context propagation. In high load environment, the overhead of tracking the current context is too high. In these cases, having a way to disable this feature is necessary, and then manual propagation can be done instead which is very light.