### PR TITLE
add safety net for uri errors in http plugin

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -28,7 +28,15 @@ function patch (http, methodName, tracer, config) {
 
   function makeRequestTrace (request) {
     return function requestTrace () {
-      const args = normalizeArgs.apply(null, arguments)
+      let args
+
+      try {
+        args = normalizeArgs.apply(null, arguments)
+      } catch (e) {
+        log.error(e)
+        return request.apply(this, arguments)
+      }
+
       const uri = args.uri
       const options = args.options
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add safety net for URI errors in `http` plugin.

### Motivation
<!-- What inspired you to submit this pull request? -->

When the URI is invalid, the `http` module throws an exception. Since we parse the URI before passing it to the original function, it would cause the tracer to throw the exception instead. By catching the exception and passing the invalid URI to the original function, the exception thrown will not appear to come from the tracer.