### PR TITLE
Update bluebird github link

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -524,7 +524,7 @@ declare namespace plugins {
   interface amqplib extends Integration {}
 
   /**
-   * This plugin patches the [bluebird](https://github.com/squaremo/amqp.node)
+   * This plugin patches the [bluebird](https://github.com/petkaantonov/bluebird)
    * module to bind the promise callback the the caller context.
    */
   interface bluebird extends Integration {}


### PR DESCRIPTION
### What does this PR do?
Updates the docs to fix an incorrect link to bluebird.

### Motivation
Expected to be taken to bluebird github link, was instead taken to amqp.