### PR TITLE
prefix span context properties with an underscore

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -25,8 +25,8 @@ function formatSpan (span) {
   const spanContext = span.context()
 
   return {
-    trace_id: spanContext.traceId,
-    span_id: spanContext.spanId,
+    trace_id: spanContext._traceId,
+    span_id: spanContext._spanId,
     parent_id: spanContext._parentId,
     name: String(spanContext._name),
     resource: String(spanContext._name),

--- a/src/format.js
+++ b/src/format.js
@@ -27,9 +27,9 @@ function formatSpan (span) {
   return {
     trace_id: spanContext.traceId,
     span_id: spanContext.spanId,
-    parent_id: spanContext.parentId,
-    name: String(spanContext.name),
-    resource: String(spanContext.name),
+    parent_id: spanContext._parentId,
+    name: String(spanContext._name),
+    resource: String(spanContext._name),
     error: 0,
     meta: {},
     metrics: {},
@@ -39,7 +39,7 @@ function formatSpan (span) {
 }
 
 function extractTags (trace, span) {
-  const tags = span.context().tags
+  const tags = span.context()._tags
 
   Object.keys(tags).forEach(tag => {
     switch (tag) {
@@ -78,14 +78,14 @@ function extractError (trace, span) {
 function extractMetrics (trace, span) {
   const spanContext = span.context()
 
-  Object.keys(spanContext.metrics).forEach(metric => {
-    if (typeof spanContext.metrics[metric] === 'number') {
-      trace.metrics[metric] = spanContext.metrics[metric]
+  Object.keys(spanContext._metrics).forEach(metric => {
+    if (typeof spanContext._metrics[metric] === 'number') {
+      trace.metrics[metric] = spanContext._metrics[metric]
     }
   })
 
-  if (spanContext.sampling.priority !== undefined) {
-    trace.metrics[SAMPLING_PRIORITY_KEY] = spanContext.sampling.priority
+  if (spanContext._sampling.priority !== undefined) {
+    trace.metrics[SAMPLING_PRIORITY_KEY] = spanContext._sampling.priority
   }
 }
 

--- a/src/opentracing/propagation/text_map.js
+++ b/src/opentracing/propagation/text_map.js
@@ -14,8 +14,8 @@ const logKeys = [traceKey, spanKey, samplingKey]
 
 class TextMapPropagator {
   inject (spanContext, carrier) {
-    carrier[traceKey] = spanContext.traceId.toString()
-    carrier[spanKey] = spanContext.spanId.toString()
+    carrier[traceKey] = spanContext._traceId.toString()
+    carrier[spanKey] = spanContext._spanId.toString()
 
     this._injectSamplingPriority(spanContext, carrier)
     this._injectBaggageItems(spanContext, carrier)

--- a/src/opentracing/propagation/text_map.js
+++ b/src/opentracing/propagation/text_map.js
@@ -42,7 +42,7 @@ class TextMapPropagator {
   }
 
   _injectSamplingPriority (spanContext, carrier) {
-    const priority = spanContext.sampling.priority
+    const priority = spanContext._sampling.priority
 
     if (Number.isInteger(priority)) {
       carrier[samplingKey] = priority.toString()
@@ -50,8 +50,8 @@ class TextMapPropagator {
   }
 
   _injectBaggageItems (spanContext, carrier) {
-    spanContext.baggageItems && Object.keys(spanContext.baggageItems).forEach(key => {
-      carrier[baggagePrefix + key] = String(spanContext.baggageItems[key])
+    spanContext._baggageItems && Object.keys(spanContext._baggageItems).forEach(key => {
+      carrier[baggagePrefix + key] = String(spanContext._baggageItems[key])
     })
   }
 
@@ -60,7 +60,7 @@ class TextMapPropagator {
       const match = key.match(baggageExpr)
 
       if (match) {
-        spanContext.baggageItems[match[1]] = carrier[key]
+        spanContext._baggageItems[match[1]] = carrier[key]
       }
     })
   }
@@ -69,7 +69,7 @@ class TextMapPropagator {
     const priority = parseInt(carrier[samplingKey], 10)
 
     if (Number.isInteger(priority)) {
-      spanContext.sampling.priority = parseInt(carrier[samplingKey], 10)
+      spanContext._sampling.priority = parseInt(carrier[samplingKey], 10)
     }
   }
 }

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -37,8 +37,8 @@ class DatadogSpan extends Span {
   toString () {
     const spanContext = this.context()
     const json = JSON.stringify({
-      traceId: spanContext.traceId,
-      spanId: spanContext.spanId,
+      traceId: spanContext._traceId,
+      spanId: spanContext._spanId,
       parentId: spanContext._parentId,
       service: spanContext._tags['service.name'],
       name: spanContext._name,
@@ -53,9 +53,9 @@ class DatadogSpan extends Span {
 
     if (parent) {
       spanContext = new SpanContext({
-        traceId: parent.traceId,
+        traceId: parent._traceId,
         spanId: platform.id(),
-        parentId: parent.spanId,
+        parentId: parent._spanId,
         sampled: parent._sampled,
         sampling: parent._sampling,
         baggageItems: Object.assign({}, parent._baggageItems),

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -29,9 +29,9 @@ class DatadogSpan extends Span {
     this._startTime = startTime
 
     this._spanContext = this._createContext(parent)
-    this._spanContext.name = operationName
-    this._spanContext.tags = tags
-    this._spanContext.metrics = metrics
+    this._spanContext._name = operationName
+    this._spanContext._tags = tags
+    this._spanContext._metrics = metrics
   }
 
   toString () {
@@ -39,10 +39,10 @@ class DatadogSpan extends Span {
     const json = JSON.stringify({
       traceId: spanContext.traceId,
       spanId: spanContext.spanId,
-      parentId: spanContext.parentId,
-      service: spanContext.tags['service.name'],
-      name: spanContext.name,
-      resource: truncate(spanContext.tags['resource.name'], { length: 100 })
+      parentId: spanContext._parentId,
+      service: spanContext._tags['service.name'],
+      name: spanContext._name,
+      resource: truncate(spanContext._tags['resource.name'], { length: 100 })
     })
 
     return `Span${json}`
@@ -56,10 +56,10 @@ class DatadogSpan extends Span {
         traceId: parent.traceId,
         spanId: platform.id(),
         parentId: parent.spanId,
-        sampled: parent.sampled,
-        sampling: parent.sampling,
-        baggageItems: Object.assign({}, parent.baggageItems),
-        trace: parent.trace.started.length !== parent.trace.finished.length ? parent.trace : null
+        sampled: parent._sampled,
+        sampling: parent._sampling,
+        baggageItems: Object.assign({}, parent._baggageItems),
+        trace: parent._trace.started.length !== parent._trace.finished.length ? parent._trace : null
       })
     } else {
       const spanId = platform.id()
@@ -70,7 +70,7 @@ class DatadogSpan extends Span {
       })
     }
 
-    spanContext.trace.started.push(this)
+    spanContext._trace.started.push(this)
 
     return spanContext
   }
@@ -84,21 +84,21 @@ class DatadogSpan extends Span {
   }
 
   _setOperationName (name) {
-    this._spanContext.name = name
+    this._spanContext._name = name
   }
 
   _setBaggageItem (key, value) {
-    this._spanContext.baggageItems[key] = value
+    this._spanContext._baggageItems[key] = value
   }
 
   _getBaggageItem (key) {
-    return this._spanContext.baggageItems[key]
+    return this._spanContext._baggageItems[key]
   }
 
   _addTags (keyValuePairs) {
     try {
       Object.keys(keyValuePairs).forEach(key => {
-        this._spanContext.tags[key] = String(keyValuePairs[key])
+        this._spanContext._tags[key] = String(keyValuePairs[key])
       })
     } catch (e) {
       log.error(e)
@@ -113,16 +113,16 @@ class DatadogSpan extends Span {
     finishTime = parseFloat(finishTime) || platform.now()
 
     this._duration = finishTime - this._startTime
-    this._spanContext.trace.finished.push(this)
-    this._spanContext.isFinished = true
+    this._spanContext._trace.finished.push(this)
+    this._spanContext._isFinished = true
     this._prioritySampler.sample(this)
 
-    if (this._spanContext.sampled) {
+    if (this._spanContext._sampled) {
       this._recorder.record(this)
     }
 
-    this._spanContext.children
-      .filter(child => !child.context().isFinished)
+    this._spanContext._children
+      .filter(child => !child.context()._isFinished)
       .forEach(child => {
         log.error(`Parent span ${this} was finished before child span ${child}.`)
       })

--- a/src/opentracing/span_context.js
+++ b/src/opentracing/span_context.js
@@ -8,16 +8,16 @@ class DatadogSpanContext extends SpanContext {
 
     this.traceId = props.traceId
     this.spanId = props.spanId
-    this.parentId = props.parentId || null
-    this.name = props.name
-    this.children = props.children || []
-    this.isFinished = props.isFinished || false
-    this.tags = props.tags || {}
-    this.metrics = props.metrics || {}
-    this.sampled = props.sampled === undefined || props.sampled
-    this.sampling = props.sampling || {}
-    this.baggageItems = props.baggageItems || {}
-    this.trace = props.trace || {
+    this._parentId = props.parentId || null
+    this._name = props.name
+    this._children = props.children || []
+    this._isFinished = props.isFinished || false
+    this._tags = props.tags || {}
+    this._metrics = props.metrics || {}
+    this._sampled = props.sampled === undefined || props.sampled
+    this._sampling = props.sampling || {}
+    this._baggageItems = props.baggageItems || {}
+    this._trace = props.trace || {
       started: [],
       finished: []
     }

--- a/src/opentracing/span_context.js
+++ b/src/opentracing/span_context.js
@@ -6,8 +6,8 @@ class DatadogSpanContext extends SpanContext {
   constructor (props) {
     super()
 
-    this.traceId = props.traceId
-    this.spanId = props.spanId
+    this._traceId = props.traceId
+    this._spanId = props.spanId
     this._parentId = props.parentId || null
     this._name = props.name
     this._children = props.children || []

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -57,7 +57,7 @@ class DatadogTracer extends Tracer {
     })
 
     if (parent && parent.type() === opentracing.REFERENCE_CHILD_OF) {
-      parent.referencedContext().children.push(span)
+      parent.referencedContext()._children.push(span)
     }
 
     return span

--- a/src/plugins/util/redis.js
+++ b/src/plugins/util/redis.js
@@ -20,7 +20,7 @@ const redis = {
       }
     })
 
-    span.setTag('service.name', config.service || `${span.context().tags['service.name']}-redis`)
+    span.setTag('service.name', config.service || `${span.context()._tags['service.name']}-redis`)
 
     return span
   }

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -95,7 +95,7 @@ function startSpan (tracer, config, req, res, name) {
   req._datadog.config = config
 
   if (req._datadog.span) {
-    req._datadog.span.context().name = name
+    req._datadog.span.context()._name = name
     return req._datadog.span
   }
 
@@ -176,7 +176,7 @@ function addResponseTags (req) {
 
 function addResourceTag (req) {
   const span = req._datadog.span
-  const tags = span.context().tags
+  const tags = span.context()._tags
 
   if (tags['resource.name']) return
 

--- a/src/priority_sampler.js
+++ b/src/priority_sampler.js
@@ -26,7 +26,7 @@ class PrioritySampler {
 
   isSampled (span) {
     const context = this._getContext(span)
-    const key = `service:${context.tags[SERVICE_NAME]},env:${this._env}`
+    const key = `service:${context._tags[SERVICE_NAME]},env:${this._env}`
     const sampler = this._samplers[key] || this._samplers[DEFAULT_KEY]
 
     return sampler.isSampled(span)
@@ -35,16 +35,16 @@ class PrioritySampler {
   sample (span) {
     const context = this._getContext(span)
 
-    if (context.sampling.priority !== undefined) return
+    if (context._sampling.priority !== undefined) return
 
-    const tag = parseInt(context.tags[SAMPLING_PRIORITY], 10)
+    const tag = parseInt(context._tags[SAMPLING_PRIORITY], 10)
 
     if (this.validate(tag)) {
-      context.sampling.priority = tag
+      context._sampling.priority = tag
       return
     }
 
-    context.sampling.priority = this.isSampled(span) ? AUTO_KEEP : AUTO_REJECT
+    context._sampling.priority = this.isSampled(span) ? AUTO_KEEP : AUTO_REJECT
   }
 
   update (rates) {

--- a/src/writer.js
+++ b/src/writer.js
@@ -19,7 +19,7 @@ class Writer {
   }
 
   append (span) {
-    const trace = span.context().trace
+    const trace = span.context()._trace
 
     if (trace.started.length === trace.finished.length) {
       const formattedTrace = trace.finished.map(format)

--- a/test/dd-trace.spec.js
+++ b/test/dd-trace.spec.js
@@ -47,9 +47,9 @@ describe('dd-trace', () => {
       const payload = msgpack.decode(req.body, { codec })
 
       expect(payload[0][0].trace_id).to.be.instanceof(Uint64BE)
-      expect(payload[0][0].trace_id.toString()).to.equal(span.context().traceId.toString())
+      expect(payload[0][0].trace_id.toString()).to.equal(span.context()._traceId.toString())
       expect(payload[0][0].span_id).to.be.instanceof(Uint64BE)
-      expect(payload[0][0].span_id.toString()).to.equal(span.context().spanId.toString())
+      expect(payload[0][0].span_id.toString()).to.equal(span.context()._spanId.toString())
       expect(payload[0][0].service).to.equal('test')
       expect(payload[0][0].name).to.equal('hello')
       expect(payload[0][0].resource).to.equal('/hello/:name')

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -17,11 +17,11 @@ describe('format', () => {
     spanContext = {
       traceId: id,
       spanId: id,
-      parentId: id,
-      tags: {},
-      metrics: {},
-      sampling: {},
-      name: 'operation'
+      _parentId: id,
+      _tags: {},
+      _metrics: {},
+      _sampling: {},
+      _name: 'operation'
     }
 
     span = {
@@ -39,9 +39,9 @@ describe('format', () => {
 
       expect(trace.trace_id).to.equal(span.context().traceId)
       expect(trace.span_id).to.equal(span.context().spanId)
-      expect(trace.parent_id).to.equal(span.context().parentId)
-      expect(trace.name).to.equal(span.context().name)
-      expect(trace.resource).to.equal(span.context().name)
+      expect(trace.parent_id).to.equal(span.context()._parentId)
+      expect(trace.name).to.equal(span.context()._name)
+      expect(trace.resource).to.equal(span.context()._name)
       expect(trace.error).to.equal(0)
       expect(trace.start).to.be.instanceof(Int64BE)
       expect(trace.start.toNumber()).to.equal(span._startTime * 1e6)
@@ -50,9 +50,9 @@ describe('format', () => {
     })
 
     it('should extract Datadog specific tags', () => {
-      spanContext.tags['service.name'] = 'service'
-      spanContext.tags['span.type'] = 'type'
-      spanContext.tags['resource.name'] = 'resource'
+      spanContext._tags['service.name'] = 'service'
+      spanContext._tags['span.type'] = 'type'
+      spanContext._tags['resource.name'] = 'resource'
 
       trace = format(span)
 
@@ -62,10 +62,10 @@ describe('format', () => {
     })
 
     it('should only extract tags that are not Datadog specific to meta', () => {
-      spanContext.tags['service.name'] = 'service'
-      spanContext.tags['span.type'] = 'type'
-      spanContext.tags['resource.name'] = 'resource'
-      spanContext.tags['foo.bar'] = 'foobar'
+      spanContext._tags['service.name'] = 'service'
+      spanContext._tags['span.type'] = 'type'
+      spanContext._tags['resource.name'] = 'resource'
+      spanContext._tags['foo.bar'] = 'foobar'
 
       trace = format(span)
 
@@ -76,7 +76,7 @@ describe('format', () => {
     })
 
     it('should extract metrics', () => {
-      spanContext.metrics = { metric: 50 }
+      spanContext._metrics = { metric: 50 }
 
       trace = format(span)
 
@@ -84,7 +84,7 @@ describe('format', () => {
     })
 
     it('should ignore metrics with invalid values', () => {
-      spanContext.metrics = { metric: 'test' }
+      spanContext._metrics = { metric: 'test' }
 
       trace = format(span)
 
@@ -103,7 +103,7 @@ describe('format', () => {
 
     describe('when there is an `error` tag ', () => {
       it('should set the error flag when error tag is true', () => {
-        spanContext.tags['error'] = true
+        spanContext._tags['error'] = true
 
         trace = format(span)
 
@@ -111,7 +111,7 @@ describe('format', () => {
       })
 
       it('should not set the error flag when error is false', () => {
-        spanContext.tags['error'] = false
+        spanContext._tags['error'] = false
 
         trace = format(span)
 
@@ -119,7 +119,7 @@ describe('format', () => {
       })
 
       it('should not extract error to meta', () => {
-        spanContext.tags['error'] = true
+        spanContext._tags['error'] = true
 
         trace = format(span)
 
@@ -128,9 +128,9 @@ describe('format', () => {
     })
 
     it('should set the error flag when there is an error-related tag', () => {
-      spanContext.tags['error.type'] = 'Error'
-      spanContext.tags['error.msg'] = 'boom'
-      spanContext.tags['error.stack'] = ''
+      spanContext._tags['error.type'] = 'Error'
+      spanContext._tags['error.msg'] = 'boom'
+      spanContext._tags['error.stack'] = ''
 
       trace = format(span)
 
@@ -138,8 +138,8 @@ describe('format', () => {
     })
 
     it('should sanitize the input', () => {
-      spanContext.name = null
-      spanContext.tags = {
+      spanContext._name = null
+      spanContext._tags = {
         'foo.bar': null
       }
       span._startTime = NaN
@@ -155,7 +155,7 @@ describe('format', () => {
     })
 
     it('should include the sampling priority', () => {
-      spanContext.sampling.priority = 0
+      spanContext._sampling.priority = 0
       trace = format(span)
       expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
     })

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -37,8 +37,8 @@ describe('format', () => {
     it('should convert a span to the correct trace format', () => {
       trace = format(span)
 
-      expect(trace.trace_id).to.equal(span.context().traceId)
-      expect(trace.span_id).to.equal(span.context().spanId)
+      expect(trace.trace_id).to.equal(span.context()._traceId)
+      expect(trace.span_id).to.equal(span.context()._spanId)
       expect(trace.parent_id).to.equal(span.context()._parentId)
       expect(trace.name).to.equal(span.context()._name)
       expect(trace.resource).to.equal(span.context()._name)

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -49,16 +49,16 @@ describe('Span', () => {
   it('should add itself to the context trace started spans', () => {
     span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
 
-    expect(span.context().trace.started).to.deep.equal([span])
+    expect(span.context()._trace.started).to.deep.equal([span])
   })
 
   it('should use a parent context', () => {
     const parent = {
       traceId: new Uint64BE(123, 123),
       spanId: new Uint64BE(456, 456),
-      sampled: false,
-      baggageItems: { foo: 'bar' },
-      trace: {
+      _sampled: false,
+      _baggageItems: { foo: 'bar' },
+      _trace: {
         started: ['span'],
         finished: []
       }
@@ -67,18 +67,18 @@ describe('Span', () => {
     span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation', parent })
 
     expect(span.context().traceId).to.deep.equal(new Uint64BE(123, 123))
-    expect(span.context().parentId).to.deep.equal(new Uint64BE(456, 456))
-    expect(span.context().baggageItems).to.deep.equal({ foo: 'bar' })
-    expect(span.context().trace.started).to.deep.equal(['span', span])
+    expect(span.context()._parentId).to.deep.equal(new Uint64BE(456, 456))
+    expect(span.context()._baggageItems).to.deep.equal({ foo: 'bar' })
+    expect(span.context()._trace.started).to.deep.equal(['span', span])
   })
 
   it('should start a new trace if the parent trace is finished', () => {
     const parent = {
       traceId: new Uint64BE(123, 123),
       spanId: new Uint64BE(456, 456),
-      sampled: false,
-      baggageItems: { foo: 'bar' },
-      trace: {
+      _sampled: false,
+      _baggageItems: { foo: 'bar' },
+      _trace: {
         started: ['span'],
         finished: ['span']
       }
@@ -86,11 +86,11 @@ describe('Span', () => {
 
     span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation', parent })
 
-    expect(span.context().trace.started).to.deep.equal([span])
+    expect(span.context()._trace.started).to.deep.equal([span])
   })
 
   it('should set the sample rate metric from the sampler', () => {
-    expect(span.context().metrics).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
+    expect(span.context()._metrics).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
   })
 
   describe('tracer', () => {
@@ -106,7 +106,7 @@ describe('Span', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'foo' })
       span.setOperationName('bar')
 
-      expect(span.context().name).to.equal('bar')
+      expect(span.context()._name).to.equal('bar')
     })
   })
 
@@ -115,14 +115,14 @@ describe('Span', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.setBaggageItem('foo', 'bar')
 
-      expect(span.context().baggageItems).to.have.property('foo', 'bar')
+      expect(span.context()._baggageItems).to.have.property('foo', 'bar')
     })
   })
 
   describe('getBaggageItem', () => {
     it('should get a baggage item', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
-      span._spanContext.baggageItems.foo = 'bar'
+      span._spanContext._baggageItems.foo = 'bar'
 
       expect(span.getBaggageItem('foo')).to.equal('bar')
     })
@@ -133,7 +133,7 @@ describe('Span', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.setTag('foo', 'bar')
 
-      expect(span.context().tags).to.have.property('foo', 'bar')
+      expect(span.context()._tags).to.have.property('foo', 'bar')
     })
   })
 
@@ -142,14 +142,14 @@ describe('Span', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.addTags({ foo: 'bar' })
 
-      expect(span.context().tags).to.have.property('foo', 'bar')
+      expect(span.context()._tags).to.have.property('foo', 'bar')
     })
 
     it('should ensure tags are strings', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.addTags({ foo: 123 })
 
-      expect(span.context().tags).to.have.property('foo', '123')
+      expect(span.context()._tags).to.have.property('foo', '123')
     })
 
     it('should handle errors', () => {
@@ -166,7 +166,7 @@ describe('Span', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.finish()
 
-      expect(span.context().trace.finished).to.deep.equal([span])
+      expect(span.context()._trace.finished).to.deep.equal([span])
     })
 
     it('should record the span if sampled', () => {
@@ -200,12 +200,12 @@ describe('Span', () => {
 
     it('should generate sampling priority', () => {
       prioritySampler.sample = span => {
-        span.context().sampling.priority = 2
+        span.context()._sampling.priority = 2
       }
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.finish()
 
-      expect(span.context().sampling.priority).to.equal(2)
+      expect(span.context()._sampling.priority).to.equal(2)
     })
   })
 })

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -42,8 +42,8 @@ describe('Span', () => {
   it('should have a default context', () => {
     span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
 
-    expect(span.context().traceId).to.deep.equal(new Uint64BE(123, 123))
-    expect(span.context().spanId).to.deep.equal(new Uint64BE(123, 123))
+    expect(span.context()._traceId).to.deep.equal(new Uint64BE(123, 123))
+    expect(span.context()._spanId).to.deep.equal(new Uint64BE(123, 123))
   })
 
   it('should add itself to the context trace started spans', () => {
@@ -54,8 +54,8 @@ describe('Span', () => {
 
   it('should use a parent context', () => {
     const parent = {
-      traceId: new Uint64BE(123, 123),
-      spanId: new Uint64BE(456, 456),
+      _traceId: new Uint64BE(123, 123),
+      _spanId: new Uint64BE(456, 456),
       _sampled: false,
       _baggageItems: { foo: 'bar' },
       _trace: {
@@ -66,7 +66,7 @@ describe('Span', () => {
 
     span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation', parent })
 
-    expect(span.context().traceId).to.deep.equal(new Uint64BE(123, 123))
+    expect(span.context()._traceId).to.deep.equal(new Uint64BE(123, 123))
     expect(span.context()._parentId).to.deep.equal(new Uint64BE(456, 456))
     expect(span.context()._baggageItems).to.deep.equal({ foo: 'bar' })
     expect(span.context()._trace.started).to.deep.equal(['span', span])
@@ -74,8 +74,8 @@ describe('Span', () => {
 
   it('should start a new trace if the parent trace is finished', () => {
     const parent = {
-      traceId: new Uint64BE(123, 123),
-      spanId: new Uint64BE(456, 456),
+      _traceId: new Uint64BE(123, 123),
+      _spanId: new Uint64BE(456, 456),
       _sampled: false,
       _baggageItems: { foo: 'bar' },
       _trace: {

--- a/test/opentracing/span_context.spec.js
+++ b/test/opentracing/span_context.spec.js
@@ -28,8 +28,8 @@ describe('SpanContext', () => {
     const spanContext = new SpanContext(props)
 
     expect(spanContext).to.deep.equal({
-      traceId: '123',
-      spanId: '456',
+      _traceId: '123',
+      _spanId: '456',
       _parentId: '789',
       _name: 'test',
       _children: ['span'],
@@ -71,8 +71,8 @@ describe('SpanContext', () => {
     })
 
     expect(spanContext).to.deep.equal({
-      traceId: '123',
-      spanId: '456',
+      _traceId: '123',
+      _spanId: '456',
       _parentId: null,
       _name: undefined,
       _children: [],

--- a/test/opentracing/span_context.spec.js
+++ b/test/opentracing/span_context.spec.js
@@ -27,7 +27,23 @@ describe('SpanContext', () => {
     }
     const spanContext = new SpanContext(props)
 
-    expect(spanContext).to.deep.equal(props)
+    expect(spanContext).to.deep.equal({
+      traceId: '123',
+      spanId: '456',
+      _parentId: '789',
+      _name: 'test',
+      _children: ['span'],
+      _isFinished: true,
+      _tags: {},
+      _metrics: {},
+      _sampled: false,
+      _sampling: { priority: 2 },
+      _baggageItems: { foo: 'bar' },
+      _trace: {
+        started: ['span1', 'span2'],
+        finished: ['span1']
+      }
+    })
   })
 
   it('should have the correct default values', () => {
@@ -54,6 +70,22 @@ describe('SpanContext', () => {
       spanId: expected.spanId
     })
 
-    expect(spanContext).to.deep.equal(expected)
+    expect(spanContext).to.deep.equal({
+      traceId: '123',
+      spanId: '456',
+      _parentId: null,
+      _name: undefined,
+      _children: [],
+      _isFinished: false,
+      _tags: {},
+      _metrics: {},
+      _sampled: true,
+      _sampling: {},
+      _baggageItems: {},
+      _trace: {
+        started: [],
+        finished: []
+      }
+    })
   })
 })

--- a/test/opentracing/tracer.spec.js
+++ b/test/opentracing/tracer.spec.js
@@ -141,7 +141,7 @@ describe('Tracer', () => {
     it('should start a span that is the child of a span', () => {
       const parent = new SpanContext()
 
-      parent.children = []
+      parent._children = []
       fields.references = [
         new Reference(opentracing.REFERENCE_CHILD_OF, parent)
       ]

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -986,7 +986,7 @@ describe('Plugin', () => {
 
               try {
                 expect(scope).to.not.be.null
-                expect(scope.span().context()).to.have.property('name', 'graphql.execute')
+                expect(scope.span().context()).to.have.property('_name', 'graphql.execute')
                 done()
               } catch (e) {
                 done(e)

--- a/test/plugins/util/redis.spec.js
+++ b/test/plugins/util/redis.spec.js
@@ -16,7 +16,7 @@ describe('plugins/util/redis', () => {
     it('should start a span with the correct tags', () => {
       span = redis.instrument(tracer, config, '1', 'set', ['foo', 'bar'])
 
-      expect(span.context().tags).to.deep.include({
+      expect(span.context()._tags).to.deep.include({
         'span.kind': 'client',
         'service.name': 'test-redis',
         'resource.name': 'set',
@@ -38,7 +38,7 @@ describe('plugins/util/redis', () => {
 
       span = redis.instrument(tracer, config, '1', 'ping', [])
 
-      expect(span.context().parentId.toString()).to.equal(parent.context().spanId.toString())
+      expect(span.context()._parentId.toString()).to.equal(parent.context().spanId.toString())
     })
 
     it('should trim command arguments if yoo long', () => {
@@ -50,7 +50,7 @@ describe('plugins/util/redis', () => {
 
       span = redis.instrument(tracer, config, '1', 'get', [key])
 
-      const rawCommand = span.context().tags['redis.raw_command']
+      const rawCommand = span.context()._tags['redis.raw_command']
 
       expect(rawCommand).to.have.length(104)
       expect(rawCommand.substr(0, 10)).to.equal('GET aaaaaa')
@@ -72,7 +72,7 @@ describe('plugins/util/redis', () => {
 
       span = redis.instrument(tracer, config, '1', 'get', values)
 
-      const rawCommand = span.context().tags['redis.raw_command']
+      const rawCommand = span.context()._tags['redis.raw_command']
 
       expect(rawCommand).to.have.length(1000)
       expect(rawCommand.substr(0, 10)).to.equal('GET aaaaaa')

--- a/test/plugins/util/redis.spec.js
+++ b/test/plugins/util/redis.spec.js
@@ -38,7 +38,7 @@ describe('plugins/util/redis', () => {
 
       span = redis.instrument(tracer, config, '1', 'ping', [])
 
-      expect(span.context()._parentId.toString()).to.equal(parent.context().spanId.toString())
+      expect(span.context()._parentId.toString()).to.equal(parent.context()._spanId.toString())
     })
 
     it('should trim command arguments if yoo long', () => {

--- a/test/plugins/util/tx.spec.js
+++ b/test/plugins/util/tx.spec.js
@@ -21,8 +21,8 @@ describe('plugins/util/tx', () => {
     it('should set the out.host and out.port tags', () => {
       tx.setHost(span, 'example.com', '1234')
 
-      expect(span.context().tags).to.have.property('out.host', 'example.com')
-      expect(span.context().tags).to.have.property('out.port', '1234')
+      expect(span.context()._tags).to.have.property('out.host', 'example.com')
+      expect(span.context()._tags).to.have.property('out.port', '1234')
     })
   })
 
@@ -45,9 +45,9 @@ describe('plugins/util/tx', () => {
 
         wrapper(error)
 
-        expect(span.context().tags).to.have.property('error.msg', error.message)
-        expect(span.context().tags).to.have.property('error.type', error.name)
-        expect(span.context().tags).to.have.property('error.stack', error.stack)
+        expect(span.context()._tags).to.have.property('error.msg', error.message)
+        expect(span.context()._tags).to.have.property('error.type', error.name)
+        expect(span.context()._tags).to.have.property('error.stack', error.stack)
       })
     })
 
@@ -71,9 +71,9 @@ describe('plugins/util/tx', () => {
 
         return promise.catch(err => {
           expect(err).to.equal(error)
-          expect(span.context().tags).to.have.property('error.msg', error.message)
-          expect(span.context().tags).to.have.property('error.type', error.name)
-          expect(span.context().tags).to.have.property('error.stack', error.stack)
+          expect(span.context()._tags).to.have.property('error.msg', error.message)
+          expect(span.context()._tags).to.have.property('error.type', error.name)
+          expect(span.context()._tags).to.have.property('error.stack', error.stack)
         })
       })
     })

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -58,7 +58,7 @@ describe('plugins/util/web', () => {
 
         span = web.instrument(tracer, config, req, res, 'test.request')
 
-        expect(span.context().traceId.toString()).to.equal('123')
+        expect(span.context()._traceId.toString()).to.equal('123')
         expect(span.context()._parentId.toString()).to.equal('456')
       })
 

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -59,7 +59,7 @@ describe('plugins/util/web', () => {
         span = web.instrument(tracer, config, req, res, 'test.request')
 
         expect(span.context().traceId.toString()).to.equal('123')
-        expect(span.context().parentId.toString()).to.equal('456')
+        expect(span.context()._parentId.toString()).to.equal('456')
       })
 
       it('should set the service name', () => {
@@ -67,7 +67,7 @@ describe('plugins/util/web', () => {
 
         span = web.instrument(tracer, config, req, res, 'test.request')
 
-        expect(span.context().tags).to.have.property(SERVICE_NAME, 'custom')
+        expect(span.context()._tags).to.have.property(SERVICE_NAME, 'custom')
       })
 
       it('should activate a scope with the span', () => {
@@ -88,7 +88,7 @@ describe('plugins/util/web', () => {
 
         res.end()
 
-        expect(span.context().tags).to.include({
+        expect(span.context()._tags).to.include({
           [SPAN_TYPE]: HTTP,
           [HTTP_URL]: 'http://localhost/user/123',
           [HTTP_METHOD]: 'GET',
@@ -103,7 +103,7 @@ describe('plugins/util/web', () => {
 
         res.end()
 
-        expect(span.context().tags).to.include({
+        expect(span.context()._tags).to.include({
           [`${HTTP_HEADERS}.host`]: 'localhost'
         })
       })
@@ -122,7 +122,7 @@ describe('plugins/util/web', () => {
         span = web.instrument(tracer, config, req, res, 'test.request')
         span = web.instrument(tracer, config, req, res, 'test2.request')
 
-        expect(span.context().name).to.equal('test2.request')
+        expect(span.context()._name).to.equal('test2.request')
       })
 
       it('should allow overriding the span service name', () => {
@@ -130,7 +130,7 @@ describe('plugins/util/web', () => {
         config.service = 'test2'
         span = web.instrument(tracer, config, req, res, 'test.request')
 
-        expect(span.context().tags).to.have.property('service.name', 'test2')
+        expect(span.context()._tags).to.have.property('service.name', 'test2')
       })
 
       it('should only wrap res.end once', () => {
@@ -190,7 +190,7 @@ describe('plugins/util/web', () => {
 
         res.end()
 
-        expect(span.context().tags).to.include({
+        expect(span.context()._tags).to.include({
           [RESOURCE_NAME]: 'GET',
           [HTTP_STATUS_CODE]: '200'
         })
@@ -201,7 +201,7 @@ describe('plugins/util/web', () => {
 
         res.end()
 
-        expect(span.context().tags).to.include({
+        expect(span.context()._tags).to.include({
           [ERROR]: 'true'
         })
       })
@@ -211,7 +211,7 @@ describe('plugins/util/web', () => {
 
         res.end()
 
-        expect(span.context().tags).to.include({
+        expect(span.context()._tags).to.include({
           [ERROR]: 'true'
         })
       })
@@ -221,7 +221,7 @@ describe('plugins/util/web', () => {
 
         res.end()
 
-        expect(span.context().tags).to.include({
+        expect(span.context()._tags).to.include({
           [HTTP_ROUTE]: '/custom/route'
         })
       })
@@ -255,7 +255,7 @@ describe('plugins/util/web', () => {
 
         res.end()
 
-        expect(span.context().tags).to.have.property('resource.name', 'GET /custom/route')
+        expect(span.context()._tags).to.have.property('resource.name', 'GET /custom/route')
       })
     })
   })
@@ -273,8 +273,8 @@ describe('plugins/util/web', () => {
       web.enterRoute(req, '/bar')
       res.end()
 
-      expect(span.context().tags).to.have.property(RESOURCE_NAME, 'GET /foo/bar')
-      expect(span.context().tags).to.have.property(HTTP_ROUTE, '/foo/bar')
+      expect(span.context()._tags).to.have.property(RESOURCE_NAME, 'GET /foo/bar')
+      expect(span.context()._tags).to.have.property(HTTP_ROUTE, '/foo/bar')
     })
   })
 
@@ -292,7 +292,7 @@ describe('plugins/util/web', () => {
       web.exitRoute(req)
       res.end()
 
-      expect(span.context().tags).to.have.property(RESOURCE_NAME, 'GET /foo')
+      expect(span.context()._tags).to.have.property(RESOURCE_NAME, 'GET /foo')
     })
   })
 

--- a/test/priority_sampler.spec.js
+++ b/test/priority_sampler.spec.js
@@ -17,8 +17,8 @@ describe('PrioritySampler', () => {
 
   beforeEach(() => {
     context = {
-      tags: {},
-      sampling: {}
+      _tags: {},
+      _sampling: {}
     }
 
     span = {
@@ -59,31 +59,31 @@ describe('PrioritySampler', () => {
     it('should set the correct priority by default', () => {
       prioritySampler.sample(span)
 
-      expect(context.sampling.priority).to.equal(AUTO_KEEP)
+      expect(context._sampling.priority).to.equal(AUTO_KEEP)
     })
 
     it('should set the priority from the corresponding tag', () => {
-      context.tags[SAMPLING_PRIORITY] = `${USER_KEEP}`
+      context._tags[SAMPLING_PRIORITY] = `${USER_KEEP}`
 
       prioritySampler.sample(span)
 
-      expect(context.sampling.priority).to.equal(USER_KEEP)
+      expect(context._sampling.priority).to.equal(USER_KEEP)
     })
 
     it('should freeze the sampling priority once set', () => {
       prioritySampler.sample(span)
 
-      context.tags[SAMPLING_PRIORITY] = `${USER_KEEP}`
+      context._tags[SAMPLING_PRIORITY] = `${USER_KEEP}`
 
       prioritySampler.sample(span)
 
-      expect(context.sampling.priority).to.equal(AUTO_KEEP)
+      expect(context._sampling.priority).to.equal(AUTO_KEEP)
     })
 
     it('should accept a span context', () => {
       prioritySampler.sample(context)
 
-      expect(context.sampling.priority).to.equal(AUTO_KEEP)
+      expect(context._sampling.priority).to.equal(AUTO_KEEP)
     })
   })
 
@@ -95,11 +95,11 @@ describe('PrioritySampler', () => {
 
       prioritySampler.sample(span)
 
-      expect(context.sampling.priority).to.equal(AUTO_REJECT)
+      expect(context._sampling.priority).to.equal(AUTO_REJECT)
     })
 
     it('should update service rates', () => {
-      context.tags[SERVICE_NAME] = 'hello'
+      context._tags[SERVICE_NAME] = 'hello'
 
       prioritySampler.update({
         'service:hello,env:test': AUTO_REJECT
@@ -107,7 +107,7 @@ describe('PrioritySampler', () => {
 
       prioritySampler.sample(span)
 
-      expect(context.sampling.priority).to.equal(AUTO_REJECT)
+      expect(context._sampling.priority).to.equal(AUTO_REJECT)
     })
   })
 })

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -40,7 +40,7 @@ describe('Tracer', () => {
     it('should use the parent context', done => {
       tracer.trace('parent', parent => {
         tracer.trace('child', child => {
-          expect(child.context()).to.have.property('parentId', parent.context().spanId)
+          expect(child.context()).to.have.property('_parentId', parent.context().spanId)
           done()
         })
       })
@@ -49,7 +49,7 @@ describe('Tracer', () => {
     it('should support explicitly creating a root span', done => {
       tracer.trace('parent', parent => {
         tracer.trace('child', { childOf: null }, child => {
-          expect(child.context()).to.have.property('parentId', null)
+          expect(child.context()).to.have.property('_parentId', null)
           done()
         })
       })
@@ -57,30 +57,30 @@ describe('Tracer', () => {
 
     it('should set default tags', done => {
       tracer.trace('name', current => {
-        expect(current.context().tags).to.have.property('service.name', 'service')
-        expect(current.context().tags).to.have.property('resource.name', 'name')
-        expect(current.context().tags).to.not.have.property('span.type')
+        expect(current.context()._tags).to.have.property('service.name', 'service')
+        expect(current.context()._tags).to.have.property('resource.name', 'name')
+        expect(current.context()._tags).to.not.have.property('span.type')
         done()
       })
     })
 
     it('should support service option', done => {
       tracer.trace('name', { service: 'test' }, current => {
-        expect(current.context().tags).to.have.property('service.name', 'test')
+        expect(current.context()._tags).to.have.property('service.name', 'test')
         done()
       })
     })
 
     it('should support resource option', done => {
       tracer.trace('name', { resource: 'test' }, current => {
-        expect(current.context().tags).to.have.property('resource.name', 'test')
+        expect(current.context()._tags).to.have.property('resource.name', 'test')
         done()
       })
     })
 
     it('should support type option', done => {
       tracer.trace('name', { type: 'test' }, current => {
-        expect(current.context().tags).to.have.property('span.type', 'test')
+        expect(current.context()._tags).to.have.property('span.type', 'test')
         done()
       })
     })
@@ -91,7 +91,7 @@ describe('Tracer', () => {
       }
 
       tracer.trace('name', { tags }, current => {
-        expect(current.context().tags).to.have.property('foo', 'bar')
+        expect(current.context()._tags).to.have.property('foo', 'bar')
         done()
       })
     })
@@ -104,7 +104,7 @@ describe('Tracer', () => {
 
       tracer.trace('name', { childOf }, current => {
         expect(current.context().traceId).to.equal(childOf.traceId)
-        expect(current.context().parentId).to.equal(childOf.spanId)
+        expect(current.context()._parentId).to.equal(childOf.spanId)
         done()
       })
     })

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -40,7 +40,7 @@ describe('Tracer', () => {
     it('should use the parent context', done => {
       tracer.trace('parent', parent => {
         tracer.trace('child', child => {
-          expect(child.context()).to.have.property('_parentId', parent.context().spanId)
+          expect(child.context()).to.have.property('_parentId', parent.context()._spanId)
           done()
         })
       })
@@ -103,8 +103,8 @@ describe('Tracer', () => {
       })
 
       tracer.trace('name', { childOf }, current => {
-        expect(current.context().traceId).to.equal(childOf.traceId)
-        expect(current.context()._parentId).to.equal(childOf.spanId)
+        expect(current.context()._traceId).to.equal(childOf._traceId)
+        expect(current.context()._parentId).to.equal(childOf._spanId)
         done()
       })
     })

--- a/test/writer.spec.js
+++ b/test/writer.spec.js
@@ -21,7 +21,7 @@ describe('Writer', () => {
     }
 
     span = {
-      context: sinon.stub().returns({ trace })
+      context: sinon.stub().returns({ _trace: trace })
     }
 
     response = JSON.stringify({


### PR DESCRIPTION
This PR updates the span context to prefix properties with an underscore to make it clear they shouldn't be used externally. In the past, we would simply forbid access to all context properties, meaning this was not an issue. Now that we want to expose the trace/span IDs, we need to make it explicit which properties can be used by the user.