### PR TITLE
fix incorrect percentiles when count is 0

### DIFF
--- a/src/native/metrics/Histogram.cpp
+++ b/src/native/metrics/Histogram.cpp
@@ -11,7 +11,7 @@ namespace datadog {
   uint64_t Histogram::avg() { return count_ == 0 ? 0 : sum_ / count_; }
   uint64_t Histogram::count() { return count_; }
   uint64_t Histogram::percentile(double value) {
-    return static_cast<uint64_t>(std::round(digest_->quantile(value)));
+    return count_ == 0 ? 0 : static_cast<uint64_t>(std::round(digest_->quantile(value)));
   }
 
   void Histogram::reset() {


### PR DESCRIPTION
This PR fixes incorrect percentiles when count is 0. T-digest seems to be using the maximum integer value when no data has been added.