### PR TITLE
fix wrong quantization when using BSON in the query

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -37,7 +37,7 @@ function assertVersions () {
   internals.forEach(assertInstrumentation)
 
   Object.keys(externals)
-    .filter(name => ~filter.indexOf(name))
+    .filter(name => ~names.indexOf(name))
     .forEach(name => {
       [].concat(externals[name]).forEach(assertInstrumentation)
     })

--- a/src/plugins/mongodb-core.js
+++ b/src/plugins/mongodb-core.js
@@ -130,7 +130,7 @@ function isObject (val) {
 }
 
 function isBSON (val) {
-  return val && val._bsontype && typeof val.toJSON === 'function'
+  return val && val._bsontype
 }
 
 module.exports = [

--- a/src/plugins/mongodb-core.js
+++ b/src/plugins/mongodb-core.js
@@ -114,8 +114,7 @@ function getResource (ns, cmd, query, operationName) {
 function sanitize (input) {
   const output = {}
 
-  if (!isObject(input) || Buffer.isBuffer(input)) return '?'
-  if (isBSON(input)) return sanitize(input.toJSON())
+  if (!isObject(input) || Buffer.isBuffer(input) || isBSON(input)) return '?'
 
   for (const key in input) {
     if (typeof input[key] === 'function') continue

--- a/src/plugins/mongodb-core.js
+++ b/src/plugins/mongodb-core.js
@@ -104,12 +104,13 @@ function getResource (ns, cmd, query, operationName) {
 function sanitize (input) {
   const output = {}
 
+  if (!isObject(input) || Buffer.isBuffer(input)) return '?'
+  if (isBSON(input)) return sanitize(input.toJSON())
+
   for (const key in input) {
-    if (isObject(input[key]) && !Buffer.isBuffer(input[key])) {
-      output[key] = sanitize(input[key])
-    } else {
-      output[key] = '?'
-    }
+    if (typeof input[key] === 'function') continue
+
+    output[key] = sanitize(input[key])
   }
 
   return output
@@ -117,6 +118,10 @@ function sanitize (input) {
 
 function isObject (val) {
   return typeof val === 'object' && val !== null && !(val instanceof Array)
+}
+
+function isBSON (val) {
+  return val && val._bsontype && typeof val.toJSON === 'function'
 }
 
 module.exports = [

--- a/test/plugins/externals.json
+++ b/test/plugins/externals.json
@@ -18,5 +18,11 @@
       "name": "ws",
       "versions": ["6.1.0"]
     }
+  ],
+  "mongodb-core": [
+    {
+      "name": "bson",
+      "versions": ["4.0.0"]
+    }
   ]
 }

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -130,6 +130,47 @@ describe('Plugin', () => {
             }, () => {})
           })
 
+          it('should sanitize BSON as values and not as objects', done => {
+            const BSON = require(`../../versions/bson@4.0.0`).get()
+
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+                const resource = `find test.${collection} {"_id":"?"}`
+
+                expect(span).to.have.property('resource', resource)
+              })
+              .then(done)
+              .catch(done)
+
+            server.command(`test.${collection}`, {
+              find: `test.${collection}`,
+              query: {
+                _id: new BSON.ObjectID('123456781234567812345678')
+              }
+            }, () => {})
+          })
+
+          it('should skip functions when sanitizing', done => {
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+                const resource = `find test.${collection} {"_id":"?"}`
+
+                expect(span).to.have.property('resource', resource)
+              })
+              .then(done)
+              .catch(done)
+
+            server.command(`test.${collection}`, {
+              find: `test.${collection}`,
+              query: {
+                _id: '1234',
+                foo: () => {}
+              }
+            }, () => {})
+          })
+
           it('should run the callback in the parent context', done => {
             if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
 


### PR DESCRIPTION
This PR fixes wrong quantization when using BSON in the query. BSON creates typed objects which were handled as plain objects. However, BSON objects have an underlying JSON representation which is now properly used. I've also added a check for methods to skip them if a typed object is used in general.