### PR TITLE
add experimental global runtime id tag

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -43,6 +43,7 @@ tracer.init({
   trackAsyncScope: false,
   experimental: {
     b3: true,
+    runtimeId: true,
     exporter: 'log',
     peers: ['foo', /bar/],
     sampler: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -264,6 +264,12 @@ export declare interface TracerOptions {
     b3?: boolean
 
     /**
+     * Whether to add an auto-generated `runtime-id` tag to spans and metrics.
+     * @default false
+     */
+    runtimeId?: boolean
+
+    /**
      * Whether to write traces to log output, rather than send to an agent
      * @default false
      */

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -5,6 +5,9 @@ const platform = require('./platform')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
 const tagger = require('./tagger')
+const id = require('./id')
+
+const runtimeId = `${id().toString()}${id().toString()}`
 
 class Config {
   constructor (service, options) {
@@ -69,6 +72,7 @@ class Config {
     this.trackAsyncScope = options.trackAsyncScope !== false
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
+      runtimeId: !(!options.experimental || !options.experimental.runtimeId),
       exporter: options.experimental && options.experimental.exporter,
       peers: (options.experimental && options.experimental.peers) || [],
       sampler
@@ -81,6 +85,12 @@ class Config {
       platform.env('DD_TRACE_LOG_LEVEL'),
       'debug'
     )
+
+    if (this.experimental.runtimeId) {
+      tagger.add(tags, {
+        'runtime-id': runtimeId
+      })
+    }
   }
 }
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -123,6 +123,7 @@ describe('Config', () => {
       logLevel: logLevel,
       experimental: {
         b3: true,
+        runtimeId: true,
         sampler: {
           sampleRate: 1,
           rateLimit: 1000
@@ -149,10 +150,12 @@ describe('Config', () => {
     expect(config).to.have.property('scope', 'noop')
     expect(config).to.have.property('clientToken', '789')
     expect(config).to.have.property('logLevel', logLevel)
-    expect(config).to.have.deep.property('tags', {
-      'foo': 'bar'
-    })
+    expect(config).to.have.property('tags')
+    expect(config.tags).to.have.property('foo', 'bar')
+    expect(config.tags).to.have.property('runtime-id')
+    expect(config.tags['runtime-id']).to.match(/^[0-9a-f]{32}$/)
     expect(config).to.have.nested.property('experimental.b3', true)
+    expect(config).to.have.nested.property('experimental.runtimeId', true)
     expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: 1, rateLimit: 1000 })
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add experimental global runtime ID tag.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was added a while back, and was then removed because the cardinality was too high in some cases which could cause issues. The runtime ID can be useful however when debugging a specific issue and trying to correlate a trace with runtime metrics, so I added it back as an experimental feature disabled by default.