### PR TITLE
add support for when

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -17,5 +17,6 @@ module.exports = {
   'mysql2': require('./mysql2'),
   'pg': require('./pg'),
   'redis': require('./redis'),
-  'restify': require('./restify')
+  'restify': require('./restify'),
+  'when': require('./when')
 }

--- a/src/plugins/when.js
+++ b/src/plugins/when.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const tx = require('./util/promise')
+
+module.exports = [
+  {
+    name: 'when',
+    file: 'lib/Promise.js',
+    versions: ['3'],
+    patch (Promise, tracer, config) {
+      this.wrap(Promise.prototype, 'then', tx.createWrapThen(tracer, config))
+    },
+    unpatch (Promise) {
+      this.unwrap(Promise.prototype, 'then')
+    }
+  }
+]

--- a/test/plugins/when.spec.js
+++ b/test/plugins/when.spec.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const agent = require('./agent')
+const plugin = require('../../src/plugins/when')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let when
+  let tracer
+
+  describe('when', () => {
+    withVersions(plugin, 'when', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'when')
+            .then(() => {
+              when = require(`../../versions/when@${version}`).get()
+            })
+        })
+
+        it('should run the then() callback in context where then() was called', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+          const deferred = when.defer()
+          const promise = deferred.promise
+
+          setImmediate(() => {
+            tracer.scopeManager().activate({})
+            deferred.resolve()
+          })
+
+          tracer.scopeManager().activate(span)
+
+          return promise
+            .then(() => {
+              tracer.scopeManager().activate({})
+            })
+            .then(() => {
+              const scope = tracer.scopeManager().active()
+
+              expect(scope).to.not.be.null
+              expect(scope.span()).to.equal(span)
+            })
+        })
+
+        it('should run the catch() callback in context where catch() was called', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+          const deferred = when.defer()
+          const promise = deferred.promise
+
+          setImmediate(() => {
+            tracer.scopeManager().activate({})
+            deferred.reject(new Error())
+          })
+
+          tracer.scopeManager().activate(span)
+
+          return promise
+            .catch(err => {
+              tracer.scopeManager().activate({})
+              throw err
+            })
+            .catch(() => {
+              const scope = tracer.scopeManager().active()
+
+              expect(scope).to.not.be.null
+              expect(scope.span()).to.equal(span)
+            })
+        })
+
+        it('should run the onProgress callback in context where then() was called', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+          const deferred = when.defer()
+          const promise = deferred.promise
+
+          setImmediate(() => {
+            tracer.scopeManager().activate({})
+            deferred.resolve()
+          })
+
+          tracer.scopeManager().activate(span)
+
+          return promise
+            .then(() => {
+              tracer.scopeManager().activate({})
+            })
+            .then(() => {}, () => {}, () => {
+              const scope = tracer.scopeManager().active()
+
+              expect(scope).to.not.be.null
+              expect(scope.span()).to.equal(span)
+            })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for `when`, more specifically to fix context propagation since`when` uses its own internal queuing mechanism that loses the current context otherwise.