### PR TITLE
Fix Issue #620: pino plugin logs extra undefined values

### DIFF
--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -18,7 +18,7 @@ function createWrapGenLog (tracer, config) {
       const log = genLog(z)
 
       return function logWithTrace (a, b, c, d, e, f, g, h, i, j, k) {
-        const args = [a, b, c, d, e, f, g, h, i, j, k]
+        const args = [a, b, c, d, e, f, g, h, i, j, k].slice(0, arguments.length)
 
         if (!a) {
           args[0] = {}

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -50,6 +50,7 @@ describe('Plugin', () => {
             const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
             expect(record).to.not.have.property('dd')
+            expect(record).to.have.deep.property('msg', 'message')
           })
         })
       })
@@ -72,6 +73,8 @@ describe('Plugin', () => {
               trace_id: span.context().toTraceId(),
               span_id: span.context().toSpanId()
             })
+
+            expect(record).to.have.deep.property('msg', 'message')
           })
         })
       })


### PR DESCRIPTION
### What does this PR do?
The goal of this PR is to fix #620 - a minor bug with the pino plugin for pino v4.

The plugin defines a `logWithTrace(a, b, c, d, e, f, g, h, i, j, k)` function that wraps the `log` function returned by pino's [`genLog`](https://github.com/pinojs/pino/blob/v4.17.6/lib/tools.js#L61).

But if `logWithTrace` is only called with `a, b, c` (for example), the plugin calls `log` with the rest of those `e, f, g, h, i, j, k` values which logs them as `undefined`.

The pino implementation looks at `arguments.length` to decide how many values were passed in, and when it is called from `logWithTrace`, the `arguments` array contains values for all of `a, b, c, d, e, f, g, h, i, j, k` and logs them.

### Motivation
I'm using dd-trace-js with pino v4 and noticed it was logging lots of extra `undefined` values 🙂 

### Plugin Checklist
- [x] Unit tests.
- [x] CircleCI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/src/plugins/index.js
