### PR TITLE
remove dependencies on zone.js and core-js

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,7 +2,6 @@ Component,Origin,License,Copyright
 require,@types/node,MIT,Copyright Authors
 require,bowser,MIT,Copyright 2015 Dustin Diaz
 require,container-info,MIT,Copyright 2018 Stephen Belanger
-require,core-js,MIT,Copyright 2014-2019 Denis Pushkarev
 require,hdr-histogram-js,BSD-2-Clause,Copyright 2016 Alexandre Victoor
 require,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
@@ -28,7 +27,6 @@ require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,tar,ISC,Copyright Isaac Z. Schlueter and Contributors
 require,url-parse,MIT,Copyright 2015 Unshift.io Arnout Kazemier the Contributors
 require,whatwg-fetch,MIT,Copyright 2014-2016 GitHub Inc.
-require,zone.js,MIT,Copyright 2010-2019 Google LLC.
 dev,@babel/core,MIT,Copyright 2014-present Sebastian McKenzie and other contributors
 dev,@babel/preset-env,MIT,Copyright 2014-present Sebastian McKenzie and other contributors
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/node": "^10.12.18",
     "bowser": "^2.5.3",
     "container-info": "^1.0.1",
-    "core-js": "^3.3.4",
     "hdr-histogram-js": "^1.1.4",
     "int64-buffer": "^0.1.9",
     "koalas": "^1.0.2",
@@ -78,8 +77,7 @@
     "shimmer": "^1.2.0",
     "tar": "^4.4.8",
     "url-parse": "^1.4.3",
-    "whatwg-fetch": "^3.0.0",
-    "zone.js": "^0.10.2"
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",

--- a/packages/dd-trace/browser.js
+++ b/packages/dd-trace/browser.js
@@ -1,7 +1,6 @@
 'use strict'
 
-require('whatwg-fetch')
-require('core-js/stable')
+require('whatwg-fetch') // TODO: remove depenency
 
 const platform = require('./src/platform')
 const browser = require('./src/platform/browser')

--- a/packages/dd-trace/src/scope/zone.js
+++ b/packages/dd-trace/src/scope/zone.js
@@ -3,7 +3,7 @@
 // TODO: Zone metrics
 
 const Base = require('./base')
-const Zone = require('zone.js/dist/zone') && window.Zone
+const Zone = window.Zone
 
 let singleton = null
 
@@ -17,10 +17,14 @@ class Scope extends Base {
   }
 
   _active () {
+    if (!Zone) return null
+
     return Zone.current.get('_datadog_span')
   }
 
   _activate (span, callback) {
+    if (!Zone) return callback()
+
     const spec = {
       properties: {
         _datadog_span: span


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove dependencies on `zone.js` and `core-js`.

### Motivation
<!-- What inspired you to submit this pull request? -->

These are large dependencies that significantly increase the size of the browser bundle. It also means we make assumptions about the target browsers which may be incorrect since we don't control it. Removing these dependencies and leaving it to the user to provide the correct polyfills for what they need to support is more flexible and means we are not adding unnecessary overhead.