### PR TITLE
Add typings for ext submodules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,5 +9,5 @@
 !README.md
 !binding.gyp
 !index.js
-!index.d.ts
+!*.d.ts
 !package.json

--- a/.npmignore
+++ b/.npmignore
@@ -9,5 +9,5 @@
 !README.md
 !binding.gyp
 !index.js
-!*.d.ts
+!index.d.ts
 !package.json

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -1,5 +1,26 @@
 import ddTrace, { tracer, Tracer, TracerOptions, Span, SpanContext, SpanOptions, Scope } from '..';
-import { HTTP_HEADERS } from '../ext/formats';
+import { formats, kinds, priority, tags, types } from '../ext';
+import { BINARY, HTTP_HEADERS, LOG, TEXT_MAP } from '../ext/formats';
+import { SERVER, CLIENT, PRODUCER, CONSUMER } from '../ext/kinds'
+import { USER_REJECT, AUTO_REJECT, AUTO_KEEP, USER_KEEP } from '../ext/priority'
+import {
+  ANALYTICS,
+  ERROR,
+  HTTP_METHOD,
+  HTTP_REQUEST_HEADERS,
+  HTTP_RESPONSE_HEADERS,
+  HTTP_ROUTE,
+  HTTP_STATUS_CODE,
+  HTTP_URL,
+  MANUAL_DROP,
+  MANUAL_KEEP,
+  RESOURCE_NAME,
+  SAMPLING_PRIORITY,
+  SERVICE_NAME,
+  SPAN_KIND,
+  SPAN_TYPE,
+} from '../ext/tags'
+import { HTTP, WEB } from '../ext/types'
 import * as opentracing from 'opentracing';
 
 opentracing.initGlobalTracer(tracer);

--- a/ext/formats.d.ts
+++ b/ext/formats.d.ts
@@ -4,7 +4,7 @@ declare const formats: {
   TEXT_MAP: typeof opentracing.FORMAT_TEXT_MAP
   HTTP_HEADERS: typeof opentracing.FORMAT_HTTP_HEADERS
   BINARY: typeof opentracing.FORMAT_BINARY
-  LOG: boolean
+  LOG: 'log'
 }
 
 export = formats

--- a/ext/formats.d.ts
+++ b/ext/formats.d.ts
@@ -1,0 +1,10 @@
+import * as opentracing from 'opentracing'
+
+declare const formats: {
+  TEXT_MAP: typeof opentracing.FORMAT_TEXT_MAP
+  HTTP_HEADERS: typeof opentracing.FORMAT_HTTP_HEADERS
+  BINARY: typeof opentracing.FORMAT_BINARY
+  LOG: boolean
+}
+
+export = formats

--- a/ext/index.d.ts
+++ b/ext/index.d.ts
@@ -1,0 +1,5 @@
+import * as priority from './priority'
+import * as tags from './tags'
+import * as formats from './formats'
+
+export { priority, tags, formats }

--- a/ext/index.d.ts
+++ b/ext/index.d.ts
@@ -1,5 +1,7 @@
+import * as formats from './formats'
+import * as kinds from './kinds'
 import * as priority from './priority'
 import * as tags from './tags'
-import * as formats from './formats'
+import * as types from './types'
 
-export { priority, tags, formats }
+export { formats, kinds, priority, tags, types }

--- a/ext/index.js
+++ b/ext/index.js
@@ -1,11 +1,15 @@
 'use strict'
 
+const formats = require('./formats')
+const kinds = require('./kinds')
 const priority = require('./priority')
 const tags = require('./tags')
-const formats = require('./formats')
+const types = require('./types')
 
 module.exports = {
+  formats,
+  kinds,
   priority,
   tags,
-  formats
+  types
 }

--- a/ext/kinds.d.ts
+++ b/ext/kinds.d.ts
@@ -1,8 +1,8 @@
 declare const kinds: {
-  SERVER: string
-  CLIENT: string
-  PRODUCER: string
-  CONSUMER: string
+  SERVER: 'server'
+  CLIENT: 'client'
+  PRODUCER: 'producer'
+  CONSUMER: 'consumer'
 }
 
 export = kinds

