### PR TITLE
fix jest tests breaking because of unsupported require syntax

### DIFF
--- a/benchmark/scope/async_hooks.js
+++ b/benchmark/scope/async_hooks.js
@@ -33,7 +33,7 @@ const asyncHooks = {
 }
 
 const Scope = proxyquire('../../packages/dd-trace/src/scope/async_hooks', {
-  './async_hooks/': asyncHooks,
+  './async_hooks/index': asyncHooks,
   '../platform': platform
 })
 

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const asyncHooks = require('./async_hooks/')
+const asyncHooks = require('./async_hooks/index')
 const eid = asyncHooks.executionAsyncId
 const Base = require('./base')
 const platform = require('../platform')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update imports to not use a trailing slash.

### Motivation
<!-- What inspired you to submit this pull request? -->

Jest doesn't support this syntax as reported in #585.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Fixes #585