### PR TITLE
update linux prebuilds to use ubuntu 14.04 to get an older glibcxx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,9 +484,9 @@ jobs:
       - store_artifacts:
           path: ./docs/out
 
-  prebuild-linux-x64:
+  prebuild-linux-x64: &prebuild-linux-x64
     docker:
-      - image: node:8.5.0
+      - image: node:10.0.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:
@@ -508,17 +508,14 @@ jobs:
           paths:
             - ./prebuilds
 
-  prebuild-linux-x32:
+  prebuild-linux-x32: &prebuild-linux-x32
     docker:
-      - image: node:8.5.0
+      - image: node:10.0.0
     working_directory: ~/dd-trace-js
     resource_class: small
     environment:
       - ARCH=x32
     steps:
-      - run:
-          name: Install job dependencies
-          command: apt-get update && apt-get install -y g++-multilib
       - checkout
       - *yarn-versions
       - *restore-yarn-cache
@@ -527,6 +524,22 @@ jobs:
       - *yarn-prebuild
       - store_artifacts:
           path: ./addons-linux-x32.tgz
+
+  prebuild-linux-x64-legacy:
+    <<: *prebuild-linux-x64
+    docker:
+      - image: rochdev/holy-node-box
+    environment:
+      - ARCH=x64
+      - NODE_ABI=57,59
+
+  prebuild-linux-x32-legacy:
+    <<: *prebuild-linux-x32
+    docker:
+      - image: rochdev/holy-node-box
+    environment:
+      - ARCH=x32
+      - NODE_ABI=57,59
 
   prebuild-darwin-x64:
     macos:
@@ -710,24 +723,10 @@ workflows:
       - node-router
       - node-when
       - node-winston
-      - prebuild-linux-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-linux-x32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x64
+      - prebuild-linux-x32
+      - prebuild-linux-x64-legacy
+      - prebuild-linux-x32-legacy
       - prebuild-darwin-x64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,7 +502,7 @@ jobs:
           name: Compile prebuilt binaries
           command: yarn prebuild
       - store_artifacts:
-          path: ./addons-linux-x64.tgz
+          path: ./prebuilds
       - save_cache:
           key: '{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}'
           paths:
@@ -526,7 +526,7 @@ jobs:
       - *save-yarn-cache
       - *yarn-prebuild
       - store_artifacts:
-          path: ./addons-linux-x32.tgz
+          path: ./prebuilds
 
   prebuild-linux-x64-legacy:
     <<: *prebuild-linux-x64
@@ -544,7 +544,7 @@ jobs:
       - ARCH=x32
       - NODE_ABI=57,59
 
-  prebuild-darwin-x64:
+  prebuild-darwin-x64: &prebuild-darwin
     macos:
       xcode: "10.2.0"
     working_directory: ~/dd-trace-js
@@ -559,26 +559,14 @@ jobs:
       - *save-yarn-cache
       - *yarn-prebuild
       - store_artifacts:
-          path: ./addons-darwin-x64.tgz
+          path: ./prebuilds
 
   prebuild-darwin-x32:
-    macos:
-      xcode: "10.2.0"
-    working_directory: ~/dd-trace-js
-    resource_class: medium
+    <<: *prebuild-darwin
     environment:
       - ARCH=x32
-    steps:
-      - checkout
-      - *yarn-versions
-      - *restore-yarn-cache
-      - *yarn-install
-      - *save-yarn-cache
-      - *yarn-prebuild
-      - store_artifacts:
-          path: ./addons-darwin-x32.tgz
 
-  prebuild-win32-x64:
+  prebuild-win32-x64: &prebuild-win32
     executor: win/vs2019
     working_directory: ~/dd-trace-js
     environment:
@@ -591,22 +579,12 @@ jobs:
       - *save-yarn-cache
       - *yarn-prebuild
       - store_artifacts:
-          path: ./addons-win32-x64.tgz
+          path: ./prebuilds
 
   prebuild-win32-ia32:
-    executor: win/vs2019
-    working_directory: ~/dd-trace-js
+    <<: *prebuild-win32
     environment:
       - ARCH=ia32
