### PR TITLE
fix error in graphql plugin with unpatched context values

### DIFF
--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -31,9 +31,7 @@ function createWrapExecute (tracer, config, defaultFieldResolver) {
 
       const span = startExecutionSpan(tracer, config, operation, args)
 
-      Object.defineProperty(contextValue, '_datadog_graphql', {
-        value: { source, span, fields: {} }
-      })
+      contextValue._datadog_graphql = { source, span, fields: {} }
 
       return call(execute, span, this, [args], (err, res) => {
         finishResolvers(contextValue)
@@ -135,6 +133,8 @@ function wrapResolve (resolve, tracer, config) {
     : pathToArray
 
   function resolveWithTrace (source, args, contextValue, info) {
+    if (!contextValue._datadog_graphql) return resolve.apply(this, arguments)
+
     const path = responsePathAsArray(info.path)
     const depth = path.filter(item => typeof item === 'string').length
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix error in `graphql` plugin with unpatched context values.

### Motivation
<!-- What inspired you to submit this pull request? -->

It's possible when using Apollo that resolvers receive a context value that was not patched by the tracer, but in general it should never be the case. A test was not added since I don't know how to reproduce.