### PR TITLE
disable fs for now

### DIFF
--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -52,6 +52,7 @@ class Instrumenter {
       Object.keys(plugins)
         .filter(name => !this._plugins.has(plugins[name]))
         .forEach(name => {
+          if (name === 'fs') return // disabling fs for now
           this._set(plugins[name], { name, config: {} })
         })
     }


### PR DESCRIPTION
### What does this PR do?
Disable fs plugin for now

### Motivation
Traces are showing a lot of error spans because many *normal* usages of `fs` involve some error propagation. We'll disable it for now until we have a better solution.
