### PR TITLE
fix wrong latency when the event loop is blocked without computation

### DIFF
--- a/src/native/metrics/EventLoop.cpp
+++ b/src/native/metrics/EventLoop.cpp
@@ -4,10 +4,15 @@ namespace datadog {
   // http://docs.libuv.org/en/v1.x/design.html#the-i-o-loop
   EventLoop::EventLoop() {
     uv_check_init(uv_default_loop(), &check_handle_);
+    uv_prepare_init(uv_default_loop(), &prepare_handle_);
     uv_unref(reinterpret_cast<uv_handle_t*>(&check_handle_));
+    uv_unref(reinterpret_cast<uv_handle_t*>(&prepare_handle_));
 
     check_handle_.data = (void*)this;
-    check_usage_ = usage();
+    prepare_handle_.data = (void*)this;
+
+    check_time_ = uv_hrtime();
+    prepare_time_ = uv_hrtime();
   }
 
   EventLoop::~EventLoop() {
@@ -16,30 +21,27 @@ namespace datadog {
 
   void EventLoop::check_cb (uv_check_t* handle) {
     EventLoop* self = (EventLoop*)handle->data;
-    self->tick();
+    self->check_time_ = uv_hrtime();
   }
 
-  void EventLoop::tick () {
-    uint64_t usage = this->usage();
+  void EventLoop::prepare_cb (uv_prepare_t* handle) {
+    EventLoop* self = (EventLoop*)handle->data;
 
-    histogram_.add(usage - check_usage_);
-    check_usage_ = usage;
+    if (self->check_time_ != 0) {
+      self->histogram_.add(uv_hrtime() - self->check_time_);
+      self->check_time_ = 0;
+    }
   }
 
   void EventLoop::enable() {
     uv_check_start(&check_handle_, &EventLoop::check_cb);
+    uv_prepare_start(&prepare_handle_, &EventLoop::prepare_cb);
   }
 
   void EventLoop::disable() {
     uv_check_stop(&check_handle_);
+    uv_prepare_stop(&prepare_handle_);
     histogram_.reset();
-  }
-
-  uint64_t EventLoop::usage() {
-    uv_rusage_t usage;
-    uv_getrusage(&usage);
-
-    return time_to_micro(usage.ru_utime) + time_to_micro(usage.ru_stime);
   }
 
   void EventLoop::inject(Object carrier) {

--- a/src/native/metrics/EventLoop.hpp
+++ b/src/native/metrics/EventLoop.hpp
@@ -23,6 +23,7 @@ namespace datadog {
       uv_prepare_t prepare_handle_;
       uint64_t check_time_;
       uint64_t prepare_time_;
+      uint64_t timeout_;
       Histogram histogram_;
 
       uint64_t usage();

--- a/src/native/metrics/EventLoop.hpp
+++ b/src/native/metrics/EventLoop.hpp
@@ -14,13 +14,15 @@ namespace datadog {
 
       void enable();
       void disable();
-      void tick();
       void inject(Object carrier);
     protected:
       static void check_cb (uv_check_t* handle);
+      static void prepare_cb (uv_prepare_t* handle);
     private:
       uv_check_t check_handle_;
-      uint64_t check_usage_;
+      uv_prepare_t prepare_handle_;
+      uint64_t check_time_;
+      uint64_t prepare_time_;
       Histogram histogram_;
 
       uint64_t usage();

--- a/src/platform/node/metrics.js
+++ b/src/platform/node/metrics.js
@@ -189,11 +189,11 @@ function captureNativeMetrics () {
   client.gauge('cpu.user', userPercent.toFixed(2))
   client.gauge('cpu.total', totalPercent.toFixed(2))
 
-  client.gauge('event_loop.tick.max', stats.eventLoop.max)
-  client.gauge('event_loop.tick.min', stats.eventLoop.min)
-  client.gauge('event_loop.tick.sum', stats.eventLoop.sum)
-  client.gauge('event_loop.tick.avg', stats.eventLoop.avg)
-  client.gauge('event_loop.tick.count', stats.eventLoop.count)
+  client.gauge('event_loop.latency.max', stats.eventLoop.max)
+  client.gauge('event_loop.latency.min', stats.eventLoop.min)
+  client.gauge('event_loop.latency.sum', stats.eventLoop.sum)
+  client.gauge('event_loop.latency.avg', stats.eventLoop.avg)
+  client.gauge('event_loop.latency.count', stats.eventLoop.count)
 
   Object.keys(stats.gc).forEach(type => {
     client.gauge(`gc.${type}.min`, stats.gc[type].min)

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -424,11 +424,11 @@ describe('Platform', () => {
             expect(client.gauge).to.have.been.calledWith('heap.peak_malloced_memory')
           }
 
-          expect(client.gauge).to.have.been.calledWith('event_loop.tick.max')
-          expect(client.gauge).to.have.been.calledWith('event_loop.tick.min')
-          expect(client.gauge).to.have.been.calledWith('event_loop.tick.sum')
-          expect(client.gauge).to.have.been.calledWith('event_loop.tick.avg')
-          expect(client.gauge).to.have.been.calledWith('event_loop.tick.count')
+          expect(client.gauge).to.have.been.calledWith('event_loop.latency.max')
+          expect(client.gauge).to.have.been.calledWith('event_loop.latency.min')
+          expect(client.gauge).to.have.been.calledWith('event_loop.latency.sum')
+          expect(client.gauge).to.have.been.calledWith('event_loop.latency.avg')
+          expect(client.gauge).to.have.been.calledWith('event_loop.latency.count')
 
           expect(client.gauge).to.have.been.calledWith('gc.all.max')
           expect(client.gauge).to.have.been.calledWith('gc.all.min')


### PR DESCRIPTION
This PR fixes the latency metrics when the event loop is blocked without computation.

In the previous iteration, we were using CPU usage to know that work is happening and blocking the loop, but this is actually incorrect since it's possible to block the loop without doing any computation.

By using `check` and `prepare` handles instead, it's possible to calculate exactly how much time was blocked running application code. The only downside to this approach is that it doesn't account for blocking in any polling callback. To mitigate this, the polling latency is included if it goes beyond the timeout for the current iteration since this means it was not idle and was actually blocking other code from running.

See http://docs.libuv.org/en/v1.x/design.html#the-i-o-loop for an explication of when every handle runs.