### PR TITLE
fix incorrect asynchronous resource metrics

### DIFF
--- a/src/platform/node/metrics.js
+++ b/src/platform/node/metrics.js
@@ -47,12 +47,15 @@ module.exports = function () {
         errorHandler: () => {}
       })
 
+      client.maxBufferSize = Infinity // set after to prevent flush interval
+
       time = process.hrtime()
 
       if (nativeMetrics) {
         interval = setInterval(() => {
           captureCommonMetrics()
           captureNativeMetrics()
+          client.flushQueue()
         }, INTERVAL)
       } else {
         cpuUsage = process.cpuUsage()
@@ -61,6 +64,7 @@ module.exports = function () {
           captureCommonMetrics()
           captureCpuUsage()
           captureHeapSpace()
+          client.flushQueue()
         }, INTERVAL)
       }
 

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -373,7 +373,8 @@ describe('Platform', () => {
 
         client = {
           gauge: sinon.spy(),
-          increment: sinon.spy()
+          increment: sinon.spy(),
+          flushQueue: sinon.spy()
         }
 
         metrics = proxyquire('../src/platform/node/metrics', {
@@ -465,6 +466,8 @@ describe('Platform', () => {
           expect(client.gauge).to.have.been.calledWith('heap.used_size.by.space')
           expect(client.gauge).to.have.been.calledWith('heap.available_size.by.space')
           expect(client.gauge).to.have.been.calledWith('heap.physical_size.by.space')
+
+          expect(client.flushQueue).to.have.been.called
         })
       })
 
@@ -562,6 +565,8 @@ describe('Platform', () => {
             expect(client.gauge).to.have.been.calledWith('heap.available_size.by.space')
             expect(client.gauge).to.have.been.calledWith('heap.physical_size.by.space')
           }
+
+          expect(client.flushQueue).to.have.been.called
         })
       })
     })


### PR DESCRIPTION
This PR fixes async resource metrics that were affected by creating a UDP resource on every call to `gauge`. By buffering them and sending them all at once, we avoid any new async resource from being created while the metrics are being sent.