### PR TITLE
add benchmarks for node platform metrics

### DIFF
--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -103,7 +103,7 @@ suite
   })
   .add('Histogram', {
     fn () {
-      histogram.record(Math.round(Math.random() * 3e12))
+      histogram.record(Math.round(Math.random() * 3.6e12))
     }
   })
 

--- a/benchmark/platform/node.js
+++ b/benchmark/platform/node.js
@@ -3,12 +3,18 @@
 const benchmark = require('../benchmark')
 const platform = require('../../packages/dd-trace/src/platform')
 const node = require('../../packages/dd-trace/src/platform/node')
+const Config = require('../../packages/dd-trace/src/config')
 
 platform.use(node)
 
 const suite = benchmark('platform (node)')
 
 const traceStub = require('../stubs/trace')
+const spanStub = require('../stubs/span')
+const config = new Config('bench', {})
+
+platform.configure(config)
+platform.metrics().start()
 
 suite
   .add('now', {
@@ -19,6 +25,41 @@ suite
   .add('msgpack#prefix', {
     fn () {
       platform.msgpack.prefix(traceStub)
+    }
+  })
+  .add('metrics#track', {
+    fn () {
+      platform.metrics().track(spanStub).finish()
+    }
+  })
+  .add('metrics#boolean', {
+    fn () {
+      platform.metrics().boolean('test', Math.random() < 0.5)
+    }
+  })
+  .add('metrics#histogram', {
+    fn () {
+      platform.metrics().histogram('test', Math.random() * 3.6e12)
+    }
+  })
+  .add('metrics#gauge', {
+    fn () {
+      platform.metrics().gauge('test', Math.random())
+    }
+  })
+  .add('metrics#increment', {
+    fn () {
+      platform.metrics().boolean('test')
+    }
+  })
+  .add('metrics#increment (monotonic)', {
+    fn () {
+      platform.metrics().boolean('test', true)
+    }
+  })
+  .add('metrics#decrement', {
+    fn () {
+      platform.metrics().boolean('test')
     }
   })
 

--- a/benchmark/stubs/span.js
+++ b/benchmark/stubs/span.js
@@ -36,7 +36,10 @@ const span = {
     _name: 'operation'
   }),
   _startTime: 1500000000000.123456,
-  _duration: 100
+  _duration: 100,
+  _spanContext: {
+    _name: 'operation'
+  }
 }
 
 module.exports = span


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add benchmarks for Node platform metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

Ensure that runtime and tracer metrics overhead is low enough that they can be enabled by default.