### PR TITLE
add support for rhea

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,19 @@ jobs:
         environment:
           - PLUGINS=restify
 
+  node-rhea:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - SERVICES=qpid
+          - PLUGINS=rhea
+      - image: scholzj/qpid-cpp:1.38.0
+        command: -p 5673
+        environment:
+          - QPIDD_ADMIN_USERNAME=admin
+          - QPIDD_ADMIN_PASSWORD=admin
+
   node-router:
     <<: *node-plugin-base
     docker:
@@ -840,6 +853,7 @@ workflows:
       - node-q
       - node-redis
       - node-restify
+      - node-rhea
       - node-router
       - node-when
       - node-winston
@@ -990,6 +1004,7 @@ workflows:
       - node-q
       - node-redis
       - node-restify
+      - node-rhea
       - node-router
       - node-tedious
       - node-when

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
       - image: node:8
         environment:
           - SERVICES=qpid
-          - PLUGINS=amqp10,rhea
+          - PLUGINS=amqp10|rhea
       - image: scholzj/qpid-cpp:1.38.0
         command: -p 5673
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
       - image: node:8
         environment:
           - SERVICES=qpid
-          - PLUGINS=amqp10
+          - PLUGINS=amqp10,rhea
       - image: scholzj/qpid-cpp:1.38.0
         command: -p 5673
         environment:
@@ -518,19 +518,6 @@ jobs:
       - image: node:8
         environment:
           - PLUGINS=restify
-
-  node-rhea:
-    <<: *node-plugin-base
-    docker:
-      - image: node:8
-        environment:
-          - SERVICES=qpid
-          - PLUGINS=rhea
-      - image: scholzj/qpid-cpp:1.38.0
-        command: -p 5673
-        environment:
-          - QPIDD_ADMIN_USERNAME=admin
-          - QPIDD_ADMIN_PASSWORD=admin
 
   node-router:
     <<: *node-plugin-base
@@ -853,7 +840,6 @@ workflows:
       - node-q
       - node-redis
       - node-restify
-      - node-rhea
       - node-router
       - node-when
       - node-winston
@@ -1004,7 +990,6 @@ workflows:
       - node-q
       - node-redis
       - node-restify
-      - node-rhea
       - node-router
       - node-tedious
       - node-when

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -174,6 +174,7 @@ tracer.use('q');
 tracer.use('redis');
 tracer.use('restify');
 tracer.use('restify', httpServerOptions);
+tracer.use('rhea');
 tracer.use('router');
 tracer.use('tedious');
 tracer.use('when');

