### PR TITLE
fix tests not running for plugin utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "services": "node ./scripts/install_plugin_modules && node test/setup/services",
     "tdd": "yarn services && NO_DEPRECATION=* mocha --watch 'test/setup/**/*.js'",
     "test": "yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit 'test/setup/all.js' 'test/**/*.spec.js'",
-    "test:core": "mocha --exit --exclude \"test/plugins/**/*.spec.js\" --file test/setup/core.js \"test/**/*.spec.js\"",
+    "test:core": "mocha --exit --exclude \"test/plugins/*.spec.js\" --exclude \"test/plugins/http/*.spec.js\" --file test/setup/core.js \"test/**/*.spec.js\"",
     "test:plugins": "yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit --file \"test/setup/all.js\" \"test/plugins/@($(echo $PLUGINS)).spec.js\" \"test/plugins/@($(echo $PLUGINS))/**/*.spec.js\"",
     "leak:core": "node ./scripts/install_plugin_modules && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape 'test/leak/{,!(node_modules|plugins)/**/}/*.js'",
     "leak:plugins": "yarn services && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape \"test/leak/plugins/@($(echo $PLUGINS)).js\""


### PR DESCRIPTION
This PR fixes tests not running for plugin utils since they were in a path that was excluded from tests.