### PR TITLE
fix mongodb build failing because of new image release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
         environment:
           - SERVICES=mongo
           - PLUGINS=mongodb-core
-      - image: bitnami/mongodb:3.6
+      - image: bitnami/mongodb:3.6.11
         environment:
           - MONGODB_REPLICA_SET_MODE=primary
           - MONGODB_ADVERTISED_HOSTNAME=localhost


### PR DESCRIPTION
A new version of the image was released today and is broken. The version is now fixed to a patch version that is known to work.