### PR TITLE
Account for path conventions for WHATWG url

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -156,7 +156,6 @@ function patch (http, methodName, tracer, config) {
       inputURL = urlToOptions(inputURL)
     }
 
-    // possible case missing for else
     if (typeof inputOptions === 'function') {
       callback = inputOptions
       inputOptions = inputURL || {}
@@ -166,25 +165,26 @@ function patch (http, methodName, tracer, config) {
 
     // normalize getHeaders
     inputURL.headers = inputURL.headers || {}
-    // inputURL.hostname = inputURL.host || inputURL.hostname || 'localhost'
 
     const uri = url.format(inputURL)
-    const options = inputURL
+    // const options = inputURL
 
-    console.log(uri, options)
-    return { uri, options, callback }
+    return { uri, options: inputURL, callback }
   }
 
   // https://github.com/nodejs/node/blob/7e911d8b03a838e5ac6bb06c5b313533e89673ef/lib/internal/url.js#L1271
   function urlToOptions (url) {
+    const agent = url.agent || http.globalAgent
     const options = {
-      protocol: url.protocol,
+      protocol: url.protocol || agent.protocol,
       hostname: typeof url.hostname === 'string' && url.hostname.startsWith('[')
         ? url.hostname.slice(1, -1)
-        : url.hostname,
+        : url.hostname ||
+        url.host ||
+        'localhost',
       hash: url.hash,
       search: url.search,
-      pathname: url.pathname,
+      pathname: url.pathname || url.path || '/',
       path: `${url.pathname || ''}${url.search || ''}`,
       href: url.href
     }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -172,10 +172,13 @@ function patch (http, methodName, tracer, config) {
       coalesedOptions = inputURL
     }
 
-    // normalize getHeaders
-    coalesedOptions.headers = coalesedOptions.headers || {}
+    coalesedOptions.headers = normalizeHeaders(coalesedOptions)
 
     return coalesedOptions
+  }
+
+  function normalizeHeaders (options) {
+    return options.headers || {}
   }
 
   // https://github.com/nodejs/node/blob/7e911d8b03a838e5ac6bb06c5b313533e89673ef/lib/internal/url.js#L1271

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -148,14 +148,11 @@ function patch (http, methodName, tracer, config) {
   function normalizeArgs (inputURL, inputOptions, callback) {
     inputURL = normalizeOptions(inputURL)
 
-    [callback, inputOptions] = normalizeCallback(inputURL, callback, inputURL)
+    const [callbackNormalilzed, inputOptionsNormalized] = normalizeCallback(inputOptions, callback, inputURL)
+    const coalesedOptions = coaleseOptions(inputURL, inputOptionsNormalized)
+    const uri = url.format(coalesedOptions)
 
-    inputURL = coaleseOptions(inputURL, inputOptions)
-
-    // normalize urlString
-    const uri = url.format(inputURL)
-
-    return { uri, options: inputURL, callback }
+    return { uri: uri, options: coalesedOptions, callback: callbackNormalilzed }
   }
 
   function normalizeCallback (inputOptions, callback, inputURL) {

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -145,14 +145,15 @@ function patch (http, methodName, tracer, config) {
     })
   }
 
-  function normalizeArgs (inputURL, inputOptions, callback) {
+  function normalizeArgs (inputURL, inputOptions, cb) {
     inputURL = normalizeOptions(inputURL)
 
-    const [callbackNormalilzed, inputOptionsNormalized] = normalizeCallback(inputOptions, callback, inputURL)
-    const coalesedOptions = coaleseOptions(inputURL, inputOptionsNormalized)
-    const uri = url.format(coalesedOptions)
+    const [callback, inputOptionsNormalized] = normalizeCallback(inputOptions, cb, inputURL)
+    const options = combineOptions(inputURL, inputOptionsNormalized)
+    normalizeHeaders(options)
+    const uri = url.format(options)
 
-    return { uri: uri, options: coalesedOptions, callback: callbackNormalilzed }
+    return { uri, options, callback }
   }
 
   function normalizeCallback (inputOptions, callback, inputURL) {
@@ -163,22 +164,16 @@ function patch (http, methodName, tracer, config) {
     }
   }
 
-  function coaleseOptions (inputURL, inputOptions) {
-    let coalesedOptions
-
+  function combineOptions (inputURL, inputOptions) {
     if (typeof inputOptions === 'object') {
-      coalesedOptions = Object.assign(inputURL || {}, inputOptions)
+      return Object.assign(inputURL || {}, inputOptions)
     } else {
-      coalesedOptions = inputURL
+      return inputURL
     }
-
-    coalesedOptions.headers = normalizeHeaders(coalesedOptions)
-
-    return coalesedOptions
   }
 
   function normalizeHeaders (options) {
-    return options.headers || {}
+    options.headers = options.headers || {}
   }
 
   // https://github.com/nodejs/node/blob/7e911d8b03a838e5ac6bb06c5b313533e89673ef/lib/internal/url.js#L1271

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -167,7 +167,6 @@ function patch (http, methodName, tracer, config) {
     inputURL.headers = inputURL.headers || {}
 
     const uri = url.format(inputURL)
-    // const options = inputURL
 
     return { uri, options: inputURL, callback }
   }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -154,17 +154,15 @@ function patch (http, methodName, tracer, config) {
       options.protocol = options.protocol || agent.protocol
       options.hostname = options.hostname || 'localhost'
       options.pathname = options.pathname || '/'
-      
+
       return url.format(options)
     } else {
-      var output = typeof uri === 'string' ? uri : url.format({
+      return typeof uri === 'string' ? uri : url.format({
         protocol: options.protocol || agent.protocol,
         hostname: options.hostname || options.host || 'localhost',
         port: options.port,
         pathname: options.path || options.pathname || '/'
       })
-
-      return output
     }
   }
 

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -182,6 +182,11 @@ function patch (http, methodName, tracer, config) {
     }
 
     options.headers = options.headers || {}
+
+    if (!options.path && inputURL instanceof url.URL) {
+      options.path = `${options.pathname || ''}${options.search || ''}`
+    }
+
     return options
   }
 }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -171,6 +171,7 @@ function patch (http, methodName, tracer, config) {
     const uri = url.format(inputURL)
     const options = inputURL
 
+    console.log(uri, options)
     return { uri, options, callback }
   }
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -98,6 +98,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
+                expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                 expect(traces[0][0]).to.not.be.undefined
               })
               .then(done)
