### PR TITLE
fix split traces when using knex

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -109,6 +109,7 @@ tracer.use('http', {
   client: httpClientOptions
 });
 tracer.use('ioredis');
+tracer.use('knex');
 tracer.use('koa');
 tracer.use('koa', httpServerOptions);
 tracer.use('memcached');

--- a/index.d.ts
+++ b/index.d.ts
@@ -315,6 +315,7 @@ interface Plugins {
   "hapi": plugins.hapi;
   "http": plugins.http;
   "ioredis": plugins.ioredis;
+  "knex": plugins.knex;
   "koa": plugins.koa;
   "memcached": plugins.memcached;
   "mongodb-core": plugins.mongodb_core;
@@ -621,6 +622,12 @@ declare namespace plugins {
    * [ioredis](https://github.com/luin/ioredis) module.
    */
   interface ioredis extends Integration {}
+
+  /**
+   * This plugin patches the [knex](https://knexjs.org/)
+   * module to bind the promise callback the the caller context.
+   */
+  interface knex extends Integration {}
 
   /**
    * This plugin automatically instruments the

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -14,6 +14,7 @@ module.exports = {
   'hapi': require('./hapi'),
   'http': require('./http'),
   'ioredis': require('./ioredis'),
+  'knex': require('./knex'),
   'koa': require('./koa'),
   'memcached': require('./memcached'),
   'mongodb-core': require('./mongodb-core'),

--- a/src/plugins/knex.js
+++ b/src/plugins/knex.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const tx = require('./util/promise')
+
+function createPatch (file) {
+  return {
+    name: 'knex',
+    versions: ['>=0.8.0'],
+    file,
+    patch (Builder, tracer, config) {
+      this.wrap(Builder.prototype, 'then', tx.createWrapThen(tracer, config))
+    },
+    unpatch (Builder) {
+      this.unwrap(Builder.prototype, 'then')
+    }
+  }
+}
+
+module.exports = [
+  createPatch('lib/query/builder.js'),
+  createPatch('lib/raw.js'),
+  createPatch('lib/schema/builder.js')
+]

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -141,11 +141,12 @@ module.exports = {
   // Wipe the require cache.
   wipe () {
     const basedir = path.join(__dirname, '..', '..', 'versions')
-    const exceptions = ['/libpq/'] // wiping native modules results in errors
+    const exceptions = ['/libpq/', '/sqlite3/'] // wiping native modules results in errors
+      .map(exception => new RegExp(exception))
 
     Object.keys(require.cache)
       .filter(name => name.indexOf(basedir) !== -1)
-      .filter(name => [].concat(exceptions).reduce((prev, next) => name.indexOf(next) === -1, true))
+      .filter(name => !exceptions.some(exception => exception.test(name)))
       .forEach(name => {
         delete require.cache[name]
       })

--- a/test/plugins/externals.json
+++ b/test/plugins/externals.json
@@ -15,6 +15,12 @@
       "versions": ["3.1.1"]
     }
   ],
+  "knex": [
+    {
+      "name": "sqlite3",
+      "versions": ["4.0.7"]
+    }
+  ],
   "koa": [
     {
       "name": "koa-websocket",

--- a/test/plugins/knex.spec.js
+++ b/test/plugins/knex.spec.js
@@ -1,0 +1,53 @@
+'use strict'
+
+// TODO: fix tests failing when re-running in watch mode
+
+const agent = require('./agent')
+const plugin = require('../../src/plugins/knex')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let knex
+  let client
+  let tracer
+
+  describe('knex', () => {
+    withVersions(plugin, 'knex', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, ['knex'])
+            .then(() => {
+              knex = require(`../../versions/knex@${version}`).get()
+              client = knex({
+                client: 'sqlite3',
+                connection: {
+                  filename: ':memory:'
+                }
+              })
+            })
+        })
+        it('should propagate context', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+
+          return tracer.scope().activate(span, () => {
+            return client.raw('PRAGMA user_version')
+              .then(() => {
+                expect(tracer.scope().active()).to.equal(span)
+              })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes traces being split in multiple traces when using [Knex](http://knexjs.org/) because it has its own internal promise implementation that causes the context to be lost. By patching the internal promise like we do for promise libraries, the context is propagated properly and the traces are not longer split.