### PR TITLE
fix cassandra-driver plugin not working for >=4.4

### DIFF
--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -148,7 +148,7 @@ describe('Plugin', () => {
           })
         })
 
-        it('should run event liteners in the correct scope', done => {
+        it('should run event listeners in the correct scope', done => {
           if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
 
           const emitter = client.stream('SELECT now() FROM local;')
@@ -156,7 +156,7 @@ describe('Plugin', () => {
           const scope = tracer.scope()
 
           scope.activate(span, () => {
-            emitter.on('readable', () => {
+            emitter.once('readable', () => {
               expect(scope.active()).to.equal(span)
               done()
             })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `cassandra-driver` plugin not working for >=4.4

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests started failing on `master` since today's 4.4 release of `cassandra-driver`.