### PR TITLE
add limitd-client plugin to fix scope propagation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,12 @@ jobs:
           - SERVICES=limitd
           - PLUGINS=limitd-client
       - image: rochdev/limitd
+        environment:
+          - PORT=9231
+          - DB=/var/limitd/database
+          - BUCKET_1_NAME=user
+          - BUCKET_1_SIZE=10
+          - BUCKET_1_PER_SECOND=5
 
   node-memcached:
     <<: *node-plugin-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,8 +289,6 @@ jobs:
           - PLUGINS=limitd-client
       - image: rochdev/limitd
         environment:
-          - PORT=9231
-          - DB=/var/limitd/database
           - BUCKET_1_NAME=user
           - BUCKET_1_SIZE=10
           - BUCKET_1_PER_SECOND=5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,15 @@ jobs:
         environment:
           - PLUGINS=koa
 
+  node-limitd-client:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - SERVICES=limitd
+          - PLUGINS=limitd-client
+      - image: rochdev/limitd
+
   node-memcached:
     <<: *node-plugin-base
     docker:
@@ -574,6 +583,7 @@ workflows:
       - node-http2
       - node-knex
       - node-koa
+      - node-limitd-client
       - node-memcached
       - node-mongodb-core
       - node-tedious
@@ -660,6 +670,7 @@ workflows:
       - node-http2
       - node-knex
       - node-koa
+      - node-limitd-client
       - node-memcached
       - node-mongodb-core
       - node-mysql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -587,7 +587,7 @@ workflows:
       - node-http2
       - node-knex
       - node-koa
-      - node-limitd-client
+      # - node-limitd-client
       - node-memcached
       - node-mongodb-core
       - node-tedious
@@ -674,7 +674,7 @@ workflows:
       - node-http2
       - node-knex
       - node-koa
-      - node-limitd-client
+      # - node-limitd-client
       - node-memcached
       - node-mongodb-core
       - node-mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,6 @@ services:
   limitd:
     image: rochdev/limitd
     environment:
-      - PORT=9231
-      - DB=/var/limitd/database
       - BUCKET_1_NAME=user
       - BUCKET_1_SIZE=10
       - BUCKET_1_PER_SECOND=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,3 +56,13 @@ services:
       - CASSANDRA_TOKEN=-9223372036854775808
     ports:
       - "127.0.0.1:9042:9042"
+  limitd:
+    image: rochdev/limitd
+    environment:
+      - PORT=9231
+      - DB=/var/limitd/database
+      - BUCKET_1_NAME=user
+      - BUCKET_1_SIZE=10
+      - BUCKET_1_PER_SECOND=5
+    ports:
+      - "127.0.0.1:9231:9231"

