### PR TITLE
update post install script to not run locally

### DIFF
--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -20,7 +20,7 @@ const platforms = [
   'win32-ia32'
 ]
 
-if (process.env.DD_NATIVE_METRICS !== 'false') {
+if (process.env.DD_NATIVE_METRICS !== 'false' && __dirname.indexOf('/node_modules/') !== -1) {
   if (buildFromSource === 'true' || buildFromSource === 'dd-trace' || !platforms.includes(name)) {
     extract()
       .then(rebuild)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update post install script to not run locally.

### Motivation
<!-- What inspired you to submit this pull request? -->

It should not run locally. It was not a problem before because it was simply downloading files. Now that we delete files when it runs, we have to make sure it doesn't run every time `yarn` is called.