### PR TITLE
update elasticsearch container to be more efficient

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ docker-base: &docker-base
       image: mongo:3.6
     - &elasticsearch
       image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+      environment:
+        - discovery.type=single-node
+        - "ES_JAVA_OPTS=-Xms64m -Xmx64m"
     - &rabbitmq
       image: rabbitmq:3.6-alpine
 build-node-base: &node-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - "127.0.0.1:27017:27017"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms64m -Xmx64m"
     ports:
       - "127.0.0.1:9200:9200"
   rabbitmq:


### PR DESCRIPTION
This PR adds the following options to the Elasticsearch container to make it more efficient:

* `discovery.type=single-node`: This option will prevent Elasticsearch from trying to operate in multiple nodes mode, and disable the associated checks.
* `ES_JAVA_OPTS=-Xms64m -Xmx64m`: This option reduces the heap size to 64mb from the default of 1gb. For testing purposes, this is more than enough.