### PR TITLE
fixed agent-writer-error-message-bug

### DIFF
--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -77,7 +77,7 @@ class Writer {
       try {
         this._prioritySampler.update(JSON.parse(res).rate_by_service)
       } catch (e) {
-        log.error(err)
+        log.error(e)
       }
     })
   }


### PR DESCRIPTION
### What does this PR do?
the bug in writer exposes **null** error-message like here:
```
Request to the agent: {"path":"/v0.4/traces","method":"PUT","headers":{"Content-Type":"application/msgpack","Datadog-Meta-Lang":"nodejs","Datadog-Meta-Lang-Version":"v10.16.3","Datadog-Meta-Lang-Interpreter":"v8","Datadog-Meta-Tracer-Version":"0.15.4","X-Datadog-Trace-Count":"1"},"protocol":"http:","hostname":"192.168.88.19","port":"8126"}
Inject into carrier: {"x-datadog-trace-id":"<someid>","x-datadog-parent-id":"<someid>","x-datadog-sampling-priority":"-1"}.
Response from the agent: {"rate_by_service":{"service:,env:":1,"service:auth-graphql,env:":1,"service:auth-graphql,env:none":1,"service:auth-http-client,env:":1,"service:auth-http-client,env:none":1}}

Error: null
    at Object.error (/project/node_modules/dd-trace/packages/dd-trace/src/log.js:61:15)
    at platform.request (/project/node_modules/dd-trace/packages/dd-trace/src/exporters/agent/writer.js:79:13)
    at IncomingMessage.res.on (/project/node_modules/dd-trace/packages/dd-trace/src/platform/node/request.js:33:9)
    at scope.activate (/project/node_modules/dd-trace/packages/dd-trace/src/scope/base.js:66:19)
    at Scope._activate (/project/node_modules/dd-trace/packages/dd-trace/src/scope/base.js:40:14)
    at Scope.activate (/project/node_modules/dd-trace/packages/dd-trace/src/scope/base.js:11:17)
    at IncomingMessage.bound (/project/node_modules/dd-trace/packages/dd-trace/src/scope/base.js:65:20)
    at IncomingMessage.emit (events.js:203:15)
    at IncomingMessage.EventEmitter.emit (domain.js:448:20)
    at endReadableNT (_stream_readable.js:1145:12)
```
