### PR TITLE
Adds an option to skip downloading binaries

### DIFF
--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -13,12 +13,16 @@ const pkg = require('../package.json')
 const name = `${os.platform()}-${os.arch()}`
 
 if (process.env.DD_NATIVE_METRICS !== 'false') {
-  download(`v${pkg.version}`)
-    .catch(() => getLatestTag().then(download))
-    .then(persist)
-    .then(extract)
-    .then(cleanup)
-    .catch(rebuild)
+  if (process.env.DD_SKIP_DOWNLOAD !== 'true') {
+    download(`v${pkg.version}`)
+      .catch(() => getLatestTag().then(download))
+      .then(persist)
+      .then(extract)
+      .then(cleanup)
+      .catch(rebuild)
+  } else {
+    rebuild()
+  }
 }
 
 function rebuild () {

--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -13,7 +13,7 @@ const pkg = require('../package.json')
 const name = `${os.platform()}-${os.arch()}`
 
 if (process.env.DD_NATIVE_METRICS !== 'false') {
-  if (process.env.DD_SKIP_DOWNLOAD !== 'true') {
+  if (process.env.DD_SKIP_PREBUILT_DOWNLOAD !== 'true') {
     download(`v${pkg.version}`)
       .catch(() => getLatestTag().then(download))
       .then(persist)


### PR DESCRIPTION
We are using your module in our company and since we are behind a corporate proxy installs would stall. Please consider this PR that adds a `DD_SKIP_DOWNLOAD` environment variable. If `true`, the `post_install` script will try to rebuild the binaries without attempting to download the pre-built binaries from GitHub.

Let me know if you need me to do any changes and thanks in advance.