### PR TITLE
fix client.batch() promise support in cassandra-driver plugin

### DIFF
--- a/src/plugins/util/tx.js
+++ b/src/plugins/util/tx.js
@@ -35,6 +35,8 @@ function wrapPromise (span, promise) {
     () => finish(span),
     err => finish(span, err)
   )
+
+  return promise
 }
 
 function finish (span, error) {

--- a/test/plugins/cassandra-driver.spec.js
+++ b/test/plugins/cassandra-driver.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const semver = require('semver')
 const agent = require('./agent')
 const plugin = require('../../src/plugins/cassandra-driver')
 
@@ -95,7 +96,11 @@ describe('Plugin', () => {
             .then(done)
             .catch(done)
 
-          client.batch(queries, { prepare: true })
+          try {
+            client.batch(queries, { prepare: true })
+          } catch (e) {
+            // older versions require a callback
+          }
         })
 
         it('should handle errors', done => {
@@ -197,6 +202,79 @@ describe('Plugin', () => {
           client.execute('SELECT now() FROM local;', err => err && done(err))
         })
       })
+
+      // Promise support added in 3.2.0
+      if (semver.intersects(version, '>=3.2.0')) {
+        describe('with the promise API', () => {
+          let client
+
+          before(() => {
+            return agent.load(plugin, 'cassandra-driver')
+          })
+
+          after(() => {
+            return agent.close()
+          })
+
+          beforeEach(done => {
+            cassandra = require(`../../versions/cassandra-driver@${version}`).get()
+
+            client = new cassandra.Client({
+              contactPoints: ['127.0.0.1'],
+              localDataCenter: 'datacenter1',
+              keyspace: 'system'
+            })
+
+            client.keyspace
+
+            client.connect(done)
+          })
+
+          afterEach(done => {
+            client.shutdown(done)
+          })
+
+          it('should do automatic instrumentation', done => {
+            const query = 'SELECT now() FROM local;'
+
+            agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('service', 'test-cassandra')
+                expect(traces[0][0]).to.have.property('resource', query)
+                expect(traces[0][0]).to.have.property('type', 'cassandra')
+                expect(traces[0][0].meta).to.have.property('db.type', 'cassandra')
+                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                expect(traces[0][0].meta).to.have.property('out.host', '127.0.0.1')
+                expect(traces[0][0].meta).to.have.property('out.port', '9042')
+                expect(traces[0][0].meta).to.have.property('cassandra.query', query)
+                expect(traces[0][0].meta).to.have.property('cassandra.keyspace', 'system')
+              })
+              .then(done)
+              .catch(done)
+
+            client.execute(query)
+              .catch(done)
+          })
+
+          it('should support batch queries', done => {
+            const id = '1234'
+            const queries = [
+              { query: 'INSERT INTO test.test (id) VALUES (?)', params: [id] },
+              `UPDATE test.test SET test='test' WHERE id='${id}';`
+            ]
+
+            agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
+              })
+              .then(done)
+              .catch(done)
+
+            client.batch(queries, { prepare: true })
+              .catch(done)
+          })
+        })
+      }
     })
   })
 })


### PR DESCRIPTION
This PR fixes the `cassandra-driver` plugin swallowing promises returned by `client.batch()` because it would always pass a callback to the original method.

Fixes #520 