### PR TITLE
add automatic log correlation of tracer identifiers for winston

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -79,17 +79,28 @@ class Instrumenter {
         if (typeof nodule[name] !== 'function') {
           throw new Error(`Expected object ${nodule} to contain method ${name}.`)
         }
+
+        Object.defineProperty(nodule[name], '_datadog_patched', {
+          value: true,
+          configurable: true
+        })
       })
     })
 
-    return shimmer.massWrap.call(this, nodules, names, wrapper)
+    shimmer.massWrap.call(this, nodules, names, wrapper)
   }
 
   unwrap (nodules, names, wrapper) {
     nodules = [].concat(nodules)
     names = [].concat(names)
 
-    return shimmer.massUnwrap.call(this, nodules, names, wrapper)
+    shimmer.massUnwrap.call(this, nodules, names, wrapper)
+
+    nodules.forEach(nodule => {
+      names.forEach(name => {
+        nodule[name] && delete nodule[name]._datadog_patched
+      })
+    })
   }
 
   hookModule (moduleExports, moduleName, moduleBaseDir) {

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -19,5 +19,6 @@ module.exports = {
   'q': require('./q'),
   'redis': require('./redis'),
   'restify': require('./restify'),
-  'when': require('./when')
+  'when': require('./when'),
+  'winston': require('./winston')
 }

--- a/src/plugins/util/log.js
+++ b/src/plugins/util/log.js
@@ -9,7 +9,7 @@ const log = {
 
     record = record || {}
 
-    if (scope && record) {
+    if (scope) {
       const span = scope.span()
 
       record['dd.trace_id'] = span.context().toTraceId()

--- a/src/plugins/util/log.js
+++ b/src/plugins/util/log.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tx = require('./tx')
+
+const log = {
+  // Add trace identifiers from the current scope to a log record.
+  correlate (tracer, record) {
+    const scope = tracer.scopeManager().active()
+
+    record = record || {}
+
+    if (scope && record) {
+      const span = scope.span()
+
+      record['dd.trace_id'] = span.context().toTraceId()
+      record['dd.span_id'] = span.context().toSpanId()
+    }
+
+    return record
+  }
+}
+
+module.exports = Object.assign({}, tx, log)

--- a/src/plugins/winston.js
+++ b/src/plugins/winston.js
@@ -1,0 +1,80 @@
+'use strict'
+
+function createWrapWrite (tracer, config) {
+  return function wrapWrite (write) {
+    return function writeWithTrace (chunk, encoding, callback) {
+      correlate(tracer.scopeManager().active(), chunk)
+
+      return write.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapLog (tracer, config) {
+  return function wrapLog (log) {
+    return function logWithTrace (level, msg, meta, callback) {
+      const scope = tracer.scopeManager().active()
+
+      if (!scope || arguments.length < 1) return log.apply(this, arguments)
+
+      for (let i = 0, l = arguments.length; i < l; i++) {
+        if (typeof arguments[i] !== 'object') continue
+
+        correlate(scope, arguments[i])
+
+        return log.apply(this, arguments)
+      }
+
+      meta = correlate(scope)
+      callback = arguments[arguments.length - 1]
+
+      const index = typeof callback === 'function'
+        ? arguments.length - 1
+        : arguments.length
+
+      Array.prototype.splice.call(arguments, index, 0, meta)
+
+      return log.apply(this, arguments)
+    }
+  }
+}
+
+function correlate (scope, record) {
+  record = record || {}
+
+  if (scope && record) {
+    const span = scope.span()
+
+    record['dd.trace_id'] = span.context().toTraceId()
+    record['dd.span_id'] = span.context().toSpanId()
+  }
+
+  return record
+}
+
+module.exports = [
+  {
+    name: 'winston',
+    file: 'lib/winston/logger.js',
+    versions: ['3'],
+    patch (Logger, tracer, config) {
+      if (!config.correlate) return
+      this.wrap(Logger.prototype, 'write', createWrapWrite(tracer, config))
+    },
+    unpatch (Logger) {
+      this.unwrap(Logger.prototype, 'write')
+    }
+  },
+  {
+    name: 'winston',
+    file: 'lib/winston/logger.js',
+    versions: ['1 - 2'],
+    patch (logger, tracer, config) {
+      if (!config.correlate) return
+      this.wrap(logger.Logger.prototype, 'log', createWrapLog(tracer, config))
+    },
+    unpatch (logger) {
+      this.unwrap(logger.Logger.prototype, 'log')
+    }
+  }
+]

--- a/test/plugins/util/log.spec.js
+++ b/test/plugins/util/log.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+
+describe('plugins/util/log', () => {
+  let log
+  let tracer
+
+  beforeEach(() => {
+    tracer = require('../../..').init({ service: 'test', plugins: false })
+    log = require('../../../src/plugins/util/log')
+  })
+
+  describe('correlate', () => {
+    it('should attach the current scope trace identifiers to the log record', () => {
+      const record = {}
+      const span = tracer.startSpan('test')
+
+      tracer.scopeManager().activate(span)
+
+      log.correlate(tracer, record)
+
+      expect(record).to.include({
+        'dd.trace_id': span.context().toTraceId(),
+        'dd.span_id': span.context().toSpanId()
+      })
+    })
+
+    it('should return a new correlated log record if one was not provided', () => {
+      const span = tracer.startSpan('test')
+
+      tracer.scopeManager().activate(span)
+
+      const record = log.correlate(tracer)
+
+      expect(record).to.include({
+        'dd.trace_id': span.context().toTraceId(),
+        'dd.span_id': span.context().toSpanId()
+      })
+    })
+
+    it('should do nothing if there is no active scope', () => {
+      const span = tracer.startSpan('test')
+      const record = log.correlate(tracer)
+
+      expect(record).to.not.include({
+        'dd.trace_id': span.context().toTraceId(),
+        'dd.span_id': span.context().toSpanId()
+      })
+    })
+  })
+})

--- a/test/plugins/winston.spec.js
+++ b/test/plugins/winston.spec.js
@@ -1,0 +1,144 @@
+'use strict'
+
+const semver = require('semver')
+const agent = require('./agent')
+const plugin = require('../../src/plugins/winston')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let winston
+  let tracer
+  let transport
+  let span
+
+  function setup (version) {
+    span = tracer.startSpan('test')
+
+    winston = require(`../../versions/winston@${version}`).get()
+
+    class Transport extends winston.Transport {}
+
+    Transport.prototype.log = sinon.spy()
+
+    transport = new Transport()
+
+    if (winston.configure) {
+      winston.configure({
+        transports: [transport]
+      })
+    } else {
+      winston.add(Transport)
+      winston.remove(winston.transports.Console)
+    }
+  }
+
+  describe('winston', () => {
+    withVersions(plugin, 'winston', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'winston')
+            .then(() => {
+              setup(version)
+            })
+        })
+
+        it('should not alter the default behavior', () => {
+          const meta = {
+            'dd.trace_id': span.context().toTraceId(),
+            'dd.span_id': span.context().toSpanId()
+          }
+
+          tracer.scopeManager().activate(span)
+
+          winston.info('message')
+
+          if (semver.intersects(version, '>=3')) {
+            expect(transport.log).to.not.have.been.calledWithMatch(meta)
+          } else {
+            expect(transport.log).to.not.have.been.calledWithMatch('info', 'message', meta)
+          }
+        })
+      })
+
+      describe('with configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'winston', { correlate: true })
+            .then(() => {
+              setup(version)
+            })
+        })
+
+        it('should add the trace identifiers to the default logger', () => {
+          const meta = {
+            'dd.trace_id': span.context().toTraceId(),
+            'dd.span_id': span.context().toSpanId()
+          }
+
+          tracer.scopeManager().activate(span)
+
+          winston.info('message')
+
+          if (semver.intersects(version, '>=3')) {
+            expect(transport.log).to.have.been.calledWithMatch(meta)
+          } else {
+            expect(transport.log).to.have.been.calledWithMatch('info', 'message', meta)
+          }
+        })
+
+        it('should add the trace identifiers to logger instances', () => {
+          const options = {
+            transports: [transport]
+          }
+
+          const meta = {
+            'dd.trace_id': span.context().toTraceId(),
+            'dd.span_id': span.context().toSpanId()
+          }
+
+          const logger = winston.createLogger
+            ? winston.createLogger(options)
+            : new winston.Logger(options)
+
+          tracer.scopeManager().activate(span)
+
+          logger.info('message')
+
+          if (semver.intersects(version, '>=3')) {
+            expect(transport.log).to.have.been.calledWithMatch(meta)
+          } else {
+            expect(transport.log).to.have.been.calledWithMatch('info', 'message', meta)
+          }
+        })
+
+        if (semver.intersects(version, '>=3')) {
+          it('should add the trace identifiers when streaming', () => {
+            const logger = winston.createLogger({
+              transports: [transport]
+            })
+
+            tracer.scopeManager().activate(span)
+
+            logger.write({
+              level: 'info',
+              message: 'message'
+            })
+
+            expect(transport.log).to.have.been.calledWithMatch({
+              'dd.trace_id': span.context().toTraceId(),
+              'dd.span_id': span.context().toSpanId()
+            })
+          })
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for automatic log correlation of trace identifiers to [winston](https://github.com/winstonjs/winston).