### PR TITLE
add metrics for the number of active asynchronous resources

### DIFF
--- a/src/platform/node/metrics.js
+++ b/src/platform/node/metrics.js
@@ -8,6 +8,7 @@ const INTERVAL = 10 * 1000
 
 let nativeMetrics = null
 
+let metrics
 let interval
 let client
 let time
@@ -17,7 +18,7 @@ let counters
 reset()
 
 module.exports = function () {
-  return {
+  return metrics || (metrics = { // cache the metrics instance
     start: () => {
       const StatsD = require('hot-shots')
 
@@ -69,26 +70,18 @@ module.exports = function () {
       reset()
     },
 
-    increment: (name) => {
+    increment: (name, count) => {
       if (!client) return
 
-      if (counters[name] !== undefined) {
-        counters[name]++
-      } else {
-        counters[name] = 1
-      }
+      counters[name] = (counters[name] || 0) + (count || 1)
     },
 
-    decrement: (name) => {
+    decrement: (name, count) => {
       if (!client) return
 
-      if (counters[name] !== undefined) {
-        counters[name]--
-      } else {
-        counters[name] = -1
-      }
+      counters[name] = (counters[name] || 0) - (count || 1)
     }
-  }
+  })
 }
 
 function reset () {

--- a/src/scope/async_hooks/async_wrap.js
+++ b/src/scope/async_hooks/async_wrap.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const asyncWrap = process.binding('async_wrap')
+
 let asyncHook
 
 try {
@@ -12,13 +14,19 @@ try {
 
 const stack = []
 
+const providers = Object.keys(asyncWrap.Providers)
+  .reduce((prev, next) => {
+    prev[asyncWrap.Providers[next]] = next
+    return prev
+  }, {})
+
 module.exports = {
   createHook (callbacks) {
     const hooks = {}
 
     if (callbacks.init) {
       hooks.init = (uid, handle, provider, parentUid, parentHandle) => {
-        callbacks.init(uid)
+        callbacks.init(uid, providers[provider])
       }
     }
 

--- a/src/scope/new/scope.js
+++ b/src/scope/new/scope.js
@@ -8,7 +8,7 @@ const platform = require('../../platform')
 let singleton = null
 
 class Scope extends Base {
-  constructor (debug) {
+  constructor (options) {
     if (singleton) return singleton
 
     super()
@@ -24,7 +24,7 @@ class Scope extends Base {
 
     this._hook.enable()
 
-    if (debug) {
+    if (options && options.debug) {
       this._debug()
     }
   }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -24,7 +24,9 @@ class DatadogTracer extends Tracer {
     }
 
     this._scopeManager = new ScopeManager()
-    this._scope = new Scope(config.debug)
+    this._scope = new Scope({
+      debug: config.debug
+    })
   }
 
   trace (name, options, fn) {

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -24,7 +24,7 @@ class DatadogTracer extends Tracer {
     }
 
     this._scopeManager = new ScopeManager()
-    this._scope = new Scope()
+    this._scope = new Scope(config.debug)
   }
 
   trace (name, options, fn) {

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -454,6 +454,48 @@ describe('Platform', () => {
         })
       })
 
+      describe('increment', () => {
+        it('should increment a counter by the provided count', () => {
+          metrics.apply(platform).start()
+          metrics.apply(platform).increment('test', 1)
+          metrics.apply(platform).increment('test', 2)
+
+          clock.tick(10000)
+
+          expect(client.gauge).to.have.been.calledWith('test', 3)
+        })
+
+        it('should increment a counter by 1 without a count', () => {
+          metrics.apply(platform).start()
+          metrics.apply(platform).increment('test')
+
+          clock.tick(10000)
+
+          expect(client.gauge).to.have.been.calledWith('test', 1)
+        })
+      })
+
+      describe('decrement', () => {
+        it('should increment a counter by the provided count', () => {
+          metrics.apply(platform).start()
+          metrics.apply(platform).decrement('test', 1)
+          metrics.apply(platform).decrement('test', 2)
+
+          clock.tick(10000)
+
+          expect(client.gauge).to.have.been.calledWith('test', -3)
+        })
+
+        it('should increment a counter by 1 without a count', () => {
+          metrics.apply(platform).start()
+          metrics.apply(platform).decrement('test')
+
+          clock.tick(10000)
+
+          expect(client.gauge).to.have.been.calledWith('test', -1)
+        })
+      })
+
       describe('without native metrics', () => {
         beforeEach(() => {
           metrics = proxyquire('../src/platform/node/metrics', {

--- a/test/scope/scope.spec.js
+++ b/test/scope/scope.spec.js
@@ -8,10 +8,31 @@ wrapIt()
 describe('Scope', () => {
   let scope
   let span
+  let platform
+  let metrics
 
   beforeEach(() => {
+    platform = require('../../src/platform')
+    metrics = platform.metrics()
+
+    sinon.spy(metrics, 'increment')
+    sinon.spy(metrics, 'decrement')
+
     scope = new Scope()
     span = new Span()
+  })
+
+  afterEach(() => {
+    metrics.increment.restore()
+    metrics.decrement.restore()
+  })
+
+  it('should keep track of asynchronous resource count', () => {
+    scope._init(0)
+    scope._destroy(0)
+
+    expect(metrics.increment).to.have.been.calledWith('async.resources')
+    expect(metrics.decrement).to.have.been.calledWith('async.resources')
   })
 
   describe('active()', () => {

--- a/test/scope/scope.spec.js
+++ b/test/scope/scope.spec.js
@@ -2,17 +2,16 @@
 
 const Scope = require('../../src/scope/new/scope')
 const Span = require('opentracing').Span
+const platform = require('../../src/platform')
 
 wrapIt()
 
 describe('Scope', () => {
   let scope
   let span
-  let platform
   let metrics
 
   beforeEach(() => {
-    platform = require('../../src/platform')
     metrics = platform.metrics()
 
     sinon.spy(metrics, 'increment')


### PR DESCRIPTION
This PR adds metrics for the number of active asynchronous resources. This will allow the tracer to detect if any Node internal asynchronous resource `destroy` hook is never called, which has been a recurrent problem causing memory leaks. When this happens, `debug` can be set to true on the tracer options to get additional metrics per resource type.