### PR TITLE
fix undefined type resulting in wrong async resource metrics

### DIFF
--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -57,7 +57,7 @@ class Scope extends Base {
     }
   }
 
-  _ref (span, asyncId) {
+  _ref (asyncId, span) {
     this._spans[asyncId] = span
 
     if (span) {
@@ -71,7 +71,9 @@ class Scope extends Base {
     }
   }
 
-  _unref (span, asyncId) {
+  _unref (asyncId) {
+    const span = this._spans[asyncId]
+
     delete this._spans[asyncId]
 
     if (span) {
@@ -86,7 +88,7 @@ class Scope extends Base {
   _init (asyncId, type, triggerAsyncId, resource) {
     const span = this._active()
 
-    this._ref(span, asyncId)
+    this._ref(asyncId, span)
 
     this._types[asyncId] = type
 
@@ -108,10 +110,9 @@ class Scope extends Base {
   }
 
   _destroy (asyncId) {
-    const span = this._spans[asyncId]
     const type = this._types[asyncId]
 
-    this._unref(span, asyncId)
+    this._unref(asyncId)
 
     delete this._types[asyncId]
 
@@ -122,7 +123,7 @@ class Scope extends Base {
   }
 
   _promiseResolve (asyncId) {
-    delete this._spans[asyncId]
+    this._unref(asyncId)
   }
 }
 

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -51,7 +51,6 @@ class Scope extends Base {
     if (ids) {
       ids.forEach(asyncId => {
         delete this._spans[asyncId]
-        delete this._types[asyncId]
       })
 
       this._refs.delete(span)
@@ -59,6 +58,8 @@ class Scope extends Base {
   }
 
   _ref (span, asyncId) {
+    this._spans[asyncId] = span
+
     if (span) {
       const ids = this._refs.get(span)
 
@@ -71,6 +72,8 @@ class Scope extends Base {
   }
 
   _unref (span, asyncId) {
+    delete this._spans[asyncId]
+
     if (span) {
       const ids = this._refs.get(span)
 
@@ -80,31 +83,15 @@ class Scope extends Base {
     }
   }
 
-  _add (asyncId, type) {
+  _init (asyncId, type, triggerAsyncId, resource) {
     const span = this._active()
 
     this._ref(span, asyncId)
 
-    this._spans[asyncId] = span
     this._types[asyncId] = type
-  }
-
-  _delete (asyncId) {
-    const span = this._spans[asyncId]
-
-    this._unref(span, asyncId)
-
-    delete this._spans[asyncId]
-    delete this._types[asyncId]
-  }
-
-  _init (asyncId, type, triggerAsyncId, resource) {
-    this._add(asyncId, type)
-
-    this._first = this._first || asyncId
 
     if (hasKeepAliveBug && (type === 'TCPWRAP' || type === 'HTTPPARSER')) {
-      this._delete(this._weaks.get(resource))
+      this._destroy(this._weaks.get(resource))
       this._weaks.set(resource, asyncId)
     }
 
@@ -121,18 +108,21 @@ class Scope extends Base {
   }
 
   _destroy (asyncId) {
+    const span = this._spans[asyncId]
     const type = this._types[asyncId]
 
-    this._delete(asyncId)
+    this._unref(span, asyncId)
 
-    if (asyncId >= this._first) {
+    delete this._types[asyncId]
+
+    if (type) {
       platform.metrics().decrement('async.resources')
       platform.metrics().decrement('async.resources.by.type', `resource_type:${type}`)
     }
   }
 
   _promiseResolve (asyncId) {
-    this._delete(asyncId)
+    delete this._spans[asyncId]
   }
 }
 

--- a/packages/dd-trace/test/scope/async_hooks.spec.js
+++ b/packages/dd-trace/test/scope/async_hooks.spec.js
@@ -84,12 +84,12 @@ describe('Scope', () => {
     it('should work around the HTTP keep-alive bug in Node', () => {
       const resource = {}
 
-      sinon.spy(scope, '_delete')
+      sinon.spy(scope, '_destroy')
 
       scope._init(1, 'TCPWRAP', 0, resource)
       scope._init(1, 'TCPWRAP', 0, resource)
 
-      expect(scope._delete).to.have.been.called
+      expect(scope._destroy).to.have.been.called
     })
   }
 

--- a/packages/dd-trace/test/scope/async_hooks.spec.js
+++ b/packages/dd-trace/test/scope/async_hooks.spec.js
@@ -26,31 +26,25 @@ describe('Scope', () => {
   })
 
   it('should keep track of asynchronous resource count', () => {
-    const asyncId = scope._first + 1
-
-    scope._init(asyncId, 'TEST')
-    scope._destroy(asyncId)
+    scope._init(0, 'TEST')
+    scope._destroy(0)
 
     expect(metrics.increment).to.have.been.calledWith('async.resources')
     expect(metrics.decrement).to.have.been.calledWith('async.resources')
   })
 
   it('should keep track of asynchronous resource count by type', () => {
-    const asyncId = scope._first + 1
-
-    scope._init(asyncId, 'TEST')
-    scope._destroy(asyncId)
+    scope._init(0, 'TEST')
+    scope._destroy(0)
 
     expect(metrics.increment).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
     expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
   })
 
   it('should only track promise destroys once', () => {
-    const asyncId = scope._first + 1
-
-    scope._init(asyncId, 'TEST')
-    scope._promiseResolve(asyncId)
-    scope._destroy(asyncId)
+    scope._init(0, 'TEST')
+    scope._promiseResolve(0)
+    scope._destroy(0)
 
     expect(metrics.decrement).to.have.been.calledTwice
     expect(metrics.decrement).to.have.been.calledWith('async.resources')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `undefined` type when calculating the async resource metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

With the new mechanism in the scope manager to remove spans early from memory to release the trace, the type information was removed as well. This means that the metrics for the actual types would always go up and a single metric for `undefined` would go always go down.