### PR TITLE
add experimental support for thenables in the scope manager

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 5
+    "ecmaVersion": 2017
   },
   "extends": [
     "eslint:recommended",

--- a/benchmark/scope/async_hooks.js
+++ b/benchmark/scope/async_hooks.js
@@ -37,7 +37,9 @@ const Scope = proxyquire('../../packages/dd-trace/src/scope/async_hooks', {
   '../platform': platform
 })
 
-const scope = new Scope()
+const scope = new Scope({
+  experimental: {}
+})
 
 let fn
 let promise

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -40,7 +40,8 @@ tracer.init({
   env: 'test',
   runtimeMetrics: true,
   experimental: {
-    b3: true
+    b3: true,
+    thenables: true
   },
   hostname: 'agent',
   logger: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -241,6 +241,8 @@ export declare interface TracerOptions {
      * @default false
      */
     exporter?: 'log-exporter' | 'agent-exporter'
+
+    thenables?: boolean
   };
 
   /**

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -55,7 +55,9 @@ class Config {
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: (options.experimental && options.experimental.exporter === exporters.LOG)
-        ? exporters.LOG : exporters.AGENT
+        ? exporters.LOG
+        : exporters.AGENT,
+      thenables: !(!options.experimental || !options.experimental.thenables)
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = process.env.DD_CONTEXT_PROPAGATION === 'false' ? scopes.NOOP : scope

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -17,7 +17,7 @@ class NoopTracer extends Tracer {
     }
 
     this._scopeManager = new ScopeManager()
-    this._scope = new Scope()
+    this._scope = new Scope(config)
     this._span = new Span(this)
   }
 

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const asyncHooks = require('async_hooks')
-const eid = asyncHooks.executionAsyncId
 const Base = require('./base')
 const platform = require('../platform')
 const semver = require('semver')
@@ -12,45 +11,76 @@ const hasKeepAliveBug = !semver.satisfies(process.version, '^8.13 || >=10.14.2')
 let singleton = null
 
 class Scope extends Base {
-  constructor () {
+  constructor (config) {
     if (singleton) return singleton
 
     super()
 
     singleton = this
 
+    this._thenables = config.experimental.thenables
+    this._current = null
     this._spans = Object.create(null)
     this._types = Object.create(null)
     this._weaks = new WeakMap()
+    this._promises = [false]
+    this._depth = 0
     this._hook = asyncHooks.createHook({
       init: this._init.bind(this),
+      before: this._before.bind(this),
+      after: this._after.bind(this),
       destroy: this._destroy.bind(this),
       promiseResolve: this._destroy.bind(this)
     })
 
+    this._enabled = true
     this._hook.enable()
   }
 
   _active () {
-    return this._spans[eid()]
+    return this._current
   }
 
   _enter (span) {
-    this._spans[eid()] = span
+    this._depth++
+    this._current = span
+    this._promises[this._depth] = false
   }
 
   _exit (span) {
-    const asyncId = eid()
+    this._thenables && this._await(span)
+    this._current = span
+    this._depth--
+  }
 
-    if (span) {
-      this._spans[asyncId] = span
-    } else {
-      delete this._spans[asyncId]
+  _await (span) {
+    if (!this._promises[this._depth]) return
+
+    this._awaitAsync(span)
+  }
+
+  // https://github.com/nodejs/node/issues/22360
+  async _awaitAsync (span) {
+    await {
+      then: () => {
+        this._current = span
+      }
+    }
+  }
+
+  _initPromise () {
+    if (!this._promises[this._depth]) {
+      this._enabled = false
+      this._promises[this._depth] = true
+      this._await(this._current)
+      this._enabled = true
     }
   }
 
   _init (asyncId, type, triggerAsyncId, resource) {
-    this._spans[asyncId] = this._active()
+    if (!this._enabled) return
+
+    this._spans[asyncId] = this._current
     this._types[asyncId] = type
 
     if (hasKeepAliveBug && (type === 'TCPWRAP' || type === 'HTTPPARSER')) {
@@ -60,6 +90,21 @@ class Scope extends Base {
 
     platform.metrics().increment('async.resources')
     platform.metrics().increment('async.resources.by.type', `resource_type:${type}`)
+
+    if (this._thenables && type === 'PROMISE') {
+      this._initPromise()
+    }
+  }
+
+  _before (asyncId) {
+    this._current = this._spans[asyncId]
+    this._promises[this._depth] = false
+  }
+
+  _after () {
+    this._await(null)
+    this._current = null
+    this._promises[this._depth] = false
   }
 
   _destroy (asyncId) {

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -134,7 +134,7 @@ function getScope (config) {
     Scope = require('./scope/async_hooks')
   }
 
-  return new Scope()
+  return new Scope(config)
 }
 
 module.exports = DatadogTracer

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -33,6 +33,7 @@ describe('Config', () => {
     expect(config).to.have.property('reportHostname', false)
     expect(config).to.have.property('scope', undefined)
     expect(config).to.have.nested.property('experimental.b3', false)
+    expect(config).to.have.nested.property('experimental.thenables', false)
   })
 
   it('should initialize from the default service', () => {
@@ -113,7 +114,8 @@ describe('Config', () => {
       plugins: false,
       scope: 'noop',
       experimental: {
-        b3: true
+        b3: true,
+        thenables: true
       }
     })
 
@@ -138,6 +140,7 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
+    expect(config).to.have.nested.property('experimental.thenables', true)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/scope/async_hooks.spec.js
+++ b/packages/dd-trace/test/scope/async_hooks.spec.js
@@ -17,7 +17,9 @@ describe('Scope', () => {
     sinon.spy(metrics, 'increment')
     sinon.spy(metrics, 'decrement')
 
-    scope = new Scope()
+    scope = new Scope({
+      experimental: {}
+    })
   })
 
   afterEach(() => {

--- a/packages/dd-trace/test/scope/async_hooks.spec.js
+++ b/packages/dd-trace/test/scope/async_hooks.spec.js
@@ -1,14 +1,17 @@
 'use strict'
 
+const { AsyncResource, executionAsyncId } = require('async_hooks')
 const semver = require('semver')
 const Scope = require('../../src/scope/async_hooks')
+const Span = require('opentracing').Span
 const platform = require('../../src/platform')
 const testScope = require('./test')
 
 wrapIt()
 
-describe('Scope', () => {
+describe('Scope (async_hooks)', () => {
   let scope
+  let span
   let metrics
 
   beforeEach(() => {
@@ -20,6 +23,8 @@ describe('Scope', () => {
     scope = new Scope({
       experimental: {}
     })
+
+    span = new Span()
   })
 
   afterEach(() => {
@@ -53,6 +58,20 @@ describe('Scope', () => {
     expect(metrics.decrement).to.have.been.calledWith('async.resources.by.type')
   })
 
+  it('should not break propagation for nested resources', done => {
+    scope.activate(span, () => {
+      const asyncResource = new AsyncResource(
+        'TEST', { triggerAsyncId: executionAsyncId(), requireManualDestroy: false }
+      )
+
+      asyncResource.runInAsyncScope(() => {})
+
+      expect(scope.active()).to.equal(span)
+
+      done()
+    })
+  })
+
   if (!semver.satisfies(process.version, '^8.13 || >=10.14.2')) {
     it('should work around the HTTP keep-alive bug in Node', () => {
       const resource = {}
@@ -65,6 +84,78 @@ describe('Scope', () => {
       expect(scope._destroy).to.have.been.called
     })
   }
+
+  describe('with a thenable', () => {
+    let thenable
+    let test
+
+    beforeEach(() => {
+      thenable = {
+        then: () => {}
+      }
+
+      test = async () => {
+        await thenable
+      }
+    })
+
+    it('should not alter the active span when using await', () => {
+      scope.bind(thenable)
+      scope.activate(span, () => test())
+
+      expect(scope.active()).to.be.null
+    })
+
+    it('should use the active span when using await', done => {
+      thenable.then = () => {
+        expect(scope.active()).to.equal(span)
+        done()
+      }
+
+      scope.bind(thenable)
+      scope.activate(span, () => test())
+    })
+
+    it('should use the active span when using await in a timer', done => {
+      thenable.then = () => {
+        expect(scope.active()).to.equal(span)
+        done()
+      }
+
+      test = async () => {
+        setTimeout(async () => {
+          await thenable
+        })
+      }
+
+      scope.bind(thenable)
+      scope.activate(span, () => test())
+    })
+
+    it('should use the active span when using await in nested scopes', done => {
+      thenable.then = () => {
+        expect(scope.active()).to.equal(span)
+        done()
+      }
+
+      scope.bind(thenable)
+      scope.activate({}, async () => {
+        scope.activate(span, () => test())
+      })
+    })
+
+    it('should use the active span when using await in nested scopes', done => {
+      thenable.then = () => {
+        expect(scope.active()).to.equal(span)
+        done()
+      }
+
+      scope.bind(thenable)
+      scope.activate({}, async () => {
+        scope.activate(span, () => test())
+      })
+    })
+  })
 
   testScope(() => scope)
 })

--- a/packages/dd-trace/test/scope/test.js
+++ b/packages/dd-trace/test/scope/test.js
@@ -189,66 +189,6 @@ module.exports = factory => {
       })
     })
 
-    describe('with a thenable', () => {
-      let thenable
-      let test
-
-      beforeEach(() => {
-        thenable = {
-          then: () => {}
-        }
-
-        test = async () => {
-          await thenable
-        }
-      })
-
-      it('should not alter the active span when using await', () => {
-        scope.bind(thenable)
-        scope.activate(span, () => test())
-
-        expect(scope.active()).to.be.null
-      })
-
-      it('should use the active span when using await', done => {
-        thenable.then = () => {
-          expect(scope.active()).to.equal(span)
-          done()
-        }
-
-        scope.bind(thenable)
-        scope.activate(span, () => test())
-      })
-
-      it('should use the active span when using await in a timer', done => {
-        thenable.then = () => {
-          expect(scope.active()).to.equal(span)
-          done()
-        }
-
-        test = async () => {
-          setTimeout(async () => {
-            await thenable
-          })
-        }
-
-        scope.bind(thenable)
-        scope.activate(span, () => test())
-      })
-
-      it('should use the active span when using await in nested scopes', done => {
-        thenable.then = () => {
-          expect(scope.active()).to.equal(span)
-          done()
-        }
-
-        scope.bind(thenable)
-        scope.activate({}, async () => {
-          scope.activate(span, () => test())
-        })
-      })
-    })
-
     describe('with an event emitter', () => {
       let emitter
 

--- a/packages/dd-trace/test/scope/test.js
+++ b/packages/dd-trace/test/scope/test.js
@@ -189,6 +189,66 @@ module.exports = factory => {
       })
     })
 
+    describe('with a thenable', () => {
+      let thenable
+      let test
+
+      beforeEach(() => {
+        thenable = {
+          then: () => {}
+        }
+
+        test = async () => {
+          await thenable
+        }
+      })
+
+      it('should not alter the active span when using await', () => {
+        scope.bind(thenable)
+        scope.activate(span, () => test())
+
+        expect(scope.active()).to.be.null
+      })
+
+      it('should use the active span when using await', done => {
+        thenable.then = () => {
+          expect(scope.active()).to.equal(span)
+          done()
+        }
+
+        scope.bind(thenable)
+        scope.activate(span, () => test())
+      })
+
+      it('should use the active span when using await in a timer', done => {
+        thenable.then = () => {
+          expect(scope.active()).to.equal(span)
+          done()
+        }
+
+        test = async () => {
+          setTimeout(async () => {
+            await thenable
+          })
+        }
+
+        scope.bind(thenable)
+        scope.activate(span, () => test())
+      })
+
+      it('should use the active span when using await in nested scopes', done => {
+        thenable.then = () => {
+          expect(scope.active()).to.equal(span)
+          done()
+        }
+
+        scope.bind(thenable)
+        scope.activate({}, async () => {
+          scope.activate(span, () => test())
+        })
+      })
+    })
+
     describe('with an event emitter', () => {
       let emitter
 

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -12,7 +12,11 @@ const AsyncHooksScope = require('../../src/scope/async_hooks')
 const agent = require('../plugins/agent')
 const externals = require('../plugins/externals.json')
 
-const asyncHooksScope = new AsyncHooksScope()
+const asyncHooksScope = new AsyncHooksScope({
+  experimental: {
+    thenables: true
+  }
+})
 
 chai.use(sinonChai)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds experimental support for thenables in the scope manager.

### Motivation
<!-- What inspired you to submit this pull request? -->

Users are having issues with thenables that are not native promises such has Knex because of an [issue in Node](https://github.com/nodejs/node/issues/22360).