### PR TITLE
fix event listeners in net plugin

### DIFF
--- a/src/plugins/net.js
+++ b/src/plugins/net.js
@@ -99,11 +99,11 @@ function setupListeners (socket, span, protocol) {
   }
 
   const cleanupListener = () => {
-    socket.off('connect', localListener)
+    socket.removeListener('connect', localListener)
 
     events.forEach(event => {
-      socket.off(event, wrapListener)
-      socket.off(event, cleanupListener)
+      socket.removeListener(event, wrapListener)
+      socket.removeListener(event, cleanupListener)
     })
   }
 

--- a/test/plugins/dns.spec.js
+++ b/test/plugins/dns.spec.js
@@ -31,6 +31,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'dns.hostname': 'localhost',
+            'dns.address': '127.0.0.1',
             'span.kind': 'client'
           })
         })

--- a/test/plugins/net.spec.js
+++ b/test/plugins/net.spec.js
@@ -164,35 +164,6 @@ describe('Plugin', () => {
       })
     })
 
-    it('should instrument close', done => {
-      const socket = new net.Socket()
-
-      agent
-        .use(traces => {
-          expect(traces[0][0]).to.deep.include({
-            name: 'tcp.connect',
-            service: 'test-tcp',
-            resource: `localhost:${port}`
-          })
-          expect(traces[0][0].meta).to.deep.include({
-            'span.kind': 'client',
-            'tcp.family': 'IPv4',
-            'tcp.remote.host': 'localhost',
-            'tcp.remote.port': `${port}`,
-            'out.host': 'localhost',
-            'out.port': `${port}`
-          })
-          expect(traces[0][0].parent_id.toString()).to.equal(parent.context().toSpanId())
-        })
-        .then(done)
-        .catch(done)
-
-      tracer.scope().activate(parent, () => {
-        socket.connect({ port })
-        socket.destroy()
-      })
-    })
-
     it('should instrument error', done => {
       const socket = new net.Socket()
 


### PR DESCRIPTION
This PR fixes the following issues with event listeners in the `net` plugin:

* The event listeners would not be cleaned up after the span is finished. When sockets are reused, this would lead to new event listeners constantly added and never removed.
* The `close` and `timeout` events were not handled. This could cause a memory leak if the socket was destroyed or timed out since the span would never be finished.

Since the `lookup` event cannot be reliably associated with the correct span when `connect()` is called multiple times, the `tcp.remote.address` tag was moved to the `dns` plugin instead as a new `dns.address` tag.