### PR TITLE
remove runtime-id tag from runtime metrics and traces

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -4,7 +4,6 @@ const Int64BE = require('int64-buffer').Int64BE
 const constants = require('./constants')
 const tags = require('../../../ext/tags')
 const log = require('./log')
-const platform = require('./platform')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -80,7 +80,6 @@ function extractTags (trace, span) {
   }
 
   if (span.tracer()._service === tags['service.name']) {
-    addTag(trace.meta, 'runtime-id', platform.runtime().id())
     addTag(trace.meta, 'language', 'javascript')
   }
 

--- a/packages/dd-trace/src/platform/node/metrics.js
+++ b/packages/dd-trace/src/platform/node/metrics.js
@@ -24,8 +24,7 @@ module.exports = function () {
   return metrics || (metrics = { // cache the metrics instance
     start: (options) => {
       const tags = [
-        `service:${this._config.service}`,
-        `runtime-id:${this.runtime().id()}`
+        `service:${this._config.service}`
       ]
 
       if (this._config.env) {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -43,9 +43,6 @@ describe('format', () => {
     }
 
     platform = {
-      runtime: sinon.stub().returns({
-        id: sinon.stub().returns('1234')
-      }),
       hostname: sinon.stub().returns('my_hostname')
     }
 

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -170,7 +170,6 @@ describe('format', () => {
       trace = format(span)
 
       expect(trace.meta['language']).to.equal('javascript')
-      expect(trace.meta['runtime-id']).to.equal('1234')
     })
 
     it('should add runtime tags only for the root service', () => {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -178,7 +178,6 @@ describe('format', () => {
       trace = format(span)
 
       expect(trace.meta).to.not.have.property('language')
-      expect(trace.meta).to.not.have.property('runtime-id')
     })
 
     describe('when there is an `error` tag ', () => {

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -433,7 +433,6 @@ describe('Platform', () => {
             host: 'localhost',
             tags: [
               'service:service',
-              'runtime-id:1234',
               'env:test'
             ]
           })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the `runtime-id` tag from runtime metrics and traces.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was originally added to correlate between the runtime metrics from a process and traces generated in the same process. However, the cardinality of the runtime ID is too high to be useful. We will introduce a better way to correlate in a future version.