### PR TITLE
fix hapi plugin for hapi namespace change

### DIFF
--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -51,18 +51,7 @@ function createWrapDispatch (tracer, config) {
 module.exports = [
   {
     name: '@hapi/hapi',
-    versions: ['>=18.2'],
-    file: 'lib/request.js',
-    patch (Request, tracer, config) {
-      this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
-    },
-    unpatch (Request) {
-      this.unwrap(Request, 'generate')
-    }
-  },
-  {
-    name: '@hapi/hapi',
-    versions: ['>=17.9 <18'],
+    versions: ['>=17.9'],
     file: 'lib/request.js',
     patch (Request, tracer, config) {
       this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
@@ -73,18 +62,7 @@ module.exports = [
   },
   {
     name: 'hapi',
-    versions: ['18 - 18.1'],
-    file: 'lib/request.js',
-    patch (Request, tracer, config) {
-      this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
-    },
-    unpatch (Request) {
-      this.unwrap(Request, 'generate')
-    }
-  },
-  {
-    name: 'hapi',
-    versions: ['17.1 - 17.8'],
+    versions: ['>=17.1'],
     file: 'lib/request.js',
     patch (Request, tracer, config) {
       this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
@@ -117,29 +95,7 @@ module.exports = [
   },
   {
     name: '@hapi/hapi',
-    versions: ['>=18.2'],
-    file: 'lib/core.js',
-    patch (Core, tracer, config) {
-      this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))
-    },
-    unpatch (Core) {
-      this.unwrap(Core.prototype, '_dispatch')
-    }
-  },
-  {
-    name: '@hapi/hapi',
-    versions: ['>=17.9 <18'],
-    file: 'lib/core.js',
-    patch (Core, tracer, config) {
-      this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))
-    },
-    unpatch (Core) {
-      this.unwrap(Core.prototype, '_dispatch')
-    }
-  },
-  {
-    name: 'hapi',
-    versions: ['18 - 18.1'],
+    versions: ['>=17.9'],
     file: 'lib/core.js',
     patch (Core, tracer, config) {
       this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))
@@ -161,7 +117,7 @@ module.exports = [
   },
   {
     name: 'hapi',
-    versions: ['17 - 17.8'],
+    versions: ['>=17'],
     file: 'lib/core.js',
     patch (Core, tracer, config) {
       this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))

--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -50,8 +50,41 @@ function createWrapDispatch (tracer, config) {
 
 module.exports = [
   {
+    name: '@hapi/hapi',
+    versions: ['>=18.2'],
+    file: 'lib/request.js',
+    patch (Request, tracer, config) {
+      this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
+    },
+    unpatch (Request) {
+      this.unwrap(Request, 'generate')
+    }
+  },
+  {
+    name: '@hapi/hapi',
+    versions: ['>=17.9 <18'],
+    file: 'lib/request.js',
+    patch (Request, tracer, config) {
+      this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
+    },
+    unpatch (Request) {
+      this.unwrap(Request, 'generate')
+    }
+  },
+  {
     name: 'hapi',
-    versions: ['>=17.1'],
+    versions: ['18 - 18.1'],
+    file: 'lib/request.js',
+    patch (Request, tracer, config) {
+      this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
+    },
+    unpatch (Request) {
+      this.unwrap(Request, 'generate')
+    }
+  },
+  {
+    name: 'hapi',
+    versions: ['17.1 - 17.8'],
     file: 'lib/request.js',
     patch (Request, tracer, config) {
       this.wrap(Request, 'generate', createWrapGenerate(tracer, config))
@@ -83,6 +116,39 @@ module.exports = [
     }
   },
   {
+    name: '@hapi/hapi',
+    versions: ['>=18.2'],
+    file: 'lib/core.js',
+    patch (Core, tracer, config) {
+      this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))
+    },
+    unpatch (Core) {
+      this.unwrap(Core.prototype, '_dispatch')
+    }
+  },
+  {
+    name: '@hapi/hapi',
+    versions: ['>=17.9 <18'],
+    file: 'lib/core.js',
+    patch (Core, tracer, config) {
+      this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))
+    },
+    unpatch (Core) {
+      this.unwrap(Core.prototype, '_dispatch')
+    }
+  },
+  {
+    name: 'hapi',
+    versions: ['18 - 18.1'],
+    file: 'lib/core.js',
+    patch (Core, tracer, config) {
+      this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))
+    },
+    unpatch (Core) {
+      this.unwrap(Core.prototype, '_dispatch')
+    }
+  },
+  {
     name: 'hapi',
     versions: ['7.2 - 16'],
     file: 'lib/connection.js',
@@ -95,7 +161,7 @@ module.exports = [
   },
   {
     name: 'hapi',
-    versions: ['>=17'],
+    versions: ['17 - 17.8'],
     file: 'lib/core.js',
     patch (Core, tracer, config) {
       this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -16,7 +16,7 @@ describe('Plugin', () => {
   let handler
 
   describe('hapi', () => {
-    withVersions(plugin, 'hapi', version => {
+    withVersions(plugin, ['hapi', '@hapi/hapi'], (version, module) => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
         handler = (request, h, body) => h.response ? h.response(body) : h(body)
@@ -29,7 +29,7 @@ describe('Plugin', () => {
       before(() => {
         return agent.load(plugin, 'hapi')
           .then(() => {
-            Hapi = require(`../../../versions/hapi@${version}`).get()
+            Hapi = require(`../../../versions/${module}@${version}`).get()
           })
       })
 


### PR DESCRIPTION
### What does this PR do?
Updates the hapi plugin to correctly handle recent hapi change to scoped package

### Motivation
The hapi package was recently moved from 'hapi' to '@hapi/hapi' ([changlog][6]). This resulted in the hapi plugin no longer patching correctly. This affects hapi version >= [17.9][7] and >= [18.2][8]. Version 18.0 to 18.1 still uses the old unscoped package name.

[6]: https://hapijs.com/changelog
[7]: https://github.com/hapijs/hapi/milestone/261
[8]: https://github.com/hapijs/hapi/milestone/259

### Plugin Checklist
- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/src/plugins/index.js
