### PR TITLE
fix errors caused by instrumentation when the tracer is disabled

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -14,6 +14,7 @@ shimmer({ logger: () => {} })
 class Instrumenter {
   constructor (tracer) {
     this._tracer = tracer
+    this._enabled = false
     this._names = new Set()
     this._plugins = new Map()
     this._instrumented = new Map()
@@ -55,6 +56,8 @@ class Instrumenter {
   }
 
   reload () {
+    if (!this._enabled) return
+
     const instrumentations = Array.from(this._plugins.keys())
       .reduce((prev, current) => prev.concat(current), [])
 
@@ -126,6 +129,10 @@ class Instrumenter {
       })
 
     return moduleExports
+  }
+
+  enable () {
+    this._enabled = true
   }
 
   _set (plugin, meta) {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -57,6 +57,7 @@ class Tracer extends BaseTracer {
           platform.configure(config)
 
           this._tracer = new DatadogTracer(config)
+          this._instrumenter.enable()
           this._instrumenter.patch(config)
         }
       } catch (e) {

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -35,6 +35,7 @@ describe('TracerProxy', () => {
     }
 
     instrumenter = {
+      enable: sinon.spy(),
       patch: sinon.spy(),
       use: sinon.spy()
     }
@@ -103,6 +104,7 @@ describe('TracerProxy', () => {
       it('should set up automatic instrumentation', () => {
         proxy.init()
 
+        expect(instrumenter.enable).to.have.been.called
         expect(instrumenter.patch).to.have.been.called
       })
 


### PR DESCRIPTION
This PR fixes errors that were caused by instrumentation even when the tracer was disabled. Any plugin registered with `tracer.use()` would end up patching the corresponding module even when the tracer is disabled, causing errors from plugins trying to access tracer properties.

The instrumenter now has to be enabled explicitly before it will apply patching.

Fixes #378 