### PR TITLE
add memory leak protection when async resources are not destroyed

### DIFF
--- a/benchmark/scope/async_hooks.js
+++ b/benchmark/scope/async_hooks.js
@@ -25,8 +25,15 @@ const asyncHooks = {
     this.destroy = hooks.destroy
     this.promiseResolve = hooks.promiseResolve
 
-    this.before = asyncId => ids.push(asyncId)
-    this.after = asyncId => ids.pop(asyncId)
+    this.before = asyncId => {
+      ids.push(asyncId)
+      hooks.before(asyncId)
+    }
+
+    this.after = asyncId => {
+      ids.pop(asyncId)
+      hooks.after(asyncId)
+    }
 
     return hook
   }

--- a/benchmark/stubs/span.js
+++ b/benchmark/stubs/span.js
@@ -9,6 +9,9 @@ const id = new Uint64BE(0x12345678, 0x12345678)
 
 const span = {
   tracer: () => ({
+    scope: () => ({
+      _wipe: () => {}
+    }),
     _service: 'service'
   }),
   addTags: () => {},

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -50,7 +50,7 @@ describe('Plugin', () => {
 
           memcached = new Memcached('localhost:11211', { retries: 0 })
 
-          const span = {}
+          const span = tracer.startSpan('web.request')
 
           tracer.scope().activate(span, () => {
             memcached.get('test', err => {

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const asyncHooks = require('./async_hooks/index')
-const eid = asyncHooks.executionAsyncId
 const Base = require('./base')
 const platform = require('../platform')
 const semver = require('semver')
@@ -22,8 +21,11 @@ class Scope extends Base {
     this._spans = Object.create(null)
     this._types = Object.create(null)
     this._weaks = new WeakMap()
+    this._refs = new WeakMap()
     this._hook = asyncHooks.createHook({
       init: this._init.bind(this),
+      before: this._before.bind(this),
+      after: this._after.bind(this),
       destroy: this._destroy.bind(this),
       promiseResolve: this._destroy.bind(this)
     })
@@ -32,26 +34,59 @@ class Scope extends Base {
   }
 
   _active () {
-    return this._spans[eid()]
+    return this._current
   }
 
   _enter (span) {
-    this._spans[eid()] = span
+    this._current = span
   }
 
   _exit (span) {
-    const asyncId = eid()
+    this._current = span
+  }
 
+  _wipe (span) {
+    const ids = this._refs.get(span)
+
+    if (ids) {
+      ids.forEach(asyncId => {
+        delete this._spans[asyncId]
+        delete this._types[asyncId]
+      })
+
+      this._refs.delete(span)
+    }
+  }
+
+  _ref (span, asyncId) {
     if (span) {
-      this._spans[asyncId] = span
-    } else {
-      delete this._spans[asyncId]
+      const ids = this._refs.get(span)
+
+      if (ids) {
+        ids.add(asyncId)
+      } else {
+        this._refs.set(span, new Set([asyncId]))
+      }
+    }
+  }
+
+  _unref (span, asyncId) {
+    if (span) {
+      const ids = this._refs.get(span)
+
+      if (ids) {
+        ids.delete(asyncId)
+      }
     }
   }
 
   _init (asyncId, type, triggerAsyncId, resource) {
-    this._spans[asyncId] = this._active()
+    const span = this._active()
+
+    this._spans[asyncId] = span
     this._types[asyncId] = type
+
+    this._ref(span, asyncId)
 
     if (hasKeepAliveBug && (type === 'TCPWRAP' || type === 'HTTPPARSER')) {
       this._destroy(this._weaks.get(resource))
@@ -62,8 +97,19 @@ class Scope extends Base {
     platform.metrics().increment('async.resources.by.type', `resource_type:${type}`)
   }
 
+  _before (asyncId) {
+    this._current = this._spans[asyncId]
+  }
+
+  _after () {
+    delete this._current
+  }
+
   _destroy (asyncId) {
+    const span = this._spans[asyncId]
     const type = this._types[asyncId]
+
+    this._unref(span, asyncId)
 
     if (type) {
       platform.metrics().decrement('async.resources')

--- a/packages/dd-trace/src/scope/base.js
+++ b/packages/dd-trace/src/scope/base.js
@@ -57,6 +57,8 @@ class Scope {
 
   _exit () {}
 
+  _wipe () {}
+
   _bindFn (fn, span) {
     const scope = this
     const spanOrActive = this._spanOrActive(span)

--- a/packages/dd-trace/src/writer.js
+++ b/packages/dd-trace/src/writer.js
@@ -27,6 +27,7 @@ class Writer {
     if (trace.started.length === trace.finished.length) {
       this._prioritySampler.sample(spanContext)
 
+      // Consumers are always finished before any child spans are started.
       if (trace.started.length > 1 || span.context()._tags['span.kind'] !== 'consumer') {
         trace.started.forEach(span => span.tracer().scope()._wipe(span))
       }

--- a/packages/dd-trace/src/writer.js
+++ b/packages/dd-trace/src/writer.js
@@ -27,6 +27,10 @@ class Writer {
     if (trace.started.length === trace.finished.length) {
       this._prioritySampler.sample(spanContext)
 
+      if (trace.started.length > 1 || span.context()._tags['span.kind'] !== 'consumer') {
+        trace.started.forEach(span => span.tracer().scope()._wipe(span))
+      }
+
       const formattedTrace = trace.finished.map(format)
 
       if (spanContext._sampling.drop === true) {


### PR DESCRIPTION
### What does this PR do?

Add memory leak protection when async resources are not destroyed by removing all span references from the scope manager for spans of a finished trace.

### Motivation

When an async resource is not destroyed properly, it causes any span in the associated scope to stay in memory forever. While this means there is an existing memory leak, usually it's barely noticeable. Since a span also holds its entire trace in memory, it means that the tracer makes these existing memory leaks several orders of magnitude worse, potentially resulting in an eventual OOM.