### PR TITLE
remove replica set in mongo build due to bug in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,10 +280,7 @@ jobs:
         environment:
           - SERVICES=mongo
           - PLUGINS=mongodb-core
-      - image: bitnami/mongodb:3.6.11
-        environment:
-          - MONGODB_REPLICA_SET_MODE=primary
-          - MONGODB_ADVERTISED_HOSTNAME=localhost
+      - image: circleci/mongo
 
   node-net:
     <<: *node-plugin-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,7 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
   mongo:
-    image: bitnami/mongodb:3.6
-    environment:
-      - MONGODB_REPLICA_SET_MODE=primary
-      - MONGODB_ADVERTISED_HOSTNAME=localhost
+    image: circleci/mongo
     ports:
       - "127.0.0.1:27017:27017"
   elasticsearch:

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const semver = require('semver')
+// const semver = require('semver')
 const agent = require('./agent')
 const Buffer = require('safe-buffer').Buffer
 const plugin = require('../../src/plugins/mongodb-core')
@@ -315,54 +315,54 @@ describe('Plugin', () => {
         })
       })
 
-      describe('with a replica set', () => {
-        if (!semver.intersects(version, '>=2.0.5')) return // bug with replica sets before 2.0.5
+      // describe('with a replica set', () => {
+      //   if (!semver.intersects(version, '>=2.0.5')) return // bug with replica sets before 2.0.5
 
-        before(() => {
-          return agent.load(plugin, 'mongodb-core')
-        })
+      //   before(() => {
+      //     return agent.load(plugin, 'mongodb-core')
+      //   })
 
-        after(() => {
-          return agent.close()
-        })
+      //   after(() => {
+      //     return agent.close()
+      //   })
 
-        beforeEach(done => {
-          mongo = require(`../../versions/mongodb-core@${version}`).get()
+      //   beforeEach(done => {
+      //     mongo = require(`../../versions/mongodb-core@${version}`).get()
 
-          server = new mongo.ReplSet([{
-            host: 'localhost',
-            port: 27017
-          }], {
-            setName: 'replicaset',
-            reconnect: false,
-            connectionTimeout: 1000
-          })
+      //     server = new mongo.ReplSet([{
+      //       host: 'localhost',
+      //       port: 27017
+      //     }], {
+      //       setName: 'replicaset',
+      //       reconnect: false,
+      //       connectionTimeout: 1000
+      //     })
 
-          server.on('connect', () => done())
-          server.on('error', done)
+      //     server.on('connect', () => done())
+      //     server.on('error', done)
 
-          server.connect()
-        })
+      //     server.connect()
+      //   })
 
-        it('should set the correct host/port tags', done => {
-          agent
-            .use(traces => {
-              const span = traces[0][0]
+      //   it('should set the correct host/port tags', done => {
+      //     agent
+      //       .use(traces => {
+      //         const span = traces[0][0]
 
-              expect(span.meta).to.have.property('out.host', 'localhost')
-              expect(span.meta).to.have.property('out.port', '27017')
-            })
-            .then(done)
-            .catch(done)
+      //         expect(span.meta).to.have.property('out.host', 'localhost')
+      //         expect(span.meta).to.have.property('out.port', '27017')
+      //       })
+      //       .then(done)
+      //       .catch(done)
 
-          const cursor = server.cursor(`test.${collection}`, {
-            insert: `test.${collection}`,
-            documents: [{ a: 1 }]
-          }, {})
+      //     const cursor = server.cursor(`test.${collection}`, {
+      //       insert: `test.${collection}`,
+      //       documents: [{ a: 1 }]
+      //     }, {})
 
-          cursor.next()
-        })
-      })
+      //     cursor.next()
+      //   })
+      // })
 
       describe('with configuration', () => {
         before(() => {

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// const semver = require('semver')
 const agent = require('./agent')
 const Buffer = require('safe-buffer').Buffer
 const plugin = require('../../src/plugins/mongodb-core')
@@ -314,55 +313,6 @@ describe('Plugin', () => {
           })
         })
       })
-
-      // describe('with a replica set', () => {
-      //   if (!semver.intersects(version, '>=2.0.5')) return // bug with replica sets before 2.0.5
-
-      //   before(() => {
-      //     return agent.load(plugin, 'mongodb-core')
-      //   })
-
-      //   after(() => {
-      //     return agent.close()
-      //   })
-
-      //   beforeEach(done => {
-      //     mongo = require(`../../versions/mongodb-core@${version}`).get()
-
-      //     server = new mongo.ReplSet([{
-      //       host: 'localhost',
-      //       port: 27017
-      //     }], {
-      //       setName: 'replicaset',
-      //       reconnect: false,
-      //       connectionTimeout: 1000
-      //     })
-
-      //     server.on('connect', () => done())
-      //     server.on('error', done)
-
-      //     server.connect()
-      //   })
-
-      //   it('should set the correct host/port tags', done => {
-      //     agent
-      //       .use(traces => {
-      //         const span = traces[0][0]
-
-      //         expect(span.meta).to.have.property('out.host', 'localhost')
-      //         expect(span.meta).to.have.property('out.port', '27017')
-      //       })
-      //       .then(done)
-      //       .catch(done)
-
-      //     const cursor = server.cursor(`test.${collection}`, {
-      //       insert: `test.${collection}`,
-      //       documents: [{ a: 1 }]
-      //     }, {})
-
-      //     cursor.next()
-      //   })
-      // })
 
       describe('with configuration', () => {
         before(() => {

--- a/test/setup/services/mongo.js
+++ b/test/setup/services/mongo.js
@@ -8,14 +8,6 @@ function waitForMongo () {
     const operation = new RetryOperation('mongo')
 
     operation.attempt(currentAttempt => {
-      // const server = new mongo.ReplSet([{
-      //   host: 'localhost',
-      //   port: 27017
-      // }], {
-      //   setName: 'replicaset',
-      //   reconnect: false
-      // })
-
       const server = new mongo.Server({
         host: 'localhost',
         port: 27017,

--- a/test/setup/services/mongo.js
+++ b/test/setup/services/mongo.js
@@ -8,11 +8,17 @@ function waitForMongo () {
     const operation = new RetryOperation('mongo')
 
     operation.attempt(currentAttempt => {
-      const server = new mongo.ReplSet([{
+      // const server = new mongo.ReplSet([{
+      //   host: 'localhost',
+      //   port: 27017
+      // }], {
+      //   setName: 'replicaset',
+      //   reconnect: false
+      // })
+
+      const server = new mongo.Server({
         host: 'localhost',
-        port: 27017
-      }], {
-        setName: 'replicaset',
+        port: 27017,
         reconnect: false
       })
 


### PR DESCRIPTION
This PR removes the replica set in the Mongo build since there is a bug in CircleCI that prevents the container from running properly. This issue has made our build fail for a couple months at this point, and it's becoming clear the bug will not be fixed in a timely fashion. This means we have to temporarily disable the test for replica sets so that at least the other tests can run.