### PR TITLE
remove flaky memory leak tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,7 +533,6 @@ workflows:
     jobs:
       - lint
       - typescript
-      - node-leaks
       - node-core-4
       - node-core-6
       - node-core-8


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove flaky memory leak tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Our current strategy to test for memory leaks is slow and flaky. We need to revisit how we do these tests, but in the meantime we can't rely on these tests so they should be removed.