### PR TITLE
fix support for mongodb after mongodb-core merge

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -76,7 +76,7 @@ function addHost (span, topology) {
 
 function wrapCallback (tracer, span, done, cursor) {
   return tracer.scope().bind((err, res) => {
-    if (err instanceof Error) {
+    if (err) {
       span.addTags({
         'error.type': err.name,
         'error.msg': err.message,

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -76,7 +76,7 @@ function addHost (span, topology) {
 
 function wrapCallback (tracer, span, done, cursor) {
   return tracer.scope().bind((err, res) => {
-    if (err) {
+    if (err instanceof Error) {
       span.addTags({
         'error.type': err.name,
         'error.msg': err.message,
@@ -136,23 +136,40 @@ function isBSON (val) {
   return val && val._bsontype
 }
 
+function patch (core, tracer, config) {
+  this.wrap(core.Server.prototype, 'command', createWrapOperation(tracer, config))
+  this.wrap(core.Server.prototype, 'insert', createWrapOperation(tracer, config, 'insert'))
+  this.wrap(core.Server.prototype, 'update', createWrapOperation(tracer, config, 'update'))
+  this.wrap(core.Server.prototype, 'remove', createWrapOperation(tracer, config, 'remove'))
+
+  if (core.Cursor.prototype.next) {
+    this.wrap(core.Cursor.prototype, 'next', createWrapNext(tracer, config))
+  } else if (core.Cursor.prototype._next) {
+    this.wrap(core.Cursor.prototype, '_next', createWrapNext(tracer, config))
+  }
+}
+
+function unpatch (core) {
+  this.unwrap(core.Server.prototype, 'command')
+  this.unwrap(core.Server.prototype, 'insert')
+  this.unwrap(core.Server.prototype, 'update')
+  this.unwrap(core.Server.prototype, 'remove')
+  this.unwrap(core.Cursor.prototype, 'next')
+  this.unwrap(core.Cursor.prototype, '_next')
+}
+
 module.exports = [
+  {
+    name: 'mongodb',
+    versions: ['>=3.3'],
+    file: 'lib/core/index.js',
+    patch,
+    unpatch
+  },
   {
     name: 'mongodb-core',
     versions: ['>=2'],
-    patch (mongo, tracer, config) {
-      this.wrap(mongo.Server.prototype, 'command', createWrapOperation(tracer, config))
-      this.wrap(mongo.Server.prototype, 'insert', createWrapOperation(tracer, config, 'insert'))
-      this.wrap(mongo.Server.prototype, 'update', createWrapOperation(tracer, config, 'update'))
-      this.wrap(mongo.Server.prototype, 'remove', createWrapOperation(tracer, config, 'remove'))
-      this.wrap(mongo.Cursor.prototype, 'next', createWrapNext(tracer, config))
-    },
-    unpatch (mongo) {
-      this.unwrap(mongo.Server.prototype, 'command')
-      this.unwrap(mongo.Server.prototype, 'insert')
-      this.unwrap(mongo.Server.prototype, 'update')
-      this.unwrap(mongo.Server.prototype, 'remove')
-      this.unwrap(mongo.Cursor.prototype, 'next')
-    }
+    patch,
+    unpatch
   }
 ]

--- a/packages/datadog-plugin-mongodb-core/test/index.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/index.spec.js
@@ -6,14 +6,25 @@ const plugin = require('../src')
 wrapIt()
 
 describe('Plugin', () => {
-  let mongo
   let server
   let id
   let tracer
   let collection
 
   describe('mongodb-core', () => {
-    withVersions(plugin, 'mongodb-core', version => {
+    withVersions(plugin, ['mongodb', 'mongodb-core'], (version, moduleName) => {
+      const getServer = () => {
+        return moduleName === 'mongodb'
+          ? require(`../../../versions/${moduleName}@${version}`).get().CoreServer
+          : require(`../../../versions/${moduleName}@${version}`).get().Server
+      }
+
+      const next = (cursor, cb) => {
+        return cursor._next
+          ? cursor._next(cb)
+          : cursor.next(cb)
+      }
+
       beforeEach(() => {
         id = require('../../dd-trace/src/id')
         tracer = require('../../dd-trace')
@@ -35,9 +46,9 @@ describe('Plugin', () => {
         })
 
         beforeEach(done => {
-          mongo = require(`../../../versions/mongodb-core@${version}`).get()
+          const Server = getServer()
 
-          server = new mongo.Server({
+          server = new Server({
             host: 'localhost',
             port: 27017,
             reconnect: false
@@ -227,7 +238,7 @@ describe('Plugin', () => {
               documents: [{ a: 1 }]
             }, {})
 
-            cursor.next()
+            next(cursor)
           })
 
           it('should have the correct index', done => {
@@ -239,14 +250,14 @@ describe('Plugin', () => {
                 query: {}
               }, { batchSize: 1 })
 
-              cursor.next()
+              next(cursor)
             })
 
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('mongodb.cursor.index', '0')
               })
-              .then(() => cursor.next())
+              .then(() => next(cursor))
               .catch(done)
 
             agent
@@ -280,7 +291,7 @@ describe('Plugin', () => {
               }
             })
 
-            cursor.next()
+            next(cursor)
           })
 
           it('should run the callback in the parent context', done => {
@@ -291,7 +302,7 @@ describe('Plugin', () => {
               query: { a: 1 }
             })
 
-            cursor.next(() => {
+            next(cursor, () => {
               expect(tracer.scope().active()).to.be.null
               done()
             })
@@ -314,7 +325,7 @@ describe('Plugin', () => {
               query: 'invalid'
             })
 
-            cursor.next(err => {
+            next(cursor, err => {
               error = err
             })
           })
@@ -331,9 +342,9 @@ describe('Plugin', () => {
         })
 
         beforeEach(done => {
-          mongo = require(`../../../versions/mongodb-core@${version}`).get()
+          const Server = getServer()
 
-          server = new mongo.Server({
+          server = new Server({
             host: 'localhost',
             port: 27017,
             reconnect: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix support for `mongodb` after `mongodb-core` merge.

### Motivation
<!-- What inspired you to submit this pull request? -->

Since `mongodb` 3.3, `mongodb-core` has been merged with `mongodb`, effectively changing the instrumented library name and the location of the internal modules.

Fixes #697