### PR TITLE
fix async scope tracking not resolving awaited promises

### DIFF
--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -82,8 +82,9 @@ class Scope extends Base {
   // https://github.com/nodejs/node/issues/22360
   async _awaitAsync (span) {
     await {
-      then: () => {
+      then (resolve) {
         this._current = span
+        resolve()
       }
     }
   }

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -82,7 +82,7 @@ class Scope extends Base {
   // https://github.com/nodejs/node/issues/22360
   async _awaitAsync (span) {
     await {
-      then (resolve) {
+      then: (resolve) => {
         this._current = span
         resolve()
       }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix async scope tracking not resolving awaited promises, which would end up holding unresolved promises in memory.

### Motivation
<!-- What inspired you to submit this pull request? -->

The issue would cause a constant increase in memory. While it wouldn't end up crashing the process since the promises would eventually be garbage collected, it would still cause the memory to grow almost to the maximum available memory before going back down.

Reported in #759 