### PR TITLE
Move @types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@types/node": "^10.12.18",
     "bowser": "^2.5.3",
     "container-info": "^1.0.1",
     "hdr-histogram-js": "^1.1.4",
@@ -82,6 +81,7 @@
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",
+    "@types/node": "^10.12.18",
     "axios": "^0.18.0",
     "babel-loader": "^8.0.6",
     "benchmark": "^2.1.4",


### PR DESCRIPTION
### What does this PR do?
Move `@types/node`, the only `@types` package, to the devDependencies.

### Motivation
These aren't needed at runtime
