### PR TITLE
fix(EventEmitter): use listener ddId when registering

### DIFF
--- a/src/scope/new/base.js
+++ b/src/scope/new/base.js
@@ -131,11 +131,11 @@ function wrapAddListener (addListener, scope, span) {
 
     const events = this._datadog_events[eventName]
 
-    if (!events[id]) {
-      events[id] = []
+    if (!events[listener._datadog_id]) {
+      events[listener._datadog_id] = []
     }
 
-    events[id].push(bound)
+    events[listener._datadog_id].push(bound)
 
     return addListener.call(this, eventName, bound)
   }

--- a/test/scope/scope.spec.js
+++ b/test/scope/scope.spec.js
@@ -291,6 +291,13 @@ describe('Scope', () => {
         emitter.on('test', listener2)
         emitter.on('test', listener2)
 
+        emitter.removeListener('test', listener)
+        emitter.removeListener('test', listener2)
+
+        emitter.on('test', listener)
+        emitter.on('test', listener2)
+        emitter.on('test', listener2)
+
         emitter.removeListener('test', listener2)
 
         emitter.on('test', () => {


### PR DESCRIPTION
Hello Datadog team,

The method `wrapRemoveListener` doesn't clear the _datadog_id variable from a listener.
This means that when re-registering the same listener for another event emitter, the scope's id and the listener's id can be out of sync. This makes it impossible to successfully de-register event listeners.

Let me know if the PR is correctly set up! Thanks for the great logging service :)