### PR TITLE
fix incorrect middleware name when wrapped using express-async-errors

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -53,6 +53,8 @@ function wrapRouterMethod (original) {
 }
 
 function wrapLayerHandle (layer, handle) {
+  handle._name = handle._name || layer.name
+
   if (handle.length === 4) {
     return function (error, req, res, next) {
       return callHandle(layer, handle, req, [error, req, res, wrapNext(layer, req, next)])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix incorrect middleware name when wrapped using [express-async-errors](https://github.com/davidbanham/express-async-errors).

### Motivation
<!-- What inspired you to submit this pull request? -->

Middleware wrapped by `express-async-errors` are always named `newFn` which means the real name of the middleware is hidden.