### PR TITLE
add a log propagator to allow correlation of a trace with logs

### DIFF
--- a/ext/formats.js
+++ b/ext/formats.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const opentracing = require('opentracing')
+
+module.exports = {
+  TEXT_MAP: opentracing.FORMAT_TEXT_MAP,
+  HTTP_HEADERS: opentracing.FORMAT_HTTP_HEADERS,
+  BINARY: opentracing.FORMAT_BINARY,
+  LOG: 'log'
+}

--- a/ext/index.js
+++ b/ext/index.js
@@ -2,8 +2,10 @@
 
 const priority = require('./priority')
 const tags = require('./tags')
+const formats = require('./formats')
 
 module.exports = {
   priority,
-  tags
+  tags,
+  formats
 }

--- a/src/opentracing/propagation/log.js
+++ b/src/opentracing/propagation/log.js
@@ -8,8 +8,8 @@ const spanKey = 'dd.span_id'
 
 class LogPropagator {
   inject (spanContext, carrier) {
-    carrier[traceKey] = spanContext.traceId.toString()
-    carrier[spanKey] = spanContext.spanId.toString()
+    carrier[traceKey] = spanContext.toTraceId()
+    carrier[spanKey] = spanContext.toSpanId()
   }
 
   extract (carrier) {

--- a/src/opentracing/propagation/log.js
+++ b/src/opentracing/propagation/log.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const Uint64BE = require('int64-buffer').Uint64BE
+const DatadogSpanContext = require('../span_context')
+
+const traceKey = 'dd.trace_id'
+const spanKey = 'dd.span_id'
+
+class LogPropagator {
+  inject (spanContext, carrier) {
+    carrier[traceKey] = spanContext.traceId.toString()
+    carrier[spanKey] = spanContext.spanId.toString()
+  }
+
+  extract (carrier) {
+    if (!carrier[traceKey] || !carrier[spanKey]) {
+      return null
+    }
+
+    const spanContext = new DatadogSpanContext({
+      traceId: new Uint64BE(carrier[traceKey], 10),
+      spanId: new Uint64BE(carrier[spanKey], 10)
+    })
+
+    return spanContext
+  }
+}
+
+module.exports = LogPropagator

--- a/src/opentracing/propagation/text_map.js
+++ b/src/opentracing/propagation/text_map.js
@@ -14,8 +14,8 @@ const logKeys = [traceKey, spanKey, samplingKey]
 
 class TextMapPropagator {
   inject (spanContext, carrier) {
-    carrier[traceKey] = spanContext._traceId.toString()
-    carrier[spanKey] = spanContext._spanId.toString()
+    carrier[traceKey] = spanContext.toTraceId()
+    carrier[spanKey] = spanContext.toSpanId()
 
     this._injectSamplingPriority(spanContext, carrier)
     this._injectBaggageItems(spanContext, carrier)

--- a/src/opentracing/span_context.js
+++ b/src/opentracing/span_context.js
@@ -22,6 +22,14 @@ class DatadogSpanContext extends SpanContext {
       finished: []
     }
   }
+
+  toTraceId () {
+    return this._traceId.toString()
+  }
+
+  toSpanId () {
+    return this._spanId.toString()
+  }
 }
 
 module.exports = DatadogSpanContext

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -12,6 +12,8 @@ const PrioritySampler = require('../priority_sampler')
 const TextMapPropagator = require('./propagation/text_map')
 const HttpPropagator = require('./propagation/http')
 const BinaryPropagator = require('./propagation/binary')
+const LogPropagator = require('./propagation/log')
+const formats = require('../../ext/formats')
 const log = require('../log')
 
 class DatadogTracer extends Tracer {
@@ -31,9 +33,10 @@ class DatadogTracer extends Tracer {
     this._recorder.init()
     this._sampler = new Sampler(config.sampleRate)
     this._propagators = {
-      [opentracing.FORMAT_TEXT_MAP]: new TextMapPropagator(),
-      [opentracing.FORMAT_HTTP_HEADERS]: new HttpPropagator(),
-      [opentracing.FORMAT_BINARY]: new BinaryPropagator()
+      [formats.TEXT_MAP]: new TextMapPropagator(),
+      [formats.HTTP_HEADERS]: new HttpPropagator(),
+      [formats.BINARY]: new BinaryPropagator(),
+      [formats.LOG]: new LogPropagator()
     }
   }
 

--- a/test/opentracing/propagation/log.spec.js
+++ b/test/opentracing/propagation/log.spec.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const Uint64BE = require('int64-buffer').Uint64BE
+const SpanContext = require('../../../src/opentracing/span_context')
+
+describe('LogPropagator', () => {
+  let LogPropagator
+  let propagator
+  let log
+
+  beforeEach(() => {
+    LogPropagator = require('../../../src/opentracing/propagation/log')
+    propagator = new LogPropagator()
+    log = {
+      'dd.trace_id': '123',
+      'dd.span_id': '18446744073709551160' // -456 casted to uint64
+    }
+  })
+
+  describe('inject', () => {
+    it('should inject the span context into the carrier', () => {
+      const carrier = {}
+      const spanContext = new SpanContext({
+        traceId: new Uint64BE(0, 123),
+        spanId: new Uint64BE(-456)
+      })
+
+      propagator.inject(spanContext, carrier)
+
+      expect(carrier).to.have.property('dd.trace_id', '123')
+      expect(carrier).to.have.property('dd.span_id', '18446744073709551160') // -456 casted to uint64
+    })
+  })
+
+  describe('extract', () => {
+    it('should extract a span context from the carrier', () => {
+      const carrier = log
+      const spanContext = propagator.extract(carrier)
+
+      expect(spanContext).to.deep.equal(new SpanContext({
+        traceId: new Uint64BE(0, 123),
+        spanId: new Uint64BE(-456)
+      }))
+    })
+
+    it('should return null if the carrier does not contain a trace', () => {
+      const carrier = {}
+      const spanContext = propagator.extract(carrier)
+
+      expect(spanContext).to.equal(null)
+    })
+  })
+})

--- a/test/opentracing/span_context.spec.js
+++ b/test/opentracing/span_context.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const Uint64BE = require('int64-buffer').Uint64BE
+
 describe('SpanContext', () => {
   let SpanContext
 
@@ -86,6 +88,28 @@ describe('SpanContext', () => {
         started: [],
         finished: []
       }
+    })
+  })
+
+  describe('toTraceId()', () => {
+    it('should return the trace ID as string', () => {
+      const spanContext = new SpanContext({
+        traceId: new Uint64BE(123),
+        spanId: new Uint64BE(456)
+      })
+
+      expect(spanContext.toTraceId()).to.equal('123')
+    })
+  })
+
+  describe('toSpanId()', () => {
+    it('should return the span ID as string', () => {
+      const spanContext = new SpanContext({
+        traceId: new Uint64BE(123),
+        spanId: new Uint64BE(456)
+      })
+
+      expect(spanContext.toSpanId()).to.equal('456')
     })
   })
 })


### PR DESCRIPTION
This PR adds a propagator to allow correlation of a trace/span with logs. The propagator can be used with `tracer.inject()` like other propagators. The idea behind using a propagator is that a log entry is a carrier similar to an HTTP header, and the user should not have to worry about how to format the log entry themselves.

In the rare case where they are not using JSON and need full control on the log format, it's also already possible to access the IDs on the span context by using `span.context().toTraceId()` and `span.context().toSpanId()`.