### PR TITLE
update the koa plugin to capture the entire framework duration

### DIFF
--- a/packages/datadog-plugin-koa/src/index.js
+++ b/packages/datadog-plugin-koa/src/index.js
@@ -18,7 +18,7 @@ function createWrapCallback (tracer, config) {
   }
 }
 
-function createWrapCreateContext (tracer, config) {
+function createWrapCreateContext () {
   return function wrapCreateContext (createContext) {
     return function createContextWithTrace (req, res) {
       const ctx = createContext.apply(this, arguments)
@@ -33,9 +33,7 @@ function createWrapCreateContext (tracer, config) {
   }
 }
 
-function createWrapUse (tracer, config) {
-  config = web.normalizeConfig(config)
-
+function createWrapUse () {
   return function wrapUse (use) {
     return function useWithTrace () {
       const result = use.apply(this, arguments)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the `koa` plugin to capture the entire framework duration instead of just the duration from the point when the Datadog middleware was run.

### Motivation
<!-- What inspired you to submit this pull request? -->

Using a middleware to start instrumenting means that parts of the framework running before the middleware was not included in the timing. This will be especially important when the `http` and `koa` spans will no longer be merged. This change is similar to what was done for Express in #627 