### PR TITLE
remove support for koa-router 8.x until properly supported

### DIFF
--- a/packages/datadog-plugin-koa/src/index.js
+++ b/packages/datadog-plugin-koa/src/index.js
@@ -123,7 +123,7 @@ module.exports = [
   },
   {
     name: 'koa-router',
-    versions: ['>=7'],
+    versions: ['7'],
     patch (Router, tracer, config) {
       this.wrap(Router.prototype, 'register', createWrapRegister(tracer, config))
     },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove support for `koa-router` 8.x until properly supported.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests are failing in koa-router 8.x because the path is wrong.