### PR TITLE
replace custom env var with standard flag to skip prebuilt download

### DIFF
--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -11,9 +11,10 @@ const tar = require('tar')
 const pkg = require('../package.json')
 
 const name = `${os.platform()}-${os.arch()}`
+const buildFromSource = process.env.npm_config_build_from_source
 
 if (process.env.DD_NATIVE_METRICS !== 'false') {
-  if (process.env.DD_SKIP_PREBUILT_DOWNLOAD !== 'true') {
+  if (buildFromSource !== 'true' && buildFromSource !== 'dd-trace') {
     download(`v${pkg.version}`)
       .catch(() => getLatestTag().then(download))
       .then(persist)


### PR DESCRIPTION
### What does this PR do?

Replace custom environment variable with standard `--build-from-source` flag to skip downloading prebuilt addons.

### Motivation

The ability to skip downloading prebuilt addons was requested in #590. It was mentioned in this PR that other native modules support a `--build-from-source` flag to force local compilation. It turns out this behavior is standard, so we should support that instead of having our own custom environment variable.
