### PR TITLE
fix dns plugin not properly binding the callback to the parent scope

### DIFF
--- a/packages/datadog-plugin-dns/src/index.js
+++ b/packages/datadog-plugin-dns/src/index.js
@@ -106,10 +106,11 @@ function startSpan (tracer, config, operation, tags) {
 
 function wrapArgs (span, args, callback) {
   const original = args[args.length - 1]
+  const fn = tx.wrap(span, original)
 
   args[args.length - 1] = function () {
     callback && callback.apply(null, arguments)
-    return tx.wrap(span, original).apply(this, arguments)
+    return fn.apply(this, arguments)
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `dns` plugin not properly binding the callback to the parent scope.

### Motivation
<!-- What inspired you to submit this pull request? -->

The scope was bound inside the callback instead of before, meaning the scope was bound to the current span and not the parent.