### PR TITLE
add docs folder to npmignore except typescript definitions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,7 @@
 !ext/**/*
 !lib/**/*
 !src/**/*
-!docs/**/*.d.ts
+!docs/index.d.ts
 !CONTRIBUTING.md
 !LICENSE
 !LICENSE-3rdparty.csv


### PR DESCRIPTION
This PR is a temporary fix until v0.11.0 that completely addresses the issue.

Fixes #513