### PR TITLE
add environment variables to configure the priority sampler

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -45,7 +45,7 @@ class Config {
 
     Object.assign(sampler, {
       sampleRate: coalesce(sampler.sampleRate, platform.env('DD_SAMPLE_RATE')),
-      rateLimit: coalesce(sampler.sampleRate, platform.env('DD_RATE_LIMIT'))
+      rateLimit: coalesce(sampler.rateLimit, platform.env('DD_RATE_LIMIT'))
     })
 
     this.enabled = String(enabled) === 'true'

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -41,6 +41,13 @@ class Config {
     tagger.add(tags, platform.env('DD_TRACE_GLOBAL_TAGS'))
     tagger.add(tags, options.tags)
 
+    const sampler = (options.experimental && options.experimental.sampler) || {}
+
+    Object.assign(sampler, {
+      sampleRate: coalesce(sampler.sampleRate, platform.env('DD_SAMPLE_RATE')),
+      rateLimit: coalesce(sampler.sampleRate, platform.env('DD_RATE_LIMIT'))
+    })
+
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.logInjection = String(logInjection) === 'true'
@@ -64,7 +71,7 @@ class Config {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: options.experimental && options.experimental.exporter,
       peers: (options.experimental && options.experimental.peers) || [],
-      sampler: (options.experimental && options.experimental.sampler) || {}
+      sampler
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -122,7 +122,11 @@ describe('Config', () => {
       clientToken: '789',
       logLevel: logLevel,
       experimental: {
-        b3: true
+        b3: true,
+        sampler: {
+          sampleRate: 1,
+          rateLimit: 1000
+        }
       }
     })
 
@@ -149,6 +153,7 @@ describe('Config', () => {
       'foo': 'bar'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
+    expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: 1, rateLimit: 1000 })
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -54,6 +54,8 @@ describe('Config', () => {
     platform.env.withArgs('DD_ENV').returns('test')
     platform.env.withArgs('DD_CLIENT_TOKEN').returns('789')
     platform.env.withArgs('DD_TRACE_GLOBAL_TAGS').returns('foo:bar,baz:qux')
+    platform.env.withArgs('DD_SAMPLE_RATE').returns('0.5')
+    platform.env.withArgs('DD_RATE_LIMIT').returns('-1')
 
     const config = new Config()
 
@@ -68,6 +70,7 @@ describe('Config', () => {
     expect(config).to.have.property('env', 'test')
     expect(config).to.have.property('clientToken', '789')
     expect(config).to.have.deep.property('tags', { foo: 'bar', baz: 'qux' })
+    expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: '0.5', rateLimit: '-1' })
   })
 
   it('should initialize from environment variables with url taking precedence', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add environment variables to configure the priority sampler.

### Motivation
<!-- What inspired you to submit this pull request? -->

It makes it easier to configure the values in different environments. It will also be easier to migrate to the new configuration since the environment variables won't change.