### PR TITLE
fix error in pg plugin when using pg without pg-native

### DIFF
--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -73,21 +73,20 @@ module.exports = [
     versions: ['>=4'],
     patch (pg, tracer, config) {
       this.wrap(pg.Client.prototype, 'query', createWrapQuery(tracer, config))
-
-      try {
-        this.wrap(pg.native.Client.prototype, 'query', createWrapQuery(tracer, config))
-      } catch (e) {
-        // skip native
-      }
     },
     unpatch (pg) {
       this.unwrap(pg.Client.prototype, 'query')
-
-      try {
-        this.unwrap(pg.native.Client, 'query')
-      } catch (e) {
-        // skip native
-      }
+    }
+  },
+  {
+    name: 'pg',
+    versions: ['>=4'],
+    file: 'lib/native/index.js',
+    patch (Client, tracer, config) {
+      this.wrap(Client.prototype, 'query', createWrapQuery(tracer, config))
+    },
+    unpatch (Client) {
+      this.unwrap(Client.prototype, 'query')
     }
   }
 ]


### PR DESCRIPTION
This PR fixes an error being logged when using `pg` without `pg-native` since the plugin would always attempt to patch the native version. The plugin will now only patch `pg-native` when the native files are required, which is the expected behavior.

Fixes #522 