### PR TITLE
update test services to only wait 1 minute for the server to start

### DIFF
--- a/test/setup/operation.js
+++ b/test/setup/operation.js
@@ -4,7 +4,7 @@ const retry = require('retry')
 const BaseRetryOperation = require('retry/lib/retry_operation')
 
 const options = {
-  retries: 300,
+  retries: 60,
   factor: 1,
   minTimeout: 1000,
   maxTimeout: 1000,


### PR DESCRIPTION
When CircleCI is having issues, it's possible that the container for the server fails and then the test will wait for the server until the maximum number of retries is reached. Since servers should always start within a few second, waiting for 5 minutes only increases the time and cost of the build with no benefit.