### PR TITLE
add support for disabling individual plugins

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -47,9 +47,9 @@ export declare interface Tracer extends opentracing.Tracer {
   /**
    * Enable and optionally configure a plugin.
    * @param plugin The name of a built-in plugin.
-   * @param config Configuration options.
+   * @param config Configuration options. Can also be `false` to disable the plugin.
    */
-  use<P extends keyof Plugins>(plugin: P, config?: Plugins[P]): this;
+  use<P extends keyof Plugins>(plugin: P, config?: Plugins[P] | boolean): this;
 
   /**
    * Returns a reference to the current scope.
@@ -294,6 +294,12 @@ declare namespace plugins {
      * The service name to be used for this plugin.
      */
     service?: string;
+
+    /**
+     * Whether to enable the plugin.
+     * @default true
+     */
+    enabled?: boolean;
   }
 
   /** @hidden */

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -92,6 +92,9 @@ tracer.use('router');
 tracer.use('when');
 tracer.use('winston');
 
+tracer.use('express', false)
+tracer.use('express', { enabled: false })
+
 span = tracer.startSpan('test');
 span = tracer.startSpan('test', {});
 span = tracer.startSpan('test', {

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -22,6 +22,10 @@ class Instrumenter {
   }
 
   use (name, config) {
+    if (typeof config === 'boolean') {
+      config = { enabled: config }
+    }
+
     config = config || {}
 
     try {
@@ -130,7 +134,11 @@ class Instrumenter {
             .filter(instrumentation => moduleName === filename(instrumentation))
             .filter(instrumentation => matchVersion(moduleVersion, instrumentation.versions))
             .forEach(instrumentation => {
-              this._patch(instrumentation, moduleExports, this._plugins.get(plugin).config)
+              const config = this._plugins.get(plugin).config
+
+              if (config.enabled !== false) {
+                this._patch(instrumentation, moduleExports, config)
+              }
             })
         } catch (e) {
           log.error(e)

--- a/test/instrumenter.spec.js
+++ b/test/instrumenter.spec.js
@@ -168,6 +168,22 @@ describe('Instrumenter', () => {
 
         expect(integrations.express.patch).to.have.been.calledOnce
       })
+
+      it('should not patch disabled plugins', () => {
+        instrumenter.use('express-mock', { enabled: false })
+
+        require('express-mock')
+
+        expect(integrations.express.patch).to.not.have.been.called
+      })
+
+      it('should not patch disabled plugins using shorthand', () => {
+        instrumenter.use('express-mock', false)
+
+        require('express-mock')
+
+        expect(integrations.express.patch).to.not.have.been.called
+      })
     })
 
     describe('patch', () => {


### PR DESCRIPTION
This PR adds support for disabling individual plugins. While in general disabling plugins is discourage, it can be useful when debugging an issue.