-    steps:
-      - checkout
-      - *yarn-versions
-      - *restore-yarn-cache
-      - *yarn-install
-      - *save-yarn-cache
-      - *yarn-prebuild
-      - store_artifacts:
-          path: ./addons-win32-ia32.tgz
 
   alpine:
     docker:
@@ -726,46 +704,22 @@ workflows:
       - node-router
       - node-when
       - node-winston
-      - prebuild-linux-x64
+      - prebuild-linux-x64 #:
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
+          #       - /v\d+\.\d+/
+          #   tags:
+          #     only:
+          #       - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - prebuild-linux-x32
       - prebuild-linux-x64-legacy
       - prebuild-linux-x32-legacy
-      - prebuild-darwin-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-darwin-x32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-win32-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-win32-ia32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-darwin-x64
+      - prebuild-darwin-x32
+      - prebuild-win32-x64
+      - prebuild-win32-ia32
       - alpine
       - alpine-prebuilt:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,9 @@ jobs:
     environment:
       - ARCH=x32
     steps:
+      - run:
+          name: Install job dependencies
+          command: apt-get update && apt-get install -y g++-multilib
       - checkout
       - *yarn-versions
       - *restore-yarn-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,22 +704,78 @@ workflows:
       - node-router
       - node-when
       - node-winston
-      - prebuild-linux-x64 #:
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
-          #       - /v\d+\.\d+/
-          #   tags:
-          #     only:
-          #       - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-linux-x32
-      - prebuild-linux-x64-legacy
-      - prebuild-linux-x32-legacy
-      - prebuild-darwin-x64
-      - prebuild-darwin-x32
-      - prebuild-win32-x64
-      - prebuild-win32-ia32
+      - prebuild-linux-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x64-legacy:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x32-legacy:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-darwin-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-darwin-x32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-win32-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-win32-ia32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - alpine
       - alpine-prebuilt:
           requires:

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -52,6 +52,7 @@ dev,karma-chrome-launcher,MIT,Copyright 2011-2013 Google, Inc.
 dev,karma-firefox-launcher,MIT,Copyright 2011-2013 Google, Inc.
 dev,karma-mocha,MIT,Copyright 2011-2013 Google, Inc.
 dev,karma-webpack,MIT,Copyright JS Foundation and other contributors
