### PR TITLE
fix missing TS type for passing variables as an array to graphql

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -111,6 +111,7 @@ tracer.use('express');
 tracer.use('express', httpServerOptions);
 tracer.use('generic-pool');
 tracer.use('graphql', graphqlOptions);
+tracer.use('graphql', { variables: ['foo', 'bar'] });
 tracer.use('hapi');
 tracer.use('hapi', httpServerOptions);
 tracer.use('http');

--- a/index.d.ts
+++ b/index.d.ts
@@ -603,11 +603,11 @@ declare namespace plugins {
     depth?: number;
 
     /**
-     * A callback to enable recording of variables. By default, no variables are
-     * recorded. For example, using `variables => variables` would record all
-     * variables.
+     * An array of variable names to record. Can also be a callback that returns
+     * the key/value pairs to record. For example, using
+     * `variables => variables` would record all variables.
      */
-    variables?: (variables: { [key: string]: any }) => { [key: string]: any };
+    variables?: string[] | ((variables: { [key: string]: any }) => { [key: string]: any });
 
     /**
      * Whether to collapse list items into a single element. (i.e. single


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing TypeScript type definition for passing variables as an array to the `graphql` plugin.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix #608 