### PR TITLE
fix fastify plugin not validating the status code for errors

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -168,18 +168,17 @@ const web = {
   // Validate a request's status code and then add error tags if necessary
   addStatusError (req, statusCode) {
     const span = req._datadog.span
+    const error = req._datadog.error
 
-    if (!span.context()._tags[ERROR] && !req._datadog.config.validateStatus(statusCode)) {
-      span.setTag(ERROR, true)
+    if (!req._datadog.config.validateStatus(statusCode)) {
+      span.setTag(ERROR, error || true)
     }
   },
 
   // Add an error to the request
   addError (req, error) {
-    const span = req._datadog.span
-
-    if (span && error instanceof Error) {
-      span.setTag(ERROR, error)
+    if (error instanceof Error) {
+      req._datadog.error = req._datadog.error || error
     }
   }
 }

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -561,6 +561,19 @@ describe('plugins/util/web', () => {
       const error = new Error('boom')
 
       web.addError(req, error)
+      web.addStatusError(req, 500)
+
+      expect(tags).to.include({
+        [ERROR]: error
+      })
+    })
+
+    it('should not override an existing error', () => {
+      const error = new Error('boom')
+
+      web.addError(req, error)
+      web.addError(req, new Error('prrr'))
+      web.addStatusError(req, 500)
 
       expect(tags).to.include({
         [ERROR]: error
@@ -577,15 +590,20 @@ describe('plugins/util/web', () => {
       })
     })
 
-    it('should not remove an existing error', () => {
-      const error = new Error('boom')
-
-      web.addError(req, error)
+    it('should flag the request as an error', () => {
       web.addStatusError(req, 500)
 
       expect(tags).to.include({
-        [ERROR]: error
+        [ERROR]: true
       })
+    })
+
+    it('should only flag requests as an error for configured status codes', () => {
+      config.validateStatus = () => true
+
+      web.addStatusError(req, 500)
+
+      expect(tags).to.not.have.property(ERROR)
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix Fastify plugin not validating the status code for errors, resulting in any error being always flagged as an error even if configured otherwise.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix #629 