### PR TITLE
disable codecov in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,9 @@ node-core-base: &node-core-base
         command: yarn test:core
     - store_artifacts:
         path: ./coverage/lcov-report
-    - run:
-        name: Code coverage
-        command: yarn codecov
+    # - run:
+    #     name: Code coverage
+    #     command: yarn codecov
     - run:
         name: Benchmark
         command: yarn bench
@@ -73,9 +73,9 @@ node-plugin-base: &node-plugin-base
         command: yarn test:plugins
     - store_artifacts:
         path: ./coverage/lcov-report
-    - run:
-        name: Code coverage
-        command: yarn codecov
+    # - run:
+    #     name: Code coverage
+    #     command: yarn codecov
     - run:
         name: Memory leak tests
         command: yarn leak:plugins


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable Codecov in CircleCI.

### Motivation
<!-- What inspired you to submit this pull request? -->

There seems to be an issue with Codecov since it usually takes over 2 minutes to upload the report which should be a matter of seconds. I have contacted support, but in the meantime let's disable it.