### PR TITLE
fix logging of unfinished span outputting false positives

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -123,7 +123,7 @@ class DatadogSpan extends Span {
     }
 
     this._spanContext.children
-      .filter(child => !child.isFinished)
+      .filter(child => !child.context().isFinished)
       .forEach(child => {
         log.error(`Parent span ${this} was finished before child span ${child}.`)
       })

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -295,9 +295,9 @@ function updateFinishTime (contextValue, path) {
 }
 
 function finishOperation (contextValue, error) {
-  for (const key in contextValue._datadog_fields) {
+  Object.keys(contextValue._datadog_fields).reverse().forEach(key => {
     contextValue._datadog_fields[key].span.finish(contextValue._datadog_fields[key].finishTime)
-  }
+  })
 
   addError(contextValue._datadog_spans.executeSpan, error)
 


### PR DESCRIPTION
This PR fixes logging of unfinished span outputting false positives. This was caused by trying to access a property on the span instead of span context. It also changes the order in which the `graphql` integration field spans are finished to avoid the error.