### PR TITLE
update supported engines to be less strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": "^4.7 || ^6.9 || >=8"
+    "node": ">=4"
   },
   "dependencies": {
     "@types/node": "^10.12.18",

--- a/src/platform/node/validate.js
+++ b/src/platform/node/validate.js
@@ -2,7 +2,7 @@
 
 const semver = require('semver')
 
-const SUPPORTED_VERSIONS = '^4.7 || ^6.9 || >=8'
+const SUPPORTED_VERSIONS = '>=4'
 
 function validate () {
   if (!semver.satisfies(process.versions.node, SUPPORTED_VERSIONS)) {


### PR DESCRIPTION
This PR updates the supported engines to be less strict.

Originally, the engines were made more strict because of potential issues with old versions of Node that have bugs which may impact the tracer. However, there are similar issues with versions above the currently supported engines, so this proved to be less predictable that expected.

Instead of bumping the version number constantly as we find new bugs in Node, we should instead loosen the range to support the entire range of the major versions we support.

If any user hits one of the issues we were trying to avoid, we can recommend they update Node and/or we can investigate a way to work around the issue.