### PR TITLE
remove default rate limit in priority sampler

### DIFF
--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -28,7 +28,7 @@ const priorities = new Set([
 ])
 
 class PrioritySampler {
-  constructor (env, { sampleRate, rateLimit = 100, rules = [] } = {}) {
+  constructor (env, { sampleRate, rateLimit = -1, rules = [] } = {}) {
     this._env = env
     this._rules = this._normalizeRules(rules, sampleRate)
     this._limiter = new RateLimiter(rateLimit)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the default rate limit for Tracing without Limits.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tracing without Limits is not without limits if it has limits.