### PR TITLE
Add experimental support for decoupling tracer error and debug logs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -241,6 +241,11 @@ export declare interface TracerOptions {
      * @default false
      */
     exporter?: 'log' | 'browser' | 'agent'
+    /**
+     * Whether to log only errors and not also debug messages when debug logging enabled
+     * @default false
+     */
+    onlyErrors?: boolean    
   };
 
   /**

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -57,7 +57,8 @@ class Config {
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: options.experimental && options.experimental.exporter,
-      peers: (options.experimental && options.experimental.peers) || []
+      peers: (options.experimental && options.experimental.peers) || [],
+      onlyErrors: !(!options.experimental || !options.experimental.onlyErrors)
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope

--- a/packages/dd-trace/src/log.js
+++ b/packages/dd-trace/src/log.js
@@ -10,6 +10,7 @@ const _default = {
 let _logger
 let _enabled
 let _deprecate
+let _onlyErrors
 
 const log = {
   use (logger) {
@@ -20,8 +21,9 @@ const log = {
     return this
   },
 
-  toggle (enabled) {
+  toggle (enabled, onlyErrors) {
     _enabled = enabled
+    _onlyErrors = onlyErrors
 
     return this
   },
@@ -38,7 +40,7 @@ const log = {
   },
 
   debug (message) {
-    if (_enabled) {
+    if (_enabled && !_onlyErrors) {
       _logger.debug(message instanceof Function ? message() : message)
     }
 

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -32,7 +32,7 @@ class DatadogTracer extends Tracer {
     super()
 
     log.use(config.logger)
-    log.toggle(config.debug)
+    log.toggle(config.debug, config.experimental.onlyErrors)
 
     this._service = config.service
     this._url = config.url

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -36,6 +36,7 @@ describe('Config', () => {
     expect(config).to.have.property('apiKey', undefined)
     expect(config).to.have.property('appKey', undefined)
     expect(config).to.have.nested.property('experimental.b3', false)
+    expect(config).to.have.nested.property('experimental.onlyErrors', false)
   })
 
   it('should initialize from the default service', () => {
@@ -123,7 +124,8 @@ describe('Config', () => {
       apiKey: '123',
       appKey: '456',
       experimental: {
-        b3: true
+        b3: true,
+        onlyErrors: true
       }
     })
 
@@ -151,6 +153,7 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
+    expect(config).to.have.nested.property('experimental.onlyErrors', true)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -126,6 +126,33 @@ describe('log', () => {
       expect(console.log).to.have.been.calledWith('debug')
       expect(console.error).to.have.been.calledWith(error)
     })
+
+    it('should enable only error logs when enabled with onlyErrors argument set to true', () => {
+      log.toggle(true, true)
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.not.have.been.called
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should enable error and debug logs when enabled with onlyErrors argument set to false', () => {
+      log.toggle(true, false)
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should enable error and debug logs when enabled without onlyErrors argument', () => {
+      log.toggle(true)
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith(error)
+    })
   })
 
   describe('use', () => {


### PR DESCRIPTION
### What does this PR do?
This PR addresses the use case introduced in [Issue 599](https://github.com/DataDog/dd-trace-js/issues/559) for when a user wants to forward tracer errors to their logger but ignore debug messages. Currently the logger requires `debug` and `error` keys for the `logger` object and will always compute the debug message even if a custom logger is passed with `debug` set to a `noop` function. This PR adds experimental support for an `onlyErrors` configuration option which disables the debug message computation and output, if both the tracer's logger is enabled and `experimental.onlyErrors` is set to `true`

### Motivation
It has been hanging around in the Open Issues for awhile and it bothered me that the logging wasn't as flexible as it ought to be. I wanted to avoid changing the format of user's existing custom loggers, so adding this via the `experimental` options felt like a low friction way to help resolve the issue for users going forward while maintaining backward compatibility for existing implementations.

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
Thanks for taking a look! Let me know what y'all think or if it's worth the hassle of adding, happy to address any feedback. Not terribly familiar with Typescript and a bit rusty with Node in general, so apologies if I've missed something here. That being said, seems to help a few users out there who want to reduce the noise in their logs while still forwarding relevant tracer errors, and seemed like low hanging fruit, so figured I'd give it a shot.
