### PR TITLE
fix xhr errors throwing in sync mode

### DIFF
--- a/packages/datadog-plugin-xmlhttprequest/src/index.js
+++ b/packages/datadog-plugin-xmlhttprequest/src/index.js
@@ -48,7 +48,14 @@ function createWrapSend (tracer, config) {
       this.addEventListener('load', () => span.setTag('http.status', this.status))
       this.addEventListener('loadend', () => span.finish())
 
-      return tracer.scope().bind(send, span).apply(this, arguments)
+      try {
+        return tracer.scope().bind(send, span).apply(this, arguments)
+      } catch (e) {
+        span.setTag('error', e)
+        span.finish()
+
+        throw e
+      }
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix XMLHttpRequest errors throwing in sync mode.

### Motivation
<!-- What inspired you to submit this pull request? -->

When a request is sent in sync mode and fails, the `send` method throws instead of emitting an `error` event. This meant that we were not finishing the spans properly.