@@ -153,6 +154,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
+                expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)
@@ -179,6 +181,7 @@ describe('Plugin', () => {
             getPort().then(port => {
               agent
                 .use(traces => {
+                  expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                   expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
                 })
                 .then(done)
@@ -202,6 +205,7 @@ describe('Plugin', () => {
             getPort().then(port => {
               agent
                 .use(traces => {
+                  expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                   expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
                 })
                 .then(done)

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -123,6 +123,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
+                console.log(traces[0][0].meta)
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)
@@ -225,7 +226,7 @@ describe('Plugin', () => {
           it('should support configuration as an WHATWG URL object', async () => {
             const app = express()
             const port = await getPort()
-            const url = new URL(`${protocol}:localhost:${port}/user`)
+            const url = new URL(`${protocol}://localhost:${port}/user`)
 
             app.get('/user', (req, res) => res.status(200).send())
 
@@ -235,6 +236,7 @@ describe('Plugin', () => {
             })
 
             await agent.use(traces => {
+              expect(traces[0][0].meta).to.have.property('http.status_code', '200')
               expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
             })
           })

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -123,7 +123,6 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                console.log(traces[0][0].meta)
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/DataDog/dd-trace-js/issues/847

The previous fix for this did not appropriately handle the fact that WHATWG URL's do not have a `path` field (`/user?xyz=abc`) and so it needs to be added while generating the uri by combining the `pathname` and `search` fields

### Motivation
The path of requests was being malformed for users using WHATWG URLs per https://github.com/DataDog/dd-trace-js/issues/847

### Additional Notes
Missed this in the tests originally so i've added another expectation to this test to ensure we _actually_ return a 200 response successfully
