### PR TITLE
fix tracer exception because of missing metrics api method

### DIFF
--- a/packages/dd-trace/src/platform/browser/metrics.js
+++ b/packages/dd-trace/src/platform/browser/metrics.js
@@ -16,9 +16,13 @@ module.exports = function () {
       }
     },
 
+    boolean () {},
+
     histogram () {},
 
     count () {},
+
+    gauge () {},
 
     increment () {},
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix tracer exception because of missing metrics api method.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `boolean` and `gauge` methods were added to Node in the runtime metrics, but not in the browser. This resulted in an exception and some parts of the tracer not working.