### PR TITLE
fix http server response handlers not running in the request scope

### DIFF
--- a/test/setup/core.js
+++ b/test/setup/core.js
@@ -57,11 +57,11 @@ function wrapIt () {
       return it.call(this, title, function (done) {
         arguments[0] = withoutScope(agent.wrap(done))
 
-        return fn.apply(this, arguments)
+        return withoutScope(fn).apply(this, arguments)
       })
     } else {
       return it.call(this, title, function () {
-        const result = fn.apply(this, arguments)
+        const result = withoutScope(fn).apply(this, arguments)
 
         if (result && result.then) {
           return result


### PR DESCRIPTION
This PR fixes http server response handlers not running in the request scope. There were actually several issues causing this:

- Overriding `res.end` and calling the original would cause the scope to be closed before the new handler runs.
- If the context was lost at the moment `res.end()` was called, it would not be in the request scope.
- Event handlers listening on response events may run outside of the request context.

The changes in this PR fix all 3 issues by binding these different handlers to the request scope and not manually closing the scope at the end of the request.