### PR TITLE
replace memory leak detection mechanism with erasing finished traces

### DIFF
--- a/benchmark/scope/async_hooks.js
+++ b/benchmark/scope/async_hooks.js
@@ -25,15 +25,8 @@ const asyncHooks = {
     this.destroy = hooks.destroy
     this.promiseResolve = hooks.promiseResolve
 
-    this.before = asyncId => {
-      ids.push(asyncId)
-      hooks.before(asyncId)
-    }
-
-    this.after = asyncId => {
-      ids.pop(asyncId)
-      hooks.after(asyncId)
-    }
+    this.before = asyncId => ids.push(asyncId)
+    this.after = asyncId => ids.pop(asyncId)
 
     return hook
   }

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -56,20 +56,13 @@ class DatadogSpan extends Span {
     let spanContext
 
     if (parent) {
-      const trace = parent._trace
-      const finished = trace.started.length === trace.finished.length
-
       spanContext = new SpanContext({
         traceId: parent._traceId,
         spanId: platform.id(),
         parentId: parent._spanId,
         sampling: parent._sampling,
         baggageItems: parent._baggageItems,
-        trace: {
-          started: finished ? [] : trace.started,
-          finished: finished ? [] : trace.finished,
-          origin: trace.origin
-        }
+        trace: parent._trace
       })
     } else {
       const spanId = platform.id()

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const asyncHooks = require('./async_hooks/index')
+const eid = asyncHooks.executionAsyncId
 const Base = require('./base')
 const platform = require('../platform')
 const semver = require('semver')
@@ -21,75 +22,35 @@ class Scope extends Base {
     this._spans = Object.create(null)
     this._types = Object.create(null)
     this._weaks = new WeakMap()
-    this._refs = new WeakMap()
     this._hook = asyncHooks.createHook({
       init: this._init.bind(this),
-      before: this._before.bind(this),
-      after: this._after.bind(this),
       destroy: this._destroy.bind(this),
-      promiseResolve: this._promiseResolve.bind(this)
+      promiseResolve: this._destroy.bind(this)
     })
 
     this._hook.enable()
   }
 
   _active () {
-    return this._current
+    return this._spans[eid()]
   }
 
   _enter (span) {
-    this._current = span
+    this._spans[eid()] = span
   }
 
   _exit (span) {
-    this._current = span
-  }
-
-  _wipe (span) {
-    const ids = this._refs.get(span)
-
-    if (ids) {
-      ids.forEach(asyncId => {
-        delete this._spans[asyncId]
-      })
-
-      this._refs.delete(span)
-    }
-  }
-
-  _ref (asyncId, span) {
-    this._spans[asyncId] = span
+    const asyncId = eid()
 
     if (span) {
-      const ids = this._refs.get(span)
-
-      if (ids) {
-        ids.add(asyncId)
-      } else {
-        this._refs.set(span, new Set([asyncId]))
-      }
-    }
-  }
-
-  _unref (asyncId) {
-    const span = this._spans[asyncId]
-
-    delete this._spans[asyncId]
-
-    if (span) {
-      const ids = this._refs.get(span)
-
-      if (ids) {
-        ids.delete(asyncId)
-      }
+      this._spans[asyncId] = span
+    } else {
+      delete this._spans[asyncId]
     }
   }
 
   _init (asyncId, type, triggerAsyncId, resource) {
-    const span = this._active()
-
-    this._ref(asyncId, span)
-
+    this._spans[asyncId] = this._active()
     this._types[asyncId] = type
 
     if (hasKeepAliveBug && (type === 'TCPWRAP' || type === 'HTTPPARSER')) {
@@ -101,29 +62,16 @@ class Scope extends Base {
     platform.metrics().increment('async.resources.by.type', `resource_type:${type}`)
   }
 
-  _before (asyncId) {
-    this._current = this._spans[asyncId]
-  }
-
-  _after () {
-    delete this._current
-  }
-
   _destroy (asyncId) {
     const type = this._types[asyncId]
-
-    this._unref(asyncId)
-
-    delete this._types[asyncId]
 
     if (type) {
       platform.metrics().decrement('async.resources')
       platform.metrics().decrement('async.resources.by.type', `resource_type:${type}`)
     }
-  }
 
-  _promiseResolve (asyncId) {
-    this._unref(asyncId)
+    delete this._spans[asyncId]
+    delete this._types[asyncId]
   }
 }
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -77,24 +77,6 @@ describe('Span', () => {
     expect(span.context()._trace).to.equal(parent._trace)
   })
 
-  it('should start a new trace if the parent trace is finished', () => {
-    const parent = {
-      _traceId: '123',
-      _spanId: '456',
-      _baggageItems: { foo: 'bar' },
-      _trace: {
-        started: ['span'],
-        finished: ['span'],
-        origin: 'synthetics'
-      }
-    }
-
-    span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation', parent })
-
-    expect(span.context()._trace.started).to.deep.equal([span])
-    expect(span.context()._trace.origin).to.equal('synthetics')
-  })
-
   it('should set the sample rate metric from the sampler', () => {
     expect(span.context()._metrics).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
   })

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -74,8 +74,7 @@ describe('Span', () => {
     expect(span.context()._traceId).to.deep.equal('123')
     expect(span.context()._parentId).to.deep.equal('456')
     expect(span.context()._baggageItems).to.deep.equal({ foo: 'bar' })
-    expect(span.context()._trace.started).to.deep.equal(['span', span])
-    expect(span.context()._trace.origin).to.equal('synthetics')
+    expect(span.context()._trace).to.equal(parent._trace)
   })
 
   it('should start a new trace if the parent trace is finished', () => {

--- a/packages/dd-trace/test/plugins/util/tx.spec.js
+++ b/packages/dd-trace/test/plugins/util/tx.spec.js
@@ -42,12 +42,13 @@ describe('plugins/util/tx', () => {
         const callback = sinon.spy()
         const error = new Error('boom')
         const wrapper = tx.wrap(span, callback)
+        const tags = span.context()._tags
 
         wrapper(error)
 
-        expect(span.context()._tags).to.have.property('error.msg', error.message)
-        expect(span.context()._tags).to.have.property('error.type', error.name)
-        expect(span.context()._tags).to.have.property('error.stack', error.stack)
+        expect(tags).to.have.property('error.msg', error.message)
+        expect(tags).to.have.property('error.type', error.name)
+        expect(tags).to.have.property('error.stack', error.stack)
       })
 
       it('should return a wrapper that runs in the current scope', done => {
@@ -82,14 +83,15 @@ describe('plugins/util/tx', () => {
       it('should set the error tags when the promise is rejected', () => {
         const error = new Error('boom')
         const promise = Promise.reject(error)
+        const tags = span.context()._tags
 
         tx.wrap(span, promise)
 
         return promise.catch(err => {
           expect(err).to.equal(error)
-          expect(span.context()._tags).to.have.property('error.msg', error.message)
-          expect(span.context()._tags).to.have.property('error.type', error.name)
-          expect(span.context()._tags).to.have.property('error.stack', error.stack)
+          expect(tags).to.have.property('error.msg', error.message)
+          expect(tags).to.have.property('error.type', error.name)
+          expect(tags).to.have.property('error.stack', error.stack)
         })
       })
     })

--- a/packages/dd-trace/test/scope/async_hooks.spec.js
+++ b/packages/dd-trace/test/scope/async_hooks.spec.js
@@ -41,43 +41,14 @@ describe('Scope', () => {
     expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type', 'resource_type:TEST')
   })
 
-  it('should only track promise destroys once', () => {
+  it('should only track destroys once', () => {
     scope._init(0, 'TEST')
-    scope._promiseResolve(0)
+    scope._destroy(0)
     scope._destroy(0)
 
     expect(metrics.decrement).to.have.been.calledTwice
     expect(metrics.decrement).to.have.been.calledWith('async.resources')
     expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type')
-  })
-
-  it('should have a safeguard against async resource leaks', done => {
-    const span = {}
-
-    scope.activate(span, () => {
-      setImmediate(() => {
-        expect(scope.active()).to.be.null
-        done()
-      })
-
-      scope._wipe(span)
-    })
-  })
-
-  it('should preserve the current scope even with the memory leak safeguard', done => {
-    const parent = {}
-    const child = {}
-
-    scope.activate(parent, () => {
-      setImmediate(() => {
-        scope.activate(child, () => {
-          scope._wipe(parent)
-
-          expect(scope.active()).to.equal(child)
-          done()
-        })
-      })
-    })
   })
 
   if (!semver.satisfies(process.version, '^8.13 || >=10.14.2')) {

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -115,16 +115,18 @@ describe('Tracer', () => {
 
     it('should handle exceptions', () => {
       let span
+      let tags
 
       try {
         tracer.trace('name', {}, _span => {
           span = _span
+          tags = span.context()._tags
           sinon.spy(span, 'finish')
           throw new Error('boom')
         })
       } catch (e) {
         expect(span.finish).to.have.been.called
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           'error.type': e.name,
           'error.msg': e.message,
           'error.stack': e.stack
@@ -153,10 +155,12 @@ describe('Tracer', () => {
       it('should handle errors', () => {
         const error = new Error('boom')
         let span
+        let tags
         let done
 
         tracer.trace('name', {}, (_span, _done) => {
           span = _span
+          tags = span.context()._tags
           sinon.spy(span, 'finish')
           done = _done
         })
@@ -164,7 +168,7 @@ describe('Tracer', () => {
         done(error)
 
         expect(span.finish).to.have.been.called
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           'error.type': error.name,
           'error.msg': error.message,
           'error.stack': error.stack
@@ -200,16 +204,18 @@ describe('Tracer', () => {
 
       it('should handle rejected promises', done => {
         let span
+        let tags
 
         tracer
           .trace('name', {}, _span => {
             span = _span
+            tags = span.context()._tags
             sinon.spy(span, 'finish')
             return Promise.reject(new Error('boom'))
           })
           .catch(e => {
             expect(span.finish).to.have.been.called
-            expect(span.context()._tags).to.include({
+            expect(tags).to.include({
               'error.type': e.name,
               'error.msg': e.message,
               'error.stack': e.stack

--- a/packages/dd-trace/test/writer.spec.js
+++ b/packages/dd-trace/test/writer.spec.js
@@ -131,24 +131,16 @@ describe('Writer', () => {
       expect(prioritySampler.sample).to.have.been.calledWith(span.context())
     })
 
-    it('should remove spans from all scopes when the trace is finished', () => {
-      trace.started = [span, span]
-      trace.finished = [span, span]
-
-      writer.append(span)
-
-      expect(scope._wipe).to.have.been.calledTwice
-      expect(scope._wipe).to.have.been.calledWith(span)
-    })
-
-    it('should wait for more spans before removing for consumers', () => {
-      span.context()._tags['span.kind'] = 'consumer'
+    it('should erase the trace once finished', () => {
       trace.started = [span]
       trace.finished = [span]
 
       writer.append(span)
 
-      expect(scope._wipe).to.not.have.been.called
+      expect(trace).to.have.deep.property('started', [])
+      expect(trace).to.have.deep.property('finished', [])
+      expect(span.context()).to.have.deep.property('_tags', {})
+      expect(span.context()).to.have.deep.property('_metrics', {})
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Replace the memory leak detection mechanism added last week with a simpler approach of erasing finished traces. Erasing means removing any data that is no longer relevant on the span context of every span after a trace is finished. This includes the reference to the trace itself, tags, and metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

The memory leak detection mechanism was a breaking change in how context propagation works, which means the tracer usability was impacted. It was also not possible to completely prevent the tracer from being impacted by the leak so the fix was technically incomplete.

It's important to note that the goal here is to reduce the impact that the tracer has on existing memory leaks in the application itself. By erasing the trace, holding a span in memory will have a much lesser impact.