### PR TITLE
fix runtime metrics in node 8 for windows and mac

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -9,7 +9,7 @@ const execSync = require('child_process').execSync
 const platform = os.platform()
 const arch = process.env.ARCH || os.arch()
 
-const { NODE_ABI = '64,67,72,79' } = process.env
+const { NODE_ABI } = process.env
 
 // https://nodejs.org/en/download/releases/
 const targets = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix runtime metrics in Node 8 for Windows and macOS.

### Motivation
<!-- What inspired you to submit this pull request? -->

The new release scripts were configured to skip Node 8 by default, and it's only explicitly added in Linux.