### PR TITLE
feat: support unix sockets for requests

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -56,9 +56,6 @@ class Writer {
 
   _request (data, count) {
     const options = {
-      protocol: this._url.protocol,
-      hostname: this._url.hostname,
-      port: this._url.port,
       path: '/v0.4/traces',
       method: 'PUT',
       headers: {
@@ -69,6 +66,14 @@ class Writer {
         'Datadog-Meta-Tracer-Version': tracerVersion,
         'X-Datadog-Trace-Count': String(count)
       }
+    }
+
+    if (this._url.protocol === 'unix:') {
+      options.socketPath = this._url.pathname
+    } else {
+      options.protocol = this._url.protocol
+      options.hostname = this._url.hostname
+      options.port = this._url.port
     }
 
     log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)

--- a/test/writer.spec.js
+++ b/test/writer.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const URL = require('url-parse')
+
 describe('Writer', () => {
   let Writer
   let writer
@@ -174,6 +176,22 @@ describe('Writer', () => {
       setTimeout(() => {
         expect(log.error).to.have.been.calledWith(error)
         done()
+      })
+    })
+
+    context('with the url as a unix socket', () => {
+      beforeEach(() => {
+        url = new URL('unix:/path/to/somesocket.sock')
+        writer = new Writer(prioritySampler, url, 3)
+      })
+
+      it('should make a request to the socket', () => {
+        writer.append(span)
+        writer.flush()
+
+        expect(platform.request).to.have.been.calledWithMatch({
+          socketPath: url.pathname
+        })
       })
     })
   })


### PR DESCRIPTION
Hi, me again! I was finally able to test this on our infrastructure. I was getting an error from the http module about "unix:" not being a supported protocol. By using the `socketPath` option instead of protocol/host/port, I could get it to work.