### PR TITLE
add collapse option to graphql integration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -180,6 +180,7 @@ query HelloWorld {
 | service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                                 |
 | variables       | `undefined`                                      | A callback to enable recording of variables. By default, no variables are recorded. For example, using `variables => variables` would record all variables. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
+| collapse        | false                                            | Collapse list items to a single element. (i.e. single `users.*.name` span instead of `users.0.name`, `users.1.name`, etc) |
 
 <h3 id="hapi">hapi</h3>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -180,7 +180,7 @@ query HelloWorld {
 | service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                                 |
 | variables       | `undefined`                                      | A callback to enable recording of variables. By default, no variables are recorded. For example, using `variables => variables` would record all variables. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
-| collapse        | false                                            | Collapse list items to a single element. (i.e. single `users.*.name` span instead of `users.0.name`, `users.1.name`, etc) |
+| collapse        | false                                            | Whether to collapse list items into a single element. (i.e. single `users.*.name` span instead of `users.0.name`, `users.1.name`, etc) |
 
 <h3 id="hapi">hapi</h3>
 

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -167,7 +167,8 @@ function assertField (tracer, config, operation, path) {
 
   if (!field) {
     field = operation._datadog_fields[path.join('.')] = {
-      pending: 0
+      pending: 0,
+      error: null
     }
 
     const fieldParent = getFieldParent(operation, path)
@@ -307,9 +308,11 @@ function createPathSpan (tracer, config, name, childOf, path) {
 function finish (scope, operation, path, error) {
   const field = getField(operation, path)
 
-  field.pending = error ? 0 : field.pending - 1
+  field.pending--
 
-  if (field.pending !== 0) return
+  if (field.error || field.pending > 0) return
+
+  field.error = error
 
   const span = scope.span()
 


### PR DESCRIPTION
This PR adds a "collapse" option to the `graphql` integration. This can be used to collapse list item fields into a single span instead of multiple spans. (i.e. single `users.*.name` span instead of `users.0.name`, `users.1.name`, etc)

There are a few main use cases where this is useful:

* To limit the verbosity and performance impact of big lists. For example, if 5000 items are returned from the data source, 5000 field spans and 5000 resolve spans would be created. This is also true for nesting where 1000 items returned with 1000 child items each would result in 2M spans.
* When the list item resolvers are mostly synchronous and their timing is irrelevant.
* When using something like Dataloader which will make a single request for all items, meaning the duration will be the same for every resolver anyway.