### PR TITLE
fix calling web.instrument multiple times not updating metadata

### DIFF
--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -8,8 +8,6 @@ function createWrapMethod (tracer, config) {
   config = web.normalizeConfig(config)
 
   function ddTrace (req, res, next) {
-    if (web.active(req)) return next()
-
     web.instrument(tracer, config, req, res, 'express.request')
 
     next()

--- a/src/plugins/koa.js
+++ b/src/plugins/koa.js
@@ -6,8 +6,6 @@ function createWrapUse (tracer, config) {
   config = web.normalizeConfig(config)
 
   function ddTrace (ctx, next) {
-    if (web.active(ctx.req)) return next()
-
     web.instrument(tracer, config, ctx.req, ctx.res, 'koa.request')
 
     return next()

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -132,6 +132,14 @@ describe('plugins/util/web', () => {
 
         expect(span.context().tags).to.have.property('service.name', 'test2')
       })
+
+      it('should only wrap res.end once', () => {
+        span = web.instrument(tracer, config, req, res, 'test.request')
+        const end = res.end
+        span = web.instrument(tracer, config, req, res, 'test.request')
+
+        expect(end).to.equal(res.end)
+      })
     })
 
     describe('on request end', () => {


### PR DESCRIPTION
This PR fixes calling `web.instrument()` multiple times not updating metadata such as the span name. If also removes some checks in the frameworks that are no longer needed because of this change.