### PR TITLE
 add support for pg-native

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
   node-postgres:
     <<: *node-plugin-base
     docker:
-      - image: node:6.9
+      - image: node:6
         environment:
           - SERVICES=postgres
           - PLUGINS=pg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,9 @@ jobs:
       - *restore-yarn-cache
       - *yarn-install
       - *save-yarn-cache
+      - run:
+          name: Rebuild native extensions
+          command: npm rebuild
       - *unit-tests
       - *leak-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,9 +298,6 @@ jobs:
       - image: postgres:9.5
     steps:
       - checkout
-      - run:
-          name: Install Postgres
-          command: apt-get install libpq-dev g++ make
       - *versions
       - *restore-yarn-cache
       - *yarn-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,9 +305,6 @@ jobs:
       - *restore-yarn-cache
       - *yarn-install
       - *save-yarn-cache
-      - run:
-          name: Rebuild native extensions
-          command: npm rebuild
       - *unit-tests
       - *leak-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
   node-postgres:
     <<: *node-plugin-base
     docker:
-      - image: node:6
+      - image: node:8
         environment:
           - SERVICES=postgres
           - PLUGINS=pg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,9 +302,9 @@ jobs:
           name: Install Postgres
           command: apt-get install libpq-dev g++ make
       - *versions
-      - *restore-yarn-cache
+      # - *restore-yarn-cache
       - *yarn-install
-      - *save-yarn-cache
+      # - *save-yarn-cache
       - *unit-tests
       - *leak-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
   node-postgres:
     <<: *node-plugin-base
     docker:
-      - image: node:8
+      - image: node:6.9
         environment:
           - SERVICES=postgres
           - PLUGINS=pg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,15 @@ node-plugin-base: &node-plugin-base
   resource_class: small
   steps:
     - checkout
-    - run:
+    - &versions
+      run:
         name: Versions
         command: yarn versions
     - &restore-yarn-cache
       restore_cache:
         key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-    - run:
+    - &yarn-install
+      run:
         name: Install dependencies
         command: yarn install
     - &save-yarn-cache
@@ -51,10 +53,12 @@ node-plugin-base: &node-plugin-base
         paths:
           - ./node_modules
           - ./yarn.lock
-    - run:
+    - &unit-tests
+      run:
         name: Unit tests
         command: yarn test:plugins
-    - run:
+    - &leak-tests
+      run:
         name: Memory leak tests
         command: yarn leak:plugins
 
@@ -290,7 +294,19 @@ jobs:
         environment:
           - SERVICES=postgres
           - PLUGINS=pg
+          - PG_TEST_NATIVE=true
       - image: postgres:9.5
+    steps:
+      - checkout
+      - run:
+          name: Install Postgres
+          command: apt-get install libpq-dev g++ make
+      - *versions
+      - *restore-yarn-cache
+      - *yarn-install
+      - *save-yarn-cache
+      - *unit-tests
+      - *leak-tests
 
   node-q:
     <<: *node-plugin-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,9 +302,9 @@ jobs:
           name: Install Postgres
           command: apt-get install libpq-dev g++ make
       - *versions
-      # - *restore-yarn-cache
+      - *restore-yarn-cache
       - *yarn-install
-      # - *save-yarn-cache
+      - *save-yarn-cache
       - *unit-tests
       - *leak-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,13 @@ node-plugin-base: &node-plugin-base
   resource_class: small
   steps:
     - checkout
-    - &versions
-      run:
+    - run:
         name: Versions
         command: yarn versions
     - &restore-yarn-cache
       restore_cache:
         key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-    - &yarn-install
-      run:
+    - run:
         name: Install dependencies
         command: yarn install
     - &save-yarn-cache
@@ -53,12 +51,10 @@ node-plugin-base: &node-plugin-base
         paths:
           - ./node_modules
           - ./yarn.lock
-    - &unit-tests
-      run:
+    - run:
         name: Unit tests
         command: yarn test:plugins
-    - &leak-tests
-      run:
+    - run:
         name: Memory leak tests
         command: yarn leak:plugins
 
@@ -296,14 +292,6 @@ jobs:
           - PLUGINS=pg
           - PG_TEST_NATIVE=true
       - image: postgres:9.5
