### PR TITLE
update several tracer components to be platform agnostic

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -4,7 +4,6 @@ const URL = require('url-parse')
 const platform = require('./platform')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
-const exporters = require('../../../ext/exporters')
 
 class Config {
   constructor (service, options) {
@@ -54,9 +53,7 @@ class Config {
     this.runtimeMetrics = String(runtimeMetrics) === 'true'
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
-      exporter: (options.experimental && options.experimental.exporter === exporters.LOG)
-        ? exporters.LOG
-        : exporters.AGENT,
+      exporter: options.experimental && options.experimental.exporter,
       thenables: !(!options.experimental || !options.experimental.thenables)
     }
     this.reportHostname = String(reportHostname) === 'true'

--- a/packages/dd-trace/src/encode.js
+++ b/packages/dd-trace/src/encode.js
@@ -1,6 +1,11 @@
 'use strict'
 
 const msgpack = require('msgpack-lite')
-const codec = msgpack.createCodec({ int64: true })
 
-module.exports = data => msgpack.encode(data, { codec })
+let codec
+
+module.exports = data => {
+  codec = codec || msgpack.createCodec({ int64: true })
+
+  return msgpack.encode(data, { codec })
+}

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -4,7 +4,7 @@ const Writer = require('./writer')
 const Scheduler = require('./scheduler')
 
 class AgentExporter {
-  constructor (url, interval) {
+  constructor ({ url, interval }) {
     this._writer = new Writer(url)
 
     if (interval > 0) {

--- a/packages/dd-trace/src/exporters/log/index.js
+++ b/packages/dd-trace/src/exporters/log/index.js
@@ -5,11 +5,6 @@ const log = require('../../log')
 const MAX_SIZE = 255 * 1024 // 255kb
 
 class LogExporter {
-  constructor (outputStream, maxSize = MAX_SIZE) {
-    this._outputStream = outputStream
-    this._maxSize = maxSize
-  }
-
   export (spans) {
     log.debug(() => `Adding trace to queue: ${JSON.stringify(spans)}`)
 
@@ -18,11 +13,11 @@ class LogExporter {
 
     for (const span of spans) {
       const spanStr = JSON.stringify(span)
-      if (spanStr.length > this._maxSize) {
+      if (spanStr.length > MAX_SIZE) {
         log.debug('Span too large to send to logs, dropping')
         continue
       }
-      if (spanStr.length + size + 1 > this._maxSize) {
+      if (spanStr.length + size + 1 > MAX_SIZE) {
         this._printSpans(queue)
         queue = []
         size = 0
@@ -47,7 +42,7 @@ class LogExporter {
       }
     }
     logLine += ']}\n'
-    this._outputStream.write(logLine)
+    console.log(logLine) // eslint-disable-line no-console
   }
 }
 

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -1,20 +1,17 @@
 'use strict'
 
-const semver = require('semver')
-const hook = require('require-in-the-middle')
-const parse = require('module-details-from-path')
-const path = require('path')
 const shimmer = require('shimmer')
-const uniq = require('lodash.uniq')
 const log = require('./log')
-
-const pathSepExpr = new RegExp(`\\${path.sep}`, 'g')
+const platform = require('./platform')
 
 shimmer({ logger: () => {} })
+
+const plugins = platform.plugins
 
 class Instrumenter {
   constructor (tracer) {
     this._tracer = tracer
+    this._loader = new platform.Loader(this)
     this._enabled = false
     this._names = new Set()
     this._plugins = new Map()
@@ -29,50 +26,39 @@ class Instrumenter {
     config = config || {}
 
     try {
-      this._set(require(`../../datadog-plugin-${name}/src`), { name, config })
+      this._set(plugins[name.toLowerCase()], { name, config })
     } catch (e) {
       log.debug(`Could not find a plugin named "${name}".`)
     }
 
-    this.reload()
+    if (this._enabled) {
+      this._loader.reload(this._plugins)
+    }
   }
 
-  patch (config) {
+  enable (config) {
     config = config || {}
 
     if (config.plugins !== false) {
-      const plugins = require('./plugins')
-
       Object.keys(plugins)
+        .filter(name => !this._plugins.has(plugins[name]))
         .forEach(name => {
-          this._plugins.has(plugins[name]) || this._set(plugins[name], { name, config: {} })
+          this._set(plugins[name], { name, config: {} })
         })
     }
 
-    this.reload()
+    this._enabled = true
+    this._loader.reload(this._plugins)
   }
 
-  unpatch () {
-    this._instrumented.forEach((moduleExports, instrumentation) => {
-      this._unpatch(instrumentation)
-    })
+  disable () {
+    for (const instrumentation of this._instrumented.keys()) {
+      this.unpatch(instrumentation)
+    }
 
     this._plugins.clear()
-  }
-
-  reload () {
-    if (!this._enabled) return
-
-    const instrumentations = Array.from(this._plugins.keys())
-      .reduce((prev, current) => prev.concat(current), [])
-
-    const instrumentedModules = uniq(instrumentations
-      .map(instrumentation => instrumentation.name))
-
-    this._names = new Set(instrumentations
-      .map(instrumentation => filename(instrumentation)))
-
-    hook(instrumentedModules, { internals: true }, this.hookModule.bind(this))
+    this._enabled = false
+    this._loader.reload(this._plugins)
   }
 
   wrap (nodules, names, wrapper) {
@@ -108,86 +94,36 @@ class Instrumenter {
     })
   }
 
-  hookModule (moduleExports, moduleName, moduleBaseDir) {
-    moduleName = moduleName.replace(pathSepExpr, '/')
+  load (plugin, meta) {
+    if (this._enabled) {
+      const instrumentations = [].concat(plugin)
 
-    if (!this._names.has(moduleName)) {
-      return moduleExports
-    }
-
-    if (moduleBaseDir) {
-      moduleBaseDir = moduleBaseDir.replace(pathSepExpr, '/')
-    }
-
-    const moduleVersion = getVersion(moduleBaseDir)
-
-    Array.from(this._plugins.keys())
-      .filter(plugin => [].concat(plugin).some(instrumentation =>
-        filename(instrumentation) === moduleName && matchVersion(moduleVersion, instrumentation.versions)
-      ))
-      .forEach(plugin => this._validate(plugin, moduleName, moduleBaseDir, moduleVersion))
-
-    this._plugins
-      .forEach((meta, plugin) => {
-        try {
-          [].concat(plugin)
-            .filter(instrumentation => moduleName === filename(instrumentation))
-            .filter(instrumentation => matchVersion(moduleVersion, instrumentation.versions))
-            .forEach(instrumentation => {
-              const config = this._plugins.get(plugin).config
-
-              if (config.enabled !== false) {
-                moduleExports = this._patch(instrumentation, moduleExports, config) || moduleExports
-              }
+      try {
+        instrumentations
+          .forEach(instrumentation => {
+            this._loader.getModules(instrumentation).forEach(nodule => {
+              this.patch(instrumentation, nodule, meta.config)
             })
-        } catch (e) {
-          log.error(e)
-          this._fail(plugin)
-          log.debug(`Error while trying to patch ${meta.name}. The plugin has been disabled.`)
-        }
-      })
-
-    return moduleExports
-  }
-
-  enable () {
-    this._enabled = true
-  }
-
-  _set (plugin, meta) {
-    this._plugins.set(plugin, meta)
-    this._load(plugin, meta)
-  }
-
-  _validate (plugin, moduleName, moduleBaseDir, moduleVersion) {
-    const meta = this._plugins.get(plugin)
-    const instrumentations = [].concat(plugin)
-
-    for (let i = 0; i < instrumentations.length; i++) {
-      if (moduleName.indexOf(instrumentations[i].name) !== 0) continue
-      if (instrumentations[i].versions && !matchVersion(moduleVersion, instrumentations[i].versions)) continue
-      if (instrumentations[i].file && !exists(moduleBaseDir, instrumentations[i].file)) {
-        this._fail(plugin)
-        log.debug([
-          `Plugin "${meta.name}" requires "${instrumentations[i].file}" which was not found.`,
-          `The plugin was disabled.`
-        ].join(' '))
-        break
+          })
+      } catch (e) {
+        log.error(e)
+        this.unload(plugin)
+        log.debug(`Error while trying to patch ${meta.name}. The plugin has been disabled.`)
       }
     }
   }
 
-  _fail (plugin) {
+  unload (plugin) {
     [].concat(plugin)
       .forEach(instrumentation => {
-        this._unpatch(instrumentation)
+        this.unpatch(instrumentation)
         this._instrumented.delete(instrumentation)
       })
 
     this._plugins.delete(plugin)
   }
 
-  _patch (instrumentation, moduleExports, config) {
+  patch (instrumentation, moduleExports, config) {
     let instrumented = this._instrumented.get(instrumentation)
 
     if (!instrumented) {
@@ -200,7 +136,7 @@ class Instrumenter {
     }
   }
 
-  _unpatch (instrumentation) {
+  unpatch (instrumentation) {
     const instrumented = this._instrumented.get(instrumentation)
 
     if (instrumented) {
@@ -214,84 +150,9 @@ class Instrumenter {
     }
   }
 
-  _load (plugin, meta) {
-    if (this._enabled) {
-      const instrumentations = [].concat(plugin)
-
-      try {
-        instrumentations
-          .forEach(instrumentation => {
-            getModules(instrumentation).forEach(nodule => {
-              this._patch(instrumentation, nodule, meta.config)
-            })
-          })
-      } catch (e) {
-        log.error(e)
-        this._fail(plugin)
-        log.debug(`Error while trying to patch ${meta.name}. The plugin has been disabled.`)
-      }
-    }
-  }
-}
-
-function getModules (instrumentation) {
-  const modules = []
-  const ids = Object.keys(require.cache)
-
-  let pkg
-
-  for (let i = 0, l = ids.length; i < l; i++) {
-    const id = ids[i].replace(pathSepExpr, '/')
-
-    if (!id.includes(`/node_modules/${instrumentation.name}/`)) continue
-
-    if (instrumentation.file) {
-      if (!id.endsWith(`/node_modules/${filename(instrumentation)}`)) continue
-
-      const basedir = getBasedir(ids[i])
-
-      pkg = require(`${basedir}/package.json`)
-    } else {
-      const basedir = getBasedir(ids[i])
-
-      pkg = require(`${basedir}/package.json`)
-
-      if (!id.endsWith(`/node_modules/${instrumentation.name}/${pkg.main || 'index.js'}`)) continue
-    }
-
-    if (!matchVersion(pkg.version, instrumentation.versions)) continue
-
-    modules.push(require.cache[ids[i]].exports)
-  }
-
-  return modules
-}
-
-function getBasedir (id) {
-  return parse(id).basedir.replace(pathSepExpr, '/')
-}
-
-function matchVersion (version, ranges) {
-  return !version || (ranges && ranges.some(range => semver.satisfies(version, range)))
-}
-
-function getVersion (moduleBaseDir) {
-  if (moduleBaseDir) {
-    const packageJSON = `${moduleBaseDir}/package.json`
-    return require(packageJSON).version
-  }
-}
-
-function filename (plugin) {
-  return [plugin.name, plugin.file].filter(val => val).join('/')
-}
-
-function exists (basedir, file) {
-  try {
-    require.resolve(`${basedir}/${file}`)
-    return true
-  } catch (e) {
-    return false
+  _set (plugin, meta) {
+    this._plugins.set(plugin, meta)
+    this.load(plugin, meta)
   }
 }
 

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -42,9 +42,11 @@ class DatadogTracer extends Tracer {
     this._prioritySampler = new PrioritySampler(config.env)
 
     if (config.experimental.exporter === exporters.LOG) {
-      this._exporter = new LogExporter(process.stdout)
+      this._exporter = new LogExporter(config)
+    } else if (config.experimental.exporter === exporters.AGENT) {
+      this._exporter = new AgentExporter(config)
     } else {
-      this._exporter = new AgentExporter(config.url, config.flushInterval)
+      this._exporter = new platform.Exporter(config)
     }
 
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)

--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -12,6 +12,10 @@ const msgpack = require('./msgpack')
 const metrics = require('./metrics')
 const Uint64BE = require('./uint64be')
 const hostname = require('./hostname')
+const plugins = require('../../plugins')
+const Loader = require('./loader')
+const Scope = require('../../scope/async_hooks')
+const Exporter = require('../../exporters/agent')
 
 const emitter = new EventEmitter()
 
@@ -41,9 +45,13 @@ const platform = {
   metrics,
   Uint64BE,
   hostname,
+  plugins,
   on: emitter.on.bind(emitter),
   once: emitter.once.bind(emitter),
-  off: emitter.removeListener.bind(emitter)
+  off: emitter.removeListener.bind(emitter),
+  Loader,
+  Scope,
+  Exporter
 }
 
 process.once('beforeExit', () => emitter.emit('exit'))

--- a/packages/dd-trace/src/platform/node/loader.js
+++ b/packages/dd-trace/src/platform/node/loader.js
@@ -1,0 +1,154 @@
+'use strict'
+
+const semver = require('semver')
+const hook = require('require-in-the-middle')
+const parse = require('module-details-from-path')
+const path = require('path')
+const uniq = require('lodash.uniq')
+const log = require('../../log')
+
+const pathSepExpr = new RegExp(`\\${path.sep}`, 'g')
+
+class Loader {
+  constructor (instrumenter) {
+    this._instrumenter = instrumenter
+  }
+
+  reload (plugins) {
+    this._plugins = plugins
+
+    const instrumentations = Array.from(this._plugins.keys())
+      .reduce((prev, current) => prev.concat(current), [])
+
+    const instrumentedModules = uniq(instrumentations
+      .map(instrumentation => instrumentation.name))
+
+    this._names = new Set(instrumentations
+      .map(instrumentation => filename(instrumentation)))
+
+    hook(instrumentedModules, { internals: true }, this._hookModule.bind(this))
+  }
+
+  getModules (instrumentation) {
+    const modules = []
+    const ids = Object.keys(require.cache)
+
+    let pkg
+
+    for (let i = 0, l = ids.length; i < l; i++) {
+      const id = ids[i].replace(pathSepExpr, '/')
+
+      if (!id.includes(`/node_modules/${instrumentation.name}/`)) continue
+
+      if (instrumentation.file) {
+        if (!id.endsWith(`/node_modules/${filename(instrumentation)}`)) continue
+
+        const basedir = getBasedir(ids[i])
+
+        pkg = require(`${basedir}/package.json`)
+      } else {
+        const basedir = getBasedir(ids[i])
+
+        pkg = require(`${basedir}/package.json`)
+
+        if (!id.endsWith(`/node_modules/${instrumentation.name}/${pkg.main || 'index.js'}`)) continue
+      }
+
+      if (!matchVersion(pkg.version, instrumentation.versions)) continue
+
+      modules.push(require.cache[ids[i]].exports)
+    }
+
+    return modules
+  }
+
+  _hookModule (moduleExports, moduleName, moduleBaseDir) {
+    moduleName = moduleName.replace(pathSepExpr, '/')
+
+    if (!this._names.has(moduleName)) {
+      return moduleExports
+    }
+
+    if (moduleBaseDir) {
+      moduleBaseDir = moduleBaseDir.replace(pathSepExpr, '/')
+    }
+
+    const moduleVersion = getVersion(moduleBaseDir)
+
+    Array.from(this._plugins.keys())
+      .filter(plugin => [].concat(plugin).some(instrumentation =>
+        filename(instrumentation) === moduleName && matchVersion(moduleVersion, instrumentation.versions)
+      ))
+      .forEach(plugin => this._validate(plugin, moduleName, moduleBaseDir, moduleVersion))
+
+    this._plugins
+      .forEach((meta, plugin) => {
+        try {
+          [].concat(plugin)
+            .filter(instrumentation => moduleName === filename(instrumentation))
+            .filter(instrumentation => matchVersion(moduleVersion, instrumentation.versions))
+            .forEach(instrumentation => {
+              const config = this._plugins.get(plugin).config
+
+              if (config.enabled !== false) {
+                moduleExports = this._instrumenter.patch(instrumentation, moduleExports, config) || moduleExports
+              }
+            })
+        } catch (e) {
+          log.error(e)
+          this._instrumenter.unload(plugin)
+          log.debug(`Error while trying to patch ${meta.name}. The plugin has been disabled.`)
+        }
+      })
+
+    return moduleExports
+  }
+
+  _validate (plugin, moduleName, moduleBaseDir, moduleVersion) {
+    const meta = this._plugins.get(plugin)
+    const instrumentations = [].concat(plugin)
+
+    for (let i = 0; i < instrumentations.length; i++) {
+      if (moduleName.indexOf(instrumentations[i].name) !== 0) continue
+      if (instrumentations[i].versions && !matchVersion(moduleVersion, instrumentations[i].versions)) continue
+      if (instrumentations[i].file && !exists(moduleBaseDir, instrumentations[i].file)) {
+        this._instrumenter.unload(plugin)
+        log.debug([
+          `Plugin "${meta.name}" requires "${instrumentations[i].file}" which was not found.`,
+          `The plugin was disabled.`
+        ].join(' '))
+        break
+      }
+    }
+  }
+}
+
+function getBasedir (id) {
+  return parse(id).basedir.replace(pathSepExpr, '/')
+}
+
+function matchVersion (version, ranges) {
+  return !version || (ranges && ranges.some(range => semver.satisfies(version, range)))
+}
+
+function getVersion (moduleBaseDir) {
+  if (moduleBaseDir) {
+    const packageJSON = `${moduleBaseDir}/package.json`
+    return require(packageJSON).version
+  }
+}
+
+function filename (plugin) {
+  return [plugin.name, plugin.file].filter(val => val).join('/')
+}
+
+function exists (basedir, file) {
+  try {
+    require.resolve(`${basedir}/${file}`)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+module.exports = Loader

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -42,8 +42,7 @@ class Tracer extends BaseTracer {
           }
 
           this._tracer = new DatadogTracer(config)
-          this._instrumenter.enable()
-          this._instrumenter.patch(config)
+          this._instrumenter.enable(config)
         }
       } catch (e) {
         log.error(e)

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -3,6 +3,7 @@
 const Tracer = require('./opentracing/tracer')
 const tags = require('../../../ext/tags')
 const scopes = require('../../../ext/scopes')
+const platform = require('./platform')
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
@@ -131,7 +132,7 @@ function getScope (config) {
   if (config.scope === NOOP) {
     Scope = require('./scope/base')
   } else {
-    Scope = require('./scope/async_hooks')
+    Scope = platform.Scope
   }
 
   return new Scope(config)

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -1,7 +1,8 @@
 'use strict'
 
 describe('Exporter', () => {
-  const url = 'www.example.com'
+  let url
+  let interval
   let Scheduler
   let scheduler
   let Exporter
@@ -11,6 +12,8 @@ describe('Exporter', () => {
   let span
 
   beforeEach(() => {
+    url = 'www.example.com'
+    interval = 1000
     span = {}
     scheduler = {
       start: sinon.spy(),
@@ -31,12 +34,12 @@ describe('Exporter', () => {
 
   describe('when interval is set to a positive number', () => {
     beforeEach(() => {
-      exporter = new Exporter(url, 1000)
+      exporter = new Exporter({ url, interval })
     })
 
     it('should schedule flushing after the configured interval', () => {
       writer.length = 0
-      exporter = new Exporter(url, 1000)
+      exporter = new Exporter({ url, interval })
       Scheduler.firstCall.args[0]()
 
       expect(scheduler.start).to.have.been.called
@@ -59,7 +62,7 @@ describe('Exporter', () => {
 
   describe('when interval is set to 0', () => {
     beforeEach(() => {
-      exporter = new Exporter(writer, 0)
+      exporter = new Exporter({ url, interval: 0 })
     })
 
     it('should flush right away when interval is set to 0', () => {

--- a/packages/dd-trace/test/exporters/log/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/log/exporter.spec.js
@@ -4,40 +4,40 @@ describe('LogExporter', () => {
   let Exporter
   let exporter
   let span
-  let outputStream
+  let log
 
   beforeEach(() => {
-    span = { formatted: true }
+    span = { tag: 'test' }
 
-    outputStream = {
-      write: sinon.stub()
-    }
+    log = sinon.stub(console, 'log')
 
     Exporter = proxyquire('../src/exporters/log', {})
-    exporter = new Exporter(outputStream)
+    exporter = new Exporter()
+  })
+
+  afterEach(() => {
+    log.restore()
   })
 
   describe('export', () => {
-    it('should flush its traces to the output stream', () => {
+    it('should flush its traces to the console', () => {
       exporter.export([span, span])
-      const result = '{"datadog_traces":[{"formatted":true},{"formatted":true}]}'
-      expect(outputStream.write).to.have.been.calledWithMatch(result)
+      const result = '{"datadog_traces":[{"tag":"test"},{"tag":"test"}]}'
+      expect(log).to.have.been.calledWithMatch(result)
     })
 
     it('should send spans over multiple log lines when they are too large for a single log line', () => {
-      const maxSize = 20
-      exporter = new Exporter(outputStream, maxSize)
+      span.tag = new Array(200000).fill('a').join('')
       exporter.export([span, span])
-      const result = '{"datadog_traces":[{"formatted":true}]}'
-      expect(outputStream.write).to.have.calledTwice
-      expect(outputStream.write).to.have.been.calledWithMatch(result)
+      const result = `{"datadog_traces":[{"tag":"${span.tag}"}]}`
+      expect(log).to.have.calledTwice
+      expect(log).to.have.been.calledWithMatch(result)
     })
 
     it('should drop spans if they are too large for a single log line', () => {
-      const maxSize = 5
-      exporter = new Exporter(outputStream, maxSize)
+      span.tag = new Array(300000).fill('a').join('')
       exporter.export([span, span])
-      expect(outputStream.write).not.to.have.been.called
+      expect(log).not.to.have.been.called
     })
   })
 })

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const proxyquire = require('proxyquire').noCallThru()
+const proxyquire = require('proxyquire')
 const path = require('path')
 
 describe('Instrumenter', () => {
@@ -56,11 +56,13 @@ describe('Instrumenter', () => {
 
     Instrumenter = proxyquire('../src/instrumenter', {
       'shimmer': shimmer,
-      './plugins': {
-        'http': integrations.http,
-        'express-mock': integrations.express,
-        'mysql-mock': integrations.mysql,
-        'other': integrations.other
+      './platform': {
+        plugins: {
+          'http': integrations.http,
+          'express-mock': integrations.express,
+          'mysql-mock': integrations.mysql,
+          'other': integrations.other
+        }
       },
       '../../datadog-plugin-http/src': integrations.http,
       '../../datadog-plugin-express-mock/src': integrations.express,
@@ -91,7 +93,7 @@ describe('Instrumenter', () => {
         const config = { foo: 'bar' }
 
         instrumenter.use('express-mock', config)
-        instrumenter.patch()
+        instrumenter.enable()
 
         const express = require('express-mock')
 
@@ -100,7 +102,7 @@ describe('Instrumenter', () => {
 
       it('should default to an empty plugin configuration', () => {
         instrumenter.use('express-mock')
-        instrumenter.patch()
+        instrumenter.enable()
 
         const express = require('express-mock')
 
@@ -110,7 +112,7 @@ describe('Instrumenter', () => {
       it('should reapply the require hook when called multiple times', () => {
         instrumenter.use('mysql-mock')
         instrumenter.use('express-mock')
-        instrumenter.patch()
+        instrumenter.enable()
 
         require('express-mock')
 
@@ -199,7 +201,7 @@ describe('Instrumenter', () => {
 
     describe('patch', () => {
       it('should patch modules from node_modules when they are loaded', () => {
-        instrumenter.patch()
+        instrumenter.enable()
 
         const express = require('express-mock')
 
@@ -208,7 +210,7 @@ describe('Instrumenter', () => {
 
       it('should only patch a module if its version is supported by the plugin ', () => {
         integrations.express.versions = ['^3.0.0']
-        instrumenter.patch()
+        instrumenter.enable()
 
         const express = require('express-mock')
 
@@ -216,7 +218,7 @@ describe('Instrumenter', () => {
       })
 
       it('should patch native modules when they are loaded', () => {
-        instrumenter.patch()
+        instrumenter.enable()
 
         const http = require('http')
 
@@ -228,7 +230,7 @@ describe('Instrumenter', () => {
         const Connection = require('mysql-mock/lib/connection')
         const Pool = require('mysql-mock/lib/pool')
 
-        instrumenter.patch()
+        instrumenter.enable()
 
         const mysql = require('mysql-mock')
 
@@ -244,7 +246,7 @@ describe('Instrumenter', () => {
 
         const Connection = require('mysql-mock/lib/connection')
 
-        instrumenter.patch()
+        instrumenter.enable()
 
         const mysql = require('mysql-mock')
 
@@ -254,7 +256,7 @@ describe('Instrumenter', () => {
       })
 
       it('should replace the module exports with the return value of the plugin', () => {
-        instrumenter.patch()
+        instrumenter.enable()
 
         const other = require('other')
 
@@ -264,18 +266,18 @@ describe('Instrumenter', () => {
 
     describe('unpatch', () => {
       it('should unpatch patched modules', () => {
-        instrumenter.patch()
+        instrumenter.enable()
 
         const express = require('express-mock')
 
-        instrumenter.unpatch()
+        instrumenter.disable()
 
         expect(integrations.express.unpatch).to.have.been.calledWith(express, tracer)
       })
 
       it('should remove the require hooks', () => {
-        instrumenter.patch()
-        instrumenter.unpatch()
+        instrumenter.enable()
+        instrumenter.disable()
 
         require('express-mock')
 
@@ -284,11 +286,11 @@ describe('Instrumenter', () => {
 
       it('should handle errors', () => {
         integrations.mysql[0].unpatch = sinon.stub().throws(new Error())
-        instrumenter.patch()
+        instrumenter.enable()
 
         require('mysql-mock')
 
-        expect(() => instrumenter.unpatch()).to.not.throw()
+        expect(() => instrumenter.disable()).to.not.throw()
         expect(integrations.mysql[1].unpatch).to.have.been.called
       })
     })
@@ -330,37 +332,17 @@ describe('Instrumenter', () => {
     describe('use', () => {
       it('should still allow adding plugins manually by name', () => {
         instrumenter.use('express-mock')
-        instrumenter.patch({ plugins: false })
+        instrumenter.enable({ plugins: false })
 
         const express = require('express-mock')
 
         expect(integrations.express.patch).to.have.been.calledWithMatch(express, 'tracer', {})
       })
     })
-
-    describe('patch', () => {
-      it('should not patch any module', () => {
-        instrumenter.patch({ plugins: false })
-
-        const express = require('express-mock')
-
-        expect(integrations.express.patch).to.not.have.been.calledWithMatch(express, 'tracer', {})
-      })
-    })
   })
 
   describe('with the instrumenter disabled', () => {
     describe('use', () => {
-      it('should not patch modules when they are loaded when the tracer is disabled', () => {
-        instrumenter.patch()
-
-        require('express-mock')
-
-        expect(integrations.express.patch).to.not.have.been.called
-      })
-    })
-
-    describe('patch', () => {
       it('should not patch if the tracer is disabled', () => {
         instrumenter.use('express-mock')
 

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -86,14 +86,14 @@ describe('Tracer', () => {
     }
 
     platform = {
-      hostname: sinon.stub().returns('my_hostname')
+      hostname: sinon.stub().returns('my_hostname'),
+      Exporter: AgentExporter
     }
 
     Tracer = proxyquire('../src/opentracing/tracer', {
       './span': Span,
       './span_context': SpanContext,
       '../priority_sampler': PrioritySampler,
-      '../exporters/agent': AgentExporter,
       '../exporters/log': LogExporter,
       '../span_processor': SpanProcessor,
       '../sampler': Sampler,
@@ -109,7 +109,7 @@ describe('Tracer', () => {
     tracer = new Tracer(config)
 
     expect(AgentExporter).to.have.been.called
-    expect(AgentExporter).to.have.been.calledWith(config.url, config.flushInterval)
+    expect(AgentExporter).to.have.been.calledWith(config)
     expect(SpanProcessor).to.have.been.calledWith(exporter, prioritySampler)
   })
 
@@ -121,7 +121,6 @@ describe('Tracer', () => {
 
     expect(AgentExporter).not.to.have.been.called
     expect(LogExporter).to.have.been.called
-    expect(LogExporter).to.have.been.calledWith(process.stdout)
     expect(SpanProcessor).to.have.been.calledWith(exporter, prioritySampler)
   })
 

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -41,7 +41,7 @@ module.exports = {
         config = [].concat(config)
 
         server.on('close', () => {
-          tracer._instrumenter.unpatch()
+          tracer._instrumenter.disable()
           tracer = null
         })
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -64,10 +64,10 @@ describe('TracerProxy', () => {
     Proxy = proxyquire('../src/proxy', {
       './tracer': DatadogTracer,
       './noop/tracer': NoopTracer,
-      './instrumenter': Instrumenter,
       './config': Config,
       './platform': platform,
-      './analytics_sampler': analyticsSampler
+      './analytics_sampler': analyticsSampler,
+      './instrumenter': Instrumenter
     })
 
     proxy = new Proxy()
@@ -116,13 +116,12 @@ describe('TracerProxy', () => {
         proxy.init()
 
         expect(instrumenter.enable).to.have.been.called
-        expect(instrumenter.patch).to.have.been.called
       })
 
       it('should update the delegate before setting up instrumentation', () => {
         proxy.init()
 
-        expect(instrumenter.patch).to.have.been.calledAfter(DatadogTracer)
+        expect(instrumenter.enable).to.have.been.calledAfter(DatadogTracer)
       })
 
       it('should not capture metrics by default', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the following tracer components to be platform agnostic:

* Node-specific code was moved out of the instrumenter.
* The log exporter no longer depends on `process`.
* Exporters no longer have options other than what can be configured on the tracer.
* The default exporter and scope manager is based on the current platform.

### Motivation
<!-- What inspired you to submit this pull request? -->

The tracer should not depend on Node.