### PR TITLE
fix support for new elasticsearch version as a new module

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -2,11 +2,10 @@
 
 const fs = require('fs')
 const path = require('path')
-const requireDir = require('require-dir')
 const crypto = require('crypto')
 const semver = require('semver')
 const exec = require('./helpers/exec')
-const plugins = requireDir('../src/plugins')
+const plugins = require('../src/plugins')
 const externals = require('../test/plugins/externals')
 
 const workspaces = new Set()
@@ -66,6 +65,10 @@ function assertModules (name, version) {
 function assertFolder (name, version) {
   if (!fs.existsSync(folder())) {
     fs.mkdirSync(folder())
+  }
+
+  if (name && name.includes(path.sep)) {
+    name.split(path.sep).reduce(parent => assertFolder(parent))
   }
 
   if (!fs.existsSync(folder(name, version))) {

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -172,7 +172,7 @@ class Instrumenter {
     const instrumentations = [].concat(plugin)
 
     for (let i = 0; i < instrumentations.length; i++) {
-      if (instrumentations[i].name !== moduleName) continue
+      if (moduleName.indexOf(instrumentations[i].name) !== 0) continue
       if (instrumentations[i].versions && !matchVersion(moduleVersion, instrumentations[i].versions)) continue
       if (instrumentations[i].file && !exists(moduleBaseDir, instrumentations[i].file)) {
         this._fail(plugin)

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -125,7 +125,7 @@ class Instrumenter {
       .filter(plugin => [].concat(plugin).some(instrumentation =>
         filename(instrumentation) === moduleName && matchVersion(moduleVersion, instrumentation.versions)
       ))
-      .forEach(plugin => this._validate(plugin, moduleBaseDir, moduleVersion))
+      .forEach(plugin => this._validate(plugin, moduleName, moduleBaseDir, moduleVersion))
 
     this._plugins
       .forEach((meta, plugin) => {
@@ -167,11 +167,12 @@ class Instrumenter {
     this._load(plugin, meta)
   }
 
-  _validate (plugin, moduleBaseDir, moduleVersion) {
+  _validate (plugin, moduleName, moduleBaseDir, moduleVersion) {
     const meta = this._plugins.get(plugin)
     const instrumentations = [].concat(plugin)
 
     for (let i = 0; i < instrumentations.length; i++) {
+      if (instrumentations[i].name !== moduleName) continue
       if (instrumentations[i].versions && !matchVersion(moduleVersion, instrumentations[i].versions)) continue
       if (instrumentations[i].file && !exists(moduleBaseDir, instrumentations[i].file)) {
         this._fail(plugin)

--- a/src/plugins/elasticsearch.js
+++ b/src/plugins/elasticsearch.js
@@ -5,7 +5,7 @@ const analyticsSampler = require('../analytics_sampler')
 
 function createWrapRequest (tracer, config) {
   return function wrapRequest (request) {
-    return function requestWithTrace (params, cb) {
+    return function requestWithTrace (params, options, cb) {
       const childOf = tracer.scope().active()
       const span = tracer.startSpan('elasticsearch.query', {
         childOf,
@@ -17,21 +17,27 @@ function createWrapRequest (tracer, config) {
           'span.type': 'elasticsearch',
           'elasticsearch.url': params.path,
           'elasticsearch.method': params.method,
-          'elasticsearch.params': JSON.stringify(params.query)
+          'elasticsearch.params': JSON.stringify(params.querystring || params.query)
         }
       })
 
-      if (JSON.stringify(params.body)) {
+      if (params.body) {
         span.setTag('elasticsearch.body', JSON.stringify(params.body))
       }
 
       analyticsSampler.sample(span, config.analytics)
 
-      cb = tracer.scope().bind(cb, childOf)
+      cb = request.length === 2 || typeof options === 'function'
+        ? tracer.scope().bind(options, childOf)
+        : tracer.scope().bind(cb, childOf)
 
       return tracer.scope().activate(span, () => {
-        if (typeof cb === 'function') {
-          return request.call(this, params, wrapCallback(tracer, span, cb))
+        if (typeof cb === 'function' || typeof options === 'function') {
+          if (request.length === 2) {
+            return request.call(this, params, wrapCallback(tracer, span, cb))
+          } else {
+            return request.call(this, params, options, wrapCallback(tracer, span, cb))
+          }
         } else {
           const promise = request.apply(this, arguments)
 
@@ -72,6 +78,17 @@ module.exports = [
     name: 'elasticsearch',
     file: 'src/lib/transport.js',
     versions: ['>=10'],
+    patch (Transport, tracer, config) {
+      this.wrap(Transport.prototype, 'request', createWrapRequest(tracer, config))
+    },
+    unpatch (Transport) {
+      this.unwrap(Transport.prototype, 'request')
+    }
+  },
+  {
+    name: '@elastic/elasticsearch',
+    file: 'lib/Transport.js',
+    versions: ['>=5.6.16'], // initial version of this module
     patch (Transport, tracer, config) {
       this.wrap(Transport.prototype, 'request', createWrapRequest(tracer, config))
     },

--- a/src/plugins/elasticsearch.js
+++ b/src/plugins/elasticsearch.js
@@ -32,7 +32,7 @@ function createWrapRequest (tracer, config) {
         : tracer.scope().bind(cb, childOf)
 
       return tracer.scope().activate(span, () => {
-        if (typeof cb === 'function' || typeof options === 'function') {
+        if (typeof cb === 'function') {
           if (request.length === 2) {
             return request.call(this, params, wrapCallback(tracer, span, cb))
           } else {

--- a/test/instrumenter.spec.js
+++ b/test/instrumenter.spec.js
@@ -295,6 +295,21 @@ describe('Instrumenter', () => {
         expect(integrations.mysql[0].patch).to.have.been.calledWithMatch(Connection, 'tracer', {})
         expect(integrations.mysql[1].patch).to.have.been.calledWithMatch(Pool, 'tracer', {})
       })
+
+      it('should support patching multiple modules with different files', () => {
+        integrations.mysql[1].name = '@mysql/mock'
+        integrations.mysql[1].file = 'invalid.js'
+
+        const Connection = require('mysql-mock/lib/connection')
+
+        instrumenter.patch()
+
+        const mysql = require('mysql-mock')
+
+        expect(mysql).to.deep.equal({ name: 'mysql' })
+
+        expect(integrations.mysql[0].patch).to.have.been.calledWithMatch(Connection, 'tracer', {})
+      })
     })
 
     describe('unpatch', () => {

--- a/test/setup/core.js
+++ b/test/setup/core.js
@@ -75,13 +75,12 @@ function withVersions (plugin, modules, range, cb) {
       .forEach(instrumentation => {
         instrumentation.versions
           .forEach(version => {
-            console.log(moduleName, version)
             try {
               const min = semver.coerce(version).version
               require(`../../versions/${moduleName}@${min}`).get()
               testVersions.set(min, { range: version, test: min })
             } catch (e) {
-            // skip unsupported version
+              // skip unsupported version
             }
 
             agent.wipe()
@@ -91,7 +90,7 @@ function withVersions (plugin, modules, range, cb) {
               require(`../../versions/${moduleName}@${version}`).get()
               testVersions.set(max, { range: version, test: version })
             } catch (e) {
-            // skip unsupported version
+              // skip unsupported version
             }
 
             agent.wipe()

--- a/test/setup/core.js
+++ b/test/setup/core.js
@@ -48,10 +48,11 @@ function wrapIt () {
   }
 }
 
-function withVersions (plugin, moduleName, range, cb) {
+function withVersions (plugin, modules, range, cb) {
   const instrumentations = [].concat(plugin)
-  const testVersions = new Map()
   const names = [].concat(plugin).map(instrumentation => instrumentation.name)
+
+  modules = [].concat(modules)
 
   names.forEach(name => {
     if (externals[name]) {
@@ -66,40 +67,45 @@ function withVersions (plugin, moduleName, range, cb) {
     range = null
   }
 
-  instrumentations
-    .filter(instrumentation => instrumentation.name === moduleName)
-    .forEach(instrumentation => {
-      instrumentation.versions
-        .forEach(version => {
-          try {
-            const min = semver.coerce(version).version
-            require(`../../versions/${moduleName}@${min}`).get()
-            testVersions.set(min, { range: version, test: min })
-          } catch (e) {
+  modules.forEach(moduleName => {
+    const testVersions = new Map()
+
+    instrumentations
+      .filter(instrumentation => instrumentation.name === moduleName)
+      .forEach(instrumentation => {
+        instrumentation.versions
+          .forEach(version => {
+            console.log(moduleName, version)
+            try {
+              const min = semver.coerce(version).version
+              require(`../../versions/${moduleName}@${min}`).get()
+              testVersions.set(min, { range: version, test: min })
+            } catch (e) {
             // skip unsupported version
-          }
+            }
 
-          agent.wipe()
+            agent.wipe()
 
-          try {
-            const max = require(`../../versions/${moduleName}@${version}`).version()
-            require(`../../versions/${moduleName}@${version}`).get()
-            testVersions.set(max, { range: version, test: version })
-          } catch (e) {
+            try {
+              const max = require(`../../versions/${moduleName}@${version}`).version()
+              require(`../../versions/${moduleName}@${version}`).get()
+              testVersions.set(max, { range: version, test: version })
+            } catch (e) {
             // skip unsupported version
-          }
+            }
 
-          agent.wipe()
-        })
-    })
+            agent.wipe()
+          })
+      })
 
-  Array.from(testVersions)
-    .filter(v => !range || semver.satisfies(v[0], range))
-    .sort(v => v[0].localeCompare(v[0]))
-    .map(v => Object.assign({}, v[1], { version: v[0] }))
-    .forEach(v => {
-      describe(`with ${moduleName} ${v.range} (${v.version})`, () => cb(v.test))
-    })
+    Array.from(testVersions)
+      .filter(v => !range || semver.satisfies(v[0], range))
+      .sort(v => v[0].localeCompare(v[0]))
+      .map(v => Object.assign({}, v[1], { version: v[0] }))
+      .forEach(v => {
+        describe(`with ${moduleName} ${v.range} (${v.version})`, () => cb(v.test, moduleName))
+      })
 
-  agent.wipe()
+    agent.wipe()
+  })
 }


### PR DESCRIPTION
This PR fixes support for newer versions of the Elasticsearch module. The module moved to a new name from `elasticsearch` to `@elastic/elasticsearch` and the versioning scheme changed from semantic versioning to match the server version instead. There were a few breaking changes as well which have been fixed.