### PR TITLE
add multiple plugins support to the test agent

### DIFF
--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -37,6 +37,9 @@ module.exports = {
 
         listener = server.listen(port, 'localhost', resolve)
 
+        pluginName = [].concat(pluginName)
+        config = [].concat(config)
+
         server.on('close', () => {
           tracer._instrumenter.unpatch()
           tracer = null
@@ -49,8 +52,9 @@ module.exports = {
           plugins: false
         })
 
-        tracer.use('bluebird')
-        tracer.use(pluginName, config)
+        for (let i = 0, l = pluginName.length; i < l; i++) {
+          tracer.use(pluginName[i], config[i])
+        }
       })
     })
   },

--- a/test/plugins/ioredis.spec.js
+++ b/test/plugins/ioredis.spec.js
@@ -23,7 +23,7 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => agent.load(plugin, 'ioredis'))
+        before(() => agent.load(plugin, ['ioredis', 'bluebird']))
         after(() => agent.close())
 
         it('should do automatic instrumentation when using callbacks', done => {


### PR DESCRIPTION
This PR adds multiple plugins support to the test agent. This avoids having to load multiple plugins when not necessary.