### PR TITLE
add support for http servers without any framework

### DIFF
--- a/src/plugins/http/client.js
+++ b/src/plugins/http/client.js
@@ -3,7 +3,7 @@
 const url = require('url')
 const opentracing = require('opentracing')
 const semver = require('semver')
-const log = require('../log')
+const log = require('../../log')
 
 const Tags = opentracing.Tags
 const FORMAT_HTTP_HEADERS = opentracing.FORMAT_HTTP_HEADERS

--- a/src/plugins/http/index.js
+++ b/src/plugins/http/index.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const client = require('./client')
+const server = require('./server')
+
+module.exports = [].concat(client, server)

--- a/src/plugins/http/server.js
+++ b/src/plugins/http/server.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const web = require('../util/web')
+
+function createWrapListen (tracer, config) {
+  config = web.normalizeConfig(config)
+
+  return function wrapListen (listen) {
+    const listener = (req, res) => {
+      web.instrument(tracer, config, req, res, 'http.request')
+    }
+
+    return function listenWithTrace () {
+      this.removeListener('request', listener)
+      this.prependListener('request', listener)
+
+      return listen.apply(this, arguments)
+    }
+  }
+}
+
+function plugin (name) {
+  return {
+    name,
+    patch (http, tracer, config) {
+      this.wrap(http.Server.prototype, 'listen', createWrapListen(tracer, config))
+    },
+    unpatch (http) {
+      this.unwrap(http.Server.prototype, 'listen')
+    }
+  }
+}
+
+module.exports = [
+  plugin('http'),
+  plugin('https')
+]

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const getPort = require('get-port')
-const agent = require('./agent')
+const agent = require('../agent')
 const semver = require('semver')
 
 wrapIt()
@@ -34,8 +34,8 @@ describe('Plugin', () => {
       }
 
       beforeEach(() => {
-        plugin = require('../../src/plugins/http')
-        tracer = require('../..')
+        plugin = require('../../../src/plugins/http/client')
+        tracer = require('../../..')
         appListener = null
       })
 

--- a/test/plugins/http/server.spec.js
+++ b/test/plugins/http/server.spec.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const getPort = require('get-port')
+const agent = require('../agent')
+const axios = require('axios')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let plugin
+  let http
+  let listener
+  let appListener
+  let tracer
+  let port
+  let app
+
+  describe('http/server', () => {
+    beforeEach(() => {
+      plugin = require('../../../src/plugins/http/server')
+      tracer = require('../../..')
+      listener = (req, res) => {
+        app && app(req, res)
+        res.writeHead(200)
+        res.end()
+      }
+    })
+
+    beforeEach(() => {
+      return getPort().then(newPort => {
+        port = newPort
+      })
+    })
+
+    afterEach(() => {
+      appListener && appListener.close()
+      return agent.close()
+    })
+
+    describe('without configuration', () => {
+      beforeEach(() => {
+        return agent.load(plugin, 'http')
+          .then(() => {
+            http = require('http')
+          })
+      })
+
+      beforeEach(done => {
+        const server = new http.Server(listener)
+        appListener = server
+          .listen(port, 'localhost', () => done())
+      })
+
+      it('should do automatic instrumentation', done => {
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('name', 'http.request')
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('type', 'http')
+            expect(traces[0][0]).to.have.property('resource', 'GET')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+            expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+            expect(traces[0][0].meta).to.have.property('http.method', 'GET')
+            expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+          })
+          .then(done)
+          .catch(done)
+
+        axios.get(`http://localhost:${port}/user`).catch(done)
+      })
+
+      it('should run the request listener in the request scope', done => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
+        app = (req, res) => {
+          expect(tracer.scopeManager().active()).to.not.be.null
+          done()
+        }
+
+        axios.get(`http://localhost:${port}/user`).catch(done)
+      })
+    })
+  })
+})

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -105,6 +105,31 @@ describe('plugins/util/web', () => {
           [`${HTTP_HEADERS}.host`]: 'localhost'
         })
       })
+
+      it('should only start one span for the entire request', () => {
+        const span1 = web.instrument(tracer, config, req, res, 'test.request')
+        const scope1 = tracer.scopeManager().active()
+        const span2 = web.instrument(tracer, config, req, res, 'test.request')
+        const scope2 = tracer.scopeManager().active()
+
+        expect(span1).to.equal(span2)
+        expect(scope1).to.equal(scope2)
+      })
+
+      it('should allow overriding the span name', () => {
+        span = web.instrument(tracer, config, req, res, 'test.request')
+        span = web.instrument(tracer, config, req, res, 'test2.request')
+
+        expect(span.context().name).to.equal('test2.request')
+      })
+
+      it('should allow overriding the span service name', () => {
+        span = web.instrument(tracer, config, req, res, 'test.request')
+        config.service = 'test2'
+        span = web.instrument(tracer, config, req, res, 'test.request')
+
+        expect(span.context().tags).to.have.property('service.name', 'test2')
+      })
     })
 
     describe('on request end', () => {


### PR DESCRIPTION
This PR adds support for HTTP servers using the `http` module directly without any framework. It also updates the web instrumentation utility to support multiple request stages to allow frameworks to update the request span if one is already attached to the request.