### PR TITLE
update tests to wipe the require cache only once per suite

### DIFF
--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -52,7 +52,7 @@ module.exports = {
     })
   },
 
-  // Register a callback with expectations to be run on ever agent call.
+  // Register a callback with expectations to be run on every agent call.
   use (callback) {
     const deferred = {}
     const promise = new Promise((resolve, reject) => {

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -8,12 +8,11 @@ const getPort = require('get-port')
 const express = require('express')
 const path = require('path')
 
+const handlers = new Set()
 let agent = null
 let listener = null
 let tracer = null
-let handlers = []
-let promise
-let skip = []
+let skipped = []
 
 module.exports = {
   load (plugin, pluginName, config) {
@@ -27,14 +26,7 @@ module.exports = {
 
     agent.put('/v0.3/traces', (req, res) => {
       res.status(200).send('OK')
-
-      if (skip[0]) {
-        skip[0].resolve()
-        skip.shift()
-      } else if (handlers[0]) {
-        handlers[0](req.body)
-        handlers.shift()
-      }
+      handlers.forEach(handler => handler(req.body))
     })
 
     return getPort().then(port => {
@@ -60,36 +52,74 @@ module.exports = {
     })
   },
 
-  use (callback, count) {
-    count = count || 1
-    promise = Promise.reject(new Error('No request was expected.'))
+  // use (callback, count) {
+  //   count = count || 1
+  //   promise = Promise.reject(new Error('No request was expected.'))
 
-    for (let i = 0; i < count; i++) {
-      promise = promise.catch(() => new Promise((resolve, reject) => {
-        handlers.push(function () {
-          try {
-            callback.apply(null, arguments)
-            resolve()
-          } catch (e) {
-            reject(e)
-          }
-        })
-      }))
+  //   for (let i = 0; i < count; i++) {
+  //     promise = promise.catch(() => new Promise((resolve, reject) => {
+  //       handlers.push(function () {
+  //         try {
+  //           callback.apply(null, arguments)
+  //           resolve()
+  //         } catch (e) {
+  //           reject(e)
+  //         }
+  //       })
+  //     }))
+  //   }
+
+  //   return promise
+  // },
+
+  use (callback) {
+    const deferred = {}
+    const promise = new Promise((resolve, reject) => {
+      deferred.resolve = resolve
+      deferred.reject = reject
+    })
+
+    const timeout = setTimeout(() => {
+      if (error) {
+        deferred.reject(error)
+      }
+    }, 1000)
+
+    let error
+
+    const handler = function () {
+      try {
+        callback.apply(null, arguments)
+        handlers.delete(handler)
+        clearTimeout(timeout)
+        deferred.resolve()
+      } catch (e) {
+        error = error || e
+      }
     }
+
+    handler.promise = promise
+    handlers.add(handler)
 
     return promise
   },
 
-  skip (count) {
-    for (let i = 0; i < count; i++) {
-      const defer = {}
+  promise () {
+    const promises = Array.from(handlers)
+      .map(handler => handler.promise.catch(e => e))
 
-      defer.promise = new Promise((resolve, reject) => {
-        defer.resolve = resolve
-        defer.reject = reject
-      })
+    return Promise.all(promises)
+      .then(results => results.find(e => e instanceof Error))
+  },
 
-      skip.push(defer)
+  reset () {
+    handlers.clear()
+  },
+
+  wrap (callback) {
+    return error => {
+      this.promise()
+        .then(err => callback(error || err))
     }
   },
 
@@ -100,17 +130,19 @@ module.exports = {
 
   close () {
     const timeout = setTimeout(() => {
-      skip.forEach(defer => defer.resolve())
+      skipped.forEach(defer => defer.resolve())
     }, 1000)
 
-    return Promise.all(skip.map(defer => defer.promise))
+    this.wipe()
+
+    return Promise.all(skipped.map(defer => defer.promise))
       .then(() => {
         clearTimeout(timeout)
         listener.close()
         listener = null
         agent = null
-        handlers = []
-        skip = []
+        handlers.clear()
+        skipped = []
         delete require.cache[require.resolve('../..')]
       })
   },

--- a/test/plugins/amqplib.spec.js
+++ b/test/plugins/amqplib.spec.js
@@ -18,30 +18,32 @@ describe('Plugin', () => {
 
       afterEach(() => {
         connection.close()
-        agent.close()
-        agent.wipe()
       })
 
       describe('without configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'amqplib')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
         describe('when using a callback', () => {
           beforeEach(done => {
-            agent.load(plugin, 'amqplib')
-              .then(() => {
-                require(`./versions/amqplib@${version}`).get('amqplib/callback_api')
-                  .connect((err, conn) => {
-                    connection = conn
+            require(`./versions/amqplib@${version}`).get('amqplib/callback_api')
+              .connect((err, conn) => {
+                connection = conn
 
-                    if (err != null) {
-                      return done(err)
-                    }
+                if (err != null) {
+                  return done(err)
+                }
 
-                    conn.createChannel((err, ch) => {
-                      channel = ch
-                      done(err)
-                    })
-                  })
+                conn.createChannel((err, ch) => {
+                  channel = ch
+                  done(err)
+                })
               })
-              .catch(done)
           })
 
           describe('when sending commands', () => {
@@ -211,8 +213,7 @@ describe('Plugin', () => {
 
         describe('when using a promise', () => {
           beforeEach(() => {
-            return agent.load(plugin, 'amqplib')
-              .then(() => require(`./versions/amqplib@${version}`).get().connect())
+            return require(`./versions/amqplib@${version}`).get().connect()
               .then(conn => (connection = conn))
               .then(conn => conn.createChannel())
               .then(ch => (channel = ch))
@@ -230,24 +231,28 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'amqplib', { service: 'test' })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
         beforeEach(done => {
-          agent.load(plugin, 'amqplib', { service: 'test' })
-            .then(() => {
-              require(`./versions/amqplib@${version}`).get('amqplib/callback_api')
-                .connect((err, conn) => {
-                  connection = conn
+          require(`./versions/amqplib@${version}`).get('amqplib/callback_api')
+            .connect((err, conn) => {
+              connection = conn
 
-                  if (err !== null) {
-                    return done(err)
-                  }
+              if (err !== null) {
+                return done(err)
+              }
 
-                  conn.createChannel((err, ch) => {
-                    channel = ch
-                    done(err)
-                  })
-                })
+              conn.createChannel((err, ch) => {
+                channel = ch
+                done(err)
+              })
             })
-            .catch(done)
         })
 
         it('should be configured with the correct values', done => {

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -15,22 +15,22 @@ describe('Plugin', () => {
         tracer = require('../..')
       })
 
-      afterEach(() => {
-        agent.close()
-        agent.wipe()
-      })
-
       describe('without configuration', () => {
         let client
 
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'elasticsearch')
-            .then(() => {
-              elasticsearch = require(`./versions/elasticsearch@${version}`).get()
-              client = new elasticsearch.Client({
-                host: 'localhost:9200'
-              })
-            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          elasticsearch = require(`./versions/elasticsearch@${version}`).get()
+          client = new elasticsearch.Client({
+            host: 'localhost:9200'
+          })
         })
 
         it('should sanitize the resource name', done => {
@@ -212,14 +212,19 @@ describe('Plugin', () => {
       describe('with configuration', () => {
         let client
 
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'elasticsearch', { service: 'test' })
-            .then(() => {
-              elasticsearch = require(`./versions/elasticsearch@${version}`).get()
-              client = new elasticsearch.Client({
-                host: 'localhost:9200'
-              })
-            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          elasticsearch = require(`./versions/elasticsearch@${version}`).get()
+          client = new elasticsearch.Client({
+            host: 'localhost:9200'
+          })
         })
 
         it('should be configured with the correct values', done => {

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -19,16 +19,20 @@ describe('Plugin', () => {
       })
 
       afterEach(() => {
-        agent.close()
         appListener.close()
       })
 
       describe('without configuration', () => {
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'express')
-            .then(() => {
-              express = require(`./versions/express@${version}`).get()
-            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          express = require(`./versions/express@${version}`).get()
         })
 
         it('should do automatic instrumentation on app routes', done => {
@@ -470,11 +474,6 @@ describe('Plugin', () => {
 
             appListener = app.listen(port, 'localhost', () => {
               axios.get(`http://localhost:${port}/app/user/123`)
-                .then(res => {
-                  expect(res.status).to.equal(200)
-                  expect(res.data).to.be.empty
-                  done()
-                })
                 .catch(done)
             })
           })
@@ -541,18 +540,19 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        let config
-
-        beforeEach(() => {
-          config = {
+        before(() => {
+          return agent.load(plugin, 'express', {
             service: 'custom',
             validateStatus: code => code < 400
-          }
+          })
+        })
 
-          return agent.load(plugin, 'express', config)
-            .then(() => {
-              express = require(`./versions/express@${version}`).get()
-            })
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          express = require(`./versions/express@${version}`).get()
         })
 
         it('should be configured with the correct service name', done => {

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -136,24 +136,23 @@ describe('Plugin', () => {
 
   describe('graphql', () => {
     withVersions(plugin, 'graphql', version => {
-      beforeEach(() => {
-        tracer = require('../..')
-
+      before(() => {
         sort = spans => spans.sort((a, b) => a.start.toString() > b.start.toString() ? 1 : -1)
       })
 
-      afterEach(() => {
-        agent.close()
-        agent.wipe()
-      })
-
       describe('without configuration', () => {
-        beforeEach(() => {
+        before(() => {
+          tracer = require('../..')
+
           return agent.load(plugin, 'graphql')
             .then(() => {
               graphql = require(`./versions/graphql@${version}`).get()
               buildSchema()
             })
+        })
+
+        after(() => {
+          return agent.close()
         })
 
         it('should instrument operations', done => {
@@ -389,9 +388,8 @@ describe('Plugin', () => {
           graphql.graphql(schema, source)
             .then((result) => {
               expect(result.data.human.pets[0].owner.name).to.equal('test')
-
-              done()
             })
+            .then(done)
             .catch(done)
         })
 
@@ -687,12 +685,18 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        beforeEach(() => {
+        before(() => {
+          tracer = require('../..')
+
           return agent.load(plugin, 'graphql', { service: 'test' })
             .then(() => {
               graphql = require(`./versions/graphql@${version}`).get()
               buildSchema()
             })
+        })
+
+        after(() => {
+          return agent.close()
         })
 
         it('should be configured with the correct values', done => {

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -23,28 +23,31 @@ describe('Plugin', () => {
       })
 
       afterEach(() => {
-        agent.close()
         server.destroy()
       })
 
       describe('without configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'mongodb-core')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
         beforeEach(done => {
-          agent.load(plugin, 'mongodb-core')
-            .then(() => {
-              mongo = require(`./versions/mongodb-core@${version}`).get()
+          mongo = require(`./versions/mongodb-core@${version}`).get()
 
-              server = new mongo.Server({
-                host: 'localhost',
-                port: 27017,
-                reconnect: false
-              })
+          server = new mongo.Server({
+            host: 'localhost',
+            port: 27017,
+            reconnect: false
+          })
 
-              server.on('connect', () => done())
-              server.on('error', done)
+          server.on('connect', () => done())
+          server.on('error', done)
 
-              server.connect()
-            })
-            .catch(done)
+          server.connect()
         })
 
         describe('server', () => {
@@ -281,29 +284,27 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        let config
+        before(() => {
+          return agent.load(plugin, 'mongodb-core', { service: 'custom' })
+        })
+
+        after(() => {
+          return agent.close()
+        })
 
         beforeEach(done => {
-          config = {
-            service: 'custom'
-          }
+          mongo = require(`./versions/mongodb-core@${version}`).get()
 
-          agent.load(plugin, 'mongodb-core', config)
-            .then(() => {
-              mongo = require(`./versions/mongodb-core@${version}`).get()
+          server = new mongo.Server({
+            host: 'localhost',
+            port: 27017,
+            reconnect: false
+          })
 
-              server = new mongo.Server({
-                host: 'localhost',
-                port: 27017,
-                reconnect: false
-              })
+          server.on('connect', () => done())
+          server.on('error', done)
 
-              server.on('connect', () => done())
-              server.on('error', done)
-
-              server.connect()
-            })
-            .catch(done)
+          server.connect()
         })
 
         it('should be configured with the correct values', done => {

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -15,27 +15,27 @@ describe('Plugin', () => {
         tracer = require('../..')
       })
 
-      afterEach(() => {
-        agent.close()
-        agent.wipe()
-      })
-
       describe('without configuration', () => {
         let connection
 
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'mysql')
-            .then(() => {
-              mysql = require(`./versions/mysql@${version}`).get()
+        })
 
-              connection = mysql.createConnection({
-                host: 'localhost',
-                user: 'root',
-                database: 'db'
-              })
+        after(() => {
+          return agent.close()
+        })
 
-              connection.connect()
-            })
+        beforeEach(() => {
+          mysql = require(`./versions/mysql@${version}`).get()
+
+          connection = mysql.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          connection.connect()
         })
 
         afterEach(done => {
@@ -116,25 +116,25 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         let connection
-        let config
+
+        before(() => {
+          return agent.load(plugin, 'mysql', { service: 'custom' })
+        })
+
+        after(() => {
+          return agent.close()
+        })
 
         beforeEach(() => {
-          config = {
-            service: 'custom'
-          }
+          mysql = require(`./versions/mysql@${version}`).get()
 
-          return agent.load(plugin, 'mysql', config)
-            .then(() => {
-              mysql = require(`./versions/mysql@${version}`).get()
+          connection = mysql.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
 
-              connection = mysql.createConnection({
-                host: 'localhost',
-                user: 'root',
-                database: 'db'
-              })
-
-              connection.connect()
-            })
+          connection.connect()
         })
 
         afterEach(done => {
@@ -154,18 +154,23 @@ describe('Plugin', () => {
       describe('with a connection pool', () => {
         let pool
 
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'mysql')
-            .then(() => {
-              mysql = require(`./versions/mysql@${version}`).get()
+        })
 
-              pool = mysql.createPool({
-                connectionLimit: 10,
-                host: 'localhost',
-                user: 'root',
-                database: 'db'
-              })
-            })
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          mysql = require(`./versions/mysql@${version}`).get()
+
+          pool = mysql.createPool({
+            connectionLimit: 10,
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
         })
 
         afterEach(done => {

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -15,27 +15,27 @@ describe('Plugin', () => {
         tracer = require('../..')
       })
 
-      afterEach(() => {
-        agent.close()
-        agent.wipe()
-      })
-
       describe('without configuration', () => {
         let connection
 
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'mysql2')
-            .then(() => {
-              mysql2 = require(`./versions/mysql2@${version}`).get()
+        })
 
-              connection = mysql2.createConnection({
-                host: 'localhost',
-                user: 'root',
-                database: 'db'
-              })
+        after(() => {
+          return agent.close()
+        })
 
-              connection.connect()
-            })
+        beforeEach(() => {
+          mysql2 = require(`./versions/mysql2@${version}`).get()
+
+          connection = mysql2.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          connection.connect()
         })
 
         afterEach(done => {
@@ -119,25 +119,25 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         let connection
-        let config
+
+        before(() => {
+          return agent.load(plugin, 'mysql2', { service: 'custom' })
+        })
+
+        after(() => {
+          return agent.close()
+        })
 
         beforeEach(() => {
-          config = {
-            service: 'custom'
-          }
+          mysql2 = require(`./versions/mysql2@${version}`).get()
 
-          return agent.load(plugin, 'mysql2', config)
-            .then(() => {
-              mysql2 = require(`./versions/mysql2@${version}`).get()
+          connection = mysql2.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
 
-              connection = mysql2.createConnection({
-                host: 'localhost',
-                user: 'root',
-                database: 'db'
-              })
-
-              connection.connect()
-            })
+          connection.connect()
         })
 
         afterEach(done => {
@@ -159,17 +159,22 @@ describe('Plugin', () => {
       describe('with a connection pool', () => {
         let pool
 
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'mysql2')
-            .then(() => {
-              mysql2 = require(`./versions/mysql2@${version}`).get()
+        })
 
-              pool = mysql2.createPool({
-                connectionLimit: 10,
-                host: 'localhost',
-                user: 'root'
-              })
-            })
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          mysql2 = require(`./versions/mysql2@${version}`).get()
+
+          pool = mysql2.createPool({
+            connectionLimit: 10,
+            host: 'localhost',
+            user: 'root'
+          })
         })
 
         afterEach(done => {

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -16,26 +16,26 @@ describe('Plugin', () => {
         tracer = require('../..')
       })
 
-      afterEach(() => {
-        agent.close()
-      })
-
       describe('when using a client', () => {
+        before(() => {
+          return agent.load(plugin, 'pg')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
         beforeEach(done => {
-          agent.load(plugin, 'pg')
-            .then(() => {
-              pg = require(`./versions/pg@${version}`).get()
+          pg = require(`./versions/pg@${version}`).get()
 
-              client = new pg.Client({
-                user: 'postgres',
-                password: 'postgres',
-                database: 'postgres',
-                application_name: 'test'
-              })
+          client = new pg.Client({
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres',
+            application_name: 'test'
+          })
 
-              client.connect(err => done(err))
-            })
-            .catch(done)
+          client.connect(err => done(err))
         })
 
         it('should do automatic instrumentation when using callbacks', done => {
@@ -108,24 +108,28 @@ describe('Plugin', () => {
       describe('when using a pool', () => {
         let pool
 
+        before(() => {
+          return agent.load(plugin, 'pg')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
         beforeEach(done => {
-          agent.load(plugin, 'pg')
-            .then(() => {
-              pg = require('pg')
+          pg = require('pg')
 
-              pool = new pg.Pool({
-                user: 'postgres',
-                password: 'postgres',
-                database: 'postgres',
-                application_name: 'test'
-              })
+          pool = new pg.Pool({
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres',
+            application_name: 'test'
+          })
 
-              pool.connect((err, c) => {
-                client = c
-                done(err)
-              })
-            })
-            .catch(done)
+          pool.connect((err, c) => {
+            client = c
+            done(err)
+          })
         })
 
         afterEach(() => {
@@ -149,26 +153,24 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        let config
+        before(() => {
+          return agent.load(plugin, 'pg', { service: 'custom' })
+        })
+
+        after(() => {
+          return agent.close()
+        })
 
         beforeEach(done => {
-          config = {
-            service: 'custom'
-          }
+          pg = require('pg')
 
-          agent.load(plugin, 'pg', config)
-            .then(() => {
-              pg = require('pg')
+          client = new pg.Client({
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres'
+          })
 
-              client = new pg.Client({
-                user: 'postgres',
-                password: 'postgres',
-                database: 'postgres'
-              })
-
-              client.connect(err => done(err))
-            })
-            .catch(done)
+          client.connect(err => done(err))
         })
 
         it('should be configured with the correct values', done => {

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -18,16 +18,20 @@ describe('Plugin', () => {
 
       afterEach(() => {
         client.quit()
-        agent.close()
       })
 
       describe('without configuration', () => {
-        beforeEach(() => {
+        before(() => {
           return agent.load(plugin, 'redis')
-            .then(() => {
-              redis = require(`./versions/redis@${version}`).get()
-              client = redis.createClient()
-            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          redis = require(`./versions/redis@${version}`).get()
+          client = redis.createClient()
         })
 
         it('should do automatic instrumentation when using callbacks', done => {
@@ -102,18 +106,17 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        let config
+        before(() => {
+          return agent.load(plugin, 'redis', { service: 'custom' })
+        })
+
+        after(() => {
+          return agent.close()
+        })
 
         beforeEach(() => {
-          config = {
-            service: 'custom'
-          }
-
-          return agent.load(plugin, 'redis', config)
-            .then(() => {
-              redis = require(`./versions/redis@${version}`).get()
-              client = redis.createClient()
-            })
+          redis = require(`./versions/redis@${version}`).get()
+          client = redis.createClient()
         })
 
         it('should be configured with the correct values', done => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -44,6 +44,10 @@ after(() => {
   scopeManager._disable()
 })
 
+afterEach(() => {
+  agent.reset()
+})
+
 waitForServices()
   .then(run)
   .catch(err => {
@@ -219,7 +223,7 @@ function wrapIt () {
 
     if (fn.length > 0) {
       return it.call(this, title, function (done) {
-        arguments[0] = withoutScope(done)
+        arguments[0] = withoutScope(agent.wrap(done))
 
         return fn.apply(this, arguments)
       })
@@ -231,9 +235,11 @@ function wrapIt () {
           return result
             .then(withoutScope(res => res))
             .catch(withoutScope(err => Promise.reject(err)))
+            .then(() => agent.promise())
         }
 
-        return result
+        return agent.promise()
+          .then(() => result)
       })
     }
   }


### PR DESCRIPTION
This PR updates the tests to wipe the require cache only once per suite. Doing this after every single test is very expensive, and was only done to work around an issue where tests needed to know the exact number of requests the agent should get, otherwise they would leak onto other tests. The new logic will skip any request which doesn't match, so the exact number doesn't need to be known in advance. This should improve the stability and speed of the tests.