### PR TITLE
fix alpine test for prebuilt native addon

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -46,7 +46,6 @@ dev,prebuildify,MIT,Copyright 2017 Mathias Buus
 dev,proxyquire,MIT,Copyright 2013 Thorsten Lorenz
 dev,require-dir,MIT,2012-2015 Aseem Kishore
 dev,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
-dev,rimraf,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen
 dev,sinon-chai,WTFPL and BSD-2-Clause,Copyright 2004 Sam Hocevar 2012–2017 Domenic Denicola

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "proxyquire": "^1.8.0",
     "require-dir": "^1.0.0",
     "retry": "^0.10.1",
-    "rimraf": "^2.6.3",
     "sinon": "^4.2.1",
     "sinon-chai": "^2.14.0",
     "tape": "^4.9.1",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -7,7 +7,6 @@ const os = require('os')
 const tar = require('tar')
 const semver = require('semver')
 const fs = require('fs')
-const rm = require('rimraf')
 
 const name = `${os.platform()}-${process.env.ARCH || os.arch()}`
 const targets = abi.allTargets
@@ -34,8 +33,6 @@ const cb = err => {
     file: `addons-${name}.tgz`,
     cwd: path.join(__dirname, '..')
   }, ['prebuilds'])
-
-  rm.sync(path.join(__dirname, '..', 'prebuilds'))
 }
 
 prebuildify({


### PR DESCRIPTION
Fix Alpine test for prebuilt native addon failing because the `prebuilds` folder was removed after the `prebuild` script as a cleanup step. This step should not be necessary so it's safe to remove it.