### PR TITLE
add hapi integration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -181,6 +181,25 @@ query HelloWorld {
 | variables       | `undefined`                                      | A callback to enable recording of variables. By default, no variables are recorded. For example, using `variables => variables` would record all variables. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
 
+<h3 id="hapi">hapi</h3>
+
+<h5 id="hapi-tags">Tags</h5>
+
+| Tag              | Description                                               |
+|------------------|-----------------------------------------------------------|
+| http.url         | The complete URL of the request.                          |
+| http.method      | The HTTP method of the request.                           |
+| http.status_code | The HTTP status code of the response.                     |
+| http.headers.*   | A recorded HTTP header.                                   |
+
+<h5 id="hapi-config">Configuration Options</h5>
+
+| Option           | Default                   | Description                            |
+|------------------|---------------------------|----------------------------------------|
+| service          | *Service name of the app* | The service name for this integration. |
+| validateStatus   | `code => code < 500`      | Callback function to determine if there was an error. It should take a status code as its only parameter and return `true` for success or `false` for errors. |
+| headers          | `[]`                      | An array of headers to include in the span metadata. |
+
 <h3 id="http">http / https</h3>
 
 <h5 id="http-tags">Tags</h5>

--- a/ext/kinds.js
+++ b/ext/kinds.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  SERVER: 'server',
+  CLIENT: 'client',
+  PRODUCER: 'producer',
+  CONSUMER: 'consumer'
+}

--- a/ext/tags.js
+++ b/ext/tags.js
@@ -1,8 +1,17 @@
 'use strict'
 
 module.exports = {
+  // Common
   SERVICE_NAME: 'service.name',
   RESOURCE_NAME: 'resource.name',
   SPAN_TYPE: 'span.type',
-  SAMPLING_PRIORITY: 'sampling.priority'
+  SPAN_KIND: 'span.kind',
+  SAMPLING_PRIORITY: 'sampling.priority',
+  ERROR: 'error',
+
+  // HTTP
+  HTTP_URL: 'http.url',
+  HTTP_METHOD: 'http.method',
+  HTTP_STATUS_CODE: 'http.status_code',
+  HTTP_HEADERS: 'http.headers'
 }

--- a/ext/types.js
+++ b/ext/types.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  HTTP: 'http'
+}

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -1,67 +1,16 @@
 'use strict'
 
-const opentracing = require('opentracing')
-const Tags = opentracing.Tags
-const FORMAT_HTTP_HEADERS = opentracing.FORMAT_HTTP_HEADERS
 const METHODS = require('methods').concat('use', 'route', 'param', 'all')
 const pathToRegExp = require('path-to-regexp')
