### PR TITLE
Add option to add hostname tag to every trace

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -302,7 +302,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | sampleRate     |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval  |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | runtimeMetrics | DD_RUNTIME_METRICS_ENABLED   | false     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
-| reportHostname | DD_TRACE_REPORT_HOSTNAME     | false     | Whether or not to report the system's hostname as a tag in every trace |
+| reportHostname | DD_TRACE_REPORT_HOSTNAME     | false     | Report the system's hostname as a tag in every trace. |
 | experimental   |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins        |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -302,7 +302,7 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | sampleRate     |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval  |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | runtimeMetrics | DD_RUNTIME_METRICS_ENABLED   | false     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
-| reportHostname | DD_TRACE_REPORT_HOSTNAME     | false     | Report the system's hostname as a tag in every trace. |
+| reportHostname | DD_TRACE_REPORT_HOSTNAME     | false     | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |
 | experimental   |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins        |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -297,11 +297,12 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 | port           | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
 | dogstatsd.port | DD_DOGSTATSD_PORT            | 8125      | The port of the Dogstatsd agent that metrics will be submitted to. |
 | env            | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
-| logInjection   | DD_LOGS_INJECTION            | false     | Enable automatic injection of trace IDs in logs for supported logging libraries.
+| logInjection   | DD_LOGS_INJECTION            | false     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
 | tags           |                              | {}        | Set global tags that should be applied to all spans. |
 | sampleRate     |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval  |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | runtimeMetrics | DD_RUNTIME_METRICS_ENABLED   | false     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
+| reportHostname | DD_TRACE_REPORT_HOSTNAME     | false     | Whether or not to report the system's hostname as a tag in every trace |
 | experimental   |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins        |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 

--- a/src/config.js
+++ b/src/config.js
@@ -30,6 +30,7 @@ class Config {
       platform.env('DD_TRACE_ANALYTICS_ENABLED'),
       platform.env('DD_TRACE_ANALYTICS')
     )
+    const reportHostname = coalesce(options.reportHostname, platform.env('DD_TRACE_REPORT_HOSTNAME'), false)
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
@@ -49,6 +50,7 @@ class Config {
     }
     this.runtimeMetrics = String(runtimeMetrics) === 'true'
     this.experimental = {}
+    this.reportHostname = String(reportHostname) === 'true'
   }
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,5 +5,6 @@ module.exports = {
   SAMPLING_PRIORITY_KEY: '_sampling_priority_v1',
   ANALYTICS_KEY: '_dd1.sr.eausr',
   ORIGIN_KEY: '_dd.origin',
+  HOSTNAME_KEY: '_dd.hostname',
   REFERENCE_NOOP: 'noop'
 }

--- a/src/format.js
+++ b/src/format.js
@@ -10,6 +10,7 @@ const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY
 const ANALYTICS = tags.ANALYTICS
 const ORIGIN_KEY = constants.ORIGIN_KEY
