### PR TITLE
Add docs sampleRate environment variable

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -322,7 +322,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | env            | `DD_ENV`                       | -           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
 | logInjection   | `DD_LOGS_INJECTION`            | `false`     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
 | tags           | `DD_TAGS`                      | `{}`        | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value,key:value` |
-| sampleRate     | -                              | `1`         | Percentage of spans to sample as a float between 0 and 1. |
+| sampleRate     | `DD_TRACE_SAMPLE_RATE`         | `1`         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval  | -                              | `2000`      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED`   | `false`     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
 | reportHostname | `DD_TRACE_REPORT_HOSTNAME`     | `false`     | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |


### PR DESCRIPTION
### What does this PR do?

Fix documentation agent configuration

### Motivation

Configuration change with environment variable (no code change)

### Additional Notes

[Check already existing source code for environment variable](https://github.com/DataDog/dd-trace-js/blob/ee4b819bbfc786fe6bc922a4f95fdaf22cb57d09/packages/dd-trace/src/config.js#L47)

```
sampleRate: coalesce(sampler.sampleRate, platform.env('DD_TRACE_SAMPLE_RATE')),
```
