### PR TITLE
update browser exporter to send env as a tag

### DIFF
--- a/packages/dd-trace/src/exporters/browser/index.js
+++ b/packages/dd-trace/src/exporters/browser/index.js
@@ -22,11 +22,8 @@ class BrowserExporter {
   }
 
   export (spans) {
-    const env = this._env
-    const meta = {
-      '_dd.source': 'browser'
-    }
-    const json = JSON.stringify({ spans, env, meta })
+    const meta = this._traceMeta()
+    const json = JSON.stringify({ spans, meta })
     const size = json.length + (this._queue.length > 0 ? DELIMITER.length : 0)
 
     if (this._size + size > MAX_SIZE) {
@@ -55,6 +52,16 @@ class BrowserExporter {
       this._flushing = false
     })
   }
+
+  _traceMeta () {
+    const meta = {
+      '_dd.source': 'browser'
+    }
+
+    addTag(meta, 'env', this._env)
+
+    return meta
+  }
 }
 
 function send (url, body, callback) {
@@ -70,6 +77,12 @@ function send (url, body, callback) {
     req.addEventListener('loadend', callback)
     req.send(body)
   }
+}
+
+function addTag (meta, key, value) {
+  if (!value) return
+
+  meta[key] = value
 }
 
 module.exports = BrowserExporter


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the browser exporter to send environment as a tag.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `env` field is deprecated and the environment should be sent as a tag instead.