### PR TITLE
update span.addTags() to accept error objects

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -76,9 +76,9 @@ function extractTags (trace, span) {
 }
 
 function extractError (trace, span) {
-  const error = span._error
+  const error = span.context()._tags['error']
 
-  if (error) {
+  if (error instanceof Error) {
     trace.meta['error.msg'] = error.message
     trace.meta['error.type'] = error.name
     trace.meta['error.stack'] = error.stack

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -105,7 +105,7 @@ class DatadogSpan extends Span {
   _addTags (keyValuePairs) {
     try {
       Object.keys(keyValuePairs).forEach(key => {
-        this._spanContext._tags[key] = String(keyValuePairs[key])
+        this._spanContext._tags[key] = keyValuePairs[key]
       })
     } catch (e) {
       log.error(e)

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -97,13 +97,14 @@ describe('format', () => {
     })
 
     it('should extract errors', () => {
-      span._error = new Error('boom')
+      const error = new Error('boom')
 
+      spanContext._tags['error'] = error
       trace = format(span)
 
-      expect(trace.meta['error.msg']).to.equal('boom')
-      expect(trace.meta['error.type']).to.equal('Error')
-      expect(trace.meta['error.stack']).to.equal(span._error.stack)
+      expect(trace.meta['error.msg']).to.equal(error.message)
+      expect(trace.meta['error.type']).to.equal(error.name)
+      expect(trace.meta['error.stack']).to.equal(error.stack)
     })
 
     it('should extract the origin', () => {

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -161,11 +161,11 @@ describe('Span', () => {
       expect(span.context()._tags).to.have.property('foo', 'bar')
     })
 
-    it('should ensure tags are strings', () => {
+    it('should store the original values', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.addTags({ foo: 123 })
 
-      expect(span.context()._tags).to.have.property('foo', '123')
+      expect(span.context()._tags).to.have.property('foo', 123)
     })
 
     it('should handle errors', () => {

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -300,7 +300,7 @@ describe('plugins/util/web', () => {
         res.end()
 
         expect(span.context()._tags).to.include({
-          [ERROR]: 'true'
+          [ERROR]: true
         })
       })
 
@@ -310,7 +310,7 @@ describe('plugins/util/web', () => {
         res.end()
 
         expect(span.context()._tags).to.include({
-          [ERROR]: 'true'
+          [ERROR]: true
         })
       })
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -65,15 +65,15 @@ describe('Tracer', () => {
 
     it('should support analytics', () => {
       tracer.trace('name', { analytics: true }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, '1')
+        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, 1)
       })
 
       tracer.trace('name', { analytics: false }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, '0')
+        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, 0)
       })
 
       tracer.trace('name', { analytics: 0.5 }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, '0.5')
+        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, 0.5)
       })
 
       tracer.trace('name', { analytics: 2 }, span => {


### PR DESCRIPTION
This PR updates `span.addTags()` to accept error objects. This will make it easier to add an error instead of having to set 3 individual tags with the correct values.