### PR TITLE
fix serializing tag values with no toString method

### DIFF
--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -159,5 +159,25 @@ describe('format', () => {
       trace = format(span)
       expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
     })
+
+    it('should support objects without a toString implementation', () => {
+      spanContext._tags['foo'] = Object.create(null)
+      trace = format(span)
+      expect(trace.meta['foo']).to.equal('{}')
+    })
+
+    it('should support objects with a non-function toString property', () => {
+      spanContext._tags['foo'] = Object.create(null)
+      spanContext._tags['foo'].toString = 'baz'
+      trace = format(span)
+      expect(trace.meta['foo']).to.equal('{"toString":"baz"}')
+    })
+
+    it('should ignore complex objects with circular references', () => {
+      spanContext._tags['foo'] = Object.create(null)
+      spanContext._tags['foo'].baz = spanContext._tags['foo']
+      trace = format(span)
+      expect(trace.meta).to.not.have.property('foo')
+    })
   })
 })


### PR DESCRIPTION
This PR fixes serializing tag values with no `toString` method which would result in an exception. Now we attempt to use `JSON.stringify` as a backup solution, and simply skip the tag if everything fails.

Thanks @alloy for helping to [reproduce and fix](https://github.com/artsy/metaphysics/pull/1501)!