### PR TITLE
fix already flushed traces being reused by new child spans

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -33,7 +33,7 @@ class DatadogSpan extends Span {
         parentId: parent.spanId,
         sampled: parent.sampled,
         baggageItems: Object.assign({}, parent.baggageItems),
-        trace: parent.trace
+        trace: parent.trace.started.length !== parent.trace.finished.length ? parent.trace : null
       })
     } else {
       const spanId = platform.id()

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -56,6 +56,23 @@ describe('Span', () => {
     expect(span.context().trace.started).to.deep.equal(['span', span])
   })
 
+  it('should start a new trace if the parent trace is finished', () => {
+    const parent = {
+      traceId: new Uint64BE(123, 123),
+      spanId: new Uint64BE(456, 456),
+      sampled: false,
+      baggageItems: { foo: 'bar' },
+      trace: {
+        started: ['span'],
+        finished: ['span']
+      }
+    }
+
+    span = new Span(tracer, { operationName: 'operation', parent })
+
+    expect(span.context().trace.started).to.deep.equal([span])
+  })
+
   describe('tracer', () => {
     it('should return its parent tracer', () => {
       span = new Span(tracer, { operationName: 'operation' })


### PR DESCRIPTION
This PR fixes already flushed traces being reused by new child spans when they follow from their parent. This would result in the agent counting the request for the wrong service, which would impact service metrics.