### PR TITLE
add rum context as tags to browser traces

### DIFF
--- a/packages/dd-trace/src/platform/browser/tags.js
+++ b/packages/dd-trace/src/platform/browser/tags.js
@@ -3,4 +3,9 @@
 const bowser = require('bowser/bundled')
 const navigator = bowser.parse(window.navigator.userAgent)
 
-module.exports = () => ({ navigator })
+module.exports = () => {
+  const rum = window.DD_RUM
+  const context = rum && rum.getInternalContext && rum.getInternalContext()
+
+  return { navigator, ...context }
+}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add RUM context as tags to browser traces.

### Motivation
<!-- What inspired you to submit this pull request? -->

This will allow correlating between RUM and APM.