### PR TITLE
fix tsconfig for current versions of @types/node

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["es2017"],
     "moduleResolution": "node",
     "module": "commonjs",
     "baseUrl": "."


### PR DESCRIPTION
### What does this PR do?
Sets the ECMAScript version in docs/tsconfig.json so that `@types/node` doesn't fail.
### Motivation
Builds were all breaking because docs wouldn't generate.
