### PR TITLE
fix older versions of node 8 image not supported by the native addons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,7 @@ jobs:
 
   prebuild-linux-x64:
     docker:
-      - image: node:8.5.0
+      - image: node:8
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:
@@ -510,7 +510,7 @@ jobs:
 
   prebuild-linux-x32:
     docker:
-      - image: node:8.5.0
+      - image: node:8
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:
@@ -710,8 +710,24 @@ workflows:
       - node-router
       - node-when
       - node-winston
-      - prebuild-linux-x64
-      - prebuild-linux-x32
+      - prebuild-linux-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - prebuild-darwin-x64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,7 @@ jobs:
 
   prebuild-linux-x64:
     docker:
-      - image: node:8
+      - image: node:8.0.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:
@@ -510,7 +510,7 @@ jobs:
 
   prebuild-linux-x32:
     docker:
-      - image: node:8
+      - image: node:8.0.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,7 @@ jobs:
 
   prebuild-linux-x64:
     docker:
-      - image: node:8
+      - image: node:8.5.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:
@@ -510,7 +510,7 @@ jobs:
 
   prebuild-linux-x32:
     docker:
-      - image: node:8
+      - image: node:8.5.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,24 +710,8 @@ workflows:
       - node-router
       - node-when
       - node-winston
-      - prebuild-linux-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-linux-x32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x64
+      - prebuild-linux-x32
       - prebuild-darwin-x64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,7 @@ jobs:
 
   prebuild-linux-x64:
     docker:
-      - image: node:8.0.0
+      - image: node:8.5.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:
@@ -510,7 +510,7 @@ jobs:
 
   prebuild-linux-x32:
     docker:
-      - image: node:8.0.0
+      - image: node:8.5.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix older versions of Node 8 image not supported by the native addons. By building on the `node:8.5.0` image instead of `node:8` we make sure to use an older version of GLIBCXX that is supported by all Node 8 images.

### Motivation
<!-- What inspired you to submit this pull request? -->

The native addons were previously built on the `node:8` image which uses `GLIBCXX_3.4.21` which is not available in older versions of the image.