### PR TITLE
enable collapse option by default

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -180,7 +180,7 @@ query HelloWorld {
 | service         | *Service name of the app suffixed with -graphql* | The service name for this integration.                                 |
 | variables       | `undefined`                                      | A callback to enable recording of variables. By default, no variables are recorded. For example, using `variables => variables` would record all variables. |
 | depth           | -1                                               | The maximum depth of fields/resolvers to instrument. Set to `0` to only instrument the operation or to -1 to instrument all fields/resolvers. |
-| collapse        | false                                            | Whether to collapse list items into a single element. (i.e. single `users.*.name` span instead of `users.0.name`, `users.1.name`, etc) |
+| collapse        | true                                             | Whether to collapse list items into a single element. (i.e. single `users.*.name` span instead of `users.0.name`, `users.1.name`, etc) |
 
 <h3 id="hapi">hapi</h3>
 

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -386,7 +386,8 @@ function addError (span, error) {
 function validateConfig (config) {
   return Object.assign({}, config, {
     depth: getDepth(config),
-    variables: getVariablesFilter(config)
+    variables: getVariablesFilter(config),
+    collapse: config.collapse === undefined || !!config.collapse
   })
 }
 

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -391,15 +391,13 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans).to.have.length(10)
+              expect(spans).to.have.length(8)
 
               const execute = spans[3]
               const friendsField = spans[4]
               const friendsResolve = spans[5]
-              const friend0NameField = spans[6]
-              const friend0NameResolve = spans[7]
-              const friend1NameField = spans[8]
-              const friend1NameResolve = spans[9]
+              const friendNameField = spans[6]
+              const friendNameResolve = spans[7]
 
               expect(execute).to.have.property('name', 'graphql.execute')
 
@@ -411,21 +409,13 @@ describe('Plugin', () => {
               expect(friendsResolve).to.have.property('resource', 'friends')
               expect(friendsResolve.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friend0NameField).to.have.property('name', 'graphql.field')
-              expect(friend0NameField).to.have.property('resource', 'friends.0.name')
-              expect(friend0NameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
+              expect(friendNameField).to.have.property('name', 'graphql.field')
+              expect(friendNameField).to.have.property('resource', 'friends.*.name')
+              expect(friendNameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friend0NameResolve).to.have.property('name', 'graphql.resolve')
-              expect(friend0NameResolve).to.have.property('resource', 'friends.0.name')
-              expect(friend0NameResolve.parent_id.toString()).to.equal(friend0NameField.span_id.toString())
-
-              expect(friend1NameField).to.have.property('name', 'graphql.field')
-              expect(friend1NameField).to.have.property('resource', 'friends.1.name')
-              expect(friend1NameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
-
-              expect(friend1NameResolve).to.have.property('name', 'graphql.resolve')
-              expect(friend1NameResolve).to.have.property('resource', 'friends.1.name')
-              expect(friend1NameResolve.parent_id.toString()).to.equal(friend1NameField.span_id.toString())
+              expect(friendNameResolve).to.have.property('name', 'graphql.resolve')
+              expect(friendNameResolve).to.have.property('resource', 'friends.*.name')
+              expect(friendNameResolve.parent_id.toString()).to.equal(friendNameField.span_id.toString())
             })
             .then(done)
             .catch(done)
@@ -937,7 +927,7 @@ describe('Plugin', () => {
                 ].indexOf(span.resource) !== -1
               })
 
-              expect(spans).to.have.length(16)
+              expect(spans).to.have.length(12)
               expect(ignored).to.have.length(0)
             })
             .then(done)
@@ -947,11 +937,11 @@ describe('Plugin', () => {
         })
       })
 
-      describe('with collapsing enabled', () => {
+      describe('with collapsing disabled', () => {
         before(() => {
           tracer = require('../..')
 
-          return agent.load(plugin, 'graphql', { collapse: true })
+          return agent.load(plugin, 'graphql', { collapse: false })
         })
 
         after(() => {
@@ -963,20 +953,22 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should collapse list field resolvers', done => {
+        it('should not collapse list field resolvers', done => {
           const source = `{ friends { name } }`
 
           agent
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans).to.have.length(8)
+              expect(spans).to.have.length(10)
 
               const execute = spans[3]
               const friendsField = spans[4]
               const friendsResolve = spans[5]
-              const friendNameField = spans[6]
-              const friendNameResolve = spans[7]
+              const friend0NameField = spans[6]
+              const friend0NameResolve = spans[7]
+              const friend1NameField = spans[8]
+              const friend1NameResolve = spans[9]
 
               expect(execute).to.have.property('name', 'graphql.execute')
 
@@ -988,13 +980,21 @@ describe('Plugin', () => {
               expect(friendsResolve).to.have.property('resource', 'friends')
               expect(friendsResolve.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friendNameField).to.have.property('name', 'graphql.field')
-              expect(friendNameField).to.have.property('resource', 'friends.*.name')
-              expect(friendNameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
+              expect(friend0NameField).to.have.property('name', 'graphql.field')
+              expect(friend0NameField).to.have.property('resource', 'friends.0.name')
+              expect(friend0NameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friendNameResolve).to.have.property('name', 'graphql.resolve')
-              expect(friendNameResolve).to.have.property('resource', 'friends.*.name')
-              expect(friendNameResolve.parent_id.toString()).to.equal(friendNameField.span_id.toString())
+              expect(friend0NameResolve).to.have.property('name', 'graphql.resolve')
+              expect(friend0NameResolve).to.have.property('resource', 'friends.0.name')
+              expect(friend0NameResolve.parent_id.toString()).to.equal(friend0NameField.span_id.toString())
+
+              expect(friend1NameField).to.have.property('name', 'graphql.field')
+              expect(friend1NameField).to.have.property('resource', 'friends.1.name')
+              expect(friend1NameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
+
+              expect(friend1NameResolve).to.have.property('name', 'graphql.resolve')
+              expect(friend1NameResolve).to.have.property('resource', 'friends.1.name')
+              expect(friend1NameResolve.parent_id.toString()).to.equal(friend1NameField.span_id.toString())
             })
             .then(done)
             .catch(done)


### PR DESCRIPTION
As explained in #316, not collapsing the fields can result in a very high number of spans. To avoid any issue by simply enabling the tracer, it's safer to change the default to true.