### PR TITLE
fix sampling priority being locked too early

### DIFF
--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -70,7 +70,7 @@ suite
   })
   .add('Writer#append', {
     onStart () {
-      writer = new Writer({}, {})
+      writer = new Writer({ sample: () => {} }, {})
     },
     fn () {
       writer.append(spanStub)

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -124,7 +124,6 @@ class DatadogSpan extends Span {
     this._duration = finishTime - this._startTime
     this._spanContext._trace.finished.push(this)
     this._spanContext._isFinished = true
-    this._prioritySampler.sample(this)
     this._handle.finish()
 
     if (this._spanContext._sampled) {

--- a/src/writer.js
+++ b/src/writer.js
@@ -25,6 +25,8 @@ class Writer {
     const trace = spanContext._trace
 
     if (trace.started.length === trace.finished.length) {
+      this._prioritySampler.sample(spanContext)
+
       const formattedTrace = trace.finished.map(format)
 
       if (spanContext._sampling.drop === true) {

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -230,15 +230,5 @@ describe('Span', () => {
 
       expect(recorder.record).to.have.been.calledOnce
     })
-
-    it('should generate sampling priority', () => {
-      prioritySampler.sample = span => {
-        span.context()._sampling.priority = 2
-      }
-      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
-      span.finish()
-
-      expect(span.context()._sampling.priority).to.equal(2)
-    })
   })
 })

--- a/test/writer.spec.js
+++ b/test/writer.spec.js
@@ -61,7 +61,8 @@ describe('Writer', () => {
     }
 
     prioritySampler = {
-      update: sinon.stub()
+      update: sinon.stub(),
+      sample: sinon.stub()
     }
 
     Writer = proxyquire('../src/writer', {
@@ -111,6 +112,12 @@ describe('Writer', () => {
       writer.append(span)
 
       expect(writer._queue).to.be.empty
+    })
+
+    it('should generate sampling priority', () => {
+      writer.append(span)
+
+      expect(prioritySampler.sample).to.have.been.calledWith(span.context())
     })
   })
 


### PR DESCRIPTION
This PR fixes the sampling priority being locked too quickly. Since a finished span cannot be flushed until the entire trace is finished, it's not necessary to lock it at that point and we can wait just before the actual flush.