### PR TITLE
enable net and dns plugins

### DIFF
--- a/src/plugins/dns.js
+++ b/src/plugins/dns.js
@@ -163,5 +163,3 @@ module.exports = [
     }
   }
 ]
-
-module.exports = [] // disable this integration for the upcoming release

--- a/src/plugins/net.js
+++ b/src/plugins/net.js
@@ -110,5 +110,3 @@ module.exports = {
     this.unwrap(net.Socket.prototype, 'connect')
   }
 }
-
-module.exports = [] // disable this integration for the upcoming release

--- a/test/plugins/dns.spec.js
+++ b/test/plugins/dns.spec.js
@@ -6,8 +6,6 @@ const plugin = require('../../src/plugins/dns')
 
 wrapIt()
 
-const describe = () => {} // integration disabled for the upcoming release
-
 describe('Plugin', () => {
   let dns
 

--- a/test/plugins/net.spec.js
+++ b/test/plugins/net.spec.js
@@ -6,8 +6,6 @@ const plugin = require('../../src/plugins/net')
 
 wrapIt()
 
-const describe = () => {} // integration disabled for the upcoming release
-
 describe('Plugin', () => {
   let net
   let tcp


### PR DESCRIPTION
This PR re-enables the `net` and `dns` plugins that were disabled for v0.8.0 since the new scope manager on which they rely was not ready.