### PR TITLE
[http] fix suppressed error event and span never finishing

### DIFF
--- a/src/plugins/http/client.js
+++ b/src/plugins/http/client.js
@@ -91,16 +91,8 @@ function patch (http, methodName, tracer, config) {
     }
   }
 
-  function finish (req, span, config, error) {
+  function finish (req, span, config) {
     addRequestHeaders(req, span, config)
-
-    if (error) {
-      span.addTags({
-        'error.type': error.name,
-        'error.msg': error.message,
-        'error.stack': error.stack
-      })
-    }
 
     span.finish()
   }

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -460,16 +460,22 @@ describe('Plugin', () => {
 
         it('should handle connection errors', done => {
           getPort().then(port => {
+            let error
+
             agent
               .use(traces => {
-                expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-                expect(traces[0][0].meta).to.have.property('error.msg', `connect ECONNREFUSED 127.0.0.1:${port}`)
-                expect(traces[0][0].meta).to.have.property('error.stack')
+                expect(traces[0][0].meta).to.have.property('error.type', error.name)
+                expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+                expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
               })
               .then(done)
               .catch(done)
 
             const req = http.request(`${protocol}://localhost:${port}/user`)
+
+            req.on('error', err => {
+              error = err
+            })
 
             req.end()
           })


### PR DESCRIPTION
This PR fixes 2 issues in the `http` integration:

* The error event was handled by the integration, preventing it from throwing if no other handler is present.
* In some cases, the span would never finish. By listening to the request 'close' event, we can make sure to finish the span at the very least when the connection is closed. This may cause the span to finish too early (before the last chunk is consumed) but it shouldn't make too much of a difference in duration.