+const HOSTNAME_KEY = constants.HOSTNAME_KEY
 
 const map = {
   'service.name': 'service',
@@ -47,6 +48,7 @@ function formatSpan (span) {
 function extractTags (trace, span) {
   const origin = span.context()._trace.origin
   const tags = span.context()._tags
+  const hostname = span.context()._hostname
 
   Object.keys(tags).forEach(tag => {
     switch (tag) {
@@ -55,6 +57,7 @@ function extractTags (trace, span) {
       case 'resource.name':
         addTag(trace, map[tag], tags[tag])
         break
+      case HOSTNAME_KEY:
       case ANALYTICS:
         break
       case 'error':
@@ -79,6 +82,8 @@ function extractTags (trace, span) {
     addTag(trace.meta, 'runtime-id', platform.runtime().id())
     addTag(trace.meta, 'language', 'javascript')
   }
+
+  addTag(trace.meta, HOSTNAME_KEY, hostname)
 }
 
 function extractError (trace, span) {

--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -21,6 +21,7 @@ class DatadogSpan extends Span {
     const metrics = {
       [SAMPLE_RATE_METRIC_KEY]: sampler.rate()
     }
+    const hostname = fields.hostname
 
     this._parentTracer = tracer
     this._sampler = sampler
@@ -32,6 +33,7 @@ class DatadogSpan extends Span {
     this._spanContext._name = operationName
     this._spanContext._tags = tags
     this._spanContext._metrics = metrics
+    this._spanContext._hostname = hostname
 
     this._handle = platform.metrics().track(this)
   }

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -17,6 +17,7 @@ const NoopSpan = require('../noop/span')
 const formats = require('../../ext/formats')
 const log = require('../log')
 const constants = require('../constants')
+const platform = require('../platform')
 
 const REFERENCE_NOOP = constants.REFERENCE_NOOP
 const REFERENCE_CHILD_OF = opentracing.REFERENCE_CHILD_OF
@@ -47,6 +48,9 @@ class DatadogTracer extends Tracer {
       [formats.BINARY]: new BinaryPropagator(),
       [formats.LOG]: new LogPropagator()
     }
+    if (config.reportHostname) {
+      this._hostname = platform.hostname()
+    }
   }
 
   _startSpan (name, fields) {
@@ -72,7 +76,8 @@ class DatadogTracer extends Tracer {
       operationName: fields.operationName || name,
       parent,
       tags: Object.assign(tags, this._tags, fields.tags),
-      startTime: fields.startTime
+      startTime: fields.startTime,
+      hostname: this._hostname
     })
 
     return span

--- a/src/platform/node/hostname.js
+++ b/src/platform/node/hostname.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const os = require('os')
+
+module.exports = () => os.hostname()

--- a/src/platform/node/index.js
+++ b/src/platform/node/index.js
@@ -11,6 +11,7 @@ const request = require('./request')
 const msgpack = require('./msgpack')
 const metrics = require('./metrics')
 const Uint64BE = require('./uint64be')
+const hostname = require('./hostname')
 
 const emitter = new EventEmitter()
 
@@ -39,6 +40,7 @@ const platform = {
   msgpack,
   metrics,
   Uint64BE,
+  hostname,
   on: emitter.on.bind(emitter),
   once: emitter.once.bind(emitter),
   off: emitter.removeListener.bind(emitter)

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -30,6 +30,7 @@ describe('Config', () => {
     expect(config).to.have.deep.property('tags', {})
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
+    expect(config).to.have.property('reportHostname', false)
   })
 
   it('should initialize from the default service', () => {
@@ -47,6 +48,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
     platform.env.withArgs('DD_RUNTIME_METRICS_ENABLED').returns('true')
+    platform.env.withArgs('DD_TRACE_REPORT_HOSTNAME').returns('true')
     platform.env.withArgs('DD_ENV').returns('test')
 
     const config = new Config()
@@ -58,8 +60,9 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.hostname', 'agent')
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.nested.property('dogstatsd.port', '5218')
-    expect(config).to.have.property('runtimeMetrics', true)
     expect(config).to.have.property('service', 'service')
+    expect(config).to.have.property('runtimeMetrics', true)
+    expect(config).to.have.property('reportHostname', true)
     expect(config).to.have.property('env', 'test')
   })
 
@@ -104,6 +107,7 @@ describe('Config', () => {
       tags,
       flushInterval: 5000,
       runtimeMetrics: true,
+      reportHostname: true,
       plugins: false
     })
 
@@ -121,6 +125,7 @@ describe('Config', () => {
     expect(config.tags).to.have.property('foo', 'bar')
     expect(config).to.have.property('flushInterval', 5000)
     expect(config).to.have.property('runtimeMetrics', true)
+    expect(config).to.have.property('reportHostname', true)
     expect(config).to.have.property('plugins', false)
     expect(config).to.have.deep.property('tags', {
       'foo': 'bar'
@@ -178,6 +183,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
     platform.env.withArgs('DD_SERVICE_NAME').returns('service')
     platform.env.withArgs('DD_RUNTIME_METRICS_ENABLED').returns('true')
+    platform.env.withArgs('DD_TRACE_REPORT_HOSTNAME').returns('true')
     platform.env.withArgs('DD_ENV').returns('test')
 
     const config = new Config('test', {
@@ -191,6 +197,7 @@ describe('Config', () => {
         port: 8888
       },
       runtimeMetrics: false,
+      reportHostname: false,
       service: 'test',
       env: 'development'
     })
@@ -203,6 +210,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.nested.property('dogstatsd.port', '8888')
     expect(config).to.have.property('runtimeMetrics', false)
+    expect(config).to.have.property('reportHostname', false)
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
   })


### PR DESCRIPTION
### What does this PR do?
Adds the `_dd.hostname` tag to every trace with the value as the hostname of the system.

### Motivation

### Additional Notes
May want to test for the existence of the tag downstream

Config options are `reportHostname` and `DD_TRACE_REPORT_HOSTNAME` (environment variable).

### Review Checklist
- [x] Added tests