### PR TITLE
Patch the express.set method as well

### DIFF
--- a/packages/datadog-plugin-express/src/index.js
+++ b/packages/datadog-plugin-express/src/index.js
@@ -3,6 +3,7 @@
 const METHODS = require('methods').concat('use', 'route', 'param', 'all', 'set')
 const web = require('../../dd-trace/src/plugins/util/web')
 const routerPlugin = require('../../datadog-plugin-router/src')
+const qs = require('qs')
 
 function createWrapMethod (tracer, config) {
   config = web.normalizeConfig(config)
@@ -17,6 +18,11 @@ function createWrapMethod (tracer, config) {
     return function methodWithTrace () {
       if (!this._datadog_trace_patched && !this._router) {
         this._datadog_trace_patched = true
+        // override the default query parser setting
+        this.set('query parser', (str) => {
+          return qs.parse(str, {depth: 11});
+        });
+
         this.use(ddTrace)
       }
       return original.apply(this, arguments)

--- a/packages/datadog-plugin-express/src/index.js
+++ b/packages/datadog-plugin-express/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const METHODS = require('methods').concat('use', 'route', 'param', 'all')
+const METHODS = require('methods').concat('use', 'route', 'param', 'all', 'set')
 const web = require('../../dd-trace/src/plugins/util/web')
 const routerPlugin = require('../../datadog-plugin-router/src')
 


### PR DESCRIPTION
Ensure that things like below are still workable.

```
const qs = require('qs')
app.set('query parser', (str) => {
  return qs.parse(str, {depth: 11});
});
```

Otherwise the customised query parser is never invoked if tracing is enabled.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
