### PR TITLE
fix mongodb-core plugin swallowing missing callback errors

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -5,7 +5,12 @@ const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 
 function createWrapOperation (tracer, config, operationName) {
   return function wrapOperation (operation) {
-    return function operationWithTrace (ns, ops, options, callback) {
+    return function operationWithTrace (ns, ops) {
+      const index = arguments.length - 1
+      const callback = arguments[index]
+
+      if (typeof callback !== 'function') return operation.apply(this, arguments)
+
       const scope = tracer.scope()
       const childOf = scope.active()
       const span = tracer.startSpan('mongodb.query', { childOf })
@@ -14,15 +19,9 @@ function createWrapOperation (tracer, config, operationName) {
 
       analyticsSampler.sample(span, config.analytics)
 
-      if (typeof options === 'function') {
-        return scope
-          .bind(operation, span)
-          .call(this, ns, ops, wrapCallback(tracer, span, options))
-      } else {
-        return scope
-          .bind(operation, span)
-          .call(this, ns, ops, options, wrapCallback(tracer, span, callback))
-      }
+      arguments[index] = wrapCallback(tracer, span, callback)
+
+      return scope.bind(operation, span).apply(this, arguments)
     }
   }
 }

--- a/packages/datadog-plugin-mongodb-core/test/index.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/index.spec.js
@@ -197,6 +197,14 @@ describe('Plugin', () => {
               server.destroy()
             })
           })
+
+          it('should not swallow missing callback errors', done => {
+            try {
+              server.insert(`test.${collection}`, [{ a: 1 }], {})
+            } catch (e) {
+              done()
+            }
+          })
         })
 
         describe('cursor', () => {
@@ -249,7 +257,7 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.insert(`test.${collection}`, [{ a: 1 }, { a: 2 }], {})
+            server.insert(`test.${collection}`, [{ a: 1 }, { a: 2 }], {}, () => {})
           })
 
           it('should sanitize the query as the resource', done => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix mongodb-core plugin swallowing missing callback errors.

### Motivation
<!-- What inspired you to submit this pull request? -->

We should not alter or hide errors from the underlying library in plugins.