### PR TITLE
update browser exporter to use sendBeacon when available

### DIFF
--- a/packages/dd-trace/src/exporters/browser/index.js
+++ b/packages/dd-trace/src/exporters/browser/index.js
@@ -55,7 +55,9 @@ class BrowserExporter {
 }
 
 function send (url, body, callback) {
-  if (window.fetch) {
+  if (window.navigator && window.navigator.sendBeacon) {
+    window.navigator.sendBeacon(url, body)
+  } else if (window.fetch) {
     window.fetch(url, { body, method: 'POST', keepalive: true, mode: 'no-cors' })
       .then(callback, callback)
   } else {

--- a/packages/dd-trace/test/browser.test.js
+++ b/packages/dd-trace/test/browser.test.js
@@ -22,7 +22,15 @@ describe('dd-trace', () => {
     })
   })
 
-  if (window.fetch) {
+  if (window.navigator && window.navigator.sendBeacon) {
+    beforeEach(() => {
+      fetch = sinon.stub(window.navigator, 'sendBeacon')
+    })
+
+    afterEach(() => {
+      window.navigator.sendBeacon.restore()
+    })
+  } else if (window.fetch) {
     beforeEach(() => {
       fetch = sinon.stub(window, 'fetch').returns({
         then: resolve => resolve()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the browser exporter to use `window.navigator.sendBeacon` when available.

### Motivation
<!-- What inspired you to submit this pull request? -->

Firefox doesn't support the `keepalive` option for Fetch, and instead cancels the request and logs an error.