### PR TITLE
add tests for building on alpine and run prebuilds on alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,10 @@ prebuild-linux-base: &prebuild-linux-base
   working_directory: ~/dd-trace-js
   resource_class: small
   steps:
-    - checkout
     - run:
         name: Install job dependencies
         command: apt-get update && apt-get install -y g++-multilib
+    - checkout
     - *yarn-versions
     - *restore-yarn-cache
     - *yarn-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,15 +454,9 @@ jobs:
           name: Install job dependencies
           command: apk add git
       - checkout
-      - run:
-          name: Versions
-          command: yarn versions
+      - *yarn-versions
       - *restore-yarn-cache
-      - run:
-          name: Install dependencies
-          command: yarn install
-          environment:
-            DD_NATIVE_METRICS: "false"
+      - *yarn-install
       - *save-yarn-cache
       - restore_cache:
           key: prebuild-linux-x64-{{ .Environment.CIRCLE_WORKFLOW_ID }}
@@ -474,58 +468,62 @@ workflows:
   version: 2
   build:
     jobs:
-      # - lint
-      # - typescript
-      # - node-leaks
-      # - node-core-4
-      # - node-core-6
-      # - node-core-8
+      - lint
+      - typescript
+      - node-leaks
+      - node-core-4
+      - node-core-6
+      - node-core-8
       - node-core-10
-      # - node-core-latest
-      # - node-amqplib
-      # - node-amqp10
-      # - node-bluebird
-      # - node-bunyan
-      # - node-cassandra
-      # - node-dns
-      # - node-elasticsearch
-      # - node-express
-      # - node-generic-pool
-      # - node-graphql
-      # - node-hapi
-      # - node-http
-      # - node-koa
-      # - node-memcached
-      # - node-mongodb-core
-      # - node-mysql
-      # - node-net
-      # - node-pino
-      # - node-postgres
-      # - node-q
-      # - node-redis
-      # - node-restify
-      # - node-when
-      # - node-winston
+      - node-core-latest
+      - node-amqplib
+      - node-amqp10
+      - node-bluebird
+      - node-bunyan
+      - node-cassandra
+      - node-dns
+      - node-elasticsearch
+      - node-express
+      - node-generic-pool
+      - node-graphql
+      - node-hapi
+      - node-http
+      - node-koa
+      - node-memcached
+      - node-mongodb-core
+      - node-mysql
+      - node-net
+      - node-pino
+      - node-postgres
+      - node-q
+      - node-redis
+      - node-restify
+      - node-when
+      - node-winston
       - prebuild-linux-x64:
-          filters: &prebuild-filter
+          filters:
             branches:
               only:
                 - master
                 - /v\d+\.\d+\.\d+/
       - prebuild-linux-x32:
-          <<: *prebuild-filter
-      # - prebuild-darwin-x64:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #           - /v\d+\.\d+\.\d+/
-      # - prebuild-darwin-x32:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #           - /v\d+\.\d+\.\d+/
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+\.\d+/
+      - prebuild-darwin-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+\.\d+/
+      - prebuild-darwin-x32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+\.\d+/
       - alpine
       - alpine-prebuilt:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,15 @@ node-core-base: &node-core-base
   resource_class: small
   steps:
     - checkout
-    - run:
+    - &yarn-versions
+      run:
         name: Versions
         command: yarn versions
     - &restore-yarn-cache
       restore_cache:
         key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-    - run:
+    - &yarn-install
+      run:
         name: Install dependencies
         command: yarn install --ignore-engines
         environment:
@@ -27,7 +29,8 @@ node-core-base: &node-core-base
     - run:
         name: Compile native code
         command: yarn rebuild
-    - run:
+    - &yarn-test-core
+      run:
         name: Unit tests
         command: yarn test:core
     - run:
@@ -75,18 +78,13 @@ prebuild-linux-base: &prebuild-linux-base
     - run:
         name: Install job dependencies
         command: apt-get update && apt-get install -y g++-multilib
-    - run:
-        name: Versions
-        command: yarn versions
+    - *yarn-versions
     - *restore-yarn-cache
-    - run:
-        name: Install dependencies
-        command: yarn install
-        environment:
-          DD_NATIVE_METRICS: "false"
+    - *yarn-install
     - *save-yarn-cache
-    - run:
-        name: Compile prebuild binaries
+    - &yarn-prebuild
+      run:
+        name: Compile prebuilt binaries
         command: yarn prebuild
     - store_artifacts:
         path: ./prebuilds
