### PR TITLE
feat: add config option for additional request headers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -302,6 +302,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
+| requestHeaders |                             | {}        | Additional headers for requests to the trace agent. |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -113,6 +113,12 @@ export declare interface TracerOptions {
   service?: string;
 
   /**
+   * The url of the trace agent that the tracer will submit to.
+   * Takes priority over hostname and port, if set.
+   */
+  url?: string;
+
+  /**
    * The address of the trace agent that the tracer will submit to.
    * @default 'localhost'
    */

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -167,6 +167,11 @@ export declare interface TracerOptions {
    * Global tags that should be assigned to every span.
    */
   tags?: { [key: string]: any };
+
+  /**
+   * Additional headers for requests to the trace agent.
+   */
+  requestHeaders?: { [key:string]: any  }
 }
 
 /** @hidden */

--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,7 @@ class Config {
     const sampleRate = coalesce(Math.min(Math.max(options.sampleRate, 0), 1), 1)
     const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
     const plugins = coalesce(options.plugins, true)
+    const requestHeaders = coalesce(options.requestHeaders, null)
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
@@ -37,6 +38,7 @@ class Config {
     this.logger = options.logger
     this.plugins = !!plugins
     this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
+    this.requestHeaders = requestHeaders || {}
   }
 }
 

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -29,7 +29,7 @@ class DatadogTracer extends Tracer {
     this._tags = config.tags
     this._logInjection = config.logInjection
     this._prioritySampler = new PrioritySampler(config.env)
-    this._writer = new Writer(this._prioritySampler, config.url, config.bufferSize)
+    this._writer = new Writer(this._prioritySampler, config.url, config.bufferSize, config.requestHeaders)
     this._recorder = new Recorder(this._writer, config.flushInterval)
     this._recorder.init()
     this._sampler = new Sampler(config.sampleRate)

--- a/src/writer.js
+++ b/src/writer.js
@@ -7,11 +7,12 @@ const encode = require('./encode')
 const tracerVersion = require('../lib/version')
 
 class Writer {
-  constructor (prioritySampler, url, size) {
+  constructor (prioritySampler, url, size, requestHeaders) {
     this._queue = []
     this._prioritySampler = prioritySampler
     this._url = url
     this._size = size
+    this._requestHeaders = requestHeaders
   }
 
   get length () {
@@ -61,14 +62,14 @@ class Writer {
       port: this._url.port,
       path: '/v0.4/traces',
       method: 'PUT',
-      headers: {
+      headers: Object.assign({
         'Content-Type': 'application/msgpack',
         'Datadog-Meta-Lang': platform.name(),
         'Datadog-Meta-Lang-Version': platform.version(),
         'Datadog-Meta-Lang-Interpreter': platform.engine(),
         'Datadog-Meta-Tracer-Version': tracerVersion,
         'X-Datadog-Trace-Count': String(count)
-      }
+      }, this._requestHeaders)
     }
 
     log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -29,6 +29,7 @@ describe('Config', () => {
     expect(config).to.have.deep.property('tags', {})
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
+    expect(config).to.have.deep.property('requestHeaders', {})
   })
 
   it('should initialize from the default service', () => {
@@ -79,6 +80,7 @@ describe('Config', () => {
   it('should initialize from the options', () => {
     const logger = {}
     const tags = { foo: 'bar' }
+    const headers = { 'X-Extra-Header': 'header value' }
     const config = new Config({
       enabled: false,
       debug: true,
@@ -90,7 +92,8 @@ describe('Config', () => {
       logger,
       tags,
       flushInterval: 5000,
-      plugins: false
+      plugins: false,
+      requestHeaders: headers
     })
 
     expect(config).to.have.property('enabled', false)
@@ -105,6 +108,7 @@ describe('Config', () => {
     expect(config).to.have.deep.property('tags', tags)
     expect(config).to.have.property('flushInterval', 5000)
     expect(config).to.have.property('plugins', false)
+    expect(config).to.have.deep.property('requestHeaders', headers)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/test/opentracing/tracer.spec.js
+++ b/test/opentracing/tracer.spec.js
@@ -73,7 +73,8 @@ describe('Tracer', () => {
       sampleRate: 0.5,
       logger: 'logger',
       tags: {},
-      debug: false
+      debug: false,
+      requestHeaders: {}
     }
 
     log = {
@@ -99,7 +100,7 @@ describe('Tracer', () => {
     tracer = new Tracer(config)
 
     expect(Writer).to.have.been.called
-    expect(Writer).to.have.been.calledWith(prioritySampler, config.url, config.bufferSize)
+    expect(Writer).to.have.been.calledWith(prioritySampler, config.url, config.bufferSize, config.requestHeaders)
     expect(Recorder).to.have.been.calledWith(writer, config.flushInterval)
     expect(recorder.init).to.have.been.called
   })

--- a/test/writer.spec.js
+++ b/test/writer.spec.js
@@ -69,7 +69,7 @@ describe('Writer', () => {
       './encode': encode,
       '../lib/version': 'tracerVersion'
     })
-    writer = new Writer(prioritySampler, url, 3)
+    writer = new Writer(prioritySampler, url, 3, { 'X-Extra-Header': 'extra-header' })
   })
 
   describe('length', () => {
@@ -157,7 +157,8 @@ describe('Writer', () => {
           'Datadog-Meta-Lang-Version': 'version',
           'Datadog-Meta-Lang-Interpreter': 'interpreter',
           'Datadog-Meta-Tracer-Version': 'tracerVersion',
-          'X-Datadog-Trace-Count': '2'
+          'X-Datadog-Trace-Count': '2',
+          'X-Extra-Header': 'extra-header'
         },
         data: 'prefixed'
       })


### PR DESCRIPTION
We connect to the DataDog agent via Envoy, and we send traffic to Envoy via unix sockets for security reasons. I need to be able to specify the Envoy url as `unix:/path/to/socket` and add an HTTP header like `Host: production.datadog-agent` for Envoy to direct traffic to the correct cluster.

I'm opening this as a draft pull request because I haven't tested it on our production infrastructure yet. I'm definitely open to changes if you'd like me to do this differently!