### PR TITLE
force mocha to exit after tests are done

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "jsdoc:watch": "gulp jsdoc:watch",
     "lint": "eslint . && node scripts/check_licenses.js",
     "tdd": "node ./scripts/install_plugin_modules && mocha --watch",
-    "test": "node ./scripts/install_plugin_modules && nyc --reporter text --reporter lcov mocha 'test/**/*.spec.js'",
+    "test": "node ./scripts/install_plugin_modules && nyc --reporter text --reporter lcov mocha --exit 'test/**/*.spec.js'",
     "leak": "(cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape 'test/leak/{,!(node_modules)/**/}/*.js'"
   },
   "repository": {


### PR DESCRIPTION
This PR forces Mocha to exit after the tests are done. Sometimes the test step gets stuck in the build after all tests are done. Finding the cause would be time consuming, so instead we can simply force the process to exit after the suite has run. We can address the root cause later.