### PR TITLE
remove tagging in version script

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -33,8 +33,6 @@ add('package.json')
 add('packages/dd-trace/lib/version.js')
 exec(`git commit -m "${tag}"`)
 exec(`git push -u origin HEAD`)
-exec(`git tag ${tag}`)
-exec(`git push origin refs/tags/${tag}`)
 
 function getIncrement () {
   const increments = ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove tagging in version script.

### Motivation
<!-- What inspired you to submit this pull request? -->

By adding the tag as a release in the UI instead, we avoid tagging too quickly before the release PR was actually approved.