### PR TITLE
 [http] Add connection establishment tracing.

### DIFF
--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -70,9 +70,10 @@ module.exports = {
 
     let error
 
-    const handler = function () {
+    const handler = function (traces) {
       try {
-        callback.apply(null, arguments)
+        const sorted = traces.map(spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1))
+        callback(sorted)
         handlers.delete(handler)
         clearTimeout(timeout)
         deferred.resolve()

--- a/test/plugins/amqp10.spec.js
+++ b/test/plugins/amqp10.spec.js
@@ -82,7 +82,7 @@ describe('Plugin', () => {
                 expect(span.meta).to.have.property('amqp.link.role', 'sender')
                 expect(span.meta).to.have.property('amqp.link.handle', '1')
                 expect(span.meta['amqp.link.name']).to.match(/^amq\.topic_[0-9a-f-]+$/)
-              }, 2)
+              })
               .then(done)
               .catch(done)
 
@@ -100,7 +100,7 @@ describe('Plugin', () => {
                 expect(span.meta).to.have.property('error.type', error.name)
                 expect(span.meta).to.have.property('error.msg', error.message)
                 expect(span.meta).to.have.property('error.stack', error.stack)
-              }, 2)
+              })
               .then(done)
               .catch(done)
 
@@ -136,7 +136,7 @@ describe('Plugin', () => {
                 expect(span.meta).to.have.property('amqp.link.role', 'receiver')
                 expect(span.meta).to.have.property('amqp.link.handle', '0')
                 expect(span.meta['amqp.link.name']).to.match(/^amq\.topic_[0-9a-f-]+$/)
-              }, 2)
+              })
               .then(done)
               .catch(done)
 
@@ -189,7 +189,7 @@ describe('Plugin', () => {
               const span = traces[0][0]
 
               expect(span).to.have.property('service', 'test')
-            }, 2)
+            })
             .then(done)
             .catch(done)
 

--- a/test/plugins/amqplib.spec.js
+++ b/test/plugins/amqplib.spec.js
@@ -58,7 +58,7 @@ describe('Plugin', () => {
                   expect(span).to.have.property('type', 'worker')
                   expect(span.meta).to.have.property('out.host', 'localhost')
                   expect(span.meta).to.have.property('out.port', '5672')
-                }, 2)
+                })
                 .then(done)
                 .catch(done)
 
@@ -76,7 +76,7 @@ describe('Plugin', () => {
                   expect(span).to.have.property('type', 'worker')
                   expect(span.meta).to.have.property('out.host', 'localhost')
                   expect(span.meta).to.have.property('out.port', '5672')
-                }, 3)
+                })
                 .then(done)
                 .catch(done)
 
@@ -95,7 +95,7 @@ describe('Plugin', () => {
                   expect(span.meta).to.have.property('error.type', error.name)
                   expect(span.meta).to.have.property('error.msg', error.message)
                   expect(span.meta).to.have.property('error.stack', error.stack)
-                }, 2)
+                })
                 .then(done)
                 .catch(done)
 
@@ -121,7 +121,7 @@ describe('Plugin', () => {
                   expect(span.meta).to.have.property('out.port', '5672')
                   expect(span.meta).to.have.property('span.kind', 'producer')
                   expect(span.meta).to.have.property('amqp.routingKey', 'routingKey')
-                }, 3)
+                })
                 .then(done)
                 .catch(done)
 
@@ -140,7 +140,7 @@ describe('Plugin', () => {
                   expect(span.meta).to.have.property('error.type', error.name)
                   expect(span.meta).to.have.property('error.msg', error.message)
                   expect(span.meta).to.have.property('error.stack', error.stack)
-                }, 2)
+                })
                 .then(done)
                 .catch(done)
 
@@ -169,7 +169,7 @@ describe('Plugin', () => {
                   expect(span.meta).to.have.property('out.port', '5672')
                   expect(span.meta).to.have.property('span.kind', 'consumer')
                   expect(span.meta).to.have.property('amqp.consumerTag', consumerTag)
-                }, 5)
+                })
                 .then(done)
                 .catch(done)
 
@@ -266,7 +266,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0]).to.have.property('resource', 'queue.declare test')
-            }, 2)
+            })
             .then(done)
             .catch(done)
 

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -99,8 +99,8 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('parent_id')
-                expect(traces[0][0].parent_id).to.not.be.null
+                expect(traces[0][1]).to.have.property('parent_id')
+                expect(traces[0][1].parent_id).to.not.be.null
               })
               .then(done)
               .catch(done)
