### PR TITLE
fix sample rate resulting in incorrect metrics

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -13,6 +13,7 @@ function format (span) {
 
   extractError(formatted, span._error)
   extractTags(formatted, span._tags)
+  extractMetrics(formatted, span._metrics)
 
   return formatted
 }
@@ -30,6 +31,7 @@ function formatSpan (span) {
     service: String(tracer._service),
     error: 0,
     meta: {},
+    metrics: {},
     start: new Int64BE(Math.round(span._startTime * 1e6)),
     duration: new Int64BE(Math.round(span._duration * 1e6))
   }
@@ -56,6 +58,14 @@ function extractTags (trace, tags) {
         break
       default:
         trace.meta[tag] = String(tags[tag])
+    }
+  })
+}
+
+function extractMetrics (trace, metrics) {
+  Object.keys(metrics).forEach(metric => {
+    if (typeof metrics[metric] === 'number') {
+      trace.metrics[metric] = metrics[metric]
     }
   })
 }

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -7,17 +7,22 @@ const platform = require('../platform')
 const log = require('../log')
 
 class DatadogSpan extends Span {
-  constructor (tracer, fields) {
+  constructor (tracer, sampler, fields) {
     super()
 
     const startTime = fields.startTime || platform.now()
     const operationName = fields.operationName
     const parent = fields.parent || null
     const tags = fields.tags || {}
+    const metrics = {
+      _sample_rate: sampler.rate()
+    }
 
     this._parentTracer = tracer
+    this._sampler = sampler
     this._operationName = operationName
     this._tags = Object.assign({}, tags)
+    this._metrics = metrics
     this._startTime = startTime
 
     this._spanContext = this._createContext(parent)
@@ -40,7 +45,7 @@ class DatadogSpan extends Span {
       spanContext = new SpanContext({
         traceId: spanId,
         spanId,
-        sampled: this._parentTracer._isSampled(this)
+        sampled: this._sampler.isSampled(this)
       })
     }
 

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -46,7 +46,7 @@ class DatadogTracer extends Tracer {
       tags.env = this._env
     }
 
-    return new Span(this, {
+    return new Span(this, this._sampler, {
       operationName: fields.operationName || name,
       parent: getParent(fields.references),
       tags: Object.assign(tags, this._tags, fields.tags),
@@ -75,10 +75,6 @@ class DatadogTracer extends Tracer {
       log.error(e)
       return null
     }
-  }
-
-  _isSampled (span) {
-    return this._sampler.isSampled(span)
   }
 }
 

--- a/src/sampler.js
+++ b/src/sampler.js
@@ -5,6 +5,10 @@ class Sampler {
     this._rate = rate
   }
 
+  rate () {
+    return this._rate
+  }
+
   isSampled (span) {
     return this._rate === 1 || Math.random() < this._rate
   }

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -26,6 +26,7 @@ describe('format', () => {
       context: sinon.stub().returns(spanContext),
       _operationName: 'operation',
       _tags: {},
+      _metrics: {},
       _startTime: 1500000000000.123456,
       _duration: 100
     }
@@ -74,6 +75,22 @@ describe('format', () => {
       expect(trace.meta['span.type']).to.be.undefined
       expect(trace.meta['resource.name']).to.be.undefined
       expect(trace.meta['foo.bar']).to.equal('foobar')
+    })
+
+    it('should extract metrics', () => {
+      const metrics = { metric: 50 }
+
+      span._metrics = metrics
+      trace = format(span)
+
+      expect(trace.metrics).to.deep.equal(metrics)
+    })
+
+    it('should ignore metrics with invalid values', () => {
+      span._metrics = { metric: 'test' }
+      trace = format(span)
+
+      expect(trace.metrics).to.deep.equal({})
     })
 
     it('should extract errors', () => {

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -6,6 +6,7 @@ describe('Span', () => {
   let Span
   let span
   let tracer
+  let sampler
   let platform
 
   beforeEach(() => {
@@ -14,8 +15,12 @@ describe('Span', () => {
     platform.id.onSecondCall().returns(new Uint64BE(456, 456))
 
     tracer = {
-      _record: sinon.stub(),
-      _isSampled: sinon.stub().returns(true)
+      _record: sinon.stub()
+    }
+
+    sampler = {
+      rate: sinon.stub().returns(1),
+      isSampled: sinon.stub().returns(true)
     }
 
     Span = proxyquire('../src/opentracing/span', {
@@ -24,14 +29,14 @@ describe('Span', () => {
   })
 
   it('should have a default context', () => {
-    span = new Span(tracer, { operationName: 'operation' })
+    span = new Span(tracer, sampler, { operationName: 'operation' })
 
     expect(span.context().traceId).to.deep.equal(new Uint64BE(123, 123))
     expect(span.context().spanId).to.deep.equal(new Uint64BE(123, 123))
   })
 
   it('should add itself to the context trace started spans', () => {
-    span = new Span(tracer, { operationName: 'operation' })
+    span = new Span(tracer, sampler, { operationName: 'operation' })
 
     expect(span.context().trace.started).to.deep.equal([span])
   })
@@ -48,7 +53,7 @@ describe('Span', () => {
       }
     }
 
-    span = new Span(tracer, { operationName: 'operation', parent })
+    span = new Span(tracer, sampler, { operationName: 'operation', parent })
 
     expect(span.context().traceId).to.deep.equal(new Uint64BE(123, 123))
     expect(span.context().parentId).to.deep.equal(new Uint64BE(456, 456))
@@ -56,9 +61,13 @@ describe('Span', () => {
     expect(span.context().trace.started).to.deep.equal(['span', span])
   })
 
+  it('should set the sample rate metric from the sampler', () => {
+    expect(span._metrics).to.have.property('_sample_rate', 1)
+  })
+
   describe('tracer', () => {
     it('should return its parent tracer', () => {
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
 
       expect(span.tracer()).to.equal(tracer)
     })
@@ -66,7 +75,7 @@ describe('Span', () => {
 
   describe('setOperationName', () => {
     it('should set the operation name', () => {
-      span = new Span(tracer, { operationName: 'foo' })
+      span = new Span(tracer, sampler, { operationName: 'foo' })
       span.setOperationName('bar')
 
       expect(span._operationName).to.equal('bar')
@@ -75,7 +84,7 @@ describe('Span', () => {
 
   describe('setBaggageItem', () => {
     it('should set a baggage item', () => {
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.setBaggageItem('foo', 'bar')
 
       expect(span.context().baggageItems).to.have.property('foo', 'bar')
@@ -84,7 +93,7 @@ describe('Span', () => {
 
   describe('getBaggageItem', () => {
     it('should get a baggage item', () => {
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span._spanContext.baggageItems.foo = 'bar'
 
       expect(span.getBaggageItem('foo')).to.equal('bar')
@@ -93,7 +102,7 @@ describe('Span', () => {
 
   describe('setTag', () => {
     it('should set a tag', () => {
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.setTag('foo', 'bar')
 
       expect(span._tags).to.have.property('foo', 'bar')
@@ -102,21 +111,21 @@ describe('Span', () => {
 
   describe('addTags', () => {
     it('should add tags', () => {
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.addTags({ foo: 'bar' })
 
       expect(span._tags).to.have.property('foo', 'bar')
     })
 
     it('should ensure tags are strings', () => {
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.addTags({ foo: 123 })
 
       expect(span._tags).to.have.property('foo', '123')
     })
 
     it('should handle errors', () => {
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
 
       expect(() => span.addTags()).not.to.throw()
     })
@@ -126,7 +135,7 @@ describe('Span', () => {
     it('should add itself to the context trace finished spans', () => {
       tracer._record.returns(Promise.resolve())
 
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.finish()
 
       expect(span.context().trace.finished).to.deep.equal([span])
@@ -135,7 +144,7 @@ describe('Span', () => {
     it('should record the span if sampled', () => {
       tracer._record.returns(Promise.resolve())
 
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.finish()
 
       expect(tracer._record).to.have.been.calledWith(span)
@@ -143,9 +152,9 @@ describe('Span', () => {
 
     it('should not record the span if not sampled', () => {
       tracer._record.returns(Promise.resolve())
-      tracer._isSampled.returns(false)
+      sampler.isSampled.returns(false)
 
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.finish()
 
       expect(tracer._record).to.not.have.been.called
@@ -154,7 +163,7 @@ describe('Span', () => {
     it('should not record the span if already finished', () => {
       tracer._record.returns(Promise.resolve())
 
-      span = new Span(tracer, { operationName: 'operation' })
+      span = new Span(tracer, sampler, { operationName: 'operation' })
       span.finish()
       span.finish()
 

--- a/test/opentracing/tracer.spec.js
+++ b/test/opentracing/tracer.spec.js
@@ -111,7 +111,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       const testSpan = tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWith(tracer, {
+      expect(Span).to.have.been.calledWith(tracer, sampler, {
         operationName: 'name',
         parent: null,
         tags: {
@@ -135,7 +135,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         operationName: 'name',
         parent
       })
@@ -151,7 +151,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         operationName: 'name',
         parent
       })
@@ -168,7 +168,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         operationName: 'name',
         parent
       })
@@ -184,7 +184,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         operationName: 'name',
         parent: null
       })
@@ -196,7 +196,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         operationName: 'name',
         parent: null
       })
@@ -210,7 +210,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         operationName: 'name',
         parent: null
       })
@@ -230,7 +230,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         tags: {
           'foo': 'tracer',
           'bar': 'span',
@@ -245,7 +245,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, {
+      expect(Span).to.have.been.calledWithMatch(tracer, sampler, {
         tags: {
           'env': 'test'
         }

--- a/test/sampler.spec.js
+++ b/test/sampler.spec.js
@@ -13,6 +13,14 @@ describe('Sampler', () => {
     Math.random.restore()
   })
 
+  describe('rate', () => {
+    it('should return the sample rate', () => {
+      sampler = new Sampler(0.5)
+
+      expect(sampler.rate()).to.equal(0.5)
+    })
+  })
+
   describe('isSampled', () => {
     it('should always sample when rate is 1', () => {
       sampler = new Sampler(1)


### PR DESCRIPTION
This PR fixes the metrics being incorrect when a sample rate is set. The agent expects to receive a `_sample_rate` metrics so it knows to calculate the correct average according to this value. Since this value was not sent, the metrics would be calculated with the assumption that all traces are sampled at the client.