### PR TITLE
fix error in express plugin with capturing groups in routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "msgpack-lite": "^0.1.26",
     "opentracing": ">=0.12.1",
     "parent-module": "^0.1.0",
-    "path-to-regexp": "^2.2.1",
+    "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "read-pkg-up": "^3.0.0",
     "require-in-the-middle": "^2.2.2",

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -757,6 +757,32 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('should support capturing groups in routes', done => {
+          const app = express()
+
+          app.get('/:path(*)', (req, res) => {
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /:path(*)')
+                expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = app.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(done)
+            })
+          })
+        })
       })
 
       describe('with configuration', () => {


### PR DESCRIPTION
This PR fixes an error in the `express` plugin when using capturing groups in routes. It seems to be a regression introduced in `path-to-regexp` 0.2.x which was never fixed to this day. Since `express` uses 0.1.x anyway, we now do the same.

Fixes #466 