### PR TITLE
update mongodb image to use a fixed older version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
         environment:
           - SERVICES=mongo
           - PLUGINS=mongodb-core
-      - image: bitnami/mongodb:3.6.11
+      - image: bitnami/mongodb:3.6.8
         environment:
           - MONGODB_REPLICA_SET_MODE=primary
           - MONGODB_ADVERTISED_HOSTNAME=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
   mongo:
-    image: bitnami/mongodb:3.6
+    image: bitnami/mongodb:3.6.8
     environment:
       - MONGODB_REPLICA_SET_MODE=primary
       - MONGODB_ADVERTISED_HOSTNAME=localhost


### PR DESCRIPTION
This PR updates the mongodb image to use a fixed older version since it has been randomly crashing for a few weeks. By using a version that is over 3 months old, it should fix the issue since we didn't have this problem back then.