### PR TITLE
fix error in graphql when field depth is higher than config

### DIFF
--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -141,7 +141,7 @@ function wrapResolve (resolve, tracer, config, responsePathAsArray) {
     const depth = path.filter(item => typeof item === 'string').length
 
     if (config.depth > 0 && config.depth < depth) {
-      return call(resolve, this, arguments, err => updateFinishTime(scope, contextValue, path, err))
+      return call(resolve, this, arguments, () => updateFinishTime(contextValue, path))
     }
 
     const fieldParent = getFieldParent(contextValue, path)


### PR DESCRIPTION
This PR fixes an error in the GraphQL integration when the actual depth field is higher than the maximum configured depth.