### PR TITLE
fix plugin test externals not loaded if not instrumented

### DIFF
--- a/test/setup/core.js
+++ b/test/setup/core.js
@@ -80,12 +80,15 @@ function wrapIt () {
 function withVersions (plugin, moduleName, range, cb) {
   const instrumentations = [].concat(plugin)
   const testVersions = new Map()
+  const names = [].concat(plugin).map(instrumentation => instrumentation.name)
 
-  if (externals[moduleName]) {
-    [].concat(externals[moduleName]).forEach(external => {
-      instrumentations.push(external)
-    })
-  }
+  names.forEach(name => {
+    if (externals[name]) {
+      [].concat(externals[name]).forEach(external => {
+        instrumentations.push(external)
+      })
+    }
+  })
 
   if (!cb) {
     cb = range


### PR DESCRIPTION
This PR fixes plugin test externals not loaded if not instrumented. For example, if we wanted to use `apollo-server` in a `graphql` plugin test but we don't instrument `apollo-server`, it wouldn't be imported. The fix inspects the entire plugin to make a decision instead of an individual module name.