### PR TITLE
fix restify crashing with array middleware

### DIFF
--- a/src/plugins/restify.js
+++ b/src/plugins/restify.js
@@ -45,6 +45,8 @@ function wrapMiddleware (middleware) {
 }
 
 function wrapFn (fn) {
+  if (Array.isArray(fn)) return wrapMiddleware(fn)
+
   return function (req, res, next) {
     return web.reactivate(req, () => fn.apply(this, arguments))
   }

--- a/test/plugins/restify.spec.js
+++ b/test/plugins/restify.spec.js
@@ -146,6 +146,31 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('should support array middleware', done => {
+          const server = restify.createServer()
+
+          server.get('/user/:id', [(req, res, next) => {
+            res.send(200)
+            return next()
+          }])
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
+                expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user/123`)
+                .catch(done)
+            })
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
This PR fixes the `restify` plugin throwing when passed an array middleware. One very common use of array middleware is from `restify-router`.

Fixes #440 