### PR TITLE
fix missing configuration options in typescript definitions

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -38,10 +38,13 @@ tracer.init({
   logInjection: true,
   analytics: true,
   env: 'test',
+  url: 'http://localhost',
   runtimeMetrics: true,
   trackAsyncScope: false,
   experimental: {
-    b3: true
+    b3: true,
+    exporter: 'log',
+    peers: ['foo']
   },
   hostname: 'agent',
   logger: {
@@ -53,11 +56,13 @@ tracer.init({
   dogstatsd: {
     port: 8888
   },
+  flushInterval: 1000,
   sampleRate: 0.1,
   service: 'test',
   tags: {
     foo: 'bar'
   },
+  reportHostname: true,
   scope: 'noop'
 });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -219,6 +219,12 @@ export declare interface TracerOptions {
   sampleRate?: number;
 
   /**
+   * Interval in milliseconds at which the tracer will submit traces to the agent.
+   * @default 2000
+   */
+  flushInterval?: number;
+
+  /**
    * Whether to enable runtime metrics.
    * @default false
    */
@@ -236,11 +242,18 @@ export declare interface TracerOptions {
    */
   experimental?: boolean | {
     b3?: boolean
+
     /**
      * Whether to write traces to log output, rather than send to an agent
      * @default false
      */
     exporter?: 'log' | 'browser' | 'agent'
+
+    /**
+     * List of peer service URLs that will be called by this service. This is used to determine whether to send the distributed context from the browser.
+     * @default []
+     */
+    peers?: string[]
   };
 
   /**
@@ -270,6 +283,12 @@ export declare interface TracerOptions {
    * doing.
    */
   scope?: 'async_hooks' | 'noop'
+
+  /**
+   * Whether to report the hostname of the service host. This is used when the agent is deployed on a different host and cannot determine the hostname automatically.
+   * @default false
+   */
+  reportHostname?: boolean
 }
 
 /** @hidden */


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing configuration options in TypeScript definitions.

### Motivation
<!-- What inspired you to submit this pull request? -->

Users are otherwise required to use type `any`.

Fixes #714 