### PR TITLE
update xhr and fetch plugins to activate their span on the scope

### DIFF
--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -22,7 +22,7 @@ function createWrapFetch (tracer, config) {
 
       init = inject(init, tracer, span, url.origin)
 
-      const promise = fetch.call(this, resource, init)
+      const promise = tracer.scope().bind(fetch, span).call(this, resource, init)
 
       promise.then(res => {
         span.setTag('http.status_code', res.status)

--- a/packages/datadog-plugin-xmlhttprequest/src/index.js
+++ b/packages/datadog-plugin-xmlhttprequest/src/index.js
@@ -35,7 +35,7 @@ function createWrapSend (tracer, config) {
         span.finish()
       })
 
-      return send.apply(this, arguments)
+      return tracer.scope().bind(send, span).apply(this, arguments)
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update `xmlhttprequest` and `fetch` plugins to activate their span on the scope.

### Motivation
<!-- What inspired you to submit this pull request? -->

Needed for any internal instrumentation to be in the correct scope.