### PR TITLE
add tracer.trace() and tracer.wrap() as high level APIs

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, ServerResponse } from "http";
 import * as opentracing from "opentracing";
 import { SpanOptions } from "opentracing/lib/tracer";
 
-export declare interface SpanOptions extends SpanOptions {}
+export { SpanOptions };
 
 /**
  * Tracer is the entry-point of the Datadog tracing implementation.
@@ -71,7 +71,7 @@ export declare interface Tracer extends opentracing.Tracer {
    * which case the span will finish at the end of the function execution.
    */
   trace<T>(name: string, fn: (span?: Span, fn?: (error?: Error) => any) => T): T;
-  trace<T>(name: string, options: SpanOptions, fn: (span?: Span, done?: (error?: Error) => string) => T): T;
+  trace<T>(name: string, options: TraceOptions & SpanOptions, fn: (span?: Span, done?: (error?: Error) => string) => T): T;
 
   /**
    * Wrap a function to automatically create a span activated on its
@@ -88,7 +88,26 @@ export declare interface Tracer extends opentracing.Tracer {
    * which case the span will finish at the end of the function execution.
    */
   wrap<T = (...args: any[]) => any>(name: string, fn: T): T;
-  wrap<T = (...args: any[]) => any>(name: string, options: SpanOptions, fn: T): T;
+  wrap<T = (...args: any[]) => any>(name: string, options: TraceOptions & SpanOptions, fn: T): T;
+}
+
+export declare interface TraceOptions {
+  /**
+   * The resource you are tracing. The resource name must not be longer than
+   * 5000 characters.
+   */
+  resource?: string,
+
+  /**
+   * The service you are tracing. The service name must not be longer than
+   * 100 characters.
+   */
+  service?: string,
+
+  /**
+   * The type of request.
+   */
+  type?: string
 }
 
 /**

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -57,8 +57,8 @@ export declare interface Tracer extends opentracing.Tracer {
   scope(): Scope;
 
   /**
-   * Instrument a function by automatically creating a span and activating the
-   * span on the function scope.
+   * Instruments a function by automatically creating a span activated on its
+   * scope.
    *
    * The span will automatically be finished when one of these conditions is
    * met:
@@ -74,7 +74,18 @@ export declare interface Tracer extends opentracing.Tracer {
   trace<T>(name: string, options: SpanOptions, fn: (span?: Span, done?: (error?: Error) => string) => T): T;
 
   /**
-   * Wrap a function to automatically call tracer.tracer() when it's called.
+   * Wrap a function to automatically create a span activated on its
+   * scope when it's called.
+   *
+   * The span will automatically be finished when one of these conditions is
+   * met:
+   *
+   * * The function returns a promise, in which case the span will finish when
+   * the promise is resolved or rejected.
+   * * The function takes a callback as its last parameter, in which case the
+   * span will finish when that callback is called.
+   * * The function doesn't accept a callback and doesn't return a promise, in
+   * which case the span will finish at the end of the function execution.
    */
   wrap<T = (...args: any[]) => any>(name: string, fn: T): T;
   wrap<T = (...args: any[]) => any>(name: string, options: SpanOptions, fn: T): T;

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -55,6 +55,29 @@ export declare interface Tracer extends opentracing.Tracer {
    * Returns a reference to the current scope.
    */
   scope(): Scope;
+
+  /**
+   * Instrument a function by automatically creating a span and activating the
+   * span on the function scope.
+   *
+   * The span will automatically be finished when one of these conditions is
+   * met:
+   *
+   * * The function returns a promise, in which case the span will finish when
+   * the promise is resolved or rejected.
+   * * The function takes a callback as its second parameter, in which case the
+   * span will finish when that callback is called.
+   * * The function doesn't accept a callback and doesn't return a promise, in
+   * which case the span will finish at the end of the function execution.
+   */
+  trace<T>(name: string, fn: (span?: Span, fn?: (error?: Error) => any) => T): T;
+  trace<T>(name: string, options: SpanOptions, fn: (span?: Span, done?: (error?: Error) => string) => T): T;
+
+  /**
+   * Wrap a function to automatically call tracer.tracer() when it's called.
+   */
+  wrap<T = (...args: any[]) => any>(name: string, fn: T): T;
+  wrap<T = (...args: any[]) => any>(name: string, options: SpanOptions, fn: T): T;
 }
 
 /**

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -5,6 +5,7 @@ let span: Span;
 let context: SpanContext;
 let traceId: string;
 let spanId: string;
+let promise: Promise<void>;
 
 ddTrace.init();
 tracer.init({
@@ -102,6 +103,19 @@ span = tracer.startSpan('test', {
   }
 });
 
+tracer.trace('test', () => {})
+tracer.trace('test', { tags: { foo: 'bar' }}, () => {})
+tracer.trace('test', (span: Span) => {})
+tracer.trace('test', (span: Span, fn: () => void) => {})
+tracer.trace('test', (span: Span, fn: (err: Error) => string) => {})
+
+promise = tracer.trace('test', () => Promise.resolve())
+
+tracer.wrap('test', () => {})
+tracer.wrap('test', (foo: string) => 'test')
+
+promise = tracer.wrap('test', () => Promise.resolve())()
+
 const carrier = {}
 
 tracer.inject(span || span.context(), HTTP_HEADERS, carrier);
@@ -119,7 +133,7 @@ scope.activate(span, () => {});
 scope.bind((arg1: string, arg2: number): string => 'test');
 scope.bind((arg1: string, arg2: number): string => 'test', span);
 
-const promise = Promise.resolve();
+Promise.resolve();
 
 scope.bind(promise);
 scope.bind(promise, span);

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -105,6 +105,7 @@ span = tracer.startSpan('test', {
 
 tracer.trace('test', () => {})
 tracer.trace('test', { tags: { foo: 'bar' }}, () => {})
+tracer.trace('test', { service: 'foo', resource: 'bar', type: 'baz' }, () => {})
 tracer.trace('test', (span: Span) => {})
 tracer.trace('test', (span: Span, fn: () => void) => {})
 tracer.trace('test', (span: Span, fn: (err: Error) => string) => {})

--- a/src/noop/tracer.js
+++ b/src/noop/tracer.js
@@ -22,8 +22,12 @@ class NoopTracer extends Tracer {
     this._scope = new Scope()
   }
 
-  trace (operationName, options, callback) {
-    callback(this.startSpan())
+  trace (name, options, fn) {
+    return fn(span, () => {})
+  }
+
+  wrap (name, options, fn) {
+    return fn
   }
 
   scopeManager () {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -49,22 +49,22 @@ class Tracer extends BaseTracer {
     return this
   }
 
-  trace (operationName, options, callback) {
-    this._deprecate('trace')
-
-    if (callback) {
-      return this._tracer.trace(operationName, options, callback)
-    } else if (options instanceof Function) {
-      return this._tracer.trace(operationName, options)
-    } else if (options) {
-      return new Promise((resolve, reject) => {
-        this._tracer.trace(operationName, options, span => resolve(span))
-      })
-    } else {
-      return new Promise((resolve, reject) => {
-        this._tracer.trace(operationName, span => resolve(span))
-      })
+  trace (name, options, fn) {
+    if (!fn) {
+      fn = options
+      options = {}
     }
+
+    return this._tracer.trace(name, options, fn)
+  }
+
+  wrap (name, options, fn) {
+    if (!fn) {
+      fn = options
+      options = {}
+    }
+
+    return this._tracer.wrap(name, options, fn)
   }
 
   startSpan () {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -55,6 +55,10 @@ class Tracer extends BaseTracer {
       options = {}
     }
 
+    if (typeof fn !== 'function') return
+
+    options = options || {}
+
     return this._tracer.trace(name, options, fn)
   }
 
@@ -63,6 +67,10 @@ class Tracer extends BaseTracer {
       fn = options
       options = {}
     }
+
+    if (typeof fn !== 'function') return fn
+
+    options = options || {}
 
     return this._tracer.wrap(name, options, fn)
   }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -27,9 +27,9 @@ class DatadogTracer extends Tracer {
   trace (name, options, fn) {
     if (typeof fn !== 'function') return
 
-    options = Object.assign({}, options, {
+    options = Object.assign({}, {
       childOf: this.scope().active()
-    })
+    }, options)
 
     const span = this.startSpan(name, options)
 

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -25,8 +25,6 @@ class DatadogTracer extends Tracer {
   }
 
   trace (name, options, fn) {
-    if (typeof fn !== 'function') return
-
     options = Object.assign({}, {
       childOf: this.scope().active()
     }, options)

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,14 +1,11 @@
 'use strict'
 
-const opentracing = require('opentracing')
 const Tracer = require('./opentracing/tracer')
 const tags = require('../ext/tags')
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
-
-const noop = new opentracing.Span()
 
 class DatadogTracer extends Tracer {
   constructor (config) {
@@ -98,7 +95,7 @@ class DatadogTracer extends Tracer {
   }
 
   currentSpan () {
-    return noop // return a noop span instead of null to avoid crashing the app
+    return this.scope().active()
   }
 }
 
@@ -115,9 +112,9 @@ function addError (span, error) {
 function addTags (span, options) {
   const tags = {}
 
-  if (options.type) {
-    tags['span.type'] = options.type
-  }
+  if (options.type) tags[SPAN_TYPE] = options.type
+  if (options.service) tags[SERVICE_NAME] = options.service
+  if (options.resource) tags[RESOURCE_NAME] = options.resource
 
   span.addTags(tags)
 }

--- a/test/noop.spec.js
+++ b/test/noop.spec.js
@@ -12,11 +12,26 @@ describe('NoopTracer', () => {
   })
 
   describe('trace', () => {
-    it('should return a noop span', done => {
-      tracer.trace('test', {}, span => {
+    it('should provide a span and done function', () => {
+      tracer.trace('test', {}, (span, done) => {
         expect(span).to.be.instanceof(Span)
-        done()
+        expect(done).to.be.a('function')
+        expect(done).to.not.throw()
       })
+    })
+
+    it('should return the return value of the function', () => {
+      const result = tracer.trace('test', {}, () => 'test')
+
+      expect(result).to.equal('test')
+    })
+  })
+
+  describe('wrap', () => {
+    it('should return the function', () => {
+      const fn = () => {}
+
+      expect(tracer.wrap('test', {}, fn)).to.equal(fn)
     })
   })
 

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -16,7 +16,8 @@ describe('TracerProxy', () => {
   beforeEach(() => {
     tracer = {
       use: sinon.stub().returns('tracer'),
-      trace: sinon.stub().returns('span'),
+      trace: sinon.stub().returns('test'),
+      wrap: sinon.stub().returns('fn'),
       startSpan: sinon.stub().returns('span'),
       inject: sinon.stub().returns('tracer'),
       extract: sinon.stub().returns('spanContext'),
@@ -26,7 +27,8 @@ describe('TracerProxy', () => {
 
     noop = {
       use: sinon.stub().returns('tracer'),
-      trace: sinon.stub().returns('span'),
+      trace: sinon.stub().returns('test'),
+      wrap: sinon.stub().returns('fn'),
       startSpan: sinon.stub().returns('span'),
       inject: sinon.stub().returns('noop'),
       extract: sinon.stub().returns('spanContext'),
@@ -117,42 +119,35 @@ describe('TracerProxy', () => {
 
     describe('trace', () => {
       it('should call the underlying NoopTracer', () => {
-        const returnValue = proxy.trace('a', 'b', 'c')
+        const callback = () => 'test'
+        const returnValue = proxy.trace('a', 'b', callback)
 
-        expect(noop.trace).to.have.been.calledWith('a', 'b', 'c')
-        expect(returnValue).to.equal('span')
+        expect(noop.trace).to.have.been.calledWith('a', 'b', callback)
+        expect(returnValue).to.equal('test')
       })
 
-      it('should return a promise if a callback is not provided', () => {
-        const promise = proxy.trace('a', 'b')
-
-        expect(noop.trace).to.have.been.calledWith('a', 'b')
-
-        noop.trace.firstCall.args[2]('span')
-
-        return promise.then(span => {
-          expect(span).to.equal('span')
-        })
-      })
-
-      it('should work without options for callbacks', () => {
-        const callback = () => {}
+      it('should work without options', () => {
+        const callback = () => 'test'
         const returnValue = proxy.trace('a', callback)
 
-        expect(noop.trace).to.have.been.calledWith('a', callback)
-        expect(returnValue).to.equal('span')
+        expect(noop.trace).to.have.been.calledWith('a', {}, callback)
+        expect(returnValue).to.equal('test')
+      })
+    })
+
+    describe('wrap', () => {
+      it('should call the underlying NoopTracer', () => {
+        const returnValue = proxy.wrap('a', 'b', 'fn')
+
+        expect(noop.wrap).to.have.been.calledWith('a', 'b', 'fn')
+        expect(returnValue).to.equal('fn')
       })
 
-      it('should work without options for promises', () => {
-        const promise = proxy.trace('a')
+      it('should work without options', () => {
+        const returnValue = proxy.wrap('a', 'fn')
 
-        expect(noop.trace).to.have.been.calledWith('a')
-
-        noop.trace.firstCall.args[1]('span')
-
-        return promise.then(span => {
-          expect(span).to.equal('span')
-        })
+        expect(noop.wrap).to.have.been.calledWith('a', {}, 'fn')
+        expect(returnValue).to.equal('fn')
       })
     })
 
@@ -218,42 +213,35 @@ describe('TracerProxy', () => {
 
     describe('trace', () => {
       it('should call the underlying DatadogTracer', () => {
-        const returnValue = proxy.trace('a', 'b', 'c')
+        const callback = () => 'test'
+        const returnValue = proxy.trace('a', 'b', callback)
 
-        expect(tracer.trace).to.have.been.calledWith('a', 'b', 'c')
-        expect(returnValue).to.equal('span')
-      })
-
-      it('should return a promise if a callback is not provided', () => {
-        const promise = proxy.trace('a', 'b')
-
-        expect(tracer.trace).to.have.been.calledWith('a', 'b')
-
-        tracer.trace.firstCall.args[2]('span')
-
-        return promise.then(span => {
-          expect(span).to.equal('span')
-        })
+        expect(tracer.trace).to.have.been.calledWith('a', 'b', callback)
+        expect(returnValue).to.equal('test')
       })
 
       it('should work without options', () => {
-        const callback = () => {}
+        const callback = () => 'test'
         const returnValue = proxy.trace('a', callback)
 
-        expect(tracer.trace).to.have.been.calledWith('a', callback)
-        expect(returnValue).to.equal('span')
+        expect(tracer.trace).to.have.been.calledWith('a', {}, callback)
+        expect(returnValue).to.equal('test')
+      })
+    })
+
+    describe('wrap', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.wrap('a', 'b', 'fn')
+
+        expect(tracer.wrap).to.have.been.calledWith('a', 'b', 'fn')
+        expect(returnValue).to.equal('fn')
       })
 
-      it('should work without options for promises', () => {
-        const promise = proxy.trace('a')
+      it('should work without options', () => {
+        const returnValue = proxy.wrap('a', 'fn')
 
-        expect(tracer.trace).to.have.been.calledWith('a')
-
-        tracer.trace.firstCall.args[1]('span')
-
-        return promise.then(span => {
-          expect(span).to.equal('span')
-        })
+        expect(tracer.wrap).to.have.been.calledWith('a', {}, 'fn')
+        expect(returnValue).to.equal('fn')
       })
     })
 

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -133,21 +133,36 @@ describe('TracerProxy', () => {
         expect(noop.trace).to.have.been.calledWith('a', {}, callback)
         expect(returnValue).to.equal('test')
       })
+
+      it('should ignore calls without an invalid callback', () => {
+        proxy.wrap('a', 'b')
+
+        expect(noop.trace).to.not.have.been.called
+      })
     })
 
     describe('wrap', () => {
       it('should call the underlying NoopTracer', () => {
-        const returnValue = proxy.wrap('a', 'b', 'fn')
+        const callback = () => 'test'
+        const returnValue = proxy.wrap('a', 'b', callback)
 
-        expect(noop.wrap).to.have.been.calledWith('a', 'b', 'fn')
+        expect(noop.wrap).to.have.been.calledWith('a', 'b', callback)
         expect(returnValue).to.equal('fn')
       })
 
       it('should work without options', () => {
-        const returnValue = proxy.wrap('a', 'fn')
+        const callback = () => 'test'
+        const returnValue = proxy.wrap('a', callback)
 
-        expect(noop.wrap).to.have.been.calledWith('a', {}, 'fn')
+        expect(noop.wrap).to.have.been.calledWith('a', {}, callback)
         expect(returnValue).to.equal('fn')
+      })
+
+      it('should ignore calls without an invalid callback', () => {
+        const returnValue = proxy.wrap('a', 'b')
+
+        expect(noop.wrap).to.not.have.been.called
+        expect(returnValue).to.equal('b')
       })
     })
 
@@ -231,16 +246,18 @@ describe('TracerProxy', () => {
 
     describe('wrap', () => {
       it('should call the underlying DatadogTracer', () => {
-        const returnValue = proxy.wrap('a', 'b', 'fn')
+        const callback = () => 'test'
+        const returnValue = proxy.wrap('a', 'b', callback)
 
-        expect(tracer.wrap).to.have.been.calledWith('a', 'b', 'fn')
+        expect(tracer.wrap).to.have.been.calledWith('a', 'b', callback)
         expect(returnValue).to.equal('fn')
       })
 
       it('should work without options', () => {
-        const returnValue = proxy.wrap('a', 'fn')
+        const callback = () => 'test'
+        const returnValue = proxy.wrap('a', callback)
 
-        expect(tracer.wrap).to.have.been.calledWith('a', {}, 'fn')
+        expect(tracer.wrap).to.have.been.calledWith('a', {}, callback)
         expect(returnValue).to.equal('fn')
       })
     })

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -221,6 +221,29 @@ describe('Tracer', () => {
       expect(tracer.trace).to.have.been.calledWith('name', {})
       expect(result).to.equal('test')
     })
+
+    it('should wait for the callback to be called before finishing the span', done => {
+      const fn = tracer.wrap('name', {}, sinon.spy(function (cb) {
+        const span = tracer.scope().active()
+
+        sinon.spy(span, 'finish')
+
+        setImmediate(() => {
+          expect(span.finish).to.not.have.been.called
+        })
+
+        setImmediate(() => cb())
+
+        setImmediate(() => {
+          expect(span.finish).to.have.been.called
+          done()
+        })
+      }))
+
+      sinon.spy(tracer, 'trace')
+
+      fn(() => {})
+    })
   })
 
   describe('currentSpan', () => {

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -49,9 +49,30 @@ describe('Tracer', () => {
       })
     })
 
-    it('should run activate the span', () => {
+    it('should activate the span', () => {
       tracer.trace('name', {}, span => {
         expect(tracer.scope().active()).to.equal(span)
+      })
+    })
+
+    it('should start the span as a child of the active span', () => {
+      const childOf = tracer.startSpan('parent')
+
+      tracer.scope().activate(childOf, () => {
+        tracer.trace('name', {}, span => {
+          expect(span.context()._parentId.toString()).to.equal(childOf.context().toSpanId())
+        })
+      })
+    })
+
+    it('should allow overriding the parent span', () => {
+      const root = tracer.startSpan('root')
+      const childOf = tracer.startSpan('parent')
+
+      tracer.scope().activate(root, () => {
+        tracer.trace('name', { childOf }, span => {
+          expect(span.context()._parentId.toString()).to.equal(childOf.context().toSpanId())
+        })
       })
     })
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -29,22 +29,180 @@ describe('Tracer', () => {
   })
 
   describe('trace', () => {
-    it('should run the callback with a noop span', done => {
-      tracer.trace('name', current => {
-        expect(current).to.be.instanceof(Span)
+    it('should run the callback with a new span', () => {
+      tracer.trace('name', {}, span => {
+        expect(span).to.be.instanceof(Span)
+        expect(span.context()._name).to.equal('name')
+      })
+    })
+
+    it('should accept options', () => {
+      const options = {
+        tags: {
+          foo: 'bar'
+        }
+      }
+
+      tracer.trace('name', options, span => {
+        expect(span).to.be.instanceof(Span)
+        expect(span.context()._tags).to.include(options.tags)
+      })
+    })
+
+    it('should run activate the span', () => {
+      tracer.trace('name', {}, span => {
+        expect(tracer.scope().active()).to.equal(span)
+      })
+    })
+
+    it('should return the value from the callback', () => {
+      const result = tracer.trace('name', {}, span => 'test')
+
+      expect(result).to.equal('test')
+    })
+
+    it('should finish the span', () => {
+      let span
+
+      tracer.trace('name', {}, (_span) => {
+        span = _span
+        sinon.spy(span, 'finish')
+      })
+
+      expect(span.finish).to.have.been.called
+    })
+
+    it('should handle exceptions', () => {
+      let span
+
+      try {
+        tracer.trace('name', {}, _span => {
+          span = _span
+          sinon.spy(span, 'finish')
+          throw new Error('boom')
+        })
+      } catch (e) {
+        expect(span.finish).to.have.been.called
+        expect(span.context()._tags).to.include({
+          'error.type': e.name,
+          'error.msg': e.message,
+          'error.stack': e.stack
+        })
+      }
+    })
+
+    describe('with a callback taking a callback', () => {
+      it('should wait for the callback to be called before finishing the span', () => {
+        let span
+        let done
+
+        tracer.trace('name', {}, (_span, _done) => {
+          span = _span
+          sinon.spy(span, 'finish')
+          done = _done
+        })
+
+        expect(span.finish).to.not.have.been.called
+
         done()
+
+        expect(span.finish).to.have.been.called
+      })
+
+      it('should handle errors', () => {
+        const error = new Error('boom')
+        let span
+        let done
+
+        tracer.trace('name', {}, (_span, _done) => {
+          span = _span
+          sinon.spy(span, 'finish')
+          done = _done
+        })
+
+        done(error)
+
+        expect(span.finish).to.have.been.called
+        expect(span.context()._tags).to.include({
+          'error.type': error.name,
+          'error.msg': error.message,
+          'error.stack': error.stack
+        })
+      })
+    })
+
+    describe('with a callback returning a promise', () => {
+      it('should wait for the promise to resolve before finishing the span', done => {
+        const deferred = {}
+        const promise = new Promise(resolve => {
+          deferred.resolve = resolve
+        })
+
+        let span
+
+        tracer
+          .trace('name', {}, _span => {
+            span = _span
+            sinon.spy(span, 'finish')
+            return promise
+          })
+          .then(() => {
+            expect(span.finish).to.have.been.called
+            done()
+          })
+          .catch(done)
+
+        expect(span.finish).to.not.have.been.called
+
+        deferred.resolve()
+      })
+
+      it('should handle rejected promises', done => {
+        let span
+
+        tracer
+          .trace('name', {}, _span => {
+            span = _span
+            sinon.spy(span, 'finish')
+            return Promise.reject(new Error('boom'))
+          })
+          .catch(e => {
+            expect(span.finish).to.have.been.called
+            expect(span.context()._tags).to.include({
+              'error.type': e.name,
+              'error.msg': e.message,
+              'error.stack': e.stack
+            })
+            done()
+          })
+          .catch(done)
       })
     })
   })
 
-  describe('currentSpan', () => {
-    it('should return the current span', done => {
-      tracer.trace('name', current => {
-        expect(tracer.currentSpan()).to.equal(current)
-        done()
-      })
-    })
+  describe('wrap', () => {
+    it('should return a new function that automatically calls tracer.trace()', () => {
+      const it = {}
+      const callback = sinon.spy(function (foo) {
+        expect(tracer.scope().active()).to.not.be.null
+        expect(this).to.equal(it)
+        expect(foo).to.equal('foo')
 
+        return 'test'
+      })
+      const fn = tracer.wrap('name', {}, callback)
+
+      sinon.spy(tracer, 'trace')
+
+      const result = fn.call(it, 'foo')
+
+      expect(callback).to.have.been.called
+      expect(tracer.trace).to.have.been.calledWith('name', {})
+      expect(result).to.equal('test')
+    })
+  })
+
+  describe('currentSpan', () => {
     it('should return a noop span', () => {
       expect(tracer.currentSpan()).to.not.be.null
     })

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -38,6 +38,9 @@ describe('Tracer', () => {
 
     it('should accept options', () => {
       const options = {
+        service: 'service',
+        resource: 'resource',
+        type: 'type',
         tags: {
           foo: 'bar'
         }
@@ -46,6 +49,11 @@ describe('Tracer', () => {
       tracer.trace('name', options, span => {
         expect(span).to.be.instanceof(Span)
         expect(span.context()._tags).to.include(options.tags)
+        expect(span.context()._tags).to.include({
+          'service.name': 'service',
+          'resource.name': 'resource',
+          'span.type': 'type'
+        })
       })
     })
 
@@ -243,12 +251,6 @@ describe('Tracer', () => {
       sinon.spy(tracer, 'trace')
 
       fn(() => {})
-    })
-  })
-
-  describe('currentSpan', () => {
-    it('should return a noop span', () => {
-      expect(tracer.currentSpan()).to.not.be.null
     })
   })
 })


### PR DESCRIPTION
This PR adds a `tracer.trace()` and `tracer.wrap()` as high level APIs to make it easier to do manual instrumentation without having to manage the span and scope lifecycle manually.

For example, the following are equivalent:

##### tracer.trace()

```javascript
tracer.trace('web.request', () => {
  // some code
})
```

```javascript
const childOf = tracer.scope().active()
const span = tracer.startSpan('test', { childOf })

try {
  tracer.scope().activate(span, () => {
    // some code
  })
} catch (e) {
  span.addTags({
    'error.type': e.name,
    'error.msg': e.message,
    'error.stack': e.stack,
  })

  throw e
} finally {
  span.finish()
}
```

##### tracer.wrap()

```javascript
const fn = tracer.wrap('web.request', () => {
  // some code
})
```

```javascript
const childOf = tracer.scope().active()
const span = tracer.startSpan('test', { childOf })

const fn = tracer.scope().bind(() => {
  try {
    // some code
  } catch (e) {
    span.addTags({
      'error.type': e.name,
      'error.msg': e.message,
      'error.stack': e.stack,
    })

    throw e
  } finally {
    span.finish()
  }
}, span)
```

It also allows to wait for a promise to be resolved or a callback to be called before finishing the span, which makes it a lot simpler to manually instrument asynchronous operations.

For example, the following are equivalent for wrapping a function that returns a promise:

```javascript
const fn = tracer.wrap('web.request', () => {
  return new Promise((resolve, reject) => {
    // some code
  })
})
```

```javascript
const childOf = tracer.scope().active()
const span = tracer.startSpan('test', { childOf })

const fn = tracer.scope().bind(() => {
  const promise = new Promise((resolve, reject) => {
    // some code
  })

  promise
    .then(() => span.finish()
    .catch(err => {
      span.addTags({
        'error.type': err.name,
        'error.msg': err.message,
        'error.stack': err.stack,
      })
      span.finish()
    })

  return promise
}, span)
```