### PR TITLE
Add workaround for loopback

### DIFF
--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const axios = require('axios')
 const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -817,6 +818,78 @@ describe('Plugin', () => {
               axios
                 .get(`http://localhost:${port}/user`)
                 .catch(done)
+            })
+          })
+        })
+
+        withVersions(plugin, 'loopback', loopbackVersion => {
+          let loopback
+
+          beforeEach(() => {
+            loopback = require(`../../../versions/loopback@${loopbackVersion}`).get()
+          })
+
+          it('should handle loopback with express middleware', done => {
+            const app = loopback()
+
+            app.get('/dd', (req, res) => {
+              res.status(200).send()
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('service', 'test')
+                  expect(spans[0]).to.have.property('type', 'web')
+                  expect(spans[0]).to.have.property('resource', 'GET /dd-1')
+                  expect(spans[0].meta).to.have.property('span.kind', 'server')
+                  expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/dd`)
+                  expect(spans[0].meta).to.have.property('http.method', 'GET')
+                  expect(spans[0].meta).to.have.property('http.status_code', '200')
+                })
+                .then(done)
+                .catch(done)
+
+              appListener = app.listen(port, 'localhost', () => {
+                axios.get(`http://localhost:${port}/dd`)
+                  .catch(done)
+              })
+            })
+          })
+
+          it('should handle loopback re-sorting', done => {
+            const app = loopback()
+
+            app.middleware('final', [], function throwError (req, res) {
+              throw new Error('should not reach')
+            })
+
+            app.get('/dd', function handleDD (req, res) {
+              res.status(200).send()
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[4]).to.have.property('name', 'express.middleware')
+                  expect(spans[4]).to.have.property('service', 'test')
+                  expect(spans[4]).to.have.property('type', 'web')
+                  expect(spans[4]).to.have.property('resource', 'handleDD')
+                  expect(spans[4].meta).to.have.property('span.kind', 'server')
+                  expect(spans[4].meta).to.have.property('http.method', 'GET')
+                  expect(spans[4].meta).to.have.property('http.status_code', '200')
+                })
+                .then(done)
+                .catch(done)
+
+              appListener = app.listen(port, 'localhost', () => {
+                axios.get(`http://localhost:${port}/dd`)
+                  .catch(done)
+              })
             })
           })
         })

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const path = require('path')
 const axios = require('axios')
 const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -877,11 +876,7 @@ describe('Plugin', () => {
 
                   expect(spans[4]).to.have.property('name', 'express.middleware')
                   expect(spans[4]).to.have.property('service', 'test')
-                  expect(spans[4]).to.have.property('type', 'web')
                   expect(spans[4]).to.have.property('resource', 'handleDD')
-                  expect(spans[4].meta).to.have.property('span.kind', 'server')
-                  expect(spans[4].meta).to.have.property('http.method', 'GET')
-                  expect(spans[4].meta).to.have.property('http.status_code', '200')
                 })
                 .then(done)
                 .catch(done)

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -843,7 +843,7 @@ describe('Plugin', () => {
 
                   expect(spans[0]).to.have.property('service', 'test')
                   expect(spans[0]).to.have.property('type', 'web')
-                  expect(spans[0]).to.have.property('resource', 'GET /dd-1')
+                  expect(spans[0]).to.have.property('resource', 'GET /dd')
                   expect(spans[0].meta).to.have.property('span.kind', 'server')
                   expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/dd`)
                   expect(spans[0].meta).to.have.property('http.method', 'GET')

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -68,7 +68,7 @@ function wrapLayerHandle (layer, handle) {
   }
 
   // This is a workaround for the `loopback` library so that it can find the correct express layer
-  //  that contains the real handle function
+  // that contains the real handle function
   wrapCallHandle._datadog_orig = handle
 
   return wrapCallHandle

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -69,7 +69,7 @@ function wrapLayerHandle (layer, handle) {
 
   // This is a workaround for the `loopback` library so that it can find the correct express layer
   //  that contains the real handle function
-  wrapCallHandle.origHandle = handle
+  wrapCallHandle._datadog_orig = handle
 
   return wrapCallHandle
 }

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -55,15 +55,23 @@ function wrapRouterMethod (original) {
 function wrapLayerHandle (layer, handle) {
   handle._name = handle._name || layer.name
 
+  let wrapCallHandle
+
   if (handle.length === 4) {
-    return function (error, req, res, next) {
+    wrapCallHandle = function (error, req, res, next) {
       return callHandle(layer, handle, req, [error, req, res, wrapNext(layer, req, next)])
     }
   } else {
-    return function (req, res, next) {
+    wrapCallHandle = function (req, res, next) {
       return callHandle(layer, handle, req, [req, res, wrapNext(layer, req, next)])
     }
   }
+
+  // This is a workaround for the `loopback` library so that it can find the correct express layer
+  //  that contains the real handle function
+  wrapCallHandle.origHandle = handle
+
+  return wrapCallHandle
 }
 
 function wrapStack (stack, offset, matchers) {

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -1,4 +1,10 @@
 {
+  "express": [
+    {
+      "name": "loopback",
+      "versions": [">=2.13.0"]
+    }
+  ],
   "generic-pool": [
     {
       "name": "generic-pool",


### PR DESCRIPTION
### What does this PR do?
This PR adds a workaround to support the `loopback` library. Since `loopback` tries to find the `express` layers by comparing `handler` functions, it can't find the layers since we wrap the `handlers`. This causes the `router` stack to be filled with entries that are un-sortable. This is an issue because adding a new layer will cause the layer to be put at the bottom of the stack, below the `raiseUrlNotFoundError` layer, even after sorting. That means requests will throw a 404 error even though the route is properly registered.

This PR makes use of `loopback`'s [aggressive search](https://github.com/strongloop/loopback/blob/9b1d4885ab869d977bc7d464aa861b4f88691862/lib/server-app.js#L235-L241) for the original `handle` function by adding a reference to the original `handle` function.

### Motivation
Support loopback.
