### PR TITLE
fix analytics config tag and possible values

### DIFF
--- a/ext/tags.js
+++ b/ext/tags.js
@@ -7,7 +7,7 @@ module.exports = {
   SPAN_TYPE: 'span.type',
   SPAN_KIND: 'span.kind',
   SAMPLING_PRIORITY: 'sampling.priority',
-  ANALYTICS_SAMPLE_RATE: '_dd1.sr.eausr',
+  ANALYTICS: '_dd1.sr.eausr',
   ERROR: 'error',
 
   // HTTP

--- a/ext/types.js
+++ b/ext/types.js
@@ -4,5 +4,3 @@ module.exports = {
   HTTP: 'http',
   WEB: 'web'
 }
-
-const tags = require('./tags')

--- a/ext/types.js
+++ b/ext/types.js
@@ -4,3 +4,5 @@ module.exports = {
   HTTP: 'http',
   WEB: 'web'
 }
+
+const tags = require('./tags')

--- a/src/analytics_sampler.js
+++ b/src/analytics_sampler.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ANALYTICS_SAMPLE_RATE = require('../ext/tags').ANALYTICS_SAMPLE_RATE
+const ANALYTICS = require('../ext/tags').ANALYTICS
 
 module.exports = {
   sample (span, config, useDefault) {
@@ -8,9 +8,9 @@ module.exports = {
 
     if (useDefault) {
       if (config.sampleRate === undefined) {
-        span.setTag(ANALYTICS_SAMPLE_RATE, 1)
+        span.setTag(ANALYTICS, 1)
       } else if (config.sampleRate >= 0 && config.sampleRate <= 1) {
-        span.setTag(ANALYTICS_SAMPLE_RATE, config.sampleRate)
+        span.setTag(ANALYTICS, config.sampleRate)
       }
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,6 @@
 module.exports = {
   SAMPLE_RATE_METRIC_KEY: '_sample_rate',
   SAMPLING_PRIORITY_KEY: '_sampling_priority_v1',
-  ANALYTICS_SAMPLE_RATE_KEY: '_dd1.sr.eausr',
+  ANALYTICS_KEY: '_dd1.sr.eausr',
   ORIGIN_KEY: '_dd.origin'
 }

--- a/src/format.js
+++ b/src/format.js
@@ -6,8 +6,8 @@ const tags = require('../ext/tags')
 const log = require('./log')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
-const ANALYTICS_SAMPLE_RATE_KEY = constants.ANALYTICS_SAMPLE_RATE_KEY
-const ANALYTICS_SAMPLE_RATE = tags.ANALYTICS_SAMPLE_RATE
+const ANALYTICS_KEY = constants.ANALYTICS_KEY
+const ANALYTICS = tags.ANALYTICS
 const ORIGIN_KEY = constants.ORIGIN_KEY
 
 const map = {
@@ -54,7 +54,7 @@ function extractTags (trace, span) {
       case 'resource.name':
         addTag(trace, map[tag], tags[tag])
         break
-      case ANALYTICS_SAMPLE_RATE:
+      case ANALYTICS:
         break
       case 'error':
         if (tags[tag]) {
@@ -87,7 +87,7 @@ function extractError (trace, span) {
 
 function extractMetrics (trace, span) {
   const spanContext = span.context()
-  const analyticsSampleRate = parseFloat(spanContext._tags[ANALYTICS_SAMPLE_RATE])
+  const analytics = spanContext._tags[ANALYTICS]
 
   Object.keys(spanContext._metrics).forEach(metric => {
     if (typeof spanContext._metrics[metric] === 'number') {
@@ -99,8 +99,15 @@ function extractMetrics (trace, span) {
     trace.metrics[SAMPLING_PRIORITY_KEY] = spanContext._sampling.priority
   }
 
-  if (analyticsSampleRate >= 0 && analyticsSampleRate <= 1) {
-    trace.metrics[ANALYTICS_SAMPLE_RATE_KEY] = analyticsSampleRate
+  switch (typeof analytics) {
+    case 'number':
+      if (!isNaN(analytics)) {
+        trace.metrics[ANALYTICS_KEY] = Math.max(Math.min(analytics, 1), 0)
+      }
+      break
+    case 'boolean':
+      trace.metrics[ANALYTICS_KEY] = analytics ? 1 : 0
+      break
   }
 }
 

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -105,7 +105,7 @@ class DatadogSpan extends Span {
   _addTags (keyValuePairs) {
     try {
       Object.keys(keyValuePairs).forEach(key => {
-        this._spanContext._tags[key] = String(keyValuePairs[key])
+        this._spanContext._tags[key] = keyValuePairs[key]
       })
     } catch (e) {
       log.error(e)

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -6,7 +6,7 @@ const tags = require('../ext/tags')
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
-const ANALYTICS_SAMPLE_RATE = tags.ANALYTICS_SAMPLE_RATE
+const ANALYTICS = tags.ANALYTICS
 
 class DatadogTracer extends Tracer {
   constructor (config) {
@@ -117,11 +117,7 @@ function addTags (span, options) {
   if (options.service) tags[SERVICE_NAME] = options.service
   if (options.resource) tags[RESOURCE_NAME] = options.resource
 
-  if (typeof options.analytics === 'number' && options.analytics >= 0 && options.analytics <= 1) {
-    tags[ANALYTICS_SAMPLE_RATE] = options.analytics
-  } else if (typeof options.analytics === 'boolean') {
-    tags[ANALYTICS_SAMPLE_RATE] = options.analytics ? 1 : 0
-  }
+  tags[ANALYTICS] = options.analytics
 
   span.addTags(tags)
 }

--- a/test/analytics_sampler.spec.js
+++ b/test/analytics_sampler.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ANALYTICS_SAMPLE_RATE = require('../ext/tags').ANALYTICS_SAMPLE_RATE
+const ANALYTICS = require('../ext/tags').ANALYTICS
 
 describe('analyticsSampler', () => {
   let sampler
@@ -22,7 +22,7 @@ describe('analyticsSampler', () => {
         enabled: true
       }, true)
 
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS_SAMPLE_RATE, 1)
+      expect(span.setTag).to.have.been.calledWith(ANALYTICS, 1)
     })
 
     it('should sample a span with the provided rate', () => {
@@ -31,7 +31,7 @@ describe('analyticsSampler', () => {
         sampleRate: 0.5
       }, true)
 
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS_SAMPLE_RATE, 0.5)
+      expect(span.setTag).to.have.been.calledWith(ANALYTICS, 0.5)
     })
 
     it('should sample only when enabled', () => {
@@ -59,7 +59,7 @@ describe('analyticsSampler', () => {
         }
       })
 
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS_SAMPLE_RATE, 0.5)
+      expect(span.setTag).to.have.been.calledWith(ANALYTICS, 0.5)
     })
 
     it('should ignore invalid values', () => {

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -5,8 +5,8 @@ const constants = require('../src/constants')
 const tags = require('../ext/tags')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
-const ANALYTICS_SAMPLE_RATE_KEY = constants.ANALYTICS_SAMPLE_RATE_KEY
-const ANALYTICS_SAMPLE_RATE = tags.ANALYTICS_SAMPLE_RATE
+const ANALYTICS_KEY = constants.ANALYTICS_KEY
+const ANALYTICS = tags.ANALYTICS
 const ORIGIN_KEY = constants.ORIGIN_KEY
 
 const id = new Int64BE(0x02345678, 0x12345678)
@@ -194,9 +194,33 @@ describe('format', () => {
     })
 
     it('should include the analytics sample rate', () => {
-      spanContext._tags[ANALYTICS_SAMPLE_RATE] = '0.5'
+      spanContext._tags[ANALYTICS] = 0.5
       trace = format(span)
-      expect(trace.metrics[ANALYTICS_SAMPLE_RATE_KEY]).to.equal(0.5)
+      expect(trace.metrics[ANALYTICS_KEY]).to.equal(0.5)
+    })
+
+    it('should limit the min analytics sample rate', () => {
+      spanContext._tags[ANALYTICS] = -1
+      trace = format(span)
+      expect(trace.metrics[ANALYTICS_KEY]).to.equal(0)
+    })
+
+    it('should limit the max analytics sample rate', () => {
+      spanContext._tags[ANALYTICS] = 2
+      trace = format(span)
+      expect(trace.metrics[ANALYTICS_KEY]).to.equal(1)
+    })
+
+    it('should accept boolean true for analytics', () => {
+      spanContext._tags[ANALYTICS] = true
+      trace = format(span)
+      expect(trace.metrics[ANALYTICS_KEY]).to.equal(1)
+    })
+
+    it('should accept boolean false for analytics', () => {
+      spanContext._tags[ANALYTICS] = false
+      trace = format(span)
+      expect(trace.metrics[ANALYTICS_KEY]).to.equal(0)
     })
   })
 })

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -161,13 +161,6 @@ describe('Span', () => {
       expect(span.context()._tags).to.have.property('foo', 'bar')
     })
 
-    it('should ensure tags are strings', () => {
-      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
-      span.addTags({ foo: 123 })
-
-      expect(span.context()._tags).to.have.property('foo', '123')
-    })
-
     it('should handle errors', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
 

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -300,7 +300,7 @@ describe('plugins/util/web', () => {
         res.end()
 
         expect(span.context()._tags).to.include({
-          [ERROR]: 'true'
+          [ERROR]: true
         })
       })
 
@@ -310,7 +310,7 @@ describe('plugins/util/web', () => {
         res.end()
 
         expect(span.context()._tags).to.include({
-          [ERROR]: 'true'
+          [ERROR]: true
         })
       })
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -64,20 +64,8 @@ describe('Tracer', () => {
     })
 
     it('should support analytics', () => {
-      tracer.trace('name', { analytics: true }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS, 1)
-      })
-
-      tracer.trace('name', { analytics: false }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS, 0)
-      })
-
       tracer.trace('name', { analytics: 0.5 }, span => {
         expect(span.context()._tags).to.have.property(ANALYTICS, 0.5)
-      })
-
-      tracer.trace('name', { analytics: 2 }, span => {
-        expect(span.context()._tags).to.not.have.property(ANALYTICS)
       })
     })
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -7,7 +7,7 @@ const tags = require('../ext/tags')
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
-const ANALYTICS_SAMPLE_RATE = tags.ANALYTICS_SAMPLE_RATE
+const ANALYTICS = tags.ANALYTICS
 
 wrapIt()
 
@@ -65,19 +65,19 @@ describe('Tracer', () => {
 
     it('should support analytics', () => {
       tracer.trace('name', { analytics: true }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, '1')
+        expect(span.context()._tags).to.have.property(ANALYTICS, 1)
       })
 
       tracer.trace('name', { analytics: false }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, '0')
+        expect(span.context()._tags).to.have.property(ANALYTICS, 0)
       })
 
       tracer.trace('name', { analytics: 0.5 }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS_SAMPLE_RATE, '0.5')
+        expect(span.context()._tags).to.have.property(ANALYTICS, 0.5)
       })
 
       tracer.trace('name', { analytics: 2 }, span => {
-        expect(span.context()._tags).to.not.have.property(ANALYTICS_SAMPLE_RATE)
+        expect(span.context()._tags).to.not.have.property(ANALYTICS)
       })
     })
 


### PR DESCRIPTION
This PR fixes trace analytics client configuration that was not working according to the specification/documentation.