### PR TITLE
update prepublish script to use last workflow run instead of first

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -84,10 +84,17 @@ function getWorkflowId (pipeline) {
   return fetch(`pipeline/${pipeline.id}`)
     .then(response => {
       const workflows = response.data.workflows
-      const workflow = workflows[workflows.length - 1]
+        .sort((a, b) => (a.stopped_at < b.stopped_at) ? 1 : -1)
+      const running = workflows.find(workflow => !workflow.stopped_at)
+
+      if (running) {
+        throw new Error(`Workflow ${running.id} is still running for pipeline ${pipeline.id}.`)
+      }
+
+      const workflow = workflows[0]
 
       if (!workflow) {
-        throw new Error(`Unable to find CircleCI workflow for pipeline ${workflow.id}.`)
+        throw new Error(`Unable to find CircleCI workflow for pipeline ${pipeline.id}.`)
       }
 
       return workflow.id

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -83,7 +83,8 @@ function getPipeline () {
 function getWorkflowId (pipeline) {
   return fetch(`pipeline/${pipeline.id}`)
     .then(response => {
-      const workflow = response.data.workflows[0]
+      const workflows = response.data.workflows
+      const workflow = workflows[workflows.length - 1]
 
       if (!workflow) {
         throw new Error(`Unable to find CircleCI workflow for pipeline ${workflow.id}.`)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update prepublish script to use last workflow run instead of first.

### Motivation
<!-- What inspired you to submit this pull request? -->

If a workflow fails, subsequent runs will otherwise be ignored and will prevent releases.