### PR TITLE
 use http.route in http hooks for the resource name if not provided

### DIFF
--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -42,10 +42,8 @@ class DatadogTracer extends Tracer {
     const references = getReferences(fields.references)
     const parent = getParent(references)
     const tags = {
-      'resource.name': name
+      'service.name': this._service
     }
-
-    tags['service.name'] = this._service
 
     if (this._env) {
       tags.env = this._env

--- a/test/opentracing/tracer.spec.js
+++ b/test/opentracing/tracer.spec.js
@@ -130,8 +130,7 @@ describe('Tracer', () => {
         parent: null,
         tags: {
           'foo': 'bar',
-          'service.name': 'service',
-          'resource.name': 'name'
+          'service.name': 'service'
         },
         startTime: fields.startTime
       })


### PR DESCRIPTION
This PR updates the http hooks to use the `http.route` tag when building the resource name if the user didn't explicitly provide a resource name. This replaces the old behavior where both would need to be overridden.