### PR TITLE
add an alternative scope manager in pure JS for older versions of Node

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,5 +1,5 @@
 Component,Origin,License,Copyright
-require,@datadog/async-listener,BSD-2-Clause,Copyright 2013-2017 Forrest L Norvell 2019 Datadog
+require,@datadog/async-listener,BSD-2-Clause,Copyright 2013-2017 Forrest L Norvell 2019 Datadog Inc.
 require,@types/node,MIT,Copyright Authors
 require,async-hook-jl,MIT,Copyright 2015 Andreas Madsen
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,4 +1,5 @@
 Component,Origin,License,Copyright
+require,@datadog/async-listener,BSD-2-Clause,Copyright 2013-2017 Forrest L Norvell 2019 Datadog
 require,@types/node,MIT,Copyright Authors
 require,async-hook-jl,MIT,Copyright 2015 Andreas Madsen
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
@@ -9,7 +10,7 @@ require,lodash.pick,MIT,Copyright JS Foundation and other contributors
 require,lodash.sortby,MIT,Copyright JS Foundation and other contributors
 require,lodash.truncate,MIT,Copyright JS Foundation and other contributors
 require,lodash.uniq,MIT,Copyright JS Foundation and other contributors
-require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk 2013-2014 TJ Holowaychuk
+require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk
 require,module-details-from-path,MIT,Copyright 2016 Thomas Watson Steen
 require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki
 require,nan,MIT,Copyright 2018 NAN contributors

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -4,6 +4,6 @@ const execSync = require('child_process').execSync
 const exec = cmd => execSync(cmd, { stdio: [0, 1, 2] })
 
 exec('node benchmark/core')
-exec('node benchmark/scope')
+exec('node benchmark/scope/async_hooks')
 exec('node benchmark/platform/node')
 exec('node benchmark/dd-trace')

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -5,5 +5,6 @@ const exec = cmd => execSync(cmd, { stdio: [0, 1, 2] })
 
 exec('node benchmark/core')
 exec('node benchmark/scope/async_hooks')
+exec('node benchmark/scope/async-listener')
 exec('node benchmark/platform/node')
 exec('node benchmark/dd-trace')

--- a/benchmark/scope/async-listener.js
+++ b/benchmark/scope/async-listener.js
@@ -1,0 +1,136 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const benchmark = require('../benchmark')
+
+const suite = benchmark('scope')
+
+const spanStub = require('../stubs/span')
+
+const asyncListener = {
+  addAsyncListener (hooks) {
+    this.create = hooks.create
+    this.before = hooks.before
+    this.after = hooks.after
+    this.error = hooks.error
+
+    return this
+  }
+}
+
+const Scope = proxyquire('../../src/scope/async-listener', {
+  '@datadog/async-listener': asyncListener
+})
+
+const scope = new Scope()
+const context = {}
+
+let fn
+let promise
+let emitter
+
+suite
+  .add('Scope#activate', {
+    fn () {
+      scope.activate(spanStub, () => {
+        asyncListener.create(spanStub)
+      })
+
+      asyncListener.before(context, spanStub)
+      asyncListener.after(context, spanStub)
+    }
+  })
+  .add('Scope#activate (nested)', {
+    fn () {
+      asyncListener.create(spanStub)
+      asyncListener.before(context, spanStub)
+
+      scope.activate(spanStub, () => {
+        asyncListener.create(spanStub)
+        asyncListener.after(context, spanStub)
+      })
+
+      asyncListener.before(context, spanStub)
+
+      scope.activate(spanStub, () => {
+        asyncListener.create(spanStub)
+        asyncListener.after(context, spanStub)
+      })
+
+      asyncListener.before(context, spanStub)
+      asyncListener.after(context, spanStub)
+    }
+  })
+  .add('Scope#active', {
+    fn () {
+      scope.active()
+    }
+  })
+  .add('Scope#bind (null)', {
+    fn () {
+      scope.bind(null, {})
+    }
+  })
+  .add('Scope#bind (fn)', {
+    fn () {
+      scope.bind(() => {}, {})
+    }
+  })
+  .add('Scope#bind (fn())', {
+    onStart () {
+      fn = scope.bind(() => {}, {})
+    },
+    fn () {
+      fn()
+    }
+  })
+  .add('Scope#bind (promise)', {
+    fn () {
+      const promise = {
+        then: () => {}
+      }
+
+      scope.bind(promise, {})
+    }
+  })
+  .add('Scope#bind (promise.then)', {
+    onStart () {
+      promise = scope.bind({
+        then: () => {}
+      }, {})
+    },
+    fn () {
+      promise.then(() => {})
+    }
+  })
+  .add('Scope#bind (emitter)', {
+    fn () {
+      const emitter = {
+        addListener: () => {},
+        on: () => {},
+        emit: () => {},
+        removeListener: () => {}
+      }
+
+      scope.bind(emitter, {})
+    }
+  })
+  .add('Scope#bind (emitter.on/off)', {
+    onStart () {
+      emitter = scope.bind({
+        addListener: () => {},
+        on: () => {},
+        emit: () => {},
+        removeListener: () => {},
+        off: () => {}
+      }, {})
+    },
+    fn () {
+      const listener = () => {}
+
+      emitter.on('test', listener)
+      emitter.off('test', listener)
+    }
+  })
+
+suite.run()

