### PR TITLE
[WIP] KubeMQ (kubets) Plugin

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -459,6 +459,7 @@ interface Plugins {
   "tedious": plugins.tedious;
   "when": plugins.when;
   "winston": plugins.winston;
+  "kubets": plugins.kubets;
 }
 
 /** @hidden */
@@ -978,6 +979,12 @@ declare namespace plugins {
    * on the tracer.
    */
   interface winston extends Integration {}
+
+  /**
+   * This plugin automatically instruments the
+   * [kubets](https://github.com/yomanz/kubets/) module.
+   */
+  interface kubets extends Integration {}
 }
 
 /**

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -18,9 +18,8 @@ function createWrapHandler (tracer, config, handler) {
       if (!server || !server.type) return false
       if (!args[0]) return false
       if (server.type !== 'unary' && !isEmitter(args[0])) return false
-      if (server.type === 'unary' && typeof args[1] !== 'function') return false
 
-      return true
+      return !(server.type === 'unary' && typeof args[1] !== 'function');
     }
 
     return function funcWithTrace (call, callback) {

--- a/packages/datadog-plugin-kubets/src/index.js
+++ b/packages/datadog-plugin-kubets/src/index.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
+
+function addTagsForRequest (tracer, config, span, request) {
+  span.addTags({
+    'service.name': config.service || `${tracer._service}-kubets`,
+    channel: request.getChannel(),
+    body: request.getBody(),
+    metadata: request.getMetadata()
+  })
+  span.setTag('type.query') // TODO: Differentiate between query and events
+}
+
+function createWrapSendRequest (tracer, config) {
+  return function wrapSendRequest (sendFunction) { // This runs BEFORE the function
+    return function sendRequestWithTrace (request) { // This is the Request kubets class, this is where it gets ran
+      const span = tracer.startSpan('kubets.request')
+      addTagsForRequest(tracer, config, span, request)
+
+      analyticsSampler.sample(span, config.analytics, true)
+
+      tracer.scope().activate(span, () => {
+        try {
+          sendFunction.apply(this, arguments)
+        } catch (e) {
+          throw addError(span, e)
+        } finally {
+          span.finish()
+        }
+      })
+    }
+  }
+}
+
+function addError (span, error) {
+  span.addTags({
+    'error.type': error.name,
+    'error.msg': error.message,
+    'error.stack': error.stack
+  })
+
+  return error
+}
+module.exports = [
+  {
+    name: 'kubets',
+    versions: ['>=0.2'],
+    patch ({ GeneralSender, GeneralReceiver }, tracer, config) {
+      this.wrap(GeneralSender.prototype, 'send', createWrapSendRequest(tracer, config))
+    },
+    unpatch ({ GeneralSender, GeneralReceiver }) {
+      this.unwrap(GeneralSender.prototype, 'send')
+    }
+  }
+]

--- a/packages/datadog-plugin-kubets/src/index.js
+++ b/packages/datadog-plugin-kubets/src/index.js
@@ -7,7 +7,7 @@ function addTagsForRequest (tracer, config, span, request) {
 
   span.addTags({
     'service.name': config.service || `${tracer._service}-kubets`,
-    channel: request.getChannel(),
+    channel: request.getChannel() || 'No channel specified',
     body: (typeof body === 'string' ? body : body.toString()) || 'No body specified',
     metadata: request.getMetadata() || 'No metadata specified'
   });

--- a/packages/datadog-plugin-kubets/test/index.spec.js
+++ b/packages/datadog-plugin-kubets/test/index.spec.js
@@ -1,0 +1,278 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const plugin = require('../src')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let tracer
+  let connection
+  let channel
+
+  describe('amqplib', () => {
+    withVersions(plugin, 'amqplib', version => {
+      beforeEach(() => {
+        tracer = require('../../dd-trace')
+      })
+
+      afterEach(() => {
+        connection.close()
+      })
+
+      describe('without configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'amqplib')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        describe('when using a callback', () => {
+          beforeEach(done => {
+            require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
+              .connect((err, conn) => {
+                connection = conn
+
+                if (err != null) {
+                  return done(err)
+                }
+
+                conn.createChannel((err, ch) => {
+                  channel = ch
+                  done(err)
+                })
+              })
+          })
+
+          describe('when sending commands', () => {
+            it('should do automatic instrumentation for immediate commands', done => {
+              agent
+                .use(traces => {
+                  const span = traces[0][0]
+
+                  expect(span).to.have.property('name', 'amqp.command')
+                  expect(span).to.have.property('service', 'test-amqp')
+                  expect(span).to.have.property('resource', 'queue.declare test')
+                  expect(span).to.have.property('type', 'worker')
+                  expect(span.meta).to.have.property('out.host', 'localhost')
+                  expect(span.metrics).to.have.property('out.port', 5672)
+                }, 2)
+                .then(done)
+                .catch(done)
+
+              channel.assertQueue('test', {}, () => {})
+            })
+
+            it('should do automatic instrumentation for queued commands', done => {
+              agent
+                .use(traces => {
+                  const span = traces[0][0]
+
+                  expect(span).to.have.property('name', 'amqp.command')
+                  expect(span).to.have.property('service', 'test-amqp')
+                  expect(span).to.have.property('resource', 'queue.delete test')
+                  expect(span).to.have.property('type', 'worker')
+                  expect(span.meta).to.have.property('out.host', 'localhost')
+                  expect(span.metrics).to.have.property('out.port', 5672)
+                }, 3)
+                .then(done)
+                .catch(done)
+
+              channel.assertQueue('test', {}, () => {})
+              channel.deleteQueue('test', () => {})
+            })
+
+            it('should handle errors', done => {
+              let error
+
+              agent
+                .use(traces => {
+                  const span = traces[0][0]
+
+                  expect(span).to.have.property('error', 1)
+                  expect(span.meta).to.have.property('error.type', error.name)
+                  expect(span.meta).to.have.property('error.msg', error.message)
+                  expect(span.meta).to.have.property('error.stack', error.stack)
+                }, 2)
+                .then(done)
+                .catch(done)
+
+              try {
+                channel.deleteQueue(null, () => {})
+              } catch (e) {
+                error = e
+              }
+            })
+          })
+
+          describe('when publishing messages', () => {
+            it('should do automatic instrumentation', done => {
+              agent
+                .use(traces => {
+                  const span = traces[0][0]
+
+                  expect(span).to.have.property('name', 'amqp.command')
+                  expect(span).to.have.property('service', 'test-amqp')
+                  expect(span).to.have.property('resource', 'basic.publish exchange routingKey')
+                  expect(span).to.have.property('type', 'worker')
+                  expect(span.meta).to.have.property('out.host', 'localhost')
+                  expect(span.meta).to.have.property('span.kind', 'producer')
+                  expect(span.meta).to.have.property('amqp.routingKey', 'routingKey')
+                  expect(span.metrics).to.have.property('out.port', 5672)
+                }, 3)
+                .then(done)
+                .catch(done)
+
+              channel.assertExchange('exchange', 'direct', {}, () => {})
+              channel.publish('exchange', 'routingKey', Buffer.from('content'))
+            })
+
+            it('should handle errors', done => {
+              let error
+
+              agent
+                .use(traces => {
+                  const span = traces[0][0]
+
+                  expect(span).to.have.property('error', 1)
+                  expect(span.meta).to.have.property('error.type', error.name)
+                  expect(span.meta).to.have.property('error.msg', error.message)
+                  expect(span.meta).to.have.property('error.stack', error.stack)
+                }, 2)
+                .then(done)
+                .catch(done)
+
+              try {
+                channel.sendToQueue('test', 'invalid')
+              } catch (e) {
+                error = e
+              }
+            })
+          })
+
+          describe('when consuming messages', () => {
+            it('should do automatic instrumentation', done => {
+              let consumerTag
+              let queue
+
+              agent
+                .use(traces => {
+                  const span = traces[0][0]
+
+                  expect(span).to.have.property('name', 'amqp.command')
+                  expect(span).to.have.property('service', 'test-amqp')
+                  expect(span).to.have.property('resource', `basic.deliver ${queue}`)
+                  expect(span).to.have.property('type', 'worker')
+                  expect(span.meta).to.have.property('out.host', 'localhost')
+                  expect(span.meta).to.have.property('span.kind', 'consumer')
+                  expect(span.meta).to.have.property('amqp.consumerTag', consumerTag)
+                  expect(span.metrics).to.have.property('out.port', 5672)
+                }, 5)
+                .then(done)
+                .catch(done)
+
+              channel.assertQueue('', {}, (err, ok) => {
+                if (err) return done(err)
+
+                queue = ok.queue
+
+                channel.sendToQueue(ok.queue, Buffer.from('content'))
+                channel.consume(ok.queue, () => {}, {}, (err, ok) => {
+                  if (err) return done(err)
+                  consumerTag = ok.consumerTag
+                })
+              })
+            })
+
+            it('should run the command callback in the parent context', done => {
+              if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
+              channel.assertQueue('', {}, (err, ok) => {
+                if (err) return done(err)
+
+                channel.consume(ok.queue, () => {}, {}, () => {
+                  expect(tracer.scope().active()).to.be.null
+                  done()
+                })
+              })
+            })
+
+            it('should run the delivery callback in the current context', done => {
+              if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
+              channel.assertQueue('', {}, (err, ok) => {
+                if (err) return done(err)
+
+                channel.sendToQueue(ok.queue, Buffer.from('content'))
+                channel.consume(ok.queue, () => {
+                  expect(tracer.scope().active()).to.not.be.null
+                  done()
+                }, {}, err => err && done(err))
+              })
+            })
+          })
+        })
+
+        describe('when using a promise', () => {
+          beforeEach(() => {
+            return require(`../../../versions/amqplib@${version}`).get().connect()
+              .then(conn => (connection = conn))
+              .then(conn => conn.createChannel())
+              .then(ch => (channel = ch))
+          })
+
+          it('should run the callback in the parent context', done => {
+            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+
+            channel.assertQueue('test', {})
+              .then(() => {
+                expect(tracer.scope().active()).to.be.null
+                done()
+              })
+              .catch(done)
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        before(() => {
+          return agent.load(plugin, 'amqplib', { service: 'test' })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(done => {
+          require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
+            .connect((err, conn) => {
+              connection = conn
+
+              if (err !== null) {
+                return done(err)
+              }
+
+              conn.createChannel((err, ch) => {
+                channel = ch
+                done(err)
+              })
+            })
+        })
+
+        it('should be configured with the correct values', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'test')
+              expect(traces[0][0]).to.have.property('resource', 'queue.declare test')
+            }, 2)
+            .then(done)
+            .catch(done)
+
+          channel.assertQueue('test', {}, () => {})
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-kubets/test/leak.js
+++ b/packages/datadog-plugin-kubets/test/leak.js
@@ -1,0 +1,40 @@
+'use strict'
+
+require('../../dd-trace')
+  .init({ plugins: false, sampleRate: 0 })
+  .use('amqplib')
+
+const test = require('tape')
+const profile = require('../../dd-trace/test/profile')
+
+test('amqplib plugin should not leak when using callbacks', t => {
+  require('../../../versions/amqplib').get('amqplib/callback_api')
+    .connect((err, conn) => {
+      if (err) return t.fail(err)
+
+      conn.createChannel((err, ch) => {
+        if (err) return t.fail(err)
+
+        profile(t, operation, 400).then(() => conn.close())
+
+        function operation (done) {
+          ch.assertQueue('test', {}, done)
+        }
+      })
+    })
+})
+
+test('amqplib plugin should not leak when using promises', t => {
+  require('../../../versions/amqplib').get().connect()
+    .then(conn => {
+      return conn.createChannel()
+        .then(ch => {
+          profile(t, operation, 400).then(() => conn.close())
+
+          function operation (done) {
+            ch.assertQueue('test', {}).then(done)
+          }
+        })
+    })
+    .catch(t.fail)
+})

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -17,6 +17,7 @@ module.exports = {
   'google-cloud-pubsub': require('../../../datadog-plugin-google-cloud-pubsub/src'),
   'graphql': require('../../../datadog-plugin-graphql/src'),
   'grpc': require('../../../datadog-plugin-grpc/src'),
+  'kubets': require('../../../datadog-plugin-kubets/src'),
   'hapi': require('../../../datadog-plugin-hapi/src'),
   'http': require('../../../datadog-plugin-http/src'),
   'http2': require('../../../datadog-plugin-http2/src'),


### PR DESCRIPTION
### What does this PR do?
It adds a plugin compatible with KubeMQ, specifically [kubets](https://github.com/Yomanz/Kubets)

### Motivation
I setup APM today and it was dope but I really needed a bit extra information from kubemq.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
This would be SO much easier if it was in typescript :)
Issue: https://github.com/DataDog/dd-trace-js/issues/864