### PR TITLE
fix using log correlation with a custom logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lodash.truncate": "^4.4.2",
     "lodash.uniq": "^4.5.0",
     "methods": "^1.1.2",
+    "module-details-from-path": "^1.0.3",
     "msgpack-lite": "^0.1.26",
     "opentracing": "0.14.1",
     "parent-module": "^0.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ class Config {
 
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
+    const logInjection = coalesce(options.logInjection, platform.env('DD_LOGS_INJECTION'), false)
     const env = coalesce(options.env, platform.env('DD_ENV'))
     const url = coalesce(options.url, platform.env('DD_TRACE_AGENT_URL'), null)
     const protocol = 'http'
@@ -26,6 +27,7 @@ class Config {
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
+    this.logInjection = String(logInjection) === 'true'
     this.env = env
     this.url = url ? new URL(url) : new URL(`${protocol}://${hostname}:${port}`)
     this.tags = Object.assign({}, options.tags)

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -27,6 +27,7 @@ class DatadogTracer extends Tracer {
     this._url = config.url
     this._env = config.env
     this._tags = config.tags
+    this._logInjection = config.logInjection
     this._prioritySampler = new PrioritySampler(config.env)
     this._writer = new Writer(this._prioritySampler, config.url, config.bufferSize)
     this._recorder = new Recorder(this._writer, config.flushInterval)

--- a/src/plugins/bunyan.js
+++ b/src/plugins/bunyan.js
@@ -16,7 +16,7 @@ module.exports = {
   name: 'bunyan',
   versions: ['>=1'],
   patch (Logger, tracer, config) {
-    if (!config.correlate) return
+    if (!tracer._logInjection) return
     this.wrap(Logger.prototype, '_emit', createWrapEmit(tracer, config))
   },
   unpatch (Logger) {

--- a/src/plugins/pino.js
+++ b/src/plugins/pino.js
@@ -41,8 +41,7 @@ module.exports = [
     name: 'pino',
     versions: ['>=5'],
     patch (pino, tracer, config) {
-      if (!config.correlate) return
-
+      if (!tracer._logInjection) return
       this.wrap(Object.getPrototypeOf(pino()), pino.symbols.writeSym, createWrapWrite(tracer, config))
     },
     unpatch (pino) {
@@ -54,8 +53,7 @@ module.exports = [
     versions: ['4'],
     file: 'lib/tools.js',
     patch (tools, tracer, config) {
-      if (!config.correlate) return
-
+      if (!tracer._logInjection) return
       this.wrap(tools, 'genLog', createWrapGenLog(tracer, config))
     },
     unpatch (tools) {
@@ -66,8 +64,7 @@ module.exports = [
     name: 'pino',
     versions: ['2 - 3'],
     patch (pino, tracer, config) {
-      if (!config.correlate) return
-
+      if (!tracer._logInjection) return
       this.wrap(Object.getPrototypeOf(pino()), 'asJson', createWrapWrite(tracer, config))
     },
     unpatch (pino) {

--- a/src/plugins/winston.js
+++ b/src/plugins/winston.js
@@ -47,7 +47,7 @@ module.exports = [
     file: 'lib/winston/logger.js',
     versions: ['>=3'],
     patch (Logger, tracer, config) {
-      if (!config.correlate) return
+      if (!tracer._logInjection) return
       this.wrap(Logger.prototype, 'write', createWrapWrite(tracer, config))
     },
     unpatch (Logger) {
@@ -59,7 +59,7 @@ module.exports = [
     file: 'lib/winston/logger.js',
     versions: ['1 - 2'],
     patch (logger, tracer, config) {
-      if (!config.correlate) return
+      if (!tracer._logInjection) return
       this.wrap(logger.Logger.prototype, 'log', createWrapLog(tracer, config))
     },
     unpatch (logger) {

--- a/test/instrumenter.spec.js
+++ b/test/instrumenter.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const proxyquire = require('proxyquire').noCallThru()
+const path = require('path')
 
 describe('Instrumenter', () => {
   let Instrumenter
@@ -67,7 +68,13 @@ describe('Instrumenter', () => {
   })
 
   afterEach(() => {
-    delete require.cache[require.resolve('mysql-mock')]
+    const basedir = path.resolve(path.join(__dirname, 'node_modules'))
+
+    Object.keys(require.cache)
+      .filter(name => name.indexOf(basedir) !== -1)
+      .forEach(name => {
+        delete require.cache[name]
+      })
   })
 
   describe('with integrations enabled', () => {
@@ -141,6 +148,15 @@ describe('Instrumenter', () => {
 
         expect(integrations.mysql[0].patch).to.not.have.been.called
         expect(integrations.mysql[1].patch).to.not.have.been.called
+      })
+
+      it('should attempt to patch already loaded modules', () => {
+        const express = require('express-mock')
+
+        instrumenter.use('express-mock')
+
+        expect(integrations.express.patch).to.have.been.called
+        expect(integrations.express.patch).to.have.been.calledWith(express, 'tracer', {})
       })
     })
 

--- a/test/plugins/bunyan.spec.js
+++ b/test/plugins/bunyan.spec.js
@@ -29,6 +29,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'bunyan', version => {
       beforeEach(() => {
         tracer = require('../..')
+        return agent.load(plugin, 'bunyan')
       })
 
       afterEach(() => {
@@ -37,10 +38,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'bunyan')
-            .then(() => {
-              setup(version)
-            })
+          setup(version)
         })
 
         it('should not alter the default behavior', () => {
@@ -61,10 +59,8 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'bunyan', { correlate: true })
-            .then(() => {
-              setup(version)
-            })
+          tracer._tracer._logInjection = true
+          setup(version)
         })
 
         it('should add the trace identifiers to logger instances', () => {

--- a/test/plugins/pino.spec.js
+++ b/test/plugins/pino.spec.js
@@ -29,6 +29,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'pino', version => {
       beforeEach(() => {
         tracer = require('../..')
+        return agent.load(plugin, 'pino')
       })
 
       afterEach(() => {
@@ -37,10 +38,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'pino')
-            .then(() => {
-              setup(version)
-            })
+          setup(version)
         })
 
         it('should not alter the default behavior', () => {
@@ -61,10 +59,8 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'pino', { correlate: true })
-            .then(() => {
-              setup(version)
-            })
+          tracer._tracer._logInjection = true
+          setup(version)
         })
 
         it('should add the trace identifiers to logger instances', () => {

--- a/test/plugins/winston.spec.js
+++ b/test/plugins/winston.spec.js
@@ -37,6 +37,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'winston', version => {
       beforeEach(() => {
         tracer = require('../..')
+        return agent.load(plugin, 'winston')
       })
 
       afterEach(() => {
@@ -45,10 +46,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'winston')
-            .then(() => {
-              setup(version)
-            })
+          setup(version)
         })
 
         it('should not alter the default behavior', () => {
@@ -71,10 +69,8 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'winston', { correlate: true })
-            .then(() => {
-              setup(version)
-            })
+          tracer._tracer._logInjection = true
+          setup(version)
         })
 
         it('should add the trace identifiers to the default logger', () => {


### PR DESCRIPTION
This PR fixes log correlation when used with a custom logger. The problem was with the way instrumentation works, where the tracer must be imported before the instrumented module. This works well in most cases, but since a custom logger can be registered with the tracer, it has to be imported first, meaning the tracer doesn't have time to patch it. By attempting to load the module from the require cache, we can patch it after the fact. This won't work for all cases, but it will work for this purpose specifically.