### PR TITLE
fix typescript breaking with different opentracing versions

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -1,5 +1,8 @@
 import ddTrace, { tracer, Tracer, TracerOptions, Span, SpanContext, SpanOptions, Scope } from '..';
 import { HTTP_HEADERS } from '../ext/formats';
+import * as opentracing from 'opentracing';
+
+opentracing.initGlobalTracer(tracer);
 
 let span: Span;
 let context: SpanContext;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "methods": "^1.1.2",
     "module-details-from-path": "^1.0.3",
     "msgpack-lite": "^0.1.26",
-    "opentracing": "0.14.1",
+    "opentracing": ">=0.12.1",
     "parent-module": "^0.1.0",
     "path-to-regexp": "^2.2.1",
     "performance-now": "^2.1.0",


### PR DESCRIPTION
This PR fixes the tracer using a different `opentracing-javascript` version that dependent projects. This would cause incompatibilities between the two OT TypeScript definitions in use.

By using a less restrictive semantic version, it ensures we will use the same version as the user. The downside is that there may be breaking changes in OT, but for now we need to bite the bullet until we can find a better strategy.

Fixes #462, #464 