### PR TITLE
update tests to not wait for services to be started by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=bluebird
 
   node-bunyan:
@@ -163,7 +162,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=bunyan
 
   node-cassandra:
@@ -182,7 +180,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=dns
 
   node-elasticsearch:
@@ -202,7 +199,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=express
 
   node-generic-pool:
@@ -210,7 +206,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=generic-pool
 
   node-graphql:
@@ -218,7 +213,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=graphql
 
   node-hapi:
@@ -226,7 +220,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=hapi
 
   node-http:
@@ -234,7 +227,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=http
 
   node-koa:
@@ -242,7 +234,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=koa
 
   node-memcached:
@@ -283,7 +274,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=net
 
   node-pino:
@@ -291,7 +281,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=pino
 
   node-postgres:
@@ -309,7 +298,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=q
 
   node-redis:
@@ -326,7 +314,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=restify
 
   node-router:
@@ -334,7 +321,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=router
 
   node-when:
@@ -342,7 +328,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=when
 
   node-winston:
@@ -350,7 +335,6 @@ jobs:
     docker:
       - image: node:8
         environment:
-          - SERVICES=
           - PLUGINS=winston
 
   typescript:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . && node scripts/check_licenses.js",
     "services": "node ./scripts/install_plugin_modules && node test/setup/services",
     "tdd": "yarn services && NO_DEPRECATION=* mocha --watch 'test/setup/**/*.js'",
-    "test": "yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit 'test/setup/all.js' 'test/**/*.spec.js'",
+    "test": "SERVICES=* yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit 'test/setup/all.js' 'test/**/*.spec.js'",
     "test:core": "mocha --exit --exclude \"test/plugins/*.spec.js\" --exclude \"test/plugins/http/*.spec.js\" --file test/setup/core.js \"test/**/*.spec.js\"",
     "test:plugins": "yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit --file \"test/setup/all.js\" \"test/plugins/@($(echo $PLUGINS)).spec.js\" \"test/plugins/@($(echo $PLUGINS))/**/*.spec.js\"",
     "leak:core": "node ./scripts/install_plugin_modules && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape 'test/leak/{,!(node_modules|plugins)/**/}/*.js'",

--- a/test/setup/services.js
+++ b/test/setup/services.js
@@ -12,7 +12,9 @@ function waitForServices () {
   let names = fs.readdirSync(path.join(__dirname, 'services'))
     .map(item => item.replace('.js', ''))
 
-  if (process.env.hasOwnProperty('SERVICES')) {
+  if (!process.env.SERVICES) return Promise.resolve()
+
+  if (process.env.SERVICES !== '*') {
     const filter = process.env.SERVICES.split('|')
     names = names.filter(name => ~filter.indexOf(name))
   }


### PR DESCRIPTION
This PR updates tests to not wait for services to be started by default since otherwise the environment variable has to explicitly be set when developing locally.