### PR TITLE
fix wrong artifact used for node 8 on linux when releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,14 +710,78 @@ workflows:
       - node-router
       - node-when
       - node-winston
-      - prebuild-linux-x64
-      - prebuild-linux-x32
-      - prebuild-linux-x64-legacy
-      - prebuild-linux-x32-legacy
-      - prebuild-darwin-x64
-      - prebuild-darwin-x32
-      - prebuild-win32-x64
-      - prebuild-win32-ia32
+      - prebuild-linux-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x64-legacy:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x32-legacy:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-darwin-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-darwin-x32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-win32-x64:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-win32-ia32:
+          filters:
+            branches:
+              only:
+                - master
+                - /v\d+\.\d+/
+            tags:
+              only:
+                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - alpine
       - alpine-prebuilt:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,6 +491,7 @@ jobs:
     resource_class: small
     environment:
       - ARCH=x64
+      - NODE_VERSIONS=>=10
     steps:
       - checkout
       - *yarn-versions
@@ -515,6 +516,7 @@ jobs:
     resource_class: small
     environment:
       - ARCH=x32
+      - NODE_VERSIONS=>=10
     steps:
       - run:
           name: Install job dependencies
@@ -534,7 +536,7 @@ jobs:
       - image: rochdev/holy-node-box
     environment:
       - ARCH=x64
-      - NODE_ABI=57,59
+      - NODE_VERSIONS=<10
 
   prebuild-linux-x32-legacy:
     <<: *prebuild-linux-x32
@@ -542,7 +544,7 @@ jobs:
       - image: rochdev/holy-node-box
     environment:
       - ARCH=x32
-      - NODE_ABI=57,59
+      - NODE_VERSIONS=<10
 
   prebuild-darwin-x64: &prebuild-darwin
     macos:
@@ -551,6 +553,7 @@ jobs:
     resource_class: medium
     environment:
       - ARCH=x64
+      - NODE_VERSIONS=*
     steps:
       - checkout
       - *yarn-versions
@@ -565,12 +568,14 @@ jobs:
     <<: *prebuild-darwin
     environment:
       - ARCH=x32
+      - NODE_VERSIONS=*
 
   prebuild-win32-x64: &prebuild-win32
     executor: win/vs2019
     working_directory: ~/dd-trace-js
     environment:
       - ARCH=x64
+      - NODE_VERSIONS=*
     steps:
       - checkout
       - *yarn-versions
@@ -585,6 +590,7 @@ jobs:
     <<: *prebuild-win32
     environment:
       - ARCH=ia32
+      - NODE_VERSIONS=*
 
   alpine:
     docker:
@@ -704,78 +710,14 @@ workflows:
       - node-router
       - node-when
       - node-winston
-      - prebuild-linux-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-linux-x32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-linux-x64-legacy:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-linux-x32-legacy:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-darwin-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-darwin-x32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-win32-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-win32-ia32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+/
-            tags:
-              only:
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
+      - prebuild-linux-x64
+      - prebuild-linux-x32
+      - prebuild-linux-x64-legacy
+      - prebuild-linux-x32-legacy
+      - prebuild-darwin-x64
+      - prebuild-darwin-x32
+      - prebuild-win32-x64
+      - prebuild-win32-ia32
       - alpine
       - alpine-prebuilt:
           requires:

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -5,11 +5,12 @@ const os = require('os')
 const fs = require('fs')
 const mkdirp = require('mkdirp')
 const execSync = require('child_process').execSync
+const semver = require('semver')
 
 const platform = os.platform()
 const arch = process.env.ARCH || os.arch()
 
-const { NODE_ABI } = process.env
+const { NODE_VERSIONS = '>=10' } = process.env
 
 // https://nodejs.org/en/download/releases/
 const targets = [
@@ -19,7 +20,7 @@ const targets = [
   { version: '11.0.0', abi: '67' },
   { version: '12.0.0', abi: '72' },
   { version: '13.0.0', abi: '79' }
-].filter(target => !NODE_ABI || NODE_ABI.split(',').some(abi => target.abi === abi))
+].filter(target => semver.satisfies(target.version, NODE_VERSIONS))
 
 prebuildify()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix wrong artifact used for node 8 on linux when releasing.

### Motivation
<!-- What inspired you to submit this pull request? -->

The native extensions for Node 8 were built twice, once with the correct GLIBCXX and once with an incorrect GLIBCXX. When releasing, both were added to the same zip in random order depending on which one would download first. If the wrong version was added to the zip last, it would cause segmentation faults.