### PR TITLE
disable net and dns plugins

### DIFF
--- a/src/plugins/dns.js
+++ b/src/plugins/dns.js
@@ -161,3 +161,5 @@ module.exports = [
     }
   }
 ]
+
+module.exports = [] // disable this integration for the upcoming release

--- a/src/plugins/net.js
+++ b/src/plugins/net.js
@@ -105,3 +105,5 @@ module.exports = {
     this.unwrap(net.Socket.prototype, 'connect')
   }
 }
+
+module.exports = [] // disable this integration for the upcoming release

--- a/test/plugins/dns.spec.js
+++ b/test/plugins/dns.spec.js
@@ -6,6 +6,8 @@ const plugin = require('../../src/plugins/dns')
 
 wrapIt()
 
+const describe = () => {} // integration disabled for the upcoming release
+
 describe('Plugin', () => {
   let dns
 

--- a/test/plugins/net.spec.js
+++ b/test/plugins/net.spec.js
@@ -6,6 +6,8 @@ const plugin = require('../../src/plugins/net')
 
 wrapIt()
 
+const describe = () => {} // integration disabled for the upcoming release
+
 describe('Plugin', () => {
   let net
   let tcp


### PR DESCRIPTION
This PR disables the `net` and `dns` plugins since we want to exclude them from 0.8.0 because they depend on the new scope manager which will only land in 0.9.0.