### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -219,6 +219,12 @@ export declare interface TracerOptions {
   sampleRate?: number;
 
   /**
+   * Interval in milliseconds at which the tracer will submit traces to the agent.
+   * @default 2000
+   */
+  flushInterval?: number;
+
+  /**
    * Whether to enable runtime metrics.
    * @default false
    */


### PR DESCRIPTION
### What does this PR do?
Updates a typescript type for tracer options. One parameter was missing.

### Motivation
I use datadog at work and I have to bypass TracerOptions with an `any`.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] TypeScript [definitions][1].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts

### Additional Notes
None
