### PR TITLE
fix http client holding onto async resources in some cases

### DIFF
--- a/packages/dd-trace/src/writer.js
+++ b/packages/dd-trace/src/writer.js
@@ -84,14 +84,17 @@ class Writer {
 
     log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)
 
-    platform
-      .request(Object.assign({ data }, options))
-      .then(res => {
-        log.debug(`Response from the agent: ${res}`)
+    platform.request(Object.assign({ data }, options), (err, res) => {
+      if (err) return log.error(err)
 
+      log.debug(`Response from the agent: ${res}`)
+
+      try {
         this._prioritySampler.update(JSON.parse(res).rate_by_service)
-      })
-      .catch(e => log.error(e))
+      } catch (e) {
+        log.error(err)
+      }
+    })
   }
 }
 

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -225,7 +225,7 @@ describe('Platform', () => {
             'Content-Type': 'application/octet-stream'
           },
           data: Buffer.from(JSON.stringify({ foo: 'bar' }))
-        }).then(res => {
+        }, (err, res) => {
           expect(res).to.equal('OK')
         })
       })
@@ -250,7 +250,7 @@ describe('Platform', () => {
             'Content-Type': 'application/octet-stream'
           },
           data: [Buffer.from('fizz', 'utf-8'), Buffer.from('buzz', 'utf-8')]
-        }).then(res => {
+        }, (err, res) => {
           expect(res).to.equal('OK')
         })
       })
@@ -263,29 +263,27 @@ describe('Platform', () => {
         request({
           path: '/path',
           method: 'PUT'
+        }, err => {
+          expect(err).to.be.instanceof(Error)
+          expect(err.message).to.equal('Error from the agent: 400 Bad Request')
+          done()
         })
-          .catch(err => {
-            expect(err).to.be.instanceof(Error)
-            expect(err.message).to.equal('Error from the agent: 400 Bad Request')
-            done()
-          })
       })
 
-      it('should timeout after 5 seconds by default', done => {
+      it('should timeout after 2 seconds by default', done => {
         nock('http://localhost:80')
           .put('/path')
-          .socketDelay(5001)
+          .socketDelay(2001)
           .reply(200)
 
         request({
           path: '/path',
           method: 'PUT'
+        }, err => {
+          expect(err).to.be.instanceof(Error)
+          expect(err.message).to.equal('Network error trying to reach the agent: socket hang up')
+          done()
         })
-          .catch(err => {
-            expect(err).to.be.instanceof(Error)
-            expect(err.message).to.equal('Network error trying to reach the agent: socket hang up')
-            done()
-          })
       })
 
       it('should have a configurable timeout', done => {
@@ -298,12 +296,11 @@ describe('Platform', () => {
           path: '/path',
           method: 'PUT',
           timeout: 2000
+        }, err => {
+          expect(err).to.be.instanceof(Error)
+          expect(err.message).to.equal('Network error trying to reach the agent: socket hang up')
+          done()
         })
-          .catch(err => {
-            expect(err).to.be.instanceof(Error)
-            expect(err.message).to.equal('Network error trying to reach the agent: socket hang up')
-            done()
-          })
       })
     })
 

--- a/packages/dd-trace/test/writer.spec.js
+++ b/packages/dd-trace/test/writer.spec.js
@@ -9,7 +9,6 @@ describe('Writer', () => {
   let trace
   let span
   let platform
-  let request
   let response
   let format
   let encode
@@ -35,13 +34,11 @@ describe('Writer', () => {
       }
     })
 
-    request = Promise.resolve(response)
-
     platform = {
       name: sinon.stub(),
       version: sinon.stub(),
       engine: sinon.stub(),
-      request: sinon.stub().returns(request),
+      request: sinon.stub().yields(null, response),
       msgpack: {
         prefix: sinon.stub()
       }
@@ -166,7 +163,7 @@ describe('Writer', () => {
     it('should log request errors', done => {
       const error = new Error('boom')
 
-      platform.request.returns(Promise.reject(error))
+      platform.request.yields(error)
 
       writer.append(span)
       writer.flush()


### PR DESCRIPTION
### What does this PR do?

Add a response timeout as a safety net if the response takes too long, and replace the promise with a callback to avoid holding onto the promise async resources if the request hangs or is aborted.

### Motivation

Some users are seeing a constant increase in the number of `PROMISE` async resources. The only place where we create a promise is in the HTTP client that flushes traces to the agent. By removing this promise, we ensure that we cannot be the cause of such issue.