### PR TITLE
add support for node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,11 @@ jobs:
     docker:
       - image: node:10
 
+  node-core-12:
+    <<: *node-core-base
+    docker:
+      - image: node:12
+
   node-core-latest:
     <<: *node-core-base
     docker:
@@ -494,6 +499,7 @@ workflows:
       - node-core-6
       - node-core-8
       - node-core-10
+      - node-core-12
       - node-core-latest
       - node-amqplib
       - node-amqp10
@@ -560,6 +566,7 @@ workflows:
       - node-core-6
       - node-core-8
       - node-core-10
+      - node-core-12
       - node-core-latest
       - node-amqplib
       - node-amqp10

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "graphql": "0.13.2",
     "mocha": "^5.2.0",
     "nock": "^9.6.1",
-    "node-abi": "^2.7.1",
+    "node-abi": "^2.8.0",
     "prebuildify": "^2.11.0",
     "proxyquire": "^1.8.0",
     "require-dir": "^1.0.0",

--- a/src/native/metrics/SpanTracker.cpp
+++ b/src/native/metrics/SpanTracker.cpp
@@ -46,8 +46,7 @@ namespace datadog {
     if (!enabled_) return nullptr;
 
     v8::Isolate *isolate = v8::Isolate::GetCurrent();
-    v8::Local<v8::String> context_key = v8::String::NewFromUtf8(isolate, "_spanContext");
-    v8::Local<v8::Object> context = v8::Local<v8::Object>::Cast(span->Get(context_key));
+    v8::Local<v8::Object> context = value<v8::Object>(span, "_spanContext");
 
     ++unfinished_total_;
 
@@ -56,8 +55,7 @@ namespace datadog {
     handle->tracker = this;
     handle->context = new v8::Persistent<v8::Object>(isolate, context);
 
-    v8::Local<v8::String> name_key = v8::String::NewFromUtf8(isolate, "_name");
-    std::string name = to_string(context->Get(name_key));
+    std::string name = to_string(value<v8::String>(context, "_name"));
 
     if (unfinished_.find(name) == unfinished_.end()) {
       unfinished_.insert(std::make_pair(name, 0));

--- a/src/native/metrics/SpanTracker.cpp
+++ b/src/native/metrics/SpanTracker.cpp
@@ -46,7 +46,7 @@ namespace datadog {
     if (!enabled_) return nullptr;
 
     v8::Isolate *isolate = v8::Isolate::GetCurrent();
-    v8::Local<v8::Object> context = value<v8::Object>(span, "_spanContext");
+    v8::Local<v8::Object> context = v8::Local<v8::Object>::Cast(value(span, "_spanContext"));
 
     ++unfinished_total_;
 
@@ -55,7 +55,7 @@ namespace datadog {
     handle->tracker = this;
     handle->context = new v8::Persistent<v8::Object>(isolate, context);
 
-    std::string name = to_string(value<v8::String>(context, "_name"));
+    std::string name = to_string(value(context, "_name"));
 
     if (unfinished_.find(name) == unfinished_.end()) {
       unfinished_.insert(std::make_pair(name, 0));

--- a/src/native/metrics/SpanTracker.hpp
+++ b/src/native/metrics/SpanTracker.hpp
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <nan.h>
 #include <v8.h>
 
 #include "Collector.hpp"

--- a/src/native/metrics/SpanTracker.hpp
+++ b/src/native/metrics/SpanTracker.hpp
@@ -2,7 +2,6 @@
 
 #include <unordered_map>
 #include <string>
-#include <nan.h>
 #include <v8.h>
 
 #include "Collector.hpp"

--- a/src/native/metrics/utils.cpp
+++ b/src/native/metrics/utils.cpp
@@ -11,7 +11,7 @@ namespace datadog {
     return Nan::New(str).ToLocalChecked();
   }
 
-  template <class T> v8::Local<T> value(v8::Local<v8::Object> obj, std::string key) {
-    return Nan::To<T>(Nan::Get(obj, from_string(key)).ToLocalChecked());
+  v8::Local<v8::Value> value(v8::Local<v8::Object> obj, std::string key) {
+    return Nan::Get(obj, from_string(key)).ToLocalChecked();
   }
 }

--- a/src/native/metrics/utils.cpp
+++ b/src/native/metrics/utils.cpp
@@ -6,4 +6,12 @@ namespace datadog {
   std::string to_string(v8::Local<v8::Value> handle) {
     return *Nan::Utf8String(handle);
   }
+
+  v8::Local<v8::String> from_string(std::string str) {
+    return Nan::New(str).ToLocalChecked();
+  }
+
+  template <class T> v8::Local<T> value(v8::Local<v8::Object> obj, std::string key) {
+    return Nan::To<T>(Nan::Get(obj, from_string(key)).ToLocalChecked());
+  }
 }

--- a/src/native/metrics/utils.hpp
+++ b/src/native/metrics/utils.hpp
@@ -6,6 +6,5 @@
 namespace datadog {
   std::string to_string(v8::Local<v8::Value> handle);
   v8::Local<v8::String> from_string(std::string str);
-  v8::Local<v8::String> from_string(std::string str);
-  template <class T> v8::Local<T> value(v8::Local<v8::Object> obj, std::string key);
+  v8::Local<v8::Value> value(v8::Local<v8::Object> obj, std::string key);
 }

--- a/src/native/metrics/utils.hpp
+++ b/src/native/metrics/utils.hpp
@@ -5,4 +5,7 @@
 
 namespace datadog {
   std::string to_string(v8::Local<v8::Value> handle);
+  v8::Local<v8::String> from_string(std::string str);
+  v8::Local<v8::String> from_string(std::string str);
+  template <class T> v8::Local<T> value(v8::Local<v8::Object> obj, std::string key);
 }


### PR DESCRIPTION
This PR adds support for Node 12 by making the following changes:

* Update usage of any deprecated APIs in v8 for native addons
* Update `node-abi` to the latest version which contains the ABI version for Node 12
* Add Node 12 tests to CI