### PR TITLE
add support for latest module versions in all plugins

### DIFF
--- a/src/plugins/amqp10.js
+++ b/src/plugins/amqp10.js
@@ -127,7 +127,7 @@ module.exports = [
   {
     name: 'amqp10',
     file: 'lib/sender_link.js',
-    versions: ['3.x'],
+    versions: ['>=3'],
     patch (SenderLink, tracer, config) {
       this.wrap(SenderLink.prototype, 'send', createWrapSend(tracer, config))
     },
@@ -138,7 +138,7 @@ module.exports = [
   {
     name: 'amqp10',
     file: 'lib/receiver_link.js',
-    versions: ['3.x'],
+    versions: ['>=3'],
     patch (ReceiverLink, tracer, config) {
       this.wrap(ReceiverLink.prototype, '_messageReceived', createWrapMessageReceived(tracer, config))
     },

--- a/src/plugins/amqplib.js
+++ b/src/plugins/amqplib.js
@@ -129,7 +129,7 @@ module.exports = [
   {
     name: 'amqplib',
     file: 'lib/defs.js',
-    versions: ['0.5.x'],
+    versions: ['>=0.5'],
     patch (defs, tracer, config) {
       methods = Object.keys(defs)
         .filter(key => Number.isInteger(defs[key]))
@@ -143,7 +143,7 @@ module.exports = [
   {
     name: 'amqplib',
     file: 'lib/channel.js',
-    versions: ['0.5.x'],
+    versions: ['>=0.5'],
     patch (channel, tracer, config) {
       this.wrap(channel.Channel.prototype, 'sendImmediately', createWrapSendImmediately(tracer, config))
       this.wrap(channel.Channel.prototype, 'sendMessage', createWrapSendMessage(tracer, config))

--- a/src/plugins/bluebird.js
+++ b/src/plugins/bluebird.js
@@ -5,7 +5,7 @@ const tx = require('./util/promise')
 module.exports = [
   {
     name: 'bluebird',
-    versions: ['2.0.2 - 3'], // 2.0.0 and 2.0.1 were removed from npm
+    versions: ['>=2.0.2'], // 2.0.0 and 2.0.1 were removed from npm
     patch (Promise, tracer, config) {
       this.wrap(Promise.prototype, '_then', tx.createWrapThen(tracer, config))
     },

--- a/src/plugins/bunyan.js
+++ b/src/plugins/bunyan.js
@@ -14,7 +14,7 @@ function createWrapEmit (tracer, config) {
 
 module.exports = {
   name: 'bunyan',
-  versions: ['1 - 2'],
+  versions: ['>=1'],
   patch (Logger, tracer, config) {
     if (!config.correlate) return
     this.wrap(Logger.prototype, '_emit', createWrapEmit(tracer, config))

--- a/src/plugins/elasticsearch.js
+++ b/src/plugins/elasticsearch.js
@@ -64,7 +64,7 @@ module.exports = [
   {
     name: 'elasticsearch',
     file: 'src/lib/transport.js',
-    versions: ['>=10 <=15'],
+    versions: ['>=10'],
     patch (Transport, tracer, config) {
       this.wrap(Transport.prototype, 'request', createWrapRequest(tracer, config))
     },

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -36,7 +36,7 @@ function unpatch (express) {
 
 module.exports = {
   name: 'express',
-  versions: ['4.x'],
+  versions: ['>=4'],
   patch,
   unpatch
 }

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -441,7 +441,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'execution/execute.js',
-    versions: ['>=0.10 <=14'],
+    versions: ['>=0.10'],
     patch (execute, tracer, config) {
       this.wrap(execute, 'execute', createWrapExecute(
         tracer,
@@ -457,7 +457,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'language/parser.js',
-    versions: ['>=0.10 <=14'],
+    versions: ['>=0.10'],
     patch (parser, tracer, config) {
       this.wrap(parser, 'parse', createWrapParse(tracer, validateConfig(config)))
     },
@@ -468,7 +468,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'validation/validate.js',
-    versions: ['>=0.10 <=14'],
+    versions: ['>=0.10'],
     patch (validate, tracer, config) {
       this.wrap(validate, 'validate', createWrapValidate(tracer, validateConfig(config)))
     },

--- a/src/plugins/hapi.js
+++ b/src/plugins/hapi.js
@@ -48,7 +48,7 @@ function createWrapExecute (tracer, config) {
 module.exports = [
   {
     name: 'hapi',
-    versions: ['^17.1'],
+    versions: ['>=17.1'],
     file: 'lib/request.js',
     patch (Request, tracer, config) {
       this.wrap(Request, 'generate', createWrapGenerate(tracer, config))

--- a/src/plugins/ioredis.js
+++ b/src/plugins/ioredis.js
@@ -18,7 +18,7 @@ function createWrapSendCommand (tracer, config) {
 
 module.exports = {
   name: 'ioredis',
-  versions: ['>=2 <=4'],
+  versions: ['>=2'],
   patch (Redis, tracer, config) {
     this.wrap(Redis.prototype, 'sendCommand', createWrapSendCommand(tracer, config))
   },

--- a/src/plugins/koa.js
+++ b/src/plugins/koa.js
@@ -57,7 +57,7 @@ function createWrapRegister (tracer, config) {
 module.exports = [
   {
     name: 'koa',
-    versions: ['2.x'],
+    versions: ['>=2'],
     patch (Koa, tracer, config) {
       this.wrap(Koa.prototype, 'use', createWrapUse(tracer, config))
     },
@@ -67,7 +67,7 @@ module.exports = [
   },
   {
     name: 'koa-router',
-    versions: ['7.x'],
+    versions: ['>=7'],
     patch (Router, tracer, config) {
       this.wrap(Router.prototype, 'register', createWrapRegister(tracer, config))
     },

--- a/src/plugins/memcached.js
+++ b/src/plugins/memcached.js
@@ -89,7 +89,7 @@ function getAddress (client, server, query) {
 
 module.exports = {
   name: 'memcached',
-  versions: ['^2.2'],
+  versions: ['>=2.2'],
   patch (Memcached, tracer, config) {
     this.wrap(Memcached.prototype, 'command', createWrapCommand(tracer, config))
   },

--- a/src/plugins/mongodb-core.js
+++ b/src/plugins/mongodb-core.js
@@ -136,7 +136,7 @@ function isBSON (val) {
 module.exports = [
   {
     name: 'mongodb-core',
-    versions: ['>=2 <=3'],
+    versions: ['>=2'],
     patch (mongo, tracer, config) {
       this.wrap(mongo.Server.prototype, 'command', createWrapOperation(tracer, config))
       this.wrap(mongo.Server.prototype, 'insert', createWrapOperation(tracer, config, 'insert'))

--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -73,7 +73,7 @@ module.exports = [
   {
     name: 'mysql',
     file: 'lib/Connection.js',
-    versions: ['2.x'],
+    versions: ['>=2'],
     patch: patchConnection,
     unpatch: unpatchConnection
   }

--- a/src/plugins/mysql2.js
+++ b/src/plugins/mysql2.js
@@ -73,7 +73,7 @@ module.exports = [
   {
     name: 'mysql2',
     file: 'lib/connection.js',
-    versions: ['1.x'],
+    versions: ['>=1'],
     patch: patchConnection,
     unpatch: unpatchConnection
   }

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -73,7 +73,7 @@ function unpatch (pg) {
 
 module.exports = {
   name: 'pg',
-  versions: ['>=4 <=7'],
+  versions: ['>=4'],
   patch,
   unpatch
 }

--- a/src/plugins/pino.js
+++ b/src/plugins/pino.js
@@ -39,7 +39,7 @@ function createWrapGenLog (tracer, config) {
 module.exports = [
   {
     name: 'pino',
-    versions: ['5'],
+    versions: ['>=5'],
     patch (pino, tracer, config) {
       if (!config.correlate) return
 

--- a/src/plugins/q.js
+++ b/src/plugins/q.js
@@ -5,7 +5,7 @@ const tx = require('./util/promise')
 module.exports = [
   {
     name: 'q',
-    versions: ['1'],
+    versions: ['>=1'],
     patch (Q, tracer, config) {
       this.wrap(Q.makePromise.prototype, 'then', tx.createWrapThen(tracer, config))
     },

--- a/src/plugins/redis.js
+++ b/src/plugins/redis.js
@@ -45,7 +45,7 @@ function startSpan (tracer, config, client, command, args) {
 module.exports = [
   {
     name: 'redis',
-    versions: ['^2.6'],
+    versions: ['>=2.6'],
     patch (redis, tracer, config) {
       this.wrap(redis.RedisClient.prototype, 'internal_send_command', createWrapInternalSendCommand(tracer, config))
     },

--- a/src/plugins/restify.js
+++ b/src/plugins/restify.js
@@ -53,7 +53,7 @@ function wrapFn (fn) {
 module.exports = [
   {
     name: 'restify',
-    versions: ['>=3 <=7'],
+    versions: ['>=3'],
     file: 'lib/server.js',
     patch (Server, tracer, config) {
       this.wrap(Server.prototype, '_setupRequest', createWrapSetupRequest(tracer, config))

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -160,7 +160,7 @@ function addError (span, error) {
 
 module.exports = {
   name: 'router',
-  versions: ['1.x'],
+  versions: ['>=1'],
   patch (Router, tracer, config) {
     this.wrap(Router.prototype, 'handle', createWrapHandle(tracer, config))
     this.wrap(Router.prototype, 'process_params', createWrapProcessParams(tracer, config))

--- a/src/plugins/when.js
+++ b/src/plugins/when.js
@@ -6,7 +6,7 @@ module.exports = [
   {
     name: 'when',
     file: 'lib/Promise.js',
-    versions: ['3'],
+    versions: ['>=3'],
     patch (Promise, tracer, config) {
       this.wrap(Promise.prototype, 'then', tx.createWrapThen(tracer, config))
     },

--- a/src/plugins/winston.js
+++ b/src/plugins/winston.js
@@ -45,7 +45,7 @@ module.exports = [
   {
     name: 'winston',
     file: 'lib/winston/logger.js',
-    versions: ['3'],
+    versions: ['>=3'],
     patch (Logger, tracer, config) {
       if (!config.correlate) return
       this.wrap(Logger.prototype, 'write', createWrapWrite(tracer, config))


### PR DESCRIPTION
This PR adds the latest version of supported modules in every plugins. This will allow us to support new versions with no code change when the instrumented APIs didn't change.