### PR TITLE
fix distributed tracing compatibility and improve performance

### DIFF
--- a/src/opentracing/propagation/text_map.js
+++ b/src/opentracing/propagation/text_map.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Uint64BE = require('int64-buffer').Uint64BE
-const Int64BE = require('int64-buffer').Int64BE
 const DatadogSpanContext = require('../span_context')
 
 const traceKey = 'x-datadog-trace-id'
@@ -11,8 +10,8 @@ const baggageExpr = new RegExp(`^${baggagePrefix}(.+)$`)
 
 class TextMapPropagator {
   inject (spanContext, carrier) {
-    carrier[traceKey] = new Int64BE(spanContext.traceId.toBuffer()).toString()
-    carrier[spanKey] = new Int64BE(spanContext.spanId.toBuffer()).toString()
+    carrier[traceKey] = spanContext.traceId.toString()
+    carrier[spanKey] = spanContext.spanId.toString()
 
     spanContext.baggageItems && Object.keys(spanContext.baggageItems).forEach(key => {
       carrier[baggagePrefix + key] = String(spanContext.baggageItems[key])

--- a/src/platform/node/id.js
+++ b/src/platform/node/id.js
@@ -1,6 +1,36 @@
 'use strict'
 
+const Buffer = require('safe-buffer').Buffer
 const Uint64BE = require('int64-buffer').Uint64BE
 const randomBytes = require('crypto').randomBytes
 
-module.exports = () => new Uint64BE(randomBytes(8))
+const hiSeed = randomBytes(4).readUInt32BE()
+const loSeed = randomBytes(4).readUInt32BE()
+
+function pseudoRandom () {
+  const buffer = Buffer.allocUnsafe(8)
+
+  const hi = randomUInt32(hiSeed) & 0x7FFFFFFF // only positive int64
+  const lo = randomUInt32(loSeed)
+
+  writeUInt32BE(buffer, hi, 0)
+  writeUInt32BE(buffer, lo, 4)
+
+  return buffer
+}
+
+function randomUInt32 (seed) {
+  return seed ^ Math.floor(Math.random() * (0xFFFFFFFF + 1))
+}
+
+function writeUInt32BE (buffer, value, offset) {
+  buffer[3 + offset] = value & 255
+  value = value >> 8
+  buffer[2 + offset] = value & 255
+  value = value >> 8
+  buffer[1 + offset] = value & 255
+  value = value >> 8
+  buffer[0 + offset] = value & 255
+}
+
+module.exports = () => new Uint64BE(pseudoRandom())

--- a/test/opentracing/propagation/text_map.spec.js
+++ b/test/opentracing/propagation/text_map.spec.js
@@ -14,7 +14,7 @@ describe('TextMapPropagator', () => {
     propagator = new TextMapPropagator()
     textMap = {
       'x-datadog-trace-id': '123',
-      'x-datadog-parent-id': '-456',
+      'x-datadog-parent-id': '18446744073709551160', // -456 casted to uint64
       'ot-baggage-foo': 'bar'
     }
     baggageItems = {

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -62,20 +62,27 @@ describe('Platform', () => {
       let randomBytes
 
       beforeEach(() => {
-        randomBytes = sinon.stub()
+        const seed = Buffer.alloc(4)
+
+        seed.writeUInt32BE(0xFF000000)
+
+        randomBytes = sinon.stub().returns(seed)
+
+        sinon.stub(Math, 'random')
+
         id = proxyquire('../src/platform/node/id', {
           'crypto': { randomBytes }
         })
       })
 
-      it('should return a random 64bit ID', () => {
-        const buffer = Buffer.alloc(8)
-        buffer.writeUInt32BE(0x12345678)
-        buffer.writeUInt32BE(0x87654321, 4)
+      afterEach(() => {
+        Math.random.restore()
+      })
 
-        randomBytes.returns(buffer)
+      it('should return a random 63bit ID', () => {
+        Math.random.returns(0x0000FF00 / (0xFFFFFFFF + 1))
 
-        expect(id().toString('16')).to.equal('1234567887654321')
+        expect(id().toBuffer().toString('hex')).to.equal('7f00ff00ff00ff00')
       })
     })
 


### PR DESCRIPTION
This PR fixes distributed tracing compatibility with other tracer implementations and improves performance.

Right now most tracer implementations accept only unsigned IDs. Java was historically an exception, but switched to unsigned as well since 0.12. By sending unsigned IDs during distributed tracing, it ensures compatibility with all tracers. The first bit is also removed to effectively make the result a positive-only signed integer to maintain compatibility with older versions.

Performance has also been greatly improved by using pseudo random IDs instead of cryptographically secure IDs. A local seed is used because `Math.random()` is known to sometimes reuse seeds in some cases. Since its underlying implementation is xorshift128+, this could result in the exact same sequence of IDs in 2 different processes. By adding a XOR with a secure local seed, this is avoided.