### PR TITLE
fix browser tracing prototype breaking cors

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -56,7 +56,8 @@ class Config {
     this.trackAsyncScope = options.trackAsyncScope !== false
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
-      exporter: options.experimental && options.experimental.exporter
+      exporter: options.experimental && options.experimental.exporter,
+      peers: (options.experimental && options.experimental.peers) || []
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = process.env.DD_CONTEXT_PROPAGATION === 'false' ? scopes.NOOP : scope

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -44,6 +44,7 @@ class DatadogTracer extends Tracer {
     this._exporter = getExporter(config)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)
     this._sampler = new Sampler(config.sampleRate)
+    this._peers = config.experimental.peers
     this._propagators = {
       [formats.TEXT_MAP]: new TextMapPropagator(config),
       [formats.HTTP_HEADERS]: new HttpPropagator(config),

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const uniq = require('lodash.uniq')
 const analyticsSampler = require('../../analytics_sampler')
 const FORMAT_HTTP_HEADERS = require('opentracing').FORMAT_HTTP_HEADERS
 const log = require('../../log')
@@ -236,6 +237,8 @@ function wrapEnd (req) {
 
   if (end === req._datadog.end) return
 
+  res.writeHead = wrapWriteHead(req)
+
   let _end = req._datadog.end = res.end = function () {
     req._datadog.beforeEnd.forEach(beforeEnd => beforeEnd())
 
@@ -257,6 +260,55 @@ function wrapEnd (req) {
       _end = scope.bind(value, req._datadog.span)
     }
   })
+}
+
+function wrapWriteHead (req) {
+  const res = req._datadog.res
+  const writeHead = res.writeHead
+
+  return function (statusCode, statusMessage, headers) {
+    headers = typeof statusMessage === 'string' ? headers : statusMessage
+    headers = Object.assign(res.getHeaders(), headers)
+
+    if (req.method.toLowerCase() === 'options' && isOriginAllowed(req, headers)) {
+      addAllowHeaders(req, headers)
+    }
+
+    return writeHead.apply(this, arguments)
+  }
+}
+
+function addAllowHeaders (req, headers) {
+  const res = req._datadog.res
+  const allowHeaders = splitHeader(headers['access-control-allow-headers'])
+  const requestHeaders = splitHeader(req.headers['access-control-request-headers'])
+  const contextHeaders = [
+    'x-datadog-parent-id',
+    'x-datadog-sampled',
+    'x-datadog-sampling-priority',
+    'x-datadog-trace-id'
+  ]
+
+  for (const header of contextHeaders) {
+    if (~requestHeaders.indexOf(header)) {
+      allowHeaders.push(header)
+    }
+  }
+
+  if (allowHeaders.length > 0) {
+    res.setHeader('access-control-allow-headers', uniq(allowHeaders).join(','))
+  }
+}
+
+function isOriginAllowed (req, headers) {
+  const origin = req.headers['origin']
+  const allowOrigin = headers['access-control-allow-origin']
+
+  return origin && (allowOrigin === '*' || allowOrigin === origin)
+}
+
+function splitHeader (str) {
+  return typeof str === 'string' ? str.split(/\s*,\s*/) : []
 }
 
 function wrapEvents (req) {

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -44,7 +44,10 @@ describe('plugins/util/web', () => {
     end = sinon.stub()
     res = {
       end,
-      getHeader: sinon.stub()
+      getHeader: sinon.stub(),
+      getHeaders: sinon.stub().returns({}),
+      setHeader: sinon.spy(),
+      writeHead: () => {}
     }
     res.getHeader.withArgs('server').returns('test')
     config = { hooks: {} }
@@ -246,6 +249,79 @@ describe('plugins/util/web', () => {
             [HTTP_URL]: 'http://localhost/user/123'
           })
         })
+      })
+
+      it('should handle CORS preflight', () => {
+        const headers = [
+          'x-datadog-parent-id',
+          'x-datadog-sampled',
+          'x-datadog-sampling-priority',
+          'x-datadog-trace-id'
+        ].join(',')
+
+        req.method = 'OPTIONS'
+        req.headers['origin'] = 'http://test.com'
+        req.headers['access-control-request-headers'] = headers
+
+        res.getHeaders.returns({
+          'access-control-allow-origin': 'http://test.com'
+        })
+
+        web.instrument(tracer, config, req, res, 'test.request')
+
+        res.writeHead()
+
+        expect(res.setHeader).to.have.been.calledWith('access-control-allow-headers', headers)
+      })
+
+      it('should handle CORS preflight with partial headers', () => {
+        const headers = [
+          'x-datadog-parent-id',
+          'x-datadog-trace-id'
+        ].join(',')
+
+        req.method = 'OPTIONS'
+        req.headers['origin'] = 'http://test.com'
+        req.headers['access-control-request-headers'] = headers
+
+        res.getHeaders.returns({
+          'access-control-allow-origin': 'http://test.com'
+        })
+
+        web.instrument(tracer, config, req, res, 'test.request')
+
+        res.writeHead()
+
+        expect(res.setHeader).to.have.been.calledWith('access-control-allow-headers', headers)
+      })
+
+      it('should handle CORS preflight when the origin does not match', () => {
+        const headers = ['x-datadog-trace-id']
+
+        req.method = 'OPTIONS'
+        req.headers['origin'] = 'http://test.com'
+        req.headers['access-control-request-headers'] = headers
+
+        web.instrument(tracer, config, req, res, 'test.request')
+
+        res.writeHead()
+
+        expect(res.setHeader).to.not.have.been.called
+      })
+
+      it('should handle CORS preflight when no header was requested', () => {
+        req.method = 'OPTIONS'
+        req.headers['origin'] = 'http://test.com'
+
+        res.getHeaders.returns({
+          'access-control-allow-origin': 'http://test.com'
+        })
+
+        web.instrument(tracer, config, req, res, 'test.request')
+
+        res.writeHead()
+
+        expect(res.setHeader).to.not.have.been.called
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix browser tracing prototype breaking CORS.

### Motivation
<!-- What inspired you to submit this pull request? -->

Using the browser tracing prototype sends additional headers for context propagation. This means that if the remote endpoint is not on the same origin, the additional headers would not be recognized and the request would fail. The patch forces the tracer to be configured with any origins that are considered peers for context propagation. It also automatically accepts the propagation headers for any instrumented server when the origin is already allowed.