### PR TITLE
make log exporter the default only in beta versions for lambda

### DIFF
--- a/packages/dd-trace/src/platform/node/exporter.js
+++ b/packages/dd-trace/src/platform/node/exporter.js
@@ -4,9 +4,11 @@ const AgentExporter = require('../../exporters/agent')
 const LogExporter = require('../../exporters/log')
 const env = require('./env')
 const exporters = require('../../../../../ext/exporters')
+const version = require('../../../lib/version')
 
 module.exports = name => {
   const inAWSLambda = env('AWS_LAMBDA_FUNCTION_NAME') !== undefined
+  const isBeta = /^\d+\.\d+\.\d+-beta\.\d+$/.test(version) // TODO: remove when GA
 
   switch (name) {
     case exporters.LOG:
@@ -14,6 +16,6 @@ module.exports = name => {
     case exporters.AGENT:
       return AgentExporter
     default:
-      return inAWSLambda ? LogExporter : AgentExporter
+      return inAWSLambda && isBeta ? LogExporter : AgentExporter
   }
 }

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -590,17 +590,32 @@ describe('Platform', () => {
         expect(Exporter).to.be.equal(AgentExporter)
       })
 
-      it('should create an LogExporter when in lambda environment', () => {
+      it('should create an LogExporter when in Lambda environment with a beta', () => {
         const Exporter = proxyquire('../src/platform/node/exporter', {
           './env': (key) => {
             if (key === 'AWS_LAMBDA_FUNCTION_NAME') {
               return 'my-func'
             }
             return undefined
-          }
+          },
+          '../../../lib/version': '0.16.0-beta.1'
         })()
 
         expect(Exporter).to.be.equal(LogExporter)
+      })
+
+      it('should create an AgentExporter when in Lambda environment without a beta', () => {
+        const Exporter = proxyquire('../src/platform/node/exporter', {
+          './env': (key) => {
+            if (key === 'AWS_LAMBDA_FUNCTION_NAME') {
+              return 'my-func'
+            }
+            return undefined
+          },
+          '../../../lib/version': '0.16.0'
+        })()
+
+        expect(Exporter).to.be.equal(AgentExporter)
       })
 
       it('should allow configuring the exporter', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Make log exporter the default only in beta versions for Lambda.

### Motivation
<!-- What inspired you to submit this pull request? -->

We are not yet GA for using the tracer in Lambda with the log forwarder. This means public documentation doesn't yet exist and functionalities may change. Current users of the feature already use beta versions of the tracer, so this change will continue to support them while not introducing a breaking change to official releases.