### PR TITLE
add request hook for http client request spans

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -54,7 +54,10 @@ const httpServerOptions = {
 
 const httpClientOptions = {
   ...httpOptions,
-  splitByDomain: true
+  splitByDomain: true,
+  hooks: {
+    request: (span, req, res) => {}
+  }
 };
 
 const graphqlOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse } from "http";
+import { ClientRequest, IncomingMessage, ServerResponse } from "http";
 import * as opentracing from "opentracing";
 import { SpanOptions } from "opentracing/lib/tracer";
 
@@ -451,6 +451,16 @@ declare namespace plugins {
      * @default code => code < 400
      */
     validateStatus?: (code: number) => boolean;
+
+    /**
+     * Hooks to run before spans are finished.
+     */
+    hooks?: {
+      /**
+       * Hook to execute just before the request span finishes.
+       */
+      request?: (span?: opentracing.Span, req?: ClientRequest, res?: IncomingMessage) => any;
+    };
   }
 
   /**
@@ -590,6 +600,20 @@ declare namespace plugins {
      * Configuration for HTTP servers.
      */
     server?: HttpServer
+
+    /**
+     * Hooks to run before spans are finished.
+     */
+    hooks?: {
+      /**
+       * Hook to execute just before the request span finishes.
+       */
+      request?: (
+        span?: opentracing.Span,
+        req?: IncomingMessage | ClientRequest,
+        res?: ServerResponse | IncomingMessage
+      ) => any;
+    };
   }
 
   /**

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -804,6 +804,56 @@ describe('Plugin', () => {
           })
         })
       })
+
+      describe('with hooks configuration', () => {
+        let config
+
+        beforeEach(() => {
+          config = {
+            server: false,
+            client: {
+              hooks: {
+                request: (span, req, res) => {
+                  span.setTag('resource.name', `${req.method} ${req._route}`)
+                }
+              }
+            }
+          }
+
+          return agent.load(plugin, 'http', config)
+            .then(() => {
+              http = require(protocol)
+              express = require('express')
+            })
+        })
+
+        it('should run the request hook before the span is finished', done => {
+          const app = express()
+
+          app.get('/user', (req, res) => {
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('resource', 'GET /user')
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(app, port, () => {
+              const req = http.request(`${protocol}://localhost:${port}/user`, res => {
+                res.on('data', () => {})
+              })
+
+              req._route = '/user'
+
+              req.end()
+            })
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
This PR adds a request hook for http client request spans. This is needed to be able to update the resource name since otherwise there is no way to get a reference to the span.

This is a breaking change since hooks that were registered for servers in the shared http config will start being executed for client requests as well.

Closes #524 