### PR TITLE
Support circular references in tags and better array formatting

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -141,7 +141,7 @@ function addTag (meta, key, value, seen) {
       }
 
       break
-    default: // eslint-disable-line no-fallthrough
+    default:
       addTag(meta, key, serialize(value))
   }
 }

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -165,7 +165,7 @@ function addTagArray (meta, key, array, seen) {
   function replacer (key, value) {
     if (typeof value === 'object') {
       if (seen && ~seen.indexOf(value)) return '[Circular]'
-      if (!Array.isArray(value)) return getConstructor(value) || '[object Object]'
+      if (!Array.isArray(value)) return serialize(value) || '[object Object]'
 
       seen.push(value)
     }
@@ -173,11 +173,6 @@ function addTagArray (meta, key, array, seen) {
   }
   const formattedArray = JSON.stringify(array, replacer)
   addTag(meta, key, formattedArray, seen)
-}
-
-function getConstructor (obj) {
-  const desc = Object.getOwnPropertyDescriptor(obj, 'constructor')
-  return desc && typeof desc.value === 'function' && desc.value.name
 }
 
 function serialize (obj) {

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -165,7 +165,7 @@ function addTagArray (meta, key, array, seen) {
   function replacer (key, value) {
     if (typeof value === 'object') {
       if (seen && ~seen.indexOf(value)) return '[Circular]'
-      if (!Array.isArray(value)) return serialize(value) || '[object Object]'
+      if (!Array.isArray(value)) return '[object Object]'
 
       seen.push(value)
     }

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -163,19 +163,9 @@ function addObjectTag (meta, key, value, seen) {
 }
 
 function addArrayTag (meta, key, array, seen) {
-  const formattedArray = JSON.stringify(array, (key, value) => {
-    if (typeof value === 'object') {
-      if (seen && ~seen.indexOf(value)) return '[Circular]'
-      if (!Array.isArray(value)) return '[object Object]'
-
-      seen.push(value)
-    }
-    return value
-  })
+  const formattedArray = formatArray(array, seen)
 
   addTag(meta, key, formattedArray, seen)
-
-  seen.pop()
 }
 
 function formatArray (value, seen) {

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -169,7 +169,7 @@ function addArrayTag (meta, key, array, seen) {
 }
 
 function formatArray (value, seen) {
-  if (typeof value !== 'object') return `"${serialize(value)}"`
+  if (typeof value !== 'object') return `${serialize(value)}`
   if (seen && ~seen.indexOf(value)) return '[Circular]'
   if (!Array.isArray(value)) return '[object Object]'
 

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -157,7 +157,7 @@ describe('format', () => {
 
       trace = format(span)
 
-      expect(trace.meta['root.level1.array']).to.equal('[hello]')
+      expect(trace.meta['root.level1.array']).to.equal('hello')
       expect(trace.meta['root.level1.level2']).to.be.undefined
       expect(trace.meta['root.level1.level2.level3']).to.be.undefined
     })
@@ -169,7 +169,7 @@ describe('format', () => {
 
       trace = format(span)
 
-      expect(trace.meta['root.array']).to.equal('[a,[b,[c]]]')
+      expect(trace.meta['root.array']).to.equal('a,b,c')
     })
 
     it('should support objects in arrays', () => {
@@ -181,7 +181,7 @@ describe('format', () => {
 
       trace = format(span)
 
-      expect(trace.meta['root.array']).to.equal('[a,[object Object],[object Object]]')
+      expect(trace.meta['root.array']).to.equal('a,[object Object],[object Object]')
     })
 
     it('should add runtime tags', () => {
@@ -335,27 +335,6 @@ describe('format', () => {
       expect(trace.meta['circularTag.A.B.C.D.E.self']).to.equal('[Circular]')
     })
 
-    it('should support circular references in an array', () => {
-      const tag = { 'foo': 'bar' }
-
-      tag['baz'] = ['qux', tag]
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag.foo']).to.equal('bar')
-      expect(trace.meta['circularTag.baz']).to.equal('[qux,[Circular]]')
-    })
-
-    it('should support circular referenced arrays', () => {
-      const tag = ['foo', ['bar', ['baz']]]
-
-      tag[1][1][1] = ['quuz', tag[1]]
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag']).to.equal('[foo,[bar,[baz,[quuz,[Circular]]]]]')
-    })
-
     it('should support circular references in a class', () => {
       class CircularTag {
         constructor () {
@@ -417,8 +396,8 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag.baz']).to.equal('[bar]')
-      expect(trace.meta['circularTag.qux']).to.equal('[bar]')
+      expect(trace.meta['circularTag.baz']).to.equal('bar')
+      expect(trace.meta['circularTag.qux']).to.equal('bar')
     })
 
     it('should support re-used arrays within arrays', () => {
@@ -428,23 +407,7 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag']).to.equal('[[object Object],[[object Object]]]')
-    })
-
-    it('should support doubly-linked arrays', () => {
-      const tag = {
-        selfArrA: ['ghost_eater'],
-        selfArrB: ['space_invader']
-      }
-
-      tag.selfArrA[1] = tag.selfArrB
-      tag.selfArrB[1] = tag.selfArrA
-
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag.selfArrA']).to.equal('[ghost_eater,[space_invader,[Circular]]]')
-      expect(trace.meta['circularTag.selfArrB']).to.equal('[space_invader,[ghost_eater,[Circular]]]')
+      expect(trace.meta['circularTag']).to.equal('[object Object],[object Object]')
     })
 
     it('should include the analytics sample rate', () => {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -181,7 +181,7 @@ describe('format', () => {
 
       trace = format(span)
 
-      expect(trace.meta['root.array']).to.equal('["a","[object Object]","[object Object]"]')
+      expect(trace.meta['root.array']).to.equal('["a",[object Object],[object Object]]')
     })
 
     it('should add runtime tags', () => {
@@ -343,7 +343,7 @@ describe('format', () => {
       trace = format(span)
 
       expect(trace.meta['circularTag.foo']).to.equal('bar')
-      expect(trace.meta['circularTag.baz']).to.equal('["qux","[Circular]"]')
+      expect(trace.meta['circularTag.baz']).to.equal('["qux",[Circular]]')
     })
 
     it('should support circular referenced arrays', () => {
@@ -353,7 +353,7 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag']).to.equal('["foo",["bar",["baz",["quuz","[Circular]"]]]]')
+      expect(trace.meta['circularTag']).to.equal('["foo",["bar",["baz",["quuz",[Circular]]]]]')
     })
 
     it('should support circular references in a class', () => {
@@ -428,7 +428,7 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag']).to.equal('["[object Object]",["[object Object]"]]')
+      expect(trace.meta['circularTag']).to.equal('[[object Object],[[object Object]]]')
     })
 
     it('should support doubly-linked arrays', () => {
@@ -443,8 +443,8 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag.selfArrA']).to.equal('["ghost_eater",["space_invader","[Circular]"]]')
-      expect(trace.meta['circularTag.selfArrB']).to.equal('["space_invader","[Circular]"]')
+      expect(trace.meta['circularTag.selfArrA']).to.equal('["ghost_eater",["space_invader",[Circular]]]')
+      expect(trace.meta['circularTag.selfArrB']).to.equal('["space_invader",["ghost_eater",[Circular]]]')
     })
 
     it('should include the analytics sample rate', () => {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -157,7 +157,7 @@ describe('format', () => {
 
       trace = format(span)
 
-      expect(trace.meta['root.level1.array']).to.equal('["hello"]')
+      expect(trace.meta['root.level1.array']).to.equal('[hello]')
       expect(trace.meta['root.level1.level2']).to.be.undefined
       expect(trace.meta['root.level1.level2.level3']).to.be.undefined
     })
@@ -169,7 +169,7 @@ describe('format', () => {
 
       trace = format(span)
 
-      expect(trace.meta['root.array']).to.equal('["a",["b",["c"]]]')
+      expect(trace.meta['root.array']).to.equal('[a,[b,[c]]]')
     })
 
     it('should support objects in arrays', () => {
@@ -181,7 +181,7 @@ describe('format', () => {
 
       trace = format(span)
 
-      expect(trace.meta['root.array']).to.equal('["a",[object Object],[object Object]]')
+      expect(trace.meta['root.array']).to.equal('[a,[object Object],[object Object]]')
     })
 
     it('should add runtime tags', () => {
@@ -343,7 +343,7 @@ describe('format', () => {
       trace = format(span)
 
       expect(trace.meta['circularTag.foo']).to.equal('bar')
-      expect(trace.meta['circularTag.baz']).to.equal('["qux",[Circular]]')
+      expect(trace.meta['circularTag.baz']).to.equal('[qux,[Circular]]')
     })
 
     it('should support circular referenced arrays', () => {
@@ -353,7 +353,7 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag']).to.equal('["foo",["bar",["baz",["quuz",[Circular]]]]]')
+      expect(trace.meta['circularTag']).to.equal('[foo,[bar,[baz,[quuz,[Circular]]]]]')
     })
 
     it('should support circular references in a class', () => {
@@ -417,8 +417,8 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag.baz']).to.equal('["bar"]')
-      expect(trace.meta['circularTag.qux']).to.equal('["bar"]')
+      expect(trace.meta['circularTag.baz']).to.equal('[bar]')
+      expect(trace.meta['circularTag.qux']).to.equal('[bar]')
     })
 
     it('should support re-used arrays within arrays', () => {
@@ -443,8 +443,8 @@ describe('format', () => {
       spanContext._tags['circularTag'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag.selfArrA']).to.equal('["ghost_eater",["space_invader",[Circular]]]')
-      expect(trace.meta['circularTag.selfArrB']).to.equal('["space_invader",["ghost_eater",[Circular]]]')
+      expect(trace.meta['circularTag.selfArrA']).to.equal('[ghost_eater,[space_invader,[Circular]]]')
+      expect(trace.meta['circularTag.selfArrB']).to.equal('[space_invader,[ghost_eater,[Circular]]]')
     })
 
     it('should include the analytics sample rate', () => {


### PR DESCRIPTION
### What does this PR do?
This PR removes depth when it comes to tags and instead detects circular references. This will allow us to get infinite visibility for objects-as-tags.

This PR also changes the way we format arrays. We now leverage `JSON.stringify` to nest arrays rather than flattening them.

### Motivation
We want to ensure we can always get meaningful information from tags while at the same time ensuring readability.

### Additional Notes
Please check the tests to see what the expected behaviour is, thanks!
