### PR TITLE
Automatically detect AWS lambda environment

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -4,7 +4,6 @@ const URL = require('url-parse')
 const platform = require('./platform')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
-const exporters = require('../../../ext/exporters')
 
 class Config {
   constructor (service, options) {
@@ -37,12 +36,6 @@ class Config {
     const apiKey = coalesce(options.apiKey, platform.env('DD_API_KEY'))
     const appKey = coalesce(options.appKey, platform.env('DD_APP_KEY'))
 
-    const lambdaFunctionName = platform.env('AWS_LAMBDA_FUNCTION_NAME')
-    let lambdaExporter
-    if (lambdaFunctionName !== undefined) {
-      lambdaExporter = exporters.LOG
-    }
-
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.logInjection = String(logInjection) === 'true'
@@ -53,7 +46,7 @@ class Config {
     this.sampleRate = sampleRate
     this.logger = options.logger
     this.plugins = !!plugins
-    this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), lambdaFunctionName, service, 'node')
+    this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
     this.analytics = String(analytics) === 'true'
     this.tags = Object.assign({}, options.tags)
     this.dogstatsd = {
@@ -63,7 +56,7 @@ class Config {
     this.trackAsyncScope = options.trackAsyncScope !== false
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
-      exporter: coalesce(options.experimental && options.experimental.exporter, lambdaExporter),
+      exporter: options.experimental && options.experimental.exporter,
       peers: (options.experimental && options.experimental.peers) || []
     }
     this.reportHostname = String(reportHostname) === 'true'

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -4,6 +4,7 @@ const URL = require('url-parse')
 const platform = require('./platform')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
+const exporters = require('../../../ext/exporters')
 
 class Config {
   constructor (service, options) {
@@ -36,6 +37,12 @@ class Config {
     const apiKey = coalesce(options.apiKey, platform.env('DD_API_KEY'))
     const appKey = coalesce(options.appKey, platform.env('DD_APP_KEY'))
 
+    const lambdaFunctionName = platform.env('AWS_LAMBDA_FUNCTION_NAME')
+    let lambdaExporter
+    if (lambdaFunctionName !== undefined) {
+      lambdaExporter = exporters.LOG
+    }
+
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.logInjection = String(logInjection) === 'true'
@@ -46,7 +53,7 @@ class Config {
     this.sampleRate = sampleRate
     this.logger = options.logger
     this.plugins = !!plugins
-    this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
+    this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), lambdaFunctionName, service, 'node')
     this.analytics = String(analytics) === 'true'
     this.tags = Object.assign({}, options.tags)
     this.dogstatsd = {
@@ -56,7 +63,7 @@ class Config {
     this.trackAsyncScope = options.trackAsyncScope !== false
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
-      exporter: options.experimental && options.experimental.exporter,
+      exporter: coalesce(options.experimental && options.experimental.exporter, lambdaExporter),
       peers: (options.experimental && options.experimental.peers) || []
     }
     this.reportHostname = String(reportHostname) === 'true'

--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -13,9 +13,13 @@ const plugins = require('../../plugins')
 const hostname = require('./hostname')
 const Loader = require('./loader')
 const Scope = require('../../scope/async_hooks')
-const Exporter = require('../../exporters/agent')
+const AgentExporter = require('../../exporters/agent')
+const LogExporter = require('../../exporters/log')
 
 const emitter = new EventEmitter()
+
+const inAWSLambda = env('AWS_LAMBDA_FUNCTION_NAME') !== undefined
+const Exporter = inAWSLambda ? LogExporter : AgentExporter
 
 const platform = {
   _config: {},

--- a/packages/dd-trace/src/platform/node/service.js
+++ b/packages/dd-trace/src/platform/node/service.js
@@ -5,6 +5,11 @@ const readPkgUp = require('read-pkg-up')
 const parentModule = require('parent-module')
 
 function service () {
+  const lambdaFunction = process.env['AWS_LAMBDA_FUNCTION_NAME']
+  if (lambdaFunction) {
+    return lambdaFunction
+  }
+
   const callerPath = parentModule()
   const parentPath = parentModule(callerPath)
   const cwd = path.dirname(parentPath || callerPath)


### PR DESCRIPTION
### What does this PR do?
Autodetects the AWS lambda environment, and modifies the default configuration to use the log exporter and the correct service name.

### Motivation
Reducing boilerplate customer's have to write when using the tracer in lambda.
