### PR TITLE
fix redis/ioredis plugins not binding their callbacks to the parent scope

### DIFF
--- a/src/plugins/util/tx.js
+++ b/src/plugins/util/tx.js
@@ -18,10 +18,14 @@ const tx = {
 }
 
 function wrapCallback (span, callback) {
+  const scopeManager = span.tracer().scopeManager()
+  const scope = scopeManager.active()
+
   return function (err) {
     finish(span, err)
 
     if (callback) {
+      scopeManager.activate(scope ? scope.span() : null)
       callback.apply(this, arguments)
     }
   }

--- a/test/plugins/util/tx.spec.js
+++ b/test/plugins/util/tx.spec.js
@@ -49,6 +49,26 @@ describe('plugins/util/tx', () => {
         expect(span.context().tags).to.have.property('error.type', error.name)
         expect(span.context().tags).to.have.property('error.stack', error.stack)
       })
+
+      it('should return a wrapper that runs in the current scope', done => {
+        const parent = {}
+        const child = {}
+
+        tracer.scopeManager().activate(parent)
+
+        const wrapper = tx.wrap(span, () => {
+          const scope = tracer.scopeManager().active()
+
+          expect(scope).to.not.be.null
+          expect(scope.span()).to.equal(parent)
+
+          done()
+        })
+
+        tracer.scopeManager().activate(child)
+
+        wrapper()
+      })
     })
 
     describe('with a promise', () => {


### PR DESCRIPTION
This PR fixes the `redis` and `ioredis` plugins not binding their callbacks to the parent scope.