### PR TITLE
fix auto instrumentation of loaded modules without an entrypoint defined

### DIFF
--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -256,7 +256,7 @@ function getModules (instrumentation) {
 
       pkg = require(`${basedir}/package.json`)
 
-      if (!id.endsWith(`/node_modules/${instrumentation.name}/${pkg.main}`)) continue
+      if (!id.endsWith(`/node_modules/${instrumentation.name}/${pkg.main || 'index.js'}`)) continue
     }
 
     if (!matchVersion(pkg.version, instrumentation.versions)) continue

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -42,7 +42,12 @@ describe('Instrumenter', () => {
           patch: sinon.spy(),
           unpatch: sinon.spy()
         }
-      ]
+      ],
+      other: {
+        name: 'other',
+        versions: ['1.x'],
+        patch: sinon.spy()
+      }
     }
 
     shimmer = sinon.spy()
@@ -54,11 +59,13 @@ describe('Instrumenter', () => {
       './plugins': {
         'http': integrations.http,
         'express-mock': integrations.express,
-        'mysql-mock': integrations.mysql
+        'mysql-mock': integrations.mysql,
+        'other': integrations.other
       },
       '../../datadog-plugin-http/src': integrations.http,
       '../../datadog-plugin-express-mock/src': integrations.express,
-      '../../datadog-plugin-mysql-mock/src': integrations.mysql
+      '../../datadog-plugin-mysql-mock/src': integrations.mysql,
+      '../../datadog-plugin-other/src': integrations.other
     })
 
     instrumenter = new Instrumenter(tracer)
@@ -180,6 +187,13 @@ describe('Instrumenter', () => {
         require('express-mock')
 
         expect(integrations.express.patch).to.not.have.been.called
+      })
+
+      it('should patch modules without declared entrypoint', () => {
+        instrumenter.use('other', true)
+        require('other')
+
+        expect(integrations.other.patch).to.have.been.called
       })
     })
 

--- a/packages/dd-trace/test/node_modules/express-mock/package.json
+++ b/packages/dd-trace/test/node_modules/express-mock/package.json
@@ -2,7 +2,6 @@
   "name": "express-mock",
   "version": "4.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/dd-trace/test/node_modules/express-mock/package.json
+++ b/packages/dd-trace/test/node_modules/express-mock/package.json
@@ -2,6 +2,7 @@
   "name": "express-mock",
   "version": "4.0.0",
   "description": "",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/dd-trace/test/node_modules/other/package.json
+++ b/packages/dd-trace/test/node_modules/other/package.json
@@ -2,7 +2,6 @@
   "name": "other",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The automatic instrumentation works well but enforces the API consumer to follow a fixed lifecycle on his side. The intention of these changes is to add means to instrument already supported modules manually at any point in time.

I believe this PR would close handle issue #560, at least for my case.

Thanks for maintaining this project.

_Note: this is a WIP to validate the approach. If the owners think this make sense I will be happy to push the feature during the review process._