### PR TITLE
fix error when batch() is called without a callback

### DIFF
--- a/src/plugins/cassandra-driver.js
+++ b/src/plugins/cassandra-driver.js
@@ -56,7 +56,10 @@ function createWrapBatch (tracer, config) {
 
       return scope.bind(batch, span).call(this, queries, options, function (err) {
         finish(span, err)
-        return callback && callback.apply(this, arguments)
+
+        if (typeof callback === 'function') {
+          return callback.apply(this, arguments)
+        }
       })
     }
   }

--- a/test/plugins/cassandra-driver.spec.js
+++ b/test/plugins/cassandra-driver.spec.js
@@ -81,6 +81,23 @@ describe('Plugin', () => {
           client.batch(queries, { prepare: true }, err => err && done(err))
         })
 
+        it('should support batch queries without a callback', done => {
+          const id = '1234'
+          const queries = [
+            { query: 'INSERT INTO test.test (id) VALUES (?)', params: [id] },
+            `UPDATE test.test SET test='test' WHERE id='${id}';`
+          ]
+
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
+            })
+            .then(done)
+            .catch(done)
+
+          client.batch(queries, { prepare: true })
+        })
+
         it('should handle errors', done => {
           let error
 


### PR DESCRIPTION
This PR fixes an error when `batch()` is called without a callback in the `cassandra-driver` plugin.

Fixes #494 