### PR TITLE
fix fetch plugin dropping headers when calling non-peers

### DIFF
--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -76,7 +76,9 @@ function inject (init, tracer, span, origin) {
   const format = window.ddtrace.ext.formats.HTTP_HEADERS
   const peers = tracer._peers
 
-  if (origin !== window.location.origin && peers.indexOf(origin) === -1) return
+  if (origin !== window.location.origin && peers.indexOf(origin) === -1) {
+    return init
+  }
 
   init = init || {}
   init.headers = init.headers || {}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix fetch plugin dropping headers when calling non-peers.

### Motivation
<!-- What inspired you to submit this pull request? -->

Headers would be dropped when calling non-peers since the init options would not be returned from the propagator.