### PR TITLE
fix integrations overriding promise returned by underlying call

### DIFF
--- a/src/plugins/amqp10.js
+++ b/src/plugins/amqp10.js
@@ -114,15 +114,9 @@ function wrapPromise (promise, span) {
     return promise
   }
 
+  promise.then(() => finish(span), e => finish(span, e))
+
   return promise
-    .then(() => {
-      finish(span)
-      return promise
-    })
-    .catch(err => {
-      finish(span, err)
-      return promise
-    })
 }
 
 function getAddress (link) {

--- a/src/plugins/elasticsearch.js
+++ b/src/plugins/elasticsearch.js
@@ -27,20 +27,9 @@ function createWrapRequest (tracer, config) {
       if (typeof cb === 'function') {
         return request.call(this, params, wrapCallback(tracer, span, cb))
       } else {
-        const result = request.apply(this, arguments)
-        const promise = new Promise((resolve, reject) => {
-          result
-            .then(function () {
-              finish(span)
-              resolve.apply(this, arguments)
-            })
-            .catch(function (e) {
-              finish(span, e)
-              reject.apply(this, arguments)
-            })
-        })
+        const promise = request.apply(this, arguments)
 
-        promise.abort = result.abort
+        promise.then(() => finish(span), e => finish(span, e))
 
         return promise
       }

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -140,18 +140,10 @@ function wrapFieldResolver (fieldResolver, tracer, config, responsePathAsArray) 
 
 function call (fn, thisContext, args, callback) {
   try {
-    let result = fn.apply(thisContext, args)
+    const result = fn.apply(thisContext, args)
 
     if (result && typeof result.then === 'function') {
-      result = result
-        .then(value => {
-          callback(null, value)
-          return value
-        })
-        .catch(err => {
-          callback(err)
-          return Promise.reject(err)
-        })
+      result.then(value => callback(null, value), callback)
     } else {
       callback(null, result)
     }

--- a/test/plugins/amqp10.spec.js
+++ b/test/plugins/amqp10.spec.js
@@ -116,6 +116,16 @@ describe('Plugin', () => {
               })
             }
           })
+
+          it('should not override the returned promise', () => {
+            if (callbackPolicy === 'none') return
+
+            const promise = sender.send({ key: 'value' })
+
+            return promise.then(() => {
+              expect(promise).to.have.property('value')
+            })
+          })
         })
 
         describe('when consuming messages', () => {

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -29,7 +29,19 @@ describe('Plugin', () => {
         beforeEach(() => {
           elasticsearch = require(`../../versions/elasticsearch@${version}`).get()
           client = new elasticsearch.Client({
-            host: 'localhost:9200'
+            host: 'localhost:9200',
+            defer: () => {
+              const deferred = {}
+
+              deferred.promise = new Promise((resolve, reject) => {
+                deferred.resolve = resolve
+                deferred.reject = reject
+              })
+
+              deferred.promise.test = true
+
+              return deferred
+            }
           })
         })
 
@@ -215,6 +227,14 @@ describe('Plugin', () => {
             expect(() => {
               client.ping().abort()
             }).not.to.throw()
+          })
+
+          it('should not override the returned promise', () => {
+            const promise = client.ping()
+
+            return promise.then(() => {
+              expect(promise).to.have.property('test', true)
+            })
           })
         })
       })


### PR DESCRIPTION
The PR fixes some integrations overriding the promise that is returned by the underlying call. In most cases this doesn't cause any issue since the native `Promise` is used in both cases. However, if the user configures the module to use a promise library, they would get back a native `Promise` instead of the expected promise from the library. By not returning the new promise created to finish the span, we can effectively avoid the issue.