### PR TITLE
add automatic log correlation of tracer identifiers for pino

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,14 @@ jobs:
           - SERVICES=
           - PLUGINS=bluebird
 
+  node-bunyan:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - SERVICES=
+          - PLUGINS=bunyan
+
   node-elasticsearch:
     <<: *node-plugin-base
     docker:
@@ -243,6 +251,14 @@ jobs:
           - MONGODB_REPLICA_SET_MODE=primary
           - MONGODB_ADVERTISED_HOSTNAME=localhost
 
+  node-pino:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - SERVICES=
+          - PLUGINS=pino
+
   node-postgres:
     <<: *node-plugin-base
     docker:
@@ -293,6 +309,14 @@ jobs:
           - SERVICES=
           - PLUGINS=when
 
+  node-winston:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - SERVICES=
+          - PLUGINS=winston
+
 workflows:
   version: 2
   build:
@@ -307,6 +331,7 @@ workflows:
       - node-amqplib
       - node-amqp10
       - node-bluebird
+      - node-bunyan
       - node-elasticsearch
       - node-express
       - node-graphql
@@ -316,11 +341,13 @@ workflows:
       - node-memcached
       - node-mongodb-core
       - node-mysql
+      - node-pino
       - node-postgres
       - node-q
       - node-redis
       - node-restify
       - node-when
+      - node-winston
   nightly:
     triggers:
       - schedule:
@@ -338,6 +365,7 @@ workflows:
       - node-amqplib
       - node-amqp10
       - node-bluebird
+      - node-bunyan
       - node-elasticsearch
       - node-express
       - node-graphql
@@ -347,8 +375,10 @@ workflows:
       - node-memcached
       - node-mongodb-core
       - node-mysql
+      - node-pino
       - node-postgres
       - node-q
       - node-redis
       - node-restify
       - node-when
+      - node-winston

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -120,7 +120,7 @@ class Instrumenter {
       .filter(plugin => [].concat(plugin).some(instrumentation =>
         filename(instrumentation) === moduleName && matchVersion(moduleVersion, instrumentation.versions)
       ))
-      .forEach(plugin => this._validate(plugin, moduleBaseDir))
+      .forEach(plugin => this._validate(plugin, moduleBaseDir, moduleVersion))
 
     this._plugins
       .forEach((meta, plugin) => {
@@ -150,11 +150,12 @@ class Instrumenter {
     this._plugins.set(plugin, Object.assign({ config: {} }, meta))
   }
 
-  _validate (plugin, moduleBaseDir) {
+  _validate (plugin, moduleBaseDir, moduleVersion) {
     const meta = this._plugins.get(plugin)
     const instrumentations = [].concat(plugin)
 
     for (let i = 0; i < instrumentations.length; i++) {
+      if (instrumentations[i].versions && !matchVersion(moduleVersion, instrumentations[i].versions)) continue
       if (instrumentations[i].file && !exists(moduleBaseDir, instrumentations[i].file)) {
         this._fail(plugin)
         log.debug([

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -19,6 +19,7 @@ module.exports = {
   'mysql2': require('./mysql2'),
   'net': require('./net'),
   'pg': require('./pg'),
+  'pino': require('./pino'),
   'q': require('./q'),
   'redis': require('./redis'),
   'restify': require('./restify'),

--- a/src/plugins/pino.js
+++ b/src/plugins/pino.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const tx = require('./util/log')
+
+function createWrapWrite (tracer, config) {
+  return function wrapWrite (write) {
+    return function writeWithTrace (obj, msg, num) {
+      arguments[0] = obj = obj || {}
+
+      tx.correlate(tracer, obj)
+
+      return write.apply(this, arguments)
+    }
+  }
+}
+
+module.exports = [
+  {
+    name: 'pino',
+    versions: ['5'],
+    patch (pino, tracer, config) {
+      if (!config.correlate) return
+
+      const logger = pino()
+
+      this.wrap(Object.getPrototypeOf(logger), pino.symbols.writeSym, createWrapWrite(tracer, config))
+    },
+    unpatch (pino) {
+      const logger = pino()
+
+      this.unwrap(Object.getPrototypeOf(logger), pino.symbols.writeSym)
+    }
+  }
+]

--- a/test/plugins/pino.spec.js
+++ b/test/plugins/pino.spec.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const Writable = require('stream').Writable
+const agent = require('./agent')
+const plugin = require('../../src/plugins/pino')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let logger
+  let tracer
+  let stream
+  let span
+
+  function setup (version) {
+    const pino = require(`../../versions/pino@${version}`).get()
+
+    span = tracer.startSpan('test')
+
+    stream = new Writable()
+    stream._write = () => {}
+
+    sinon.spy(stream, 'write')
+
+    logger = pino(stream)
+  }
+
+  describe('pino', () => {
+    withVersions(plugin, 'pino', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'pino')
+            .then(() => {
+              setup(version)
+            })
+        })
+
+        it('should not alter the default behavior', () => {
+          tracer.scopeManager().activate(span)
+
+          logger.info('message')
+
+          expect(stream.write).to.have.been.called
+
+          const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+          expect(record).to.not.include({
+            'dd.trace_id': span.context().toTraceId(),
+            'dd.span_id': span.context().toSpanId()
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'pino', { correlate: true })
+            .then(() => {
+              setup(version)
+            })
+        })
+
+        it('should add the trace identifiers to logger instances', () => {
+          tracer.scopeManager().activate(span)
+
+          logger.info('message')
+
+          expect(stream.write).to.have.been.called
+
+          const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+          expect(record).to.include({
+            'dd.trace_id': span.context().toTraceId(),
+            'dd.span_id': span.context().toSpanId()
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for automatic log correlation of trace identifiers to [pino](https://github.com/pinojs/pino). It also adds `bunyan` and `winston` to the CI.