### PR TITLE
add temporary hardcoded top level metric for browser plugins

### DIFF
--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -31,6 +31,9 @@ function createWrapFetch (tracer, config) {
         }
       })
 
+      // HACK: move to backend
+      span.context()._metrics._top_level = 1
+
       if (type === REFERENCE_CHILD_OF) {
         init = inject(init, tracer, span, url.origin)
       }

--- a/packages/datadog-plugin-xmlhttprequest/src/index.js
+++ b/packages/datadog-plugin-xmlhttprequest/src/index.js
@@ -37,6 +37,9 @@ function createWrapSend (tracer, config) {
         }
       })
 
+      // HACK: move to backend
+      span.context()._metrics._top_level = 1
+
       if (type === REFERENCE_CHILD_OF) {
         inject(this, tracer, span)
       }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add temporary hardcoded top level metric for browser plugins.

### Motivation
<!-- What inspired you to submit this pull request? -->

This metric is currently required by the backend, and historically the agent was in charge of setting it on traces. Since there is no agent for browser tracing, this processing should be moved to the backend, but in the meantime we can hardcode it in the browser plugins.