### PR TITLE
fix script to work with typedoc

### DIFF
--- a/scripts/publish_docs.js
+++ b/scripts/publish_docs.js
@@ -13,9 +13,9 @@ if (!msg) {
 
 exec('yarn install', { cwd: './docs' })
 exec('rm -rf ./out', { cwd: './docs' })
-exec('git clone -b gh-pages --single-branch git@github.com:DataDog/dd-trace-js.git docs/out')
-exec('rm -rf ./docs/out')
 exec('yarn type:doc')
+exec('git init', { cwd: './docs/out' })
+exec('git remote add origin git@github.com:DataDog/dd-trace-js.git', { cwd: './docs/out' })
 exec('git add -A', { cwd: './docs/out' })
 exec(`git commit -m "${msg}"`, { cwd: './docs/out' })
-exec('git push', { cwd: './docs/out' })
+exec('git push -f master:gh-pages', { cwd: './docs/out' })

--- a/scripts/publish_docs.js
+++ b/scripts/publish_docs.js
@@ -13,8 +13,8 @@ if (!msg) {
 
 exec('yarn install', { cwd: './docs' })
 exec('rm -rf ./out', { cwd: './docs' })
-exec('yarn type:doc')
-exec('git init', { cwd: './docs/out' })
+exec('yarn type:doc') // run first because typedoc requires an empty directory
+exec('git init', { cwd: './docs/out' }) // cloning would overwrite generated docs
 exec('git remote add origin git@github.com:DataDog/dd-trace-js.git', { cwd: './docs/out' })
 exec('git add -A', { cwd: './docs/out' })
 exec(`git commit -m "${msg}"`, { cwd: './docs/out' })


### PR DESCRIPTION
This PR fixes compatibility of the publish script with typedoc since it requires the target folder to be empty.