### PR TITLE
add regexp support for peers configuration

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -44,7 +44,7 @@ tracer.init({
   experimental: {
     b3: true,
     exporter: 'log',
-    peers: ['foo'],
+    peers: ['foo', /bar/],
     sampler: {
       sampleRate: 1,
       rateLimit: 1000,

--- a/index.d.ts
+++ b/index.d.ts
@@ -273,7 +273,7 @@ export declare interface TracerOptions {
      * List of peer service URLs that will be called by this service. This is used to determine whether to send the distributed context from the browser.
      * @default []
      */
-    peers?: string[]
+    peers?: (string|RegExp)[]
 
     /**
      * Configuration of the priority sampler. Supports a global config and rules by span name or service name. The first matching rule is applied, and if no rule matches it falls back to the global config or on the rates provided by the agent if there is no global config.

--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -2,7 +2,7 @@
 
 const { Reference, REFERENCE_CHILD_OF } = require('opentracing')
 const { REFERENCE_NOOP } = require('../../dd-trace/src/constants')
-const tx = require('../../dd-trace/src/plugins/util/tx')
+const tx = require('../../dd-trace/src/plugins/util/http')
 
 function createWrapFetch (tracer, config) {
   return function wrapFetch (fetch) {
@@ -76,7 +76,7 @@ function inject (init, tracer, span, origin) {
   const format = window.ddtrace.ext.formats.HTTP_HEADERS
   const peers = tracer._peers
 
-  if (origin !== window.location.origin && peers.indexOf(origin) === -1) {
+  if (origin !== window.location.origin && !tx.isPeer(origin, peers)) {
     return init
   }
 

--- a/packages/datadog-plugin-xmlhttprequest/src/index.js
+++ b/packages/datadog-plugin-xmlhttprequest/src/index.js
@@ -2,6 +2,7 @@
 
 const { Reference, REFERENCE_CHILD_OF } = require('opentracing')
 const { REFERENCE_NOOP } = require('../../dd-trace/src/constants')
+const tx = require('../../dd-trace/src/plugins/util/http')
 
 function createWrapOpen (tracer) {
   return function wrapOpen (open) {
@@ -66,7 +67,7 @@ function inject (xhr, tracer, span) {
   const origin = xhr._datadog_url.origin
   const peers = tracer._peers
 
-  if (origin !== window.location.origin && peers.indexOf(origin) === -1) return
+  if (origin !== window.location.origin && !tx.isPeer(origin, peers)) return
 
   tracer.inject(span, format, headers)
 

--- a/packages/dd-trace/src/plugins/util/http.js
+++ b/packages/dd-trace/src/plugins/util/http.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const tx = require('./tx')
+
+const http = {
+  isPeer (origin, peers) {
+    if (!origin) return false
+
+    for (const peer of peers) {
+      if (origin === peer) return true
+      if (peer instanceof RegExp && peer.test(origin)) return true
+    }
+
+    return false
+  }
+}
+
+module.exports = Object.assign({}, tx, http)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add RegExp support for peers configuration.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, it can be difficult to know the exact peer domain in advance. For example, when using dynamic subdomains, it's possible that the peer keeps changing in which case a static configuration wouldn't work.