### PR TITLE
add support for generic-pool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,14 @@ jobs:
           - SERVICES=
           - PLUGINS=express
 
+  node-generic-pool:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - SERVICES=
+          - PLUGINS=generic-pool
+
   node-graphql:
     <<: *node-plugin-base
     docker:
@@ -351,6 +359,7 @@ workflows:
       - node-dns
       - node-elasticsearch
       - node-express
+      - node-generic-pool
       - node-graphql
       - node-hapi
       - node-http
@@ -387,6 +396,7 @@ workflows:
       - node-dns
       - node-elasticsearch
       - node-express
+      - node-generic-pool
       - node-graphql
       - node-hapi
       - node-http

--- a/src/plugins/generic-pool.js
+++ b/src/plugins/generic-pool.js
@@ -1,0 +1,44 @@
+'use strict'
+
+function createWrapAcquire (tracer, config) {
+  return function wrapAcquire (acquire) {
+    return function acquireWithTrace (callback, priority) {
+      return acquire.call(this, tracer.scope().bind(callback), priority)
+    }
+  }
+}
+
+function createWrapPool (tracer, config, instrumenter) {
+  return function wrapPool (Pool) {
+    return function PoolWithTrace (factory) {
+      const pool = Pool.apply(this, arguments)
+
+      instrumenter.wrap(pool, 'acquire', createWrapAcquire(tracer, config))
+
+      return pool
+    }
+  }
+}
+
+module.exports = [
+  {
+    name: 'generic-pool',
+    versions: ['^2.4'],
+    patch (genericPool, tracer, config) {
+      this.wrap(genericPool.Pool.prototype, 'acquire', createWrapAcquire(tracer, config))
+    },
+    unpatch (genericPool) {
+      this.unwrap(genericPool.Pool.prototype, 'acquire')
+    }
+  },
+  {
+    name: 'generic-pool',
+    versions: ['2 - 2.3'],
+    patch (genericPool, tracer, config) {
+      this.wrap(genericPool, 'Pool', createWrapPool(tracer, config, this))
+    },
+    unpatch (genericPool) {
+      this.unwrap(genericPool, 'Pool')
+    }
+  }
+]

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -8,6 +8,7 @@ module.exports = {
   'dns': require('./dns'),
   'elasticsearch': require('./elasticsearch'),
   'express': require('./express'),
+  'generic-pool': require('./generic-pool'),
   'graphql': require('./graphql'),
   'hapi': require('./hapi'),
   'http': require('./http'),

--- a/test/plugins/externals.json
+++ b/test/plugins/externals.json
@@ -1,4 +1,10 @@
 {
+  "generic-pool": [
+    {
+      "name": "generic-pool",
+      "versions": [">=3"]
+    }
+  ],
   "graphql": [
     {
       "name": "apollo-server-core",

--- a/test/plugins/generic-pool.spec.js
+++ b/test/plugins/generic-pool.spec.js
@@ -1,0 +1,104 @@
+'use strict'
+
+const agent = require('./agent')
+const plugin = require('../../src/plugins/generic-pool')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let genericPool
+  let pool
+  let tracer
+
+  describe('generic-pool', () => {
+    beforeEach(() => {
+      tracer = require('../..')
+    })
+
+    afterEach(() => {
+      return agent.close()
+    })
+
+    withVersions(plugin, 'generic-pool', '2', version => {
+      beforeEach(() => {
+        return agent.load(plugin, 'generic-pool')
+          .then(() => {
+            genericPool = require(`../../versions/generic-pool@${version}`).get()
+          })
+      })
+
+      beforeEach(() => {
+        pool = new genericPool.Pool({
+          create (cb) {
+            setImmediate(() => {
+              cb(null, {})
+            })
+          },
+          destroy () {}
+        })
+      })
+
+      it('should run the acquire() callback in context where acquire() was called', done => {
+        const span = tracer.startSpan('test')
+        const span2 = tracer.startSpan('test')
+
+        tracer.scope().activate(span, () => {
+          pool.acquire((err, resource) => {
+            pool.release(resource)
+            expect(tracer.scope().active()).to.equal(span)
+          })
+        })
+
+        tracer.scope().activate(span2, () => {
+          pool.acquire((err, resource) => {
+            pool.release(resource)
+            expect(tracer.scope().active()).to.equal(span2)
+            done()
+          })
+        })
+      })
+    })
+
+    withVersions(plugin, 'generic-pool', '>=3', version => {
+      beforeEach(() => {
+        return agent.load(plugin, 'generic-pool')
+          .then(() => {
+            genericPool = require(`../../versions/generic-pool@${version}`).get()
+          })
+      })
+
+      beforeEach(() => {
+        pool = genericPool.createPool({
+          create () {
+            return Promise.resolve({})
+          },
+          destroy () {}
+        })
+      })
+
+      it('should run the acquire() callback in context where acquire() was called', done => {
+        const span = tracer.startSpan('test')
+        const span2 = tracer.startSpan('test')
+
+        tracer.scope().activate(span, () => {
+          pool.acquire()
+            .then(resource => {
+              pool.release(resource)
+              expect(tracer.scope().active()).to.equal(span)
+            })
+            .catch(done)
+        })
+
+        tracer.scope().activate(span2, () => {
+          pool.acquire()
+            .then(resource => {
+              pool.release(resource)
+              expect(tracer.scope().active()).to.equal(span2)
+              done()
+            })
+            .catch(done)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for `generic-pool`. Similar to the promise libraries that we support, this module has its own internal queue that may lose the scope. By patching it we ensure that the handlers are bound to the correct scope.