+dev,mkdirp,MIT,Copyright 2010 James Halliday
 dev,mocha,MIT,Copyright 2011-2018 JS Foundation and contributors https://js.foundation
 dev,nock,MIT,Copyright 2017 Pedro Teixeira and other contributors
 dev,nyc,ISC,Copyright 2015 Contributors

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "karma-firefox-launcher": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-webpack": "^4.0.2",
+    "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
     "nock": "^11.3.3",
     "nyc": "^14.1.1",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -26,8 +26,8 @@ prebuildify()
 function prebuildify () {
   const cache = path.join(os.tmpdir(), 'prebuilds')
 
-  mkdirp(cache)
-  mkdirp(`prebuilds/${platform}-${arch}`)
+  mkdirp.sync(cache)
+  mkdirp.sync(`prebuilds/${platform}-${arch}`)
 
   targets.forEach(target => {
     const cmd = [

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -2,13 +2,12 @@
 
 const path = require('path')
 const os = require('os')
-const tar = require('tar')
 const fs = require('fs')
+const mkdirp = require('mkdirp')
 const execSync = require('child_process').execSync
 
 const platform = os.platform()
 const arch = process.env.ARCH || os.arch()
-const name = `${platform}-${arch}`
 
 const { NODE_ABI = '64,67,72,79' } = process.env
 
@@ -23,14 +22,12 @@ const targets = [
 ].filter(target => !NODE_ABI || NODE_ABI.split(',').some(abi => target.abi === abi))
 
 prebuildify()
-pack()
 
 function prebuildify () {
   const cache = path.join(os.tmpdir(), 'prebuilds')
 
-  mkdirSafe(cache)
-  mkdirSafe('prebuilds')
-  mkdirSafe(`prebuilds/${platform}-${arch}`)
+  mkdirp(cache)
+  mkdirp(`prebuilds/${platform}-${arch}`)
 
   targets.forEach(target => {
     const cmd = [
@@ -47,34 +44,4 @@ function prebuildify () {
 
     fs.copyFileSync('build/Release/metrics.node', `prebuilds/${platform}-${arch}/node-${target.abi}.node`)
   })
-}
-
-function pack () {
-  fs.copyFileSync(
-    path.join(__dirname, '..', 'packages', 'dd-trace', 'src', 'native', 'tdigest', 'NOTICES'),
-    path.join(__dirname, '..', 'prebuilds', 'NOTICES')
-  )
-
-  fs.copyFileSync(
-    path.join(__dirname, '..', 'packages', 'dd-trace', 'src', 'native', 'tdigest', 'LICENSE-2.0.txt'),
-    path.join(__dirname, '..', 'prebuilds', 'LICENSE-2.0.txt')
-  )
-
-  tar.create({
-    gzip: true,
-    sync: true,
-    portable: true,
-    file: `addons-${name}.tgz`,
-    cwd: path.join(__dirname, '..')
-  }, [
-    `prebuilds/${platform}-${arch}`,
-    'prebuilds/NOTICES',
-    'prebuilds/LICENSE-2.0.txt'
-  ])
-}
-
-function mkdirSafe (filename) {
-  if (!fs.existsSync(filename)) {
-    fs.mkdirSync(filename)
-  }
 }

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -10,6 +10,8 @@ const platform = os.platform()
 const arch = process.env.ARCH || os.arch()
 const name = `${platform}-${arch}`
 
+const { NODE_ABI = '64,67,72,79' } = process.env
+
 // https://nodejs.org/en/download/releases/
 const targets = [
   { version: '8.0.0', abi: '57' },
@@ -18,18 +20,10 @@ const targets = [
   { version: '11.0.0', abi: '67' },
   { version: '12.0.0', abi: '72' },
   { version: '13.0.0', abi: '79' }
-]
+].filter(target => !NODE_ABI || NODE_ABI.split(',').some(abi => target.abi === abi))
 
 prebuildify()
 pack()
-
-function retry (cmd) {
-  try {
-    execSync(cmd, { stdio: [0, 1, 2] })
-  } catch (e) {
-    retry(cmd)
-  }
-}
 
 function prebuildify () {
   const cache = path.join(os.tmpdir(), 'prebuilds')
@@ -49,7 +43,7 @@ function prebuildify () {
       '--enable_lto=false'
     ].join(' ')
 
-    retry(cmd)
+    execSync(cmd, { stdio: [0, 1, 2] })
 
     fs.copyFileSync('build/Release/metrics.node', `prebuilds/${platform}-${arch}/node-${target.abi}.node`)
   })

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -4,6 +4,7 @@
 
 const axios = require('axios')
 const fs = require('fs')
+const mkdirp = require('mkdirp')
 const os = require('os')
 const path = require('path')
 const tar = require('tar')
@@ -143,12 +144,14 @@ function downloadArtifacts (artifacts) {
 function downloadArtifact (artifact) {
   return fetch(artifact.url, { responseType: 'stream' })
     .then(response => {
-      const filename = artifact.url.split('/')
-        .slice(-3)
-        .join(path.sep)
+      const parts = artifact.url.split('/')
+      const basename = path.join(os.tmpdir(), parts.slice(-3, -1).join(path.sep))
+      const filename = parts.slice(-1)
+
+      mkdirp.sync(basename)
 
       return new Promise((resolve, reject) => {
-        response.data.pipe(fs.createWriteStream(path.join(os.tmpdir(), filename)))
+        response.data.pipe(fs.createWriteStream(path.join(basename, filename)))
           .on('finish', () => resolve())
           .on('error', reject)
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update linux prebuilds to use Ubuntu 14.04 with gcc 4.7. The release scripts had to be updated since this change means a single platform is now split across multiple CircleCI jobs.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now we are building on the `node:8.5.0` image which uses gcc 4.9 which supports GLIBCXX 3.4.20+. Some users are not using an official Node image and may be using older operating systems with a lower version support. By using Ubuntu 14.04 with gcc 4.7 instead, we support as low as GLIBCXX 3.4.17 which is the minimum version on which Node 8 itself is able to build. Any lower version is not supported by Node 8, meaning we now have full support for any glibc version supported by Node.