-const log = require('../log')
-
-const OPERATION_NAME = 'express.request'
+const web = require('./util/web')
 
 function createWrapMethod (tracer, config) {
-  const headersToRecord = getHeadersToRecord(config)
-  const validateStatus = getStatusValidator(config)
+  config = web.normalizeConfig(config)
 
   function ddTrace (req, res, next) {
-    if (req._datadog.span) return next()
+    if (web.active(req)) return next()
 
-    const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`
-    const childOf = tracer.extract(FORMAT_HTTP_HEADERS, req.headers)
-
-    const span = tracer.startSpan(OPERATION_NAME, {
-      childOf,
-      tags: {
-        [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER,
-        [Tags.HTTP_URL]: url,
-        [Tags.HTTP_METHOD]: req.method
-      }
-    })
-
-    const originalEnd = res.end
-
-    res.end = function () {
-      if (req._datadog.finished) return originalEnd.apply(this, arguments)
-
-      const returned = originalEnd.apply(this, arguments)
-      const path = req._datadog.paths.join('')
-      const resource = [req.method].concat(path).filter(val => val).join(' ')
-
-      span.setTag('resource.name', resource)
-      span.setTag('service.name', config.service || tracer._service)
-      span.setTag('span.type', 'http')
-      span.setTag(Tags.HTTP_STATUS_CODE, res.statusCode)
-
-      if (!validateStatus(res.statusCode)) {
-        span.setTag(Tags.ERROR, true)
-      }
-
-      headersToRecord.forEach(key => {
-        const value = req.headers[key]
-        if (value) {
-          span.setTag(`http.headers.${key}`, value)
-        }
-      })
-
-      span.finish()
-
-      req._datadog.scope && req._datadog.scope.close()
-      req._datadog.finished = true
-
-      return returned
-    }
-
-    req._datadog.span = span
+    web.instrument(tracer, config, req, res, 'express.request')
 
     next()
   }
@@ -80,11 +29,7 @@ function createWrapMethod (tracer, config) {
 function createWrapHandle (tracer, config) {
   return function wrapHandle (handle) {
     return function handleWithTracer (req) {
-      if (!req._datadog) {
-        Object.defineProperty(req, '_datadog', {
-          value: { paths: [] }
-        })
-      }
+      web.patch(req)
 
       return handle.apply(this, arguments)
     }
@@ -102,7 +47,7 @@ function createWrapProcessParams (tracer, config) {
         // Try to guess which path actually matched
         for (let i = 0; i < matchers.length; i++) {
           if (matchers[i].test(layer.path)) {
-            req._datadog.paths.push(matchers[i].path)
+            web.enterRoute(req, matchers[i].path)
 
             break
           }
@@ -143,46 +88,23 @@ function createWrapRouterMethod (tracer) {
 }
 
 function wrapNext (tracer, layer, req, next) {
-  if (!req._datadog.span) {
+  if (!web.active(req)) {
     return next
   }
 
   const originalNext = next
 
-  req._datadog.scope && req._datadog.scope.close()
-  req._datadog.scope = tracer.scopeManager().activate(req._datadog.span)
+  web.reactivate(req)
 
   return function (error) {
     if (!error && layer.path && !isFastStar(layer)) {
-      req._datadog.paths.pop()
+      web.exitRoute(req)
     }
 
     process.nextTick(() => {
       originalNext.apply(null, arguments)
     })
   }
-}
-
-function getHeadersToRecord (config) {
-  if (Array.isArray(config.headers)) {
-    try {
-      return config.headers.map(key => key.toLowerCase())
-    } catch (err) {
-      log.error(err)
-    }
-  } else if (config.hasOwnProperty('headers')) {
-    log.error('Expected `headers` to be an array of strings.')
-  }
-  return []
-}
-
-function getStatusValidator (config) {
-  if (typeof config.validateStatus === 'function') {
-    return config.validateStatus
-  } else if (config.hasOwnProperty('validateStatus')) {
-    log.error('Expected `validateStatus` to be a function.')
-  }
-  return code => code < 500
 }
 
 function extractMatchers (fn) {

--- a/src/plugins/hapi.js
+++ b/src/plugins/hapi.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const web = require('./util/web')
+
+function createWrapGenerate (tracer, config) {
+  config = web.normalizeConfig(config)
+
+  return function wrapGenerate (generate) {
+    return function generateWithTrace (server, req, res, options) {
+      let request
+
+      web.instrument(tracer, config, req, res, 'hapi.request', () => {
+        request = generate.apply(this, arguments)
+
+        web.beforeEnd(req, () => {
+          web.enterRoute(req, request.route.path)
+        })
+      })
+
+      return request
+    }
+  }
+}
+
+module.exports = [
+  {
+    name: 'hapi',
+    versions: ['^17.1'],
+    file: 'lib/request.js',
+    patch (Request, tracer, config) {
+      this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
+    },
+    unpatch (Request) {
+      this.unwrap(Request, 'generate')
+    }
+  },
+  {
+    name: 'hapi',
+    versions: ['<17.1'],
+    file: 'lib/request.js',
+    patch (Generator, tracer, config) {
+      this.wrap(Generator.prototype, 'request', createWrapGenerate(tracer, config))
+    },
+    unpatch (Generator) {
+      this.unwrap(Generator.prototype, 'request')
+    }
+  }
+]

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -6,6 +6,7 @@ module.exports = {
   'elasticsearch': require('./elasticsearch'),
   'express': require('./express'),
   'graphql': require('./graphql'),
+  'hapi': require('./hapi'),
   'http': require('./http'),
   'mongodb-core': require('./mongodb-core'),
   'mysql': require('./mysql'),

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -1,0 +1,194 @@
+'use strict'
+
+const FORMAT_HTTP_HEADERS = require('opentracing').FORMAT_HTTP_HEADERS
+const log = require('../../log')
+const tags = require('../../../ext/tags')
+const types = require('../../../ext/types')
+const kinds = require('../../../ext/kinds')
+
+const HTTP = types.HTTP
+const SERVER = kinds.SERVER
+const RESOURCE_NAME = tags.RESOURCE_NAME
+const SERVICE_NAME = tags.SERVICE_NAME
+const SPAN_TYPE = tags.SPAN_TYPE
+const SPAN_KIND = tags.SPAN_KIND
+const ERROR = tags.ERROR
+const HTTP_METHOD = tags.HTTP_METHOD
+const HTTP_URL = tags.HTTP_URL
+const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
+const HTTP_HEADERS = tags.HTTP_HEADERS
+
+function normalizeConfig (config) {
+  const headers = getHeadersToRecord(config)
+  const validateStatus = getStatusValidator(config)
+
+  return Object.assign({}, config, {
+    headers,
+    validateStatus
+  })
+}
+
+function instrument (tracer, config, req, res, name, callback) {
+  const childOf = tracer.extract(FORMAT_HTTP_HEADERS, req.headers)
+  const span = tracer.startSpan(name, { childOf })
+  const scope = tracer.scopeManager().activate(span)
+
+  if (config.service) {
+    span.setTag(SERVICE_NAME, config.service)
+  }
+
+  patch(req)
+
+  req._datadog.tracer = tracer
+  req._datadog.config = config
+  req._datadog.span = span
+  req._datadog.scope = scope
+  req._datadog.res = res
+
+  addRequestTags(req)
+
+  callback && callback(span)
+
+  wrapEnd(req)
+
+  return span
+}
+
+function reactivate (req) {
+  req._datadog.scope && req._datadog.scope.close()
+  req._datadog.scope = req._datadog.tracer.scopeManager().activate(req._datadog.span)
+}
+
+function finish (req) {
+  if (req._datadog.finished) return
+
+  addResponseTags(req)
+
+  req._datadog.span.finish()
+  req._datadog.scope && req._datadog.scope.close()
+  req._datadog.finished = true
+}
+
+function enterRoute (req, path) {
+  req._datadog.paths.push(path)
+}
+
+function exitRoute (req) {
+  req._datadog.paths.pop()
+}
+
+function beforeEnd (req, callback) {
+  req._datadog.beforeEnd.push(callback)
+}
+
+function wrapEnd (req) {
+  const res = req._datadog.res
+  const end = res.end
+
+  res.end = function () {
+    req._datadog.beforeEnd.forEach(beforeEnd => beforeEnd())
+
+    const returnValue = end.apply(this, arguments)
+
+    finish(req)
+
+    return returnValue
+  }
+}
+
+function patch (req) {
+  if (req._datadog) return
+
+  Object.defineProperty(req, '_datadog', {
+    value: {
+      span: null,
+      scope: null,
+      paths: [],
+      beforeEnd: []
+    }
+  })
+}
+
+function active (req) {
+  return req._datadog.span
+}
+
+function addRequestTags (req) {
+  const protocol = req.connection.encrypted ? 'https' : 'http'
+  const url = `${protocol}://${req.headers['host']}${req.url}`
+  const span = req._datadog.span
+
+  span.addTags({
+    [HTTP_URL]: url,
+    [HTTP_METHOD]: req.method,
+    [SPAN_KIND]: SERVER,
+    [SPAN_TYPE]: HTTP
+  })
+
+  addHeaders(req)
+}
+
+function addResponseTags (req) {
+  const path = req._datadog.paths.join('')
+  const resource = [req.method].concat(path).filter(val => val).join(' ')
+  const span = req._datadog.span
+  const res = req._datadog.res
+
+  span.addTags({
+    [RESOURCE_NAME]: resource,
+    [HTTP_STATUS_CODE]: res.statusCode
+  })
+
+  addStatusError(req)
+}
+
+function addHeaders (req) {
+  const span = req._datadog.span
+
+  req._datadog.config.headers.forEach(key => {
+    const value = req.headers[key]
+
+    if (value) {
+      span.setTag(`${HTTP_HEADERS}.${key}`, value)
+    }
+  })
+}
+
+function addStatusError (req) {
+  if (!req._datadog.config.validateStatus(req._datadog.res.statusCode)) {
+    req._datadog.span.setTag(ERROR, true)
+  }
+}
+
+function getHeadersToRecord (config) {
+  if (Array.isArray(config.headers)) {
+    try {
+      return config.headers.map(key => key.toLowerCase())
+    } catch (err) {
+      log.error(err)
+    }
+  } else if (config.hasOwnProperty('headers')) {
+    log.error('Expected `headers` to be an array of strings.')
+  }
+  return []
+}
+
+function getStatusValidator (config) {
+  if (typeof config.validateStatus === 'function') {
+    return config.validateStatus
+  } else if (config.hasOwnProperty('validateStatus')) {
+    log.error('Expected `validateStatus` to be a function.')
+  }
+  return code => code < 500
+}
+
+module.exports = {
+  patch,
+  active,
+  normalizeConfig,
+  instrument,
+  reactivate,
+  enterRoute,
+  exitRoute,
+  beforeEnd
+}

--- a/test/plugins/hapi.spec.js
+++ b/test/plugins/hapi.spec.js
@@ -1,0 +1,190 @@
+'use strict'
+
+const axios = require('axios')
+const getPort = require('get-port')
+const agent = require('./agent')
+const plugin = require('../../src/plugins/hapi')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let tracer
+  let Hapi
+  let server
+  let port
+
+  describe('hapi', () => {
+    withVersions(plugin, 'hapi', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        agent.close()
+        agent.wipe()
+        server.stop()
+      })
+
+      beforeEach(() => {
+        return agent.load(plugin, 'hapi')
+          .then(() => {
+            Hapi = require(`./versions/hapi@${version}`).get()
+          })
+      })
+
+      beforeEach(() => {
+        return getPort()
+          .then(_port => {
+            port = _port
+            server = Hapi.server({
+              address: '127.0.0.1',
+              port
+            })
+
+            return server.start()
+          })
+      })
+
+      it('should do automatic instrumentation on routes', done => {
+        server.route({
+          method: 'GET',
+          path: '/user/{id}',
+          handler: () => ''
+        })
+
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('name', 'hapi.request')
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('type', 'http')
+            expect(traces[0][0]).to.have.property('resource', 'GET /user/{id}')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+            expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
+            expect(traces[0][0].meta).to.have.property('http.method', 'GET')
+            expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+          })
+          .then(done)
+          .catch(done)
+
+        axios
+          .get(`http://localhost:${port}/user/123`)
+          .catch(done)
+      })
+
+      it('should run the request handler in the request scope', done => {
+        server.route({
+          method: 'GET',
+          path: '/user/{id}',
+          handler: () => {
+            expect(tracer.scopeManager().active()).to.not.be.null
+            done()
+            return ''
+          }
+        })
+
+        axios
+          .get(`http://localhost:${port}/user/123`)
+          .catch(done)
+      })
+
+      it('should run pre-handlers in the request scope', done => {
+        server.route({
+          method: 'GET',
+          path: '/user/{id}',
+          config: {
+            pre: [
+              (request, h) => {
+                expect(tracer.scopeManager().active()).to.not.be.null
+                done()
+                return ''
+              }
+            ],
+            handler: () => ''
+          }
+        })
+
+        axios
+          .get(`http://localhost:${port}/user/123`)
+          .catch(done)
+      })
+
+      it('should run request extensions in the request scope', done => {
+        server.route({
+          method: 'GET',
+          path: '/user/{id}',
+          handler: () => ''
+        })
+
+        server.ext('onRequest', (request, h) => {
+          expect(tracer.scopeManager().active()).to.not.be.null
+          done()
+          return h.continue
+        })
+
+        axios
+          .get(`http://localhost:${port}/user/123`)
+          .catch(done)
+      })
+
+      it('should extract its parent span from the headers', done => {
+        server.route({
+          method: 'GET',
+          path: '/user/{id}',
+          handler: () => ''
+        })
+
+        agent
+          .use(traces => {
+            expect(traces[0][0].trace_id.toString()).to.equal('1234')
+            expect(traces[0][0].parent_id.toString()).to.equal('5678')
+          })
+          .then(done)
+          .catch(done)
+
+        axios
+          .get(`http://localhost:${port}/user/123`, {
+            headers: {
+              'x-datadog-trace-id': '1234',
+              'x-datadog-parent-id': '5678',
+              'ot-baggage-foo': 'bar'
+            }
+          })
+          .catch(done)
+      })
+
+      it('should instrument the default route handler', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('name', 'hapi.request')
+          })
+          .then(done)
+          .catch(done)
+
+        axios
+          .get(`http://localhost:${port}/user/123`)
+          .catch(() => {})
+      })
+
+      it('should handle errors', done => {
+        server.route({
+          method: 'GET',
+          path: '/user/{id}',
+          handler: () => {
+            throw new Error()
+          }
+        })
+
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('error', 1)
+          })
+          .then(done)
+          .catch(done)
+
+        axios
+          .get(`http://localhost:${port}/user/123`)
+          .catch(() => {})
+      })
+    })
+  })
+})

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -1,0 +1,239 @@
+'use strict'
+
+const types = require('../../../ext/types')
+const kinds = require('../../../ext/kinds')
+const tags = require('../../../ext/tags')
+
+const HTTP = types.HTTP
+const SERVER = kinds.SERVER
+const RESOURCE_NAME = tags.RESOURCE_NAME
+const SERVICE_NAME = tags.SERVICE_NAME
+const SPAN_TYPE = tags.SPAN_TYPE
+const SPAN_KIND = tags.SPAN_KIND
+const ERROR = tags.ERROR
+const HTTP_METHOD = tags.HTTP_METHOD
+const HTTP_URL = tags.HTTP_URL
+const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
+const HTTP_HEADERS = tags.HTTP_HEADERS
+
+describe('plugins/util/web', () => {
+  let web
+  let tracer
+  let span
+  let req
+  let res
+  let end
+  let config
+
+  beforeEach(() => {
+    req = {
+      headers: {
+        'host': 'localhost'
+      },
+      connection: {}
+    }
+    end = sinon.stub()
+    res = {
+      end
+    }
+    config = {}
+
+    tracer = require('../../..').init({ plugins: false })
+    web = require('../../../src/plugins/util/web')
+  })
+
+  beforeEach(() => {
+    config = web.normalizeConfig(config)
+  })
+
+  describe('instrument', () => {
+    describe('on request start', () => {
+      it('should set the parent from the request headers', () => {
+        req.headers = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456'
+        }
+
+        span = web.instrument(tracer, config, req, res, 'test.request')
+
+        expect(span.context().traceId.toString()).to.equal('123')
+        expect(span.context().parentId.toString()).to.equal('456')
+      })
+
+      it('should set the service name', () => {
+        config.service = 'custom'
+
+        span = web.instrument(tracer, config, req, res, 'test.request')
+
+        expect(span.context().tags).to.have.property(SERVICE_NAME, 'custom')
+      })
+
+      it('should activate a scope with the span', () => {
+        span = web.instrument(tracer, config, req, res, 'test.request', span => {
+          const scope = tracer.scopeManager().active()
+
+          expect(scope).to.not.be.null
+          expect(scope.span()).to.equal(span)
+        })
+      })
+
+      it('should add request tags to the span', () => {
+        req.method = 'GET'
+        req.url = '/user/123'
+        res.statusCode = '200'
+
+        span = web.instrument(tracer, config, req, res, 'test.request')
+
+        res.end()
+
+        expect(span.context().tags).to.include({
+          [SPAN_TYPE]: HTTP,
+          [HTTP_URL]: 'http://localhost/user/123',
+          [HTTP_METHOD]: 'GET',
+          [SPAN_KIND]: SERVER
+        })
+      })
+
+      it('should add configured headers to the span tags', () => {
+        config.headers = ['host']
+
+        span = web.instrument(tracer, config, req, res, 'test.request')
+
+        res.end()
+
+        expect(span.context().tags).to.include({
+          [`${HTTP_HEADERS}.host`]: 'localhost'
+        })
+      })
+    })
+
+    describe('on request end', () => {
+      beforeEach(() => {
+        span = web.instrument(tracer, config, req, res, 'test.request')
+      })
+
+      it('should finish the span', () => {
+        sinon.spy(span, 'finish')
+
+        res.end()
+
+        expect(span.finish).to.have.been.called
+      })
+
+      it('should should only finish once', () => {
+        sinon.spy(span, 'finish')
+
+        res.end()
+        res.end()
+
+        expect(span.finish).to.have.been.calledOnce
+      })
+
+      it('should execute any beforeEnd handlers', () => {
+        const spy1 = sinon.spy()
+        const spy2 = sinon.spy()
+
+        web.beforeEnd(req, spy1)
+        web.beforeEnd(req, spy2)
+
+        res.end()
+
+        expect(spy1).to.have.been.called
+        expect(spy2).to.have.been.called
+      })
+
+      it('should call the original end', () => {
+        res.end()
+
+        expect(end).to.have.been.called
+      })
+
+      it('should add response tags to the span', () => {
+        req.method = 'GET'
+        req.url = '/user/123'
+        res.statusCode = '200'
+
+        res.end()
+
+        expect(span.context().tags).to.include({
+          [RESOURCE_NAME]: 'GET',
+          [HTTP_STATUS_CODE]: '200'
+        })
+      })
+
+      it('should set the error tag if the request is an error', () => {
+        res.statusCode = 500
+
+        res.end()
+
+        expect(span.context().tags).to.include({
+          [ERROR]: 'true'
+        })
+      })
+
+      it('should set the error tag if the configured validator returns false', () => {
+        config.validateStatus = () => false
+
+        res.end()
+
+        expect(span.context().tags).to.include({
+          [ERROR]: 'true'
+        })
+      })
+    })
+  })
+
+  describe('enterRoute', () => {
+    beforeEach(() => {
+      config = web.normalizeConfig(config)
+      span = web.instrument(tracer, config, req, res, 'test.request')
+    })
+
+    it('should add a route segment that will be added to the span resource name', () => {
+      req.method = 'GET'
+
+      web.enterRoute(req, '/foo')
+      web.enterRoute(req, '/bar')
+      res.end()
+
+      expect(span.context().tags).to.have.property([RESOURCE_NAME], 'GET /foo/bar')
+    })
+  })
+
+  describe('enterRoute', () => {
+    beforeEach(() => {
+      config = web.normalizeConfig(config)
+      span = web.instrument(tracer, config, req, res, 'test.request')
+    })
+
+    it('should remove a route segment', () => {
+      req.method = 'GET'
+
+      web.enterRoute(req, '/foo')
+      web.enterRoute(req, '/bar')
+      web.exitRoute(req)
+      res.end()
+
+      expect(span.context().tags).to.have.property([RESOURCE_NAME], 'GET /foo')
+    })
+  })
+
+  describe('patch', () => {
+    it('should patch the request with Datadog metadata', () => {
+      web.patch(req)
+
+      expect(req._datadog).to.deep.include({
+        paths: [],
+        beforeEnd: []
+      })
+    })
+  })
+
+  describe('active', () => {
+    it('should return the active span', () => {
+      span = web.instrument(tracer, config, req, res, 'test.request')
+
+      expect(web.active(req)).to.equal(span)
+    })
+  })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -275,10 +275,8 @@ function withVersions (plugin, moduleName, range, cb) {
     .forEach(instrumentation => {
       instrumentation.versions
         .forEach(version => {
-          const min = semver.coerce(version).version
-          const max = require(`./plugins/versions/${moduleName}@${version}`).version()
-
           try {
+            const min = semver.coerce(version).version
             require(`./plugins/versions/${moduleName}@${min}`).get()
             testVersions.set(min, { range: version, test: min })
           } catch (e) {
@@ -286,6 +284,7 @@ function withVersions (plugin, moduleName, range, cb) {
           }
 
           try {
+            const max = require(`./plugins/versions/${moduleName}@${version}`).version()
             require(`./plugins/versions/${moduleName}@${version}`).get()
             testVersions.set(max, { range: version, test: version })
           } catch (e) {


### PR DESCRIPTION
This PR adds support for the `hapi` framework. Since most of the logic was already available in the `express` integration, it was extracted so it can be shared between both frameworks.