### PR TITLE
fix machine size for darwin prebuilds in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ jobs:
     docker:
       - image: node:10
     working_directory: ~/dd-trace-js
-    resource_class: small
+    resource_class: medium
     environment:
       - ARCH=x64
     steps:
@@ -453,7 +453,7 @@ jobs:
     docker:
       - image: node:10
     working_directory: ~/dd-trace-js
-    resource_class: small
+    resource_class: medium
     environment:
       - ARCH=x32
     steps:
@@ -473,7 +473,7 @@ jobs:
     macos:
       xcode: "10.2.0"
     working_directory: ~/dd-trace-js
-    resource_class: small
+    resource_class: medium
     environment:
       - ARCH=x64
     steps:
@@ -490,7 +490,7 @@ jobs:
     macos:
       xcode: "10.2.0"
     working_directory: ~/dd-trace-js
-    resource_class: small
+    resource_class: medium
     environment:
       - ARCH=x32
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ jobs:
     docker:
       - image: node:10
     working_directory: ~/dd-trace-js
-    resource_class: medium
+    resource_class: small
     environment:
       - ARCH=x64
     steps:
@@ -453,7 +453,7 @@ jobs:
     docker:
       - image: node:10
     working_directory: ~/dd-trace-js
-    resource_class: medium
+    resource_class: small
     environment:
       - ARCH=x32
     steps:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix machine size for Darwin prebuilds in CircleCI.

### Motivation
<!-- What inspired you to submit this pull request? -->

Small machine size is not available for Darwin which results in a warning.