### PR TITLE
Darcy.rayner/add trace exporters

### DIFF
--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -11,7 +11,8 @@ const Config = require('../packages/dd-trace/src/config')
 const DatadogTracer = require('../packages/dd-trace/src/tracer')
 const DatadogSpanContext = require('../packages/dd-trace/src/opentracing/span_context')
 const TextMapPropagator = require('../packages/dd-trace/src/opentracing/propagation/text_map')
-const Writer = proxyquire('../packages/dd-trace/src/writer', {
+const Writer = require('../packages/dd-trace/src/writer')
+const AgentExporter = proxyquire('../packages/dd-trace/src/agent/exporter', {
   './platform': { request: () => Promise.resolve() }
 })
 const Sampler = require('../packages/dd-trace/src/sampler')
@@ -68,8 +69,9 @@ suite
     }
   })
   .add('Writer#append', {
-    onStart () {
-      writer = new Writer({ sample: () => {} }, {})
+    onStart() {
+      const sampler = { sample: () => { } }
+      writer = new Writer(sampler, [new AgentExporter(sampler, {})])
     },
     fn () {
       writer.append(spanStub)

--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -69,7 +69,7 @@ suite
     }
   })
   .add('Writer#append', {
-    onStart() {
+    onStart () {
       const sampler = { sample: () => { } }
       writer = new Writer(sampler, [new AgentExporter(sampler, {})])
     },

--- a/index.d.ts
+++ b/index.d.ts
@@ -236,6 +236,7 @@ export declare interface TracerOptions {
    */
   experimental?: boolean | {
     b3?: boolean
+    useLogTraceExporter?: boolean
   };
 
   /**

--- a/packages/dd-trace/src/agent/exporter.js
+++ b/packages/dd-trace/src/agent/exporter.js
@@ -1,53 +1,53 @@
-"use strict";
+'use strict'
 
 const log = require('../log')
 const platform = require('../platform')
 const tracerVersion = require('../../lib/version')
 
 class AgentExporter {
-  constructor(prioritySampler, url) {
-    this._prioritySampler = prioritySampler;
-    this._url = url;
+  constructor (prioritySampler, url) {
+    this._prioritySampler = prioritySampler
+    this._url = url
   }
 
-  send(queue) {
-    const data = platform.msgpack.prefix(queue);
-    const count = queue.length;
+  send (queue) {
+    const data = platform.msgpack.prefix(queue)
+    const count = queue.length
 
     const options = {
-      path: "/v0.4/traces",
-      method: "PUT",
+      path: '/v0.4/traces',
+      method: 'PUT',
       headers: {
-        "Content-Type": "application/msgpack",
-        "Datadog-Meta-Lang": platform.name(),
-        "Datadog-Meta-Lang-Version": platform.version(),
-        "Datadog-Meta-Lang-Interpreter": platform.engine(),
-        "Datadog-Meta-Tracer-Version": tracerVersion,
-        "X-Datadog-Trace-Count": String(count)
+        'Content-Type': 'application/msgpack',
+        'Datadog-Meta-Lang': platform.name(),
+        'Datadog-Meta-Lang-Version': platform.version(),
+        'Datadog-Meta-Lang-Interpreter': platform.engine(),
+        'Datadog-Meta-Tracer-Version': tracerVersion,
+        'X-Datadog-Trace-Count': String(count)
       }
-    };
-
-    if (this._url.protocol === "unix:") {
-      options.socketPath = this._url.pathname;
-    } else {
-      options.protocol = this._url.protocol;
-      options.hostname = this._url.hostname;
-      options.port = this._url.port;
     }
 
-    log.debug(() => `Request to the agent: ${JSON.stringify(options)}`);
+    if (this._url.protocol === 'unix:') {
+      options.socketPath = this._url.pathname
+    } else {
+      options.protocol = this._url.protocol
+      options.hostname = this._url.hostname
+      options.port = this._url.port
+    }
+
+    log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)
 
     platform.request(Object.assign({ data }, options), (err, res) => {
-      if (err) return log.error(err);
+      if (err) return log.error(err)
 
-      log.debug(`Response from the agent: ${res}`);
+      log.debug(`Response from the agent: ${res}`)
 
       try {
-        this._prioritySampler.update(JSON.parse(res).rate_by_service);
+        this._prioritySampler.update(JSON.parse(res).rate_by_service)
       } catch (e) {
-        log.error(err);
+        log.error(err)
       }
-    });
+    })
   }
 }
 

--- a/packages/dd-trace/src/agent/exporter.js
+++ b/packages/dd-trace/src/agent/exporter.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const log = require('../log')
+const platform = require('../platform')
+const tracerVersion = require('../../lib/version')
+
+class AgentExporter {
+  constructor(prioritySampler, url) {
+    this._prioritySampler = prioritySampler;
+    this._url = url;
+  }
+
+  send(queue) {
+    const data = platform.msgpack.prefix(queue);
+    const count = queue.length;
+
+    const options = {
+      path: "/v0.4/traces",
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/msgpack",
+        "Datadog-Meta-Lang": platform.name(),
+        "Datadog-Meta-Lang-Version": platform.version(),
+        "Datadog-Meta-Lang-Interpreter": platform.engine(),
+        "Datadog-Meta-Tracer-Version": tracerVersion,
+        "X-Datadog-Trace-Count": String(count)
+      }
+    };
+
+    if (this._url.protocol === "unix:") {
+      options.socketPath = this._url.pathname;
+    } else {
+      options.protocol = this._url.protocol;
+      options.hostname = this._url.hostname;
+      options.port = this._url.port;
+    }
+
+    log.debug(() => `Request to the agent: ${JSON.stringify(options)}`);
+
+    platform.request(Object.assign({ data }, options), (err, res) => {
+      if (err) return log.error(err);
+
+      log.debug(`Response from the agent: ${res}`);
+
+      try {
+        this._prioritySampler.update(JSON.parse(res).rate_by_service);
+      } catch (e) {
+        log.error(err);
+      }
+    });
+  }
+}
+
+module.exports = AgentExporter

--- a/packages/dd-trace/src/agentless/exporter.js
+++ b/packages/dd-trace/src/agentless/exporter.js
@@ -1,11 +1,9 @@
-"use strict";
+'use strict'
 
 const log = require('../log')
 
 class LogExporter {
-  constructor() { }
-
-  send(queue) {
+  send (queue) {
     log.JSON({ traces: queue })
   }
 }

--- a/packages/dd-trace/src/agentless/exporter.js
+++ b/packages/dd-trace/src/agentless/exporter.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const log = require('../log')
+
+class LogExporter {
+  constructor() { }
+
+  send(queue) {
+    log.JSON({ traces: queue })
+  }
+}
+
+module.exports = LogExporter

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -52,7 +52,8 @@ class Config {
     }
     this.runtimeMetrics = String(runtimeMetrics) === 'true'
     this.experimental = {
-      b3: !(!options.experimental || !options.experimental.b3)
+      b3: !(!options.experimental || !options.experimental.b3),
+      useLogTraceExporter: !(!options.experimental || !options.experimental.useLogTraceExporter)
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = process.env.DD_CONTEXT_PROPAGATION === 'false' ? scopes.NOOP : scope

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -42,14 +42,17 @@ class DatadogTracer extends Tracer {
 
     const exporters = []
 
+    let flushInterval = config.flushInterval
     if (config.experimental.useLogTraceExporter) {
+      // when using the LogExporter, always flush the logs immediately
       exporters.push(new LogExporter())
+      flushInterval = 0
     } else {
       exporters.push(new AgentExporter(this._prioritySampler, config.url))
     }
 
     this._writer = new Writer(this._prioritySampler, exporters)
-    this._recorder = new Recorder(this._writer, config.flushInterval)
+    this._recorder = new Recorder(this._writer, flushInterval)
     this._recorder.init()
     this._sampler = new Sampler(config.sampleRate)
     this._propagators = {

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -26,7 +26,7 @@ const REFERENCE_CHILD_OF = opentracing.REFERENCE_CHILD_OF
 const REFERENCE_FOLLOWS_FROM = opentracing.REFERENCE_FOLLOWS_FROM
 
 class DatadogTracer extends Tracer {
-  constructor (config) {
+  constructor(config) {
     super()
 
     log.use(config.logger)
@@ -42,7 +42,7 @@ class DatadogTracer extends Tracer {
 
     const exporters = []
 
-    if (config.useLogTraceExporter) {
+    if (config.experimental.useLogTraceExporter) {
       exporters.push(new LogExporter())
     } else {
       exporters.push(new AgentExporter(this._prioritySampler, config.url))
@@ -63,7 +63,7 @@ class DatadogTracer extends Tracer {
     }
   }
 
-  _startSpan (name, fields) {
+  _startSpan(name, fields) {
     const references = getReferences(fields.references)
     const reference = getParent(references)
     const type = reference && reference.type()
@@ -94,7 +94,7 @@ class DatadogTracer extends Tracer {
     return span
   }
 
-  _inject (spanContext, format, carrier) {
+  _inject(spanContext, format, carrier) {
     try {
       this._prioritySampler.sample(spanContext)
       this._propagators[format].inject(spanContext, carrier)
@@ -105,7 +105,7 @@ class DatadogTracer extends Tracer {
     return this
   }
 
-  _extract (format, carrier) {
+  _extract(format, carrier) {
     try {
       return this._propagators[format].extract(carrier)
     } catch (e) {
@@ -115,7 +115,7 @@ class DatadogTracer extends Tracer {
   }
 }
 
-function getReferences (references) {
+function getReferences(references) {
   if (!references) return []
 
   return references.filter(ref => {
@@ -135,7 +135,7 @@ function getReferences (references) {
   })
 }
 
-function getParent (references) {
+function getParent(references) {
   let parent = null
 
   for (let i = 0; i < references.length; i++) {
@@ -155,7 +155,7 @@ function getParent (references) {
   return parent
 }
 
-function isSampled (sampler, parent, type) {
+function isSampled(sampler, parent, type) {
   if (type === REFERENCE_NOOP) return false
   if (parent && !parent._traceFlags.sampled) return false
   if (!parent && !sampler.isSampled()) return false

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -9,6 +9,7 @@ const Writer = require('../writer')
 const Recorder = require('../recorder')
 const Sampler = require('../sampler')
 const AgentExporter = require('../agent/exporter')
+const LogExporter = require('../agentless/exporter')
 const PrioritySampler = require('../priority_sampler')
 const TextMapPropagator = require('./propagation/text_map')
 const HttpPropagator = require('./propagation/http')
@@ -38,9 +39,15 @@ class DatadogTracer extends Tracer {
     this._logInjection = config.logInjection
     this._analytics = config.analytics
     this._prioritySampler = new PrioritySampler(config.env)
-    const exporters = [
-      new AgentExporter(this._prioritySampler, config.url)
-    ]
+
+    const exporters = []
+
+    if (config.useLogTraceExporter) {
+      exporters.push(new LogExporter())
+    } else {
+      exporters.push(new AgentExporter(this._prioritySampler, config.url))
+    }
+
     this._writer = new Writer(this._prioritySampler, exporters)
     this._recorder = new Recorder(this._writer, config.flushInterval)
     this._recorder.init()

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -8,6 +8,7 @@ const SpanContext = require('./span_context')
 const Writer = require('../writer')
 const Recorder = require('../recorder')
 const Sampler = require('../sampler')
+const AgentExporter = require('../agent/exporter')
 const PrioritySampler = require('../priority_sampler')
 const TextMapPropagator = require('./propagation/text_map')
 const HttpPropagator = require('./propagation/http')
@@ -37,7 +38,10 @@ class DatadogTracer extends Tracer {
     this._logInjection = config.logInjection
     this._analytics = config.analytics
     this._prioritySampler = new PrioritySampler(config.env)
-    this._writer = new Writer(this._prioritySampler, config.url)
+    const exporters = [
+      new AgentExporter(this._prioritySampler, config.url)
+    ]
+    this._writer = new Writer(this._prioritySampler, exporters)
     this._recorder = new Recorder(this._writer, config.flushInterval)
     this._recorder.init()
     this._sampler = new Sampler(config.sampleRate)

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -26,7 +26,7 @@ const REFERENCE_CHILD_OF = opentracing.REFERENCE_CHILD_OF
 const REFERENCE_FOLLOWS_FROM = opentracing.REFERENCE_FOLLOWS_FROM
 
 class DatadogTracer extends Tracer {
-  constructor(config) {
+  constructor (config) {
     super()
 
     log.use(config.logger)
@@ -63,7 +63,7 @@ class DatadogTracer extends Tracer {
     }
   }
 
-  _startSpan(name, fields) {
+  _startSpan (name, fields) {
     const references = getReferences(fields.references)
     const reference = getParent(references)
     const type = reference && reference.type()
@@ -94,7 +94,7 @@ class DatadogTracer extends Tracer {
     return span
   }
 
-  _inject(spanContext, format, carrier) {
+  _inject (spanContext, format, carrier) {
     try {
       this._prioritySampler.sample(spanContext)
       this._propagators[format].inject(spanContext, carrier)
@@ -105,7 +105,7 @@ class DatadogTracer extends Tracer {
     return this
   }
 
-  _extract(format, carrier) {
+  _extract (format, carrier) {
     try {
       return this._propagators[format].extract(carrier)
     } catch (e) {
@@ -115,7 +115,7 @@ class DatadogTracer extends Tracer {
   }
 }
 
-function getReferences(references) {
+function getReferences (references) {
   if (!references) return []
 
   return references.filter(ref => {
@@ -135,7 +135,7 @@ function getReferences(references) {
   })
 }
 
-function getParent(references) {
+function getParent (references) {
   let parent = null
 
   for (let i = 0; i < references.length; i++) {
@@ -155,7 +155,7 @@ function getParent(references) {
   return parent
 }
 
-function isSampled(sampler, parent, type) {
+function isSampled (sampler, parent, type) {
   if (type === REFERENCE_NOOP) return false
   if (parent && !parent._traceFlags.sampled) return false
   if (!parent && !sampler.isSampled()) return false

--- a/packages/dd-trace/src/writer.js
+++ b/packages/dd-trace/src/writer.js
@@ -1,18 +1,16 @@
 'use strict'
 
-const platform = require('./platform')
 const log = require('./log')
 const format = require('./format')
 const encode = require('./encode')
-const tracerVersion = require('../lib/version')
 
 const MAX_SIZE = 8 * 1024 * 1024 // 8MB
 
 class Writer {
-  constructor (prioritySampler, url) {
+  constructor(prioritySampler, exporters) {
     this._queue = []
     this._prioritySampler = prioritySampler
-    this._url = url
+    this._exporters = exporters
     this._size = 0
   }
 
@@ -53,9 +51,9 @@ class Writer {
 
   flush () {
     if (this._queue.length > 0) {
-      const data = platform.msgpack.prefix(this._queue)
-
-      this._request(data, this._queue.length)
+      for (const exporter of this._exporters) {
+        exporter.send(this._queue)
+      }
 
       this._queue = []
       this._size = 0

--- a/packages/dd-trace/src/writer.js
+++ b/packages/dd-trace/src/writer.js
@@ -7,7 +7,7 @@ const encode = require('./encode')
 const MAX_SIZE = 8 * 1024 * 1024 // 8MB
 
 class Writer {
-  constructor(prioritySampler, exporters) {
+  constructor (prioritySampler, exporters) {
     this._queue = []
     this._prioritySampler = prioritySampler
     this._exporters = exporters
@@ -58,43 +58,6 @@ class Writer {
       this._queue = []
       this._size = 0
     }
-  }
-
-  _request (data, count) {
-    const options = {
-      path: '/v0.4/traces',
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/msgpack',
-        'Datadog-Meta-Lang': platform.name(),
-        'Datadog-Meta-Lang-Version': platform.version(),
-        'Datadog-Meta-Lang-Interpreter': platform.engine(),
-        'Datadog-Meta-Tracer-Version': tracerVersion,
-        'X-Datadog-Trace-Count': String(count)
-      }
-    }
-
-    if (this._url.protocol === 'unix:') {
-      options.socketPath = this._url.pathname
-    } else {
-      options.protocol = this._url.protocol
-      options.hostname = this._url.hostname
-      options.port = this._url.port
-    }
-
-    log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)
-
-    platform.request(Object.assign({ data }, options), (err, res) => {
-      if (err) return log.error(err)
-
-      log.debug(`Response from the agent: ${res}`)
-
-      try {
-        this._prioritySampler.update(JSON.parse(res).rate_by_service)
-      } catch (e) {
-        log.error(err)
-      }
-    })
   }
 
   _erase (trace) {

--- a/packages/dd-trace/test/agent/exporter.spec.js
+++ b/packages/dd-trace/test/agent/exporter.spec.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const URL = require('url-parse')
+
+describe('AgentExporter', () => {
+
+  let AgentExporter
+  let exporter
+  let prioritySampler
+  let trace
+  let platform
+  let response
+  let url
+  let log
+  let span
+
+  beforeEach(() => {
+
+    trace = {
+      started: [],
+      finished: []
+    }
+
+    span = {
+      tracer: sinon.stub().returns(tracer),
+      context: sinon.stub().returns({
+        _trace: trace,
+        _sampling: {},
+        _tags: {},
+        _traceFlags: {}
+      })
+    }
+
+    response = JSON.stringify({
+      rate_by_service: {
+        'service:hello,env:test': 1
+      }
+    })
+
+    platform = {
+      name: sinon.stub(),
+      version: sinon.stub(),
+      engine: sinon.stub(),
+      request: sinon.stub().yields(null, response),
+      msgpack: {
+        prefix: sinon.stub()
+      }
+    }
+
+
+    url = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: 8126
+    }
+
+    log = {
+      error: sinon.spy()
+    }
+
+    prioritySampler = {
+      update: sinon.stub(),
+      sample: sinon.stub()
+    }
+
+    AgentExporter = proxyquire('../src/agent/exporter', {
+      '../platform': platform,
+      '../log': log,
+      '../../lib/version': 'tracerVersion'
+    })
+    exporter = new AgentExporter(prioritySampler, url)
+  })
+
+
+  describe('send', () => {
+    it('should send traces to the agent', () => {
+      platform.msgpack.prefix.withArgs(['encoded', 'encoded']).returns('prefixed')
+      platform.name.returns('lang')
+      platform.version.returns('version')
+      platform.engine.returns('interpreter')
+
+      const queue = ['encoded', 'encoded'];
+      exporter.send(queue)
+
+      expect(platform.request).to.have.been.calledWithMatch({
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port,
+        path: '/v0.4/traces',
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/msgpack',
+          'Datadog-Meta-Lang': 'lang',
+          'Datadog-Meta-Lang-Version': 'version',
+          'Datadog-Meta-Lang-Interpreter': 'interpreter',
+          'Datadog-Meta-Tracer-Version': 'tracerVersion',
+          'X-Datadog-Trace-Count': '2'
+        },
+        data: 'prefixed'
+      })
+    })
+
+    it('should log request errors', done => {
+      const error = new Error('boom')
+
+      platform.request.yields(error)
+      const queue = ['encoded'];
+      exporter.send(queue)
+
+      setTimeout(() => {
+        expect(log.error).to.have.been.calledWith(error)
+        done()
+      })
+    })
+
+    context('with the url as a unix socket', () => {
+      beforeEach(() => {
+        url = new URL('unix:/path/to/somesocket.sock')
+        exporter = new AgentExporter(prioritySampler, url)
+      })
+
+      it('should make a request to the socket', () => {
+        const queue = ['encoded']
+        exporter.send(queue)
+
+        expect(platform.request).to.have.been.calledWithMatch({
+          socketPath: url.pathname
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/agent/exporter.spec.js
+++ b/packages/dd-trace/test/agent/exporter.spec.js
@@ -7,29 +7,12 @@ describe('AgentExporter', () => {
   let AgentExporter
   let exporter
   let prioritySampler
-  let trace
   let platform
   let response
   let url
   let log
-  let span
 
   beforeEach(() => {
-
-    trace = {
-      started: [],
-      finished: []
-    }
-
-    span = {
-      tracer: sinon.stub().returns(tracer),
-      context: sinon.stub().returns({
-        _trace: trace,
-        _sampling: {},
-        _tags: {},
-        _traceFlags: {}
-      })
-    }
 
     response = JSON.stringify({
       rate_by_service: {

--- a/packages/dd-trace/test/agent/exporter.spec.js
+++ b/packages/dd-trace/test/agent/exporter.spec.js
@@ -3,7 +3,6 @@
 const URL = require('url-parse')
 
 describe('AgentExporter', () => {
-
   let AgentExporter
   let exporter
   let prioritySampler
@@ -13,7 +12,6 @@ describe('AgentExporter', () => {
   let log
 
   beforeEach(() => {
-
     response = JSON.stringify({
       rate_by_service: {
         'service:hello,env:test': 1
@@ -29,8 +27,6 @@ describe('AgentExporter', () => {
         prefix: sinon.stub()
       }
     }
-
-
     url = {
       protocol: 'http:',
       hostname: 'localhost',
@@ -53,8 +49,6 @@ describe('AgentExporter', () => {
     })
     exporter = new AgentExporter(prioritySampler, url)
   })
-
-
   describe('send', () => {
     it('should send traces to the agent', () => {
       platform.msgpack.prefix.withArgs(['encoded', 'encoded']).returns('prefixed')
@@ -62,7 +56,7 @@ describe('AgentExporter', () => {
       platform.version.returns('version')
       platform.engine.returns('interpreter')
 
-      const queue = ['encoded', 'encoded'];
+      const queue = ['encoded', 'encoded']
       exporter.send(queue)
 
       expect(platform.request).to.have.been.calledWithMatch({
@@ -87,7 +81,7 @@ describe('AgentExporter', () => {
       const error = new Error('boom')
 
       platform.request.yields(error)
-      const queue = ['encoded'];
+      const queue = ['encoded']
       exporter.send(queue)
 
       setTimeout(() => {

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -11,6 +11,8 @@ describe('Tracer', () => {
   let span
   let PrioritySampler
   let prioritySampler
+  let agentExporter
+  let AgentExporter
   let Writer
   let writer
   let Recorder
@@ -61,6 +63,8 @@ describe('Tracer', () => {
     TextMapPropagator = sinon.stub()
     HttpPropagator = sinon.stub()
     BinaryPropagator = sinon.stub()
+    agentExporter = {}
+    AgentExporter = sinon.stub().returns(agentExporter)
     propagator = {
       inject: sinon.stub(),
       extract: sinon.stub()
@@ -92,6 +96,7 @@ describe('Tracer', () => {
       '../writer': Writer,
       '../recorder': Recorder,
       '../sampler': Sampler,
+      '../agent/exporter': AgentExporter,
       './propagation/text_map': TextMapPropagator,
       './propagation/http': HttpPropagator,
       './propagation/binary': BinaryPropagator,
@@ -104,7 +109,7 @@ describe('Tracer', () => {
     tracer = new Tracer(config)
 
     expect(Writer).to.have.been.called
-    expect(Writer).to.have.been.calledWith(prioritySampler, config.url)
+    expect(Writer).to.have.been.calledWith(prioritySampler, [agentExporter])
     expect(Recorder).to.have.been.calledWith(writer, config.flushInterval)
     expect(recorder.init).to.have.been.called
   })

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -79,7 +79,7 @@ describe('Tracer', () => {
       tags: {},
       debug: false,
       experimental: {
-        useLogTraceExporter: true
+        useLogTraceExporter: false
       }
     }
 

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -77,7 +77,10 @@ describe('Tracer', () => {
       sampleRate: 0.5,
       logger: 'logger',
       tags: {},
-      debug: false
+      debug: false,
+      experimental: {
+        useLogTraceExporter: true
+      }
     }
 
     log = {


### PR DESCRIPTION
### What does this PR do?
Adds an option to export traces via logs, as opposed to using the agent.

### Motivation
Preliminary support for lambda tracing

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [X] Unit tests.
- [X] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/src/plugins/index.js

### Additional Notes
