### PR TITLE
fix missing stack trace when logging non-errors as errors

### DIFF
--- a/packages/dd-trace/src/log.js
+++ b/packages/dd-trace/src/log.js
@@ -51,7 +51,17 @@ const log = {
         err = err()
       }
 
-      _logger.error(typeof err === 'string' ? new Error(err) : err)
+      if (typeof err !== 'object' || !err) {
+        err = String(err)
+      } else if (!err.stack) {
+        err = String(err.message || err)
+      }
+
+      if (typeof err === 'string') {
+        err = new Error(err)
+      }
+
+      _logger.error(err)
     }
 
     return this

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -74,6 +74,30 @@ describe('log', () => {
       expect(console.error.firstCall.args[0]).to.have.property('message', 'error')
     })
 
+    it('should convert empty values to errors', () => {
+      log.error()
+
+      expect(console.error).to.have.been.called
+      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+      expect(console.error.firstCall.args[0]).to.have.property('message', 'undefined')
+    })
+
+    it('should convert invalid types to errors', () => {
+      log.error(123)
+
+      expect(console.error).to.have.been.called
+      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+      expect(console.error.firstCall.args[0]).to.have.property('message', '123')
+    })
+
+    it('should reuse error messages for non-errors', () => {
+      log.error({ message: 'test' })
+
+      expect(console.error).to.have.been.called
+      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+      expect(console.error.firstCall.args[0]).to.have.property('message', 'test')
+    })
+
     it('should convert messages from callbacks to errors', () => {
       log.error(() => 'error')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing stack trace when logging non-errors as errors.

### Motivation
<!-- What inspired you to submit this pull request? -->

When `log.error()` is called with an invalid type such as `null`, the error ends up being logged without a stack trace nor a message which provides no information whatsoever to find the source of the error. By creating an error object from these, we can at least know where the error comes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Related to #706 