### PR TITLE
fix calling public methods on the no-op span context

### DIFF
--- a/src/noop/span.js
+++ b/src/noop/span.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const Span = require('opentracing').Span
+const SpanContext = require('./span_context')
+
+const context = new SpanContext()
+
+class NoopSpan extends Span {
+  _context () {
+    return context
+  }
+}
+
+module.exports = NoopSpan

--- a/src/noop/span_context.js
+++ b/src/noop/span_context.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const SpanContext = require('opentracing').SpanContext
+
+class NoopSpanContext extends SpanContext {
+  toTraceId () {
+    return ''
+  }
+
+  toSpanId () {
+    return ''
+  }
+}
+
+module.exports = NoopSpanContext

--- a/src/noop/tracer.js
+++ b/src/noop/tracer.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const Tracer = require('opentracing').Tracer
+const Span = require('./span')
+
+const span = new Span()
 
 class NoopTracer extends Tracer {
   constructor (config) {
@@ -9,9 +12,9 @@ class NoopTracer extends Tracer {
     let ScopeManager
 
     if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
-      ScopeManager = require('./scope/noop/scope_manager')
+      ScopeManager = require('../scope/noop/scope_manager')
     } else {
-      ScopeManager = require('./scope/scope_manager')
+      ScopeManager = require('../scope/scope_manager')
     }
 
     this._scopeManager = new ScopeManager()
@@ -27,6 +30,10 @@ class NoopTracer extends Tracer {
 
   currentSpan () {
     return null
+  }
+
+  _startSpan (name, options) {
+    return span
   }
 }
 

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -2,7 +2,7 @@
 
 const BaseTracer = require('opentracing').Tracer
 const memoize = require('lodash.memoize')
-const NoopTracer = require('./noop')
+const NoopTracer = require('./noop/tracer')
 const DatadogTracer = require('./tracer')
 const Config = require('./config')
 const Instrumenter = require('./instrumenter')

--- a/test/noop.spec.js
+++ b/test/noop.spec.js
@@ -7,7 +7,7 @@ describe('NoopTracer', () => {
   let tracer
 
   beforeEach(() => {
-    NoopTracer = require('../src/noop')
+    NoopTracer = require('../src/noop/tracer')
     tracer = new NoopTracer()
   })
 
@@ -23,6 +23,17 @@ describe('NoopTracer', () => {
   describe('currentSpan', () => {
     it('should return null', () => {
       expect(tracer.currentSpan()).to.be.null
+    })
+  })
+
+  describe('startSpan', () => {
+    it('should return a span with a valid context', () => {
+      const span = tracer.startSpan()
+
+      expect(span.context().toTraceId).to.be.a('function')
+      expect(span.context().toTraceId()).to.equal('')
+      expect(span.context().toSpanId).to.be.a('function')
+      expect(span.context().toSpanId()).to.equal('')
     })
   })
 })

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -53,7 +53,7 @@ describe('TracerProxy', () => {
 
     Proxy = proxyquire('../src/proxy', {
       './tracer': DatadogTracer,
-      './noop': NoopTracer,
+      './noop/tracer': NoopTracer,
       './instrumenter': Instrumenter,
       './config': Config,
       './platform': platform


### PR DESCRIPTION
This PR adds a no-op span context with the correct API. Now that we are adding public methods to the span context, we need the equivalent no-op to ensure calling these methods won't result in an exception.