### PR TITLE
replace hot-shots with internal dogstatsd implementation

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,7 +1,6 @@
 Component,Origin,License,Copyright
 require,@types/node,MIT,Copyright Authors
 require,async-hook-jl,MIT,Copyright 2015 Andreas Madsen
-require,hot-shots,MIT,Copyright 2011 Steve Ivy
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,lodash.kebabcase,MIT,Copyright JS Foundation and other contributors

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@types/node": "^10.12.18",
     "async-hook-jl": "^1.7.6",
-    "hot-shots": "^5.0.0",
     "int64-buffer": "^0.1.9",
     "koalas": "^1.0.2",
     "lodash.kebabcase": "^4.1.1",

--- a/src/platform/node/dogstatsd.js
+++ b/src/platform/node/dogstatsd.js
@@ -1,0 +1,86 @@
+'use strict'
+
+const dgram = require('dgram')
+const lookup = require('dns').lookup // cache to avoid instrumentation
+const Buffer = require('safe-buffer').Buffer
+
+const MAX_BUFFER_SIZE = 1024 // limit from the agent
+
+class Client {
+  constructor (options) {
+    options = options || {}
+
+    this._host = options.host || 'localhost'
+    this._port = options.port || 8125
+    this._prefix = options.prefix || ''
+    this._tags = options.tags || []
+    this._queue = []
+    this._buffer = ''
+    this._offset = 0
+    this._udp4 = dgram.createSocket('udp4')
+    this._udp6 = dgram.createSocket('udp6')
+  }
+
+  gauge (stat, value, tags) {
+    this._add(stat, value, 'g', tags)
+  }
+
+  increment (stat, value, tags) {
+    this._add(stat, value, 'c', tags)
+  }
+
+  flush () {
+    const queue = this._enqueue()
+
+    if (this._queue.length === 0) return
+
+    this._queue = []
+
+    lookup(this._host, (err, address, family) => {
+      if (err === null) {
+        queue.forEach(buffer => this._send(address, family, buffer))
+      }
+    })
+  }
+
+  _send (address, family, buffer) {
+    const socket = family === 6 ? this._udp6 : this._udp4
+
+    socket.send(buffer, 0, buffer.length, this._port, address)
+  }
+
+  _add (stat, value, type, tags) {
+    const message = `${this._prefix + stat}:${value}|${type}`
+
+    tags = tags ? this._tags.concat(tags) : this._tags
+
+    if (tags.length > 0) {
+      this._write(`${message}|#${tags.join(',')}\n`)
+    } else {
+      this._write(`${message}\n`)
+    }
+  }
+
+  _write (message) {
+    const offset = Buffer.byteLength(message)
+
+    if (this._offset + offset > MAX_BUFFER_SIZE) {
+      this._enqueue()
+    }
+
+    this._offset += offset
+    this._buffer += message
+  }
+
+  _enqueue () {
+    if (this._offset > 0) {
+      this._queue.push(Buffer.from(this._buffer))
+      this._buffer = ''
+      this._offset = 0
+    }
+
+    return this._queue
+  }
+}
+
+module.exports = Client

