### PR TITLE
add header tags and separate client/server config in http plugin

### DIFF
--- a/ext/tags.js
+++ b/ext/tags.js
@@ -14,5 +14,6 @@ module.exports = {
   HTTP_METHOD: 'http.method',
   HTTP_STATUS_CODE: 'http.status_code',
   HTTP_ROUTE: 'http.route',
-  HTTP_HEADERS: 'http.headers'
+  HTTP_REQUEST_HEADERS: 'http.request.headers',
+  HTTP_RESPONSE_HEADERS: 'http.response.headers'
 }

--- a/src/plugins/http/client.js
+++ b/src/plugins/http/client.js
@@ -61,6 +61,7 @@ function patch (http, methodName, tracer, config) {
       req.on('response', res => {
         span.setTag(HTTP_STATUS_CODE, res.statusCode)
 
+        addRequestHeaders(req, span, config)
         addResponseHeaders(res, span, config)
 
         if (!config.validateStatus(res.statusCode)) {
@@ -77,10 +78,10 @@ function patch (http, methodName, tracer, config) {
           'error.stack': err.stack
         })
 
+        addRequestHeaders(req, span, config)
+
         span.finish()
       })
-
-      addRequestHeaders(req, span, config)
 
       return req
     }

--- a/src/plugins/http/client.js
+++ b/src/plugins/http/client.js
@@ -183,6 +183,8 @@ function getFilter (tracer, config) {
 }
 
 function normalizeConfig (tracer, config) {
+  config = config.client || config
+
   const validateStatus = getStatusValidator(config)
   const filter = getFilter(tracer, config)
 
@@ -196,6 +198,8 @@ module.exports = [
   {
     name: 'http',
     patch: function (http, tracer, config) {
+      if (config.client === false) return
+
       patch.call(this, http, 'request', tracer, config)
       if (semver.satisfies(process.version, '>=8')) {
         /**
@@ -210,6 +214,8 @@ module.exports = [
   {
     name: 'https',
     patch: function (http, tracer, config) {
+      if (config.client === false) return
+
       if (semver.satisfies(process.version, '>=9')) {
         patch.call(this, http, 'request', tracer, config)
         patch.call(this, http, 'get', tracer, config)

--- a/src/plugins/http/server.js
+++ b/src/plugins/http/server.js
@@ -20,6 +20,8 @@ function plugin (name) {
   return {
     name,
     patch (http, tracer, config) {
+      if (config.server === false) return
+
       this.wrap(http.Server.prototype, 'emit', createWrapEmit(tracer, config))
     },
     unpatch (http) {

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -240,7 +240,7 @@ function reactivate (req) {
 
 function addRequestTags (req) {
   const protocol = req.connection.encrypted ? 'https' : 'http'
-  const url = `${protocol}://${req.headers['host']}${req.url}`
+  const url = `${protocol}://${req.headers['host']}${req.originalUrl || req.url}`
   const span = req._datadog.span
 
   span.addTags({

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -287,10 +287,7 @@ function addHeaders (req) {
 
   req._datadog.config.headers.forEach(key => {
     const reqHeader = req.headers[key]
-    const resHeader = req._datadog.res.getHeader[key]
-
-    console.log(reqHeader)
-    console.log(resHeader)
+    const resHeader = req._datadog.res.getHeader(key)
 
     if (reqHeader) {
       span.setTag(`${HTTP_REQUEST_HEADERS}.${key}`, reqHeader)

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -17,7 +17,8 @@ const HTTP_METHOD = tags.HTTP_METHOD
 const HTTP_URL = tags.HTTP_URL
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_ROUTE = tags.HTTP_ROUTE
-const HTTP_HEADERS = tags.HTTP_HEADERS
+const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
+const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 const web = {
   // Ensure the configuration has the correct structure and defaults.
@@ -285,10 +286,18 @@ function addHeaders (req) {
   const span = req._datadog.span
 
   req._datadog.config.headers.forEach(key => {
-    const value = req.headers[key]
+    const reqHeader = req.headers[key]
+    const resHeader = req._datadog.res.getHeader[key]
 
-    if (value) {
-      span.setTag(`${HTTP_HEADERS}.${key}`, value)
+    console.log(reqHeader)
+    console.log(resHeader)
+
+    if (reqHeader) {
+      span.setTag(`${HTTP_REQUEST_HEADERS}.${key}`, reqHeader)
+    }
+
+    if (resHeader) {
+      span.setTag(`${HTTP_RESPONSE_HEADERS}.${key}`, resHeader)
     }
   })
 }

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -22,6 +22,8 @@ const HTTP_HEADERS = tags.HTTP_HEADERS
 const web = {
   // Ensure the configuration has the correct structure and defaults.
   normalizeConfig (config) {
+    config = config.server || config
+
     const headers = getHeadersToRecord(config)
     const validateStatus = getStatusValidator(config)
     const hooks = getHooks(config)
@@ -149,14 +151,13 @@ function startSpan (tracer, config, req, res, name) {
   req._datadog.scope = scope
   req._datadog.res = res
 
-  addRequestTags(req)
-
   return span
 }
 
 function finish (req, res) {
   if (req._datadog.finished) return
 
+  addRequestTags(req)
   addResponseTags(req)
 
   req._datadog.config.hooks.request(req._datadog.span, req, res)

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -859,7 +859,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0].meta).to.have.property('http.headers.user-agent', 'test')
+                expect(spans[0].meta).to.have.property('http.request.headers.user-agent', 'test')
               })
               .then(done)
               .catch(done)

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -5,8 +5,12 @@ const agent = require('../agent')
 const semver = require('semver')
 const fs = require('fs')
 const path = require('path')
+const tags = require('../../../ext/tags')
 const key = fs.readFileSync(path.join(__dirname, './ssl/test.key'))
 const cert = fs.readFileSync(path.join(__dirname, './ssl/test.crt'))
+
+const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
+const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 wrapIt()
 
@@ -567,6 +571,7 @@ describe('Plugin', () => {
 
         beforeEach(() => {
           config = {
+            server: false,
             client: {
               service: 'custom'
             }
@@ -610,6 +615,7 @@ describe('Plugin', () => {
 
         beforeEach(() => {
           config = {
+            server: false,
             client: {
               validateStatus: status => status < 500
             }
@@ -653,6 +659,7 @@ describe('Plugin', () => {
 
         beforeEach(() => {
           config = {
+            server: false,
             client: {
               splitByDomain: true
             }
@@ -676,6 +683,54 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('service', `localhost:${port}`)
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(app, port, () => {
+              const req = http.request(`${protocol}://localhost:${port}/user`, res => {
+                res.on('data', () => {})
+              })
+
+              req.end()
+            })
+          })
+        })
+      })
+
+      describe('with headers configuration', () => {
+        let config
+
+        beforeEach(() => {
+          config = {
+            server: false,
+            client: {
+              headers: ['host', 'x-foo']
+            }
+          }
+
+          return agent.load(plugin, 'http', config)
+            .then(() => {
+              http = require(protocol)
+              express = require('express')
+            })
+        })
+
+        it('should add tags for the configured headers', done => {
+          const app = express()
+
+          app.get('/user', (req, res) => {
+            res.setHeader('x-foo', 'bar')
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const meta = traces[0][0].meta
+
+                expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.host`, `localhost:${port}`)
+                expect(meta).to.have.property(`${HTTP_RESPONSE_HEADERS}.x-foo`, 'bar')
               })
               .then(done)
               .catch(done)

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -567,7 +567,9 @@ describe('Plugin', () => {
 
         beforeEach(() => {
           config = {
-            service: 'custom'
+            client: {
+              service: 'custom'
+            }
           }
 
           return agent.load(plugin, 'http', config)
@@ -608,7 +610,9 @@ describe('Plugin', () => {
 
         beforeEach(() => {
           config = {
-            validateStatus: status => status < 500
+            client: {
+              validateStatus: status => status < 500
+            }
           }
 
           return agent.load(plugin, 'http', config)
@@ -649,7 +653,9 @@ describe('Plugin', () => {
 
         beforeEach(() => {
           config = {
-            splitByDomain: true
+            client: {
+              splitByDomain: true
+            }
           }
 
           return agent.load(plugin, 'http', config)

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -744,6 +744,34 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('should support adding request headers', done => {
+          const app = express()
+
+          app.get('/user', (req, res) => {
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const meta = traces[0][0].meta
+
+                expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-foo`, `bar`)
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(app, port, () => {
+              const req = http.request(`${protocol}://localhost:${port}/user`, res => {
+                res.on('data', () => {})
+              })
+
+              req.setHeader('x-foo', 'bar')
+              req.end()
+            })
+          })
+        })
       })
     })
   })

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -17,7 +17,8 @@ const HTTP_METHOD = tags.HTTP_METHOD
 const HTTP_URL = tags.HTTP_URL
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_ROUTE = tags.HTTP_ROUTE
-const HTTP_HEADERS = tags.HTTP_HEADERS
+const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
+const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 wrapIt()
 
@@ -41,8 +42,10 @@ describe('plugins/util/web', () => {
     }
     end = sinon.stub()
     res = {
-      end
+      end,
+      getHeader: sinon.stub()
     }
+    res.getHeader.withArgs('server').returns('test')
     config = { hooks: {} }
 
     tracer = require('../../..').init({ plugins: false })
@@ -162,14 +165,15 @@ describe('plugins/util/web', () => {
       })
 
       it('should add configured headers to the span tags', () => {
-        config.headers = ['host']
+        config.headers = ['host', 'server']
 
         span = web.instrument(tracer, config, req, res, 'test.request')
 
         res.end()
 
         expect(span.context()._tags).to.include({
-          [`${HTTP_HEADERS}.host`]: 'localhost'
+          [`${HTTP_REQUEST_HEADERS}.host`]: 'localhost',
+          [`${HTTP_RESPONSE_HEADERS}.server`]: 'test'
         })
       })
 
@@ -219,7 +223,7 @@ describe('plugins/util/web', () => {
         res.end()
 
         expect(span.context()._tags).to.include({
-          [`${HTTP_HEADERS}.date`]: 'now'
+          [`${HTTP_REQUEST_HEADERS}.date`]: 'now'
         })
       })
     })


### PR DESCRIPTION
This PR adds request/response header tags in the `http` plugin for both servers and clients. So far only the request headers on servers were tagged. In order to do this I had to separate the configuration between the server and client as well.

This is a breaking change since we are renaming the tags.