### PR TITLE
fix incompatibility with express-async-errors

### DIFF
--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -66,7 +66,12 @@ function wrapLayerHandle (layer, handle) {
 
 function wrapStack (stack, offset, matchers) {
   [].concat(stack).slice(offset).forEach(layer => {
-    layer.handle = wrapLayerHandle(layer, layer.handle)
+    if (layer.__handle) { // express-async-errors
+      layer.__handle = wrapLayerHandle(layer, layer.__handle)
+    } else {
+      layer.handle = wrapLayerHandle(layer, layer.handle)
+    }
+
     layer._datadog_matchers = matchers
 
     if (layer.route) {


### PR DESCRIPTION
This PR fixes an incompatibility with `express-async-errors`. The module defines a getter/setter on `Layer.prototype.handle` where it wraps the layer handler when it gets set. The problem is that we overwrite the handler in the `express` instrumentation, but after it's already been wrapped by the module. This means that we wrap their wrapper, and then reassign `layer.handle` which causes the setter to wrap our wrapper. This end up with a situation where we then have `asyncWrapper -> ddWrapper -> asyncWrapper -> handler` which results in unexpected behaviors.

Since `express-async-errors` adds a `__handle` property to the layer, we can patch that instead without triggering the setter.

The behavior is different depending on the version of Node and in some cases internal to Express, so I was unable to write a proper unit test for this.

Fixes #548