### PR TITLE
add blacklist and whiltelist options to the http plugin

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -213,11 +213,13 @@ query HelloWorld {
 
 <h5 id="http-config">Configuration Options</h5>
 
-| Option           | Default          | Description                            |
-|------------------|------------------|----------------------------------------|
+| Option           | Default                               | Description       |
+|------------------|---------------------------------------|-------------------|
 | service          | http-client                           | The service name for this integration. |
 | splitByDomain    | false                                 | Use the remote endpoint host as the service name instead of the default. |
 | validateStatus   | `code => code < 400 || code >= 500`   | Callback function to determine if an HTTP response should be recorded as an error. It should take a status code as its only parameter and return `true` for success or `false` for errors.
+| blacklist        | []                                    | List of URLs that should not be instrumented. Can be a string, RegExp, callback that takes the URL as a parameter, or an array of any of these.
+| whitelist        | /.*/                                  | List of URLs that should be instrumented. If this is set, other URLs will not be instrumented. Can be a string, RegExp, callback that takes the URL as a parameter, or an array of any of these.
 
 <h3 id="ioredis">ioredis</h3>
 


### PR DESCRIPTION
This PR adds a blacklist and whitelist options to the `http` plugin to allow filtering which endpoints should be instrumented.

Closes #325 