### PR TITLE
Move two more places to uint64be json-compatible class

### DIFF
--- a/src/opentracing/propagation/log.js
+++ b/src/opentracing/propagation/log.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const platform = require('../../platform')
 const DatadogSpanContext = require('../span_context')
 
 class LogPropagator {
@@ -19,8 +19,8 @@ class LogPropagator {
     }
 
     const spanContext = new DatadogSpanContext({
-      traceId: new Uint64BE(carrier.dd.trace_id, 10),
-      spanId: new Uint64BE(carrier.dd.span_id, 10)
+      traceId: new platform.Uint64BE(carrier.dd.trace_id, 10),
+      spanId: new platform.Uint64BE(carrier.dd.span_id, 10)
     })
 
     return spanContext

--- a/src/opentracing/propagation/text_map.js
+++ b/src/opentracing/propagation/text_map.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const pick = require('lodash.pick')
-const Uint64BE = require('int64-buffer').Uint64BE
+const platform = require('../../platform')
 const DatadogSpanContext = require('../span_context')
 const log = require('../../log')
 
@@ -29,8 +29,8 @@ class TextMapPropagator {
     }
 
     const spanContext = new DatadogSpanContext({
-      traceId: new Uint64BE(carrier[traceKey], 10),
-      spanId: new Uint64BE(carrier[spanKey], 10)
+      traceId: new platform.Uint64BE(carrier[traceKey], 10),
+      spanId: new platform.Uint64BE(carrier[spanKey], 10)
     })
 
     this._extractBaggageItems(carrier, spanContext)

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -8,6 +8,7 @@ const validate = require('./validate')
 const service = require('./service')
 const request = require('./request')
 const msgpack = require('./msgpack')
+const Uint64BE = require('./uint64be')
 
 const emitter = new EventEmitter()
 
@@ -26,6 +27,7 @@ const platform = {
   service,
   request,
   msgpack,
+  Uint64BE,
   on: emitter.on.bind(emitter),
   once: emitter.once.bind(emitter),
   off: emitter.removeListener.bind(emitter)

--- a/test/opentracing/propagation/log.spec.js
+++ b/test/opentracing/propagation/log.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const platform = require('../../../src/platform')
 const SpanContext = require('../../../src/opentracing/span_context')
 
 describe('LogPropagator', () => {
@@ -23,8 +23,8 @@ describe('LogPropagator', () => {
     it('should inject the span context into the carrier', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(-456)
+        traceId: new platform.Uint64BE(0, 123),
+        spanId: new platform.Uint64BE(-456)
       })
 
       propagator.inject(spanContext, carrier)
@@ -44,8 +44,8 @@ describe('LogPropagator', () => {
       const spanContext = propagator.extract(carrier)
 
       expect(spanContext).to.deep.equal(new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(-456)
+        traceId: new platform.Uint64BE(0, 123),
+        spanId: new platform.Uint64BE(-456)
       }))
     })
 

--- a/test/opentracing/propagation/text_map.spec.js
+++ b/test/opentracing/propagation/text_map.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Uint64BE = require('int64-buffer').Uint64BE
+const platform = require('../../../src/platform')
 const SpanContext = require('../../../src/opentracing/span_context')
 
 describe('TextMapPropagator', () => {
@@ -26,8 +26,8 @@ describe('TextMapPropagator', () => {
     it('should inject the span context into the carrier', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(-456),
+        traceId: new platform.Uint64BE(0, 123),
+        spanId: new platform.Uint64BE(-456),
         baggageItems
       })
 
@@ -41,8 +41,8 @@ describe('TextMapPropagator', () => {
     it('should handle non-string values', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(0, 456),
+        traceId: new platform.Uint64BE(0, 123),
+        spanId: new platform.Uint64BE(0, 456),
         baggageItems: {
           number: 1.23,
           bool: true,
@@ -62,8 +62,8 @@ describe('TextMapPropagator', () => {
     it('should inject an existing sampling priority', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(-456),
+        traceId: new platform.Uint64BE(0, 123),
+        spanId: new platform.Uint64BE(-456),
         sampling: {
           priority: 0
         },
@@ -82,8 +82,8 @@ describe('TextMapPropagator', () => {
       const spanContext = propagator.extract(carrier)
 
       expect(spanContext).to.deep.equal(new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(-456),
+        traceId: new platform.Uint64BE(0, 123),
+        spanId: new platform.Uint64BE(-456),
         baggageItems
       }))
     })
@@ -101,8 +101,8 @@ describe('TextMapPropagator', () => {
       const spanContext = propagator.extract(carrier)
 
       expect(spanContext).to.deep.equal(new SpanContext({
-        traceId: new Uint64BE(0, 123),
-        spanId: new Uint64BE(-456),
+        traceId: new platform.Uint64BE(0, 123),
+        spanId: new platform.Uint64BE(-456),
         sampling: {
           priority: 0
         },


### PR DESCRIPTION
This is a followup on https://github.com/DataDog/dd-trace-js/pull/446 which fixed the majority of debug log lines to print uint64 correctly when json stringifying. However, both log id's as well as propagated id's through the text_map were being truncated still in log out. This fixes both of those cases for additional consistency.