### PR TITLE
add support for promise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,13 @@ jobs:
           - PG_TEST_NATIVE=true
       - image: postgres:9.5
 
+  node-promise:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - PLUGINS=promise
+
   node-q:
     <<: *node-plugin-base
     docker:
@@ -520,6 +527,7 @@ workflows:
       - node-net
       - node-pino
       - node-postgres
+      - node-promise
       - node-q
       - node-redis
       - node-restify
@@ -587,6 +595,7 @@ workflows:
       - node-net
       - node-pino
       - node-postgres
+      - node-promise
       - node-q
       - node-redis
       - node-restify

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -118,6 +118,7 @@ tracer.use('mysql2');
 tracer.use('net');
 tracer.use('pg');
 tracer.use('pino');
+tracer.use('promise');
 tracer.use('q');
 tracer.use('redis');
 tracer.use('restify');

--- a/index.d.ts
+++ b/index.d.ts
@@ -323,6 +323,7 @@ interface Plugins {
   "net": plugins.net;
   "pg": plugins.pg;
   "pino": plugins.pino;
+  "promise": plugins.promise;
   "q": plugins.q;
   "redis": plugins.redis;
   "restify": plugins.restify;
@@ -671,6 +672,12 @@ declare namespace plugins {
    * on the tracer.
    */
   interface pino extends Integration {}
+
+  /**
+   * This plugin patches the [promise](https://github.com/then/promise)
+   * module to bind the promise callback the the caller context.
+   */
+  interface promise extends Integration {}
 
   /**
    * This plugin patches the [q](https://github.com/kriskowal/q)

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -22,6 +22,7 @@ module.exports = {
   'net': require('./net'),
   'pg': require('./pg'),
   'pino': require('./pino'),
+  'promise': require('./promise'),
   'q': require('./q'),
   'redis': require('./redis'),
   'restify': require('./restify'),

--- a/src/plugins/promise.js
+++ b/src/plugins/promise.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const tx = require('./util/promise')
+
+module.exports = [
+  {
+    name: 'promise',
+    file: 'lib/core.js',
+    versions: ['>=7'],
+    patch (Promise, tracer, config) {
+      this.wrap(Promise.prototype, 'then', tx.createWrapThen(tracer, config))
+    },
+    unpatch (Promise) {
+      this.unwrap(Promise.prototype, 'then')
+    }
+  }
+]

--- a/test/plugins/promise.spec.js
+++ b/test/plugins/promise.spec.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const agent = require('./agent')
+const plugin = require('../../src/plugins/promise')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let Promise
+  let tracer
+
+  describe('promise', () => {
+    withVersions(plugin, 'promise', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'promise')
+            .then(() => {
+              Promise = require(`../../versions/promise@${version}`).get()
+            })
+        })
+
+        it('should run the then() callback in context where then() was called', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+          const promise = new Promise((resolve, reject) => {
+            setImmediate(() => {
+              tracer.scope().activate({}, () => {
+                resolve()
+              })
+            })
+          })
+
+          return tracer.scope().activate(span, () => {
+            return promise
+              .then(() => {
+                expect(tracer.scope().active()).to.equal(span)
+              })
+          })
+        })
+
+        it('should run the catch() callback in context where catch() was called', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+          const promise = new Promise((resolve, reject) => {
+            setImmediate(() => {
+              tracer.scope().activate({}, () => {
+                reject(new Error())
+              })
+            })
+          })
+
+          return tracer.scope().activate(span, () => {
+            return promise
+              .catch(err => {
+                throw err
+              })
+              .catch(() => {
+                expect(tracer.scope().active()).to.equal(span)
+              })
+          })
+        })
+
+        it('should allow to run without a scope if not available when calling then()', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          tracer.scope().activate(null, () => {
+            const promise = new Promise((resolve, reject) => {
+              setImmediate(() => {
+                tracer.scope().activate({}, () => {
+                  resolve()
+                })
+              })
+            })
+
+            return promise
+              .then(() => {
+                expect(tracer.scope().active()).to.be.null
+              })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for the `promise` module to ensure callbacks to `then()` are bound to the correct scope.