### PR TITLE
add support for redis >=0.12 <2.6

### DIFF
--- a/src/plugins/redis.js
+++ b/src/plugins/redis.js
@@ -5,31 +5,60 @@ const Tags = require('opentracing').Tags
 function createWrapInternalSendCommand (tracer, config) {
   return function wrapInternalSendCommand (internalSendCommand) {
     return function internalSendCommandWithTrace (options) {
-      const scope = tracer.scopeManager().active()
-      const span = tracer.startSpan('redis.command', {
-        childOf: scope && scope.span(),
-        tags: {
-          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
-          [Tags.DB_TYPE]: 'redis',
-          'service.name': config.service || `${tracer._service}-redis`,
-          'resource.name': options.command,
-          'span.type': 'redis',
-          'db.name': this.selected_db || '0'
-        }
-      })
-
-      if (this.connection_options) {
-        span.addTags({
-          'out.host': String(this.connection_options.host),
-          'out.port': String(this.connection_options.port)
-        })
-      }
+      const span = startSpan(tracer, config, this, options.command)
 
       options.callback = wrapCallback(tracer, span, options.callback)
 
       return internalSendCommand.call(this, options)
     }
   }
+}
+
+function createWrapSendCommand (tracer, config) {
+  return function wrapSendCommand (sendCommand) {
+    return function sendCommandWithTrace (command, args, callback) {
+      const span = startSpan(tracer, config, this, command)
+
+      if (callback) {
+        callback = wrapCallback(tracer, span, callback)
+      } else if (args) {
+        args[(args.length || 1) - 1] = wrapCallback(tracer, span, args[args.length - 1])
+      } else {
+        args = [wrapCallback(tracer, span)]
+      }
+
+      return sendCommand.call(this, command, args, callback)
+    }
+  }
+}
+
+function startSpan (tracer, config, client, command) {
+  const scope = tracer.scopeManager().active()
+  const span = tracer.startSpan('redis.command', {
+    childOf: scope && scope.span(),
+    tags: {
+      [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+      [Tags.DB_TYPE]: 'redis',
+      'service.name': config.service || `${tracer._service}-redis`,
+      'resource.name': command,
+      'span.type': 'redis',
+      'db.name': client.selected_db || '0'
+    }
+  })
+
+  const connectionOptions = client.connection_options || client.connection_option || {
+    host: client.options.host || '127.0.0.1',
+    port: client.options.port || 6379
+  }
+
+  if (connectionOptions) {
+    span.addTags({
+      'out.host': String(connectionOptions.host),
+      'out.port': String(connectionOptions.port)
+    })
+  }
+
+  return span
 }
 
 function wrapCallback (tracer, span, done) {
@@ -44,23 +73,31 @@ function wrapCallback (tracer, span, done) {
 
     span.finish()
 
-    if (done) {
+    if (typeof done === 'function') {
       done(err, res)
     }
   }
 }
 
-function patch (redis, tracer, config) {
-  this.wrap(redis.RedisClient.prototype, 'internal_send_command', createWrapInternalSendCommand(tracer, config))
-}
-
-function unpatch (redis) {
-  this.unwrap(redis.RedisClient.prototype, 'internal_send_command')
-}
-
-module.exports = {
-  name: 'redis',
-  versions: ['^2.6'],
-  patch,
-  unpatch
-}
+module.exports = [
+  {
+    name: 'redis',
+    versions: ['^2.6'],
+    patch (redis, tracer, config) {
+      this.wrap(redis.RedisClient.prototype, 'internal_send_command', createWrapInternalSendCommand(tracer, config))
+    },
+    unpatch (redis) {
+      this.unwrap(redis.RedisClient.prototype, 'internal_send_command')
+    }
+  },
+  {
+    name: 'redis',
+    versions: ['>=0.12 <2.6'],
+    patch (redis, tracer, config) {
+      this.wrap(redis.RedisClient.prototype, 'send_command', createWrapSendCommand(tracer, config))
+    },
+    unpatch (redis) {
+      this.unwrap(redis.RedisClient.prototype, 'send_command')
+    }
+  }
+]

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -37,7 +37,6 @@ describe('Plugin', () => {
         it('should do automatic instrumentation when using callbacks', done => {
           client.on('error', done)
 
-          agent.use(() => client.get('foo')) // wait for initial info command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'redis.command')
@@ -52,6 +51,8 @@ describe('Plugin', () => {
             })
             .then(done)
             .catch(done)
+
+          client.get('foo', () => {})
         })
 
         it('should run the callback in the parent context', done => {


### PR DESCRIPTION
This PR adds versions `>=0.12 <2.6` to the `redis` module in order to support `redis-sentinel` which uses 0.12.x

Fixes #261 