### PR TITLE
fix base scope missing the _activate protected method

### DIFF
--- a/packages/dd-trace/src/scope/base.js
+++ b/packages/dd-trace/src/scope/base.js
@@ -7,6 +7,7 @@ class Scope {
 
   activate (span, callback) {
     if (typeof callback !== 'function') return callback
+    if (typeof this._activate !== 'function') return callback()
 
     try {
       return this._activate(span, callback)

--- a/packages/dd-trace/src/scope/base.js
+++ b/packages/dd-trace/src/scope/base.js
@@ -7,7 +7,6 @@ class Scope {
 
   activate (span, callback) {
     if (typeof callback !== 'function') return callback
-    if (typeof this._activate !== 'function') return callback()
 
     try {
       return this._activate(span, callback)
@@ -38,6 +37,10 @@ class Scope {
 
   _active () {
     return null
+  }
+
+  _activate (span, callback) {
+    return callback()
   }
 
   _bindFn (fn, span) {

--- a/packages/dd-trace/test/scope/base.spec.js
+++ b/packages/dd-trace/test/scope/base.spec.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const Scope = require('../../src/scope/base')
+
+wrapIt()
+
+describe('Scope (base)', () => {
+  let scope
+
+  beforeEach(() => {
+    scope = new Scope({
+      experimental: {}
+    })
+  })
+
+  it('should be a no-op when activating', done => {
+    scope.activate({}, () => {
+      expect(scope.active()).to.be.null
+      done()
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix base scope missing the `_activate` protected method, resulting in an error when it is used directly as the noop scope that is used when the tracer is disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix #790