### PR TITLE
Add experimental support for customizing tracer log levels

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -329,6 +329,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | experimental   | -                              | `{}`        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Please contact us to learn more about the available experimental features. |
 | plugins        | -                              | `true`      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 | clientToken    | `DD_CLIENT_TOKEN`              | -           | Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`. |
+| logLevel       | `DD_TRACE_LOG_LEVEL`           | `debug`     | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `'error'`, `'debug'`. |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -72,7 +72,8 @@ tracer.init({
   },
   reportHostname: true,
   scope: 'noop',
-  clientToken: 'pub123abc'
+  clientToken: 'pub123abc',
+  logLevel: 'debug'
 });
 
 const httpOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -336,6 +336,12 @@ export declare interface TracerOptions {
    * Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`.
    */
   clientToken?: string
+
+  /**
+   * A string representing the minimum tracer log level to use when debug logging is enabled
+   * @default 'debug'
+   */
+  logLevel?: 'error' | 'debug'
 }
 
 /** @hidden */

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -57,7 +57,12 @@ class Config {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: options.experimental && options.experimental.exporter,
       peers: (options.experimental && options.experimental.peers) || [],
-      sampler: (options.experimental && options.experimental.sampler) || {}
+      sampler: (options.experimental && options.experimental.sampler) || {},
+      logLevel: coalesce(
+        (options.experimental ? options.experimental.logLevel : null),
+        platform.env('LOG_LEVEL'),
+        null
+      )
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -61,7 +61,11 @@ class Config {
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope
-    this.clientToken = clientToken
+    this.logLevel = coalesce(
+      options.logLevel,
+      platform.env('DD_TRACE_LOG_LEVEL'),
+      'debug'
+    )
   }
 }
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -57,15 +57,11 @@ class Config {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: options.experimental && options.experimental.exporter,
       peers: (options.experimental && options.experimental.peers) || [],
-      sampler: (options.experimental && options.experimental.sampler) || {},
-      logLevel: coalesce(
-        (options.experimental ? options.experimental.logLevel : null),
-        platform.env('LOG_LEVEL'),
-        null
-      )
+      sampler: (options.experimental && options.experimental.sampler) || {}
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope
+    this.clientToken = clientToken
     this.logLevel = coalesce(
       options.logLevel,
       platform.env('DD_TRACE_LOG_LEVEL'),

--- a/packages/dd-trace/src/log.js
+++ b/packages/dd-trace/src/log.js
@@ -7,9 +7,10 @@ const _default = {
   error: err => console.error(err) /* eslint-disable-line no-console */
 }
 
+// based on: https://github.com/trentm/node-bunyan#levels
 const _logLevels = {
-  'debug': 0,
-  'error': 1
+  'debug': 20,
+  'error': 50
 }
 
 const _defaultLogLevel = 'debug'
@@ -23,7 +24,7 @@ const _isLogLevelEnabled = (level) => {
   return !_logLevel || _logLevels[level] >= _logLevel
 }
 
-const _setLogLevel = (logLevel) => {
+const _checkLogLevel = (logLevel) => {
   if (logLevel && typeof logLevel === 'string') {
     return _logLevels[logLevel.toLowerCase().trim()] || _logLevels[_defaultLogLevel]
   }
@@ -42,7 +43,7 @@ const log = {
 
   toggle (enabled, logLevel) {
     _enabled = enabled
-    _logLevel = _setLogLevel(logLevel)
+    _logLevel = _checkLogLevel(logLevel)
 
     return this
   },
@@ -54,7 +55,7 @@ const log = {
       _logger.error(message)
       return this
     })
-    _logLevel = _setLogLevel()
+    _logLevel = _checkLogLevel()
 
     return this
   },

--- a/packages/dd-trace/src/log.js
+++ b/packages/dd-trace/src/log.js
@@ -7,39 +7,20 @@ const _default = {
   error: err => console.error(err) /* eslint-disable-line no-console */
 }
 
+const _logLevels = ['trace', 'debug', 'info', 'warn', 'error']
+
 let _logger
 let _enabled
 let _deprecate
+let _logLevel
 
-/*
-default [error, debug]
-from: https://tools.ietf.org/html/rfc5424
+const _isLogLevelEnabled = (level) => {
+  return !_logLevel || _logLevels.indexOf(level) >= _logLevels.indexOf(_logLevel)
+}
 
-  0       Emergency: system is unusable
-  1       Alert: action must be taken immediately
-  2       Critical: critical conditions
-  3       Error: error conditions
-  4       Warning: warning conditions
-  5       Notice: normal but significant condition
-  6       Informational: informational messages
-  7       Debug: debug-level messages
-*/
-
-let _customLogLevels
-
-const _isLogLevelEnabled = (level) => { return !_customLogLevels || _customLogLevels.indexOf(level) >= 0 }
-
-const _setCustomLogLevels = (customLogLevels) => {
-  if (customLogLevels) {
-    try {
-      if (typeof customLogLevels === 'string') {
-        return customLogLevels.toLowerCase().split(',')
-      } else if (Array.isArray(customLogLevels)) {
-        return customLogLevels.map(level => level.toLowerCase())
-      }
-    } catch (e) {
-      console.warn('customlogLevels option malformed', customLogLevels, e) /* eslint-disable-line no-console */
-    }
+const _setLogLevel = (logLevel) => {
+  if (logLevel && typeof logLevel === 'string') {
+    return logLevel.toLowerCase().trim()
   }
 }
 
@@ -52,11 +33,11 @@ const log = {
     return this
   },
 
-  toggle (enabled, customLogLevels) {
+  toggle (enabled, customLogLevel) {
     _enabled = enabled
 
-    if (customLogLevels) {
-      _customLogLevels = _setCustomLogLevels(customLogLevels)
+    if (customLogLevel) {
+      _logLevel = _setLogLevel(customLogLevel)
     }
 
     return this
@@ -69,6 +50,7 @@ const log = {
       _logger.error(message)
       return this
     })
+    _logLevel = undefined
 
     return this
   },

--- a/packages/dd-trace/src/log.js
+++ b/packages/dd-trace/src/log.js
@@ -21,7 +21,7 @@ let _deprecate
 let _logLevel
 
 const _isLogLevelEnabled = (level) => {
-  return !_logLevel || _logLevels[level] >= _logLevel
+  return _logLevels[level] >= _logLevel
 }
 
 const _checkLogLevel = (logLevel) => {

--- a/packages/dd-trace/src/log.js
+++ b/packages/dd-trace/src/log.js
@@ -7,7 +7,12 @@ const _default = {
   error: err => console.error(err) /* eslint-disable-line no-console */
 }
 
-const _logLevels = ['trace', 'debug', 'info', 'warn', 'error']
+const _logLevels = {
+  'debug': 0,
+  'error': 1
+}
+
+const _defaultLogLevel = 'debug'
 
 let _logger
 let _enabled
@@ -15,13 +20,15 @@ let _deprecate
 let _logLevel
 
 const _isLogLevelEnabled = (level) => {
-  return !_logLevel || _logLevels.indexOf(level) >= _logLevels.indexOf(_logLevel)
+  return !_logLevel || _logLevels[level] >= _logLevel
 }
 
 const _setLogLevel = (logLevel) => {
   if (logLevel && typeof logLevel === 'string') {
-    return logLevel.toLowerCase().trim()
+    return _logLevels[logLevel.toLowerCase().trim()] || _logLevels[_defaultLogLevel]
   }
+
+  return _logLevels[_defaultLogLevel]
 }
 
 const log = {
@@ -33,12 +40,9 @@ const log = {
     return this
   },
 
-  toggle (enabled, customLogLevel) {
+  toggle (enabled, logLevel) {
     _enabled = enabled
-
-    if (customLogLevel) {
-      _logLevel = _setLogLevel(customLogLevel)
-    }
+    _logLevel = _setLogLevel(logLevel)
 
     return this
   },
@@ -50,7 +54,7 @@ const log = {
       _logger.error(message)
       return this
     })
-    _logLevel = undefined
+    _logLevel = _setLogLevel()
 
     return this
   },

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -28,7 +28,7 @@ class DatadogTracer extends Tracer {
     super()
 
     log.use(config.logger)
-    log.toggle(config.debug)
+    log.toggle(config.debug, config.experimental.ddTraceLogLevels)
 
     const Exporter = platform.exporter(config.experimental.exporter)
 

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -28,7 +28,7 @@ class DatadogTracer extends Tracer {
     super()
 
     log.use(config.logger)
-    log.toggle(config.debug, config.experimental.ddTraceLogLevels)
+    log.toggle(config.debug, config.experimental.logLevel)
 
     const Exporter = platform.exporter(config.experimental.exporter)
 

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -28,7 +28,7 @@ class DatadogTracer extends Tracer {
     super()
 
     log.use(config.logger)
-    log.toggle(config.debug, config.experimental.logLevel)
+    log.toggle(config.debug, config.logLevel)
 
     const Exporter = platform.exporter(config.experimental.exporter)
 

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -1,4 +1,3 @@
-
 'use strict'
 
 const opentracing = require('opentracing')

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -1,3 +1,4 @@
+
 'use strict'
 
 const opentracing = require('opentracing')

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -92,7 +92,7 @@ describe('Config', () => {
     const tags = {
       'foo': 'bar'
     }
-    const customLogLevels = ['error']
+    const customLogLevel = 'error'
     const config = new Config('test', {
       enabled: false,
       debug: true,
@@ -116,7 +116,7 @@ describe('Config', () => {
       clientToken: '789',
       experimental: {
         b3: true,
-        ddTraceLogLevels: customLogLevels
+        logLevel: customLogLevel
       }
     })
 
@@ -142,7 +142,7 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
-    expect(config).to.have.nested.property('experimental.ddTraceLogLevels', customLogLevels)
+    expect(config).to.have.nested.property('experimental.logLevel', customLogLevel)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -118,7 +118,7 @@ describe('Config', () => {
       logLevel: logLevel,
       experimental: {
         b3: true,
-        ddTraceLogLevels: customLogLevels
+        logLevel: customLogLevel
       }
     })
 
@@ -145,7 +145,7 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
-    expect(config).to.have.nested.property('experimental.ddTraceLogLevels', customLogLevels)
+    expect(config).to.have.nested.property('experimental.logLevel', customLogLevel)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -117,7 +117,8 @@ describe('Config', () => {
       clientToken: '789',
       logLevel: logLevel,
       experimental: {
-        b3: true
+        b3: true,
+        ddTraceLogLevels: customLogLevels
       }
     })
 
@@ -144,6 +145,7 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
+    expect(config).to.have.nested.property('experimental.ddTraceLogLevels', customLogLevels)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -31,6 +31,7 @@ describe('Config', () => {
     expect(config).to.have.property('reportHostname', false)
     expect(config).to.have.property('scope', undefined)
     expect(config).to.have.property('clientToken', undefined)
+    expect(config).to.have.property('logLevel', 'debug')
     expect(config).to.have.nested.property('experimental.b3', false)
   })
 
@@ -92,7 +93,7 @@ describe('Config', () => {
     const tags = {
       'foo': 'bar'
     }
-    const customLogLevel = 'error'
+    const logLevel = 'error'
     const config = new Config('test', {
       enabled: false,
       debug: true,
@@ -114,9 +115,9 @@ describe('Config', () => {
       plugins: false,
       scope: 'noop',
       clientToken: '789',
+      logLevel: logLevel,
       experimental: {
-        b3: true,
-        logLevel: customLogLevel
+        b3: true
       }
     })
 
@@ -138,11 +139,11 @@ describe('Config', () => {
     expect(config).to.have.property('plugins', false)
     expect(config).to.have.property('scope', 'noop')
     expect(config).to.have.property('clientToken', '789')
+    expect(config).to.have.property('logLevel', logLevel)
     expect(config).to.have.deep.property('tags', {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
-    expect(config).to.have.nested.property('experimental.logLevel', customLogLevel)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -92,6 +92,7 @@ describe('Config', () => {
     const tags = {
       'foo': 'bar'
     }
+    const customLogLevels = ['error']
     const config = new Config('test', {
       enabled: false,
       debug: true,
@@ -114,7 +115,8 @@ describe('Config', () => {
       scope: 'noop',
       clientToken: '789',
       experimental: {
-        b3: true
+        b3: true,
+        ddTraceLogLevels: customLogLevels
       }
     })
 
@@ -140,6 +142,7 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
+    expect(config).to.have.nested.property('experimental.ddTraceLogLevels', customLogLevels)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -117,8 +117,7 @@ describe('Config', () => {
       clientToken: '789',
       logLevel: logLevel,
       experimental: {
-        b3: true,
-        logLevel: customLogLevel
+        b3: true
       }
     })
 
@@ -145,7 +144,6 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
-    expect(config).to.have.nested.property('experimental.logLevel', customLogLevel)
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -10,6 +10,7 @@ describe('log', () => {
   beforeEach(() => {
     sinon.stub(console, 'log')
     sinon.stub(console, 'error')
+    sinon.stub(console, 'warn')
 
     error = new Error()
 
@@ -26,6 +27,7 @@ describe('log', () => {
     log.reset()
     console.log.restore()
     console.error.restore()
+    console.warn.restore()
   })
 
   it('should support chaining', () => {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -150,9 +150,9 @@ describe('log', () => {
       log.debug('debug')
       log.error(error)
 
-      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.log).to.not.have.been.called
       expect(console.error).to.have.been.calledWith(error)
-    })      
+    })
 
     it('should log all log levels greater than or equal to minimum log level', () => {
       log.toggle(true, 'debug')

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -126,6 +126,48 @@ describe('log', () => {
       expect(console.log).to.have.been.calledWith('debug')
       expect(console.error).to.have.been.calledWith(error)
     })
+
+    it('should set custom log levels when enabled with customLogLevels argument set to an array of log levels', () => {
+      log.toggle(true, ['error', 'info'])
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.not.have.been.called
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should set custom log levels when enabled with customLogLevels arg as CSV string of log levels', () => {
+      log.toggle(true, 'error,info')
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.not.have.been.called
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should log a warning if enabled with an improperly formatted Array', () => {
+      log.toggle(true, [{ 'invalid_key': 'invalid_value' }])
+
+      expect(console.log).to.have.been.calledOnce
+    })
+
+    it('should enable error and debug logs when enabled with customLogLevels argument set to null', () => {
+      log.toggle(true, null)
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should enable error and debug logs when enabled without customLogLevels argument', () => {
+      log.toggle(true)
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith(error)
+    })
   })
 
   describe('use', () => {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -10,7 +10,6 @@ describe('log', () => {
   beforeEach(() => {
     sinon.stub(console, 'log')
     sinon.stub(console, 'error')
-    sinon.stub(console, 'warn')
 
     error = new Error()
 
@@ -27,7 +26,6 @@ describe('log', () => {
     log.reset()
     console.log.restore()
     console.error.restore()
-    console.warn.restore()
   })
 
   it('should support chaining', () => {
@@ -129,8 +127,8 @@ describe('log', () => {
       expect(console.error).to.have.been.calledWith(error)
     })
 
-    it('should set custom log levels when enabled with customLogLevels argument set to an array of log levels', () => {
-      log.toggle(true, ['error', 'info'])
+    it('should set custom minimum log level when enabled with logLevel argument set to a string', () => {
+      log.toggle(true, 'error')
       log.debug('debug')
       log.error(error)
 
@@ -138,22 +136,16 @@ describe('log', () => {
       expect(console.error).to.have.been.calledWith(error)
     })
 
-    it('should set custom log levels when enabled with customLogLevels arg as CSV string of log levels', () => {
-      log.toggle(true, 'error,info')
+    it('should log all log levels greater than or equal to minimum log level', () => {
+      log.toggle(true, 'debug')
       log.debug('debug')
       log.error(error)
 
-      expect(console.log).to.not.have.been.called
+      expect(console.log).to.have.been.calledWith('debug')
       expect(console.error).to.have.been.calledWith(error)
     })
 
-    it('should log a warning if enabled with an improperly formatted Array', () => {
-      log.toggle(true, [{ 'invalid_key': 'invalid_value' }])
-
-      expect(console.warn).to.have.been.calledOnce
-    })
-
-    it('should enable error and debug logs when enabled with customLogLevels argument set to null', () => {
+    it('should enable error and debug logs when enabled with customLogLevel argument set to null', () => {
       log.toggle(true, null)
       log.debug('debug')
       log.error(error)
@@ -162,7 +154,7 @@ describe('log', () => {
       expect(console.error).to.have.been.calledWith(error)
     })
 
-    it('should enable error and debug logs when enabled without customLogLevels argument', () => {
+    it('should enable error and debug logs when enabled without customLogLevel argument', () => {
       log.toggle(true)
       log.debug('debug')
       log.error(error)
@@ -221,6 +213,18 @@ describe('log', () => {
 
       expect(console.log).to.not.have.been.called
       expect(console.error).to.not.have.been.called
+    })
+
+    it('should reset the minimum log level to defaults', () => {
+      log.use(logger)
+      log.toggle(true, 'error')
+      log.reset()
+      log.toggle(true)
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith(error)
     })
   })
 

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -10,7 +10,6 @@ describe('log', () => {
   beforeEach(() => {
     sinon.stub(console, 'log')
     sinon.stub(console, 'error')
-    sinon.stub(console, 'warn')
 
     error = new Error()
 
@@ -27,7 +26,6 @@ describe('log', () => {
     log.reset()
     console.log.restore()
     console.error.restore()
-    console.warn.restore()
   })
 
   it('should support chaining', () => {
@@ -152,9 +150,9 @@ describe('log', () => {
       log.debug('debug')
       log.error(error)
 
-      expect(console.log).to.not.have.been.called
+      expect(console.log).to.have.been.calledWith('debug')
       expect(console.error).to.have.been.calledWith(error)
-    })
+    })      
 
     it('should log all log levels greater than or equal to minimum log level', () => {
       log.toggle(true, 'debug')

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -148,7 +148,7 @@ describe('log', () => {
     it('should log a warning if enabled with an improperly formatted Array', () => {
       log.toggle(true, [{ 'invalid_key': 'invalid_value' }])
 
-      expect(console.log).to.have.been.calledOnce
+      expect(console.warn).to.have.been.calledOnce
     })
 
     it('should enable error and debug logs when enabled with customLogLevels argument set to null', () => {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -127,8 +127,26 @@ describe('log', () => {
       expect(console.error).to.have.been.calledWith(error)
     })
 
-    it('should set custom minimum log level when enabled with logLevel argument set to a string', () => {
+    it('should set minimum log level when enabled with logLevel argument set to a valid string', () => {
       log.toggle(true, 'error')
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.not.have.been.called
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should set default log level when enabled with logLevel argument set to an invalid string', () => {
+      log.toggle(true, 'not a real log level')
+      log.debug('debug')
+      log.error(error)
+
+      expect(console.log).to.have.been.calledWith('debug')
+      expect(console.error).to.have.been.calledWith(error)
+    })
+
+    it('should set min log level when enabled w/logLevel arg set to valid string w/wrong case or whitespace', () => {
+      log.toggle(true, ' ErRoR   ')
       log.debug('debug')
       log.error(error)
 
@@ -145,8 +163,8 @@ describe('log', () => {
       expect(console.error).to.have.been.calledWith(error)
     })
 
-    it('should enable error and debug logs when enabled with customLogLevel argument set to null', () => {
-      log.toggle(true, null)
+    it('should enable default log level when enabled with logLevel argument set to invalid input', () => {
+      log.toggle(true, ['trace', 'info', 'eror'])
       log.debug('debug')
       log.error(error)
 
@@ -154,7 +172,7 @@ describe('log', () => {
       expect(console.error).to.have.been.calledWith(error)
     })
 
-    it('should enable error and debug logs when enabled without customLogLevel argument', () => {
+    it('should enable default log level when enabled without logLevel argument', () => {
       log.toggle(true)
       log.debug('debug')
       log.error(error)


### PR DESCRIPTION
### What does this PR do?
Following up on Feedback from [PR-718](https://github.com/DataDog/dd-trace-js/pull/718) This PR addresses the use case introduced in [Issue 599](https://github.com/DataDog/dd-trace-js/issues/559) for when a user wants to forward tracer errors to their logger but ignore debug messages. 

 This PR adds experimental support for an ~`experimental.ddTraceLogLevels`~ _`experimental.logLevel`_ configuration option as well as `DD_TRACE_LOG_LEVEL` environment variable, which allow a user to specify the ~specific~ _minimum_ log level~s~ that they'd like to permit from the tracer's logger. It accepts the format of ~an array of strings such as `['error','debug','info']` as well as a comma separated value string such as `'error,info'`~ a string such as `'error'` or `'debug'`.

### Motivation
Implementing feedback discussed from [PR-718](https://github.com/DataDog/dd-trace-js/pull/718) 

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

I tried to incorporate the feedback from [PR-718](https://github.com/DataDog/dd-trace-js/pull/718) in this pull request. A few notes.

- Some of the implementation is a bit clunky given that I am trying to target a future logger that hasn't been written or spec'd out, so I tried to leave things flexible enough that they can adjusted if there is a larger refactor of the default logger in the future. At a high level my approach was to give the user a few ways to set the tracer log levels they'd want logged, and then ideally not have to worry about changing that format if there's a larger refactor in the future / new log levels are added.

- There's some helper methods for determining if the specific log level is enabled or not (`_isLogLevelEnabled` ) that I'd be open to feedback on if there's a better way to approach this. I tried to write a method that would automagically determine the log level's function name that was invoking it and check if that name had been whitelisted, however the approach to doing so seemed to rely on either outdated js concepts (using something like `arguments.callee` ) or methods that might not play nicely when minified (specifically `myFunction.name` had some scary language around it in this [S/O Note](https://stackoverflow.com/a/15714445) ). So the current approach is a bit clunky.

- Unclear how i ought to document this but happy to add docs/usage example to `api/docs.md` in this PR (i made the option experimental for now and it doesn't look like we really update that api/docs.md file until an option is "non-experimental").

- It's entirely possible i botched the typescript part of this, apologies if so, still need to level up with my TS.

- Any and all feedback is welcome, and generally if it's better to shelve this until there's more clarity on what logging might look like after additional log lvls have been added, thats ok too. Just trying to unblock the folks who'd been asking for it.