### PR TITLE
fix trace analytics env var inconsistent with other tracers

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,11 @@ class Config {
     const sampleRate = coalesce(Math.min(Math.max(options.sampleRate, 0), 1), 1)
     const flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
     const plugins = coalesce(options.plugins, true)
-    const analytics = coalesce(options.analytics, platform.env('DD_TRACE_ANALYTICS'))
+    const analytics = coalesce(
+      options.analytics,
+      platform.env('DD_TRACE_ANALYTICS_ENABLED'),
+      platform.env('DD_TRACE_ANALYTICS')
+    )
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'


### PR DESCRIPTION
This PR adds an environment variable alias to be consistent with other tracers to enable trace analytics.