### PR TITLE
add support for global tags in runtime metrics

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -321,7 +321,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | dogstatsd.port | `DD_DOGSTATSD_PORT`            | `8125`      | The port of the Dogstatsd agent that metrics will be submitted to. |
 | env            | `DD_ENV`                       | -           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
 | logInjection   | `DD_LOGS_INJECTION`            | `false`     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| tags           | -                              | `{}`        | Set global tags that should be applied to all spans. |
+| tags           | `DD_TAGS`                      | `{}`        | Set global tags that should be applied to all spans and metrics. |
 | sampleRate     | -                              | `1`         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval  | -                              | `2000`      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED`   | `false`     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -321,7 +321,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | dogstatsd.port | `DD_DOGSTATSD_PORT`            | `8125`      | The port of the Dogstatsd agent that metrics will be submitted to. |
 | env            | `DD_ENV`                       | -           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
 | logInjection   | `DD_LOGS_INJECTION`            | `false`     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| tags           | `DD_TAGS`                      | `{}`        | Set global tags that should be applied to all spans and metrics. |
+| tags           | `DD_TAGS`                      | `{}`        | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value,key:value` |
 | sampleRate     | -                              | `1`         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval  | -                              | `2000`      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED`   | `false`     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -4,6 +4,7 @@ const URL = require('url-parse')
 const platform = require('./platform')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
+const tagger = require('./tagger')
 
 class Config {
   constructor (service, options) {
@@ -33,6 +34,11 @@ class Config {
     const reportHostname = coalesce(options.reportHostname, platform.env('DD_TRACE_REPORT_HOSTNAME'), false)
     const scope = coalesce(options.scope, platform.env('DD_TRACE_SCOPE'))
     const clientToken = coalesce(options.clientToken, platform.env('DD_CLIENT_TOKEN'))
+    const tags = {}
+
+    tagger.add(tags, platform.env('DD_TAGS'))
+    tagger.add(tags, platform.env('DD_TRACE_TAGS'))
+    tagger.add(tags, options.tags)
 
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
@@ -47,7 +53,7 @@ class Config {
     this.plugins = !!plugins
     this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
     this.analytics = String(analytics) === 'true'
-    this.tags = Object.assign({}, options.tags)
+    this.tags = tags
     this.dogstatsd = {
       port: String(coalesce(dogstatsd.port, platform.env('DD_DOGSTATSD_PORT'), 8125))
     }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -38,6 +38,7 @@ class Config {
 
     tagger.add(tags, platform.env('DD_TAGS'))
     tagger.add(tags, platform.env('DD_TRACE_TAGS'))
+    tagger.add(tags, platform.env('DD_TRACE_GLOBAL_TAGS'))
     tagger.add(tags, options.tags)
 
     this.enabled = String(enabled) === 'true'

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -5,7 +5,6 @@ const Span = opentracing.Span
 const truncate = require('lodash.truncate')
 const SpanContext = require('./span_context')
 const platform = require('../platform')
-const log = require('../log')
 const constants = require('../constants')
 const id = require('../id')
 const tagger = require('../tagger')

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -8,6 +8,7 @@ const platform = require('../platform')
 const log = require('../log')
 const constants = require('../constants')
 const id = require('../id')
+const tagger = require('../tagger')
 
 const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 
@@ -99,36 +100,7 @@ class DatadogSpan extends Span {
   }
 
   _addTags (keyValuePairs) {
-    if (!keyValuePairs) return
-
-    if (typeof keyValuePairs === 'string') {
-      return this._addTags(
-        keyValuePairs
-          .split(',')
-          .filter(tag => tag.indexOf(':') !== -1)
-          .reduce((prev, next) => {
-            const tag = next.split(':')
-            const key = tag[0]
-            const value = tag.slice(1).join(':')
-
-            prev[key] = value
-
-            return prev
-          }, {})
-      )
-    }
-
-    if (Array.isArray(keyValuePairs)) {
-      return keyValuePairs.forEach(tags => this._addTags(tags))
-    }
-
-    try {
-      Object.keys(keyValuePairs).forEach(key => {
-        this._spanContext._tags[key] = keyValuePairs[key]
-      })
-    } catch (e) {
-      log.error(e)
-    }
+    tagger.add(this._spanContext._tags, keyValuePairs)
   }
 
   _finish (finishTime) {

--- a/packages/dd-trace/src/platform/node/metrics.js
+++ b/packages/dd-trace/src/platform/node/metrics.js
@@ -31,6 +31,15 @@ module.exports = function () {
         tags.push(`env:${this._config.env}`)
       }
 
+      Object.keys(this._config.tags)
+        .filter(key => typeof this._config.tags[key] === 'string')
+        .forEach(key => {
+          // https://docs.datadoghq.com/tagging/#defining-tags
+          const value = this._config.tags[key].replace(/[^a-z0-9_:./-]/ig, '_')
+
+          tags.push(`${key}:${value}`)
+        })
+
       options = options || {}
 
       try {

--- a/packages/dd-trace/src/tagger.js
+++ b/packages/dd-trace/src/tagger.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const log = require('./log')
+
+function add (carrier, keyValuePairs) {
+  if (!carrier || !keyValuePairs) return
+
+  if (typeof keyValuePairs === 'string') {
+    return add(
+      carrier,
+      keyValuePairs
+        .split(',')
+        .filter(tag => tag.indexOf(':') !== -1)
+        .reduce((prev, next) => {
+          const tag = next.split(':')
+          const key = tag[0]
+          const value = tag.slice(1).join(':')
+
+          prev[key] = value
+
+          return prev
+        }, {})
+    )
+  }
+
+  if (Array.isArray(keyValuePairs)) {
+    return keyValuePairs.forEach(tags => add(carrier, tags))
+  }
+
+  try {
+    Object.keys(keyValuePairs).forEach(key => {
+      carrier[key] = keyValuePairs[key]
+    })
+  } catch (e) {
+    log.error(e)
+  }
+}
+
+module.exports = { add }

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -53,7 +53,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_REPORT_HOSTNAME').returns('true')
     platform.env.withArgs('DD_ENV').returns('test')
     platform.env.withArgs('DD_CLIENT_TOKEN').returns('789')
-    platform.env.withArgs('DD_TRACE_TAGS').returns('foo:bar,baz:qux')
+    platform.env.withArgs('DD_TRACE_GLOBAL_TAGS').returns('foo:bar,baz:qux')
 
     const config = new Config()
 
@@ -183,7 +183,7 @@ describe('Config', () => {
   it('should give priority to the common agent environment variable', () => {
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('trace-agent')
     platform.env.withArgs('DD_AGENT_HOST').returns('agent')
-    platform.env.withArgs('DD_TRACE_TAGS').returns('foo:foo')
+    platform.env.withArgs('DD_TRACE_GLOBAL_TAGS').returns('foo:foo')
     platform.env.withArgs('DD_TAGS').returns('foo:bar,baz:qux')
 
     const config = new Config()
@@ -206,7 +206,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_ENV').returns('test')
     platform.env.withArgs('DD_API_KEY').returns('123')
     platform.env.withArgs('DD_APP_KEY').returns('456')
-    platform.env.withArgs('DD_TRACE_TAGS').returns('foo:bar,baz:qux')
+    platform.env.withArgs('DD_TRACE_GLOBAL_TAGS').returns('foo:bar,baz:qux')
 
     const config = new Config('test', {
       enabled: true,

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -53,6 +53,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_REPORT_HOSTNAME').returns('true')
     platform.env.withArgs('DD_ENV').returns('test')
     platform.env.withArgs('DD_CLIENT_TOKEN').returns('789')
+    platform.env.withArgs('DD_TRACE_TAGS').returns('foo:bar,baz:qux')
 
     const config = new Config()
 
@@ -66,6 +67,7 @@ describe('Config', () => {
     expect(config).to.have.property('reportHostname', true)
     expect(config).to.have.property('env', 'test')
     expect(config).to.have.property('clientToken', '789')
+    expect(config).to.have.deep.property('tags', { foo: 'bar', baz: 'qux' })
   })
 
   it('should initialize from environment variables with url taking precedence', () => {
@@ -181,10 +183,13 @@ describe('Config', () => {
   it('should give priority to the common agent environment variable', () => {
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('trace-agent')
     platform.env.withArgs('DD_AGENT_HOST').returns('agent')
+    platform.env.withArgs('DD_TRACE_TAGS').returns('foo:foo')
+    platform.env.withArgs('DD_TAGS').returns('foo:bar,baz:qux')
 
     const config = new Config()
 
     expect(config).to.have.property('hostname', 'agent')
+    expect(config).to.have.deep.property('tags', { foo: 'foo', baz: 'qux' })
   })
 
   it('should give priority to the options', () => {
@@ -201,6 +206,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_ENV').returns('test')
     platform.env.withArgs('DD_API_KEY').returns('123')
     platform.env.withArgs('DD_APP_KEY').returns('456')
+    platform.env.withArgs('DD_TRACE_TAGS').returns('foo:bar,baz:qux')
 
     const config = new Config('test', {
       enabled: true,
@@ -216,7 +222,10 @@ describe('Config', () => {
       reportHostname: false,
       service: 'test',
       env: 'development',
-      clientToken: '789'
+      clientToken: '789',
+      tags: {
+        foo: 'foo'
+      }
     })
 
     expect(config).to.have.property('enabled', true)
@@ -231,6 +240,7 @@ describe('Config', () => {
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
     expect(config).to.have.property('clientToken', '789')
+    expect(config).to.have.deep.property('tags', { foo: 'foo', baz: 'qux' })
   })
 
   it('should give priority to the options especially url', () => {

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -394,6 +394,11 @@ describe('Platform', () => {
             hostname: 'localhost',
             dogstatsd: {
               port: 8125
+            },
+            tags: {
+              str: 'bar',
+              obj: {},
+              invalid: 't{e*s#t5-:./'
             }
           },
           name: sinon.stub().returns('nodejs'),
@@ -417,7 +422,9 @@ describe('Platform', () => {
             host: 'localhost',
             tags: [
               'service:service',
-              'env:test'
+              'env:test',
+              'str:bar',
+              'invalid:t_e_s_t5-:./'
             ]
           })
         })

--- a/packages/dd-trace/test/tagger.spec.js
+++ b/packages/dd-trace/test/tagger.spec.js
@@ -1,0 +1,46 @@
+'use strict'
+
+describe('tagger', () => {
+  let carrier
+  let tagger
+
+  beforeEach(() => {
+    tagger = require('../src/tagger')
+    carrier = {}
+  })
+
+  it('should add tags as an object', () => {
+    tagger.add(carrier, { foo: 'bar' })
+
+    expect(carrier).to.have.property('foo', 'bar')
+  })
+
+  it('should add tags as a string', () => {
+    tagger.add(carrier, 'foo:bar,baz:qux:quxx,invalid')
+
+    expect(carrier).to.have.property('foo', 'bar')
+    expect(carrier).to.have.property('baz', 'qux:quxx')
+    expect(carrier).to.not.have.property('invalid')
+  })
+
+  it('should add tags as an array', () => {
+    tagger.add(carrier, ['foo:bar', 'baz:qux'])
+
+    expect(carrier).to.have.property('foo', 'bar')
+    expect(carrier).to.have.property('baz', 'qux')
+  })
+
+  it('should store the original values', () => {
+    tagger.add(carrier, { foo: 123 })
+
+    expect(carrier).to.have.property('foo', 123)
+  })
+
+  it('should handle missing key/value pairs', () => {
+    expect(() => tagger.add(carrier)).not.to.throw()
+  })
+
+  it('should handle missing carrier', () => {
+    expect(() => tagger.add()).not.to.throw()
+  })
+})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for global tags in runtime metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

Global tags are expected to be added to every data that the tracer reports.