### PR TITLE
fix default service name from the platform

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,8 +5,8 @@ const platform = require('./platform')
 const coalesce = require('koalas')
 
 class Config {
-  constructor (options) {
-    options = options || {}
+  constructor (service, options) {
+    options = typeof service === 'object' ? service : options || {}
 
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
@@ -28,18 +28,7 @@ class Config {
     this.sampleRate = sampleRate
     this.logger = options.logger
     this.plugins = !!plugins
-
-    Object.defineProperty(this, 'service', {
-      get () {
-        const service = coalesce(options.service, platform.env('DD_SERVICE_NAME'))
-
-        if (service) {
-          return service
-        }
-
-        return platform.service() || 'node'
-      }
-    })
+    this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
   }
 }
 

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events')
 const id = require('./id')
 const now = require('./now')
 const env = require('./env')
+const validate = require('./validate')
 const service = require('./service')
 const request = require('./request')
 const msgpack = require('./msgpack')
@@ -21,6 +22,7 @@ const platform = {
   id,
   now,
   env,
+  validate,
   service,
   request,
   msgpack,

--- a/src/platform/node/service.js
+++ b/src/platform/node/service.js
@@ -3,19 +3,8 @@
 const path = require('path')
 const readPkgUp = require('read-pkg-up')
 const parentModule = require('parent-module')
-const semver = require('semver')
-
-const SUPPORTED_VERSIONS = '^4.7 || ^6.9 || >=8'
 
 function service () {
-  if (!semver.satisfies(process.versions.node, SUPPORTED_VERSIONS)) {
-    throw new Error([
-      `Node ${process.versions.node} is not supported.`,
-      `Only versions of Node matching "${SUPPORTED_VERSIONS}" are supported.`,
-      `Tracing has been disabled.`
-    ].join(' '))
-  }
-
   const callerPath = parentModule()
   const parentPath = parentModule(callerPath)
   const cwd = path.dirname(parentPath || callerPath)

--- a/src/platform/node/validate.js
+++ b/src/platform/node/validate.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const semver = require('semver')
+
+const SUPPORTED_VERSIONS = '^4.7 || ^6.9 || >=8'
+
+function validate () {
+  if (!semver.satisfies(process.versions.node, SUPPORTED_VERSIONS)) {
+    throw new Error([
+      `Node ${process.versions.node} is not supported.`,
+      `Only versions of Node matching "${SUPPORTED_VERSIONS}" are supported.`,
+      `Tracing has been disabled.`
+    ].join(' '))
+  }
+}
+
+module.exports = validate

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -49,9 +49,11 @@ class Tracer extends BaseTracer {
   init (options) {
     if (this._tracer === noop) {
       try {
-        const config = new Config(options)
+        const service = platform.service()
+        const config = new Config(service, options)
 
         if (config.enabled) {
+          platform.validate()
           platform.configure(config)
 
           this._tracer = new DatadogTracer(config)

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -6,8 +6,7 @@ describe('Config', () => {
 
   beforeEach(() => {
     platform = {
-      env: sinon.stub(),
-      service: sinon.stub()
+      env: sinon.stub()
     }
 
     Config = proxyquire('../src/config', {
@@ -32,10 +31,8 @@ describe('Config', () => {
     expect(config).to.have.property('env', undefined)
   })
 
-  it('should initialize from the platform', () => {
-    platform.service.returns('test')
-
-    const config = new Config()
+  it('should initialize from the default service', () => {
+    const config = new Config('test')
 
     expect(config).to.have.property('service', 'test')
   })

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -81,7 +81,7 @@ describe('TracerProxy', () => {
 
         proxy.init(options)
 
-        expect(Config).to.have.been.calledWith(options)
+        expect(Config).to.have.been.calledWith('dd-trace', options)
         expect(DatadogTracer).to.have.been.calledWith(config)
       })
 


### PR DESCRIPTION
This PR fixes the default service name from the platform. The issue was caused by altering the code path to reach the detection of the `package.json` location. Since a mix of the call stack and module path is used for the detection, this caused the default service name to always be `dd-trace` instead of the user's module name. By restoring the previous code path, the name will now properly resolve.