### PR TITLE
update build scripts to use a single prebuilds artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -762,10 +762,20 @@ jobs:
     working_directory: ~/dd-trace-js
     resource_class: small
     steps:
+      - checkout
       - attach_workspace:
           at: ~/dd-trace-js
+      - *yarn-versions
+      - *restore-yarn-cache
+      - *yarn-install
+      - *save-yarn-cache
+      - run:
+          name: Create prebuilds archive
+          command: yarn prebuilds
       - store_artifacts:
-          path: ./prebuilds
+          path: ./prebuilds.tgz
+      - store_artifacts:
+          path: ./prebuilds.tgz.sha1
 
   # Browser
 

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ out
 versions
 build
 prebuilds
+prebuilds.*
 docs/test.js
 !packages/*/test/**/node_modules
 dist

--- a/.npmignore
+++ b/.npmignore
@@ -9,12 +9,7 @@
 !LICENSE
 !LICENSE-3rdparty.csv
 !README.md
-!addons-darwin-ia32.tgz
-!addons-darwin-x64.tgz
-!addons-linux-ia32.tgz
-!addons-linux-x64.tgz
-!addons-win32-ia32.tgz
-!addons-win32-x64.tgz
+!prebuilds.tgz
 !binding.gyp
 !index.d.ts
 !index.js

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -47,6 +47,7 @@ dev,eslint-plugin-standard,MIT,Copyright 2015 Jamund Ferguson
 dev,eventemitter3,MIT,Copyright 2014 Arnout Kazemier
 dev,express,MIT,Copyright 2009-2014 TJ Holowaychuk 2013-2014 Roman Shtylman 2014-2015 Douglas Christopher Wilson
 dev,get-port,MIT,Copyright Sindre Sorhus
+dev,glob,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,graphql,MIT,Copyright 2015 Facebook Inc.
 dev,karma,MIT,Copyright 2011-2019 Google, Inc.
 dev,karma-browserstack-launcher,MIT,Copyright 2011-2013 Google, Inc.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "rebuild": "node-gyp rebuild",
     "prebuild": "node scripts/prebuild.js",
+    "prebuilds": "node scripts/prebuilds.js",
     "bundle": "webpack --display-modules",
     "prepublishOnly": "node scripts/prepublish.js",
     "postpublish": "node scripts/postpublish.js",
@@ -99,6 +100,7 @@
     "eventemitter3": "^3.1.0",
     "express": "^4.16.2",
     "get-port": "^3.2.0",
+    "glob": "^7.1.6",
     "graphql": "0.13.2",
     "karma": "^4.3.0",
     "karma-browserstack-launcher": "^1.5.1",

--- a/scripts/prebuilds.js
+++ b/scripts/prebuilds.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const checksum = require('checksum')
+const fs = require('fs')
+const glob = require('glob')
+const os = require('os')
+const path = require('path')
+const tar = require('tar')
+
+const platforms = [
+  'darwin-ia32',
+  'darwin-x64',
+  'linux-ia32',
+  'linux-x64',
+  'win32-ia32',
+  'win32-x64'
+]
+
+zipPrebuilds()
+extractPrebuilds()
+validatePrebuilds()
+createChecksum()
+copyPrebuilds()
+
+function zipPrebuilds () {
+  tar.create({
+    gzip: true,
+    sync: true,
+    portable: true,
+    strict: true,
+    file: path.join(os.tmpdir(), 'prebuilds.tgz')
+  }, glob.sync('prebuilds/**/*.node'))
+}
+
+function extractPrebuilds () {
+  tar.extract({
+    sync: true,
+    strict: true,
+    file: path.join(os.tmpdir(), 'prebuilds.tgz'),
+    cwd: os.tmpdir()
+  })
+}
+
+function validatePrebuilds () {
+  platforms.forEach(platform => {
+    fs.readdirSync(path.join(os.tmpdir(), 'prebuilds', platform))
+      .filter(file => /^node-\d+\.node$/.test(file))
+      .forEach(file => {
+        const content = fs.readFileSync(path.join('prebuilds', platform, file))
+        const sum = fs.readFileSync(path.join('prebuilds', platform, `${file}.sha1`), 'ascii')
+
+        if (sum !== checksum(content)) {
+          throw new Error(`Invalid checksum for "prebuilds/${platform}/${file}".`)
+        }
+      })
+  })
+}
+
+function createChecksum () {
+  const file = path.join(os.tmpdir(), 'prebuilds.tgz')
+  const sum = checksum(fs.readFileSync(file))
+
+  fs.writeFileSync(`${file}.sha1`, sum)
+}
+
+function copyPrebuilds () {
+  const basename = path.normalize(path.join(__dirname, '..'))
+  const filename = 'prebuilds.tgz'
+
+  fs.copyFileSync(
+    path.join(os.tmpdir(), filename),
+    path.join(basename, filename)
+  )
+
+  fs.copyFileSync(
+    path.join(os.tmpdir(), `${filename}.sha1`),
+    path.join(basename, `${filename}.sha1`)
+  )
+}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update build scripts to use a single prebuilds artifact.

### Motivation
<!-- What inspired you to submit this pull request? -->

This avoids making too many requests to CircleCI which reduces the chances of hitting a rate limit or an error. It also makes it easier to download the prebuilds manually if needed.