### PR TITLE
fix wrong name for memcached.command tag

### DIFF
--- a/src/plugins/memcached.js
+++ b/src/plugins/memcached.js
@@ -27,7 +27,7 @@ function wrapQueryCompiler (original, client, server, span) {
 
     span.addTags({
       'resource.name': query.type,
-      'memcached.query': query.command
+      'memcached.command': query.command
     })
 
     addHost(span, client, server, query)

--- a/test/plugins/memcached.spec.js
+++ b/test/plugins/memcached.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
               expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
               expect(traces[0][0].meta).to.have.property('out.port', '11211')
-              expect(traces[0][0].meta).to.have.property('memcached.query', 'get test')
+              expect(traces[0][0].meta).to.have.property('memcached.command', 'get test')
             })
             .then(done)
             .catch(done)


### PR DESCRIPTION
This PR fixes the `memcached.command` tag that was previously set to `memcached.query`.