### PR TITLE
update benchmarks to disable real http calls

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -3,9 +3,12 @@
 /* eslint-disable no-console */
 
 const Benchmark = require('benchmark')
+const nock = require('nock')
 
 Benchmark.options.maxTime = 0.1
 Benchmark.options.minSamples = 5
+
+nock.disableNetConnect()
 
 module.exports = title => {
   const suite = new Benchmark.Suite()


### PR DESCRIPTION
This PR disables real http calls in benchmarks to avoid spamming a locally running agent with traces.