-    steps:
-      - checkout
-      - *versions
-      - *restore-yarn-cache
-      - *yarn-install
-      - *save-yarn-cache
-      - *unit-tests
-      - *leak-tests
 
   node-q:
     <<: *node-plugin-base

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -108,7 +108,7 @@ function assertWorkspace () {
 
 function install () {
   exec('yarn', { cwd: folder() })
-  exec('npm rebuild', { cwd: folder() })
+  exec('npm rebuild --scripts-prepend-node-path=true', { cwd: folder() })
 }
 
 function addFolder (name, version) {

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -108,6 +108,7 @@ function assertWorkspace () {
 
 function install () {
   exec('yarn', { cwd: folder() })
+  exec('npm rebuild', { cwd: folder() })
 }
 
 function addFolder (name, version) {

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -108,7 +108,6 @@ function assertWorkspace () {
 
 function install () {
   exec('yarn', { cwd: folder() })
-  exec('npm rebuild --scripts-prepend-node-path=true', { cwd: folder() })
 }
 
 function addFolder (name, version) {

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -4,9 +4,9 @@ const Tags = require('opentracing').Tags
 
 const OPERATION_NAME = 'pg.query'
 
-function patch (pg, tracer, config) {
-  function queryWrap (query) {
-    return function queryTrace () {
+function createWrapQuery (tracer, config) {
+  return function wrapQuery (query) {
+    return function queryWithTrace () {
       const scope = tracer.scope()
       const childOf = scope.active()
       const span = tracer.startSpan(OPERATION_NAME, {
@@ -60,17 +60,27 @@ function patch (pg, tracer, config) {
       return retval
     }
   }
-
-  this.wrap(pg.Client.prototype, 'query', queryWrap)
 }
 
-function unpatch (pg) {
-  this.unwrap(pg.Client.prototype, 'query')
-}
-
-module.exports = {
-  name: 'pg',
-  versions: ['>=4'],
-  patch,
-  unpatch
-}
+module.exports = [
+  {
+    name: 'pg',
+    versions: ['>=4'],
+    patch (pg, tracer, config) {
+      this.wrap(pg.Client.prototype, 'query', createWrapQuery(tracer, config))
+    },
+    unpatch (pg) {
+      this.unwrap(pg.Client.prototype, 'query')
+    }
+  },
+  {
+    name: 'pg-native',
+    versions: ['>=1.7.2'],
+    patch (Client, tracer, config) {
+      this.wrap(Client.prototype, 'query', createWrapQuery(tracer, config))
+    },
+    unpatch (Client) {
+      this.unwrap(Client.prototype, 'query')
+    }
+  }
+]

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -75,7 +75,7 @@ module.exports = [
   },
   {
     name: 'pg-native',
-    versions: ['>=1.7.2'],
+    versions: ['>=2.0.0'],
     patch (Client, tracer, config) {
       this.wrap(Client.prototype, 'query', createWrapQuery(tracer, config))
     },

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -75,7 +75,7 @@ module.exports = [
   },
   {
     name: 'pg-native',
-    versions: ['>=2.0.0'],
+    versions: ['>=1.7.2'],
     patch (Client, tracer, config) {
       this.wrap(Client.prototype, 'query', createWrapQuery(tracer, config))
     },

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -141,7 +141,7 @@ module.exports = {
   // Wipe the require cache.
   wipe () {
     const basedir = path.join(__dirname, '..', '..', 'versions')
-    const exceptions = ['/libpq/']
+    const exceptions = ['/libpq/'] // wiping native modules result in errors
 
     Object.keys(require.cache)
       .filter(name => name.indexOf(basedir) !== -1)

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -121,6 +121,8 @@ module.exports = {
 
   // Stop the mock agent, reset all expectations and wipe the require cache.
   close () {
+    this.wipe()
+
     listener.close()
     listener = null
     agent = null

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -141,7 +141,7 @@ module.exports = {
   // Wipe the require cache.
   wipe () {
     const basedir = path.join(__dirname, '..', '..', 'versions')
-    const exceptions = ['/libpq/'] // wiping native modules result in errors
+    const exceptions = ['/libpq/'] // wiping native modules results in errors
 
     Object.keys(require.cache)
       .filter(name => name.indexOf(basedir) !== -1)

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -120,11 +120,7 @@ module.exports = {
   },
 
   // Stop the mock agent, reset all expectations and wipe the require cache.
-  close (wipe) {
-    if (wipe !== false) {
-      this.wipe()
-    }
-
+  close () {
     listener.close()
     listener = null
     agent = null

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -120,8 +120,10 @@ module.exports = {
   },
 
   // Stop the mock agent, reset all expectations and wipe the require cache.
-  close () {
-    this.wipe()
+  close (wipe) {
+    if (wipe !== false) {
+      this.wipe()
+    }
 
     listener.close()
     listener = null
@@ -141,9 +143,11 @@ module.exports = {
   // Wipe the require cache.
   wipe () {
     const basedir = path.join(__dirname, '..', '..', 'versions')
+    const exceptions = ['/libpq/']
 
     Object.keys(require.cache)
       .filter(name => name.indexOf(basedir) !== -1)
+      .filter(name => [].concat(exceptions).reduce((prev, next) => name.indexOf(next) === -1, true))
       .forEach(name => {
         delete require.cache[name]
       })

--- a/test/plugins/externals.json
+++ b/test/plugins/externals.json
@@ -30,5 +30,11 @@
       "name": "bson",
       "versions": ["4.0.0"]
     }
+  ],
+  "pg": [
+    {
+      "name": "pg-native",
+      "versions": ["3.0.0"]
+    }
   ]
 }

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -11,7 +11,7 @@ const clients = {
 }
 
 if (process.env.PG_TEST_NATIVE === 'true') {
-  clients['pg-native'] = pg => pg.native.Client
+  clients['pg-native'] = Client => Client
 }
 
 describe('Plugin', () => {
@@ -142,7 +142,9 @@ describe('Plugin', () => {
           beforeEach(done => {
             pg = require(`../../versions/${implementation}@${version}`).get()
 
-            client = new pg.Client({
+            const Client = clients[implementation](pg)
+
+            client = new Client({
               user: 'postgres',
               password: 'postgres',
               database: 'postgres'

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -36,7 +36,7 @@ describe('Plugin', () => {
           })
 
           beforeEach(done => {
-            pg = require(`../../versions/pg@${version}`).get()
+            pg = require(`../../versions/${implementation}@${version}`).get()
 
             const Client = clients[implementation](pg)
 
@@ -140,7 +140,7 @@ describe('Plugin', () => {
           })
 
           beforeEach(done => {
-            pg = require(`../../versions/pg@${version}`).get()
+            pg = require(`../../versions/${implementation}@${version}`).get()
 
             client = new pg.Client({
               user: 'postgres',


### PR DESCRIPTION
This PR adds automatic instrumentation for the `pg.native.Client` class additionally to the existing `pg.Client` instrumentation.

Closes #334 