### PR TITLE
fix missing postgres build container password

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,6 +511,8 @@ jobs:
           - PLUGINS=pg
           - PG_TEST_NATIVE=true
       - image: postgres:9.5
+        environment:
+          - POSTGRES_PASSWORD=postgres
 
   node-promise-js:
     <<: *node-plugin-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - '127.0.0.1:11210:11210'
   postgres:
     image: postgres:9.5-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
     ports:
       - '127.0.0.1:5432:5432'
   mssql:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing Postgres build container password.

### Motivation
<!-- What inspired you to submit this pull request? -->

The build started to fail a couple days ago because a new version of the container was released which requires the password to be explicitly set.