--- a/ext/kinds.d.ts
+++ b/ext/kinds.d.ts
@@ -1,0 +1,8 @@
+declare const kinds: {
+  SERVER: string
+  CLIENT: string
+  PRODUCER: string
+  CONSUMER: string
+}
+
+export = kinds

--- a/ext/priority.d.ts
+++ b/ext/priority.d.ts
@@ -1,8 +1,8 @@
 declare const priority: {
-  USER_REJECT: number
-  AUTO_REJECT: number
-  AUTO_KEEP: number
-  USER_KEEP: number
+  USER_REJECT: -1
+  AUTO_REJECT: 0
+  AUTO_KEEP: 1
+  USER_KEEP: 2
 }
 
 export = priority

--- a/ext/priority.d.ts
+++ b/ext/priority.d.ts
@@ -1,0 +1,8 @@
+declare const priority: {
+  USER_REJECT: number
+  AUTO_REJECT: number
+  AUTO_KEEP: number
+  USER_KEEP: number
+}
+
+export = priority

--- a/ext/tags.d.ts
+++ b/ext/tags.d.ts
@@ -1,0 +1,19 @@
+declare const tags: {
+  SERVICE_NAME: string
+  RESOURCE_NAME: string
+  SPAN_TYPE: string
+  SPAN_KIND: string
+  SAMPLING_PRIORITY: string
+  ANALYTICS: string
+  ERROR: string
+  MANUAL_KEEP: string
+  MANUAL_DROP: string
+  HTTP_URL: string
+  HTTP_METHOD: string
+  HTTP_STATUS_CODE: string
+  HTTP_ROUTE: string
+  HTTP_REQUEST_HEADERS: string
+  HTTP_RESPONSE_HEADERS: string
+}
+
+export = tags

--- a/ext/tags.d.ts
+++ b/ext/tags.d.ts
@@ -1,19 +1,19 @@
 declare const tags: {
-  SERVICE_NAME: string
-  RESOURCE_NAME: string
-  SPAN_TYPE: string
-  SPAN_KIND: string
-  SAMPLING_PRIORITY: string
-  ANALYTICS: string
-  ERROR: string
-  MANUAL_KEEP: string
-  MANUAL_DROP: string
-  HTTP_URL: string
-  HTTP_METHOD: string
-  HTTP_STATUS_CODE: string
-  HTTP_ROUTE: string
-  HTTP_REQUEST_HEADERS: string
-  HTTP_RESPONSE_HEADERS: string
+  SERVICE_NAME: 'service.name'
+  RESOURCE_NAME: 'resource.name'
+  SPAN_TYPE: 'span.type'
+  SPAN_KIND: 'span.kind'
+  SAMPLING_PRIORITY: 'sampling.priority'
+  ANALYTICS: '_dd1.sr.eausr'
+  ERROR: 'error'
+  MANUAL_KEEP: 'manual.keep'
+  MANUAL_DROP: 'manual.drop'
+  HTTP_URL: 'http.url'
+  HTTP_METHOD: 'http.method'
+  HTTP_STATUS_CODE: 'http.status_code'
+  HTTP_ROUTE: 'http.route'
+  HTTP_REQUEST_HEADERS: 'http.request.headers'
+  HTTP_RESPONSE_HEADERS: 'http.response.headers'
 }
 
 export = tags

--- a/ext/types.d.ts
+++ b/ext/types.d.ts
@@ -1,6 +1,6 @@
 declare const types: {
-  HTTP: string
-  WEB: string
+  HTTP: 'http'
+  WEB: 'web'
 }
 
 export = types

--- a/ext/types.d.ts
+++ b/ext/types.d.ts
@@ -1,0 +1,6 @@
+declare const types: {
+  HTTP: string
+  WEB: string
+}
+
+export = types


### PR DESCRIPTION
I needed some of these typings, so I created the others as well. The Datadog constants are typed as `string`, to avoid duplicating the values in the type definitions, but the constants from `opentracing` are imported, so their types are narrowed to the actual values. In case you want this to be consistent, those constants could be typed as string as well (or the Datadog constants could be narrowed to their actual values).