### PR TITLE
fix invalid trace ID and span ID from dropped traces being propagated

### DIFF
--- a/src/noop/span.js
+++ b/src/noop/span.js
@@ -18,8 +18,6 @@ class NoopSpan extends Span {
 
       _noopContext: {
         value: new SpanContext({
-          traceId: 0,
-          spanId: 0,
           sampling: {
             priority: USER_REJECT
           }

--- a/src/opentracing/span_context.js
+++ b/src/opentracing/span_context.js
@@ -8,8 +8,8 @@ class DatadogSpanContext extends SpanContext {
 
     props = props || {}
 
-    this._traceId = props.traceId
-    this._spanId = props.spanId
+    this._traceId = props.traceId || 0
+    this._spanId = props.spanId || 0
     this._parentId = props.parentId || null
     this._name = props.name
     this._isFinished = props.isFinished || false

--- a/test/opentracing/propagation/text_map.spec.js
+++ b/test/opentracing/propagation/text_map.spec.js
@@ -89,6 +89,16 @@ describe('TextMapPropagator', () => {
 
       expect(carrier).to.have.property('x-datadog-origin', 'synthetics')
     })
+
+    it('should skip injection for dropped traces', () => {
+      const carrier = {}
+      const spanContext = new SpanContext()
+
+      propagator.inject(spanContext, carrier)
+
+      expect(carrier).to.not.have.property('x-datadog-trace-id')
+      expect(carrier).to.not.have.property('x-datadog-parent-id')
+    })
   })
 
   describe('extract', () => {
@@ -131,6 +141,15 @@ describe('TextMapPropagator', () => {
       const spanContext = propagator.extract(carrier)
 
       expect(spanContext._trace).to.have.property('origin', 'synthetics')
+    })
+
+    it('should skip extraction for empty traces', () => {
+      const spanContext = new SpanContext()
+      const carrier = textMap
+
+      carrier['x-datadog-trace-id'] = spanContext.toTraceId()
+
+      expect(propagator.extract(carrier)).to.be.null
     })
   })
 })

--- a/test/opentracing/span_context.spec.js
+++ b/test/opentracing/span_context.spec.js
@@ -46,8 +46,8 @@ describe('SpanContext', () => {
 
   it('should have the correct default values', () => {
     const expected = {
-      traceId: '123',
-      spanId: '456',
+      traceId: null,
+      spanId: null,
       parentId: null,
       name: undefined,
       isFinished: false,
@@ -67,8 +67,8 @@ describe('SpanContext', () => {
     })
 
     expect(spanContext).to.deep.equal({
-      _traceId: '123',
-      _spanId: '456',
+      _traceId: 0,
+      _spanId: 0,
       _parentId: null,
       _name: undefined,
       _isFinished: false,


### PR DESCRIPTION
This PR fixes the trace ID and span ID from dropped traces being propagated. Since dropped traces have all their spans pointing to a no-op span with both IDs empty, the next service would use these IDs for the parent even if they are invalid, resulting in the trace being dropped by the agent.