### PR TITLE
add redis.raw_command tag and extract common redis functionality

### DIFF
--- a/src/plugins/ioredis.js
+++ b/src/plugins/ioredis.js
@@ -1,42 +1,19 @@
 'use strict'
 
+const tx = require('./util/redis')
+
 function createWrapSendCommand (tracer, config) {
   return function wrapSendCommand (sendCommand) {
     return function sendCommandWithTrace (command, stream) {
-      const scope = tracer.scopeManager().active()
-      const span = tracer.startSpan('redis.command', {
-        childOf: scope && scope.span(),
-        tags: {
-          'span.kind': 'client',
-          'span.type': 'redis',
-          'service.name': config.service || `${tracer._service}-redis`,
-          'resource.name': command.name,
-          'db.type': 'redis',
-          'db.name': this.options.db || '0',
-          'out.host': this.options.host,
-          'out.port': String(this.options.port)
-        }
-      })
+      const db = this.options.db
+      const span = tx.instrument(tracer, config, db, command.name, command.args)
 
-      command.promise
-        .then(() => finish(span))
-        .catch(err => finish(span, err))
+      tx.setHost(span, this.options.host, this.options.port)
+      tx.wrap(span, command.promise)
 
       return sendCommand.apply(this, arguments)
     }
   }
-}
-
-function finish (span, error) {
-  if (error) {
-    span.addTags({
-      'error.type': error.name,
-      'error.msg': error.message,
-      'error.stack': error.stack
-    })
-  }
-
-  span.finish()
 }
 
 module.exports = {

--- a/src/plugins/util/redis.js
+++ b/src/plugins/util/redis.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const tx = require('./tx')
+
+const redis = {
+  // Start a span for a Redis command.
+  instrument (tracer, config, db, command, args) {
+    const scope = tracer.scopeManager().active()
+    const span = tracer.startSpan('redis.command', {
+      childOf: scope && scope.span(),
+      tags: {
+        'span.kind': 'client',
+        'resource.name': command,
+        'span.type': 'redis',
+        'db.type': 'redis',
+        'db.name': db || '0',
+        'out.host': '127.0.0.1',
+        'out.port': String(6379),
+        'redis.raw_command': formatCommand(command, args)
+      }
+    })
+
+    span.setTag('service.name', config.service || `${span.context().tags['service.name']}-redis`)
+
+    return span
+  }
+}
+
+function formatCommand (command, args) {
+  command = command.toUpperCase()
+
+  if (!args) return command
+
+  for (let i = 0, l = args.length; i < l; i++) {
+    if (typeof args[i] === 'function') continue
+
+    command = `${command} ${formatArg(args[i])}`
+
+    if (command.length > 1000) return trim(command, 1000)
+  }
+
+  return command
+}
+
+function formatArg (arg) {
+  switch (typeof arg) {
+    case 'string':
+    case 'number':
+      return trim(String(arg), 100)
+    default:
+      return '?'
+  }
+}
+
+function trim (str, maxlen) {
+  if (str.length > maxlen) {
+    str = str.substr(0, maxlen - 3) + '...'
+  }
+
+  return str
+}
+
+module.exports = Object.assign({}, tx, redis)

--- a/src/plugins/util/tx.js
+++ b/src/plugins/util/tx.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const tx = {
+  // Set the outgoing host.
+  setHost (span, hostname, port) {
+    hostname && span.setTag('out.host', hostname)
+    port && span.setTag('out.port', port)
+  },
+
+  // Wrap a promise or a callback to also finish the span.
+  wrap (span, done) {
+    if (typeof done === 'function' || !done) {
+      return wrapCallback(span, done)
+    } else if (isPromise(done)) {
+      return wrapPromise(span, done)
+    }
+  }
+}
+
+function wrapCallback (span, callback) {
+  return function (err) {
+    finish(span, err)
+
+    if (callback) {
+      callback.apply(this, arguments)
+    }
+  }
+}
+
+function wrapPromise (span, promise) {
+  promise.then(
+    () => finish(span),
+    err => finish(span, err)
+  )
+}
+
+function finish (span, error) {
+  if (error) {
+    span.addTags({
+      'error.type': error.name,
+      'error.msg': error.message,
+      'error.stack': error.stack
+    })
+  }
+
+  span.finish()
+}
+
+function isPromise (obj) {
+  return isObject(obj) && typeof obj.then === 'function'
+}
+
+function isObject (obj) {
+  return typeof obj === 'object' && obj !== null
+}
+
+module.exports = tx

--- a/test/plugins/ioredis.spec.js
+++ b/test/plugins/ioredis.spec.js
@@ -39,6 +39,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
               expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
               expect(traces[0][0].meta).to.have.property('out.port', '6379')
+              expect(traces[0][0].meta).to.have.property('redis.raw_command', 'GET foo')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -48,6 +48,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
               expect(traces[0][0].meta).to.have.property('out.host', '127.0.0.1')
               expect(traces[0][0].meta).to.have.property('out.port', '6379')
+              expect(traces[0][0].meta).to.have.property('redis.raw_command', 'GET foo')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/util/redis.spec.js
+++ b/test/plugins/util/redis.spec.js
@@ -1,0 +1,82 @@
+'use strict'
+
+describe('plugins/util/redis', () => {
+  let redis
+  let tracer
+  let config
+  let span
+
+  beforeEach(() => {
+    config = {}
+    tracer = require('../../..').init({ service: 'test', plugins: false })
+    redis = require('../../../src/plugins/util/redis')
+  })
+
+  describe('instrument', () => {
+    it('should start a span with the correct tags', () => {
+      span = redis.instrument(tracer, config, '1', 'set', ['foo', 'bar'])
+
+      expect(span.context().tags).to.deep.include({
+        'span.kind': 'client',
+        'service.name': 'test-redis',
+        'resource.name': 'set',
+        'span.type': 'redis',
+        'db.type': 'redis',
+        'db.name': '1',
+        'out.host': '127.0.0.1',
+        'out.port': '6379',
+        'redis.raw_command': 'SET foo bar'
+      })
+    })
+
+    it('should use the parent from the scope', () => {
+      if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+      const parent = tracer.startSpan('parent')
+
+      tracer.scopeManager().activate(parent)
+
+      span = redis.instrument(tracer, config, '1', 'ping', [])
+
+      expect(span.context().parentId.toString()).to.equal(parent.context().spanId.toString())
+    })
+
+    it('should trim command arguments if yoo long', () => {
+      let key = ''
+
+      for (let i = 0; i <= 100; i++) {
+        key += 'a'
+      }
+
+      span = redis.instrument(tracer, config, '1', 'get', [key])
+
+      const rawCommand = span.context().tags['redis.raw_command']
+
+      expect(rawCommand).to.have.length(104)
+      expect(rawCommand.substr(0, 10)).to.equal('GET aaaaaa')
+      expect(rawCommand.substr(94)).to.equal('aaaaaaa...')
+    })
+
+    it('should trim the command if too long', () => {
+      const values = []
+
+      for (let i = 0; i < 10; i++) {
+        let value = ''
+
+        for (let i = 0; i < 100; i++) {
+          value += 'a'
+        }
+
+        values.push(value)
+      }
+
+      span = redis.instrument(tracer, config, '1', 'get', values)
+
+      const rawCommand = span.context().tags['redis.raw_command']
+
+      expect(rawCommand).to.have.length(1000)
+      expect(rawCommand.substr(0, 10)).to.equal('GET aaaaaa')
+      expect(rawCommand.substr(990)).to.equal('aaaaaaa...')
+    })
+  })
+})

--- a/test/plugins/util/tx.spec.js
+++ b/test/plugins/util/tx.spec.js
@@ -1,0 +1,81 @@
+'use strict'
+
+describe('plugins/util/tx', () => {
+  let tx
+  let tracer
+  let span
+
+  beforeEach(() => {
+    tracer = require('../../..').init({ plugins: false })
+    span = tracer.startSpan('test')
+    tx = require('../../../src/plugins/util/tx')
+
+    sinon.spy(span, 'finish')
+  })
+
+  afterEach(() => {
+    span.finish.restore()
+  })
+
+  describe('setHost', () => {
+    it('should set the out.host and out.port tags', () => {
+      tx.setHost(span, 'example.com', '1234')
+
+      expect(span.context().tags).to.have.property('out.host', 'example.com')
+      expect(span.context().tags).to.have.property('out.port', '1234')
+    })
+  })
+
+  describe('wrap', () => {
+    describe('with a callback', () => {
+      it('should return a wrapper that finishes the span', () => {
+        const callback = sinon.spy()
+        const wrapper = tx.wrap(span, callback)
+
+        wrapper(null, 'foo', 'bar')
+
+        expect(callback).to.have.been.calledWith(null, 'foo', 'bar')
+        expect(span.finish).to.have.been.called
+      })
+
+      it('should return a wrapper that sets error tags', () => {
+        const callback = sinon.spy()
+        const error = new Error('boom')
+        const wrapper = tx.wrap(span, callback)
+
+        wrapper(error)
+
+        expect(span.context().tags).to.have.property('error.msg', error.message)
+        expect(span.context().tags).to.have.property('error.type', error.name)
+        expect(span.context().tags).to.have.property('error.stack', error.stack)
+      })
+    })
+
+    describe('with a promise', () => {
+      it('should finish the span when the promise is resolved', () => {
+        const promise = Promise.resolve('value')
+
+        tx.wrap(span, promise)
+
+        return promise.then(value => {
+          expect(value).to.equal('value')
+          expect(span.finish).to.have.been.called
+        })
+      })
+
+      it('should set the error tags when the promise is rejected', () => {
+        const error = new Error('boom')
+        const promise = Promise.reject(error)
+
+        tx.wrap(span, promise)
+
+        return promise.catch(err => {
+          expect(err).to.equal(error)
+          expect(span.context().tags).to.have.property('error.msg', error.message)
+          expect(span.context().tags).to.have.property('error.type', error.name)
+          expect(span.context().tags).to.have.property('error.stack', error.stack)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the `redis.raw_command` tag and extract functionality common to `redis` and `ioredis` in external helpers.