### PR TITLE
fix baggage items at the span level instead of trace level

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -58,7 +58,7 @@ class DatadogSpan extends Span {
         parentId: parent._spanId,
         sampled: parent._sampled,
         sampling: parent._sampling,
-        baggageItems: Object.assign({}, parent._baggageItems),
+        baggageItems: parent._baggageItems,
         trace: parent._trace.started.length !== parent._trace.finished.length ? parent._trace : null
       })
     } else {

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -111,11 +111,23 @@ describe('Span', () => {
   })
 
   describe('setBaggageItem', () => {
-    it('should set a baggage item', () => {
-      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
+    it('should set a baggage item on the trace', () => {
+      const parent = {
+        traceId: new Uint64BE(123, 123),
+        spanId: new Uint64BE(456, 456),
+        _sampled: false,
+        _baggageItems: {},
+        _trace: {
+          started: ['span'],
+          finished: ['span']
+        }
+      }
+
+      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation', parent })
       span.setBaggageItem('foo', 'bar')
 
       expect(span.context()._baggageItems).to.have.property('foo', 'bar')
+      expect(parent._baggageItems).to.have.property('foo', 'bar')
     })
   })
 


### PR DESCRIPTION
This PR fixes baggage items that were set at the span level instead of trace level. According to the OpenTracing specification, baggage items are supposed to cross the context of the entire trace, distributed or not.