### PR TITLE
fix support for passing tags as types other than object

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -102,9 +102,9 @@ class DatadogSpan extends Span {
       return this._addTags(
         keyValuePairs
           .split(',')
-          .filter(tag => tag.indexOf('=') !== -1)
+          .filter(tag => tag.indexOf(':') !== -1)
           .reduce((prev, next) => {
-            const tag = next.split('=')
+            const tag = next.split(':')
             const key = tag[0]
             const value = tag.slice(1).join('=')
 

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -98,6 +98,27 @@ class DatadogSpan extends Span {
   }
 
   _addTags (keyValuePairs) {
+    if (typeof keyValuePairs === 'string') {
+      return this._addTags(
+        keyValuePairs
+          .split(',')
+          .filter(tag => tag.indexOf('=') !== -1)
+          .reduce((prev, next) => {
+            const tag = next.split('=')
+            const key = tag[0]
+            const value = tag.slice(1).join('=')
+
+            prev[key] = value
+
+            return prev
+          }, {})
+      )
+    }
+
+    if (Array.isArray(keyValuePairs)) {
+      return keyValuePairs.forEach(tags => this._addTags(tags))
+    }
+
     try {
       Object.keys(keyValuePairs).forEach(key => {
         this._spanContext._tags[key] = keyValuePairs[key]

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -106,7 +106,7 @@ class DatadogSpan extends Span {
           .reduce((prev, next) => {
             const tag = next.split(':')
             const key = tag[0]
-            const value = tag.slice(1).join('=')
+            const value = tag.slice(1).join(':')
 
             prev[key] = value
 

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -72,10 +72,13 @@ class DatadogTracer extends Tracer {
     const span = new Span(this, this._recorder, this._sampler, this._prioritySampler, {
       operationName: fields.operationName || name,
       parent,
-      tags: Object.assign(tags, this._tags, fields.tags),
+      tags,
       startTime: fields.startTime,
       hostname: this._hostname
     })
+
+    span.addTags(this._tags)
+    span.addTags(fields.tags)
 
     return span
   }

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -158,10 +158,10 @@ describe('Span', () => {
     })
 
     it('should add tags as a string', () => {
-      span.addTags('foo:bar,baz:qux,invalid')
+      span.addTags('foo:bar,baz:qux:quxx,invalid')
 
       expect(span.context()._tags).to.have.property('foo', 'bar')
-      expect(span.context()._tags).to.have.property('baz', 'qux')
+      expect(span.context()._tags).to.have.property('baz', 'qux:quxx')
       expect(span.context()._tags).to.not.have.property('invalid')
     })
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -158,7 +158,7 @@ describe('Span', () => {
     })
 
     it('should add tags as a string', () => {
-      span.addTags('foo=bar,baz=qux,invalid')
+      span.addTags('foo:bar,baz:qux,invalid')
 
       expect(span.context()._tags).to.have.property('foo', 'bar')
       expect(span.context()._tags).to.have.property('baz', 'qux')
@@ -166,7 +166,7 @@ describe('Span', () => {
     })
 
     it('should add tags as an array', () => {
-      span.addTags(['foo=bar', 'baz=qux'])
+      span.addTags(['foo:bar', 'baz:qux'])
 
       expect(span.context()._tags).to.have.property('foo', 'bar')
       expect(span.context()._tags).to.have.property('baz', 'qux')

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -158,7 +158,6 @@ describe('Span', () => {
     })
 
     it('should add tags as a string', () => {
-      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
       span.addTags('foo=bar,baz=qux,invalid')
 
       expect(span.context()._tags).to.have.property('foo', 'bar')

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -147,23 +147,39 @@ describe('Span', () => {
   })
 
   describe('addTags', () => {
-    it('should add tags', () => {
+    beforeEach(() => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
+    })
+
+    it('should add tags as an object', () => {
       span.addTags({ foo: 'bar' })
 
       expect(span.context()._tags).to.have.property('foo', 'bar')
     })
 
-    it('should store the original values', () => {
+    it('should add tags as a string', () => {
       span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
+      span.addTags('foo=bar,baz=qux,invalid')
+
+      expect(span.context()._tags).to.have.property('foo', 'bar')
+      expect(span.context()._tags).to.have.property('baz', 'qux')
+      expect(span.context()._tags).to.not.have.property('invalid')
+    })
+
+    it('should add tags as an array', () => {
+      span.addTags(['foo=bar', 'baz=qux'])
+
+      expect(span.context()._tags).to.have.property('foo', 'bar')
+      expect(span.context()._tags).to.have.property('baz', 'qux')
+    })
+
+    it('should store the original values', () => {
       span.addTags({ foo: 123 })
 
       expect(span.context()._tags).to.have.property('foo', 123)
     })
 
     it('should handle errors', () => {
-      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
-
       expect(() => span.addTags()).not.to.throw()
     })
   })

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -31,7 +31,9 @@ describe('Tracer', () => {
   beforeEach(() => {
     fields = {}
 
-    span = {}
+    span = {
+      addTags: sinon.stub().returns(span)
+    }
     Span = sinon.stub().returns(span)
 
     prioritySampler = {
@@ -132,11 +134,14 @@ describe('Tracer', () => {
         operationName: 'name',
         parent: null,
         tags: {
-          'foo': 'bar',
           'service.name': 'service'
         },
         startTime: fields.startTime,
         hostname: undefined
+      })
+
+      expect(span.addTags).to.have.been.calledWith({
+        'foo': 'bar'
       })
 
       expect(testSpan).to.equal(span)
@@ -185,7 +190,6 @@ describe('Tracer', () => {
         operationName: 'name',
         parent: null,
         tags: {
-          'foo': 'bar',
           'service.name': 'service'
         },
         startTime: fields.startTime,
@@ -268,13 +272,8 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, recorder, sampler, prioritySampler, {
-        tags: {
-          'foo': 'tracer',
-          'bar': 'span',
-          'baz': 'span'
-        }
-      })
+      expect(span.addTags).to.have.been.calledWith(config.tags)
+      expect(span.addTags).to.have.been.calledWith(fields.tags)
     })
 
     it('should add the env tag from the env option', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix support for passing tags as types other than `object`.

### Motivation
<!-- What inspired you to submit this pull request? -->

The current behavior adds a tag for every character of a string when a string is passed. Since this is supported for metrics, users expect that it's available for span tags as well. Arrays have the same issue and are also supported by metrics, so support was added for arrays as well.