### PR TITLE
Add protocol as a configuration option for the dd-trace-agent URL

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -387,7 +387,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | enabled       | DD_TRACE_ENABLED             | true      | Whether to enable the tracer. |
 | debug         | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
 | service       | DD_SERVICE_NAME              |           | The service name to be used for this program. |
-| overrideUrl   | DD_TRACE_AGENT_URL           |           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
+| url           | DD_TRACE_AGENT_URL           |           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
 | hostname      | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the trace agent that the tracer will submit to. |
 | port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
 | env           | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -387,6 +387,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | enabled       | DD_TRACE_ENABLED             | true      | Whether to enable the tracer. |
 | debug         | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
 | service       | DD_SERVICE_NAME              |           | The service name to be used for this program. |
+| protocol      | DD_TRACE_AGENT_PROTOCOL      | http      | The protocol of the trace agent that the tracer will submit to. |
 | hostname      | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the trace agent that the tracer will submit to. |
 | port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
 | env           | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -387,7 +387,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | enabled       | DD_TRACE_ENABLED             | true      | Whether to enable the tracer. |
 | debug         | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
 | service       | DD_SERVICE_NAME              |           | The service name to be used for this program. |
-| protocol      | DD_TRACE_AGENT_PROTOCOL      | http      | The protocol of the trace agent that the tracer will submit to. |
+| overrideUrl   | DD_TRACE_AGENT_URL           |           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
 | hostname      | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the trace agent that the tracer will submit to. |
 | port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
 | env           | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,7 @@ class Config {
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
     const env = coalesce(options.env, platform.env('DD_ENV'))
-    const overrideUrl = coalesce(options.overrideUrl, platform.env('DD_TRACE_AGENT_URL'), null)
+    const url = coalesce(options.url, platform.env('DD_TRACE_AGENT_URL'), null)
     const protocol = 'http'
     const hostname = coalesce(
       options.hostname,
@@ -27,7 +27,7 @@ class Config {
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.env = env
-    this.url = overrideUrl ? new URL(overrideUrl) : new URL(`${protocol}://${hostname}:${port}`)
+    this.url = url ? new URL(url) : new URL(`${protocol}://${hostname}:${port}`)
     this.tags = Object.assign({}, options.tags)
     this.flushInterval = flushInterval
     this.bufferSize = 100000

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,8 @@ class Config {
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
     const env = coalesce(options.env, platform.env('DD_ENV'))
-    const protocol = coalesce(options.protocol, platform.env('DD_TRACE_AGENT_PROTOCOL'), 'http')
+    const overrideUrl = coalesce(options.overrideUrl, platform.env('DD_TRACE_AGENT_URL'), null)
+    const protocol = 'http'
     const hostname = coalesce(
       options.hostname,
       platform.env('DD_AGENT_HOST'),
@@ -26,7 +27,7 @@ class Config {
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.env = env
-    this.url = new URL(`${protocol}://${hostname}:${port}`)
+    this.url = overrideUrl ? new URL(overrideUrl) : new URL(`${protocol}://${hostname}:${port}`)
     this.tags = Object.assign({}, options.tags)
     this.flushInterval = flushInterval
     this.bufferSize = 100000

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,7 @@ class Config {
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
     const env = coalesce(options.env, platform.env('DD_ENV'))
-    const protocol = 'http'
+    const protocol = coalesce(options.protocol, platform.env('DD_TRACE_AGENT_PROTOCOL'), 'http')
     const hostname = coalesce(
       options.hostname,
       platform.env('DD_AGENT_HOST'),

--- a/src/platform/node/request.js
+++ b/src/platform/node/request.js
@@ -15,7 +15,7 @@ function request (options, callback) {
   options.headers['Content-Length'] = byteLength(data)
 
   return new Promise((resolve, reject) => {
-    let client = options.protocol === 'https:' ? https : http;
+    const client = options.protocol === 'https:' ? https : http
     const req = client.request(options, res => {
       let data = ''
 

--- a/src/platform/node/request.js
+++ b/src/platform/node/request.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const http = require('http')
+const https = require('https')
 
 function request (options, callback) {
   options = Object.assign({
@@ -14,7 +15,8 @@ function request (options, callback) {
   options.headers['Content-Length'] = byteLength(data)
 
   return new Promise((resolve, reject) => {
-    const req = http.request(options, res => {
+    let client = options.protocol === 'https:' ? https : http;
+    const req = client.request(options, res => {
       let data = ''
 
       res.on('data', chunk => { data += chunk })

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -36,7 +36,8 @@ class Tracer extends BaseTracer {
    * @param {boolean} [options.enabled=true] Whether to enable the tracer.
    * @param {boolean} [options.debug=false] Enable debug logging in the tracer.
    * @param {string} [options.service] The service name to be used for this program.
-   * @param {string} [options.protocol=http] The protocol of the trace agent that the tracer will submit to.
+   * @param {string} [options.overrideUrl=null] The url to the trace agent that the tracer will submit to. Takes
+   * precedence over hostname and port, if set.
    * @param {string} [options.hostname=localhost] The address of the trace agent that the tracer will submit to.
    * @param {number|string} [options.port=8126] The port of the trace agent that the tracer will submit to.
    * @param {number} [options.sampleRate=1] Percentage of spans to sample as a float between 0 and 1.

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -36,7 +36,7 @@ class Tracer extends BaseTracer {
    * @param {boolean} [options.enabled=true] Whether to enable the tracer.
    * @param {boolean} [options.debug=false] Enable debug logging in the tracer.
    * @param {string} [options.service] The service name to be used for this program.
-   * @param {string} [options.overrideUrl=null] The url to the trace agent that the tracer will submit to. Takes
+   * @param {string} [options.url=null] The url to the trace agent that the tracer will submit to. Takes
    * precedence over hostname and port, if set.
    * @param {string} [options.hostname=localhost] The address of the trace agent that the tracer will submit to.
    * @param {number|string} [options.port=8126] The port of the trace agent that the tracer will submit to.

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -36,6 +36,7 @@ class Tracer extends BaseTracer {
    * @param {boolean} [options.enabled=true] Whether to enable the tracer.
    * @param {boolean} [options.debug=false] Enable debug logging in the tracer.
    * @param {string} [options.service] The service name to be used for this program.
+   * @param {string} [options.protocol=http] The protocol of the trace agent that the tracer will submit to.
    * @param {string} [options.hostname=localhost] The address of the trace agent that the tracer will submit to.
    * @param {number|string} [options.port=8126] The port of the trace agent that the tracer will submit to.
    * @param {number} [options.sampleRate=1] Percentage of spans to sample as a float between 0 and 1.

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -107,14 +107,14 @@ describe('Config', () => {
     expect(config).to.have.property('plugins', false)
   })
 
-  it('should initialize from the options with overrideUrl taking precedence', () => {
+  it('should initialize from the options with url taking precedence', () => {
     const logger = {}
     const tags = { foo: 'bar' }
     const config = new Config({
       enabled: false,
       debug: true,
       hostname: 'agent',
-      overrideUrl: 'https://agent2:7777',
+      url: 'https://agent2:7777',
       port: 6218,
       service: 'service',
       env: 'test',
@@ -176,7 +176,7 @@ describe('Config', () => {
     expect(config).to.have.property('env', 'development')
   })
 
-  it('should give priority to the options especially overrideUrl', () => {
+  it('should give priority to the options especially url', () => {
     platform.env.withArgs('DD_TRACE_AGENT_URL').returns('http://agent2:6218')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
@@ -188,7 +188,7 @@ describe('Config', () => {
     const config = new Config({
       enabled: true,
       debug: false,
-      overrideUrl: 'https://agent3:7778',
+      url: 'https://agent3:7778',
       protocol: 'http',
       hostname: 'server',
       port: 7777,

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -49,7 +49,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
-    expect(config).to.have.nested.property('url.protocol', 'https:')
+    expect(config).to.have.nested.property('url.protocol', 'http:')
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.property('service', 'service')
@@ -57,7 +57,7 @@ describe('Config', () => {
   })
 
   it('should initialize from environment variables with url taking precedence', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:443')
+    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:7777')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
@@ -71,7 +71,7 @@ describe('Config', () => {
     expect(config).to.have.property('debug', true)
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent2')
-    expect(config).to.have.nested.property('url.port', '443')
+    expect(config).to.have.nested.property('url.port', '7777')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
   })
@@ -114,7 +114,7 @@ describe('Config', () => {
       enabled: false,
       debug: true,
       hostname: 'agent',
-      overrideUrl: 'https://agent2:443',
+      overrideUrl: 'https://agent2:7777',
       port: 6218,
       service: 'service',
       env: 'test',
@@ -129,7 +129,7 @@ describe('Config', () => {
     expect(config).to.have.property('debug', true)
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent2')
-    expect(config).to.have.nested.property('url.port', '443')
+    expect(config).to.have.nested.property('url.port', '7777')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
     expect(config).to.have.property('sampleRate', 0.5)
@@ -149,7 +149,7 @@ describe('Config', () => {
   })
 
   it('should give priority to the options', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:443')
+    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:6218')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
@@ -170,8 +170,8 @@ describe('Config', () => {
     expect(config).to.have.property('enabled', true)
     expect(config).to.have.property('debug', false)
     expect(config).to.have.nested.property('url.protocol', 'https:')
-    expect(config).to.have.nested.property('url.hostname', 'server')
-    expect(config).to.have.nested.property('url.port', '7777')
+    expect(config).to.have.nested.property('url.hostname', 'agent2')
+    expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
   })
@@ -188,7 +188,7 @@ describe('Config', () => {
     const config = new Config({
       enabled: true,
       debug: false,
-      overrideUrl: 'https://agent3:443',
+      overrideUrl: 'https://agent3:7778',
       protocol: 'http',
       hostname: 'server',
       port: 7777,
@@ -200,7 +200,7 @@ describe('Config', () => {
     expect(config).to.have.property('debug', false)
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent3')
-    expect(config).to.have.nested.property('url.port', '443')
+    expect(config).to.have.nested.property('url.port', '7778')
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
   })

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -38,6 +38,7 @@ describe('Config', () => {
   })
 
   it('should initialize from environment variables', () => {
+    platform.env.withArgs('DD_TRACE_AGENT_PROTOCOL').returns('https')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
@@ -49,6 +50,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
+    expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.property('service', 'service')
@@ -61,6 +63,7 @@ describe('Config', () => {
     const config = new Config({
       enabled: false,
       debug: true,
+      protocol: 'https',
       hostname: 'agent',
       port: 6218,
       service: 'service',
@@ -74,6 +77,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
+    expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.property('service', 'service')
@@ -95,6 +99,7 @@ describe('Config', () => {
   })
 
   it('should give priority to the options', () => {
+    platform.env.withArgs('DD_TRACE_AGENT_PROTOCOL').returns('fakeprotocol')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
@@ -105,6 +110,7 @@ describe('Config', () => {
     const config = new Config({
       enabled: true,
       debug: false,
+      protocol: 'https',
       hostname: 'server',
       port: 7777,
       service: 'test',
@@ -113,6 +119,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', true)
     expect(config).to.have.property('debug', false)
+    expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'server')
     expect(config).to.have.nested.property('url.port', '7777')
     expect(config).to.have.property('service', 'test')

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -188,7 +188,7 @@ describe('Config', () => {
     const config = new Config({
       enabled: true,
       debug: false,
-      overrideUrl: 'https://agent3:443'
+      overrideUrl: 'https://agent3:443',
       protocol: 'http',
       hostname: 'server',
       port: 7777,

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -38,7 +38,6 @@ describe('Config', () => {
   })
 
   it('should initialize from environment variables', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_PROTOCOL').returns('https')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
@@ -57,13 +56,32 @@ describe('Config', () => {
     expect(config).to.have.property('env', 'test')
   })
 
+  it('should initialize from environment variables with url taking precedence', () => {
+    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:443')
+    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
+    platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
+    platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('DD_SERVICE_NAME').returns('service')
+    platform.env.withArgs('DD_ENV').returns('test')
+
+    const config = new Config()
+
+    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('debug', true)
+    expect(config).to.have.nested.property('url.protocol', 'https:')
+    expect(config).to.have.nested.property('url.hostname', 'agent2')
+    expect(config).to.have.nested.property('url.port', '443')
+    expect(config).to.have.property('service', 'service')
+    expect(config).to.have.property('env', 'test')
+  })
+
   it('should initialize from the options', () => {
     const logger = {}
     const tags = { foo: 'bar' }
     const config = new Config({
       enabled: false,
       debug: true,
-      protocol: 'https',
       hostname: 'agent',
       port: 6218,
       service: 'service',
@@ -77,9 +95,41 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
-    expect(config).to.have.nested.property('url.protocol', 'https:')
+    expect(config).to.have.nested.property('url.protocol', 'http:')
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
+    expect(config).to.have.property('service', 'service')
+    expect(config).to.have.property('env', 'test')
+    expect(config).to.have.property('sampleRate', 0.5)
+    expect(config).to.have.property('logger', logger)
+    expect(config).to.have.deep.property('tags', tags)
+    expect(config).to.have.property('flushInterval', 5000)
+    expect(config).to.have.property('plugins', false)
+  })
+
+  it('should initialize from the options with overrideUrl taking precedence', () => {
+    const logger = {}
+    const tags = { foo: 'bar' }
+    const config = new Config({
+      enabled: false,
+      debug: true,
+      hostname: 'agent',
+      overrideUrl: 'https://agent2:443',
+      port: 6218,
+      service: 'service',
+      env: 'test',
+      sampleRate: 0.5,
+      logger,
+      tags,
+      flushInterval: 5000,
+      plugins: false
+    })
+
+    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('debug', true)
+    expect(config).to.have.nested.property('url.protocol', 'https:')
+    expect(config).to.have.nested.property('url.hostname', 'agent2')
+    expect(config).to.have.nested.property('url.port', '443')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
     expect(config).to.have.property('sampleRate', 0.5)
@@ -99,7 +149,7 @@ describe('Config', () => {
   })
 
   it('should give priority to the options', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_PROTOCOL').returns('fakeprotocol')
+    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:443')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
@@ -122,6 +172,35 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'server')
     expect(config).to.have.nested.property('url.port', '7777')
+    expect(config).to.have.property('service', 'test')
+    expect(config).to.have.property('env', 'development')
+  })
+
+  it('should give priority to the options especially overrideUrl', () => {
+    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('http://agent2:6218')
+    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
+    platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
+    platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('DD_SERVICE_NAME').returns('service')
+    platform.env.withArgs('DD_ENV').returns('test')
+
+    const config = new Config({
+      enabled: true,
+      debug: false,
+      overrideUrl: 'https://agent3:443'
+      protocol: 'http',
+      hostname: 'server',
+      port: 7777,
+      service: 'test',
+      env: 'development'
+    })
+
+    expect(config).to.have.property('enabled', true)
+    expect(config).to.have.property('debug', false)
+    expect(config).to.have.nested.property('url.protocol', 'https:')
+    expect(config).to.have.nested.property('url.hostname', 'agent3')
+    expect(config).to.have.nested.property('url.port', '443')
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
   })


### PR DESCRIPTION
This is useful for scenarios where a SSL-terminating load balancer sits in front of the datadog-agent's trace endpoint

This resolves issue #415