@@ -162,8 +162,8 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('parent_id')
-                expect(traces[0][0].parent_id).to.not.be.null
+                expect(traces[0][1]).to.have.property('parent_id')
+                expect(traces[0][1].parent_id).to.not.be.null
               })
               .then(done)
               .catch(done)

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -288,7 +288,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][1]).to.have.property('resource', 'GET /app/user/:id')
+                expect(traces[0][0]).to.have.property('resource', 'GET /app/user/:id')
               })
               .then(done)
               .catch(done)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -9,7 +9,6 @@ describe('Plugin', () => {
   let tracer
   let graphql
   let schema
-  let sort
 
   function buildSchema () {
     const Human = new graphql.GraphQLObjectType({
@@ -140,10 +139,6 @@ describe('Plugin', () => {
 
   describe('graphql', () => {
     withVersions(plugin, 'graphql', version => {
-      before(() => {
-        sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
-      })
-
       describe('without configuration', () => {
         before(() => {
           tracer = require('../..')
@@ -164,7 +159,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[0]).to.have.property('service', 'test-graphql')
@@ -183,7 +178,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
               expect(spans[0].meta).to.not.have.property('graphql.variables')
             })
             .then(done)
@@ -197,7 +192,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[4]).to.have.property('service', 'test-graphql')
@@ -215,7 +210,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[5]).to.have.property('service', 'test-graphql')
@@ -233,7 +228,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               const query = spans[0]
               const parse = spans[1]
@@ -254,7 +249,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               const query = spans[0]
               const parse = spans[1]
@@ -277,7 +272,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               const query = spans[0]
               const validate = spans[2]
@@ -310,7 +305,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(14)
 
@@ -389,7 +384,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(10)
 
@@ -438,7 +433,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(8)
               expect(spans[0]).to.have.property('name', 'graphql.mutation')
@@ -454,7 +449,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[0]).to.have.property('name', 'graphql.subscription')
@@ -487,7 +482,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(4)
               expect(spans[0]).to.have.property('resource', 'query')
@@ -515,7 +510,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(4)
               expect(spans[0]).to.have.property('resource', 'query')
@@ -532,7 +527,7 @@ describe('Plugin', () => {
           agent.use(() => { // skip first call
             agent
               .use(traces => {
-                const spans = sort(traces[0])
+                const spans = traces[0]
 
                 expect(spans).to.have.length(6)
               })
@@ -609,7 +604,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[0]).to.have.property('name', 'graphql.query')
@@ -634,7 +629,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(5)
               expect(spans[0]).to.have.property('service', 'test-graphql')
@@ -665,7 +660,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(3)
               expect(spans[2]).to.have.property('service', 'test-graphql')
@@ -704,7 +699,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[5]).to.have.property('error', 1)
@@ -737,7 +732,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[5]).to.have.property('error', 1)
@@ -797,7 +792,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(6)
               expect(spans[2]).to.have.property('service', 'test')
@@ -817,7 +812,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans[0].meta).to.have.property('graphql.variables.title', 'planet')
               expect(spans[0].meta).to.have.property('graphql.variables.who', 'REDACTED')
@@ -860,7 +855,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
 
               expect(spans).to.have.length(4)
               expect(spans[0]).to.have.property('name', 'graphql.query')
@@ -909,7 +904,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              const spans = sort(traces[0])
+              const spans = traces[0]
               const ignored = spans.filter(span => {
                 return [
                   'human.address.civicNumber',

--- a/test/plugins/http.spec.js
+++ b/test/plugins/http.spec.js
@@ -556,10 +556,10 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                const spans = traces[0]
+                const spans = traces.reduce((arr, spans) => arr.concat(spans), [])
                 // 1 parent span created in this test, 2 spans for first request, 1 span for second request.
                 expect(spans.length).to.equal(4)
-              })
+              }, 10)
               .then(done)
               .catch(done)
 
@@ -583,7 +583,7 @@ describe('Plugin', () => {
                     // ...once finished start second request that should re-use connection.
                     http.get(options, res => {
                       res.on('data', () => {})
-                      res.on('end', () => span.finish())
+                      res.on('end', () => setImmediate(() => span.finish()))
                     })
                   })
                 })


### PR DESCRIPTION
This is helpful in order to know how much time your spending on creating connections and determine if you should use keep-alive.

I also slightly refactored the tests to always sort spans before yielding them to the tests. There didn’t appear to be any test that cared about the unordered spans, but an option to not sort should be easy enough to add in the future, if that’s ever needed.