### PR TITLE
update post install script to use published prebuilds

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,12 @@
 !LICENSE
 !LICENSE-3rdparty.csv
 !README.md
+!addons-darwin-x32.tgz
+!addons-darwin-x64.tgz
+!addons-linux-x32.tgz
+!addons-linux-x64.tgz
+!addons-win32-ia32.tgz
+!addons-win32-x64.tgz
 !binding.gyp
 !index.d.ts
 !index.js

--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -68,7 +68,6 @@ function cleanup () {
     .map(name => path.join(cwd, `addons-${name}.tgz`))
     .forEach(file => {
       try {
-        console.log(file)
         fs.unlinkSync(file)
       } catch (e) {
         // Ignore as it's just to save space


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the post-install script to use published prebuilds instead of downloading them from GitHub assets.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some users have proxies in place that don't allow downloading from GitHub where `npm install` is run. They currently have to rely on building from source which is not ideal. By bundling the addons directly in the published package, we can ensure that they are always available.