@@ -102,26 +100,11 @@ prebuild-darwin-base: &prebuild-darwin-base
   resource_class: small
   steps:
     - checkout
-    - run:
-        name: Versions
-        command: yarn versions
-    - &restore-yarn-cache
-      restore_cache:
-        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-    - run:
-        name: Install dependencies
-        command: yarn install
-        environment:
-          DD_NATIVE_METRICS: "false"
-    - &save-yarn-cache
-      save_cache:
-        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-        paths:
-          - ./node_modules
-          - ./yarn.lock
-    - run:
-        name: Compile prebuilt binaries
-        command: yarn prebuild
+    - *yarn-versions
+    - *restore-yarn-cache
+    - *yarn-install
+    - *save-yarn-cache
+    - *yarn-prebuild
     - store_artifacts:
         path: ./prebuilds
 
@@ -411,21 +394,10 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - run:
-          name: Versions
-          command: yarn versions
-      - &restore-yarn-cache
-        restore_cache:
-          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-      - run:
-          name: Install dependencies
-          command: yarn install
-      - &save-yarn-cache
-        save_cache:
-          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
-            - ./yarn.lock
+      - *yarn-versions
+      - *restore-yarn-cache
+      - *yarn-install
+      - *save-yarn-cache
       - run:
           name: Test API documentation
           command: yarn type:test
@@ -465,22 +437,12 @@ jobs:
           name: Install job dependencies
           command: apk add g++ git make python
       - checkout
-      - run:
-          name: Versions
-          command: yarn versions
+      - *yarn-versions
       - *restore-yarn-cache
-      - run:
-          name: Install dependencies
-          command: yarn install
-          environment:
-            DD_NATIVE_METRICS: "false"
+      - *yarn-install
       - *save-yarn-cache
-      - run:
-          name: Compile prebuild binaries
-          command: yarn prebuild
-      - run:
-          name: Unit tests
-          command: yarn test:core
+      - *yarn-prebuild
+      - *yarn-test-core
 
   alpine-prebuilt:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ prebuild-linux-base: &prebuild-linux-base
     - store_artifacts:
         path: ./prebuilds
     - save_cache:
