### PR TITLE
fix priority sampling not updating the rates from the agent

### DIFF
--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -4,8 +4,8 @@ const Writer = require('./writer')
 const Scheduler = require('./scheduler')
 
 class AgentExporter {
-  constructor ({ url, flushInterval }) {
-    this._writer = new Writer(url)
+  constructor ({ url, flushInterval }, prioritySampler) {
+    this._writer = new Writer(url, prioritySampler)
 
     if (flushInterval > 0) {
       this._scheduler = new Scheduler(() => this._writer.flush(), flushInterval)

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -8,9 +8,10 @@ const tracerVersion = require('../../../lib/version')
 const MAX_SIZE = 8 * 1024 * 1024 // 8MB
 
 class Writer {
-  constructor (url) {
+  constructor (url, prioritySampler) {
     this._queue = []
     this._url = url
+    this._prioritySampler = prioritySampler
     this._size = 0
   }
 

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -41,7 +41,7 @@ class DatadogTracer extends Tracer {
     this._logInjection = config.logInjection
     this._analytics = config.analytics
     this._prioritySampler = new PrioritySampler(config.env)
-    this._exporter = getExporter(config)
+    this._exporter = getExporter(config, this._prioritySampler)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)
     this._sampler = new Sampler(config.sampleRate)
     this._peers = config.experimental.peers
@@ -149,16 +149,16 @@ function getParent (references) {
   return parent
 }
 
-function getExporter (config) {
+function getExporter (config, prioritySampler) {
   switch (config.experimental.exporter) {
     case exporters.LOG:
-      return new LogExporter(config)
+      return new LogExporter(config, prioritySampler)
     case exporters.BROWSER:
-      return new BrowserExporter(config)
+      return new BrowserExporter(config, prioritySampler)
     case exporters.AGENT:
-      return new AgentExporter(config)
+      return new AgentExporter(config, prioritySampler)
     default:
-      return new platform.Exporter(config)
+      return new platform.Exporter(config, prioritySampler)
   }
 }
 

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -9,6 +9,7 @@ describe('Exporter', () => {
   let exporter
   let Writer
   let writer
+  let prioritySampler
   let span
 
   beforeEach(() => {
@@ -23,6 +24,7 @@ describe('Exporter', () => {
       append: sinon.spy(),
       flush: sinon.spy()
     }
+    prioritySampler = {}
     Scheduler = sinon.stub().returns(scheduler)
     Writer = sinon.stub().returns(writer)
 
@@ -34,12 +36,12 @@ describe('Exporter', () => {
 
   describe('when interval is set to a positive number', () => {
     beforeEach(() => {
-      exporter = new Exporter({ url, flushInterval })
+      exporter = new Exporter({ url, flushInterval }, prioritySampler)
     })
 
     it('should schedule flushing after the configured interval', () => {
       writer.length = 0
-      exporter = new Exporter({ url, flushInterval })
+      exporter = new Exporter({ url, flushInterval }, prioritySampler)
       Scheduler.firstCall.args[0]()
 
       expect(scheduler.start).to.have.been.called

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -12,6 +12,7 @@ describe('Writer', () => {
   let format
   let encode
   let url
+  let prioritySampler
   let log
   let tracer
   let scope
@@ -65,6 +66,10 @@ describe('Writer', () => {
       port: 8126
     }
 
+    prioritySampler = {
+      update: sinon.spy()
+    }
+
     log = {
       error: sinon.spy()
     }
@@ -76,7 +81,7 @@ describe('Writer', () => {
       '../../encode': encode,
       '../../../lib/version': 'tracerVersion'
     })
-    writer = new Writer(url)
+    writer = new Writer(url, prioritySampler)
   })
 
   describe('length', () => {
@@ -158,6 +163,15 @@ describe('Writer', () => {
       setTimeout(() => {
         expect(log.error).to.have.been.calledWith(error)
         done()
+      })
+    })
+
+    it('should update sampling rates', () => {
+      writer.append([span])
+      writer.flush()
+
+      expect(prioritySampler.update).to.have.been.calledWith({
+        'service:hello,env:test': 1
       })
     })
 

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -109,7 +109,7 @@ describe('Tracer', () => {
     tracer = new Tracer(config)
 
     expect(AgentExporter).to.have.been.called
-    expect(AgentExporter).to.have.been.calledWith(config)
+    expect(AgentExporter).to.have.been.calledWith(config, prioritySampler)
     expect(SpanProcessor).to.have.been.calledWith(exporter, prioritySampler)
   })
 
@@ -120,7 +120,7 @@ describe('Tracer', () => {
     tracer = new Tracer(config)
 
     expect(AgentExporter).not.to.have.been.called
-    expect(LogExporter).to.have.been.called
+    expect(LogExporter).to.have.been.calledWith(config, prioritySampler)
     expect(SpanProcessor).to.have.been.calledWith(exporter, prioritySampler)
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix priority sampling not updating the rates from the agent.

### Motivation
<!-- What inspired you to submit this pull request? -->

Since the switch to a span processor and exporters, the priority sampler was no longer passed to the writer. This resulted in a lot of errors being logged, and the rates would no longer update from the agent response.

Fixes #712