### PR TITLE
fix fs readFile when options is string

### DIFF
--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -315,7 +315,7 @@ function makeFSFlagTags (resourceName, path, options, defaultFlag, config, trace
 }
 
 function makeFSTags (resourceName, path, options, config, tracer) {
-  path = options && 'fd' in options ? options.fd : path
+  path = options && typeof options === 'object' && 'fd' in options ? options.fd : path
   const tags = {
     'component': 'fs',
     'resource.name': resourceName,

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -277,6 +277,18 @@ describe('Plugin', () => {
           tested(fs, [__filename, { flag: 'r+' }], done)
         })
 
+        it('should not fail if options is a string', (done) => {
+          expectOneSpan(agent, done, {
+            resource,
+            meta: {
+              'file.flag': 'r',
+              'file.path': __filename
+            }
+          })
+
+          tested(fs, [__filename, 'utf8'], done)
+        })
+
         it('should handle errors', () =>
           testHandleErrors(fs, resource, tested, ['/badfilename', { flag: 'r' }], agent))
       })


### PR DESCRIPTION
### What does this PR do?
Fix the case where a string is passed in where the options object should be, which is supported by node.

### Motivation
It wasn't working, as it didn't have a more appropriate safety net for object access.
