### PR TITLE
Use standard span types db and cache

### DIFF
--- a/src/plugins/ioredis.js
+++ b/src/plugins/ioredis.js
@@ -8,7 +8,7 @@ function createWrapSendCommand (tracer, config) {
         childOf: scope && scope.span(),
         tags: {
           'span.kind': 'client',
-          'span.type': 'redis',
+          'span.type': 'db',
           'service.name': config.service || `${tracer._service}-redis`,
           'resource.name': command.name,
           'db.type': 'redis',

--- a/src/plugins/memcached.js
+++ b/src/plugins/memcached.js
@@ -8,7 +8,7 @@ function createWrapCommand (tracer, config) {
         childOf: scope && scope.span(),
         tags: {
           'span.kind': 'client',
-          'span.type': 'memcached',
+          'span.type': 'cache',
           'service.name': config.service || `${tracer._service}-memcached`
         }
       })

--- a/src/plugins/mongodb-core.js
+++ b/src/plugins/mongodb-core.js
@@ -233,7 +233,7 @@ function addTags (span, tracer, config, resource, ns, topology) {
   span.addTags({
     'service.name': config.service || `${tracer._service}-mongodb`,
     'resource.name': resource,
-    'span.type': 'mongodb',
+    'span.type': 'db',
     'db.name': ns
   })
 

--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -12,7 +12,7 @@ function createWrapQuery (tracer, config) {
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || `${tracer._service}-mysql`,
-          'span.type': 'sql',
+          'span.type': 'db',
           'db.type': 'mysql',
           'db.user': this.config.user,
           'out.host': this.config.host,

--- a/src/plugins/mysql2.js
+++ b/src/plugins/mysql2.js
@@ -12,7 +12,7 @@ function createWrapQuery (tracer, config) {
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || `${tracer._service}-mysql`,
-          'span.type': 'sql',
+          'span.type': 'db',
           'db.type': 'mysql',
           'db.user': this.config.user,
           'out.host': this.config.host,

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -26,7 +26,7 @@ function patch (pg, tracer, config) {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || `${tracer._service}-postgres`,
           'resource.name': statement,
-          'span.type': 'sql',
+          'span.type': 'db',
           'db.type': 'postgres'
         }
       })

--- a/src/plugins/redis.js
+++ b/src/plugins/redis.js
@@ -13,7 +13,7 @@ function createWrapInternalSendCommand (tracer, config) {
           [Tags.DB_TYPE]: 'redis',
           'service.name': config.service || `${tracer._service}-redis`,
           'resource.name': options.command,
-          'span.type': 'redis',
+          'span.type': 'cache',
           'db.name': this.selected_db || '0'
         }
       })


### PR DESCRIPTION
According to the docs, Datadog only supports `web`, `db`, `http`, `cache`, and `custom`

Docs: https://help.datadoghq.com/hc/en-us/articles/115000702546-What-is-the-Difference-Between-Type-Service-Resource-and-Name-