### PR TITLE
update build config to generate prebuilds for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,24 +560,36 @@ workflows:
               only:
                 - master
                 - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - prebuild-linux-x32:
           filters:
             branches:
               only:
                 - master
                 - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - prebuild-darwin-x64:
           filters:
             branches:
               only:
                 - master
                 - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - prebuild-darwin-x32:
           filters:
             branches:
               only:
                 - master
                 - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - alpine
       - alpine-prebuilt:
           requires:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update CircleCI build configuration to generate prebuilds for tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

When releasing beta versions, it's possible that the commit referenced by the tag doesn't exist in any branch. Prebuilt binaries should still be generated so they can be added to the release.