### PR TITLE
fix dogstatsd sockets not handling errors and preventing process exit

### DIFF
--- a/src/platform/node/dogstatsd.js
+++ b/src/platform/node/dogstatsd.js
@@ -17,8 +17,8 @@ class Client {
     this._queue = []
     this._buffer = ''
     this._offset = 0
-    this._udp4 = dgram.createSocket('udp4')
-    this._udp6 = dgram.createSocket('udp6')
+    this._udp4 = this._socket('udp4')
+    this._udp6 = this._socket('udp6')
   }
 
   gauge (stat, value, tags) {
@@ -80,6 +80,15 @@ class Client {
     }
 
     return this._queue
+  }
+
+  _socket (type) {
+    const socket = dgram.createSocket(type)
+
+    socket.on('error', () => {})
+    socket.unref()
+
+    return socket
   }
 }
 

--- a/test/platform/node/dogstatsd.spec.js
+++ b/test/platform/node/dogstatsd.spec.js
@@ -14,11 +14,15 @@ describe('Platform', () => {
 
       beforeEach(() => {
         udp6 = {
-          send: sinon.spy()
+          send: sinon.spy(),
+          on: sinon.stub().returns(udp6),
+          unref: sinon.stub().returns(udp6)
         }
 
         udp4 = {
-          send: sinon.spy()
+          send: sinon.spy(),
+          on: sinon.stub().returns(udp4),
+          unref: sinon.stub().returns(udp4)
         }
 
         dgram = {


### PR DESCRIPTION
This PR fixes the UDP sockets used by the Dogstatsd client that were not handling errors and preventing the process from exiting. The `error` event is now properly handled and `unref()` is called on both sockets.