### PR TITLE
add environment variable to set the agent globally

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,12 @@ class Config {
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
     const env = coalesce(options.env, platform.env('DD_ENV'))
     const protocol = 'http'
-    const hostname = coalesce(options.hostname, platform.env('DD_TRACE_AGENT_HOSTNAME'), 'localhost')
+    const hostname = coalesce(
+      options.hostname,
+      platform.env('DD_AGENT_HOST'),
+      platform.env('DD_TRACE_AGENT_HOSTNAME'),
+      'localhost'
+    )
     const port = coalesce(options.port, platform.env('DD_TRACE_AGENT_PORT'), 8126)
     const sampleRate = coalesce(Math.min(Math.max(options.sampleRate, 0), 1), 1)
     const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -85,6 +85,15 @@ describe('Config', () => {
     expect(config).to.have.property('plugins', false)
   })
 
+  it('should give priority to the common agent environment variable', () => {
+    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('trace-agent')
+    platform.env.withArgs('DD_AGENT_HOST').returns('agent')
+
+    const config = new Config()
+
+    expect(config).to.have.nested.property('url.hostname', 'agent')
+  })
+
   it('should give priority to the options', () => {
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')


### PR DESCRIPTION
This PR adds support for the new environment variable to configure the agent that will be used in all tracers.