### PR TITLE
update browser http request span name to browser.request

### DIFF
--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -17,7 +17,7 @@ function createWrapFetch (tracer, config) {
       const scope = tracer.scope()
       const childOf = scope.active()
       const type = isFlush(tracer._url.href, url) ? REFERENCE_NOOP : REFERENCE_CHILD_OF
-      const span = tracer.startSpan('http.request', {
+      const span = tracer.startSpan('browser.request', {
         references: [
           new Reference(type, childOf)
         ],

--- a/packages/datadog-plugin-xmlhttprequest/src/index.js
+++ b/packages/datadog-plugin-xmlhttprequest/src/index.js
@@ -23,7 +23,7 @@ function createWrapSend (tracer, config) {
       const scope = tracer.scope()
       const childOf = scope.active()
       const type = isFlush(tracer._url.href, url) ? REFERENCE_NOOP : REFERENCE_CHILD_OF
-      const span = tracer.startSpan('http.request', {
+      const span = tracer.startSpan('browser.request', {
         references: [
           new Reference(type, childOf)
         ],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update browser HTTP request span name to `browser.request` instead of `http.request`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Differentiate HTTP request that originate from Node `http` module and from the browser.