### PR TITLE
add backward compatibility for trace analytics client config

### DIFF
--- a/ext/tags.js
+++ b/ext/tags.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = {
+const tags = {
   // Common
   SERVICE_NAME: 'service.name',
   RESOURCE_NAME: 'resource.name',
@@ -18,3 +18,8 @@ module.exports = {
   HTTP_REQUEST_HEADERS: 'http.request.headers',
   HTTP_RESPONSE_HEADERS: 'http.response.headers'
 }
+
+// Deprecated
+tags.ANALYTICS_SAMPLE_RATE = tags.ANALYTICS
+
+module.exports = tags

--- a/src/format.js
+++ b/src/format.js
@@ -87,7 +87,8 @@ function extractError (trace, span) {
 
 function extractMetrics (trace, span) {
   const spanContext = span.context()
-  const analytics = spanContext._tags[ANALYTICS]
+
+  let analytics = spanContext._tags[ANALYTICS]
 
   Object.keys(spanContext._metrics).forEach(metric => {
     if (typeof spanContext._metrics[metric] === 'number') {
@@ -100,7 +101,9 @@ function extractMetrics (trace, span) {
   }
 
   switch (typeof analytics) {
-    case 'number':
+    case 'string':
+      analytics = parseFloat(analytics)
+    case 'number': // eslint-disable-line no-fallthrough
       if (!isNaN(analytics)) {
         trace.metrics[ANALYTICS_KEY] = Math.max(Math.min(analytics, 1), 0)
       }

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -222,5 +222,11 @@ describe('format', () => {
       trace = format(span)
       expect(trace.metrics[ANALYTICS_KEY]).to.equal(0)
     })
+
+    it('should accept strings for analytics', () => {
+      spanContext._tags[ANALYTICS] = '0.5'
+      trace = format(span)
+      expect(trace.metrics[ANALYTICS_KEY]).to.equal(0.5)
+    })
   })
 })


### PR DESCRIPTION
This PR adds backward compatibility for trace analytics client configuration so that we can release this as a patch with no breaking changes.