### PR TITLE
fix log injection with a null active span and update injection keys

### DIFF
--- a/src/plugins/util/log.js
+++ b/src/plugins/util/log.js
@@ -9,11 +9,13 @@ const log = {
 
     record = record || {}
 
-    if (scope) {
+    if (scope && scope.span()) {
       const span = scope.span()
 
-      record['dd.trace_id'] = span.context().toTraceId()
-      record['dd.span_id'] = span.context().toSpanId()
+      record.dd = {
+        trace_id: span.context().toTraceId(),
+        span_id: span.context().toSpanId()
+      }
     }
 
     return record

--- a/test/plugins/bunyan.spec.js
+++ b/test/plugins/bunyan.spec.js
@@ -50,10 +50,7 @@ describe('Plugin', () => {
 
           const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
-          expect(record).to.not.include({
-            'dd.trace_id': span.context().toTraceId(),
-            'dd.span_id': span.context().toSpanId()
-          })
+          expect(record).to.not.have.property('dd')
         })
       })
 
@@ -72,9 +69,9 @@ describe('Plugin', () => {
 
           const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
-          expect(record).to.include({
-            'dd.trace_id': span.context().toTraceId(),
-            'dd.span_id': span.context().toSpanId()
+          expect(record).to.have.deep.property('dd', {
+            trace_id: span.context().toTraceId(),
+            span_id: span.context().toSpanId()
           })
         })
       })

--- a/test/plugins/pino.spec.js
+++ b/test/plugins/pino.spec.js
@@ -50,10 +50,7 @@ describe('Plugin', () => {
 
           const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
-          expect(record).to.not.include({
-            'dd.trace_id': span.context().toTraceId(),
-            'dd.span_id': span.context().toSpanId()
-          })
+          expect(record).to.not.have.property('dd')
         })
       })
 
@@ -72,9 +69,9 @@ describe('Plugin', () => {
 
           const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
-          expect(record).to.include({
-            'dd.trace_id': span.context().toTraceId(),
-            'dd.span_id': span.context().toSpanId()
+          expect(record).to.have.deep.property('dd', {
+            trace_id: span.context().toTraceId(),
+            span_id: span.context().toSpanId()
           })
         })
       })

--- a/test/plugins/util/log.spec.js
+++ b/test/plugins/util/log.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+wrapIt()
+
 describe('plugins/util/log', () => {
   let log
   let tracer
@@ -18,9 +20,9 @@ describe('plugins/util/log', () => {
 
       log.correlate(tracer, record)
 
-      expect(record).to.include({
-        'dd.trace_id': span.context().toTraceId(),
-        'dd.span_id': span.context().toSpanId()
+      expect(record).to.have.deep.property('dd', {
+        trace_id: span.context().toTraceId(),
+        span_id: span.context().toSpanId()
       })
     })
 
@@ -31,20 +33,24 @@ describe('plugins/util/log', () => {
 
       const record = log.correlate(tracer)
 
-      expect(record).to.include({
-        'dd.trace_id': span.context().toTraceId(),
-        'dd.span_id': span.context().toSpanId()
+      expect(record).to.have.deep.property('dd', {
+        trace_id: span.context().toTraceId(),
+        span_id: span.context().toSpanId()
       })
     })
 
     it('should do nothing if there is no active scope', () => {
-      const span = tracer.startSpan('test')
       const record = log.correlate(tracer)
 
-      expect(record).to.not.include({
-        'dd.trace_id': span.context().toTraceId(),
-        'dd.span_id': span.context().toSpanId()
-      })
+      expect(record).to.not.have.property('dd')
+    })
+
+    it('should do nothing if the active span is null', () => {
+      tracer.scopeManager().activate(null)
+
+      const record = log.correlate(tracer)
+
+      expect(record).to.not.have.property('dd')
     })
   })
 })

--- a/test/plugins/winston.spec.js
+++ b/test/plugins/winston.spec.js
@@ -75,8 +75,10 @@ describe('Plugin', () => {
 
         it('should add the trace identifiers to the default logger', () => {
           const meta = {
-            'dd.trace_id': span.context().toTraceId(),
-            'dd.span_id': span.context().toSpanId()
+            dd: {
+              trace_id: span.context().toTraceId(),
+              span_id: span.context().toSpanId()
+            }
           }
 
           tracer.scopeManager().activate(span)
@@ -96,8 +98,10 @@ describe('Plugin', () => {
           }
 
           const meta = {
-            'dd.trace_id': span.context().toTraceId(),
-            'dd.span_id': span.context().toSpanId()
+            dd: {
+              trace_id: span.context().toTraceId(),
+              span_id: span.context().toSpanId()
+            }
           }
 
           const logger = winston.createLogger
@@ -129,8 +133,10 @@ describe('Plugin', () => {
             })
 
             expect(transport.log).to.have.been.calledWithMatch({
-              'dd.trace_id': span.context().toTraceId(),
-              'dd.span_id': span.context().toSpanId()
+              dd: {
+                trace_id: span.context().toTraceId(),
+                span_id: span.context().toSpanId()
+              }
             })
           })
         }


### PR DESCRIPTION
This PR fixes log injection with a null active span and updates the log injection keys to be actual nested properties instead of simple string keys.