### PR TITLE
improve benchmark execution speed

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -4,7 +4,7 @@
 
 const Benchmark = require('benchmark')
 
-Benchmark.options.maxTime = 0.5
+Benchmark.options.maxTime = 0.1
 Benchmark.options.minSamples = 5
 
 module.exports = title => {

--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -28,7 +28,6 @@ let propagator
 let carrier
 let writer
 let sampler
-let queue
 
 const traceStub = require('./stubs/trace')
 const spanStub = require('./stubs/span')

--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -77,21 +77,6 @@ suite
       writer.append(spanStub)
     }
   })
-  .add('Writer#flush (1000 items)', {
-    onStart () {
-      writer = new Writer({}, 1001)
-
-      for (let i = 0; i < 1000; i++) {
-        writer.append(spanStub)
-      }
-
-      queue = writer._queue
-    },
-    fn () {
-      writer._queue = queue
-      writer.flush()
-    }
-  })
   .add('Sampler#isSampled', {
     onStart () {
       sampler = new Sampler(0.5)

--- a/benchmark/platform/node.js
+++ b/benchmark/platform/node.js
@@ -1,15 +1,12 @@
 'use strict'
 
 const benchmark = require('../benchmark')
-const Buffer = require('safe-buffer').Buffer
 const platform = require('../../src/platform')
 const node = require('../../src/platform/node')
 
 platform.use(node)
 
 const suite = benchmark('platform (node)')
-
-let data
 
 const traceStub = require('../stubs/trace')
 
@@ -22,26 +19,6 @@ suite
   .add('now', {
     fn () {
       platform.now()
-    }
-  })
-  .add('request', {
-    onStart () {
-      data = Buffer.alloc(1000000)
-    },
-    fn () {
-      platform
-        .request({
-          protocol: 'http:',
-          hostname: 'test',
-          port: '8080',
-          path: '/v0.3/traces',
-          method: 'PUT',
-          headers: {
-            'Content-Type': 'application/msgpack'
-          },
-          data
-        })
-        .catch(() => {})
     }
   })
   .add('msgpack#prefix', {


### PR DESCRIPTION
This PR improves benchmark execution speed by using less samples, and by removing a few irrelevant benchmarks that were basically just clogging the event loop waiting for responses from HTTP requests. These benchmarks were not very useful anyway since they were for operations that only happen every few seconds.