### PR TITLE
add logging to text map propagator

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,6 +4,7 @@ require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,lodash.kebabcase,MIT,Copyright JS Foundation and other contributors
 require,lodash.memoize,MIT,Copyright JS Foundation and other contributors
+require,lodash.pick,MIT,Copyright JS Foundation and other contributors
 require,lodash.uniq,MIT,Copyright JS Foundation and other contributors
 require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk 2013-2014 TJ Holowaychuk
 require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "koalas": "^1.0.2",
     "lodash.kebabcase": "^4.1.1",
     "lodash.memoize": "^4.1.2",
+    "lodash.pick": "^4.4.0",
     "lodash.uniq": "^4.5.0",
     "methods": "^1.1.2",
     "msgpack-lite": "^0.1.26",

--- a/src/opentracing/propagation/text_map.js
+++ b/src/opentracing/propagation/text_map.js
@@ -1,13 +1,16 @@
 'use strict'
 
+const pick = require('lodash.pick')
 const Uint64BE = require('int64-buffer').Uint64BE
 const DatadogSpanContext = require('../span_context')
+const log = require('../../log')
 
 const traceKey = 'x-datadog-trace-id'
 const spanKey = 'x-datadog-parent-id'
 const samplingKey = 'x-datadog-sampling-priority'
 const baggagePrefix = 'ot-baggage-'
 const baggageExpr = new RegExp(`^${baggagePrefix}(.+)$`)
+const logKeys = [traceKey, spanKey, samplingKey]
 
 class TextMapPropagator {
   inject (spanContext, carrier) {
@@ -16,6 +19,8 @@ class TextMapPropagator {
 
     this._injectSamplingPriority(spanContext, carrier)
     this._injectBaggageItems(spanContext, carrier)
+
+    log.debug(() => `Inject into carrier: ${JSON.stringify(pick(carrier, logKeys))}.`)
   }
 
   extract (carrier) {
@@ -30,6 +35,8 @@ class TextMapPropagator {
 
     this._extractBaggageItems(carrier, spanContext)
     this._extractSamplingPriority(carrier, spanContext)
+
+    log.debug(() => `Extract from carrier: ${JSON.stringify(pick(carrier, logKeys))}.`)
 
     return spanContext
   }


### PR DESCRIPTION
This PR adds logging to the text map propagator. This can be useful when trying to debug why distributed tracing is not working.