### PR TITLE
update runtime metrics for beta release

### DIFF
--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -18,7 +18,7 @@ const Writer = proxyquire('../src/writer', {
 const Sampler = require('../src/sampler')
 const format = require('../src/format')
 const encode = require('../src/encode')
-const config = new Config('benchmark', '', { service: 'benchmark' })
+const config = new Config('benchmark', { service: 'benchmark' })
 
 const suite = benchmark('core')
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -287,21 +287,22 @@ tracer.use('pg', {
 
 Options can be configured as a parameter to the [init()](https://datadog.github.io/dd-trace-js/Tracer.html#init__anchor) method or as environment variables.
 
-| Config        | Environment Variable         | Default   | Description |
-| ------------- | ---------------------------- | --------- | ----------- |
-| enabled       | DD_TRACE_ENABLED             | true      | Whether to enable the tracer. |
-| debug         | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
-| service       | DD_SERVICE_NAME              |           | The service name to be used for this program. |
-| url           | DD_TRACE_AGENT_URL           |           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
-| hostname      | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the trace agent that the tracer will submit to. |
-| port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
-| env           | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
-| logInjection  | DD_LOGS_INJECTION            | false     | Enable automatic injection of trace IDs in logs for supported logging libraries.
-| tags          |                              | {}        | Set global tags that should be applied to all spans. |
-| sampleRate    |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
-| flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
-| experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
-| plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
+| Config         | Environment Variable         | Default   | Description |
+| -------------- | ---------------------------- | --------- | ----------- |
+| enabled        | DD_TRACE_ENABLED             | true      | Whether to enable the tracer. |
+| debug          | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
+| service        | DD_SERVICE_NAME              |           | The service name to be used for this program. |
+| url            | DD_TRACE_AGENT_URL           |           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
+| hostname       | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the agent that the tracer will submit to. |
+| port           | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
+| dogstatsd.port | DD_DOGSTATSD_PORT            | 8125      | The port of the Dogstatsd agent that metrics will be submitted to. |
+| env            | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
+| logInjection   | DD_LOGS_INJECTION            | false     | Enable automatic injection of trace IDs in logs for supported logging libraries.
+| tags           |                              | {}        | Set global tags that should be applied to all spans. |
+| sampleRate     |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
+| flushInterval  |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
+| experimental   |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Available experimental features: `runtimeMetrics`. |
+| plugins        |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -27,6 +27,9 @@ tracer.init({
   },
   plugins: false,
   port: 7777,
+  dogstatsd: {
+    port: 8888
+  },
   sampleRate: 0.1,
   service: 'test',
   tags: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,6 +203,17 @@ export declare interface TracerOptions {
   port?: number | string;
 
   /**
+   * Options specific for the Dogstatsd agent.
+   */
+  dogstatsd?: {
+    /**
+     * The port of the Dogstatsd agent that the metrics will submitted to.
+     * @default 8125
+     */
+    port?: number
+  };
+
+  /**
    * Set an application’s environment e.g. prod, pre-prod, stage.
    */
   env?: string;

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ const platform = require('./platform')
 const coalesce = require('koalas')
 
 class Config {
-  constructor (service, runtimeId, options) {
+  constructor (service, options) {
     options = options || {}
 
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
@@ -38,11 +38,7 @@ class Config {
     this.plugins = !!plugins
     this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
     this.analytics = String(analytics) === 'true'
-    this.runtimeId = coalesce(runtimeId, '')
-    this.tags = Object.assign({}, options.tags, {
-      'runtime-id': this.runtimeId,
-      'language': 'javascript'
-    })
+    this.tags = Object.assign({}, options.tags)
     this.dogstatsd = {
       port: String(coalesce(dogstatsd.port, platform.env('DD_DOGSTATSD_PORT'), 8125))
     }

--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,7 @@ class Config {
     const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
     const plugins = coalesce(options.plugins, true)
     const analytics = coalesce(options.analytics, platform.env('DD_TRACE_ANALYTICS'))
+    const dogstatsd = options.dogstatsd || {}
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
@@ -38,7 +39,13 @@ class Config {
     this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
     this.analytics = String(analytics) === 'true'
     this.runtimeId = coalesce(runtimeId, '')
-    this.tags = Object.assign({ 'runtime-id': this.runtimeId }, options.tags)
+    this.tags = Object.assign({}, options.tags, {
+      'runtime-id': this.runtimeId,
+      'language': 'javascript'
+    })
+    this.dogstatsd = {
+      port: String(coalesce(dogstatsd.port, platform.env('DD_DOGSTATSD_PORT'), 8125))
+    }
     this.experimental = {
       runtimeMetrics: isFlagEnabled(options.experimental, 'runtimeMetrics')
     }

--- a/src/format.js
+++ b/src/format.js
@@ -4,6 +4,7 @@ const Int64BE = require('int64-buffer').Int64BE
 const constants = require('./constants')
 const tags = require('../ext/tags')
 const log = require('./log')
+const platform = require('./platform')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY
@@ -72,6 +73,11 @@ function extractTags (trace, span) {
 
   if (origin) {
     addTag(trace.meta, ORIGIN_KEY, origin)
+  }
+
+  if (span.tracer()._service === tags['service.name']) {
+    addTag(trace.meta, 'runtime-id', platform.runtime().id())
+    addTag(trace.meta, 'language', 'javascript')
   }
 }
 

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -22,6 +22,13 @@ const platform = {
   configure (config) {
     this._config = config
   },
+  runtime () {
+    return {
+      id: () => {
+        return this._config._runtimeId || (this._config._runtimeId = this.uuid())
+      }
+    }
+  },
   id,
   uuid,
   now,

--- a/src/platform/node/metrics.js
+++ b/src/platform/node/metrics.js
@@ -40,7 +40,8 @@ module.exports = function () {
         globalTags: {
           'env': this._config.env,
           'service': this._config.service,
-          'runtime-id': this._config.runtimeId
+          'runtime-id': this._config.runtimeId,
+          'language': 'javascript'
         },
         errorHandler: () => {}
       })

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -26,8 +26,7 @@ class Tracer extends BaseTracer {
     if (this._tracer === noop) {
       try {
         const service = platform.service()
-        const runtimeId = platform.uuid()
-        const config = new Config(service, runtimeId, options)
+        const config = new Config(service, options)
 
         if (config.enabled) {
           platform.validate()

--- a/src/scope/new/scope.js
+++ b/src/scope/new/scope.js
@@ -30,14 +30,14 @@ class Scope extends Base {
   }
 
   _active () {
-    return this._spans[executionAsyncId()] || null
+    return this._get(executionAsyncId())
   }
 
   _activate (span, callback) {
     const asyncId = executionAsyncId()
-    const oldSpan = this._spans[asyncId] || null
+    const oldSpan = this._get(asyncId)
 
-    this._spans[asyncId] = span || null
+    this._spans[asyncId] = span
 
     try {
       return callback()
@@ -57,19 +57,21 @@ class Scope extends Base {
   }
 
   _init (asyncId) {
-    const span = this._spans[executionAsyncId()]
-
-    this._spans[asyncId] = span || null
+    this._spans[asyncId] = this._active()
 
     platform.metrics().increment('async.resources')
   }
 
   _destroy (asyncId) {
-    if (this._spans[asyncId] === null) {
+    if (this._spans[asyncId] !== undefined) {
       platform.metrics().decrement('async.resources')
     }
 
     delete this._spans[asyncId]
+  }
+
+  _get (asyncId) {
+    return this._spans[asyncId] || null
   }
 
   _debug () {
@@ -85,14 +87,14 @@ class Scope extends Base {
   _debugInit (asyncId, type) {
     this._types[asyncId] = type
 
-    platform.metrics().increment('async.resources.by.type', `resource.type:${type}`)
+    platform.metrics().increment('async.resources.by.type', `resource_type:${type}`)
   }
 
   _debugDestroy (asyncId) {
     const type = this._types[asyncId]
 
     if (type) {
-      platform.metrics().decrement('async.resources.by.type', `resource.type:${type}`)
+      platform.metrics().decrement('async.resources.by.type', `resource_type:${type}`)
     }
 
     delete this._types[asyncId]

--- a/src/scope/new/scope.js
+++ b/src/scope/new/scope.js
@@ -37,7 +37,7 @@ class Scope extends Base {
     const asyncId = executionAsyncId()
     const oldSpan = this._get(asyncId)
 
-    this._spans[asyncId] = span
+    this._spans[asyncId] = span || null
 
     try {
       return callback()

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -26,26 +26,15 @@ describe('Config', () => {
     expect(config).to.have.nested.property('dogstatsd.port', '8125')
     expect(config).to.have.property('flushInterval', 2000)
     expect(config).to.have.property('sampleRate', 1)
-    expect(config).to.have.deep.property('tags', {
-      'runtime-id': '',
-      'language': 'javascript'
-    })
+    expect(config).to.have.deep.property('tags', {})
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
-    expect(config).to.have.property('runtimeId', '')
   })
 
   it('should initialize from the default service', () => {
     const config = new Config('test')
 
     expect(config).to.have.property('service', 'test')
-  })
-
-  it('should initialize from the provided runtime ID', () => {
-    const config = new Config('test', '1234')
-
-    expect(config).to.have.property('runtimeId', '1234')
-    expect(config.tags).to.have.property('runtime-id', '1234')
   })
 
   it('should initialize from environment variables', () => {
@@ -94,11 +83,9 @@ describe('Config', () => {
   it('should initialize from the options', () => {
     const logger = {}
     const tags = {
-      'foo': 'bar',
-      'runtime-id': '5678',
-      'language': 'foo'
+      'foo': 'bar'
     }
-    const config = new Config('test', '1234', {
+    const config = new Config('test', {
       enabled: false,
       debug: true,
       analytics: true,
@@ -131,16 +118,14 @@ describe('Config', () => {
     expect(config).to.have.property('flushInterval', 5000)
     expect(config).to.have.property('plugins', false)
     expect(config).to.have.deep.property('tags', {
-      'foo': 'bar',
-      'runtime-id': '1234',
-      'language': 'javascript'
+      'foo': 'bar'
     })
   })
 
   it('should initialize from the options with url taking precedence', () => {
     const logger = {}
     const tags = { foo: 'bar' }
-    const config = new Config('test', '', {
+    const config = new Config('test', {
       enabled: false,
       debug: true,
       hostname: 'agent',
@@ -189,7 +174,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
     platform.env.withArgs('DD_ENV').returns('test')
 
-    const config = new Config('test', '', {
+    const config = new Config('test', {
       enabled: true,
       debug: false,
       analytics: false,
@@ -223,7 +208,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
     platform.env.withArgs('DD_ENV').returns('test')
 
-    const config = new Config('test', '', {
+    const config = new Config('test', {
       enabled: true,
       debug: false,
       url: 'https://agent3:7778',
@@ -244,8 +229,8 @@ describe('Config', () => {
   })
 
   it('should sanitize the sample rate to be between 0 and 1', () => {
-    expect(new Config('test', '', { sampleRate: -1 })).to.have.property('sampleRate', 0)
-    expect(new Config('test', '', { sampleRate: 2 })).to.have.property('sampleRate', 1)
-    expect(new Config('test', '', { sampleRate: NaN })).to.have.property('sampleRate', 1)
+    expect(new Config('test', { sampleRate: -1 })).to.have.property('sampleRate', 0)
+    expect(new Config('test', { sampleRate: 2 })).to.have.property('sampleRate', 1)
+    expect(new Config('test', { sampleRate: NaN })).to.have.property('sampleRate', 1)
   })
 })

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -23,10 +23,12 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.protocol', 'http:')
     expect(config).to.have.nested.property('url.hostname', 'localhost')
     expect(config).to.have.nested.property('url.port', '8126')
+    expect(config).to.have.nested.property('dogstatsd.port', '8125')
     expect(config).to.have.property('flushInterval', 2000)
     expect(config).to.have.property('sampleRate', 1)
     expect(config).to.have.deep.property('tags', {
-      'runtime-id': ''
+      'runtime-id': '',
+      'language': 'javascript'
     })
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
@@ -49,6 +51,7 @@ describe('Config', () => {
   it('should initialize from environment variables', () => {
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('DD_DOGSTATSD_PORT').returns('5218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
@@ -63,6 +66,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.protocol', 'http:')
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
+    expect(config).to.have.nested.property('dogstatsd.port', '5218')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
   })
@@ -89,13 +93,20 @@ describe('Config', () => {
 
   it('should initialize from the options', () => {
     const logger = {}
-    const tags = { foo: 'bar' }
-    const config = new Config('test', '', {
+    const tags = {
+      'foo': 'bar',
+      'runtime-id': '5678',
+      'language': 'foo'
+    }
+    const config = new Config('test', '1234', {
       enabled: false,
       debug: true,
       analytics: true,
       hostname: 'agent',
       port: 6218,
+      dogstatsd: {
+        port: 5218
+      },
       service: 'service',
       env: 'test',
       sampleRate: 0.5,
@@ -111,6 +122,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.protocol', 'http:')
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
+    expect(config).to.have.nested.property('dogstatsd.port', '5218')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
     expect(config).to.have.property('sampleRate', 0.5)
@@ -118,6 +130,11 @@ describe('Config', () => {
     expect(config.tags).to.have.property('foo', 'bar')
     expect(config).to.have.property('flushInterval', 5000)
     expect(config).to.have.property('plugins', false)
+    expect(config).to.have.deep.property('tags', {
+      'foo': 'bar',
+      'runtime-id': '1234',
+      'language': 'javascript'
+    })
   })
 
   it('should initialize from the options with url taking precedence', () => {
@@ -165,6 +182,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:6218')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('DD_DOGSTATSD_PORT').returns('5218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
@@ -178,6 +196,9 @@ describe('Config', () => {
       protocol: 'https',
       hostname: 'server',
       port: 7777,
+      dogstatsd: {
+        port: 8888
+      },
       service: 'test',
       env: 'development'
     })
@@ -188,6 +209,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent2')
     expect(config).to.have.nested.property('url.port', '6218')
+    expect(config).to.have.nested.property('dogstatsd.port', '8888')
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
   })

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -371,6 +371,9 @@ describe('Platform', () => {
             service: 'service',
             env: 'test',
             hostname: 'localhost',
+            dogstatsd: {
+              port: 8125
+            },
             runtimeId: '1234'
           },
           name: sinon.stub().returns('nodejs'),
@@ -424,17 +427,17 @@ describe('Platform', () => {
             expect(client.gauge).to.have.been.calledWith('heap.peak_malloced_memory')
           }
 
-          expect(client.gauge).to.have.been.calledWith('event_loop.latency.max')
-          expect(client.gauge).to.have.been.calledWith('event_loop.latency.min')
-          expect(client.gauge).to.have.been.calledWith('event_loop.latency.sum')
-          expect(client.gauge).to.have.been.calledWith('event_loop.latency.avg')
-          expect(client.gauge).to.have.been.calledWith('event_loop.latency.count')
+          expect(client.gauge).to.have.been.calledWith('event_loop.delay.max')
+          expect(client.gauge).to.have.been.calledWith('event_loop.delay.min')
+          expect(client.gauge).to.have.been.calledWith('event_loop.delay.sum')
+          expect(client.gauge).to.have.been.calledWith('event_loop.delay.avg')
+          expect(client.gauge).to.have.been.calledWith('event_loop.delay.count')
 
-          expect(client.gauge).to.have.been.calledWith('gc.all.max')
-          expect(client.gauge).to.have.been.calledWith('gc.all.min')
-          expect(client.gauge).to.have.been.calledWith('gc.all.sum')
-          expect(client.gauge).to.have.been.calledWith('gc.all.avg')
-          expect(client.gauge).to.have.been.calledWith('gc.all.count')
+          expect(client.gauge).to.have.been.calledWith('gc.pause.max')
+          expect(client.gauge).to.have.been.calledWith('gc.pause.min')
+          expect(client.gauge).to.have.been.calledWith('gc.pause.sum')
+          expect(client.gauge).to.have.been.calledWith('gc.pause.avg')
+          expect(client.gauge).to.have.been.calledWith('gc.pause.count')
         })
 
         it('should collect additional metrics in debug mode', () => {
@@ -442,10 +445,10 @@ describe('Platform', () => {
 
           clock.tick(10000)
 
-          expect(client.gauge).to.have.been.calledWith('heap.space.size')
-          expect(client.gauge).to.have.been.calledWith('heap.space.used_size')
-          expect(client.gauge).to.have.been.calledWith('heap.space.available_size')
-          expect(client.gauge).to.have.been.calledWith('heap.space.physical_size')
+          expect(client.gauge).to.have.been.calledWith('heap.size.by.space')
+          expect(client.gauge).to.have.been.calledWith('heap.used_size.by.space')
+          expect(client.gauge).to.have.been.calledWith('heap.available_size.by.space')
+          expect(client.gauge).to.have.been.calledWith('heap.physical_size.by.space')
         })
       })
 
@@ -544,10 +547,10 @@ describe('Platform', () => {
           clock.tick(10000)
 
           if (semver.gte(process.version, '6.0.0')) {
-            expect(client.gauge).to.have.been.calledWith('heap.space.size')
-            expect(client.gauge).to.have.been.calledWith('heap.space.used_size')
-            expect(client.gauge).to.have.been.calledWith('heap.space.available_size')
-            expect(client.gauge).to.have.been.calledWith('heap.space.physical_size')
+            expect(client.gauge).to.have.been.calledWith('heap.size.by.space')
+            expect(client.gauge).to.have.been.calledWith('heap.used_size.by.space')
+            expect(client.gauge).to.have.been.calledWith('heap.available_size.by.space')
+            expect(client.gauge).to.have.been.calledWith('heap.physical_size.by.space')
           }
         })
       })

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -344,6 +344,22 @@ describe('Platform', () => {
       })
     })
 
+    describe('runtime', () => {
+      beforeEach(() => {
+        platform = require('../../../src/platform/node')
+      })
+
+      describe('id', () => {
+        it('should return a UUID', () => {
+          expect(platform.runtime().id()).to.match(/^[a-f0-9]{32}$/)
+        })
+
+        it('should always return the same ID', () => {
+          expect(platform.runtime().id()).to.equal(platform.runtime().id())
+        })
+      })
+    })
+
     describe('metrics', () => {
       let metrics
       let clock
@@ -373,12 +389,14 @@ describe('Platform', () => {
             hostname: 'localhost',
             dogstatsd: {
               port: 8125
-            },
-            runtimeId: '1234'
+            }
           },
           name: sinon.stub().returns('nodejs'),
           version: sinon.stub().returns('10.0.0'),
-          engine: sinon.stub().returns('v8')
+          engine: sinon.stub().returns('v8'),
+          runtime: sinon.stub().returns({
+            id: sinon.stub().returns('1234')
+          })
         }
       })
 
@@ -395,8 +413,7 @@ describe('Platform', () => {
             globalTags: {
               'service': 'service',
               'env': 'test',
-              'runtime-id': '1234',
-              'language': 'javascript'
+              'runtime-id': '1234'
             }
           })
         })

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -395,7 +395,8 @@ describe('Platform', () => {
             globalTags: {
               'service': 'service',
               'env': 'test',
-              'runtime-id': '1234'
+              'runtime-id': '1234',
+              'language': 'javascript'
             }
           })
         })

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -51,7 +51,6 @@ describe('TracerProxy', () => {
 
     platform = {
       load: sinon.spy(),
-      uuid: sinon.stub().returns('1234'),
       metrics: sinon.stub().returns({
         start: sinon.spy()
       })
@@ -88,7 +87,7 @@ describe('TracerProxy', () => {
 
         proxy.init(options)
 
-        expect(Config).to.have.been.calledWith('dd-trace', '1234', options)
+        expect(Config).to.have.been.calledWith('dd-trace', options)
         expect(DatadogTracer).to.have.been.calledWith(config)
       })
 

--- a/test/scope/scope.spec.js
+++ b/test/scope/scope.spec.js
@@ -39,8 +39,8 @@ describe('Scope', () => {
     scope._debugInit(0, 'TEST')
     scope._debugDestroy(0)
 
-    expect(metrics.increment).to.have.been.calledWith('async.resources.by.type', 'resource.type:TEST')
-    expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type', 'resource.type:TEST')
+    expect(metrics.increment).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
+    expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
   })
 
   it('should only track destroys once', () => {

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -19,7 +19,7 @@ describe('Tracer', () => {
   let Instrumenter
 
   beforeEach(() => {
-    config = new Config('test', '', { service: 'service' })
+    config = new Config('test', { service: 'service' })
 
     instrumenter = {
       use: sinon.spy(),


### PR DESCRIPTION
This PR implements the final requirements for runtime metrics beta so that users can start trying it out.

The following changes are included:

* The Dogstatsd agent port can now be configured.
* Metric names have been adjusted according to internal document.
* The `language` tag was added to traces.
* The asynchronous metric was adjusted to properly decrement when resources are destroyed without a span.