### PR TITLE
Add support for Span.setTag('force.keep')

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,5 +4,6 @@ module.exports = {
   SAMPLE_RATE_METRIC_KEY: '_sample_rate',
   SAMPLING_PRIORITY_KEY: '_sampling_priority_v1',
   ANALYTICS_SAMPLE_RATE_KEY: '_dd1.sr.eausr',
-  ORIGIN_KEY: '_dd.origin'
+  ORIGIN_KEY: '_dd.origin',
+  PRIORITY_USER_KEEP: 2
 }

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -9,6 +9,7 @@ const log = require('../log')
 const constants = require('../constants')
 
 const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
+const PRIORITY_USER_KEEP = constants.PRIORITY_USER_KEEP
 
 class DatadogSpan extends Span {
   constructor (tracer, recorder, sampler, prioritySampler, fields) {
@@ -133,6 +134,14 @@ class DatadogSpan extends Span {
       .forEach(child => {
         log.error(`Parent span ${this} was finished before child span ${child}.`)
       })
+  }
+
+  setTag (key, value) {
+    if (key === 'force.keep') {
+      this._spanContext._sampling.priority = PRIORITY_USER_KEEP
+    } else {
+      super.setTag(key, value)
+    }
   }
 }
 

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -153,6 +153,16 @@ describe('Span', () => {
     })
   })
 
+  describe('setTag(\'force.keep\')', () => {
+    it('should set the sampling priority to USER_KEEP', () => {
+      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
+      span.setTag('force.keep')
+
+      expect(span.context()._tags).to.not.have.property('force.keep')
+      expect(span.context()._sampling.priority).to.equal(2)
+    })
+  })
+
   describe('addTags', () => {
     it('should add tags', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })


### PR DESCRIPTION
This PR adds support for `Span.setTag('force.keep')` as an alias for setting the sampling priority on the span context to USER_KEEP.