### PR TITLE
fix node-memwatch being included in user dependencies

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 coverage
 out
-test/plugins/versions
+node_modules

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -16,7 +16,6 @@ require,require-in-the-middle,MIT,Copyright 2016-2018 Thomas Watson Steen
 require,safe-buffer,MIT,Copyright Feross Aboukhadijeh
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,url-parse,MIT,Copyright 2015 Unshift.io Arnout Kazemier the Contributors
-dev,@airbnb/node-memwatch,WTFPL,Copyright Lloyd Hilaiel
 dev,amqplib,MIT,Copyright 2013-2014 Michael Bridgen
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie
 dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David Dalton

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . && node scripts/check_licenses.js",
     "tdd": "node ./scripts/install_plugin_modules && mocha --watch",
     "test": "node ./scripts/install_plugin_modules && nyc --reporter text --reporter lcov mocha 'test/**/*.spec.js'",
-    "leak": "node --no-warnings ./node_modules/.bin/tape 'test/leak/**/*.js'"
+    "leak": "(cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape 'test/leak/{,!(node_modules)/**/}/*.js'"
   },
   "repository": {
     "type": "git",
@@ -87,8 +87,5 @@
     "sinon": "^4.2.1",
     "sinon-chai": "^2.14.0",
     "tape": "^4.9.1"
-  },
-  "optionalDependencies": {
-    "@airbnb/node-memwatch": "^1.0.2"
   }
 }

--- a/scripts/check_licenses.js
+++ b/scripts/check_licenses.js
@@ -6,9 +6,9 @@ const readline = require('readline')
 const pkg = require(path.join(__dirname, '..', '/package.json'))
 
 const filePath = path.join(__dirname, '..', '/LICENSE-3rdparty.csv')
-const deps = Object.keys(pkg.dependencies)
-  .concat(Object.keys(pkg.devDependencies))
-  .concat(Object.keys(pkg.optionalDependencies))
+const deps = Object.keys(pkg.dependencies || {})
+  .concat(Object.keys(pkg.devDependencies || {}))
+  .concat(Object.keys(pkg.optionalDependencies || {}))
   .sort()
 
 let index = 0

--- a/test/leak/package.json
+++ b/test/leak/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "leak",
+  "version": "1.0.0",
+  "license": "BSD-3-Clause",
+  "private": true,
+  "dependencies": {
+    "@airbnb/node-memwatch": "^1.0.2"
+  }
+}


### PR DESCRIPTION
This PR removes the `node-memwatch` module from `optionalDependencies` since these dependencies are included when installing `dd-trace`. Since `node-memwatch` is only compatible with Node >=8, it cannot be included in the project's `devDependencies`, so I moved it to an independent `package.json`.

Fixes #257