### PR TITLE
update plugins build to require dependencies

### DIFF
--- a/packages/datadog-plugin-connect/src/index.js
+++ b/packages/datadog-plugin-connect/src/index.js
@@ -109,7 +109,7 @@ module.exports = [
   },
   {
     name: 'connect',
-    versions: ['2'],
+    versions: ['2.2.2'],
     patch (connect, tracer, config) {
       this.wrap(connect.proto, 'use', createWrapUse())
       this.wrap(connect.proto, 'handle', createWrapHandle(tracer, config))

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -83,7 +83,7 @@ function assertPackage (name, version, dependency, external) {
     version: '1.0.0',
     license: 'BSD-3-Clause',
     private: true,
-    optionalDependencies: {
+    dependencies: {
       [name]: dependency
     }
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update plugins build to require dependencies. `connect` was also updated since the minimum version we were supporting does not support Node >=0.7 and thus cannot be installed.

### Motivation
<!-- What inspired you to submit this pull request? -->

Since the dependencies for plugin tests were optional, when a dependency would fail to install, the test for that version would simply be skipped. While it could be argued that this behavior is correct in some cases, it causes the tests to require parent modules when available, resulting in the incorrect version being used.
