### PR TITLE
fix rhea integration for numeric tags

### DIFF
--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -60,8 +60,10 @@ describe('Plugin', () => {
                   'amqp.link.target.address': 'amq.topic',
                   'amqp.link.role': 'sender',
                   'amqp.delivery.state': 'accepted',
-                  'out.host': 'localhost',
-                  'out.port': '5673'
+                  'out.host': 'localhost'
+                })
+                expect(span.metrics).to.include({
+                  'out.port': 5673
                 })
               })
                 .then(done, done)


### PR DESCRIPTION
### What does this PR do?
Fixes `rhea` test after numeric tags change.

### Motivation
The test was broken on every build after that change.
