### PR TITLE
Fix link to setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Datadog APM tracing client for JavaScript.
 
 ## Getting Started
 
-For a basic product overview, check out our [setup documentation](https://docs.datadoghq.com/tracing/setup/javascript/).
+For a basic product overview, check out our [setup documentation](https://docs.datadoghq.com/tracing/languages/nodejs/).
 
 For installation, configuration, and details about using the API, check out our [API documentation](https://datadog.github.io/dd-trace-js).
 


### PR DESCRIPTION
Looks like the current link is 404ing -- not sure if there was supposed to be a redirect set up.