### PR TITLE
Inject trace ids into paperplane logs

### DIFF
--- a/packages/datadog-plugin-paperplane/src/index.js
+++ b/packages/datadog-plugin-paperplane/src/index.js
@@ -53,24 +53,53 @@ const wrapRoutes = tracer => routes => handlers => {
   return routes(traced)
 }
 
-function patch (paperplane, tracer, config) {
-  config = web.normalizeConfig(config)
-
-  if (tracer._logInjection) {
-    this.wrap(paperplane, 'logger', wrapLogger(tracer))
+module.exports = [
+  {
+    name: 'paperplane',
+    versions: ['>=2.3.2'],
+    file: 'lib/logger.js',
+    patch (exports, tracer) {
+      if (tracer._logInjection) {
+        this.wrap(exports, 'logger', wrapLogger(tracer))
+      }
+    },
+    unpatch (exports) {
+      this.unwrap(exports, 'logger')
+    }
+  },
+  {
+    name: 'paperplane',
+    versions: ['>=2.3.2'],
+    file: 'lib/mount.js',
+    patch (exports, tracer, config) {
+      config = web.normalizeConfig(config)
+      this.wrap(exports, 'mount', wrapMount(tracer, config))
+    },
+    unpatch (exports) {
+      this.unwrap(exports, 'mount')
+    }
+  },
+  {
+    name: 'paperplane',
+    versions: ['>=2.3.2'],
+    file: 'lib/routes.js',
+    patch (exports, tracer) {
+      this.wrap(exports, 'routes', wrapRoutes(tracer))
+    },
+    unpatch (exports) {
+      this.unwrap(exports, 'routes')
+    }
+  },
+  {
+    name: 'paperplane',
+    versions: ['2.3.0 - 2.3.1'],
+    patch (paperplane, tracer, config) {
+      config = web.normalizeConfig(config)
+      this.wrap(paperplane, 'mount', wrapMount(tracer, config))
+      this.wrap(paperplane, 'routes', wrapRoutes(tracer))
+    },
+    unpatch (paperplane) {
+      this.unwrap(paperplane, ['mount', 'routes'])
+    }
   }
-
-  this.wrap(paperplane, 'mount', wrapMount(tracer, config))
-  this.wrap(paperplane, 'routes', wrapRoutes(tracer))
-}
-
-function unpatch (paperplane) {
-  this.unwrap(paperplane, ['logger', 'mount', 'routes'])
-}
-
-module.exports = {
-  name: 'paperplane',
-  versions: ['>=2.3.1'],
-  patch,
-  unpatch
-}
+]

--- a/packages/datadog-plugin-paperplane/test/index.spec.js
+++ b/packages/datadog-plugin-paperplane/test/index.spec.js
@@ -432,6 +432,7 @@ describe('Plugin', () => {
           span = tracer.startSpan('test')
 
           tracer.scope().activate(span, () => {
+            /* eslint-disable no-console */
             paperplane.logger({ message: ':datadoge:' })
 
             expect(console.info).to.have.been.called
@@ -441,6 +442,7 @@ describe('Plugin', () => {
             expect(record).to.not.have.property('dd')
             expect(record).to.have.property('message', ':datadoge:')
             done()
+            /* eslint-enable no-console */
           })
         })
       })
@@ -558,6 +560,7 @@ describe('Plugin', () => {
           span = tracer.startSpan('test')
 
           tracer.scope().activate(span, () => {
+            /* eslint-disable no-console */
             paperplane.logger({ message: ':datadoge:' })
 
             expect(console.info).to.have.been.called
@@ -571,6 +574,7 @@ describe('Plugin', () => {
 
             expect(record).to.have.property('message', ':datadoge:')
             done()
+            /* eslint-enable no-console */
           })
         })
 
@@ -578,6 +582,7 @@ describe('Plugin', () => {
           span = tracer.startSpan('test')
 
           tracer.scope().activate(span, () => {
+            /* eslint-disable no-console */
             const err = new Error('Bad things happened')
             paperplane.logger(err)
 
@@ -594,10 +599,12 @@ describe('Plugin', () => {
             expect(record).to.have.property('name', 'Error')
             expect(record).to.have.property('stack')
             done()
+            /* eslint-enable no-console */
           })
         })
 
         it('should not alter logs with no active span', () => {
+          /* eslint-disable no-console */
           paperplane.logger({ message: ':datadoge:' })
 
           expect(console.info).to.have.been.called
@@ -606,6 +613,7 @@ describe('Plugin', () => {
 
           expect(record).to.not.have.property('dd')
           expect(record).to.have.property('message', ':datadoge:')
+          /* eslint-enable no-console */
         })
       })
     })


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/888052/61491986-6c551700-a97e-11e9-95d3-7b2b3877b36a.png)

### What does this PR do?

Adds support for log injection in `paperplane`.

### Motivation

When I first made the plugin for `paperplane`, I followed the examples of `express` and `hapi`.  Those don't have built-in logging, but `paperplane` does, and I totally overlooked it.  We'd like our logs to be correlated with traces in APM, so this PR aims to enable that.

### Plugin Checklist

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/src/plugins/index.js

### Additional Notes

This does bump the supported version of `paperplane` to `v2.3.1`.  That's because log injection on error logs doesn't work before that version.
