### PR TITLE
add system tags

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -7,6 +7,7 @@ const SpanContext = require('./span_context')
 const platform = require('../platform')
 const log = require('../log')
 const constants = require('../constants')
+const tracerVersion = require('../../lib/version')
 
 const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 
@@ -33,6 +34,10 @@ class DatadogSpan extends Span {
     this._spanContext.name = operationName
     this._spanContext.tags = tags
     this._spanContext.metrics = metrics
+
+    if (!parent) {
+      this._addSystemTags()
+    }
   }
 
   toString () {
@@ -74,6 +79,17 @@ class DatadogSpan extends Span {
     spanContext.trace.started.push(this)
 
     return spanContext
+  }
+
+  _addSystemTags () {
+    const info = platform.info()
+
+    info.runtime.name && this.setTag('system.runtime.name', info.runtime.name)
+    info.runtime.version && this.setTag('system.runtime.version', info.runtime.version)
+    info.interpreter.name && this.setTag('system.interpreter.name', info.interpreter.name)
+    info.interpreter.version && this.setTag('system.interpreter.version', info.interpreter.version)
+
+    this.setTag('system.tracer.version', tracerVersion)
   }
 
   _context () {

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const EventEmitter = require('events')
+const info = require('./info')
 const id = require('./id')
 const now = require('./now')
 const env = require('./env')
@@ -18,6 +19,7 @@ const platform = {
   configure (config) {
     this._config = config
   },
+  info,
   id,
   now,
   env,

--- a/src/platform/node/info.js
+++ b/src/platform/node/info.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = () => {
+  const interpreter = process.jsEngine || 'v8'
+
+  return {
+    runtime: {
+      name: 'nodejs',
+      version: process.version
+    },
+    interpreter: {
+      name: interpreter,
+      version: process.versions[interpreter]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following system tags to the root span of every trace:

* `system.runtime.name`
* `system.runtime.version`
* `system.interpreter.name`
* `system.interpreter.version`
* `system.tracer.version`