### PR TITLE
fix possible stack overflow with mysql2 command executions

### DIFF
--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -57,18 +57,11 @@ function wrapExecute (tracer, config, execute) {
 }
 
 function wrapCallback (tracer, span, parent, done) {
-  return tracer.scope().bind((err, res) => {
-    if (err) {
-      span.addTags({
-        'error.type': err.name,
-        'error.msg': err.message,
-        'error.stack': err.stack
-      })
-    }
-
+  return tracer.scope().bind((error, res) => {
+    span.addTags({ error })
     span.finish()
 
-    done(err, res)
+    done(error, res)
   }, parent)
 }
 

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -46,9 +46,8 @@ function wrapExecute (tracer, config, execute) {
     if (typeof this.onResult === 'function') {
       this.onResult = wrapCallback(tracer, span, childOf, this.onResult)
     } else {
-      this.on('end', () => {
-        span.finish()
-      })
+      this.on('error', error => span.addTags({ error }))
+      this.on('end', () => span.finish())
     }
 
     this.execute = execute

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -31,23 +31,17 @@ function wrapExecute (tracer, config, execute) {
       tags: {
         [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
         'service.name': config.service || `${tracer._service}-mysql`,
+        'resource.name': sql,
         'span.type': 'sql',
         'db.type': 'mysql',
         'db.user': connectionConfig.user,
+        'db.name': connectionConfig.database,
         'out.host': connectionConfig.host,
         'out.port': connectionConfig.port
       }
     })
 
-    if (connectionConfig.database) {
-      span.setTag('db.name', connectionConfig.database)
-    }
-
     analyticsSampler.sample(span, config.analytics)
-
-    const result = scope.bind(execute, span).apply(this, arguments)
-
-    span.setTag('resource.name', sql)
 
     if (typeof this.onResult === 'function') {
       this.onResult = wrapCallback(tracer, span, childOf, this.onResult)
@@ -59,7 +53,7 @@ function wrapExecute (tracer, config, execute) {
 
     this.execute = execute
 
-    return result
+    return scope.bind(execute, span).apply(this, arguments)
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix possible stack overflow when executing `mysql2` commands. I also changed how the commands are patched since the `prepare` function returns an internal class that is not an actual command.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, executing a `mysql2` command would result in a stack overflow. This happened because it's possible for the same command object to be executed multiple times in succession, which would cause `command.onResult` to be wrapped the same number of times, eventually leading to the issue when it's called.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Since the commands are executed internally, I didn't find a good way to test this that wouldn't be 100% synthetic.