### PR TITLE
pg plugin: support cursors

### DIFF
--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -35,25 +35,9 @@ function createWrapQuery (tracer, config) {
       const statement = (pgQuery.cursor && pgQuery.cursor.text) || pgQuery.text
       const params = this.connectionParameters
 
-      function finishSpan (err) {
-        if (err) {
-          span.addTags({
-            'error.type': err.name,
-            'error.msg': err.message,
-            'error.stack': err.stack
-          })
-        }
-
-        span.finish()
-      }
-
-      function isReadableStream (query) {
-        return query.readable && typeof query.on === 'function'
-      }
-
       if (isReadableStream(pgQuery)) {
-        pgQuery.on('close', function () { finishSpan() })
-        pgQuery.on('error', function (err) { finishSpan(err) })
+        pgQuery.on('close', () => finishSpan(span))
+        pgQuery.on('error', (err) => finishSpan(span, err))
       }
 
       span.setTag('resource.name', statement)
@@ -68,7 +52,7 @@ function createWrapQuery (tracer, config) {
       }
 
       pgQuery.callback = scope.bind((err, res) => {
-        finishSpan(err)
+        finishSpan(span, err)
 
         if (originalCallback) {
           originalCallback(err, res)
@@ -78,6 +62,18 @@ function createWrapQuery (tracer, config) {
       return retval
     }
   }
+}
+
+function finishSpan (span, err) {
+  if (err) {
+    span.setTag('error', err)
+  }
+
+  span.finish()
+}
+
+function isReadableStream (query) {
+  return query.readable && typeof query.on === 'function'
 }
 
 module.exports = [

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -57,6 +57,10 @@
     {
       "name": "pg-native",
       "versions": ["3.0.0"]
+    },
+    {
+      "name": "pg-cursor",
+      "versions": ["2.1.6"]
     }
   ]
 }


### PR DESCRIPTION
this adds support for cursor queries, where the query has a cursor object (where the sql text is), and the result is a readable stream.
see: https://node-postgres.com/api/cursor