### PR TITLE
add support for the `router` module

### DIFF
--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const METHODS = require('methods').concat('use', 'route', 'param', 'all')
-const pathToRegExp = require('path-to-regexp')
 const web = require('./util/web')
+const routerPlugin = require('./router')
 
 function createWrapMethod (tracer, config) {
   config = web.normalizeConfig(config)
@@ -26,128 +26,14 @@ function createWrapMethod (tracer, config) {
   }
 }
 
-function createWrapHandle (tracer, config) {
-  return function wrapHandle (handle) {
-    return function handleWithTracer (req) {
-      web.patch(req)
-
-      return handle.apply(this, arguments)
-    }
-  }
-}
-
-function createWrapProcessParams (tracer, config) {
-  return function wrapProcessParams (processParams) {
-    return function processParamsWithTrace (layer, called, req, res, done) {
-      const matchers = layer._datadog_matchers
-
-      req = done ? req : called
-
-      if (matchers) {
-        // Try to guess which path actually matched
-        for (let i = 0; i < matchers.length; i++) {
-          if (matchers[i].test(layer.path)) {
-            web.enterRoute(req, matchers[i].path)
-
-            break
-          }
-        }
-      }
-
-      return processParams.apply(this, arguments)
-    }
-  }
-}
-
-function createWrapRouterMethod (tracer) {
-  return function wrapRouterMethod (original) {
-    return function methodWithTrace (fn) {
-      const offset = this.stack.length
-      const router = original.apply(this, arguments)
-      const matchers = extractMatchers(fn)
-
-      this.stack.slice(offset).forEach(layer => {
-        const handle = layer.handle
-
-        if (handle.length === 4) {
-          layer.handle = (error, req, res, next) => {
-            return handle.call(layer, error, req, res, wrapNext(tracer, layer, req, next))
-          }
-        } else {
-          layer.handle = (req, res, next) => {
-            return handle.call(layer, req, res, wrapNext(tracer, layer, req, next))
-          }
-        }
-
-        layer._datadog_matchers = matchers
-      })
-
-      return router
-    }
-  }
-}
-
-function wrapNext (tracer, layer, req, next) {
-  if (!web.active(req)) {
-    return next
-  }
-
-  const originalNext = next
-
-  web.reactivate(req)
-
-  return function (error) {
-    if (!error && layer.path && !isFastStar(layer)) {
-      web.exitRoute(req)
-    }
-
-    process.nextTick(() => {
-      originalNext.apply(null, arguments)
-    })
-  }
-}
-
-function extractMatchers (fn) {
-  const arg = flatten([].concat(fn))
-
-  if (typeof arg[0] === 'function') {
-    return []
-  }
-
-  return arg.map(pattern => ({
-    path: pattern instanceof RegExp ? `(${pattern})` : pattern,
-    test: path => pathToRegExp(pattern).test(path)
-  }))
-}
-
-function isFastStar (layer) {
-  if (layer.regexp.fast_star !== undefined) {
-    return layer.regexp.fast_star
-  }
-
-  return layer._datadog_matchers.some(matcher => matcher.path === '*')
-}
-
-function flatten (arr) {
-  return arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flatten(val)) : acc.concat(val), [])
-}
-
 function patch (express, tracer, config) {
-  METHODS.forEach(method => {
-    this.wrap(express.application, method, createWrapMethod(tracer, config))
-  })
-  this.wrap(express.Router, 'handle', createWrapHandle(tracer, config))
-  this.wrap(express.Router, 'process_params', createWrapProcessParams(tracer, config))
-  this.wrap(express.Router, 'use', createWrapRouterMethod(tracer, config))
-  this.wrap(express.Router, 'route', createWrapRouterMethod(tracer, config))
+  this.wrap(express.application, METHODS, createWrapMethod(tracer, config))
+  routerPlugin.patch.call(this, { prototype: express.Router }, tracer, config)
 }
 
 function unpatch (express) {
-  METHODS.forEach(method => this.unwrap(express.application, method))
-  this.unwrap(express.Router, 'handle')
-  this.unwrap(express.Router, 'process_params')
-  this.unwrap(express.Router, 'use')
-  this.unwrap(express.Router, 'route')
+  this.unwrap(express.application, METHODS)
+  routerPlugin.unpatch.call(this, { prototype: express.Router })
 }
 
 module.exports = {

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -1,0 +1,127 @@
+'use strict'
+
+const pathToRegExp = require('path-to-regexp')
+const web = require('./util/web')
+
+function createWrapHandle (tracer, config) {
+  return function wrapHandle (handle) {
+    return function handleWithTracer (req) {
+      web.patch(req)
+
+      return handle.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapProcessParams (tracer, config) {
+  return function wrapProcessParams (processParams) {
+    return function processParamsWithTrace (layer, called, req, res, done) {
+      const matchers = layer._datadog_matchers
+
+      req = done ? req : called
+
+      if (web.active(req) && matchers) {
+        // Try to guess which path actually matched
+        for (let i = 0; i < matchers.length; i++) {
+          if (matchers[i].test(layer.path)) {
+            web.enterRoute(req, matchers[i].path)
+
+            break
+          }
+        }
+      }
+
+      return processParams.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapRouterMethod (tracer) {
+  return function wrapRouterMethod (original) {
+    return function methodWithTrace (fn) {
+      const offset = this.stack.length
+      const router = original.apply(this, arguments)
+      const matchers = extractMatchers(fn)
+
+      this.stack.slice(offset).forEach(layer => {
+        const handle = layer.handle
+
+        if (handle.length === 4) {
+          layer.handle = (error, req, res, next) => {
+            return handle.call(layer, error, req, res, wrapNext(tracer, layer, req, next))
+          }
+        } else {
+          layer.handle = (req, res, next) => {
+            return handle.call(layer, req, res, wrapNext(tracer, layer, req, next))
+          }
+        }
+
+        layer._datadog_matchers = matchers
+      })
+
+      return router
+    }
+  }
+}
+
+function wrapNext (tracer, layer, req, next) {
+  if (!web.active(req)) {
+    return next
+  }
+
+  const originalNext = next
+
+  web.reactivate(req)
+
+  return function (error) {
+    if (!error && layer.path && !isFastStar(layer)) {
+      web.exitRoute(req)
+    }
+
+    process.nextTick(() => {
+      originalNext.apply(null, arguments)
+    })
+  }
+}
+
+function extractMatchers (fn) {
+  const arg = flatten([].concat(fn))
+
+  if (typeof arg[0] === 'function') {
+    return []
+  }
+
+  return arg.map(pattern => ({
+    path: pattern instanceof RegExp ? `(${pattern})` : pattern,
+    test: path => pathToRegExp(pattern).test(path)
+  }))
+}
+
+function isFastStar (layer) {
+  if (layer.regexp.fast_star !== undefined) {
+    return layer.regexp.fast_star
+  }
+
+  return layer._datadog_matchers.some(matcher => matcher.path === '*')
+}
+
+function flatten (arr) {
+  return arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flatten(val)) : acc.concat(val), [])
+}
+
+module.exports = {
+  name: 'router',
+  versions: ['1.x'],
+  patch (Router, tracer, config) {
+    this.wrap(Router.prototype, 'handle', createWrapHandle(tracer, config))
+    this.wrap(Router.prototype, 'process_params', createWrapProcessParams(tracer, config))
+    this.wrap(Router.prototype, 'use', createWrapRouterMethod(tracer, config))
+    this.wrap(Router.prototype, 'route', createWrapRouterMethod(tracer, config))
+  },
+  unpatch (Router) {
+    this.unwrap(Router.prototype, 'handle')
+    this.unwrap(Router.prototype, 'process_params')
+    this.unwrap(Router.prototype, 'use')
+    this.unwrap(Router.prototype, 'route')
+  }
+}

--- a/test/plugins/router.spec.js
+++ b/test/plugins/router.spec.js
@@ -1,0 +1,85 @@
+'use strict'
+
+// TODO: move tests from express since it uses the router plugin now
+
+const axios = require('axios')
+const http = require('http')
+const getPort = require('get-port')
+const agent = require('./agent')
+const web = require('../../src/plugins/util/web')
+const plugin = require('../../src/plugins/router')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let tracer
+  let Router
+  let appListener
+
+  function server (router) {
+    return http.createServer((req, res) => {
+      const config = web.normalizeConfig({})
+
+      web.instrument(tracer, config, req, res, 'http.request')
+
+      return router(req, res, err => {
+        res.writeHead(err ? 500 : 404)
+        res.end()
+      })
+    })
+  }
+
+  describe('router', () => {
+    withVersions(plugin, 'router', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        appListener.close()
+      })
+
+      describe('without configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'router')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          Router = require(`../../versions/router@${version}`).get()
+        })
+
+        it('should add the route to the request span', done => {
+          const router = Router()
+          const childRouter = Router()
+
+          childRouter.use('/child/:id', (req, res) => {
+            res.writeHead(200)
+            res.end()
+          })
+
+          router.use('/parent', childRouter)
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                expect(traces[0]).to.have.length(1)
+                expect(traces[0][0]).to.have.property('resource', 'GET /parent/child/:id')
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(router).listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/parent/child/123`)
+                .catch(done)
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for the `router` module. Since the code of this module is basically the same as the Express router as it was extracted from Express but to work with any HTTP server, I moved all code related to routing from the `express` plugin to the `router` plugin. The `express` plugin now depends on the `router` plugin to handle the routing.