### PR TITLE
fix wrong image used for windows build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: win1803
+  vmImage: vs2017-win2016
 
 steps:
 - script: yarn versions && yarn install


### PR DESCRIPTION
This PR fixes the Windows build by changing the image used by the build. The image that was used previously is meant to run Docker containers, but still had Node installed until now. Since Node has now been removed from that image, we have to switch the the more appropriate Visual Studio 2017 image.

See https://github.com/Microsoft/azure-pipelines-tasks/issues/9508