### PR TITLE
add npmignore to only include relevant files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+*
+!ext/**/*
+!lib/**/*
+!src/**/*
+!CONTRIBUTING.md
+!LICENSE
+!LICENSE-3rdparty.csv
+!index.js
+!package.json
+!README.md


### PR DESCRIPTION
This PR adds a `.npmignore` file to only include relevant files in the resulting package. The original issue was that there is a bug in `npm` where not all files included in `.gitignore` are ignored. However, I took the opportunity to also make the package as lean as possible.

Fixes #343 