### PR TITLE
add net integration

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -15,6 +15,7 @@ module.exports = {
   'mongodb-core': require('./mongodb-core'),
   'mysql': require('./mysql'),
   'mysql2': require('./mysql2'),
+  'net': require('./net'),
   'pg': require('./pg'),
   'q': require('./q'),
   'redis': require('./redis'),

--- a/src/plugins/net.js
+++ b/src/plugins/net.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const tx = require('./util/tx')
+
+function createWrapConnect (tracer, config) {
+  return function wrapConnect (connect) {
+    return function connectWithTrace () {
+      const options = getOptions(arguments)
+
+      if (!options) return connect.apply(this, arguments)
+
+      const span = startSpan(tracer, config)
+
+      if (options.path) {
+        span.addTags({
+          'resource.name': `${options.path}`,
+          'socket.type': 'ipc',
+          'socket.path': options.path
+        })
+      } else if (options.port) {
+        span.addTags({
+          'resource.name': `${options.host}:${options.port}`,
+          'socket.type': 'tcp',
+          'socket.hostname': options.host,
+          'socket.port': options.port
+        })
+      }
+
+      this.once('connect', tx.wrap(span).bind(null))
+      this.once('error', tx.wrap(span))
+
+      return connect.apply(this, arguments)
+    }
+  }
+}
+
+function startSpan (tracer, config) {
+  const scope = tracer.scopeManager().active()
+  const span = tracer.startSpan('net.connect', {
+    childOf: scope && scope.span(),
+    tags: {
+      'span.kind': 'client',
+      'service.name': config.service || `${tracer._service}-net`
+    }
+  })
+
+  return span
+}
+
+function getOptions (args) {
+  if (!args[0]) return
+
+  switch (typeof args[0]) {
+    case 'object':
+      if (Array.isArray(args[0])) return getOptions(args[0])
+      if (typeof args[0].port === 'undefined' && typeof args[0].path === 'undefined') return
+      return args[0]
+    case 'number':
+      return {
+        port: args[0],
+        host: typeof args[1] === 'string' ? args[1] : 'localhost'
+      }
+    case 'string':
+      return {
+        path: args[0]
+      }
+  }
+}
+
+module.exports = {
+  name: 'net',
+  patch (net, tracer, config) {
+    this.wrap(net.Socket.prototype, 'connect', createWrapConnect(tracer, config))
+  },
+  unpatch (net) {
+    this.unwrap(net.Socket.prototype, 'connect')
+  }
+}

--- a/test/plugins/net.spec.js
+++ b/test/plugins/net.spec.js
@@ -1,0 +1,140 @@
+'use strict'
+
+const getPort = require('get-port')
+const agent = require('./agent')
+const plugin = require('../../src/plugins/net')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let net
+  let tcp
+  let ipc
+  let port
+
+  describe('net', () => {
+    afterEach(() => {
+      return agent.close()
+    })
+
+    afterEach(() => {
+      tcp.close()
+    })
+
+    afterEach(() => {
+      ipc.close()
+    })
+
+    beforeEach(() => {
+      return agent.load(plugin, 'net')
+        .then(() => {
+          net = require(`net`)
+
+          return getPort().then(_port => {
+            port = _port
+          })
+        })
+    })
+
+    beforeEach(done => {
+      tcp = new net.Server(socket => {
+        socket.write('')
+      })
+      tcp.listen(port, () => done())
+    })
+
+    beforeEach(done => {
+      ipc = new net.Server(socket => {
+        socket.write('')
+      })
+      ipc.listen('/tmp/dd-trace.sock', () => done())
+    })
+
+    it('should instrument connect with a path', done => {
+      agent
+        .use(traces => {
+          expect(traces[0][0]).to.deep.include({
+            name: 'net.connect',
+            service: 'test-net',
+            resource: '/tmp/dd-trace.sock',
+            meta: {
+              'span.kind': 'client',
+              'socket.type': 'ipc',
+              'socket.path': '/tmp/dd-trace.sock'
+            }
+          })
+        })
+        .then(done)
+        .catch(done)
+
+      net.connect('/tmp/dd-trace.sock')
+    })
+
+    it('should instrument connect with a port', done => {
+      agent
+        .use(traces => {
+          expect(traces[0][0]).to.deep.include({
+            name: 'net.connect',
+            service: 'test-net',
+            resource: `localhost:${port}`,
+            meta: {
+              'span.kind': 'client',
+              'socket.type': 'tcp',
+              'socket.port': `${port}`,
+              'socket.hostname': 'localhost'
+            }
+          })
+        })
+        .then(done)
+        .catch(done)
+
+      net.connect(port, 'localhost')
+    })
+
+    it('should instrument connect with TCP options', done => {
+      agent
+        .use(traces => {
+          expect(traces[0][0]).to.deep.include({
+            name: 'net.connect',
+            service: 'test-net',
+            resource: `localhost:${port}`,
+            meta: {
+              'span.kind': 'client',
+              'socket.type': 'tcp',
+              'socket.port': `${port}`,
+              'socket.hostname': 'localhost'
+            }
+          })
+        })
+        .then(done)
+        .catch(done)
+
+      net.connect({
+        port,
+        host: 'localhost'
+      })
+    })
+
+    it('should instrument connect with IPC options', done => {
+      agent
+        .use(traces => {
+          expect(traces[0][0]).to.deep.include({
+            name: 'net.connect',
+            service: 'test-net',
+            resource: '/tmp/dd-trace.sock',
+            meta: {
+              'span.kind': 'client',
+              'socket.type': 'ipc',
+              'socket.path': '/tmp/dd-trace.sock'
+            }
+          })
+        })
+        .then(done)
+        .catch(done)
+
+      net.connect({
+        path: '/tmp/dd-trace.sock'
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds initial automatic instrumentation support for the `net` module. For now, only `net.connect()` is instrumented.