### PR TITLE
fix graphql integration not working when using schema stitching

### DIFF
--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -242,15 +242,20 @@ function createOperationSpan (tracer, config, operation, source, variableValues,
   const parentScope = tracer.scopeManager().active()
   const tags = {
     'service.name': getService(tracer, config),
-    'resource.name': [type, name].filter(val => val).join(' '),
-    'graphql.document': source
+    'resource.name': [type, name].filter(val => val).join(' ')
   }
+
+  if (source) {
+    tags['graphql.document'] = source
+  }
+
   if (variableValues && config.variables) {
     const variables = config.variables(variableValues)
     for (const param in variables) {
       tags[`graphql.variables.${param}`] = variables[param]
     }
   }
+
   const span = tracer.startSpan(`graphql.${operation.operation}`, {
     tags,
     startTime,

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -9,7 +9,6 @@ function createWrapExecute (tracer, config, defaultFieldResolver, responsePathAs
       const args = normalizeArgs(arguments)
       const schema = args.schema
       const document = args.document
-      const contextValue = args.contextValue || {}
       const fieldResolver = args.fieldResolver || defaultFieldResolver
       const variableValues = args.variableValues
       const operation = getOperation(document)
@@ -18,49 +17,17 @@ function createWrapExecute (tracer, config, defaultFieldResolver, responsePathAs
         return execute.apply(this, arguments)
       }
 
-      args.contextValue = contextValue
       args.fieldResolver = wrapFieldResolver(fieldResolver, tracer, config, responsePathAsArray)
 
-      if (!schema._datadog_patched) {
-        wrapFields(schema._queryType, tracer, config, responsePathAsArray)
-        wrapFields(schema._mutationType, tracer, config, responsePathAsArray)
+      wrapFields(schema._queryType, tracer, config, responsePathAsArray)
+      wrapFields(schema._mutationType, tracer, config, responsePathAsArray)
 
-        schema._datadog_patched = true
-      }
+      addOperationSpan(tracer, config, operation, document, variableValues)
+      addParseSpan(tracer, config, document, operation)
+      addValidateSpan(tracer, config, document, operation)
+      addExecuteSpan(tracer, config, operation)
 
-      if (!contextValue._datadog_spans) {
-        const parseTime = document._datadog_parse_time
-        const validateTime = document._datadog_validate_time
-
-        const operationSpan = createOperationSpan(
-          tracer,
-          config,
-          operation,
-          document._datadog_source,
-          variableValues,
-          (parseTime && parseTime.start) || (validateTime && validateTime.start)
-        )
-
-        if (parseTime) {
-          const span = createSpan(tracer, config, 'parse', operationSpan, parseTime.start)
-          span.finish(parseTime.end)
-        }
-        if (validateTime) {
-          const span = createSpan(tracer, config, 'validate', operationSpan, validateTime.start)
-          span.finish(validateTime.end)
-        }
-
-        const executeSpan = createSpan(tracer, config, 'execute', operationSpan)
-
-        Object.defineProperties(contextValue, {
-          _datadog_spans: {
-            value: { executeSpan, operationSpan }
-          },
-          _datadog_fields: { value: {} }
-        })
-      }
-
-      return call(execute, this, [args], err => finishOperation(contextValue, err))
+      return call(execute, this, [args], err => finishOperation(operation, err))
     }
   }
 }
@@ -114,7 +81,7 @@ function wrapFields (type, tracer, config, responsePathAsArray) {
   Object.keys(type._fields).forEach(key => {
     const field = type._fields[key]
 
-    if (typeof field.resolve === 'function' && !field.resolve._datadog_patched) {
+    if (typeof field.resolve === 'function') {
       field.resolve = wrapResolve(field.resolve, tracer, config, responsePathAsArray)
     }
 
@@ -129,27 +96,26 @@ function wrapFields (type, tracer, config, responsePathAsArray) {
 }
 
 function wrapResolve (resolve, tracer, config, responsePathAsArray) {
-  function resolveWithTrace (source, args, contextValue, info) {
-    if (!contextValue || !contextValue._datadog_fields) {
-      return resolve.apply(arguments)
-    }
+  if (resolve._datadog_patched) return resolve
 
+  function resolveWithTrace (source, args, contextValue, info) {
+    const operation = info.operation
     const path = responsePathAsArray(info.path)
     const depth = path.filter(item => typeof item === 'string').length
-    const fieldParent = getFieldParent(contextValue, path)
+    const fieldParent = getFieldParent(operation, path)
 
     if (config.depth >= 0 && config.depth < depth) {
       const scope = tracer.scopeManager().activate(fieldParent)
 
       return call(resolve, this, arguments, () => {
         scope.close()
-        updateFinishTime(contextValue, path)
+        updateFinishTime(operation, path)
       })
     }
 
     const childOf = createPathSpan(tracer, config, 'field', fieldParent, path)
 
-    contextValue._datadog_fields[path.join('.')] = {
+    operation._datadog_fields[path.join('.')] = {
       span: childOf,
       parent: fieldParent
     }
@@ -157,7 +123,7 @@ function wrapResolve (resolve, tracer, config, responsePathAsArray) {
     const span = createPathSpan(tracer, config, 'resolve', childOf, path)
     const scope = tracer.scopeManager().activate(span)
 
-    return call(resolve, this, arguments, err => finish(scope, contextValue, path, err))
+    return call(resolve, this, arguments, err => finish(scope, operation, path, err))
   }
 
   resolveWithTrace._datadog_patched = true
@@ -200,16 +166,16 @@ function call (fn, thisContext, args, callback) {
   }
 }
 
-function getFieldParent (contextValue, path) {
+function getFieldParent (operation, path) {
   for (let i = path.length - 1; i > 0; i--) {
-    const field = getField(contextValue, path.slice(0, i))
+    const field = getField(operation, path.slice(0, i))
 
     if (field) {
       return field.span
     }
   }
 
-  return contextValue._datadog_spans.executeSpan
+  return operation._datadog_execute_span
 }
 
 function normalizeArgs (args) {
@@ -225,6 +191,48 @@ function normalizeArgs (args) {
     variableValues: args[4],
     operationName: args[5],
     fieldResolver: args[6]
+  }
+}
+
+function addOperationSpan (tracer, config, operation, document, variableValues) {
+  const parseTime = document._datadog_parse_time
+  const validateTime = document._datadog_validate_time
+  const startTime = (parseTime && parseTime.start) || (validateTime && validateTime.start)
+
+  const operationSpan = createOperationSpan(
+    tracer,
+    config,
+    operation,
+    document._datadog_source,
+    variableValues,
+    startTime
+  )
+
+  Object.defineProperty(operation, '_datadog_span', { value: operationSpan })
+  Object.defineProperty(operation, '_datadog_fields', { value: {} })
+}
+
+function addExecuteSpan (tracer, config, operation) {
+  const span = createSpan(tracer, config, 'execute', operation._datadog_span)
+
+  Object.defineProperty(operation, '_datadog_execute_span', { value: span })
+}
+
+function addParseSpan (tracer, config, document, operation) {
+  const parseTime = document._datadog_parse_time
+
+  if (parseTime) {
+    const span = createSpan(tracer, config, 'parse', operation._datadog_span, parseTime.start)
+    span.finish(parseTime.end)
+  }
+}
+
+function addValidateSpan (tracer, config, document, operation) {
+  const validateTime = document._datadog_validate_time
+
+  if (validateTime) {
+    const span = createSpan(tracer, config, 'validate', operation._datadog_span, validateTime.start)
+    span.finish(validateTime.end)
   }
 }
 
@@ -273,7 +281,7 @@ function createPathSpan (tracer, config, name, childOf, path) {
   return span
 }
 
-function finish (scope, contextValue, path, error) {
+function finish (scope, operation, path, error) {
   const span = scope.span()
 
   addError(span, error)
@@ -281,12 +289,12 @@ function finish (scope, contextValue, path, error) {
   span.finish()
   scope.close()
 
-  updateFinishTime(contextValue, path)
+  updateFinishTime(operation, path)
 }
 
-function updateFinishTime (contextValue, path) {
+function updateFinishTime (operation, path) {
   for (let i = path.length; i > 0; i--) {
-    const field = getField(contextValue, path.slice(0, i))
+    const field = getField(operation, path.slice(0, i))
 
     if (field) {
       field.finishTime = platform.now()
@@ -294,19 +302,19 @@ function updateFinishTime (contextValue, path) {
   }
 }
 
-function finishOperation (contextValue, error) {
-  Object.keys(contextValue._datadog_fields).reverse().forEach(key => {
-    contextValue._datadog_fields[key].span.finish(contextValue._datadog_fields[key].finishTime)
+function finishOperation (operation, error) {
+  Object.keys(operation._datadog_fields).reverse().forEach(key => {
+    operation._datadog_fields[key].span.finish(operation._datadog_fields[key].finishTime)
   })
 
-  addError(contextValue._datadog_spans.executeSpan, error)
+  addError(operation._datadog_execute_span, error)
 
-  contextValue._datadog_spans.executeSpan.finish()
-  contextValue._datadog_spans.operationSpan.finish()
+  operation._datadog_execute_span.finish()
+  operation._datadog_span.finish()
 }
 
-function getField (contextValue, path) {
-  return contextValue._datadog_fields[path.join('.')]
+function getField (operation, path) {
+  return operation._datadog_fields[path.join('.')]
 }
 
 function getService (tracer, config) {

--- a/test/plugins/externals.json
+++ b/test/plugins/externals.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "name": "apollo-server-core",
+    "versions": ["1.3.6"]
+  },
+  {
+    "name": "graphql-tools",
+    "versions": ["3.1.1"]
+  }
+]

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -955,6 +955,109 @@ describe('Plugin', () => {
           graphql.graphql(schema, source).catch(done)
         })
       })
+
+      withVersions(plugin, 'apollo-server-core', apolloVersion => {
+        let runQuery
+        let mergeSchemas
+        let makeExecutableSchema
+
+        before(() => {
+          tracer = require('../..')
+
+          return agent.load(plugin, 'graphql')
+            .then(() => {
+              graphql = require(`../../versions/graphql@${version}`).get()
+
+              const apolloCore = require(`../../versions/apollo-server-core@${apolloVersion}`).get()
+              const graphqlTools = require(`../../versions/graphql-tools@3.1.1`).get()
+
+              runQuery = apolloCore.runQuery
+              mergeSchemas = graphqlTools.mergeSchemas
+              makeExecutableSchema = graphqlTools.makeExecutableSchema
+            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        it('should support apollo-server schema stitching', done => {
+          agent
+            .use(traces => {
+              const spans = sort(traces[0])
+
+              expect(spans).to.have.length(11)
+
+              expect(spans[0]).to.have.property('name', 'graphql.query')
+              expect(spans[0]).to.have.property('resource', 'query MyQuery')
+
+              expect(spans[1]).to.have.property('name', 'graphql.parse')
+
+              expect(spans[2]).to.have.property('name', 'graphql.validate')
+
+              expect(spans[3]).to.have.property('name', 'graphql.execute')
+
+              expect(spans[4]).to.have.property('name', 'graphql.field')
+              expect(spans[4]).to.have.property('resource', 'hello')
+
+              expect(spans[5]).to.have.property('name', 'graphql.resolve')
+              expect(spans[5]).to.have.property('resource', 'hello')
+
+              expect(spans[6]).to.have.property('name', 'graphql.query')
+              expect(spans[6]).to.have.property('resource', 'query MyQuery')
+
+              expect(spans[7]).to.have.property('name', 'graphql.validate')
+
+              expect(spans[8]).to.have.property('name', 'graphql.execute')
+
+              expect(spans[9]).to.have.property('name', 'graphql.field')
+              expect(spans[9]).to.have.property('resource', 'hello')
+
+              expect(spans[10]).to.have.property('name', 'graphql.resolve')
+              expect(spans[10]).to.have.property('resource', 'hello')
+            })
+            .then(done)
+            .catch(done)
+
+          schema = mergeSchemas({
+            schemas: [
+              makeExecutableSchema({
+                typeDefs: `
+                  type Query {
+                    hello: String
+                  }
+                `,
+                resolvers: {
+                  Query: {
+                    hello: () => 'Hello world!'
+                  }
+                }
+              }),
+              makeExecutableSchema({
+                typeDefs: `
+                  type Query {
+                    world: String
+                  }
+                `,
+                resolvers: {
+                  Query: {
+                    world: () => 'Hello world!'
+                  }
+                }
+              })
+            ]
+          })
+
+          const params = {
+            schema,
+            query: 'query MyQuery { hello }',
+            operationName: 'MyQuery'
+          }
+
+          runQuery(params)
+            .catch(done)
+        })
+      })
     })
   })
 })

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -990,6 +990,7 @@ describe('Plugin', () => {
 
               expect(spans[0]).to.have.property('name', 'graphql.query')
               expect(spans[0]).to.have.property('resource', 'query MyQuery')
+              expect(spans[0].meta).to.have.property('graphql.document')
 
               expect(spans[1]).to.have.property('name', 'graphql.parse')
 
@@ -1005,6 +1006,7 @@ describe('Plugin', () => {
 
               expect(spans[6]).to.have.property('name', 'graphql.query')
               expect(spans[6]).to.have.property('resource', 'query MyQuery')
+              expect(spans[6].meta).to.not.have.property('graphql.document')
 
               expect(spans[7]).to.have.property('name', 'graphql.validate')
 


### PR DESCRIPTION
This PR fixes the graphql integration not working when using schema stitching. This is a feature of Apollo Server that allows merging multiple schemas together.

This was not working before because the instrumentation was storing metadata on the schema and the contextValue with the assumption that there is only one of each for every operation. Now all metadata is properly attached to the operation itself and is thus independent from the number of schemas or changes to contextValue.

Fixes #235 #307 