### PR TITLE
make requirement for async_hooks to use node version where memory usa…

### DIFF
--- a/src/scope/async_hooks/index.js
+++ b/src/scope/async_hooks/index.js
@@ -2,7 +2,7 @@
 
 const semver = require('semver')
 
-if (process && semver.gte(process.versions.node, '8.0.0')) {
+if (process && semver.gte(process.versions.node, '8.15.0')) {
   module.exports = require('./async_hooks')
 } else {
   module.exports = require('./async_wrap')


### PR DESCRIPTION
…ge is fixed

We experienced some heavy memory usage when using this agent in node version 8.9. Thought I would bump the requirement to be where the memory issue has been resolved in Node.js core.