-        key: prebuilds-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+        key: prebuilds-{{ arch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
         paths:
           - ./prebuilds
 
@@ -488,7 +488,7 @@ jobs:
           environment:
             DD_NATIVE_METRICS: "false"
       - restore_cache:
-          key: prebuilds-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: prebuilds-{{ arch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - run:
           name: Unit tests
           command: yarn test:core
@@ -534,7 +534,9 @@ workflows:
       - prebuild-darwin-x64
       - prebuild-darwin-x32
       - alpine
-      - alpine-prebuilt
+      - alpine-prebuilt:
+          requires:
+            - prebuild-linux-x64
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ prebuild-linux-base: &prebuild-linux-base
     - store_artifacts:
         path: ./prebuilds
     - save_cache:
-        key: prebuilds-{{ arch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+        key: {{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
         paths:
           - ./prebuilds
 
@@ -462,7 +462,7 @@ jobs:
     environment:
       - ARCH=x32
 
-  alpine:
+  alpine-build:
     docker:
       - image: node:10-alpine
     working_directory: ~/dd-trace-js
@@ -475,11 +475,20 @@ jobs:
       - run:
           name: Versions
           command: yarn versions
+      - &restore-yarn-cache
+        restore_cache:
+          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
       - run:
           name: Install dependencies
           command: yarn install
           environment:
             DD_NATIVE_METRICS: "false"
+      - &save-yarn-cache
+        save_cache:
+          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+            - ./yarn.lock
       - run:
           name: Compile prebuild binaries
           command: yarn prebuild
@@ -506,7 +515,7 @@ jobs:
           environment:
             DD_NATIVE_METRICS: "false"
       - restore_cache:
-          key: prebuilds-{{ arch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: prebuild-linux-x64-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - run:
           name: Check prebuilds
           command: ls prebuilds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ prebuild-linux-base: &prebuild-linux-base
   steps:
     - checkout
     - run:
-        name: Install compilation dependencies
+        name: Install job dependencies
         command: apt-get update && apt-get install -y g++-multilib
     - run:
         name: Versions
@@ -88,6 +88,10 @@ prebuild-linux-base: &prebuild-linux-base
         command: yarn prebuild
     - store_artifacts:
         path: ./prebuilds
+    - save_cache:
+        key: prebuilds-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+        paths:
+          - ./prebuilds
 
 prebuild-darwin-base: &prebuild-darwin-base
   macos:
@@ -440,6 +444,55 @@ jobs:
     environment:
       - ARCH=x32
 
+  alpine:
+    docker:
+      - image: node:10-alpine
+    working_directory: ~/dd-trace-js
+    resource_class: small
+    steps:
+      - run:
+          name: Install job dependencies
+          command: apk add g++ git make python
+      - checkout
+      - run:
+          name: Versions
+          command: yarn versions
+      - run:
+          name: Install dependencies
+          command: yarn install
+          environment:
+            DD_NATIVE_METRICS: "false"
+      - run:
+          name: Compile prebuild binaries
+          command: yarn prebuild
+      - run:
+          name: Unit tests
+          command: yarn test:core
+
+  alpine-prebuilt:
+    docker:
+      - image: node:10-alpine
+    working_directory: ~/dd-trace-js
+    resource_class: small
+    steps:
+      - run:
+          name: Install job dependencies
+          command: apk add git
+      - checkout
+      - run:
+          name: Versions
+          command: yarn versions
+      - run:
+          name: Install dependencies
+          command: yarn install
+          environment:
+            DD_NATIVE_METRICS: "false"
+      - restore_cache:
+          key: prebuilds-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+      - run:
+          name: Unit tests
+          command: yarn test:core
+
 workflows:
   version: 2
   build:
@@ -480,6 +533,8 @@ workflows:
       - prebuild-linux-x32
       - prebuild-darwin-x64
       - prebuild-darwin-x32
+      - alpine
+      - alpine-prebuilt
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,10 +506,26 @@ workflows:
       # - node-restify
       # - node-when
       # - node-winston
-      - prebuild-linux-x64
-      # - prebuild-linux-x32
-      # - prebuild-darwin-x64
-      # - prebuild-darwin-x32
+      - prebuild-linux-x64:
+          filters: &prebuild-filter
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+\.\d+/
+      - prebuild-linux-x32:
+          <<: *prebuild-filter
+      # - prebuild-darwin-x64:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #           - /v\d+\.\d+\.\d+/
+      # - prebuild-darwin-x32:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #           - /v\d+\.\d+\.\d+/
       - alpine
       - alpine-prebuilt:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,20 +78,13 @@ prebuild-linux-base: &prebuild-linux-base
     - run:
         name: Versions
         command: yarn versions
-    - &restore-yarn-cache
-      restore_cache:
-        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+    - *restore-yarn-cache
     - run:
         name: Install dependencies
         command: yarn install
         environment:
           DD_NATIVE_METRICS: "false"
-    - &save-yarn-cache
-      save_cache:
-        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-        paths:
-          - ./node_modules
-          - ./yarn.lock
+    - *save-yarn-cache
     - run:
         name: Compile prebuild binaries
         command: yarn prebuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ prebuild-linux-base: &prebuild-linux-base
     - store_artifacts:
         path: ./prebuilds
     - save_cache:
-        key: {{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+        key: '{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
         paths:
           - ./prebuilds
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ jobs:
     environment:
       - ARCH=x32
 
-  alpine-build:
+  alpine:
     docker:
       - image: node:10-alpine
     working_directory: ~/dd-trace-js
@@ -475,20 +475,13 @@ jobs:
       - run:
           name: Versions
           command: yarn versions
-      - &restore-yarn-cache
-        restore_cache:
-          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+      - *restore-yarn-cache
       - run:
           name: Install dependencies
           command: yarn install
           environment:
             DD_NATIVE_METRICS: "false"
-      - &save-yarn-cache
-        save_cache:
-          key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
-            - ./yarn.lock
+      - *save-yarn-cache
       - run:
           name: Compile prebuild binaries
           command: yarn prebuild
@@ -509,16 +502,15 @@ jobs:
       - run:
           name: Versions
           command: yarn versions
+      - *restore-yarn-cache
       - run:
           name: Install dependencies
           command: yarn install
           environment:
             DD_NATIVE_METRICS: "false"
+      - *save-yarn-cache
       - restore_cache:
           key: prebuild-linux-x64-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-      - run:
-          name: Check prebuilds
-          command: ls prebuilds
       - run:
           name: Unit tests
           command: yarn test:core
@@ -533,7 +525,7 @@ workflows:
       # - node-core-4
       # - node-core-6
       # - node-core-8
-      # - node-core-10
+      - node-core-10
       # - node-core-latest
       # - node-amqplib
       # - node-amqp10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,20 @@ prebuild-linux-base: &prebuild-linux-base
     - run:
         name: Versions
         command: yarn versions
+    - &restore-yarn-cache
+      restore_cache:
+        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
     - run:
         name: Install dependencies
         command: yarn install
         environment:
           DD_NATIVE_METRICS: "false"
+    - &save-yarn-cache
+      save_cache:
+        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+        paths:
+          - ./node_modules
+          - ./yarn.lock
     - run:
         name: Compile prebuild binaries
         command: yarn prebuild
@@ -103,11 +112,20 @@ prebuild-darwin-base: &prebuild-darwin-base
     - run:
         name: Versions
         command: yarn versions
+    - &restore-yarn-cache
+      restore_cache:
+        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
     - run:
         name: Install dependencies
         command: yarn install
         environment:
           DD_NATIVE_METRICS: "false"
+    - &save-yarn-cache
+      save_cache:
+        key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+        paths:
+          - ./node_modules
+          - ./yarn.lock
     - run:
         name: Compile prebuilt binaries
         command: yarn prebuild
@@ -490,6 +508,9 @@ jobs:
       - restore_cache:
           key: prebuilds-{{ arch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - run:
+          name: Check prebuilds
+          command: ls prebuilds
+      - run:
           name: Unit tests
           command: yarn test:core
 
@@ -497,42 +518,42 @@ workflows:
   version: 2
   build:
     jobs:
-      - lint
-      - typescript
-      - node-leaks
-      - node-core-4
-      - node-core-6
-      - node-core-8
-      - node-core-10
-      - node-core-latest
-      - node-amqplib
-      - node-amqp10
-      - node-bluebird
-      - node-bunyan
-      - node-cassandra
-      - node-dns
-      - node-elasticsearch
-      - node-express
-      - node-generic-pool
-      - node-graphql
-      - node-hapi
-      - node-http
-      - node-koa
-      - node-memcached
-      - node-mongodb-core
-      - node-mysql
-      - node-net
-      - node-pino
-      - node-postgres
-      - node-q
-      - node-redis
-      - node-restify
-      - node-when
-      - node-winston
+      # - lint
+      # - typescript
+      # - node-leaks
+      # - node-core-4
+      # - node-core-6
+      # - node-core-8
+      # - node-core-10
+      # - node-core-latest
+      # - node-amqplib
+      # - node-amqp10
+      # - node-bluebird
+      # - node-bunyan
+      # - node-cassandra
+      # - node-dns
+      # - node-elasticsearch
+      # - node-express
+      # - node-generic-pool
+      # - node-graphql
+      # - node-hapi
+      # - node-http
+      # - node-koa
+      # - node-memcached
+      # - node-mongodb-core
+      # - node-mysql
+      # - node-net
+      # - node-pino
+      # - node-postgres
+      # - node-q
+      # - node-redis
+      # - node-restify
+      # - node-when
+      # - node-winston
       - prebuild-linux-x64
-      - prebuild-linux-x32
-      - prebuild-darwin-x64
-      - prebuild-darwin-x32
+      # - prebuild-linux-x32
+      # - prebuild-darwin-x64
+      # - prebuild-darwin-x32
       - alpine
       - alpine-prebuilt:
           requires:

--- a/src/platform/node/metrics.js
+++ b/src/platform/node/metrics.js
@@ -25,7 +25,6 @@ module.exports = function () {
         nativeMetrics = require('node-gyp-build')(path.join(__dirname, '..', '..', '..'))
         nativeMetrics.start()
       } catch (e) {
-        console.log(e) // eslint-disable-line no-console
         log.error('Unable to load native metrics module. Some metrics will not be available.')
       }
 

--- a/src/platform/node/metrics.js
+++ b/src/platform/node/metrics.js
@@ -25,6 +25,7 @@ module.exports = function () {
         nativeMetrics = require('node-gyp-build')(path.join(__dirname, '..', '..', '..'))
         nativeMetrics.start()
       } catch (e) {
+        console.log(e) // eslint-disable-line no-console
         log.error('Unable to load native metrics module. Some metrics will not be available.')
       }
 


### PR DESCRIPTION
This PR adds tests to ensure that it's possible to build native addons on alpine, and also that the prebuilt binaries are compatible with alpine as well. Since the CircleCI config was starting to get a bit too verbose, I've also refactored commands that are used in multiple places to use anchors.