### PR TITLE
update async scope tracking to not track itself

### DIFF
--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -76,7 +76,9 @@ class Scope extends Base {
   _await (span) {
     if (!this._promises[this._depth]) return
 
+    this._enabled = false
     this._awaitAsync(span)
+    this._enabled = true
   }
 
   // https://github.com/nodejs/node/issues/22360
@@ -91,10 +93,8 @@ class Scope extends Base {
 
   _initPromise () {
     if (!this._promises[this._depth]) {
-      this._enabled = false
       this._promises[this._depth] = true
       this._await(this._current)
-      this._enabled = true
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update async scope tracking to not track itself.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tracking the async scope tracking adds unnecessary overhead with no benefits.