### PR TITLE
Fix traceId/parentId printing in debug JSON output

### DIFF
--- a/src/platform/node/id.js
+++ b/src/platform/node/id.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Buffer = require('safe-buffer').Buffer
-const Uint64BE = require('int64-buffer').Uint64BE
+const Uint64BE = require('./uint64be')
 const randomBytes = require('crypto').randomBytes
 
 // Cryptographically secure local seeds to mitigate Math.random() seed reuse.

--- a/src/platform/node/uint64be.js
+++ b/src/platform/node/uint64be.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const Uint64BEBase = require('int64-buffer').Uint64BE
+
+class Uint64BE extends Uint64BEBase {
+  toJSON () {
+    return this.toString()
+  }
+}
+
+module.exports = Uint64BE


### PR DESCRIPTION
I noticed that the `Encoding trace` debug logs were truncating trace_id and parent_id fields by the rightmost 3 digits. I believe this is because js can only hold 52 bits ints but these are really representative of 64bits uints and stringifying them directly through json causes the loss of precision.

Before: `Encoding trace: [{"trace_id":7660829067201367000,`
After: `Encoding trace: [{"trace_id":7660829067201366963,`

While this isn't a critical issue, it definitely confuses/makes debugging more complicated.