### PR TITLE
update runtime metrics to no longer be experimental

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -301,7 +301,8 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | tags           |                              | {}        | Set global tags that should be applied to all spans. |
 | sampleRate     |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval  |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
-| experimental   |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Available experimental features: `runtimeMetrics`. |
+| runtimeMetrics | DD_RUNTIME_METRICS_ENABLED   | false     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
+| experimental   |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins        |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 
 <h3 id="custom-logging">Custom Logging</h3>

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -17,9 +17,8 @@ tracer.init({
   logInjection: true,
   analytics: true,
   env: 'test',
-  experimental: {
-    runtimeMetrics: true
-  },
+  runtimeMetrics: true,
+  experimental: {},
   hostname: 'agent',
   logger: {
     error (message: string) {},

--- a/index.d.ts
+++ b/index.d.ts
@@ -225,16 +225,16 @@ export declare interface TracerOptions {
   sampleRate?: number;
 
   /**
+   * Whether to enable runtime metrics.
+   * @default false
+   */
+  runtimeMetrics?: boolean
+
+  /**
    * Experimental features can be enabled all at once by using true or individually using key / value pairs.
    * @default {}
    */
-  experimental?: {
-    /**
-     * Whether to enable runtime metrics.
-     * @default false
-     */
-    runtimeMetrics?: boolean
-  } | boolean;
+  experimental?: {} | boolean;
 
   /**
    * Whether to load all built-in plugins.

--- a/src/config.js
+++ b/src/config.js
@@ -25,6 +25,7 @@ class Config {
     const plugins = coalesce(options.plugins, true)
     const analytics = coalesce(options.analytics, platform.env('DD_TRACE_ANALYTICS'))
     const dogstatsd = options.dogstatsd || {}
+    const runtimeMetrics = coalesce(options.runtimeMetrics, platform.env('DD_RUNTIME_METRICS_ENABLED'), false)
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
@@ -42,14 +43,9 @@ class Config {
     this.dogstatsd = {
       port: String(coalesce(dogstatsd.port, platform.env('DD_DOGSTATSD_PORT'), 8125))
     }
-    this.experimental = {
-      runtimeMetrics: isFlagEnabled(options.experimental, 'runtimeMetrics')
-    }
+    this.runtimeMetrics = String(runtimeMetrics) === 'true'
+    this.experimental = {}
   }
-}
-
-function isFlagEnabled (obj, prop) {
-  return obj === true || (typeof obj === 'object' && obj !== null && obj[prop])
 }
 
 module.exports = Config

--- a/src/platform/node/metrics.js
+++ b/src/platform/node/metrics.js
@@ -34,7 +34,7 @@ module.exports = function () {
 
       try {
         nativeMetrics = require('node-gyp-build')(path.join(__dirname, '..', '..', '..'))
-        nativeMetrics.start(options.debug)
+        nativeMetrics.start()
       } catch (e) {
         log.error('Unable to load native metrics module. Some metrics will not be available.')
       }
@@ -51,16 +51,16 @@ module.exports = function () {
 
       if (nativeMetrics) {
         interval = setInterval(() => {
-          captureCommonMetrics(options.debug)
-          captureNativeMetrics(options.debug)
+          captureCommonMetrics()
+          captureNativeMetrics()
         }, INTERVAL)
       } else {
         cpuUsage = process.cpuUsage()
 
         interval = setInterval(() => {
-          captureCommonMetrics(options.debug)
-          captureCpuUsage(options.debug)
-          captureHeapSpace(options.debug)
+          captureCommonMetrics()
+          captureCpuUsage()
+          captureHeapSpace()
         }, INTERVAL)
       }
 

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -32,8 +32,8 @@ class Tracer extends BaseTracer {
           platform.validate()
           platform.configure(config)
 
-          if (config.experimental.runtimeMetrics) {
-            platform.metrics().start({ debug: config.debug })
+          if (config.runtimeMetrics) {
+            platform.metrics().start()
           }
 
           this._tracer = new DatadogTracer(config)

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -26,6 +26,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('dogstatsd.port', '8125')
     expect(config).to.have.property('flushInterval', 2000)
     expect(config).to.have.property('sampleRate', 1)
+    expect(config).to.have.property('runtimeMetrics', false)
     expect(config).to.have.deep.property('tags', {})
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
@@ -45,6 +46,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
+    platform.env.withArgs('DD_RUNTIME_METRICS_ENABLED').returns('true')
     platform.env.withArgs('DD_ENV').returns('test')
 
     const config = new Config()
@@ -56,6 +58,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.nested.property('dogstatsd.port', '5218')
+    expect(config).to.have.property('runtimeMetrics', true)
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
   })
@@ -100,6 +103,7 @@ describe('Config', () => {
       logger,
       tags,
       flushInterval: 5000,
+      runtimeMetrics: true,
       plugins: false
     })
 
@@ -116,6 +120,7 @@ describe('Config', () => {
     expect(config).to.have.property('logger', logger)
     expect(config.tags).to.have.property('foo', 'bar')
     expect(config).to.have.property('flushInterval', 5000)
+    expect(config).to.have.property('runtimeMetrics', true)
     expect(config).to.have.property('plugins', false)
     expect(config).to.have.deep.property('tags', {
       'foo': 'bar'
@@ -172,6 +177,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
+    platform.env.withArgs('DD_RUNTIME_METRICS_ENABLED').returns('true')
     platform.env.withArgs('DD_ENV').returns('test')
 
     const config = new Config('test', {
@@ -184,6 +190,7 @@ describe('Config', () => {
       dogstatsd: {
         port: 8888
       },
+      runtimeMetrics: false,
       service: 'test',
       env: 'development'
     })
@@ -195,6 +202,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.hostname', 'agent2')
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.nested.property('dogstatsd.port', '8888')
+    expect(config).to.have.property('runtimeMetrics', false)
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
   })

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -126,12 +126,11 @@ describe('TracerProxy', () => {
       })
 
       it('should start capturing metrics when configured', () => {
-        config.experimental = { runtimeMetrics: true }
-        config.debug = true
+        config.runtimeMetrics = true
 
         proxy.init()
 
-        expect(platform.metrics().start).to.have.been.calledWith({ debug: true })
+        expect(platform.metrics().start).to.have.been.called
       })
     })
 


### PR DESCRIPTION
This PR makes runtime metrics an official feature that is no longer experimental.