### PR TITLE
add support for graphql 0.10, 0.11, 0.12 and 14

### DIFF
--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -378,7 +378,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'execution/execute.js',
-    versions: ['0.13.x'],
+    versions: ['>=0.10 <=14'],
     patch (execute, tracer, config) {
       this.wrap(execute, 'execute', createWrapExecute(
         tracer,
@@ -394,7 +394,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'language/parser.js',
-    versions: ['0.13.x'],
+    versions: ['>=0.10 <=14'],
     patch (parser, tracer, config) {
       this.wrap(parser, 'parse', createWrapParse(tracer, validateConfig(config)))
     },
@@ -405,7 +405,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'validation/validate.js',
-    versions: ['0.13.x'],
+    versions: ['>=0.10 <=14'],
     patch (validate, tracer, config) {
       this.wrap(validate, 'validate', createWrapValidate(tracer, validateConfig(config)))
     },

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -649,15 +649,6 @@ describe('Plugin', () => {
         })
 
         it('should handle executor exceptions', done => {
-          schema = new graphql.GraphQLSchema({
-            query: new graphql.GraphQLObjectType({
-              name: 'RootQueryType',
-              fields: {
-                hello: {}
-              }
-            })
-          })
-
           const source = `{ hello }`
           const document = graphql.parse(source)
 
@@ -679,7 +670,7 @@ describe('Plugin', () => {
             .catch(done)
 
           try {
-            graphql.execute(schema, document)
+            graphql.execute({}, document)
           } catch (e) {
             error = e
           }


### PR DESCRIPTION
This PR extends GraphQL version support to `>=0.10 <=14`.

Closes #324 