### PR TITLE
fix pubsub tests

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -241,7 +241,7 @@ describe('Plugin', () => {
             'gcloud.project_id': project
           }
         }, expected)
-        return expectSomeSpan(agent, expected, TIMEOUT)
+        return expectSomeSpan(agent, expected, { timeoutMs: TIMEOUT })
       }
     })
   })

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -7,11 +7,14 @@ const id = require('../../dd-trace/src/id')
 
 wrapIt()
 
+// The roundtrip to the pubsub emulator takes time. Sometimes a *long* time.
+const TIMEOUT = 60000
+
 describe('Plugin', () => {
   let tracer
 
   describe('google-cloud-pubsub', function () {
-    this.timeout(5000) // The roundtrip to the pubsub emulator takes time
+    this.timeout(TIMEOUT)
 
     before(() => {
       process.env.PUBSUB_EMULATOR_HOST = 'localhost:8042'
@@ -238,7 +241,7 @@ describe('Plugin', () => {
             'gcloud.project_id': project
           }
         }, expected)
-        return expectSomeSpan(agent, expected)
+        return expectSomeSpan(agent, expected, TIMEOUT)
       }
     })
   })

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -60,12 +60,14 @@ module.exports = {
   },
 
   // Register a callback with expectations to be run on every agent call.
-  use (callback, timeoutMs = 1000) {
+  use (callback, options) {
     const deferred = {}
     const promise = new Promise((resolve, reject) => {
       deferred.resolve = resolve
       deferred.reject = reject
     })
+
+    const timeoutMs = options && typeof options === 'object' && options.timeoutMs ? options.timeoutMs : 1000
 
     const timeout = setTimeout(() => {
       if (error) {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -60,7 +60,7 @@ module.exports = {
   },
 
   // Register a callback with expectations to be run on every agent call.
-  use (callback) {
+  use (callback, timeoutMs = 1000) {
     const deferred = {}
     const promise = new Promise((resolve, reject) => {
       deferred.resolve = resolve
@@ -71,7 +71,7 @@ module.exports = {
       if (error) {
         deferred.reject(error)
       }
-    }, 1000)
+    }, timeoutMs)
 
     let error
 

--- a/packages/dd-trace/test/plugins/helpers.js
+++ b/packages/dd-trace/test/plugins/helpers.js
@@ -2,7 +2,7 @@
 
 const { AssertionError } = require('assert')
 
-function expectSomeSpan (agent, expected) {
+function expectSomeSpan (agent, expected, timeout) {
   return agent.use(traces => {
     const scoredErrors = []
     for (const trace of traces) {
@@ -24,7 +24,7 @@ function expectSomeSpan (agent, expected) {
     // output.
     error.message += '\n\nCandidate Traces:\n' + JSON.stringify(traces, null, 2)
     throw error
-  })
+  }, timeout)
 }
 
 // This is a bit like chai's `expect(expected).to.deep.include(actual)`, except


### PR DESCRIPTION
### What does this PR do?

Timeouts were happening regularly with pubsub tests. The timeout is now set to one minute,
and this is now reflected in `agent.use` so that the timer there can be
set to the same number.


<!-- A brief description of the change being made with this pull request. -->

### Motivation

Tests were failing in CI regularly and locally occaisionally.
<!-- What inspired you to submit this pull request? -->