### PR TITLE
add experimental priority sampling config as sampling rules

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -5,6 +5,7 @@ require,container-info,MIT,Copyright 2018 Stephen Belanger
 require,core-js,MIT,Copyright 2014-2019 Denis Pushkarev
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
+require,limiter,MIT,Copyright 2011 John Hurliman
 require,lodash.kebabcase,MIT,Copyright JS Foundation and other contributors
 require,lodash.memoize,MIT,Copyright JS Foundation and other contributors
 require,lodash.pick,MIT,Copyright JS Foundation and other contributors

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -44,7 +44,15 @@ tracer.init({
   experimental: {
     b3: true,
     exporter: 'log',
-    peers: ['foo']
+    peers: ['foo'],
+    sampler: {
+      sampleRate: 1,
+      rateLimit: 1000,
+      rules: [
+        { sampleRate: 0.5, service: 'foo', name: 'foo.request' },
+        { sampleRate: 0.1, service: /foo/, name: /foo\.request/ }
+      ]
+    }
   },
   hostname: 'agent',
   logger: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,6 +144,26 @@ export declare interface SpanContext extends opentracing.SpanContext {
 }
 
 /**
+ * Sampling rule to configure on the priority sampler.
+ */
+export declare interface SamplingRule {
+  /**
+   * Sampling rate for this rule.
+   */
+  sampleRate: Number
+
+  /**
+   * Service on which to apply this rule. The rule will apply to all services if not provided.
+   */
+  service?: string | RegExp
+
+  /**
+   * Operation name on which to apply this rule. The rule will apply to all operation names if not provided.
+   */
+  name?: string | RegExp
+}
+
+/**
  * List of options available to the tracer.
  */
 export declare interface TracerOptions {
@@ -254,6 +274,28 @@ export declare interface TracerOptions {
      * @default []
      */
     peers?: string[]
+
+    /**
+     * Configuration of the priority sampler. Supports a global config and rules by span name or service name. The first matching rule is applied, and if no rule matches it falls back to the global config or on the rates provided by the agent if there is no global config.
+     */
+    sampler?: {
+      /**
+       * Sample rate to apply globally when no other rule is matched. Omit to fallback on the dynamic rates returned by the agent instead.
+       */
+      sampleRate?: Number,
+
+      /**
+       * Global rate limit that is applied on the global sample rate and all rules.
+       * @default 100
+       */
+      rateLimit?: Number,
+
+      /**
+       * Sampling rules to apply to priority sampling.
+       * @default []
+       */
+      rules?: SamplingRule[]
+    }
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "core-js": "^3.3.4",
     "int64-buffer": "^0.1.9",
     "koalas": "^1.0.2",
+    "limiter": "^1.1.4",
     "lodash.kebabcase": "^4.1.1",
     "lodash.memoize": "^4.1.2",
     "lodash.pick": "^4.4.0",

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -56,7 +56,8 @@ class Config {
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: options.experimental && options.experimental.exporter,
-      peers: (options.experimental && options.experimental.peers) || []
+      peers: (options.experimental && options.experimental.peers) || [],
+      sampler: (options.experimental && options.experimental.sampler) || {}
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -6,5 +6,8 @@ module.exports = {
   ANALYTICS_KEY: '_dd1.sr.eausr',
   ORIGIN_KEY: '_dd.origin',
   HOSTNAME_KEY: '_dd.hostname',
-  REFERENCE_NOOP: 'noop'
+  REFERENCE_NOOP: 'noop',
+  SAMPLING_RULE_DECISION: '_dd.rule_psr',
+  SAMPLING_LIMIT_DECISION: '_dd.limit_psr',
+  SAMPLING_AGENT_DECISION: '_dd.agent_psr'
 }

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -37,7 +37,7 @@ class DatadogTracer extends Tracer {
     this._tags = config.tags
     this._logInjection = config.logInjection
     this._analytics = config.analytics
-    this._prioritySampler = new PrioritySampler(config.env)
+    this._prioritySampler = new PrioritySampler(config.env, config.experimental.sampler)
     this._exporter = new Exporter(config, this._prioritySampler)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)
     this._url = this._exporter._url

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -102,7 +102,7 @@ class PrioritySampler {
   _isSampledByRule (context, rule) {
     context._metrics[SAMPLING_RULE_DECISION] = rule.sampleRate
 
-    return rule.sampler.isSampled(context) && this._isSampledByRateLimit()
+    return rule.sampler.isSampled(context) && this._isSampledByRateLimit(context)
   }
 
   _isSampledByRateLimit (context) {

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -28,7 +28,7 @@ const priorities = new Set([
 ])
 
 class PrioritySampler {
-  constructor (env, { sampleRate, rateLimit = 100, rules = [] }) {
+  constructor (env, { sampleRate, rateLimit = 100, rules = [] } = {}) {
     this._env = env
     this._rules = this._normalizeRules(rules, sampleRate)
     this._limiter = new RateLimiter(rateLimit)

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -133,7 +133,9 @@ class PrioritySampler {
     const name = context._name
     const service = context._tags['service.name']
 
+    if (rule.name instanceof RegExp && !rule.name.test(name)) return false
     if (rule.name && rule.name !== name) return false
+    if (rule.service instanceof RegExp && !rule.service.test(service)) return false
     if (rule.service && rule.service !== service) return false
 
     return true

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -41,7 +41,7 @@ class PrioritySampler {
     const rule = this._findRule(context)
 
     return rule
-      ? this._isSampledByRule(context, rule)
+      ? this._isSampledByRule(context, rule) && this._isSampledByRateLimit(context)
       : this._isSampledByAgent(context)
   }
 
@@ -102,7 +102,7 @@ class PrioritySampler {
   _isSampledByRule (context, rule) {
     context._metrics[SAMPLING_RULE_DECISION] = rule.sampleRate
 
-    return rule.sampler.isSampled(context) && this._isSampledByRateLimit(context)
+    return rule.sampler.isSampled(context)
   }
 
   _isSampledByRateLimit (context) {

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -1,7 +1,14 @@
 'use strict'
 
+const RateLimiter = require('./rate_limiter')
 const Sampler = require('./sampler')
 const ext = require('../../../ext')
+
+const {
+  SAMPLING_RULE_DECISION,
+  SAMPLING_LIMIT_DECISION,
+  SAMPLING_AGENT_DECISION
+} = require('./constants')
 
 const SERVICE_NAME = ext.tags.SERVICE_NAME
 const SAMPLING_PRIORITY = ext.tags.SAMPLING_PRIORITY
@@ -21,17 +28,21 @@ const priorities = new Set([
 ])
 
 class PrioritySampler {
-  constructor (env) {
+  constructor (env, { sampleRate, rateLimit = 100, rules = [] }) {
     this._env = env
+    this._rules = this._normalizeRules(rules, sampleRate)
+    this._limiter = new RateLimiter(rateLimit)
+
     this.update({})
   }
 
   isSampled (span) {
     const context = this._getContext(span)
-    const key = `service:${context._tags[SERVICE_NAME]},env:${this._env}`
-    const sampler = this._samplers[key] || this._samplers[DEFAULT_KEY]
+    const rule = this._findRule(context)
 
-    return sampler.isSampled(span)
+    return rule
+      ? this._isSampledByRule(context, rule)
+      : this._isSampledByAgent(context)
   }
 
   sample (span) {
@@ -86,6 +97,46 @@ class PrioritySampler {
         return USER_REJECT
       }
     }
+  }
+
+  _isSampledByRule (context, rule) {
+    const sampled = this._limiter.isAllowed() && rule.sampler.isSampled(context)
+
+    context._metrics[SAMPLING_LIMIT_DECISION] = this._limiter.effectiveRate()
+    context._metrics[SAMPLING_RULE_DECISION] = rule.sampleRate
+
+    return sampled
+  }
+
+  _isSampledByAgent (context) {
+    const key = `service:${context._tags[SERVICE_NAME]},env:${this._env}`
+    const sampler = this._samplers[key] || this._samplers[DEFAULT_KEY]
+
+    context._metrics[SAMPLING_AGENT_DECISION] = sampler.rate()
+
+    return sampler.isSampled(context)
+  }
+
+  _normalizeRules (rules, sampleRate) {
+    return rules
+      .concat({ sampleRate })
+      .map(rule => ({ ...rule, sampleRate: parseFloat(rule.sampleRate) }))
+      .filter(rule => !isNaN(rule.sampleRate))
+      .map(rule => ({ ...rule, sampler: new Sampler(rule.sampleRate) }))
+  }
+
+  _findRule (context) {
+    return this._rules.find(rule => this._matchRule(context, rule))
+  }
+
+  _matchRule (context, rule) {
+    const name = context._name
+    const service = context._tags['service.name']
+
+    if (rule.name && rule.name !== name) return false
+    if (rule.service && rule.service !== service) return false
+
+    return true
   }
 }
 

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -100,12 +100,17 @@ class PrioritySampler {
   }
 
   _isSampledByRule (context, rule) {
-    const sampled = this._limiter.isAllowed() && rule.sampler.isSampled(context)
-
-    context._metrics[SAMPLING_LIMIT_DECISION] = this._limiter.effectiveRate()
     context._metrics[SAMPLING_RULE_DECISION] = rule.sampleRate
 
-    return sampled
+    return rule.sampler.isSampled(context) && this._isSampledByRateLimit()
+  }
+
+  _isSampledByRateLimit (context) {
+    const allowed = this._limiter.isAllowed()
+
+    context._metrics[SAMPLING_LIMIT_DECISION] = this._limiter.effectiveRate()
+
+    return allowed
   }
 
   _isSampledByAgent (context) {

--- a/packages/dd-trace/src/rate_limiter.js
+++ b/packages/dd-trace/src/rate_limiter.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const limiter = require('limiter')
+
+class RateLimiter {
+  constructor (rateLimit) {
+    this._rateLimit = parseInt(rateLimit)
+    this._limiter = new limiter.RateLimiter(this._rateLimit, 'second')
+    this._tokensRequested = 0
+    this._prevWindowRate = null
+  }
+
+  isAllowed () {
+    const curIntervalStart = this._limiter.curIntervalStart
+    const allowed = this._isAllowed()
+
+    if (curIntervalStart !== this._limiter.curIntervalStart) {
+      this._prevWindowRate = this._currentWindowRate()
+      this._tokensRequested = 0
+    }
+
+    this._tokensRequested++
+
+    return allowed
+  }
+
+  effectiveRate () {
+    const currentWindowRate = this._currentWindowRate()
+
+    if (this._prevWindowRate === null) return currentWindowRate
+
+    return (currentWindowRate + this._prevWindowRate) / 2
+  }
+
+  _isAllowed () {
+    if (this._rateLimit < 0) return true
+    if (this._rateLimit === 0) return false
+
+    return this._limiter.tryRemoveTokens(1)
+  }
+
+  _currentWindowRate () {
+    if (this._rateLimit < 0) return 1
+    if (this._rateLimit === 0) return 0
+    if (this._tokensRequested === 0) return 1
+
+    return this._limiter.tokensThisInterval / this._tokensRequested
+  }
+}
+
+module.exports = RateLimiter

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -156,7 +156,7 @@ describe('PrioritySampler', () => {
       expect(context._sampling).to.have.property('priority', AUTO_REJECT)
     })
 
-    it('should support a sample rate from a rule on service', () => {
+    it('should support a sample rate from a rule on service as string', () => {
       context._tags['service.name'] = 'test'
 
       prioritySampler = new PrioritySampler('test', {
@@ -170,7 +170,21 @@ describe('PrioritySampler', () => {
       expect(context._sampling).to.have.property('priority', AUTO_KEEP)
     })
 
-    it('should support a sample rate from a rule on name', () => {
+    it('should support a sample rate from a rule on service as string as regex', () => {
+      context._tags['service.name'] = 'test'
+
+      prioritySampler = new PrioritySampler('test', {
+        rules: [
+          { sampleRate: 0, service: /fo/ },
+          { sampleRate: 1, service: /tes/ }
+        ]
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+    })
+
+    it('should support a sample rate from a rule on name as string', () => {
       context._name = 'foo'
       context._tags['service.name'] = 'test'
 
@@ -178,6 +192,21 @@ describe('PrioritySampler', () => {
         rules: [
           { sampleRate: 0, name: 'bar' },
           { sampleRate: 1, name: 'foo' }
+        ]
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+    })
+
+    it('should support a sample rate from a rule on name as regex', () => {
+      context._name = 'foo'
+      context._tags['service.name'] = 'test'
+
+      prioritySampler = new PrioritySampler('test', {
+        rules: [
+          { sampleRate: 0, name: /ba/ },
+          { sampleRate: 1, name: /fo/ }
         ]
       })
       prioritySampler.sample(context)

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -52,7 +52,7 @@ describe('PrioritySampler', () => {
       './sampler': Sampler
     })
 
-    prioritySampler = new PrioritySampler('test', {})
+    prioritySampler = new PrioritySampler('test')
   })
 
   describe('validate', () => {

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -14,12 +14,15 @@ const USER_KEEP = ext.priority.USER_KEEP
 describe('PrioritySampler', () => {
   let PrioritySampler
   let prioritySampler
+  let Sampler
+  let sampler
   let context
   let span
 
   beforeEach(() => {
     context = {
       _tags: {},
+      _metrics: {},
       _sampling: {}
     }
 
@@ -27,9 +30,29 @@ describe('PrioritySampler', () => {
       context: sinon.stub().returns(context)
     }
 
-    PrioritySampler = require('../src/priority_sampler')
+    sampler = {
+      isSampled: sinon.stub(),
+      rate: sinon.stub().returns(0.5)
+    }
+    sampler.isSampled.onFirstCall().returns(true)
+    sampler.isSampled.onSecondCall().returns(false)
 
-    prioritySampler = new PrioritySampler('test')
+    Sampler = sinon.stub()
+    Sampler.withArgs(0).returns({
+      isSampled: sinon.stub().returns(false),
+      rate: sinon.stub().returns(0)
+    })
+    Sampler.withArgs(1).returns({
+      isSampled: sinon.stub().returns(true),
+      rate: sinon.stub().returns(1)
+    })
+    Sampler.withArgs(0.5).returns(sampler)
+
+    PrioritySampler = proxyquire('../src/priority_sampler', {
+      './sampler': Sampler
+    })
+
+    prioritySampler = new PrioritySampler('test', {})
   })
 
   describe('validate', () => {
@@ -118,6 +141,118 @@ describe('PrioritySampler', () => {
       prioritySampler.sample(context)
 
       expect(context._sampling.priority).to.equal(USER_REJECT)
+    })
+
+    it('should support a global sample rate', () => {
+      prioritySampler = new PrioritySampler('test', { sampleRate: 0.5 })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+
+      delete context._sampling.priority
+
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_REJECT)
+    })
+
+    it('should support a sample rate from a rule on service', () => {
+      context._tags['service.name'] = 'test'
+
+      prioritySampler = new PrioritySampler('test', {
+        rules: [
+          { sampleRate: 0, service: 'foo' },
+          { sampleRate: 1, service: 'test' }
+        ]
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+    })
+
+    it('should support a sample rate from a rule on name', () => {
+      context._name = 'foo'
+      context._tags['service.name'] = 'test'
+
+      prioritySampler = new PrioritySampler('test', {
+        rules: [
+          { sampleRate: 0, name: 'bar' },
+          { sampleRate: 1, name: 'foo' }
+        ]
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+    })
+
+    it('should fallback to the global sample rate', () => {
+      context._name = 'foo'
+
+      prioritySampler = new PrioritySampler('test', {
+        sampleRate: 1,
+        rules: [
+          { sampleRate: 0, name: 'bar' }
+        ]
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+    })
+
+    it('should support a rate limit', () => {
+      prioritySampler = new PrioritySampler('test', {
+        sampleRate: 1,
+        rateLimit: 1
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+
+      delete context._sampling.priority
+
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_REJECT)
+    })
+
+    it('should support disabling the rate limit', () => {
+      prioritySampler = new PrioritySampler('test', {
+        sampleRate: 1,
+        rateLimit: -1
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+
+      delete context._sampling.priority
+
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', AUTO_KEEP)
+    })
+
+    it('should add metrics for agent sample rate', () => {
+      prioritySampler.sample(span)
+
+      expect(context._metrics).to.have.property('_dd.agent_psr', 1)
+    })
+
+    it('should add metrics for rule sample rate', () => {
+      prioritySampler = new PrioritySampler('test', {
+        sampleRate: 0.5,
+        rateLimit: 1
+      })
+      prioritySampler.sample(span)
+
+      expect(context._metrics).to.have.property('_dd.rule_psr', 0.5)
+      expect(context._metrics).to.have.property('_dd.limit_psr', 1)
+
+      delete context._sampling.priority
+
+      prioritySampler.sample(context)
+
+      expect(context._metrics).to.have.property('_dd.rule_psr', 0.5)
+      expect(context._metrics).to.have.property('_dd.limit_psr', 0.5)
     })
   })
 

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -268,6 +268,16 @@ describe('PrioritySampler', () => {
 
     it('should add metrics for rule sample rate', () => {
       prioritySampler = new PrioritySampler('test', {
+        sampleRate: 0
+      })
+      prioritySampler.sample(span)
+
+      expect(context._metrics).to.have.property('_dd.rule_psr', 0)
+      expect(context._metrics).to.not.have.property('_dd.limit_psr')
+    })
+
+    it('should add metrics for rate limiter sample rate', () => {
+      prioritySampler = new PrioritySampler('test', {
         sampleRate: 0.5,
         rateLimit: 1
       })
@@ -275,13 +285,6 @@ describe('PrioritySampler', () => {
 
       expect(context._metrics).to.have.property('_dd.rule_psr', 0.5)
       expect(context._metrics).to.have.property('_dd.limit_psr', 1)
-
-      delete context._sampling.priority
-
-      prioritySampler.sample(context)
-
-      expect(context._metrics).to.have.property('_dd.rule_psr', 0.5)
-      expect(context._metrics).to.have.property('_dd.limit_psr', 0.5)
     })
   })
 

--- a/packages/dd-trace/test/rate_limiter.spec.js
+++ b/packages/dd-trace/test/rate_limiter.spec.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const RateLimiter = require('../src/rate_limiter')
+
+describe('RateLimiter', () => {
+  let clock
+  let rateLimiter
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  it('should rate limit', () => {
+    rateLimiter = new RateLimiter(2)
+
+    expect(rateLimiter.isAllowed()).to.be.true
+    expect(rateLimiter.isAllowed()).to.be.true
+    expect(rateLimiter.isAllowed()).to.be.false
+  })
+
+  it('should support disabling the rate limit', () => {
+    rateLimiter = new RateLimiter(-1)
+
+    expect(rateLimiter.isAllowed()).to.be.true
+    expect(rateLimiter.isAllowed()).to.be.true
+    expect(rateLimiter.isAllowed()).to.be.true
+  })
+
+  it('should support always rejecting', () => {
+    rateLimiter = new RateLimiter(0)
+
+    expect(rateLimiter.isAllowed()).to.be.false
+  })
+
+  it('should reset every second', () => {
+    rateLimiter = new RateLimiter(1)
+
+    rateLimiter.isAllowed()
+
+    clock.tick(1000)
+
+    expect(rateLimiter.isAllowed()).to.be.true
+  })
+
+  it('should calculate its effective rate', () => {
+    rateLimiter = new RateLimiter(1)
+
+    expect(rateLimiter.effectiveRate()).to.equal(1)
+
+    rateLimiter.isAllowed()
+
+    expect(rateLimiter.effectiveRate()).to.equal(1)
+
+    rateLimiter.isAllowed()
+
+    expect(rateLimiter.effectiveRate()).to.equal(0.5)
+
+    rateLimiter.isAllowed()
+
+    expect(rateLimiter.effectiveRate()).to.equal(0.3333333333333333)
+  })
+
+  it('should average its effective rate with the previous rate', () => {
+    rateLimiter = new RateLimiter(1)
+
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+
+    clock.tick(1000)
+
+    rateLimiter.isAllowed()
+
+    expect(rateLimiter.effectiveRate()).to.equal(0.75)
+  })
+
+  it('should always have an effective rate of 0 when limit is 0', () => {
+    rateLimiter = new RateLimiter(0)
+
+    expect(rateLimiter.effectiveRate()).to.equal(0)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add priority sampling configuration as sampling rules.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now the sample rates are provided by the agent and cannot be configured, which is incompatible with Tracing Without Limits. By adding a configuration, it becomes possible to override the agent and take the sample rate decision in the tracer.