### PR TITLE
fix log injection removing inherited properties on log records

### DIFF
--- a/packages/dd-trace/src/plugins/util/log.js
+++ b/packages/dd-trace/src/plugins/util/log.js
@@ -9,12 +9,18 @@ const log = {
 
     if (!span) return record
 
-    return Object.assign({}, record, {
+    const carrier = {
       dd: {
         trace_id: span.context().toTraceId(),
         span_id: span.context().toSpanId()
       }
-    })
+    }
+
+    for (const key in record) {
+      carrier[key] = record[key]
+    }
+
+    return carrier
   }
 }
 

--- a/packages/dd-trace/test/plugins/util/log.spec.js
+++ b/packages/dd-trace/test/plugins/util/log.spec.js
@@ -63,5 +63,20 @@ describe('plugins/util/log', () => {
         expect(record).to.not.have.property('dd')
       })
     })
+
+    it('should preserve existing properties', () => {
+      const span = tracer.startSpan('test')
+
+      tracer.scope().activate(span, () => {
+        const record = Object.create({ parent: 'parent' })
+
+        record.own = 'own'
+
+        const carrier = log.correlate(tracer, record)
+
+        expect(carrier).to.have.property('own', 'own')
+        expect(carrier).to.have.property('parent', 'parent')
+      })
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix log injection removing inherited properties on log records.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now, log injection expects a plain old JavaScript object. If the metadata received inherits from another object, any inherited properties are dropped from the final log record. By using a for loop instead of `Object.assign`, we can copy inherited properties as well.