### PR TITLE
handle null/undefined references gracefully without an error

### DIFF
--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -115,7 +115,7 @@ function getReferences (references) {
 
     const spanContext = ref.referencedContext()
 
-    if (ref.type() !== REFERENCE_NOOP && !(spanContext instanceof SpanContext)) {
+    if (ref.type() !== REFERENCE_NOOP && spanContext && !(spanContext instanceof SpanContext)) {
       log.error(() => `Expected ${spanContext} to be an instance of SpanContext`)
       return false
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Handle null/undefined references gracefully without an error.

### Motivation
<!-- What inspired you to submit this pull request? -->

`null` references are very common and shouldn't be considered errors as this can lead to performance degradation when in debug mode. Not having to create an Error object and handling null/undefined gracefully will greatly improve the performance impact.