### PR TITLE
fix noop span context trace IDs to match the backend expectation

### DIFF
--- a/src/noop/span_context.js
+++ b/src/noop/span_context.js
@@ -4,11 +4,11 @@ const SpanContext = require('opentracing').SpanContext
 
 class NoopSpanContext extends SpanContext {
   toTraceId () {
-    return ''
+    return '0'
   }
 
   toSpanId () {
-    return ''
+    return '0'
   }
 }
 

--- a/test/noop.spec.js
+++ b/test/noop.spec.js
@@ -31,9 +31,9 @@ describe('NoopTracer', () => {
       const span = tracer.startSpan()
 
       expect(span.context().toTraceId).to.be.a('function')
-      expect(span.context().toTraceId()).to.equal('')
+      expect(span.context().toTraceId()).to.equal('0')
       expect(span.context().toSpanId).to.be.a('function')
-      expect(span.context().toSpanId()).to.equal('')
+      expect(span.context().toSpanId()).to.equal('0')
     })
   })
 })


### PR DESCRIPTION
This PR fixes the noop span context trace IDs to match the backend expectation that there should always be a value when injected in logs.