### PR TITLE
add site config and update browser exporter to use it

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -18,6 +18,7 @@ class Config {
     const logInjection = coalesce(options.logInjection, platform.env('DD_LOGS_INJECTION'), false)
     const env = coalesce(options.env, platform.env('DD_ENV'))
     const url = coalesce(options.url, platform.env('DD_TRACE_AGENT_URL'), platform.env('DD_TRACE_URL'), null)
+    const site = coalesce(options.site, platform.env('DD_SITE'), 'datadoghq.com')
     const hostname = coalesce(
       options.hostname,
       platform.env('DD_AGENT_HOST'),
@@ -56,6 +57,7 @@ class Config {
     this.logInjection = String(logInjection) === 'true'
     this.env = env
     this.url = url && new URL(url)
+    this.site = site
     this.hostname = hostname || (this.url && this.url.hostname)
     this.port = String(port || (this.url && this.url.port))
     this.flushInterval = flushInterval

--- a/packages/dd-trace/src/exporters/browser/index.js
+++ b/packages/dd-trace/src/exporters/browser/index.js
@@ -9,12 +9,12 @@ const DELIMITER = '\r\n'
 // TODO: flush more often
 
 class BrowserExporter {
-  constructor ({ clientToken, url, env }) {
+  constructor ({ clientToken, url, site, env }) {
     this._queue = []
     this._flushing = false
     this._clientToken = clientToken
     this._env = env
-    this._url = url || new URL('https://public-trace-http-intake.logs.datadoghq.com')
+    this._url = url || new URL(`https://public-trace-http-intake.logs.${site}`)
     this._size = 0
 
     window.addEventListener('beforeunload', () => this._flush())

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -75,6 +75,7 @@ describe('Config', () => {
 
   it('should initialize from environment variables with url taking precedence', () => {
     platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:7777')
+    platform.env.withArgs('DD_SITE').returns('datadoghq.eu')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
@@ -89,6 +90,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent2')
     expect(config).to.have.nested.property('url.port', '7777')
+    expect(config).to.have.property('site', 'datadoghq.eu')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
   })
@@ -103,6 +105,7 @@ describe('Config', () => {
       enabled: false,
       debug: true,
       analytics: true,
+      site: 'datadoghq.eu',
       hostname: 'agent',
       port: 6218,
       dogstatsd: {
@@ -134,6 +137,7 @@ describe('Config', () => {
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
     expect(config).to.have.property('analytics', true)
+    expect(config).to.have.property('site', 'datadoghq.eu')
     expect(config).to.have.property('hostname', 'agent')
     expect(config).to.have.property('port', '6218')
     expect(config).to.have.nested.property('dogstatsd.port', '5218')
@@ -167,6 +171,7 @@ describe('Config', () => {
       debug: true,
       hostname: 'agent',
       url: 'https://agent2:7777',
+      site: 'datadoghq.eu',
       port: 6218,
       service: 'service',
       env: 'test',
@@ -182,6 +187,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent2')
     expect(config).to.have.nested.property('url.port', '7777')
+    expect(config).to.have.property('site', 'datadoghq.eu')
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
     expect(config).to.have.property('sampleRate', 0.5)
@@ -205,6 +211,7 @@ describe('Config', () => {
 
   it('should give priority to the options', () => {
     platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:6218')
+    platform.env.withArgs('DD_SITE').returns('datadoghq.eu')
     platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
     platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
     platform.env.withArgs('DD_DOGSTATSD_PORT').returns('5218')
@@ -224,6 +231,7 @@ describe('Config', () => {
       debug: false,
       analytics: false,
       protocol: 'https',
+      site: 'datadoghq.com',
       hostname: 'server',
       port: 7777,
       dogstatsd: {
@@ -246,6 +254,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('url.hostname', 'agent2')
     expect(config).to.have.nested.property('url.port', '6218')
     expect(config).to.have.nested.property('dogstatsd.port', '8888')
+    expect(config).to.have.property('site', 'datadoghq.com')
     expect(config).to.have.property('runtimeMetrics', false)
     expect(config).to.have.property('reportHostname', false)
     expect(config).to.have.property('service', 'test')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add site config and update browser exporter to use it.

### Motivation
<!-- What inspired you to submit this pull request? -->

The site can be reused for multiple different endpoints, but the URL can only be for tracing.