### PR TITLE
fix koa router double patched on every request

### DIFF
--- a/packages/datadog-plugin-koa/src/index.js
+++ b/packages/datadog-plugin-koa/src/index.js
@@ -79,6 +79,10 @@ function createWrapRoutes (tracer, config) {
             set (value) {
               router = value
 
+              if (router._dd_patched) return
+
+              router._dd_patched = true
+
               for (const layer of router.stack) {
                 wrapStack(layer)
               }

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -287,15 +287,6 @@ describe('Plugin', () => {
               axios
                 .get(`http://localhost:${port}/user/123`)
                 .catch(done)
-
-              axios
-                .get(`http://localhost:${port}/user/123`)
-              axios
-                .get(`http://localhost:${port}/user/123`)
-              axios
-                .get(`http://localhost:${port}/user/123`)
-              axios
-                .get(`http://localhost:${port}/user/123`)
             })
           })
 

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -287,6 +287,15 @@ describe('Plugin', () => {
               axios
                 .get(`http://localhost:${port}/user/123`)
                 .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/user/123`)
+              axios
+                .get(`http://localhost:${port}/user/123`)
+              axios
+                .get(`http://localhost:${port}/user/123`)
+              axios
+                .get(`http://localhost:${port}/user/123`)
             })
           })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix koa router double patched on every request by re-patching the entire router and throwing away the old patches on every middleware added.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is a regression introduced in #844. The plugin was changed to patch the routes on dispatch to make sure that the routes are final because `koa-router` clones the routes internally since this [fix](https://github.com/koajs/router/pull/24/files). This resulted in the routes being patched again on every single request.

Fixes #870 