### PR TITLE
[WIP DO NOT MERGE] console.log trace context injection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,13 @@ jobs:
         environment:
           - PLUGINS=connect
 
+  node-console:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - PLUGINS=console
+
   node-couchbase:
     <<: *node-plugin-base
     docker:

--- a/packages/datadog-plugin-console/src/index.js
+++ b/packages/datadog-plugin-console/src/index.js
@@ -6,11 +6,15 @@ function createWrapLog (tracer) {
   return function wrapEmit (emit) {
     return function emitWithTrace () {
       const data = tx.correlate(tracer, {})
-      const prefix = `[dd.trace_id=${data.trace_id} dd.span_id=${data.span_id}]`
+      let prefix = ''
+      if (data.dd !== undefined) {
+        prefix = `[dd.trace_id=${data.dd.trace_id} dd.span_id=${data.dd.span_id}]`
+      }
       if (arguments.length > 0) {
         arguments[0] = `${prefix} ${arguments[0]}`
       } else {
         arguments[0] = prefix
+        arguments.length = 1
       }
       return emit.apply(this, arguments)
     }
@@ -20,7 +24,7 @@ function createWrapLog (tracer) {
 module.exports = {
   name: 'console',
   global: true,
-  patch (cnsole, tracer, config) {
+  patch (cnsole, tracer, _) {
     if (!tracer._logInjection) return
     this.wrap(cnsole, 'log', createWrapLog(tracer))
     this.wrap(cnsole, 'error', createWrapLog(tracer))

--- a/packages/datadog-plugin-console/src/index.js
+++ b/packages/datadog-plugin-console/src/index.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const tx = require('../../dd-trace/src/plugins/util/log')
+
+function createWrapLog (tracer) {
+  return function wrapEmit (emit) {
+    return function emitWithTrace () {
+      const data = tx.correlate(tracer, {})
+      const prefix = `[dd.trace_id=${data.trace_id} dd.span_id=${data.span_id}]`
+      if (arguments.length > 0) {
+        arguments[0] = `${prefix} ${arguments[0]}`
+      } else {
+        arguments[0] = prefix
+      }
+      return emit.apply(this, arguments)
+    }
+  }
+}
+
+module.exports = {
+  name: 'console',
+  global: true,
+  patch (cnsole, tracer, config) {
+    if (!tracer._logInjection) return
+    this.wrap(cnsole, 'log', createWrapLog(tracer))
+    this.wrap(cnsole, 'error', createWrapLog(tracer))
+    this.wrap(cnsole, 'debug', createWrapLog(tracer))
+    this.wrap(cnsole, 'info', createWrapLog(tracer))
+  },
+  unpatch (cnsole) {
+    this.unwrap(cnsole, 'log')
+    this.unwrap(cnsole, 'error')
+    this.unwrap(cnsole, 'debug')
+    this.unwrap(cnsole, 'info')
+  }
+}

--- a/packages/datadog-plugin-console/test/index.spec.js
+++ b/packages/datadog-plugin-console/test/index.spec.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const plugin = require('../src')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let localConsole
+  let tracer
+  let span
+
+  function setup (version) {
+    span = tracer.startSpan('test')
+
+    localConsole = { ...console }
+    sinon.spy(localConsole, 'log')
+  }
+
+  describe('console', () => {
+    beforeEach(() => {
+      tracer = require('../../dd-trace')
+      return agent.load(plugin, 'console')
+    })
+
+    afterEach(() => {
+      return agent.close()
+    })
+
+    withVersions(plugin, 'console', version => {
+      describe('without configuration', () => {
+        beforeEach(() => {
+          setup(version)
+        })
+
+        it('should not alter the default behavior', () => {
+          tracer.scope().activate(span, () => {
+            localConsole.log('message')
+            expect(localConsole.log.firstCall.args[0]).toEqual('message')
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        beforeEach(() => {
+          tracer._tracer._logInjection = true
+          setup(version)
+        })
+        it('should add the trace identifiers to logger instances', () => {
+          tracer.scope().activate(span, () => {
+            localConsole.log('message')
+
+            expect(localConsole.log).to.have.been.called
+
+            const record = localConsole.load.firstCall.args[0].toString()
+            const traceId = span.context().toTraceId()
+            const spanId = span.context().toSpanId()
+            expect(record).toEqual(`[trace_id:${traceId}, span_id:${spanId}] message`)
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/src/platform/node/loader.js
+++ b/packages/dd-trace/src/platform/node/loader.js
@@ -17,11 +17,11 @@ class Loader {
   reload (plugins) {
     this._plugins = new Map()
     this._globalPlugins = new Map()
-    plugins.forEach((instrumentation, plugin) => {
-      if (instrumentation.global) {
-        this._globalPlugins.set(instrumentation, plugin)
+    plugins.forEach((meta, plugin) => {
+      if (plugin.global) {
+        this._globalPlugins.set(plugin, meta)
       } else {
-        this._plugins.set(instrumentation, plugin)
+        this._plugins.set(plugin, meta)
       }
     })
 

--- a/packages/dd-trace/src/platform/node/loader.js
+++ b/packages/dd-trace/src/platform/node/loader.js
@@ -17,7 +17,7 @@ class Loader {
   reload (plugins) {
     this._plugins = new Map()
     this._globalPlugins = new Map()
-    Array.from(plugins.entries).forEach(([instrumentation, plugin]) => {
+    plugins.forEach((instrumentation, plugin) => {
       if (instrumentation.global) {
         this._globalPlugins.set(instrumentation, plugin)
       } else {

--- a/packages/dd-trace/src/platform/node/loader.js
+++ b/packages/dd-trace/src/platform/node/loader.js
@@ -21,7 +21,7 @@ class Loader {
       if (instrumentation.global) {
         this._globalPlugins.set(instrumentation, plugin)
       } else {
-        this.plugins.set(instrumentation, plugin)
+        this._plugins.set(instrumentation, plugin)
       }
     })
 

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -7,6 +7,7 @@ module.exports = {
   'bunyan': require('../../../datadog-plugin-bunyan/src'),
   'cassandra-driver': require('../../../datadog-plugin-cassandra-driver/src'),
   'connect': require('../../../datadog-plugin-connect/src'),
+  'console': require('../../../datadog-plugin-console/src'),
   'couchbase': require('../../../datadog-plugin-couchbase/src'),
   'dns': require('../../../datadog-plugin-dns/src'),
   'elasticsearch': require('../../../datadog-plugin-elasticsearch/src'),

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -16,7 +16,7 @@ let tracer = null
 
 module.exports = {
   // Load the plugin on the tracer with an optional config and start a mock agent.
-  load (plugin, pluginName, config) {
+  load (plugin, pluginName, config, tracerConfig = {}) {
     tracer = require('../..')
     agent = express()
     agent.use(bodyParser.raw({ type: 'application/msgpack' }))
@@ -46,6 +46,7 @@ module.exports = {
         })
 
         tracer.init({
+          ...tracerConfig,
           service: 'test',
           port,
           flushInterval: 0,


### PR DESCRIPTION
### What does this PR do?
Extends the logInjection option to also add trace context to console.log lines.

From this
```
message
```
to this
```
[dd.trace_id=XXX dd.span_id=XXX] message
```
TODO Lock down to just be enabled in lambda environment

### Motivation
Makes it possible to correlate 

### Plugin Checklist
- [X] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [X] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
