### PR TITLE
Revert "remove default rate limit in priority sampler (#796)"

### DIFF
--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -28,7 +28,7 @@ const priorities = new Set([
 ])
 
 class PrioritySampler {
-  constructor (env, { sampleRate, rateLimit = -1, rules = [] } = {}) {
+  constructor (env, { sampleRate, rateLimit = 100, rules = [] } = {}) {
     this._env = env
     this._rules = this._normalizeRules(rules, sampleRate)
     this._limiter = new RateLimiter(rateLimit)


### PR DESCRIPTION
This reverts commit 7ab6af061f7e5434f0f2e8c1f9d10d9b23d3c455.

### What does this PR do?
Adds back the default 100 traces per second rate limit as a safety net for high volume customers.