### PR TITLE
add support to split object tags as a tag for each property

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -120,11 +120,26 @@ function extractMetrics (trace, span) {
   }
 }
 
-function addTag (meta, key, value) {
-  value = serialize(value)
+function addTag (meta, key, value, depth) {
+  depth = depth || 0
 
-  if (typeof value === 'string') {
-    meta[key] = value
+  switch (typeof value) {
+    case 'string':
+      meta[key] = value
+      break
+    case 'undefined':
+      break
+    case 'object':
+      if (value === null) break
+
+      if (!Array.isArray(value) && depth < 2) {
+        Object.keys(value).forEach(prop => {
+          addTag(meta, `${key}.${prop}`, value[prop], depth + 1)
+        })
+        break
+      }
+    default: // eslint-disable-line no-fallthrough
+      addTag(meta, key, serialize(value))
   }
 }
 

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -286,7 +286,7 @@ function startResolveSpan (tracer, config, childOf, path, info, contextValue) {
     'resource.name': `${info.fieldName}:${info.returnType}`,
     'graphql.field.name': info.fieldName,
     'graphql.field.path': path.join('.'),
-    'graphql.field.type': info.returnType
+    'graphql.field.type': info.returnType.name
   })
 
   if (fieldNode) {


### PR DESCRIPTION
This PR adds support to split object tags as a tag for each property instead of simply adding a single tag with a value of `[object Object]`.