### PR TITLE
fix errors in graphql plugin when field properties are missing

### DIFF
--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -291,11 +291,11 @@ function startResolveSpan (tracer, config, childOf, path, info, contextValue) {
   })
 
   if (fieldNode) {
-    if (document) {
+    if (document && fieldNode.loc) {
       span.setTag('graphql.source', document.substring(fieldNode.loc.start, fieldNode.loc.end))
     }
 
-    if (config.variables) {
+    if (config.variables && fieldNode.arguments) {
       const variables = config.variables(info.variableValues)
 
       fieldNode.arguments


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix errors in `graphql` plugin when field properties are missing.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix #672 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This is an edge case that I was not able to replicate in a test.