### PR TITLE
add install script to avoid rebuild on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "browser": "browser.js",
   "typings": "index.d.ts",
   "scripts": {
+    "install": "node-gyp-build",
     "rebuild": "node-gyp rebuild",
     "prebuild": "node scripts/prebuild.js",
     "prebuilds": "node scripts/prebuilds.js",

--- a/scripts/prebuilds.js
+++ b/scripts/prebuilds.js
@@ -43,16 +43,20 @@ function extractPrebuilds () {
 
 function validatePrebuilds () {
   platforms.forEach(platform => {
-    fs.readdirSync(path.join(os.tmpdir(), 'prebuilds', platform))
-      .filter(file => /^node-\d+\.node$/.test(file))
-      .forEach(file => {
-        const content = fs.readFileSync(path.join('prebuilds', platform, file))
-        const sum = fs.readFileSync(path.join('prebuilds', platform, `${file}.sha1`), 'ascii')
+    try {
+      fs.readdirSync(path.join(os.tmpdir(), 'prebuilds', platform))
+        .filter(file => /^node-\d+\.node$/.test(file))
+        .forEach(file => {
+          const content = fs.readFileSync(path.join('prebuilds', platform, file))
+          const sum = fs.readFileSync(path.join('prebuilds', platform, `${file}.sha1`), 'ascii')
 
-        if (sum !== checksum(content)) {
-          throw new Error(`Invalid checksum for "prebuilds/${platform}/${file}".`)
-        }
-      })
+          if (sum !== checksum(content)) {
+            throw new Error(`Invalid checksum for "prebuilds/${platform}/${file}".`)
+          }
+        })
+    } catch (e) {
+      // skip missing platforms
+    }
   })
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add install script to avoid rebuild on install and update prebuilds script to skip missing platforms.

### Motivation
<!-- What inspired you to submit this pull request? -->

Removing the install script causes yarn to always rebuild the project. This is a regression for #867 but it will take some investigation to fix properly.

While testing this, I also noticed that the prebuilds script requires that all platforms have been built. This is unnecessary since we already have that guarantee in the CircleCI build.