### PR TITLE
add support for WHATWG URL in http client

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -158,7 +158,17 @@ function patch (http, methodName, tracer, config) {
   }
 
   function normalizeArgs (inputURL, inputOptions, callback) {
-    let options = typeof inputURL === 'string' ? url.parse(inputURL) : Object.assign({}, inputURL)
+    let options
+
+    if (typeof inputURL === 'string') {
+      options = url.parse(inputURL)
+    } else {
+      options = {}
+      for (const key in inputURL) {
+        options[key] = inputURL[key]
+      }
+    }
+
     options.headers = options.headers || {}
     if (typeof inputOptions === 'function') {
       callback = inputOptions

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -158,6 +158,18 @@ function patch (http, methodName, tracer, config) {
   }
 
   function normalizeArgs (inputURL, inputOptions, callback) {
+    let options = normalizeURL(inputURL)
+
+    if (typeof inputOptions === 'function') {
+      callback = inputOptions
+    } else if (typeof inputOptions === 'object') {
+      options = Object.assign(options, inputOptions)
+    }
+    const uri = extractUrl(options)
+    return { uri, options, callback }
+  }
+
+  function normalizeURL (inputURL) {
     let options
 
     if (typeof inputURL === 'string') {
@@ -170,13 +182,7 @@ function patch (http, methodName, tracer, config) {
     }
 
     options.headers = options.headers || {}
-    if (typeof inputOptions === 'function') {
-      callback = inputOptions
-    } else if (typeof inputOptions === 'object') {
-      options = Object.assign(options, inputOptions)
-    }
-    const uri = extractUrl(options)
-    return { uri, options, callback }
+    return options
   }
 }
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -143,6 +143,31 @@ describe('Plugin', () => {
           })
         })
 
+        it('should support configuration as an WHATWG URL object', done => {
+          const app = express()
+
+          app.get('/user', (req, res) => {
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
+              })
+              .then(done)
+              .catch(done)
+
+            const url = new URL(`${protocol}:localhost:${port}/user`)
+
+            appListener = server(app, port, () => {
+              const req = http.request(url)
+
+              req.end()
+            })
+          })
+        })        
+
         it('should remove the query string from the URL', done => {
           const app = express()
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -143,31 +143,6 @@ describe('Plugin', () => {
           })
         })
 
-        it('should support configuration as an WHATWG URL object', done => {
-          const app = express()
-
-          app.get('/user', (req, res) => {
-            res.status(200).send()
-          })
-
-          getPort().then(port => {
-            agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
-              })
-              .then(done)
-              .catch(done)
-
-            const url = new URL(`${protocol}:localhost:${port}/user`)
-
-            appListener = server(app, port, () => {
-              const req = http.request(url)
-
-              req.end()
-            })
-          })
-        })        
-
         it('should remove the query string from the URL', done => {
           const app = express()
 
@@ -241,6 +216,31 @@ describe('Plugin', () => {
 
               appListener = server(app, port, () => {
                 const req = http.request(uri, { path: '/user' })
+
+                req.end()
+              })
+            })
+          })
+
+          it('should support configuration as an WHATWG URL object', done => {
+            const app = express()
+
+            app.get('/user', (req, res) => {
+              res.status(200).send()
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
+                })
+                .then(done)
+                .catch(done)
+
+              const url = new URL(`${protocol}:localhost:${port}/user`)
+
+              appListener = server(app, port, () => {
+                const req = http.request(url)
 
                 req.end()
               })

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -222,28 +222,20 @@ describe('Plugin', () => {
             })
           })
 
-          it('should support configuration as an WHATWG URL object', done => {
+          it('should support configuration as an WHATWG URL object', async () => {
             const app = express()
+            const port = await getPort()
+            const url = new URL(`${protocol}:localhost:${port}/user`)
 
-            app.get('/user', (req, res) => {
-              res.status(200).send()
+            app.get('/user', (req, res) => res.status(200).send())
+
+            appListener = server(app, port, () => {
+              const req = http.request(url)
+              req.end()
             })
 
-            getPort().then(port => {
-              agent
-                .use(traces => {
-                  expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
-                })
-                .then(done)
-                .catch(done)
-
-              const url = new URL(`${protocol}:localhost:${port}/user`)
-
-              appListener = server(app, port, () => {
-                const req = http.request(url)
-
-                req.end()
-              })
+            agent.use(traces => {
+              expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
             })
           })
         }

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -234,7 +234,7 @@ describe('Plugin', () => {
               req.end()
             })
 
-            agent.use(traces => {
+            await agent.use(traces => {
               expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
             })
           })


### PR DESCRIPTION
### What does this PR do?

This PR addresses the use case discussed in [Issue-829](https://github.com/DataDog/dd-trace-js/issues/829), where a user or a library the user is leveraging passes in a WHATWG URL object to their http client request. Due to the use of `Object.assign` in the http-client instrumentation's `normalizeArgs` helper function,  data properties on the WHATWG URL object do not get assigned, as they are getter / setters that exist on the prototype and not the Class. More details on this can be found [here](https://github.com/DataDog/dd-trace-js/issues/829#issuecomment-575753718). This PR instead uses a `for ... in` loop to ensure the data properties are copied. It also adds a unit test for this going forward.

### Motivation
http-client instrumentation malforms a user's request in the use case discussed above. There are also popular http client libraries that are using the `WHATWG URL Object` approach.

### Additional Notes
Per the discussion in the Open Issue, I think there are some additional considerations worth thinking about. 

1. Whether the  `for ... in` loop approach suggested above is robust enough, or too broad and should be a bit more restrictive about what it does / does not copy (such as functions? I am a bit concerned this would impact getter/setters on the Class). Let me know what you think here.

2. The broader use of Object.assign in the http client instrumentation, and whether there should be a helper function introduced more broadly that handles the work of `copy object properties for dd-trace usage, in a performant way that does not mutate the original object unintentionally`.
