### PR TITLE
fix race condition in grpc plugin causing it to be disabled

### DIFF
--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -6,13 +6,14 @@ const { ERROR } = require('../../../ext/tags')
 const kinds = require('./kinds')
 const { addMethodTags, addMetadataTags, getFilter } = require('./util')
 
-function createWrapMakeClientConstructor (tracer, config, grpc) {
+function createWrapMakeClientConstructor (tracer, config, client) {
   config = config.client || config
 
   return function wrapMakeClientConstructor (makeClientConstructor) {
     return function makeClientConstructorWithTrace (methods) {
       const ServiceClient = makeClientConstructor.apply(this, arguments)
       const proto = ServiceClient.prototype
+      const grpc = client.Client._datadog.grpc
 
       Object.keys(methods)
         .forEach(name => {
@@ -187,9 +188,7 @@ module.exports = [
     patch (client, tracer, config) {
       if (config.client === false) return
 
-      const grpc = client.Client._datadog.grpc
-
-      this.wrap(client, 'makeClientConstructor', createWrapMakeClientConstructor(tracer, config, grpc))
+      this.wrap(client, 'makeClientConstructor', createWrapMakeClientConstructor(tracer, config, client))
     },
     unpatch (client) {
       this.unwrap(client, 'makeClientConstructor')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix race condition in `grpc` plugin causing it to be disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->

Depending on how the `grpc` module is loaded, it's possible for a race condition to occur where the instrumentation for `server.js` runs before the main export resulting in a required variable not being set yet. This causes an error which in turn causes the plugin disables itself.