### PR TITLE
add trace search sampling configuration

### DIFF
--- a/ext/tags.js
+++ b/ext/tags.js
@@ -7,6 +7,7 @@ module.exports = {
   SPAN_TYPE: 'span.type',
   SPAN_KIND: 'span.kind',
   SAMPLING_PRIORITY: 'sampling.priority',
+  EVENT_SAMPLE_RATE: '_dd1.sr.eausr',
   ERROR: 'error',
 
   // HTTP

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   SAMPLE_RATE_METRIC_KEY: '_sample_rate',
-  SAMPLING_PRIORITY_KEY: '_sampling_priority_v1'
+  SAMPLING_PRIORITY_KEY: '_sampling_priority_v1',
+  EVENT_SAMPLE_RATE_KEY: '_dd1.sr.eausr'
 }

--- a/src/event_sampler.js
+++ b/src/event_sampler.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const EVENT_SAMPLE_RATE = require('../ext/tags').EVENT_SAMPLE_RATE
+
+module.exports = {
+  sample (span, rates) {
+    switch (typeof rates) {
+      case 'number':
+        if (rates < 0 || rates > 1) return
+
+        span.setTag(EVENT_SAMPLE_RATE, rates)
+
+        break
+      case 'object': {
+        const name = span.context()._name
+
+        if (rates.hasOwnProperty(name)) {
+          this.sample(span, rates[name])
+        }
+
+        break
+      }
+    }
+  }
+}

--- a/src/format.js
+++ b/src/format.js
@@ -2,8 +2,11 @@
 
 const Int64BE = require('int64-buffer').Int64BE
 const constants = require('./constants')
+const tags = require('../ext/tags')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
+const EVENT_SAMPLE_RATE_KEY = constants.EVENT_SAMPLE_RATE_KEY
+const EVENT_SAMPLE_RATE = tags.EVENT_SAMPLE_RATE
 
 const map = {
   'service.name': 'service',
@@ -59,6 +62,8 @@ function extractTags (trace, span) {
         trace.error = 1
         trace.meta[tag] = String(tags[tag])
         break
+      case EVENT_SAMPLE_RATE:
+        break
       default:
         trace.meta[tag] = String(tags[tag])
     }
@@ -77,6 +82,7 @@ function extractError (trace, span) {
 
 function extractMetrics (trace, span) {
   const spanContext = span.context()
+  const eventSampleRate = parseFloat(spanContext._tags[EVENT_SAMPLE_RATE])
 
   Object.keys(spanContext._metrics).forEach(metric => {
     if (typeof spanContext._metrics[metric] === 'number') {
@@ -86,6 +92,10 @@ function extractMetrics (trace, span) {
 
   if (spanContext._sampling.priority !== undefined) {
     trace.metrics[SAMPLING_PRIORITY_KEY] = spanContext._sampling.priority
+  }
+
+  if (eventSampleRate >= 0 && eventSampleRate <= 1) {
+    trace.metrics[EVENT_SAMPLE_RATE_KEY] = eventSampleRate
   }
 }
 

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const eventSampler = require('../../event_sampler')
 const FORMAT_HTTP_HEADERS = require('opentracing').FORMAT_HTTP_HEADERS
 const log = require('../../log')
 const tags = require('../../../ext/tags')
@@ -42,6 +43,8 @@ const web = {
     if (config.service) {
       span.setTag(SERVICE_NAME, config.service)
     }
+
+    eventSampler.sample(span, config.eventSampleRate)
 
     callback && callback(span)
 

--- a/test/event_sampler.spec.js
+++ b/test/event_sampler.spec.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const EVENT_SAMPLE_RATE = require('../ext/tags').EVENT_SAMPLE_RATE
+
+describe('eventSampler', () => {
+  let eventSampler
+  let span
+
+  beforeEach(() => {
+    eventSampler = require('../src/event_sampler')
+    span = {
+      context: sinon.stub().returns({
+        _name: 'web.request'
+      }),
+      setTag: sinon.spy()
+    }
+  })
+
+  describe('sample', () => {
+    it('should sample a span with the provided rate', () => {
+      eventSampler.sample(span, 0.5)
+
+      expect(span.setTag).to.have.been.calledWith(EVENT_SAMPLE_RATE, 0.5)
+    })
+
+    it('should sample a span with the operation specific rate', () => {
+      eventSampler.sample(span, {
+        'web.request': 0.5
+      })
+
+      expect(span.setTag).to.have.been.calledWith(EVENT_SAMPLE_RATE, 0.5)
+    })
+
+    it('should ignore invalid values', () => {
+      eventSampler.sample(span)
+      eventSampler.sample(span, 2)
+      eventSampler.sample(span, -1)
+      eventSampler.sample(span, 'foo')
+
+      expect(span.setTag).to.not.have.been.called
+    })
+
+    it('should ignore rates for different operation names', () => {
+      eventSampler.sample(span, {
+        'other.request': 0.5
+      })
+
+      expect(span.setTag).to.not.have.been.called
+    })
+  })
+})

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -2,8 +2,11 @@
 
 const Int64BE = require('int64-buffer').Int64BE
 const constants = require('../src/constants')
+const tags = require('../ext/tags')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
+const EVENT_SAMPLE_RATE_KEY = constants.EVENT_SAMPLE_RATE_KEY
+const EVENT_SAMPLE_RATE = tags.EVENT_SAMPLE_RATE
 
 const id = new Int64BE(0x02345678, 0x12345678)
 
@@ -158,6 +161,12 @@ describe('format', () => {
       spanContext._sampling.priority = 0
       trace = format(span)
       expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
+    })
+
+    it('should include the event sample rate', () => {
+      spanContext._tags[EVENT_SAMPLE_RATE] = '0.5'
+      trace = format(span)
+      expect(trace.metrics[EVENT_SAMPLE_RATE_KEY]).to.equal(0.5)
     })
   })
 })


### PR DESCRIPTION
This PR adds trace search sampling configuration on web frameworks, and also as a tag that can be set on any span.