### PR TITLE
fix service name when tracer is imported by a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,5 @@ versions
 build
 prebuilds
 docs/test.js
-!packages/*/test/node_modules
+!packages/*/test/**/node_modules
 dist

--- a/packages/dd-trace/src/platform/node/service.js
+++ b/packages/dd-trace/src/platform/node/service.js
@@ -30,7 +30,7 @@ function findPkg (cwd) {
 }
 
 function isDependency (filepath) {
-  const expr = new RegExp(`${path.sep}node_modules${path.sep}`)
+  const expr = new RegExp(`\\${path.sep}node_modules\\${path.sep}`)
   return expr.test(filepath)
 }
 

--- a/packages/dd-trace/src/platform/node/service.js
+++ b/packages/dd-trace/src/platform/node/service.js
@@ -21,11 +21,17 @@ function service () {
 function findPkg (cwd) {
   let up = readPkgUp.sync({ cwd })
 
-  while (up && /\/node_modules\//.test(up.path)) {
-    up = readPkgUp.sync({ cwd: path.resolve(path.dirname(up.path), '..') })
+  while (up && isDependency(up.path)) {
+    cwd = path.resolve(path.dirname(up.path), '..')
+    up = readPkgUp.sync({ cwd })
   }
 
   return up && up.pkg ? up.pkg : {}
+}
+
+function isDependency (filepath) {
+  const expr = new RegExp(`${path.sep}node_modules${path.sep}`)
+  return expr.test(filepath)
 }
 
 module.exports = service

--- a/packages/dd-trace/src/platform/node/service.js
+++ b/packages/dd-trace/src/platform/node/service.js
@@ -13,9 +13,19 @@ function service () {
   const callerPath = parentModule()
   const parentPath = parentModule(callerPath)
   const cwd = path.dirname(parentPath || callerPath)
-  const pkg = readPkgUp.sync({ cwd }).pkg || {}
+  const pkg = findPkg(cwd)
 
   return pkg.name
+}
+
+function findPkg (cwd) {
+  let up = readPkgUp.sync({ cwd })
+
+  while (up && /\/node_modules\//.test(up.path)) {
+    up = readPkgUp.sync({ cwd: path.resolve(path.dirname(up.path), '..') })
+  }
+
+  return up && up.pkg ? up.pkg : {}
 }
 
 module.exports = service

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -177,6 +177,12 @@ describe('Platform', () => {
 
         expect(name).to.equal('foo')
       })
+
+      it('should work even in dependencies', () => {
+        const name = require('./load/node_modules/dep')
+
+        expect(name).to.equal('foo')
+      })
     })
 
     describe('request', () => {

--- a/packages/dd-trace/test/platform/node/load/node_modules/dep/index.js
+++ b/packages/dd-trace/test/platform/node/load/node_modules/dep/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const caller = require('./load')
+
+module.exports = caller()

--- a/packages/dd-trace/test/platform/node/load/node_modules/dep/load/index.js
+++ b/packages/dd-trace/test/platform/node/load/node_modules/dep/load/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const platform = require('../../../../../../../src/platform/node')
+
+module.exports = () => platform.service()

--- a/packages/dd-trace/test/platform/node/load/node_modules/dep/package.json
+++ b/packages/dd-trace/test/platform/node/load/node_modules/dep/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bar",
+  "version": "1.0.0",
+  "description": "",
+  "main": "bar.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "private": true
+}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix service name when tracer is imported by a dependency.

### Motivation
<!-- What inspired you to submit this pull request? -->

We find the service name by locating the closest `package.json` relative to the path of the parent module that imported the tracer. This can be a library used by the app and not the app itself however.

Fixes #710