### PR TITLE
add support for promise-js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,13 @@ jobs:
           - PG_TEST_NATIVE=true
       - image: postgres:9.5
 
+  node-promise-js:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - PLUGINS=promise-js
+
   node-promise:
     <<: *node-plugin-base
     docker:
@@ -527,6 +534,7 @@ workflows:
       - node-net
       - node-pino
       - node-postgres
+      - node-promise-js
       - node-promise
       - node-q
       - node-redis
@@ -595,6 +603,7 @@ workflows:
       - node-net
       - node-pino
       - node-postgres
+      - node-promise-js
       - node-promise
       - node-q
       - node-redis

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -118,6 +118,7 @@ tracer.use('mysql2');
 tracer.use('net');
 tracer.use('pg');
 tracer.use('pino');
+tracer.use('promise-js');
 tracer.use('promise');
 tracer.use('q');
 tracer.use('redis');

--- a/index.d.ts
+++ b/index.d.ts
@@ -323,6 +323,7 @@ interface Plugins {
   "net": plugins.net;
   "pg": plugins.pg;
   "pino": plugins.pino;
+  "promise-js": plugins.promise_js;
   "promise": plugins.promise;
   "q": plugins.q;
   "redis": plugins.redis;
@@ -672,6 +673,12 @@ declare namespace plugins {
    * on the tracer.
    */
   interface pino extends Integration {}
+
+  /**
+   * This plugin patches the [promise-js](https://github.com/kevincennis/promise)
+   * module to bind the promise callback the the caller context.
+   */
+  interface promise_js extends Integration {}
 
   /**
    * This plugin patches the [promise](https://github.com/then/promise)

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -22,6 +22,7 @@ module.exports = {
   'net': require('./net'),
   'pg': require('./pg'),
   'pino': require('./pino'),
+  'promise-js': require('./promise-js'),
   'promise': require('./promise'),
   'q': require('./q'),
   'redis': require('./redis'),

--- a/src/plugins/promise-js.js
+++ b/src/plugins/promise-js.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const tx = require('./util/promise')
+
+module.exports = [
+  {
+    name: 'promise-js',
+    versions: ['>=0.0.3'],
+    patch (Promise, tracer, config) {
+      this.wrap(Promise.prototype, 'then', tx.createWrapThen(tracer, config))
+    },
+    unpatch (Promise) {
+      this.unwrap(Promise.prototype, 'then')
+    }
+  }
+]

--- a/test/plugins/promise-js.spec.js
+++ b/test/plugins/promise-js.spec.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const agent = require('./agent')
+const plugin = require('../../src/plugins/promise-js')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let Promise
+  let tracer
+
+  describe('promise-js', () => {
+    withVersions(plugin, 'promise-js', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load(plugin, 'promise-js')
+            .then(() => {
+              Promise = require(`../../versions/promise-js@${version}`).get()
+            })
+        })
+
+        it('should run the then() callback in context where then() was called', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+          const promise = new Promise((resolve, reject) => {
+            setImmediate(() => {
+              tracer.scope().activate({}, () => {
+                resolve()
+              })
+            })
+          })
+
+          return tracer.scope().activate(span, () => {
+            return promise
+              .then(() => {
+                expect(tracer.scope().active()).to.equal(span)
+              })
+          })
+        })
+
+        it('should run the catch() callback in context where catch() was called', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          const span = {}
+          const promise = new Promise((resolve, reject) => {
+            setImmediate(() => {
+              tracer.scope().activate({}, () => {
+                reject(new Error())
+              })
+            })
+          })
+
+          return tracer.scope().activate(span, () => {
+            return promise
+              .catch(err => {
+                throw err
+              })
+              .catch(() => {
+                expect(tracer.scope().active()).to.equal(span)
+              })
+          })
+        })
+
+        it('should allow to run without a scope if not available when calling then()', () => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+          tracer.scope().activate(null, () => {
+            const promise = new Promise((resolve, reject) => {
+              setImmediate(() => {
+                tracer.scope().activate({}, () => {
+                  resolve()
+                })
+              })
+            })
+
+            return promise
+              .then(() => {
+                expect(tracer.scope().active()).to.be.null
+              })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds support for the `promise-js` module to ensure callbacks to `then()` are bound to the correct scope.