### PR TITLE
fix graphql error with multiple execution of the same document

### DIFF
--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -828,6 +828,26 @@ describe('Plugin', () => {
             .then(() => done())
             .catch(done)
         })
+
+        it('should support multiple executions on a pre-parsed document', () => {
+          const source = `query MyQuery { hello(name: "world") }`
+          const document = graphql.parse(source)
+
+          expect(() => {
+            graphql.execute({ schema, document })
+            graphql.execute({ schema, document })
+          }).to.not.throw()
+        })
+
+        it('should support multiple validations on a pre-parsed document', () => {
+          const source = `query MyQuery { hello(name: "world") }`
+          const document = graphql.parse(source)
+
+          expect(() => {
+            graphql.validate(schema, document)
+            graphql.validate(schema, document)
+          }).to.not.throw()
+        })
       })
 
       describe('with configuration', () => {


### PR DESCRIPTION
This PR fixes errors with multiple execution of the same document. It's possible to call `parse()` only once to get the document and then call `execute()` multiple times with that document. The assumption was that there is a 1:1 mapping which is not the case. The fix allows everything to be called multiple times.

Fixes #431 