### PR TITLE
fix wrong operation name used by the formatter when overriden

### DIFF
--- a/benchmark/stubs/span.js
+++ b/benchmark/stubs/span.js
@@ -28,9 +28,9 @@ const span = {
       [SAMPLE_RATE_METRIC_KEY]: 1
     },
     sampled: true,
-    sampling: {}
+    sampling: {},
+    name: 'operation'
   }),
-  _operationName: 'operation',
   _startTime: 1500000000000.123456,
   _duration: 100
 }

--- a/src/format.js
+++ b/src/format.js
@@ -22,16 +22,14 @@ function format (span) {
 }
 
 function formatSpan (span) {
-  const tracer = span.tracer()
   const spanContext = span.context()
 
   return {
     trace_id: spanContext.traceId,
     span_id: spanContext.spanId,
     parent_id: spanContext.parentId,
-    name: String(span._operationName),
-    resource: String(span._operationName),
-    service: String(tracer._service),
+    name: String(spanContext.name),
+    resource: String(spanContext.name),
     error: 0,
     meta: {},
     metrics: {},

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -26,7 +26,6 @@ class DatadogSpan extends Span {
     this._sampler = sampler
     this._recorder = recorder
     this._prioritySampler = prioritySampler
-    this._operationName = operationName
     this._startTime = startTime
 
     this._spanContext = this._createContext(parent)
@@ -85,7 +84,7 @@ class DatadogSpan extends Span {
   }
 
   _setOperationName (name) {
-    this._operationName = name
+    this._spanContext.name = name
   }
 
   _setBaggageItem (key, value) {

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -106,7 +106,7 @@ describe('Span', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'foo' })
       span.setOperationName('bar')
 
-      expect(span._operationName).to.equal('bar')
+      expect(span.context().name).to.equal('bar')
     })
   })
 

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -891,7 +891,7 @@ describe('Plugin', () => {
 
               try {
                 expect(scope).to.not.be.null
-                expect(scope.span()).to.have.property('_operationName', 'graphql.execute')
+                expect(scope.span().context()).to.have.property('name', 'graphql.execute')
                 done()
               } catch (e) {
                 done(e)


### PR DESCRIPTION
This PR fixes the wrong operation name used by the formatter when the service name has been set more than once. This happened because of a refactor where the operation name was moved to the span context instead of as a private property of the span, but some of the code was still referencing the old value.

I also removed another unnecessary property access from the tracer since the service.name tag is now always set.