--- a/docs/API.md
+++ b/docs/API.md
@@ -231,6 +231,7 @@ tracer.use('pg', {
 <h5 id="koa"></h5>
 <h5 id="koa-tags"></h5>
 <h5 id="koa-config"></h5>
+<h5 id="limitd-client"></h5>
 <h5 id="memcached"></h5>
 <h5 id="memcached-tags"></h5>
 <h5 id="memcached-config"></h5>
@@ -280,6 +281,7 @@ tracer.use('pg', {
 * [ioredis](./interfaces/plugins.ioredis.html)
 * [knex](./interfaces/plugins.knex.html)
 * [koa](./interfaces/plugins.koa.html)
+* [limitd-client](./interfaces/plugins.limitd_client.html)
 * [ioredis](./interfaces/plugins.ioredis.html)
 * [mongodb-core](./interfaces/plugins.mongodb_core.html)
 * [mysql](./interfaces/plugins.mysql.html)

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -136,6 +136,7 @@ tracer.use('ioredis');
 tracer.use('knex');
 tracer.use('koa');
 tracer.use('koa', httpServerOptions);
+tracer.use('limitd-client');
 tracer.use('memcached');
 tracer.use('mongodb-core');
 tracer.use('mysql');

--- a/index.d.ts
+++ b/index.d.ts
@@ -329,6 +329,7 @@ interface Plugins {
   "ioredis": plugins.ioredis;
   "knex": plugins.knex;
   "koa": plugins.koa;
+  "limitd-client": plugins.limitd_client;
   "memcached": plugins.memcached;
   "mongodb-core": plugins.mongodb_core;
   "mysql": plugins.mysql;
@@ -713,6 +714,12 @@ declare namespace plugins {
    * [koa](https://koajs.com/) module.
    */
   interface koa extends HttpServer {}
+
+  /**
+   * This plugin automatically instruments the
+   * [limitd-client](https://github.com/limitd/node-client) module.
+   */
+  interface limitd_client extends Integration {}
 
   /**
    * This plugin automatically instruments the

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tdd": "node scripts/tdd.js",
     "test": "SERVICES=* yarn services && mocha --exit 'packages/dd-trace/test/setup/all.js' 'packages/*/test/**/*.spec.js'",
     "test:core": "nyc --include \"packages/dd-trace/src/**/*.js\" -- mocha --exit --file packages/dd-trace/test/setup/core.js \"packages/dd-trace/test/**/*.spec.js\"",
-    "test:plugins": "yarn services && nyc --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- mocha --exit --file \"packages/dd-trace/test/setup/all.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
+    "test:plugins": "yarn services && nyc --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- mocha --exit --file \"packages/dd-trace/test/setup/core.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
     "leak:core": "node ./scripts/install_plugin_modules && (cd packages/memwatch && yarn) && NODE_PATH=./packages/memwatch/node_modules node --no-warnings ./node_modules/.bin/tape 'packages/dd-trace/test/leak/**/*.js'",
     "leak:plugins": "yarn services && (cd packages/memwatch && yarn) && NODE_PATH=./packages/memwatch/node_modules node --no-warnings ./node_modules/.bin/tape \"packages/datadog-plugin-@($(echo $PLUGINS))/test/leak.js\"",
     "codecov": "codecov"

--- a/packages/datadog-plugin-limitd-client/src/index.js
+++ b/packages/datadog-plugin-limitd-client/src/index.js
@@ -1,0 +1,26 @@
+'use strict'
+
+function createWrapRequest (tracer) {
+  const scope = tracer.scope()
+
+  return function wrapRequest (original) {
+    return function requestWithTrace (request, callback) {
+      return original.call(this, request, scope.bind(callback))
+    }
+  }
+}
+
+module.exports = [
+  {
+    name: 'limitd-client',
+    versions: ['>=2.8'],
+    patch (LimitdClient, tracer) {
+      this.wrap(LimitdClient.prototype, '_directRequest', createWrapRequest(tracer))
+      this.wrap(LimitdClient.prototype, '_retriedRequest', createWrapRequest(tracer))
+    },
+    unpatch (LimitdClient) {
+      this.unwrap(LimitdClient.prototype, '_directRequest')
+      this.unwrap(LimitdClient.prototype, '_retriedRequest')
+    }
+  }
+]

--- a/packages/datadog-plugin-limitd-client/test/index.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/index.spec.js
@@ -13,7 +13,7 @@ describe('Plugin', () => {
   describe('limitd-client', () => {
     withVersions(plugin, 'limitd-client', version => {
       beforeEach(done => {
-        agent.load(plugin, ['limitd-client'])
+        agent.load(plugin, 'limitd-client')
           .then(() => {
             tracer = require('../../dd-trace')
             LimitdClient = require(`../../../versions/limitd-client@${version}`).get()
@@ -22,6 +22,7 @@ describe('Plugin', () => {
       })
 
       afterEach(() => {
+        limitd.disconnect()
         return agent.close()
       })
 

--- a/packages/datadog-plugin-limitd-client/test/index.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/index.spec.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const plugin = require('../src')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let LimitdClient
+  let limitd
+  let tracer
+
+  describe('limitd-client', () => {
+    withVersions(plugin, 'limitd-client', version => {
+      beforeEach(done => {
+        agent.load(plugin, ['limitd-client'])
+          .then(() => {
+            tracer = require('../../dd-trace')
+            LimitdClient = require(`../../../versions/limitd-client@${version}`).get()
+            limitd = new LimitdClient('limitd://127.0.0.1:9231', done)
+          })
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      it('should propagate context', done => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+        const span = {}
+
+        tracer.scope().activate(span, () => {
+          limitd.take('user', 'test', function (err, resp) {
+            if (err) return done(err)
+
+            expect(tracer.scope().active()).to.equal(span)
+
+            done()
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -19,6 +19,7 @@ module.exports = {
   'ioredis': require('../../../../packages/datadog-plugin-ioredis/src'),
   'knex': require('../../../../packages/datadog-plugin-knex/src'),
   'koa': require('../../../../packages/datadog-plugin-koa/src'),
+  'limitd-client': require('../../../../packages/datadog-plugin-limitd-client/src'),
   'memcached': require('../../../../packages/datadog-plugin-memcached/src'),
   'mongodb-core': require('../../../../packages/datadog-plugin-mongodb-core/src'),
   'mysql': require('../../../../packages/datadog-plugin-mysql/src'),

--- a/packages/dd-trace/test/setup/services/limitd.js
+++ b/packages/dd-trace/test/setup/services/limitd.js
@@ -6,7 +6,7 @@ const LimitdClient = require('../../../../../versions/limitd-client').get()
 function waitForLimitd () {
   return new Promise((resolve, reject) => {
     const operation = new RetryOperation('limitd')
-    const limitd = new LimitdClient('limitd://127.0.0.1:9231')
+    const limitd = new LimitdClient('limitd://localhost:9231')
 
     setImmediate(() => {
       operation.attempt(currentAttempt => {

--- a/packages/dd-trace/test/setup/services/limitd.js
+++ b/packages/dd-trace/test/setup/services/limitd.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const RetryOperation = require('../operation')
+const LimitdClient = require('../../../../../versions/limitd-client').get()
+
+function waitForLimitd () {
+  return new Promise((resolve, reject) => {
+    const operation = new RetryOperation('limitd')
+    const limitd = new LimitdClient('limitd://127.0.0.1:9231')
+
+    setImmediate(() => {
+      operation.attempt(currentAttempt => {
+        limitd.ping(err => {
+          if (operation.retry(err)) return
+          if (err) return reject(err)
+
+          limitd.disconnect()
+
+          resolve()
+        })
+      })
+    })
+  })
+}
+
+module.exports = waitForLimitd


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a [limitd-client](https://github.com/limitd/node-client) plugin.

### Motivation
<!-- What inspired you to submit this pull request? -->

Scope propagation is otherwise broken with `limitd-client` which results in disconnected traces.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/src/plugins/index.js