### PR TITLE
fix importing the library with typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,5 @@ package-lock.json
 yarn.lock
 out
 versions
+docs/test.js
 !test/node_modules

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "main": "typedoc.js",
   "scripts": {
     "build": "typedoc",
-    "test": "tsc --noEmit test"
+    "test": "tsc test && node test"
   },
   "license": "BSD-3-Clause",
   "private": true,

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -3,7 +3,6 @@ import { HTTP_HEADERS } from '../ext/formats';
 
 let span: Span;
 let context: SpanContext;
-let scope: Scope;
 let traceId: string;
 let spanId: string;
 
@@ -92,12 +91,6 @@ tracer.use('router');
 tracer.use('when');
 tracer.use('winston');
 
-tracer.inject(span || span.context(), HTTP_HEADERS, {});
-context = tracer.extract(HTTP_HEADERS, {});
-
-traceId = context.toTraceId();
-spanId = context.toSpanId();
-
 span = tracer.startSpan('test');
 span = tracer.startSpan('test', {});
 span = tracer.startSpan('test', {
@@ -108,6 +101,16 @@ span = tracer.startSpan('test', {
     foo: 'bar'
   }
 });
+
+const carrier = {}
+
+tracer.inject(span || span.context(), HTTP_HEADERS, carrier);
+context = tracer.extract(HTTP_HEADERS, carrier);
+
+traceId = context.toTraceId();
+spanId = context.toSpanId();
+
+const scope = tracer.scope()
 
 span = scope.active();
 

--- a/index.js
+++ b/index.js
@@ -7,3 +7,5 @@ const TracerProxy = require('./src/proxy')
 platform.use(node)
 
 module.exports = new TracerProxy()
+module.exports.default = module.exports
+module.exports.tracer = module.exports


### PR DESCRIPTION
This PR fixes importing the library with TypeScript.

Historically, we didn't support TypeScript so the library had to be required like so: `import * as tracer from 'dd-trace'`

Now that we support TypeScript, this syntax is no longer possible. The correct syntaxes are now `import tracer from 'dd-trace'` or `import { tracer } from 'dd-trace'`. However, since we were not exporting the `default` and `tracer` properties from the main module, these syntax wouldn't work after compilation.