### PR TITLE
Fix connection options for older versions of redis

### DIFF
--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -36,7 +36,7 @@ function createWrapSendCommand (tracer, config) {
 
 function startSpan (tracer, config, client, command, args) {
   const db = client.selected_db
-  const connectionOptions = client.connection_options || client.connection_option || {}
+  const connectionOptions = client.connection_options || client.connection_option || client.connectionOption || {}
   const span = tx.instrument(tracer, config, db, command, args)
 
   tx.setHost(span, connectionOptions.host, connectionOptions.port)


### PR DESCRIPTION
### What does this PR do?
In (very) old versions of redis, the connection options are stored in `connectionOption`. Changing the default port fails the tests since the plugin falls back to `6379`, which is the port we're using for the redis server.

### Motivation
It was failing some tests.
