### PR TITLE
fix query string being included in the http.url tag

### DIFF
--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -239,7 +239,7 @@ function addRequestTags (req) {
   const span = req._datadog.span
 
   span.addTags({
-    [HTTP_URL]: url,
+    [HTTP_URL]: url.split('?')[0],
     [HTTP_METHOD]: req.method,
     [SPAN_KIND]: SERVER,
     [SPAN_TYPE]: WEB

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -143,6 +143,31 @@ describe('Plugin', () => {
           })
         })
 
+        it('should remove the query string from the URL', done => {
+          const app = express()
+
+          app.get('/user', (req, res) => {
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(app, port, () => {
+              const req = http.request(`${protocol}://localhost:${port}/user?foo=bar`, res => {
+                res.on('data', () => {})
+              })
+
+              req.end()
+            })
+          })
+        })
+
         if (semver.satisfies(process.version, '>=10')) {
           it('should support a string URL and an options object, which merges and takes precedence', done => {
             const app = express()

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -224,6 +224,20 @@ describe('plugins/util/web', () => {
           })
         })
       })
+
+      it('should remove the query string from the URL', () => {
+        req.method = 'GET'
+        req.url = '/user/123?foo=bar'
+        res.statusCode = '200'
+
+        web.instrument(tracer, config, req, res, 'test.request', span => {
+          res.end()
+
+          expect(span.context()._tags).to.include({
+            [HTTP_URL]: 'http://localhost/user/123'
+          })
+        })
+      })
     })
 
     describe('on request end', () => {


### PR DESCRIPTION
This PR removes the query string from the `http.url` tag since it can include sensitive data. The query string will be added as a configurable tag in a future version.