### PR TITLE
add middleware and stack trace support for express

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -14,6 +14,7 @@
     "withVersions": true
   },
   "rules": {
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "handle-callback-err": 0
   }
 }

--- a/test/plugins/router.spec.js
+++ b/test/plugins/router.spec.js
@@ -11,6 +11,8 @@ const plugin = require('../../src/plugins/router')
 
 wrapIt()
 
+const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
+
 describe('Plugin', () => {
   let tracer
   let Router
@@ -66,8 +68,9 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0]).to.have.length(1)
-                expect(traces[0][0]).to.have.property('resource', 'GET /parent/child/:id')
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /parent/child/:id')
               })
               .then(done)
               .catch(done)


### PR DESCRIPTION
This PR adds support for instrumenting Express middleware spans, and adds support for middleware and request stack traces for server errors.