### PR TITLE
fix wrong route for koa-router 8

### DIFF
--- a/packages/datadog-plugin-koa/src/index.js
+++ b/packages/datadog-plugin-koa/src/index.js
@@ -78,9 +78,10 @@ function createWrapRoutes (tracer, config) {
           Object.defineProperty(ctx, 'router', {
             set (value) {
               router = value
-              router.stack.forEach(layer => {
+
+              for (const layer of router.stack) {
                 wrapStack(layer)
-              })
+              }
             },
 
             get () {
@@ -103,13 +104,15 @@ function wrapStack (layer) {
   layer.stack = layer.stack.map(middleware => {
     if (typeof middleware !== 'function') return middleware
 
+    const wrappedMiddleware = wrapMiddleware(middleware)
+
     return function (ctx, next) {
       if (!ctx || !web.active(ctx.req)) return middleware.apply(this, arguments)
 
       web.exitRoute(ctx.req)
       web.enterRoute(ctx.req, layer.path)
 
-      return wrapMiddleware(middleware).apply(this, arguments)
+      return wrappedMiddleware.apply(this, arguments)
     }
   })
 }

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -275,7 +275,8 @@ describe('Plugin', () => {
                 expect(spans[0]).to.have.property('resource', 'GET /user/:id')
                 expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
 
-                expect(spans[1]).to.have.property('resource', 'dispatch')
+                expect(spans[1]).to.have.property('resource')
+                expect(spans[1].resource).to.match(/^dispatch/)
 
                 expect(spans[2]).to.have.property('resource', 'handle')
               })
@@ -318,7 +319,7 @@ describe('Plugin', () => {
             })
           })
 
-          it.only('should support nested routers', done => {
+          it('should support nested routers', done => {
             const app = new Koa()
             const forums = new Router()
             const discussions = new Router()
@@ -440,7 +441,8 @@ describe('Plugin', () => {
                 expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
                 expect(spans[0].error).to.equal(1)
 
-                expect(spans[1]).to.have.property('resource', 'dispatch')
+                expect(spans[1]).to.have.property('resource')
+                expect(spans[1].resource).to.match(/^dispatch/)
                 expect(spans[1].meta).to.include({
                   'error.type': error.name
                 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix wrong route for `koa-router` 8.

### Motivation
<!-- What inspired you to submit this pull request? -->

Since koa-router 8, a change was done internally where the routes are cloned when attached to another router. This breaks support for nested routers since it means the path prefix is added to the copy which is not available to the tracer. By patching lazily on the router attached to the context, it's possible to get the final version of the route with the correct path.