### PR TITLE
fix log injection causing side effects on the provided object

### DIFF
--- a/src/plugins/bunyan.js
+++ b/src/plugins/bunyan.js
@@ -5,7 +5,7 @@ const tx = require('./util/log')
 function createWrapEmit (tracer, config) {
   return function wrapEmit (emit) {
     return function emitWithTrace (rec, noemit) {
-      tx.correlate(tracer, rec)
+      arguments[0] = tx.correlate(tracer, rec)
 
       return emit.apply(this, arguments)
     }

--- a/src/plugins/pino.js
+++ b/src/plugins/pino.js
@@ -5,9 +5,7 @@ const tx = require('./util/log')
 function createWrapWrite (tracer, config) {
   return function wrapWrite (write) {
     return function writeWithTrace (obj, msg, num) {
-      arguments[0] = obj = obj || {}
-
-      tx.correlate(tracer, obj)
+      arguments[0] = tx.correlate(tracer, obj)
 
       return write.apply(this, arguments)
     }
@@ -28,7 +26,7 @@ function createWrapGenLog (tracer, config) {
           args.unshift({})
         }
 
-        tx.correlate(tracer, args[0])
+        args[0] = tx.correlate(tracer, args[0])
 
         return log.apply(this, args)
       }

--- a/src/plugins/util/log.js
+++ b/src/plugins/util/log.js
@@ -6,18 +6,15 @@ const log = {
   // Add trace identifiers from the current scope to a log record.
   correlate (tracer, record) {
     const span = tracer.scope().active()
-    const clone = {}
 
-    Object.assign(clone, record)
+    if (!span) return record
 
-    if (span) {
-      clone.dd = {
+    return Object.assign({}, record, {
+      dd: {
         trace_id: span.context().toTraceId(),
         span_id: span.context().toSpanId()
       }
-    }
-
-    return clone
+    })
   }
 }
 

--- a/src/plugins/util/log.js
+++ b/src/plugins/util/log.js
@@ -6,17 +6,18 @@ const log = {
   // Add trace identifiers from the current scope to a log record.
   correlate (tracer, record) {
     const span = tracer.scope().active()
+    const clone = {}
 
-    record = record || {}
+    Object.assign(clone, record)
 
     if (span) {
-      record.dd = {
+      clone.dd = {
         trace_id: span.context().toTraceId(),
         span_id: span.context().toSpanId()
       }
     }
 
-    return record
+    return clone
   }
 }
 

--- a/src/plugins/winston.js
+++ b/src/plugins/winston.js
@@ -5,7 +5,7 @@ const tx = require('./util/log')
 function createWrapWrite (tracer, config) {
   return function wrapWrite (write) {
     return function writeWithTrace (chunk, encoding, callback) {
-      tx.correlate(tracer, chunk)
+      arguments[0] = tx.correlate(tracer, chunk)
 
       return write.apply(this, arguments)
     }
@@ -22,7 +22,7 @@ function createWrapLog (tracer, config) {
       for (let i = 0, l = arguments.length; i < l; i++) {
         if (typeof arguments[i] !== 'object') continue
 
-        tx.correlate(tracer, arguments[i])
+        arguments[i] = tx.correlate(tracer, arguments[i])
 
         return log.apply(this, arguments)
       }

--- a/test/plugins/util/log.spec.js
+++ b/test/plugins/util/log.spec.js
@@ -13,11 +13,10 @@ describe('plugins/util/log', () => {
 
   describe('correlate', () => {
     it('should attach the current scope trace identifiers to the log record', () => {
-      const record = {}
       const span = tracer.startSpan('test')
 
       tracer.scope().activate(span, () => {
-        log.correlate(tracer, record)
+        const record = log.correlate(tracer, {})
 
         expect(record).to.have.deep.property('dd', {
           trace_id: span.context().toTraceId(),
@@ -48,6 +47,18 @@ describe('plugins/util/log', () => {
     it('should do nothing if the active span is null', () => {
       tracer.scope().activate(null, () => {
         const record = log.correlate(tracer)
+
+        expect(record).to.not.have.property('dd')
+      })
+    })
+
+    it('should not alter the original object', () => {
+      const span = tracer.startSpan('test')
+
+      tracer.scope().activate(span, () => {
+        const record = {}
+
+        log.correlate(tracer, record)
 
         expect(record).to.not.have.property('dd')
       })

--- a/test/plugins/util/log.spec.js
+++ b/test/plugins/util/log.spec.js
@@ -39,7 +39,7 @@ describe('plugins/util/log', () => {
     })
 
     it('should do nothing if there is no active scope', () => {
-      const record = log.correlate(tracer)
+      const record = log.correlate(tracer, {})
 
       expect(record).to.not.have.property('dd')
     })
@@ -48,7 +48,7 @@ describe('plugins/util/log', () => {
       tracer.scope().activate(null, () => {
         const record = log.correlate(tracer)
 
-        expect(record).to.not.have.property('dd')
+        expect(record).to.be.undefined
       })
     })
 


### PR DESCRIPTION
This PR fixes log injection causing side effects on the provided object by adding the IDs on a clone instead and passing the clone to the underlying logger.

Fixes #523