--- a/index.d.ts
+++ b/index.d.ts
@@ -422,6 +422,7 @@ interface Plugins {
   "q": plugins.q;
   "redis": plugins.redis;
   "restify": plugins.restify;
+  "rhea": plugins.rhea;
   "router": plugins.router;
   "tedious": plugins.tedious;
   "when": plugins.when;
@@ -891,6 +892,12 @@ declare namespace plugins {
    * [restify](http://restify.com/) module.
    */
   interface restify extends HttpServer {}
+
+  /**
+   * This plugin automatically instruments the
+   * [rhea](https://github.com/amqp/rhea) module.
+   */
+  interface rhea extends Instrumentation {}
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-plugin-rhea/src/index.js
+++ b/packages/datadog-plugin-rhea/src/index.js
@@ -54,12 +54,12 @@ function createWrapReceiverDispatch (tracer, config, instrumenter) {
     return function dispatchWithTrace (eventName, msgObj) {
       patchCircularBuffer(this, instrumenter)
       if (eventName === 'message' && msgObj) {
-        const options = msgObj.receiver && msgObj.receiver.options ?
-          msgObj.receiver.options : {}
+        const options = msgObj.receiver && msgObj.receiver.options
+          ? msgObj.receiver.options : {}
         const name = options.source && options.source.address
           ? options.source.address : 'amq.topic'
-        const childOf = msgObj.message ?
-          tracer.extract('text_map', msgObj.message.delivery_annotations) : undefined
+        const childOf = msgObj.message
+          ? tracer.extract('text_map', msgObj.message.delivery_annotations) : undefined
         return tracer.trace('amqp.receive', {
           tags: {
             'component': 'rhea',

--- a/packages/datadog-plugin-rhea/src/index.js
+++ b/packages/datadog-plugin-rhea/src/index.js
@@ -1,38 +1,15 @@
 'use strict'
 
-let CircularBuffer
-let popIf
+const dd = Symbol('datadog')
+const circularBufferConstructor = Symbol('circularBufferConstructor')
 
-function patchCircularBuffer (CircularBuffer) {
-  popIf = CircularBuffer.prototype.pop_if
-  CircularBuffer.prototype.pop_if = function (fn) {
-    const wrappedFn = entry => {
-      const shouldPop = fn(entry)
-      if (shouldPop && entry._dd) {
-        const state = entry.remote_state ? entry.remote_state.constructor.composite_type : 'accepted'
-        finish(entry, state)
-      }
-      return shouldPop
-    }
-    return popIf.call(this, wrappedFn)
-  }
-}
-
-function createWrapSend (tracer, config) {
+function createWrapSend (tracer, config, instrumenter) {
   return function wrapSend (send) {
     return function sendWithTrace (msg, tag, format) {
+      patchCircularBuffer(this, instrumenter)
       const name = this.options && this.options.target && this.options.target.address
         ? this.options.target.address : 'amq.topic'
-      let host
-      let port
-      if (this.connection && this.connection.options) {
-        if (this.connection.options.host !== undefined) { host = this.connection.options.host }
-        if (this.connection.options.port !== undefined) { port = this.connection.options.port }
-      }
-      if (!CircularBuffer && this.session && this.session.outgoing && this.session.outgoing.deliveries) {
-        CircularBuffer = this.session.outgoing.deliveries.constructor
-        patchCircularBuffer(CircularBuffer)
-      }
+      const { host, port } = getHostAndPort(this.connection)
       return tracer.trace('amqp.send', {
         tags: {
           'component': 'rhea',
@@ -45,12 +22,9 @@ function createWrapSend (tracer, config) {
           'out.port': port
         }
       }, (span, done) => {
-        if (msg) {
-          msg.delivery_annotations = msg.delivery_annotations || {}
-          tracer.inject(span, 'text_map', msg.delivery_annotations)
-        }
+        addDeliveryAnnotations(msg, tracer, span)
         const delivery = send.apply(this, arguments)
-        delivery._dd = { done, span }
+        delivery[dd] = { done, span }
         return delivery
       })
     }
@@ -58,27 +32,15 @@ function createWrapSend (tracer, config) {
 }
 
 function createWrapConnectionDispatch (tracer, config) {
-  function addTags (entry, error) {
-    if (entry && entry._dd) {
-      const { span, done } = entry._dd
-      if (error) {
-        span.addTags({ error })
-      }
-      done()
-      delete entry._dd
-    }
-  }
   return function wrapDispatch (dispatch) {
     return function dispatchWithTrace (eventName, obj) {
       if (eventName === 'disconnected' && this.local_channel_map) {
         const error = obj.error || this.saved_error
         for (const key in this.local_channel_map) {
           const session = this.local_channel_map[key]
-          if (session && session.incoming && session.incoming.deliveries && session.incoming.deliveries.entries) {
-            for (const entry of session.incoming.deliveries.entries) { addTags(entry, error) }
-          }
-          if (session && session.outgoing && session.outgoing.deliveries && session.outgoing.deliveries.entries) {
-            for (const entry of session.outgoing.deliveries.entries) { addTags(entry, error) }
+          if (session) {
+            finishDeliverySpans(session.incoming, error)
+            finishDeliverySpans(session.outgoing, error)
           }
         }
       }
@@ -87,13 +49,13 @@ function createWrapConnectionDispatch (tracer, config) {
   }
 }
 
-function createWrapReceiverDispatch (tracer, config) {
+function createWrapReceiverDispatch (tracer, config, instrumenter) {
   return function wrapDispatch (dispatch) {
     return function dispatchWithTrace (eventName, msgObj) {
+      patchCircularBuffer(this, instrumenter)
       if (eventName === 'message') {
         const name = msgObj.receiver.options.source && msgObj.receiver.options.source.address
           ? msgObj.receiver.options.source.address : 'amq.topic'
-
         const childOf = tracer.extract('text_map', msgObj.message.delivery_annotations)
         return tracer.trace('amqp.receive', {
           tags: {
@@ -106,17 +68,9 @@ function createWrapReceiverDispatch (tracer, config) {
           },
           childOf
         }, (span, done) => {
-          msgObj.delivery._dd = { done, span }
-          wrapDeliveryUpdate(msgObj.delivery)
-          let dispatched
-          if (this.get_option('autoaccept', true)) {
-            span.setTag('amqp.delivery.state', 'accepted')
-            dispatched = dispatch.apply(this, arguments)
-            done()
-          } else {
-            dispatched = dispatch.apply(this, arguments)
-          }
-          return dispatched
+          msgObj.delivery[dd] = { done, span }
+          msgObj.delivery.update = wrapDeliveryUpdate(msgObj.delivery.update)
+          return dispatch.apply(this, arguments)
         })
       }
 
@@ -125,33 +79,100 @@ function createWrapReceiverDispatch (tracer, config) {
   }
 }
 
-function getStateFromData (stateData) {
-  if (stateData && stateData.descriptor && stateData.descriptor.value) {
-    switch (stateData.descriptor.value) {
-      case 36: return 'accepted'
-      case 37: return 'rejected'
-      case 38: return 'released'
-      case 39: return 'modified'
+function createWrapCircularBufferPopIf () {
+  return function wrapCircularBufferPopIf (popIf) {
+    return function wrappedPopIf (fn) {
+      const wrappedFn = entry => {
+        const shouldPop = fn(entry)
+        if (shouldPop && entry[dd]) {
+          const remoteState = entry.remote_state
+          const state = remoteState && remoteState.constructor && remoteState.constructor.composite_type
+            ? entry.remote_state.constructor.composite_type : undefined
+          finish(entry, state)
+        }
+        return shouldPop
+      }
+      return popIf.call(this, wrappedFn)
     }
   }
 }
 
-function wrapDeliveryUpdate (delivery) {
-  const update = delivery.update
-  delivery.update = function wrappedUpdate (settled, stateData) {
-    if (!(this.link && this.link.get_option('autoaccept', true))) {
-      const stateName = getStateFromData(stateData)
-      finish(this, stateName)
+function wrapDeliveryUpdate (update) {
+  const wrappedUpdate = function wrappedUpdate (settled, stateData) {
+    const state = getStateFromData(stateData)
+    if (state) {
+      this[dd].span.setTag('amqp.delivery.state', state)
     }
     return update.apply(this, arguments)
+  }
+  return wrappedUpdate
+}
+
+function patchCircularBuffer (senderOrReceiver, instrumenter) {
+  const session = senderOrReceiver.session
+  if (!session) return
+  const deliveries = session.outgoing ? session.outgoing.deliveries
+    : (session.incoming ? session.incoming.deliveries : undefined)
+  if (deliveries && deliveries.constructor) {
+    const CircularBuffer = deliveries.constructor
+    if (CircularBuffer && !CircularBuffer.prototype.pop_if._datadog_patched) {
+      instrumenter.wrap(CircularBuffer.prototype, 'pop_if', createWrapCircularBufferPopIf())
+      const SenderOrReceiver = senderOrReceiver.constructor
+      if (SenderOrReceiver) {
+        SenderOrReceiver[circularBufferConstructor] = CircularBuffer
+      }
+    }
+  }
+}
+
+function finishDeliverySpans (inOrOut, error) {
+  if (inOrOut && inOrOut.deliveries && inOrOut.deliveries.entries) {
+    for (const entry of inOrOut.deliveries.entries) {
+      if (entry && entry[dd]) {
+        const { span, done } = entry[dd]
+        span.addTags({ error })
+        done()
+        delete entry[dd]
+      }
+    }
+  }
+}
+
+function getHostAndPort (connection) {
+  let host
+  let port
+  if (connection && connection.options) {
+    host = connection.options.host
+    port = connection.options.port
+  }
+  return { host, port }
+}
+
+function addDeliveryAnnotations (msg, tracer, span) {
+  if (msg) {
+    msg.delivery_annotations = msg.delivery_annotations || {}
+    tracer.inject(span, 'text_map', msg.delivery_annotations)
+  }
+}
+
+function getStateFromData (stateData) {
+  if (stateData && stateData.descriptor && stateData.descriptor) {
+    switch (stateData.descriptor.value) {
+      case 0x24: return 'accepted'
+      case 0x25: return 'rejected'
+      case 0x26: return 'released'
+      case 0x27: return 'modified'
+    }
   }
 }
 
 function finish (delivery, state) {
-  if (delivery._dd) {
-    delivery._dd.span.setTag('amqp.delivery.state', state || 'accepted')
-    delivery._dd.done()
-    delete delivery._dd
+  if (delivery[dd]) {
+    if (state) {
+      delivery[dd].span.setTag('amqp.delivery.state', state)
+    }
+    delivery[dd].done()
+    delete delivery[dd]
   }
 }
 
@@ -161,12 +182,18 @@ module.exports = [
     versions: ['>=1'],
     file: 'lib/link.js',
     patch ({ Sender, Receiver }, tracer, config) {
-      this.wrap(Sender.prototype, 'send', createWrapSend(tracer, config))
-      this.wrap(Receiver.prototype, 'dispatch', createWrapReceiverDispatch(tracer, config))
+      this.wrap(Sender.prototype, 'send', createWrapSend(tracer, config, this))
+      this.wrap(Receiver.prototype, 'dispatch', createWrapReceiverDispatch(tracer, config, this))
     },
     unpatch ({ Sender, Receiver }, tracer) {
       this.unwrap(Sender.prototype, 'send')
       this.unwrap(Receiver.prototype, 'dispatch')
+      if (Sender[circularBufferConstructor]) {
+        this.unwrap(Sender[circularBufferConstructor].prototype, 'pop_if')
+      }
+      if (Receiver[circularBufferConstructor]) {
+        this.unwrap(Receiver[circularBufferConstructor].prototype, 'pop_if')
+      }
     }
   },
   {
@@ -178,8 +205,6 @@ module.exports = [
     },
     unpatch (Connection, tracer) {
       this.unwrap(Connection.prototype, 'dispatch')
-      CircularBuffer.prototype.pop_if = popIf
-      CircularBuffer = undefined
     }
   }
 ]

--- a/packages/datadog-plugin-rhea/src/index.js
+++ b/packages/datadog-plugin-rhea/src/index.js
@@ -1,0 +1,146 @@
+function createWrapSend (tracer, config) {
+  return function wrapSend (send) {
+    return function sendWithTrace (msg, tag, format) {
+      const name = this.options.target && this.options.target.address
+        ? this.options.target.address : 'amq.topic'
+      return tracer.trace('rhea.sender.send', { tags: {
+        'resource.name': name,
+        'service.name': config.service || `${tracer._service}-amqp`,
+        'span.kind': 'producer',
+        'amqp.link.target.address': name,
+        'amqp.link.role': 'sender',
+        'out.host': this.connection.options.host,
+        'out.port': this.connection.options.port
+      } }, (span, done) => {
+        msg.delivery_annotations = msg.delivery_annotations || {}
+        tracer.inject(span, 'text_map', msg.delivery_annotations)
+        const delivery = send.apply(this, arguments)
+        if (this.options.snd_settle_mode !== 1) {
+          delivery._dd = { done, span }
+        } else {
+          done()
+        }
+        return delivery
+      })
+    }
+  }
+}
+
+function createWrapConnectionDispatch (tracer, config) {
+  return function wrapDispatch (dispatch) {
+    return function dispatchWithTrace (eventName, obj) {
+      if (eventName === 'disconnected') {
+        for (const key in this.local_channel_map) {
+          const session = this.local_channel_map[key]
+          const addTags = entry => {
+            if (entry && entry._dd) {
+              const { span, done } = entry._dd
+              const error = obj.error || this.saved_error
+              if (error) {
+                span.addTags({
+                  'error.type': error.name,
+                  'error.msg': error.message,
+                  'error.stack': error.stack
+                })
+              }
+              done()
+            }
+          }
+          session.incoming.deliveries.entries.forEach(addTags)
+          session.outgoing.deliveries.entries.forEach(addTags)
+        }
+      }
+      return dispatch.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapSenderDispatch (tracer, config) {
+  return function wrapDispatch (dispatch) {
+    return function dispatchWithTrace (eventName, obj) {
+      if (eventName === 'settled') {
+        const state = obj.delivery.remote_state.constructor.composite_type
+        obj.delivery._dd.span.setTag('amqp.delivery.state', state)
+        obj.delivery._dd.done()
+      }
+      return dispatch.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapReceiverDispatch (tracer, config) {
+  return function wrapDispatch (dispatch) {
+    return function dispatchWithTrace (eventName, msgObj) {
+      if (eventName === 'message') {
+        const name = msgObj.receiver.options.source && msgObj.receiver.options.source.address
+          ? msgObj.receiver.options.source.address : 'amq.topic'
+
+        const childOf = tracer.extract('text_map', msgObj.message.delivery_annotations)
+        return tracer.trace('rhea.receiver.onmessage', {
+          tags: {
+            'resource.name': name,
+            'service.name': config.service || `${tracer._service}-amqp`,
+            'span.kind': 'consumer',
+            'amqp.link.source.address': name,
+            'amqp.link.role': 'receiver'
+          },
+          childOf
+        }, (span, done) => {
+          msgObj.delivery._dd = { done, span }
+          wrapDeliveryMethod('accept', 'accepted', msgObj.delivery)
+          wrapDeliveryMethod('release', 'released', msgObj.delivery)
+          wrapDeliveryMethod('reject', 'rejected', msgObj.delivery)
+          wrapDeliveryMethod('modified', 'modified', msgObj.delivery)
+          if (!this.get_option('autoaccept', true)) {
+            return dispatch.apply(this, arguments)
+          } else {
+            span.setTag('amqp.delivery.state', 'accepted')
+            const d = dispatch.apply(this, arguments)
+            done()
+            return d
+          }
+        })
+      }
+
+      return dispatch.apply(this, arguments)
+    }
+  }
+}
+
+function wrapDeliveryMethod (name, stateName, delivery) {
+  const method = delivery[name]
+  delivery[name] = function (params) {
+    this._dd.span.setTag('amqp.delivery.state', stateName)
+    this._dd.done()
+    return method.apply(this, arguments)
+  }
+}
+
+module.exports = [
+  {
+    name: 'rhea',
+    versions: ['>=1'],
+    file: 'lib/link.js',
+    patch ({ Sender, Receiver }, tracer, config) {
+      this.wrap(Sender.prototype, 'send', createWrapSend(tracer, config))
+      this.wrap(Receiver.prototype, 'dispatch', createWrapReceiverDispatch(tracer, config))
+      this.wrap(Sender.prototype, 'dispatch', createWrapSenderDispatch(tracer, config))
+    },
+    unpatch ({ Sender, Receiver }, tracer) {
+      this.unwrap(Sender.prototype, 'send')
+      this.unwrap(Receiver.prototype, 'dispatch')
+      this.unwrap(Sender.prototype, 'dispatch')
+    }
+  },
+  {
+    name: 'rhea',
+    versions: ['>=1'],
+    file: 'lib/connection.js',
+    patch (Connection, tracer, config) {
+      this.wrap(Connection.prototype, 'dispatch', createWrapConnectionDispatch(tracer, config))
+    },
+    unpatch (Connection, tracer) {
+      this.unwrap(Connection.prototype, 'dispatch')
+    }
+  }
+]

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -1,0 +1,544 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const plugin = require('../src')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let tracer
+
+  describe('rhea', () => {
+    withVersions(plugin, 'rhea', version => {
+      describe('with broker', () => {
+        let container
+        let context
+
+        beforeEach(() => {
+          tracer = require('../../dd-trace')
+        })
+
+        afterEach((done) => {
+          agent.close()
+          agent.wipe()
+          context.connection.once('connection_close', () => done())
+          context.connection.close()
+        })
+
+        describe('without configuration', () => {
+          beforeEach(() => agent.load(plugin, 'rhea'))
+
+          beforeEach(done => {
+            container = require(`../../../versions/rhea@${version}`).get()
+
+            container.once('sendable', _context => {
+              context = _context
+              done()
+            })
+            const connection = container.connect({
+              username: 'admin',
+              password: 'admin',
+              host: 'localhost',
+              port: 5673
+            })
+            connection.open_sender('amq.topic')
+            connection.open_receiver('amq.topic')
+          })
+
+          describe('sending a message', () => {
+            it('should automatically instrument', (done) => {
+              agent.use(traces => {
+                const span = traces[0][0]
+                expect(span).to.include({
+                  name: 'rhea.sender.send',
+                  resource: 'amq.topic',
+                  error: 0,
+                  service: 'test-amqp'
+                })
+                expect(span.meta).to.include({
+                  'span.kind': 'producer',
+                  'amqp.link.target.address': 'amq.topic',
+                  'amqp.link.role': 'sender',
+                  'amqp.delivery.state': 'accepted',
+                  'out.host': 'localhost',
+                  'out.port': '5673'
+                })
+              })
+                .then(done, done)
+              context.sender.send({ body: 'Hello World!' })
+            })
+
+            it('should inject span context', () => {
+              container.on('message', msg => {
+                const keys = Object.keys(msg.message.delivery_annotations)
+                expect(keys).to.include('x-datadog-trace-id')
+                expect(keys).to.include('x-datadog-parent-id')
+              })
+            })
+          })
+
+          describe('receiving a message', () => {
+            it('should automatically instrument', done => {
+              agent.use(traces => {
+                const span = traces[0][0]
+                expect(span).to.include({
+                  name: 'rhea.receiver.onmessage',
+                  resource: 'amq.topic',
+                  error: 0,
+                  service: 'test-amqp'
+                })
+                expect(span.meta).to.include({
+                  'span.kind': 'consumer',
+                  'amqp.link.source.address': 'amq.topic',
+                  'amqp.link.role': 'receiver'
+                })
+              })
+                .then(done, done)
+              context.sender.send({ body: 'Hello World!' })
+            })
+
+            it('should extract the span context', done => {
+              container.on('message', msg => {
+                const span = tracer.scope().active()
+                expect(span._spanContext._parentId).to.not.be.null
+                done()
+              })
+              context.sender.send({ body: 'Hello World!' })
+            })
+          })
+
+          describe('exception in message handler', () => {
+            it('span should have error', (done) => {
+              const Session = require(`../../../versions/rhea@${version}/node_modules/rhea/lib/session.js`)
+              const on_transfer = Session.prototype.on_transfer // eslint-disable-line camelcase
+              Session.prototype.on_transfer = function on_transfer_wrapped () { // eslint-disable-line camelcase
+                try {
+                  return on_transfer.apply(this, arguments)
+                } catch (e) {
+                  // this is just to prevent mocha from crashing
+                }
+              }
+
+              container.on('message', () => {
+                throw new Error('this is an error')
+              })
+
+              agent.use(traces => {
+                const span = traces[0][0]
+                expect(span.error).to.equal(1)
+                expect(span.meta).to.include({
+                  'error.msg': 'this is an error',
+                  'error.type': 'Error'
+                })
+                expect(span.meta['error.stack'].startsWith('Error: this is an error\n    at')).to.be.true
+                Session.prototype.on_transfer = on_transfer // eslint-disable-line camelcase
+              }).then(done, done)
+
+              context.sender.send({ body: 'Hello World!' })
+            })
+          })
+        })
+
+        describe('with configuration', () => {
+          beforeEach(() => agent.load(plugin, 'rhea', {
+            service: 'a_test_service'
+          }))
+
+          beforeEach(done => {
+            container = require(`../../../versions/rhea@${version}`).get()
+
+            container.once('sendable', function (_context) {
+              context = _context
+              done()
+            })
+            const connection = container.connect({
+              username: 'admin',
+              password: 'admin',
+              host: 'localhost',
+              port: 5673
+            })
+            connection.open_sender('amq.topic')
+            connection.open_receiver('amq.topic')
+          })
+
+          it('should use the configuration', (done) => {
+            agent.use(traces => {
+              const span = traces[0][0]
+              expect(span).to.have.property('service', 'a_test_service')
+            })
+              .then(done, done)
+            context.sender.send({ body: 'Hello World!' })
+          })
+        })
+      })
+
+      describe('without broker', () => {
+        let server
+        let serverContext
+        let client
+        let clientContext
+        let connection
+
+        beforeEach(() => {
+          tracer = require('../../dd-trace')
+        })
+
+        afterEach((done) => {
+          agent.close()
+          agent.wipe()
+          if (connection.socket_ready) {
+            connection.once('connection_close', () => done())
+            connection.close()
+          } else {
+            done()
+          }
+        })
+
+        describe('defaults', () => {
+          beforeEach(() => agent.load(plugin, 'rhea'))
+
+          beforeEach(done => {
+            const rhea = require(`../../../versions/rhea@${version}`).get()
+
+            server = rhea.create_container()
+            client = rhea.create_container()
+
+            let sendables = 0
+
+            server.once('sendable', _context => {
+              serverContext = _context
+              if (++sendables === 2) done()
+            })
+            client.once('sendable', _context => {
+              clientContext = _context
+              if (++sendables === 2) done()
+            })
+
+            const listener = server.listen({ port: 0 })
+            listener.on('listening', () => {
+              connection = client.connect(listener.address())
+              connection.open_receiver('amq.topic.2')
+              connection.open_sender('amq.topic.2')
+            })
+          })
+
+          describe('client sent message', () => {
+            it('receiving', done => {
+              const p = expectReceiving(agent)
+
+              server.on('message', msg => {
+                p.then(done, done)
+              })
+              clientContext.sender.send({ body: 'hello' })
+            })
+
+            it('sending', done => {
+              const p = expectSending(agent, null, 'amq.topic.2')
+
+              server.on('message', msg => {
+                p.then(done, done)
+              })
+              clientContext.sender.send({ body: 'hello' })
+            })
+          })
+
+          describe('server sent message', () => {
+            it('receiving', done => {
+              const p = expectReceiving(agent, null, 'amq.topic.2')
+
+              client.on('message', msg => {
+                p.then(done, done)
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+
+            it('sending', done => {
+              const p = expectSending(agent)
+
+              client.on('message', msg => {
+                p.then(done, done)
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+          })
+        })
+
+        describe('pre-settled', () => {
+          beforeEach(() => agent.load(plugin, 'rhea'))
+
+          beforeEach(done => {
+            const rhea = require(`../../../versions/rhea@${version}`).get()
+
+            server = rhea.create_container()
+            client = rhea.create_container()
+
+            let sendables = 0
+
+            server.once('sendable', _context => {
+              serverContext = _context
+              if (++sendables === 2) done()
+            })
+            client.once('sendable', _context => {
+              clientContext = _context
+              if (++sendables === 2) done()
+            })
+
+            const listener = server.listen({ port: 0 })
+            listener.on('listening', () => {
+              connection = client.connect(listener.address())
+              connection.open_receiver()
+              connection.open_sender({ snd_settle_mode: 1 })
+            })
+          })
+
+          describe('client sent message', () => {
+            it('sending', done => {
+              const p = expectSending(agent, 'pre')
+
+              server.on('message', msg => {
+                p.then(done, done)
+              })
+              clientContext.sender.send({ body: 'hello' })
+            })
+
+            it('receiving', done => {
+              const p = expectReceiving(agent)
+
+              server.on('message', msg => {
+                p.then(done, done)
+              })
+              clientContext.sender.send({ body: 'hello' })
+            })
+          })
+
+          describe('server sent message', () => {
+            it('sending', done => {
+              const p = expectSending(agent)
+
+              client.on('message', msg => {
+                p.then(done, done)
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+
+            it('receiving', done => {
+              const p = expectReceiving(agent)
+
+              client.on('message', msg => {
+                p.then(done, done)
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+          })
+        })
+
+        describe('manually settled', () => {
+          beforeEach(() => agent.load(plugin, 'rhea'))
+
+          beforeEach(done => {
+            const rhea = require(`../../../versions/rhea@${version}`).get()
+
+            server = rhea.create_container()
+            client = rhea.create_container()
+
+            server.once('sendable', _context => {
+              serverContext = _context
+              done()
+            })
+            const listener = server.listen({ port: 0 })
+            listener.on('listening', () => {
+              connection = client.connect(listener.address())
+              connection.open_receiver({ autoaccept: false })
+            })
+          })
+
+          describe('server sent message', () => {
+            it('sending', done => {
+              const p = expectSending(agent)
+
+              client.on('message', msg => {
+                msg.delivery.accept()
+                p.then(done, done)
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+
+            it('receiving accepting', done => {
+              const p = expectReceiving(agent)
+
+              client.on('message', msg => {
+                process.nextTick(() => {
+                  msg.delivery.accept()
+                  p.then(done, done)
+                })
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+
+            it('receiving rejecting', done => {
+              const p = expectReceiving(agent, 'rejected')
+
+              client.on('message', msg => {
+                process.nextTick(() => {
+                  msg.delivery.reject()
+                  p.then(done, done)
+                })
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+
+            it('receiving releasing', done => {
+              const p = expectReceiving(agent, 'released')
+
+              client.on('message', msg => {
+                process.nextTick(() => {
+                  msg.delivery.release()
+                  p.then(done, done)
+                })
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+
+            it('receiving modified', done => {
+              const p = expectReceiving(agent, 'modified')
+
+              client.on('message', msg => {
+                process.nextTick(() => {
+                  msg.delivery.modified()
+                  p.then(done, done)
+                })
+              })
+              serverContext.sender.send({ body: 'hello' })
+            })
+          })
+        })
+
+        describe('disconnect receiver side', () => {
+          beforeEach(() => agent.load(plugin, 'rhea'))
+
+          beforeEach(done => {
+            const rhea = require(`../../../versions/rhea@${version}`).get()
+
+            server = rhea.create_container()
+            client = rhea.create_container()
+
+            let sendables = 0
+
+            server.once('sendable', _context => {
+              serverContext = _context
+              if (++sendables === 2) done()
+            })
+            client.once('sendable', _context => {
+              clientContext = _context
+              if (++sendables === 2) done()
+            })
+            const listener = server.listen({ port: 0 })
+            listener.on('listening', () => {
+              connection = client.connect(Object.assign({ reconnect: false }, listener.address()))
+              connection.open_receiver({ autoaccept: false })
+              connection.open_sender()
+            })
+          })
+
+          it('sender span gets closed', (done) => {
+            const err = new Error('fake protocol error')
+            err.stack = 'a short, fake stack' // to not pollute test logs
+            agent.use(traces => {
+              const span = traces[0][0]
+              expect(span).to.include({
+                name: 'rhea.sender.send',
+                resource: 'amq.topic',
+                error: 1,
+                service: 'test-amqp'
+              })
+              expect(span.meta).to.include({
+                'span.kind': 'producer',
+                'amqp.link.target.address': 'amq.topic',
+                'amqp.link.role': 'sender',
+                'error.type': 'Error',
+                'error.msg': 'fake protocol error',
+                'error.stack': err.stack
+              })
+            }).then(done, done)
+            connection.output = function () {
+              this.saved_error = err
+              this.dispatch('protocol_error', err)
+              this.socket.end()
+            }
+            clientContext.sender.send({ body: 'hello' })
+          })
+
+          it('receiver span gets closed', (done) => {
+            const err = new Error('fake protocol error')
+            err.stack = 'a short, fake stack' // to not pollute test logs
+            agent.use(traces => {
+              const span = traces[0][0]
+              expect(span).to.include({
+                name: 'rhea.receiver.onmessage',
+                resource: 'amq.topic',
+                error: 1,
+                service: 'test-amqp'
+              })
+              expect(span.meta).to.include({
+                'span.kind': 'consumer',
+                'amqp.link.source.address': 'amq.topic',
+                'amqp.link.role': 'receiver',
+                'error.type': 'Error',
+                'error.msg': 'fake protocol error',
+                'error.stack': err.stack
+              })
+            }).then(done, done)
+            client.on('message', msg => {
+              connection.saved_error = err
+              connection.dispatch('protocol_error', err)
+              connection.socket.end()
+            })
+            serverContext.sender.send({ body: 'hello' })
+          })
+        })
+      })
+    })
+  })
+})
+
+function expectReceiving (agent, deliveryState, topic) {
+  deliveryState = deliveryState || 'accepted'
+  topic = topic || 'amq.topic'
+  return agent.use(traces => {
+    const span = traces[0][0]
+    expect(span).to.include({
+      name: 'rhea.receiver.onmessage',
+      resource: topic,
+      error: 0,
+      service: 'test-amqp'
+    })
+    expect(span.meta).to.include({
+      'span.kind': 'consumer',
+      'amqp.link.source.address': topic,
+      'amqp.link.role': 'receiver',
+      'amqp.delivery.state': deliveryState
+    })
+  })
+}
+
+function expectSending (agent, deliveryState, topic) {
+  deliveryState = deliveryState || 'accepted'
+  topic = topic || 'amq.topic'
+  return agent.use(traces => {
+    const span = traces[0][0]
+    expect(span).to.include({
+      name: 'rhea.sender.send',
+      resource: topic,
+      error: 0,
+      service: 'test-amqp'
+    })
+    expect(span.meta).to.include({
+      'span.kind': 'producer',
+      'amqp.link.target.address': topic,
+      'amqp.link.role': 'sender'
+    })
+    if (deliveryState !== 'pre') {
+      expect(span.meta['amqp.delivery.state']).to.equal('accepted')
+    }
+  })
+}

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -173,7 +173,7 @@ describe('Plugin', () => {
           }
         })
 
-        describe('defaults', () => {
+        describe('with defaults', () => {
           beforeEach(() => agent.load(plugin, 'rhea'))
 
           beforeEach(done => {
@@ -202,7 +202,7 @@ describe('Plugin', () => {
           })
 
           describe('client sent message', () => {
-            it('receiving', done => {
+            it('should be instrumented on receiving', done => {
               const p = expectReceiving(agent)
 
               server.on('message', msg => {
@@ -211,7 +211,7 @@ describe('Plugin', () => {
               clientContext.sender.send({ body: 'hello' })
             })
 
-            it('sending', done => {
+            it('should be instrumented on sending', done => {
               const p = expectSending(agent, null, 'amq.topic.2')
 
               server.on('message', msg => {
@@ -222,7 +222,7 @@ describe('Plugin', () => {
           })
 
           describe('server sent message', () => {
-            it('receiving', done => {
+            it('should be instrumented on receiving', done => {
               const p = expectReceiving(agent, null, 'amq.topic.2')
 
               client.on('message', msg => {
@@ -231,7 +231,7 @@ describe('Plugin', () => {
               serverContext.sender.send({ body: 'hello' })
             })
 
-            it('sending', done => {
+            it('should be instrumented on sending', done => {
               const p = expectSending(agent)
 
               client.on('message', msg => {
@@ -241,7 +241,7 @@ describe('Plugin', () => {
             })
 
             describe('exception in message handler', () => {
-              it('span should have error', (done) => {
+              it('should produce an error in span metadata', (done) => {
                 const Session = require(`../../../versions/rhea@${version}/node_modules/rhea/lib/session.js`)
                 const onTransfer = Session.prototype.on_transfer
                 const error = new Error('this is an error')
@@ -274,7 +274,7 @@ describe('Plugin', () => {
           })
         })
 
-        describe('pre-settled', () => {
+        describe('with pre-settled messages', () => {
           beforeEach(() => agent.load(plugin, 'rhea'))
 
           beforeEach(done => {
@@ -303,7 +303,7 @@ describe('Plugin', () => {
           })
 
           describe('client sent message', () => {
-            it('sending', done => {
+            it('should be instrumented on sending', done => {
               const p = expectSending(agent, 'accepted')
 
               server.on('message', msg => {
@@ -312,7 +312,7 @@ describe('Plugin', () => {
               clientContext.sender.send({ body: 'hello' })
             })
 
-            it('receiving', done => {
+            it('should be instrumented on receiving', done => {
               const p = expectReceiving(agent)
 
               server.on('message', msg => {
@@ -323,7 +323,7 @@ describe('Plugin', () => {
           })
 
           describe('server sent message', () => {
-            it('sending', done => {
+            it('should be instrumented on sending', done => {
               const p = expectSending(agent)
 
               client.on('message', msg => {
@@ -332,7 +332,7 @@ describe('Plugin', () => {
               serverContext.sender.send({ body: 'hello' })
             })
 
-            it('receiving', done => {
+            it('should be instrumented on receiving', done => {
               const p = expectReceiving(agent)
 
               client.on('message', msg => {
@@ -343,7 +343,7 @@ describe('Plugin', () => {
           })
         })
 
-        describe('manually settled', () => {
+        describe('with manually settled messages', () => {
           beforeEach(() => agent.load(plugin, 'rhea'))
 
           beforeEach(done => {
@@ -364,7 +364,7 @@ describe('Plugin', () => {
           })
 
           describe('server sent message', () => {
-            it('sending', done => {
+            it('should be instrumented on sending', done => {
               const p = expectSending(agent)
 
               client.on('message', msg => {
@@ -374,7 +374,7 @@ describe('Plugin', () => {
               serverContext.sender.send({ body: 'hello' })
             })
 
-            it('receiving accepting', done => {
+            it('should be instrumented on receiving and accepting', done => {
               const p = expectReceiving(agent)
 
               client.on('message', msg => {
@@ -386,7 +386,7 @@ describe('Plugin', () => {
               serverContext.sender.send({ body: 'hello' })
             })
 
-            it('receiving rejecting', done => {
+            it('should be instrumented on receiving and rejecting', done => {
               const p = expectReceiving(agent, 'rejected')
 
               client.on('message', msg => {
@@ -398,7 +398,7 @@ describe('Plugin', () => {
               serverContext.sender.send({ body: 'hello' })
             })
 
-            it('receiving releasing', done => {
+            it('should be instrumented on receiving and releasing', done => {
               const p = expectReceiving(agent, 'released')
 
               client.on('message', msg => {
@@ -410,7 +410,7 @@ describe('Plugin', () => {
               serverContext.sender.send({ body: 'hello' })
             })
 
-            it('receiving modified', done => {
+            it('should be instrumented on receiving and modifying', done => {
               const p = expectReceiving(agent, 'modified')
 
               client.on('message', msg => {
@@ -424,7 +424,7 @@ describe('Plugin', () => {
           })
         })
 
-        describe('disconnect', () => {
+        describe('on disconnect', () => {
           beforeEach(() => agent.load(plugin, 'rhea'))
 
           beforeEach(done => {
@@ -451,7 +451,7 @@ describe('Plugin', () => {
             })
           })
 
-          it('sender span gets closed', (done) => {
+          it('sender span should get closed', (done) => {
             const err = new Error('fake protocol error')
             agent.use(traces => {
               const span = traces[0][0]
@@ -479,7 +479,7 @@ describe('Plugin', () => {
             clientContext.sender.send({ body: 'hello' })
           })
 
-          it('receiver span gets closed', (done) => {
+          it('receiver span should closed', (done) => {
             const err = new Error('fake protocol error')
             agent.use(traces => {
               const span = traces[0][0]

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -515,7 +515,7 @@ describe('Plugin', () => {
 function expectReceiving (agent, deliveryState, topic) {
   deliveryState = deliveryState || deliveryState === false ? undefined : 'accepted'
   topic = topic || 'amq.topic'
-  return agent.use(traces => {
+  return Promise.resolve().then(() => agent.use(traces => {
     const span = traces[0][0]
     expect(span).to.include({
       name: 'amqp.receive',
@@ -532,13 +532,13 @@ function expectReceiving (agent, deliveryState, topic) {
       expectedMeta['amqp.delivery.state'] = deliveryState
     }
     expect(span.meta).to.include(expectedMeta)
-  })
+  }))
 }
 
 function expectSending (agent, deliveryState, topic) {
   deliveryState = deliveryState || deliveryState === false ? undefined : 'accepted'
   topic = topic || 'amq.topic'
-  return agent.use(traces => {
+  return Promise.resolve().then(() => agent.use(traces => {
     const span = traces[0][0]
     expect(span).to.include({
       name: 'amqp.send',
@@ -555,5 +555,5 @@ function expectSending (agent, deliveryState, topic) {
       expectedMeta['amqp.delivery.state'] = deliveryState
     }
     expect(span.meta).to.include(expectedMeta)
-  })
+  }))
 }

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -130,9 +130,19 @@ describe('Plugin', () => {
             connection.open_receiver('amq.topic')
           })
 
-          it('should use the configuration', (done) => {
+          it('should use the configuration for the receiver', (done) => {
             agent.use(traces => {
               const span = traces[0][0]
+              expect(span).to.have.property('name', 'amqp.receive')
+              expect(span).to.have.property('service', 'a_test_service')
+            })
+              .then(done, done)
+            context.sender.send({ body: 'Hello World!' })
+          })
+          it('should use the configuration for the sender', (done) => {
+            agent.use(traces => {
+              const span = traces[0][0]
+              expect(span).to.have.property('name', 'amqp.send')
               expect(span).to.have.property('service', 'a_test_service')
             })
               .then(done, done)

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -35,6 +35,7 @@ module.exports = {
   'q': require('../../../datadog-plugin-q/src'),
   'redis': require('../../../datadog-plugin-redis/src'),
   'restify': require('../../../datadog-plugin-restify/src'),
+  'rhea': require('../../../datadog-plugin-rhea/src'),
   'router': require('../../../datadog-plugin-router/src'),
   'tedious': require('../../../datadog-plugin-tedious/src'),
   'when': require('../../../datadog-plugin-when/src'),

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -34,41 +34,28 @@ function wrapIt () {
   const it = global.it
   const only = global.it.only
 
-  global.it = function (title, fn) {
-    if (!fn) return it.apply(this, arguments)
+  function wrap (testFn) {
+    return function (title, fn) {
+      if (!fn) return testFn.apply(this, arguments)
 
-    const length = fn.length
+      const length = fn.length
 
-    fn = asyncHooksScope.bind(fn, null)
+      fn = asyncHooksScope.bind(fn, null)
 
-    if (length > 0) {
-      return it.call(this, title, function (done) {
-        done = asyncHooksScope.bind(done, null)
+      if (length > 0) {
+        return testFn.call(this, title, function (done) {
+          done = asyncHooksScope.bind(done, null)
 
-        return fn.call(this, done)
-      })
-    } else {
-      return it.call(this, title, fn)
+          return fn.call(this, done)
+        })
+      } else {
+        return testFn.call(this, title, fn)
+      }
     }
   }
 
-  global.it.only = function (title, fn) {
-    if (!fn) return only.apply(this, arguments)
-
-    const length = fn.length
-
-    fn = asyncHooksScope.bind(fn, null)
-
-    if (length > 0) {
-      return only.call(this, title, function (done) {
-        done = asyncHooksScope.bind(done, null)
-
-        return fn.call(this, done)
-      })
-    } else {
-      return only.call(this, title, fn)
-    }
-  }
+  global.it = wrap(it)
+  global.it.only = wrap(only)
 
   global.it.skip = it.skip
 }

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -32,6 +32,7 @@ afterEach(() => {
 
 function wrapIt () {
   const it = global.it
+  const only = global.it.only
 
   global.it = function (title, fn) {
     if (!fn) return it.apply(this, arguments)
@@ -50,6 +51,26 @@ function wrapIt () {
       return it.call(this, title, fn)
     }
   }
+
+  global.it.only = function (title, fn) {
+    if (!fn) return only.apply(this, arguments)
+
+    const length = fn.length
+
+    fn = asyncHooksScope.bind(fn, null)
+
+    if (length > 0) {
+      return only.call(this, title, function (done) {
+        done = asyncHooksScope.bind(done, null)
+
+        return fn.call(this, done)
+      })
+    } else {
+      return only.call(this, title, fn)
+    }
+  }
+
+  global.it.skip = it.skip
 }
 
 function withVersions (plugin, modules, range, cb) {


### PR DESCRIPTION
### What does this PR do?
add support for rhea

### Motivation
Rhea is current recommended AMQP 1.0 client, so instrumentation needed to be added for it.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
