### PR TITLE
fix ts definitions files excluded with npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 !ext/**/*
 !lib/**/*
 !src/**/*
+!docs/**/*.d.ts
 !CONTRIBUTING.md
 !LICENSE
 !LICENSE-3rdparty.csv


### PR DESCRIPTION
This PR fixes the new TypeScript definition files being ignored when publishing the package because of the `.npmignore` rules.