### PR TITLE
fix main-finding in nodejs loader

### DIFF
--- a/packages/dd-trace/src/platform/node/loader.js
+++ b/packages/dd-trace/src/platform/node/loader.js
@@ -57,7 +57,8 @@ class Loader {
 
         pkg = require(`${basedir}/package.json`)
 
-        if (!id.endsWith(`/node_modules/${instrumentation.name}/${pkg.main || 'index.js'}`)) continue
+        const mainFile = path.posix.normalize(pkg.main || 'index.js')
+        if (!id.endsWith(`/node_modules/${instrumentation.name}/${mainFile}`)) continue
       }
 
       if (!matchVersion(pkg.version, instrumentation.versions)) continue


### PR DESCRIPTION
### What does this PR do?
`path.join` is now used to put paths together in the Node.js loader.


### Motivation
Some Node.js packages use a leading `./` to indicate their "main" file.
This broke the Node.js loader, which was using template literals to put
paths together.

