### PR TITLE
add timeout to prebuilt addons download to avoid idle sockets

### DIFF
--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -107,7 +107,7 @@ function cleanup () {
 }
 
 function getLatestTag () {
-  const promise = fetch(`https://github.com/DataDog/dd-trace-js/releases/latest`)
+  const promise = fetch('https://github.com/DataDog/dd-trace-js/releases/latest')
     .then(res => {
       const match = res.headers.location && res.headers.location.match(/^.+\/(.+)$/)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a timeout to the prebuilt addons download in the post install script. This avoids sockets to be stuck in an idle state permanently when TCP packets are dropped somewhere in the connection.

### Motivation

The issue was reported in #590. While the proposed solution makes sense since there is no point to attempt a download that will always fail, the script should still not hang when the option is not used.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
