### PR TITLE
add support for ioredis 2.x and 3.x

### DIFF
--- a/src/plugins/ioredis.js
+++ b/src/plugins/ioredis.js
@@ -18,7 +18,7 @@ function createWrapSendCommand (tracer, config) {
 
 module.exports = {
   name: 'ioredis',
-  versions: ['4.x'],
+  versions: ['>=2 <=4'],
   patch (Redis, tracer, config) {
     this.wrap(Redis.prototype, 'sendCommand', createWrapSendCommand(tracer, config))
   },

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -49,6 +49,7 @@ module.exports = {
           plugins: false
         })
 
+        tracer.use('bluebird')
         tracer.use(pluginName, config)
       })
     })

--- a/test/plugins/ioredis.spec.js
+++ b/test/plugins/ioredis.spec.js
@@ -50,11 +50,16 @@ describe('Plugin', () => {
         it('should run the callback in the parent context', () => {
           if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
 
-          const scope = tracer.scopeManager().activate({})
+          const span = {}
+
+          tracer.scopeManager().activate(span)
 
           return redis.get('foo')
             .then(() => {
-              expect(tracer.scopeManager().active()).to.equal(scope)
+              const scope = tracer.scopeManager().active()
+
+              expect(scope).to.not.be.null
+              expect(scope.span()).to.equal(span)
             })
         })
 


### PR DESCRIPTION
This PR adds support for `ioredis` 2.x and 3.x. The biggest change in 4.x was replacing Bluebird with the native Promise. Since we didn't support Bluebird before, only >=4 could be supported. Now that we do support Bluebird, it's possible to support older versions as well.