--- a/test/platform/node/dogstatsd.spec.js
+++ b/test/platform/node/dogstatsd.spec.js
@@ -1,0 +1,172 @@
+'use strict'
+
+wrapIt()
+
+describe('Platform', () => {
+  describe('Node', () => {
+    describe('dogstatsd', () => {
+      let client
+      let Client
+      let dgram
+      let udp4
+      let udp6
+      let dns
+
+      beforeEach(() => {
+        udp6 = {
+          send: sinon.spy()
+        }
+
+        udp4 = {
+          send: sinon.spy()
+        }
+
+        dgram = {
+          createSocket: sinon.stub()
+        }
+        dgram.createSocket.withArgs('udp4').returns(udp4)
+        dgram.createSocket.withArgs('udp6').returns(udp6)
+
+        dns = {
+          lookup: sinon.stub()
+        }
+
+        dns.lookup.callsFake((hostname, callback) => {
+          callback(new Error())
+        })
+
+        dns.lookup.withArgs('localhost').callsFake((hostname, callback) => {
+          callback(null, '127.0.0.1', 4)
+        })
+
+        dns.lookup.withArgs('127.0.0.1').callsFake((hostname, callback) => {
+          callback(null, hostname, 4)
+        })
+
+        dns.lookup.withArgs('::1').callsFake((hostname, callback) => {
+          callback(null, hostname, 6)
+        })
+
+        Client = proxyquire('../src/platform/node/dogstatsd', {
+          'dgram': dgram,
+          'dns': dns
+        })
+      })
+
+      it('should send gauges', () => {
+        client = new Client()
+
+        client.gauge('test.avg', 10)
+        client.flush()
+
+        expect(udp4.send).to.have.been.called
+        expect(udp4.send.firstCall.args[0].toString()).to.equal('test.avg:10|g\n')
+        expect(udp4.send.firstCall.args[1]).to.equal(0)
+        expect(udp4.send.firstCall.args[2]).to.equal(14)
+        expect(udp4.send.firstCall.args[3]).to.equal(8125)
+        expect(udp4.send.firstCall.args[4]).to.equal('127.0.0.1')
+      })
+
+      it('should send counters', () => {
+        client = new Client()
+
+        client.increment('test.count', 10)
+        client.flush()
+
+        expect(udp4.send).to.have.been.called
+        expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:10|c\n')
+        expect(udp4.send.firstCall.args[2]).to.equal(16)
+      })
+
+      it('should send multiple metrics', () => {
+        client = new Client()
+
+        client.gauge('test.avg', 10)
+        client.increment('test.count', 10)
+        client.flush()
+
+        expect(udp4.send).to.have.been.called
+        expect(udp4.send.firstCall.args[0].toString()).to.equal('test.avg:10|g\ntest.count:10|c\n')
+        expect(udp4.send.firstCall.args[2]).to.equal(30)
+      })
+
+      it('should support tags', () => {
+        client = new Client()
+
+        client.gauge('test.avg', 10, ['foo:bar', 'baz:qux'])
+        client.flush()
+
+        expect(udp4.send).to.have.been.called
+        expect(udp4.send.firstCall.args[0].toString()).to.equal('test.avg:10|g|#foo:bar,baz:qux\n')
+        expect(udp4.send.firstCall.args[2]).to.equal(31)
+      })
+
+      it('should buffer metrics', () => {
+        const value = new Array(1000).map(() => 'a').join()
+        const tags = [`foo:${value}`]
+
+        client = new Client()
+
+        client.gauge('test.avg', 1, tags)
+        client.gauge('test.avg', 1, tags)
+        client.flush()
+
+        expect(udp4.send).to.have.been.calledTwice
+      })
+
+      it('should buffer metrics', () => {
+        const value = new Array(1000).map(() => 'a').join()
+        const tags = [`foo:${value}`]
+
+        client = new Client()
+
+        client.gauge('test.avg', 1, tags)
+        client.gauge('test.avg', 1, tags)
+        client.flush()
+
+        expect(udp4.send).to.have.been.calledTwice
+      })
+
+      it('should not flush if the queue is empty', () => {
+        client = new Client()
+
+        client.flush()
+
+        expect(udp4.send).to.not.have.been.called
+        expect(udp6.send).to.not.have.been.called
+        expect(dns.lookup).to.not.have.been.called
+      })
+
+      it('should not flush if the dns lookup fails', () => {
+        client = new Client({
+          host: 'invalid'
+        })
+
+        client.gauge('test.avg', 1)
+        client.flush()
+
+        expect(udp4.send).to.not.have.been.called
+        expect(udp6.send).to.not.have.been.called
+      })
+
+      it('should support configuration', () => {
+        client = new Client({
+          host: '::1',
+          port: 7777,
+          prefix: 'prefix.',
+          tags: ['foo:bar']
+        })
+
+        client.gauge('test.avg', 1, ['baz:qux'])
+        client.flush()
+
+        expect(udp6.send).to.have.been.called
+        expect(udp6.send.firstCall.args[0].toString()).to.equal('prefix.test.avg:1|g|#foo:bar,baz:qux\n')
+        expect(udp6.send.firstCall.args[1]).to.equal(0)
+        expect(udp6.send.firstCall.args[2]).to.equal(37)
+        expect(udp6.send.firstCall.args[3]).to.equal(7777)
+        expect(udp6.send.firstCall.args[4]).to.equal('::1')
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR replaces `hot-shots` with an internal Dogstatsd implementation since we need to buffer data points without sending data multiple times, which is not supported by `hot-shots`. This also allow us to get better performance for our specific use case and customize as we need.