### PR TITLE
fix error when addTags is called with an empty parameter

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -98,6 +98,8 @@ class DatadogSpan extends Span {
   }
 
   _addTags (keyValuePairs) {
+    if (!keyValuePairs) return
+
     if (typeof keyValuePairs === 'string') {
       return this._addTags(
         keyValuePairs


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix error when `addTags` is called with an empty parameter. While this wouldn't cause a crash, it's unnecessary noise in the logs and a big performance regression considering the cost of creating an Error object.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix #637

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Since the error wouldn't actually be thrown, a test was not added as the behavior is unchanged. However, creating an Error object has a very high cost, so the fix can be validated by looking at the performance difference in the benchmark [before](https://circleci.com/gh/DataDog/dd-trace-js/47875) and [after](https://circleci.com/gh/DataDog/dd-trace-js/47969) the change. The change can be seen on the benchmark for `DatadogTracer#startSpan`