### PR TITLE
Add paperplane integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,6 +525,7 @@ workflows:
       - node-mongodb-core
       - node-mysql
       - node-net
+      - node-paperplane
       - node-pino
       - node-postgres
       - node-q
@@ -592,6 +593,7 @@ workflows:
       - node-mongodb-core
       - node-mysql
       - node-net
+      - node-paperplane
       - node-pino
       - node-postgres
       - node-q

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,13 @@ jobs:
         environment:
           - PLUGINS=net
 
+  node-paperplane:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - PLUGINS=paperplane
+
   node-pino:
     <<: *node-plugin-base
     docker:

--- a/docs/API.md
+++ b/docs/API.md
@@ -244,6 +244,8 @@ tracer.use('pg', {
 <h5 id="mysql2-config"></h5>
 <h5 id="net"></h5>
 <h5 id="paperplane"></h5>
+<h5 id="paperplane-tags"></h5>
+<h5 id="paperplane-config"></h5>
 <h5 id="pino"></h5>
 <h5 id="pg"></h5>
 <h5 id="pg-tags"></h5>

--- a/docs/API.md
+++ b/docs/API.md
@@ -243,6 +243,7 @@ tracer.use('pg', {
 <h5 id="mysql2-tags"></h5>
 <h5 id="mysql2-config"></h5>
 <h5 id="net"></h5>
+<h5 id="paperplane"></h5>
 <h5 id="pino"></h5>
 <h5 id="pg"></h5>
 <h5 id="pg-tags"></h5>
@@ -273,6 +274,7 @@ tracer.use('pg', {
 * [mysql](./interfaces/plugins.mysql.html)
 * [mysql2](./interfaces/plugins.mysql2.html)
 * [net](./interfaces/plugins.net.html)
+* [paperplane](./interfaces/plugins.paperplane.html)
 * [pino](./interfaces/plugins.pino.html)
 * [pg](./interfaces/plugins.pg.html)
 * [q](./interfaces/plugins.q.html)

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -117,6 +117,8 @@ tracer.use('mongodb-core');
 tracer.use('mysql');
 tracer.use('mysql2');
 tracer.use('net');
+tracer.use('paperplane');
+tracer.use('paperplane', httpServerOptions);
 tracer.use('pg');
 tracer.use('pino');
 tracer.use('q');

--- a/index.d.ts
+++ b/index.d.ts
@@ -322,6 +322,7 @@ interface Plugins {
   "mysql": plugins.mysql;
   "mysql2": plugins.mysql2;
   "net": plugins.net;
+  "paperplane": plugins.paperplane;
   "pg": plugins.pg;
   "pino": plugins.pino;
   "q": plugins.q;
@@ -664,6 +665,12 @@ declare namespace plugins {
    * [net](https://nodejs.org/api/net.html) module.
    */
   interface net extends Integration {}
+
+  /**
+   * This plugin automatically instruments the
+   * [paperplane](https://github.com/articulate/paperplane) module.
+   */
+  interface paperplane extends HttpServer {}
 
   /**
    * This plugin automatically instruments the

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -21,6 +21,7 @@ module.exports = {
   'mysql': require('./mysql'),
   'mysql2': require('./mysql2'),
   'net': require('./net'),
+  'paperplane': require('./paperplane'),
   'pg': require('./pg'),
   'pino': require('./pino'),
   'q': require('./q'),

--- a/src/plugins/paperplane.js
+++ b/src/plugins/paperplane.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const web = require('./util/web')
+
+const traceRoute = handler => req => {
+  const { original, route } = req
+
+  if (web.active(original)) {
+    web.enterRoute(original, route)
+  }
+
+  return handler(req)
+}
+
+const wrapMount = (tracer, config) => mount => opts => {
+  const handler = mount(opts)
+
+  const traced = (req, res) =>
+    web.instrument(
+      tracer, config, req, res, 'paperplane.request',
+      () => handler(req, res)
+    )
+
+  return traced
+}
+
+const wrapRoutes = tracer => routes => handlers => {
+  const traced = {}
+
+  for (const route in handlers) {
+    traced[route] = traceRoute(handlers[route])
+  }
+
+  return routes(traced)
+}
+
+function patch (paperplane, tracer, config) {
+  config = web.normalizeConfig(config)
+  this.wrap(paperplane, 'mount', wrapMount(tracer, config))
+  this.wrap(paperplane, 'routes', wrapRoutes(tracer))
+}
+
+function unpatch (paperplane) {
+  this.unwrap(paperplane, ['mount', 'routes'])
+}
+
+module.exports = {
+  name: 'paperplane',
+  versions: ['>=2.3'],
+  patch,
+  unpatch
+}

--- a/test/plugins/paperplane.spec.js
+++ b/test/plugins/paperplane.spec.js
@@ -69,6 +69,7 @@ describe('Plugin', () => {
 
                 expect(spans[0]).to.have.property('service', 'test')
                 expect(spans[0]).to.have.property('type', 'web')
+                expect(spans[0]).to.have.property('name', 'paperplane.request')
                 expect(spans[0]).to.have.property('resource', 'GET /user')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
                 expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)

--- a/test/plugins/paperplane.spec.js
+++ b/test/plugins/paperplane.spec.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const axios = require('axios')
+const getPort = require('get-port')
+const http = require('http')
+
+const agent = require('./agent')
+const plugin = require('../../src/plugins/paperplane')
+
+wrapIt()
+
+const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
+
+describe('Plugin', () => {
+  let paperplane
+  let server
+  let tracer
+
+  describe('paperplane', () => {
+    withVersions(plugin, 'paperplane', version => {
+      beforeEach(() => {
+        tracer = require('../..')
+      })
+
+      afterEach(() => {
+        server.close()
+      })
+
+      describe('without configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'paperplane')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          paperplane = require(`../../versions/paperplane@${version}`).get()
+        })
+
+        it('should do automatic instrumentation on app routes', done => {
+          const { methods, mount, routes, send } = paperplane
+
+          const app = routes({
+            '/user': methods({
+              GET: () => send()
+            })
+          })
+
+          server = http.createServer(mount({ app }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('service', 'test')
+                expect(spans[0]).to.have.property('type', 'web')
+                expect(spans[0]).to.have.property('resource', 'GET /user')
+                expect(spans[0].meta).to.have.property('span.kind', 'server')
+                expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+                expect(spans[0].meta).to.have.property('http.method', 'GET')
+                expect(spans[0].meta).to.have.property('http.status_code', '200')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(done)
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/plugins/paperplane.spec.js
+++ b/test/plugins/paperplane.spec.js
@@ -9,7 +9,19 @@ const plugin = require('../../src/plugins/paperplane')
 
 wrapIt()
 
-const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
+const composeP = (...fs) => x =>
+  fs.reduceRight(then, x)
+
+const cry = Function.prototype
+const logger = Function.prototype
+
+const sort = spans =>
+  spans.sort((a, b) =>
+    a.start.toString() >= b.start.toString() ? 1 : -1
+  )
+
+const then = (x, f) =>
+  Promise.resolve(x).then(f)
 
 describe('Plugin', () => {
   let paperplane
@@ -39,7 +51,7 @@ describe('Plugin', () => {
           paperplane = require(`../../versions/paperplane@${version}`).get()
         })
 
-        it('should do automatic instrumentation on app routes', done => {
+        it('should instrument exact routes', done => {
           const { methods, mount, routes, send } = paperplane
 
           const app = routes({
@@ -48,7 +60,7 @@ describe('Plugin', () => {
             })
           })
 
-          server = http.createServer(mount({ app }))
+          server = http.createServer(mount({ app, cry, logger }))
 
           getPort().then(port => {
             agent
@@ -69,6 +81,441 @@ describe('Plugin', () => {
             server.listen(port, 'localhost', () => {
               axios
                 .get(`http://localhost:${port}/user`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should instrument route patterns', done => {
+          const { methods, mount, routes, send } = paperplane
+
+          const app = routes({
+            '/user/:id': methods({
+              GET: () => send()
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /user/:id')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user/1`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should not lose the current path when changing scope', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
+          const { methods, mount, routes, send } = paperplane
+
+          const endpoints = routes({
+            '/user/:id': methods({
+              GET: () => send()
+            })
+          })
+
+          const changeScope = req =>
+            new Promise(resolve => {
+              const childOf = tracer.scope().active()
+              const child = tracer.startSpan('child', { childOf })
+
+              tracer.scope().activate(child, () => {
+                child.finish()
+                resolve(req)
+              })
+            })
+
+          const app = composeP(endpoints, changeScope)
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /user/:id')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user/123`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should not lose the current path without a scope', done => {
+          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
+          const { methods, mount, routes, send } = paperplane
+
+          const endpoints = routes({
+            '/user/:id': methods({
+              GET: () => send()
+            })
+          })
+
+          const removeScope = req =>
+            new Promise(resolve =>
+              tracer.scope().activate(null, () => resolve(req))
+            )
+
+          const app = composeP(endpoints, removeScope)
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /user/:id')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user/123`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should not lose the current path on error', done => {
+          const { methods, mount, routes } = paperplane
+
+          const app = routes({
+            '/app': methods({
+              GET: () => Promise.reject(new Error())
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /app')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/app`, {
+                  validateStatus: status => status === 500
+                })
+                .catch(done)
+            })
+          })
+        })
+
+        it('should fallback to the the verb if a path pattern could not be found', done => {
+          const { mount, send } = paperplane
+
+          const app = () => send()
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/app`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should only include paths for routes that matched', done => {
+          const { methods, mount, routes, send } = paperplane
+
+          const ok = () => send()
+
+          const app = routes({
+            '/app/baz': ok,
+            '/app/qux': ok,
+            '/app/user/:id': methods({ GET: ok }),
+            '/bar': ok,
+            '/foo': ok
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios.get(`http://localhost:${port}/app/user/123`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should extract its parent span from the headers', done => {
+          const { methods, mount, routes, send } = paperplane
+
+          const app = routes({
+            '/user': methods({
+              GET: () => send()
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent.use(traces => {
+              const spans = sort(traces[0])
+
+              expect(spans[0].trace_id.toString()).to.equal('1234')
+              expect(spans[0].parent_id.toString()).to.equal('5678')
+            })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  headers: {
+                    'x-datadog-trace-id': '1234',
+                    'x-datadog-parent-id': '5678',
+                    'ot-baggage-foo': 'bar'
+                  }
+                })
+                .catch(done)
+            })
+          })
+        })
+
+        it('should handle error status codes', done => {
+          const { methods, mount, routes } = paperplane
+
+          const app = routes({
+            '/user': methods({
+              GET: () => ({ statusCode: 500 })
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent.use(traces => {
+              const spans = sort(traces[0])
+
+              expect(spans[0]).to.have.property('error', 1)
+              expect(spans[0]).to.have.property('resource', 'GET /user')
+              expect(spans[0].meta).to.have.property('http.status_code', '500')
+
+              done()
+            })
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  validateStatus: status => status === 500
+                })
+                .catch(done)
+            })
+          })
+        })
+
+        it('should only handle errors for configured status codes', done => {
+          const { methods, mount, routes } = paperplane
+
+          const app = routes({
+            '/user': methods({
+              GET: () => ({ statusCode: 400 })
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent.use(traces => {
+              const spans = sort(traces[0])
+
+              expect(spans[0]).to.have.property('error', 0)
+              expect(spans[0]).to.have.property('resource', 'GET /user')
+              expect(spans[0].meta).to.have.property('http.status_code', '400')
+
+              done()
+            })
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  validateStatus: status => status === 400
+                })
+                .catch(done)
+            })
+          })
+        })
+
+        it('should handle request errors', done => {
+          const { mount } = paperplane
+
+          const app = () => { throw new Error('boom') }
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('error', 1)
+                expect(spans[0].meta).to.have.property('http.status_code', '500')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  validateStatus: status => status === 500
+                })
+                .catch(done)
+            })
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'paperplane', {
+            service: 'custom',
+            validateStatus: code => code < 400,
+            headers: ['User-Agent']
+          })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          paperplane = require(`../../versions/paperplane@${version}`).get()
+        })
+
+        it('should be configured with the correct service name', done => {
+          const { methods, mount, routes, send } = paperplane
+
+          const app = routes({
+            '/user': methods({
+              GET: () => send()
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('service', 'custom')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should be configured with the correct status code validator', done => {
+          const { methods, mount, routes } = paperplane
+
+          const app = routes({
+            '/user': methods({
+              GET: () => ({ statusCode: 400 })
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('error', 1)
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  validateStatus: status => status === 400
+                })
+                .catch(done)
+            })
+          })
+        })
+
+        it('should include specified headers in metadata', done => {
+          const { methods, mount, routes, send } = paperplane
+
+          const app = routes({
+            '/user': methods({
+              GET: () => send()
+            })
+          })
+
+          server = http.createServer(mount({ app, cry, logger }))
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0].meta).to.have.property('http.request.headers.user-agent', 'test')
+              })
+              .then(done)
+              .catch(done)
+
+            server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  headers: { 'User-Agent': 'test' }
+                })
                 .catch(done)
             })
           })


### PR DESCRIPTION
<p align="center">
  <a href="https://github.com/articulate/paperplane"><img src="https://cloud.githubusercontent.com/assets/888052/22172037/543e7f10-df6b-11e6-8ab8-8a1e679dd27e.png" alt="paperplane" style="max-width:100%;"></a>
</p>

<p align="center">
  This PR adds support for <a href="https://github.com/articulate/paperplane"><code>paperplane</code></a>.
</p>

I spoke with someone in the [#apm Slack channel](https://datadoghq.slack.com/messages/C3SH3KCQG/) about a month ago, and they gave me the 👍 to take a stab at it myself.  This week I finally got around to it.  The integration turned out nice and short with the `src/plugins/util/web.js` bit already extracted, and I ported over the `express` tests, only leaving out cases that didn't apply to a `paperplane` app.

We're excited for the opportunity to get APM data for all of our existing services built on `paperplane`.  Please let me know if I missed anything or if there's something I can do better.  Thanks!