--- a/benchmark/scope/async_hooks.js
+++ b/benchmark/scope/async_hooks.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const platform = require('../src/platform')
-const node = require('../src/platform/node')
-const benchmark = require('./benchmark')
+const platform = require('../../src/platform')
+const node = require('../../src/platform/node')
+const benchmark = require('../benchmark')
 
 const suite = benchmark('scope')
 
-const spanStub = require('./stubs/span')
+const spanStub = require('../stubs/span')
 
 const hook = {
   enable () {},
@@ -32,9 +32,9 @@ const asyncHooks = {
   }
 }
 
-const Scope = proxyquire('../src/scope/new/scope', {
-  '../async_hooks': asyncHooks,
-  '../../platform': platform
+const Scope = proxyquire('../../src/scope/async_hooks', {
+  './async_hooks/': asyncHooks,
+  '../platform': platform
 })
 
 const scope = new Scope()

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -54,7 +54,8 @@ tracer.init({
   service: 'test',
   tags: {
     foo: 'bar'
-  }
+  },
+  scope: 'noop'
 });
 
 const httpOptions = {

--- a/ext/scopes.d.ts
+++ b/ext/scopes.d.ts
@@ -1,0 +1,7 @@
+declare const scopes: {
+  ASYNC_LISTENER: 'async-listener'
+  ASYNC_HOOKS: 'async_hooks'
+  NOOP: 'noop'
+}
+
+export = scopes

--- a/ext/scopes.js
+++ b/ext/scopes.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  ASYNC_LISTENER: 'async-listener',
+  ASYNC_HOOKS: 'async_hooks',
+  NOOP: 'noop'
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -256,6 +256,13 @@ export declare interface TracerOptions {
    * Global tags that should be assigned to every span.
    */
   tags?: { [key: string]: any };
+
+  /**
+   * Which scope implementation to use. The default is to use the best
+   * implementation for the runtime. Only change this if you know what you are
+   * doing.
+   */
+  scope?: 'async_hooks' | 'async-listener' | 'noop'
 }
 
 /** @hidden */

--- a/index.d.ts
+++ b/index.d.ts
@@ -258,7 +258,7 @@ export declare interface TracerOptions {
   tags?: { [key: string]: any };
 
   /**
-   * Which scope implementation to use. The default is to use the best
+   * Specifies which scope implementation to use. The default is to use the best
    * implementation for the runtime. Only change this if you know what you are
    * doing.
    */

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node": ">=4"
   },
   "dependencies": {
+    "@datadog/async-listener": "^0.1.0",
     "@types/node": "^10.12.18",
     "async-hook-jl": "^1.7.6",
     "int64-buffer": "^0.1.9",

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@
 const URL = require('url-parse')
 const platform = require('./platform')
 const coalesce = require('koalas')
+const scopes = require('../ext/scopes')
 
 class Config {
   constructor (service, options) {
@@ -31,6 +32,7 @@ class Config {
       platform.env('DD_TRACE_ANALYTICS')
     )
     const reportHostname = coalesce(options.reportHostname, platform.env('DD_TRACE_REPORT_HOSTNAME'), false)
+    const scope = coalesce(options.scope, platform.env('DD_TRACE_SCOPE'))
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
@@ -51,6 +53,7 @@ class Config {
     this.runtimeMetrics = String(runtimeMetrics) === 'true'
     this.experimental = {}
     this.reportHostname = String(reportHostname) === 'true'
+    this.scope = process.env.DD_CONTEXT_PROPAGATION === 'false' ? scopes.NOOP : scope
   }
 }
 

--- a/src/noop/tracer.js
+++ b/src/noop/tracer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Tracer = require('opentracing').Tracer
-const Scope = require('../scope/new/base')
+const Scope = require('../scope/base')
 const Span = require('./span')
 
 class NoopTracer extends Tracer {

--- a/src/scope/async-listener.js
+++ b/src/scope/async-listener.js
@@ -13,7 +13,6 @@ class Scope extends Base {
 
     singleton = this
 
-    this._stack = []
     this._listener = asyncListener.addAsyncListener({
       create: (storage) => this._active(),
       before: (context, storage) => this._enter(storage),

--- a/src/scope/async-listener.js
+++ b/src/scope/async-listener.js
@@ -15,23 +15,23 @@ class Scope extends Base {
 
     this._stack = []
     this._listener = asyncListener.addAsyncListener({
-      create: () => this._active(),
+      create: (storage) => this._active(),
       before: (context, storage) => this._enter(storage),
       after: (context, storage) => this._exit(),
-      error: (storage) => this._exit()
+      error: (storage, error) => this._exit()
     })
   }
 
   _active () {
-    return this._stack[this._stack.length - 1]
+    return this._span
   }
 
   _enter (span) {
-    this._stack.push(span)
+    this._span = span
   }
 
-  _exit () {
-    this._stack.pop()
+  _exit (span) {
+    this._span = span
   }
 }
 

--- a/src/scope/async-listener.js
+++ b/src/scope/async-listener.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const asyncListener = require('@datadog/async-listener')
+const Base = require('./base')
+
+let singleton = null
+
+class Scope extends Base {
+  constructor () {
+    if (singleton) return singleton
+
+    super()
+
+    singleton = this
+
+    this._stack = []
+    this._listener = asyncListener.addAsyncListener({
+      create: () => this._active(),
+      before: (context, storage) => this._enter(storage),
+      after: (context, storage) => this._exit(),
+      error: (storage) => this._exit()
+    })
+  }
+
+  _active () {
+    return this._stack[this._stack.length - 1]
+  }
+
+  _enter (span) {
+    this._stack.push(span)
+  }
+
+  _exit () {
+    this._stack.pop()
+  }
+}
+
+module.exports = Scope

--- a/src/scope/base.js
+++ b/src/scope/base.js
@@ -36,8 +36,26 @@ class Scope {
   }
 
   _activate (span, callback) {
-    return typeof callback === 'function' && callback()
+    const active = this._active()
+
+    this._enter(span)
+
+    try {
+      return callback()
+    } catch (e) {
+      if (span && typeof span.setTag === 'function') {
+        span.setTag('error', e)
+      }
+
+      throw e
+    } finally {
+      this._exit(active)
+    }
   }
+
+  _enter () {}
+
+  _exit () {}
 
   _bindFn (fn, span) {
     const scope = this

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -116,10 +116,10 @@ function addTags (span, options) {
   span.addTags(tags)
 }
 
-function getScopeManager () {
+function getScopeManager (config) {
   let ScopeManager
 
-  if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
+  if (config.scope === NOOP) {
     ScopeManager = require('./scope/noop/scope_manager')
   } else {
     ScopeManager = require('./scope/scope_manager')

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -31,6 +31,7 @@ describe('Config', () => {
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
     expect(config).to.have.property('reportHostname', false)
+    expect(config).to.have.property('scope', undefined)
   })
 
   it('should initialize from the default service', () => {
@@ -108,7 +109,8 @@ describe('Config', () => {
       flushInterval: 5000,
       runtimeMetrics: true,
       reportHostname: true,
-      plugins: false
+      plugins: false,
+      scope: 'noop'
     })
 
     expect(config).to.have.property('enabled', false)
@@ -127,6 +129,7 @@ describe('Config', () => {
     expect(config).to.have.property('runtimeMetrics', true)
     expect(config).to.have.property('reportHostname', true)
     expect(config).to.have.property('plugins', false)
+    expect(config).to.have.property('scope', 'noop')
     expect(config).to.have.deep.property('tags', {
       'foo': 'bar'
     })

--- a/test/scope/async-listener.spec.js
+++ b/test/scope/async-listener.spec.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const Scope = require('../../src/scope/async-listener')
+const testScope = require('./test')
+
+wrapIt()
+
+describe('Scope', () => {
+  testScope(() => new Scope())
+})

--- a/test/scope/async_hooks.spec.js
+++ b/test/scope/async_hooks.spec.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const Scope = require('../../src/scope/async_hooks')
+const platform = require('../../src/platform')
+const testScope = require('./test')
+
+wrapIt()
+
+describe('Scope', () => {
+  let scope
+  let metrics
+
+  beforeEach(() => {
+    metrics = platform.metrics()
+
+    sinon.spy(metrics, 'increment')
+    sinon.spy(metrics, 'decrement')
+
+    scope = new Scope()
+  })
+
+  afterEach(() => {
+    metrics.increment.restore()
+    metrics.decrement.restore()
+  })
+
+  it('should keep track of asynchronous resource count', () => {
+    scope._init(0, 'TEST')
+    scope._destroy(0)
+
+    expect(metrics.increment).to.have.been.calledWith('async.resources')
+    expect(metrics.decrement).to.have.been.calledWith('async.resources')
+  })
+
+  it('should keep track of asynchronous resource count by type', () => {
+    scope._init(0, 'TEST')
+    scope._destroy(0)
+
+    expect(metrics.increment).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
+    expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
+  })
+
+  it('should only track destroys once', () => {
+    scope._init(0, 'TEST')
+    scope._destroy(0)
+    scope._destroy(0)
+
+    expect(metrics.decrement).to.have.been.calledTwice
+    expect(metrics.decrement).to.have.been.calledWith('async.resources')
+    expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type')
+  })
+
+  testScope(() => scope)
+})

--- a/test/scope/test.js
+++ b/test/scope/test.js
@@ -1,55 +1,14 @@
 'use strict'
 
-const Scope = require('../../src/scope/new/scope')
 const Span = require('opentracing').Span
-const platform = require('../../src/platform')
 
-wrapIt()
-
-describe('Scope', () => {
+module.exports = factory => {
   let scope
   let span
-  let metrics
 
   beforeEach(() => {
-    metrics = platform.metrics()
-
-    sinon.spy(metrics, 'increment')
-    sinon.spy(metrics, 'decrement')
-
-    scope = new Scope()
+    scope = factory()
     span = new Span()
-  })
-
-  afterEach(() => {
-    metrics.increment.restore()
-    metrics.decrement.restore()
-  })
-
-  it('should keep track of asynchronous resource count', () => {
-    scope._init(0, 'TEST')
-    scope._destroy(0)
-
-    expect(metrics.increment).to.have.been.calledWith('async.resources')
-    expect(metrics.decrement).to.have.been.calledWith('async.resources')
-  })
-
-  it('should keep track of asynchronous resource count by type', () => {
-    scope._init(0, 'TEST')
-    scope._destroy(0)
-
-    expect(metrics.increment).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
-    expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
-  })
-
-  it('should only track destroys once', () => {
-    scope._init(0, 'TEST')
-    scope._destroy(0)
-    scope._destroy(0)
-
-    expect(metrics.decrement).to.have.been.calledTwice
-    expect(metrics.decrement).to.have.been.calledWith('async.resources')
-    expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type')
   })
 
   describe('active()', () => {
@@ -320,4 +279,4 @@ describe('Scope', () => {
       })
     })
   })
-})
+}

--- a/test/scope/test.js
+++ b/test/scope/test.js
@@ -110,6 +110,20 @@ module.exports = factory => {
 
       scope.activate(span, () => {})
     })
+
+    it('should handle errors', () => {
+      const error = new Error('boom')
+
+      sinon.spy(span, 'setTag')
+
+      try {
+        scope.activate(span, () => {
+          throw error
+        })
+      } catch (e) {
+        expect(span.setTag).to.have.been.calledWith('error', e)
+      }
+    })
   })
 
   describe('bind()', () => {


### PR DESCRIPTION
This PR adds an alternative scope manager in pure JS for older versions of Node. These versions have a lot of issues with `AsyncWrap` since it was still experimental. By using a pure JS implementation we can avoid these issues.