### PR TITLE
fix immediate flushes caused by interval config being ignored

### DIFF
--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -4,11 +4,11 @@ const Writer = require('./writer')
 const Scheduler = require('./scheduler')
 
 class AgentExporter {
-  constructor ({ url, interval }) {
+  constructor ({ url, flushInterval }) {
     this._writer = new Writer(url)
 
-    if (interval > 0) {
-      this._scheduler = new Scheduler(() => this._writer.flush(), interval)
+    if (flushInterval > 0) {
+      this._scheduler = new Scheduler(() => this._writer.flush(), flushInterval)
     }
     this._scheduler && this._scheduler.start()
   }

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -2,7 +2,7 @@
 
 describe('Exporter', () => {
   let url
-  let interval
+  let flushInterval
   let Scheduler
   let scheduler
   let Exporter
@@ -13,7 +13,7 @@ describe('Exporter', () => {
 
   beforeEach(() => {
     url = 'www.example.com'
-    interval = 1000
+    flushInterval = 1000
     span = {}
     scheduler = {
       start: sinon.spy(),
@@ -34,12 +34,12 @@ describe('Exporter', () => {
 
   describe('when interval is set to a positive number', () => {
     beforeEach(() => {
-      exporter = new Exporter({ url, interval })
+      exporter = new Exporter({ url, flushInterval })
     })
 
     it('should schedule flushing after the configured interval', () => {
       writer.length = 0
-      exporter = new Exporter({ url, interval })
+      exporter = new Exporter({ url, flushInterval })
       Scheduler.firstCall.args[0]()
 
       expect(scheduler.start).to.have.been.called
@@ -62,7 +62,7 @@ describe('Exporter', () => {
 
   describe('when interval is set to 0', () => {
     beforeEach(() => {
-      exporter = new Exporter({ url, interval: 0 })
+      exporter = new Exporter({ url, flushInterval: 0 })
     })
 
     it('should flush right away when interval is set to 0', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix immediate flushes caused by interval config being ignored.

### Motivation
<!-- What inspired you to submit this pull request? -->

The flush interval config is currently ignored, including the default configuration. Flushing too often can have a negative performance impact.