### PR TITLE
fix missing out.* tags when using a mongodb replica set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,10 @@ jobs:
         environment:
           - SERVICES=mongo
           - PLUGINS=mongodb-core
-      - image: mongo:3.6
+      - image: bitnami/mongodb:3.6
+        environment:
+          - MONGODB_REPLICA_SET_MODE=primary
+          - MONGODB_ADVERTISED_HOSTNAME=localhost
 
   node-postgres:
     <<: *node-plugin-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,10 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
   mongo:
-    image: mongo:3.6
+    image: bitnami/mongodb:3.6
+    environment:
+      - MONGODB_REPLICA_SET_MODE=primary
+      - MONGODB_ADVERTISED_HOSTNAME=localhost
     ports:
       - "127.0.0.1:27017:27017"
   elasticsearch:

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -46,8 +46,8 @@ function assertVersions () {
 function assertInstrumentation (instrumentation) {
   [].concat(instrumentation.versions).forEach(version => {
     if (version) {
-      assertModules(instrumentation.name, version)
       assertModules(instrumentation.name, semver.coerce(version).version)
+      assertModules(instrumentation.name, version)
     }
   })
 }
@@ -57,8 +57,8 @@ function assertModules (name, version) {
   addFolder(name, version)
   assertFolder(name)
   assertFolder(name, version)
-  assertPackage(name)
-  assertPackage(name, version)
+  assertPackage(name, null, version)
+  assertPackage(name, version, version)
   assertIndex(name)
   assertIndex(name, version)
 }
@@ -73,14 +73,14 @@ function assertFolder (name, version) {
   }
 }
 
-function assertPackage (name, version) {
+function assertPackage (name, version, dependency) {
   fs.writeFileSync(filename(name, version, 'package.json'), JSON.stringify({
     name: [name, sha1(name).substr(0, 8), sha1(version)].filter(val => val).join('-'),
     version: '1.0.0',
     license: 'BSD-3-Clause',
     private: true,
     optionalDependencies: {
-      [name]: version
+      [name]: dependency
     }
   }, null, 2) + '\n')
 }

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const semver = require('semver')
 const agent = require('./agent')
 const Buffer = require('safe-buffer').Buffer
 const plugin = require('../../src/plugins/mongodb-core')
@@ -14,7 +15,7 @@ describe('Plugin', () => {
   let collection
 
   describe('mongodb-core', () => {
-    withVersions(plugin, 'mongodb-core', '>=3', version => {
+    withVersions(plugin, 'mongodb-core', version => {
       beforeEach(() => {
         platform = require('../../src/platform')
         tracer = require('../..')
@@ -274,6 +275,8 @@ describe('Plugin', () => {
       })
 
       describe('with a replica set', () => {
+        if (!semver.intersects(version, '>=2.0.5')) return // bug with replica sets before 2.0.5
+
         before(() => {
           return agent.load(plugin, 'mongodb-core')
         })

--- a/test/setup/services/mongo.js
+++ b/test/setup/services/mongo.js
@@ -8,9 +8,11 @@ function waitForMongo () {
     const operation = new RetryOperation('mongo')
 
     operation.attempt(currentAttempt => {
-      const server = new mongo.Server({
+      const server = new mongo.ReplSet([{
         host: 'localhost',
-        port: 27017,
+        port: 27017
+      }], {
+        setName: 'replicaset',
         reconnect: false
       })
 


### PR DESCRIPTION
This PR fixes missing `out.*` tags when using a MongoDB replica set. Since the cursor is able to use any topology, it doesn't necessarily have the hostname and port upfront when sending the query. By attempting to set the tags before and after the query, we can ensure that the tags should be set in almost all cases. This issue doesn't apply to the rest of the integration since the Server topology is instrumented directly.