### PR TITLE
Fix failure to return function reference

### DIFF
--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -71,7 +71,7 @@ class DatadogTracer extends Tracer {
             return cb.apply(this, arguments)
           }
 
-          fn.apply(this, arguments)
+          return fn.apply(this, arguments)
         })
       } else {
         return tracer.trace(name, options, () => fn.apply(this, arguments))

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -270,5 +270,15 @@ describe('Tracer', () => {
 
       fn(() => {})
     })
+
+    it('should handle rejected promises', done => {
+      const fn = tracer.wrap('name', {}, (cb) => cb())
+      const catchHandler = sinon.spy(({ message }) => expect(message).to.equal('boom'))
+
+      fn(() => Promise.reject(new Error('boom')))
+        .catch(catchHandler)
+        .then(() => expect(catchHandler).to.have.been.called)
+        .then(() => done())
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Resolves a bug

### Motivation

When wrapping my middleware chain with `tracer.wrap` I found that errors `throw`n in downstream middleware were not caught by the upstream error handler. When disabling `tracer.wrap`, the error handler caught the rejected promise as expected.

### Changes

Changed the code to return the reference to `fn.apply` so the return value (e.g. a promise) is not lost.