### PR TITLE
remove unneeded plugin variable passed into agent.load

### DIFF
--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -34,7 +34,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'amqp10')
+          return agent.load('amqp10')
             .then(() => {
               const amqp = require(`../../../versions/amqp10@${version}`).get()
               const None = amqp.Policy.Utils.SenderCallbackPolicies.None
@@ -173,7 +173,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'amqp10', { service: 'test' })
+          return agent.load('amqp10', { service: 'test' })
             .then(() => {
               const amqp = require(`../../../versions/amqp10@${version}`).get()
 

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -22,7 +22,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'amqplib')
+          return agent.load('amqplib')
         })
 
         after(() => {
@@ -238,7 +238,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load(plugin, 'amqplib', { service: 'test' })
+          return agent.load('amqplib', { service: 'test' })
         })
 
         after(() => {

--- a/packages/datadog-plugin-bunyan/test/index.spec.js
+++ b/packages/datadog-plugin-bunyan/test/index.spec.js
@@ -29,7 +29,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'bunyan', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
-        return agent.load(plugin, 'bunyan')
+        return agent.load('bunyan')
       })
 
       afterEach(() => {

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -21,7 +21,7 @@ describe('Plugin', () => {
         let client
 
         before(() => {
-          return agent.load(plugin, 'cassandra-driver')
+          return agent.load('cassandra-driver')
         })
 
         after(() => {
@@ -168,7 +168,7 @@ describe('Plugin', () => {
         let client
 
         before(() => {
-          return agent.load(plugin, 'cassandra-driver', { service: 'custom' })
+          return agent.load('cassandra-driver', { service: 'custom' })
         })
 
         after(() => {
@@ -209,7 +209,7 @@ describe('Plugin', () => {
           let client
 
           before(() => {
-            return agent.load(plugin, 'cassandra-driver')
+            return agent.load('cassandra-driver')
           })
 
           after(() => {

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -27,7 +27,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'connect')
+          return agent.load('connect')
         })
 
         after(() => {
@@ -489,7 +489,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load(plugin, 'connect', {
+          return agent.load('connect', {
             service: 'custom',
             validateStatus: code => code < 400,
             headers: ['User-Agent']
@@ -679,7 +679,7 @@ describe('Plugin', () => {
 
       describe('with middleware disabled', () => {
         before(() => {
-          return agent.load(plugin, 'connect', {
+          return agent.load('connect', {
             middleware: false
           })
         })

--- a/packages/datadog-plugin-couchbase/test/index.spec.js
+++ b/packages/datadog-plugin-couchbase/test/index.spec.js
@@ -21,7 +21,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'couchbase').then(() => {
+          return agent.load('couchbase').then(() => {
             couchbase = require(`../../../versions/couchbase@${version}`).get()
             N1qlQuery = couchbase.N1qlQuery
           })

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -16,7 +16,7 @@ describe('Plugin', () => {
     })
 
     beforeEach(() => {
-      return agent.load(plugin, 'dns')
+      return agent.load('dns')
         .then(() => {
           dns = require('dns')
           tracer = require('../../dd-trace')

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -2,7 +2,6 @@
 
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
-const plugin = require('../src')
 
 wrapIt()
 

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -19,7 +19,7 @@ describe('Plugin', () => {
         let client
 
         before(() => {
-          return agent.load(plugin, 'elasticsearch')
+          return agent.load('elasticsearch')
         })
 
         after(() => {
@@ -215,7 +215,7 @@ describe('Plugin', () => {
         let client
 
         before(() => {
-          return agent.load(plugin, 'elasticsearch', {
+          return agent.load('elasticsearch', {
             service: 'test',
             hooks: { query: (span, params) => {
               span.addTags({ 'elasticsearch.params': 'foo', 'elasticsearch.method': params.method })

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -26,7 +26,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'express')
+          return agent.load('express')
         })
 
         after(() => {
@@ -892,7 +892,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load(plugin, 'express', {
+          return agent.load('express', {
             service: 'custom',
             validateStatus: code => code < 400,
             headers: ['User-Agent']
@@ -989,7 +989,7 @@ describe('Plugin', () => {
 
       describe('with configuration for middleware disabled', () => {
         before(() => {
-          return agent.load(plugin, 'express', {
+          return agent.load('express', {
             middleware: false
           })
         })

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -24,7 +24,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'fastify')
+          return agent.load('fastify')
         })
 
         after(() => {

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -2,7 +2,6 @@
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
-const plugin = require('../src')
 
 const realFS = Object.assign({}, require('fs'))
 const os = require('os')

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -22,7 +22,7 @@ describe('Plugin', () => {
     let tmpdir
     let tracer
     afterEach(() => agent.close())
-    beforeEach(() => agent.load(plugin, 'fs').then(() => {
+    beforeEach(() => agent.load('fs').then(() => {
       tracer = require('../../dd-trace')
       fs = require('fs')
     }))

--- a/packages/datadog-plugin-generic-pool/test/index.spec.js
+++ b/packages/datadog-plugin-generic-pool/test/index.spec.js
@@ -21,7 +21,7 @@ describe('Plugin', () => {
 
     withVersions(plugin, 'generic-pool', '2', version => {
       beforeEach(() => {
-        return agent.load(plugin, 'generic-pool')
+        return agent.load('generic-pool')
           .then(() => {
             genericPool = require(`../../../versions/generic-pool@${version}`).get()
           })
@@ -61,7 +61,7 @@ describe('Plugin', () => {
 
     withVersions(plugin, 'generic-pool', '>=3', version => {
       beforeEach(() => {
-        return agent.load(plugin, 'generic-pool')
+        return agent.load('generic-pool')
           .then(() => {
             genericPool = require(`../../../versions/generic-pool@${version}`).get()
           })

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -35,7 +35,7 @@ describe('Plugin', () => {
       describe('without configuration', () => {
         beforeEach(() => {
           tracer = require('../../dd-trace')
-          agent.load(plugin, 'google-cloud-pubsub')
+          agent.load('google-cloud-pubsub')
           const { PubSub } = require(`../../../versions/@google-cloud/pubsub@${version}`).get()
           project = getProjectId()
           topicName = getTopic()
@@ -205,7 +205,7 @@ describe('Plugin', () => {
       describe('with configuration', () => {
         beforeEach(() => {
           tracer = require('../../dd-trace')
-          agent.load(plugin, 'google-cloud-pubsub', {
+          agent.load('google-cloud-pubsub', {
             service: 'a_test_service'
           })
           const { PubSub } = require(`../../../versions/@google-cloud/pubsub@${version}`).get()

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -163,7 +163,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'graphql')
+          return agent.load('graphql')
             .then(() => {
               tracer = require('../../dd-trace')
               graphql = require(`../../../versions/graphql@${version}`).get()
@@ -986,7 +986,7 @@ describe('Plugin', () => {
         before(() => {
           tracer = require('../../dd-trace')
 
-          return agent.load(plugin, 'graphql', {
+          return agent.load('graphql', {
             service: 'test',
             variables: variables => Object.assign({}, variables, { who: 'REDACTED' })
           })
@@ -1045,7 +1045,7 @@ describe('Plugin', () => {
         before(() => {
           tracer = require('../../dd-trace')
 
-          return agent.load(plugin, 'graphql', {
+          return agent.load('graphql', {
             variables: ['title']
           })
         })
@@ -1084,7 +1084,7 @@ describe('Plugin', () => {
         before(() => {
           tracer = require('../../dd-trace')
 
-          return agent.load(plugin, 'graphql', { depth: 0 })
+          return agent.load('graphql', { depth: 0 })
         })
 
         after(() => {
@@ -1155,7 +1155,7 @@ describe('Plugin', () => {
         before(() => {
           tracer = require('../../dd-trace')
 
-          return agent.load(plugin, 'graphql', { depth: 2 })
+          return agent.load('graphql', { depth: 2 })
         })
 
         after(() => {
@@ -1207,7 +1207,7 @@ describe('Plugin', () => {
         before(() => {
           tracer = require('../../dd-trace')
 
-          return agent.load(plugin, 'graphql', { collapse: false })
+          return agent.load('graphql', { collapse: false })
         })
 
         after(() => {
@@ -1261,7 +1261,7 @@ describe('Plugin', () => {
         before(() => {
           tracer = require('../../dd-trace')
 
-          return agent.load(plugin, 'graphql', { signature: false })
+          return agent.load('graphql', { signature: false })
         })
 
         after(() => {
@@ -1298,7 +1298,7 @@ describe('Plugin', () => {
         before(() => {
           tracer = require('../../dd-trace')
 
-          return agent.load(plugin, 'graphql')
+          return agent.load('graphql')
             .then(() => {
               graphql = require(`../../../versions/graphql@${version}`).get()
 

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -53,7 +53,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'grpc', version => {
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'grpc', { server: false })
+          return agent.load('grpc', { server: false })
             .then(() => {
               tracer = require('../../dd-trace')
               grpc = require(`../../../versions/grpc@${version}`).get()
@@ -404,7 +404,7 @@ describe('Plugin', () => {
             server: false
           }
 
-          return agent.load(plugin, 'grpc', config)
+          return agent.load('grpc', config)
             .then(() => {
               grpc = require(`../../../versions/grpc@${version}`).get()
             })
@@ -441,7 +441,7 @@ describe('Plugin', () => {
             server: false
           }
 
-          return agent.load(plugin, 'grpc', config)
+          return agent.load('grpc', config)
             .then(() => {
               grpc = require(`../../../versions/grpc@${version}`).get()
             })
@@ -501,7 +501,7 @@ describe('Plugin', () => {
             server: false
           }
 
-          return agent.load(plugin, 'grpc', config)
+          return agent.load('grpc', config)
             .then(() => {
               grpc = require(`../../../versions/grpc@${version}`).get()
             })

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -49,7 +49,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'grpc', version => {
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'grpc', { client: false })
+          return agent.load('grpc', { client: false })
             .then(() => {
               tracer = require('../../dd-trace')
               grpc = require(`../../../versions/grpc@${version}`).get()
@@ -313,7 +313,7 @@ describe('Plugin', () => {
             client: false
           }
 
-          return agent.load(plugin, 'grpc', config)
+          return agent.load('grpc', config)
             .then(() => {
               grpc = require(`../../../versions/grpc@${version}`).get()
             })
@@ -350,7 +350,7 @@ describe('Plugin', () => {
             client: false
           }
 
-          return agent.load(plugin, 'grpc', config)
+          return agent.load('grpc', config)
             .then(() => {
               grpc = require(`../../../versions/grpc@${version}`).get()
             })

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
       })
 
       before(() => {
-        return agent.load(plugin, 'hapi')
+        return agent.load('hapi')
           .then(() => {
             Hapi = require(`../../../versions/${module}@${version}`).get()
           })

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -50,7 +50,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'http')
+          return agent.load('http')
             .then(() => {
               http = require(protocol)
               express = require('express')
@@ -655,7 +655,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http', config)
+          return agent.load('http', config)
             .then(() => {
               http = require(protocol)
               express = require('express')
@@ -699,7 +699,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http', config)
+          return agent.load('http', config)
             .then(() => {
               http = require(protocol)
               express = require('express')
@@ -743,7 +743,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http', config)
+          return agent.load('http', config)
             .then(() => {
               http = require(protocol)
               express = require('express')
@@ -787,7 +787,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http', config)
+          return agent.load('http', config)
             .then(() => {
               http = require(protocol)
               express = require('express')
@@ -867,7 +867,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http', config)
+          return agent.load('http', config)
             .then(() => {
               http = require(protocol)
               express = require('express')

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -15,7 +15,6 @@ const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 wrapIt()
 
 describe('Plugin', () => {
-  let plugin
   let express
   let http
   let appListener
@@ -36,7 +35,6 @@ describe('Plugin', () => {
       }
 
       beforeEach(() => {
-        plugin = require('../src/client')
         tracer = require('../../dd-trace')
         appListener = null
       })

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -39,7 +39,7 @@ describe('Plugin', () => {
 
     describe('without configuration', () => {
       beforeEach(() => {
-        return agent.load(plugin, 'http')
+        return agent.load('http')
           .then(() => {
             http = require('http')
           })

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -7,7 +7,6 @@ const axios = require('axios')
 wrapIt()
 
 describe('Plugin', () => {
-  let plugin
   let http
   let listener
   let appListener
@@ -17,7 +16,6 @@ describe('Plugin', () => {
 
   describe('http/server', () => {
     beforeEach(() => {
-      plugin = require('../src/server')
       tracer = require('../../dd-trace')
       listener = (req, res) => {
         app && app(req, res)

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -16,7 +16,6 @@ wrapIt()
 const describe = () => {} // temporarily disable HTTP2 client plugin tests
 
 describe('Plugin', () => {
-  let plugin
   let http2
   let appListener
   let tracer
@@ -37,7 +36,6 @@ describe('Plugin', () => {
       }
 
       beforeEach(() => {
-        plugin = require('../src/client')
         tracer = require('../../dd-trace')
         appListener = null
       })

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -51,7 +51,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, 'http2')
+          return agent.load('http2')
             .then(() => {
               http2 = require('http2')
             })
@@ -643,7 +643,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http2', config)
+          return agent.load('http2', config)
             .then(() => {
               http2 = require('http2')
             })
@@ -690,7 +690,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http2', config)
+          return agent.load('http2', config)
             .then(() => {
               http2 = require('http2')
             })
@@ -737,7 +737,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http2', config)
+          return agent.load('http2', config)
             .then(() => {
               http2 = require('http2')
             })
@@ -782,7 +782,7 @@ describe('Plugin', () => {
             }
           }
 
-          return agent.load(plugin, 'http2', config)
+          return agent.load('http2', config)
             .then(() => {
               http2 = require('http2')
             })

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -12,7 +12,6 @@ wrapIt()
 const describe = () => {} // temporarily disable HTTP2 server plugin tests
 
 describe('Plugin', () => {
-  let plugin
   let http2
   let app
   let appListener
@@ -23,7 +22,6 @@ describe('Plugin', () => {
 
   describe('http2/server', () => {
     beforeEach(() => {
-      plugin = require('../src/server')
       tracer = require('../../dd-trace')
     })
 

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -35,7 +35,7 @@ describe('Plugin', () => {
 
     describe('without configuration', () => {
       beforeEach(() => {
-        return agent.load(plugin, 'http2')
+        return agent.load('http2')
           .then(() => {
             http2 = require('http2')
           })

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -23,7 +23,7 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => agent.load(plugin, ['ioredis', 'bluebird']))
+        before(() => agent.load(['ioredis', 'bluebird']))
         after(() => agent.close())
 
         it('should do automatic instrumentation when using callbacks', done => {
@@ -82,7 +82,7 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        before(() => agent.load(plugin, 'ioredis', { service: 'custom' }))
+        before(() => agent.load('ioredis', { service: 'custom' }))
         after(() => agent.close())
 
         it('should be configured with the correct values', done => {

--- a/packages/datadog-plugin-knex/test/index.spec.js
+++ b/packages/datadog-plugin-knex/test/index.spec.js
@@ -24,7 +24,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, ['knex'])
+          return agent.load(['knex'])
             .then(() => {
               knex = require(`../../../versions/knex@${version}`).get()
               client = knex({

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -31,7 +31,7 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => agent.load(plugin, 'koa'))
+        before(() => agent.load('koa'))
         after(() => agent.close())
 
         it('should do automatic instrumentation on 2.x middleware', done => {
@@ -503,7 +503,7 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        before(() => agent.load(plugin, 'koa', { middleware: false }))
+        before(() => agent.load('koa', { middleware: false }))
         after(() => agent.close())
 
         describe('middleware set to false', () => {

--- a/packages/datadog-plugin-limitd-client/test/index.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/index.spec.js
@@ -13,7 +13,7 @@ describe('Plugin', () => {
   describe('limitd-client', () => {
     withVersions(plugin, 'limitd-client', version => {
       beforeEach(done => {
-        agent.load(plugin, 'limitd-client')
+        agent.load('limitd-client')
           .then(() => {
             tracer = require('../../dd-trace')
             LimitdClient = require(`../../../versions/limitd-client@${version}`).get()

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -22,7 +22,7 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => agent.load(plugin, 'memcached'))
+        before(() => agent.load('memcached'))
         after(() => agent.close())
 
         it('should do automatic instrumentation when using callbacks', done => {
@@ -138,7 +138,7 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        before(() => agent.load(plugin, 'memcached', { service: 'custom' }))
+        before(() => agent.load('memcached', { service: 'custom' }))
         after(() => agent.close())
 
         beforeEach(() => {

--- a/packages/datadog-plugin-mongodb-core/test/index.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/index.spec.js
@@ -38,7 +38,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'mongodb-core')
+          return agent.load('mongodb-core')
         })
 
         after(() => {
@@ -334,7 +334,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load(plugin, 'mongodb-core', { service: 'custom' })
+          return agent.load('mongodb-core', { service: 'custom' })
         })
 
         after(() => {

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -19,7 +19,7 @@ describe('Plugin', () => {
         let connection
 
         before(() => {
-          return agent.load(plugin, 'mysql')
+          return agent.load('mysql')
         })
 
         after(() => {
@@ -124,7 +124,7 @@ describe('Plugin', () => {
         let connection
 
         before(() => {
-          return agent.load(plugin, 'mysql', { service: 'custom' })
+          return agent.load('mysql', { service: 'custom' })
         })
 
         after(() => {
@@ -161,7 +161,7 @@ describe('Plugin', () => {
         let pool
 
         before(() => {
-          return agent.load(plugin, 'mysql')
+          return agent.load('mysql')
         })
 
         after(() => {

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -19,7 +19,7 @@ describe('Plugin', () => {
         let connection
 
         before(() => {
-          return agent.load(plugin, 'mysql2')
+          return agent.load('mysql2')
         })
 
         after(() => {
@@ -173,7 +173,7 @@ describe('Plugin', () => {
         let connection
 
         before(() => {
-          return agent.load(plugin, 'mysql2', { service: 'custom' })
+          return agent.load('mysql2', { service: 'custom' })
         })
 
         after(() => {
@@ -212,7 +212,7 @@ describe('Plugin', () => {
         let pool
 
         before(() => {
-          return agent.load(plugin, 'mysql2')
+          return agent.load('mysql2')
         })
 
         after(() => {

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -2,7 +2,6 @@
 
 const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
-const plugin = require('../src')
 
 wrapIt()
 

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -28,7 +28,7 @@ describe('Plugin', () => {
     })
 
     beforeEach(() => {
-      return agent.load(plugin, 'net')
+      return agent.load('net')
         .then(() => {
           net = require(`net`)
           tracer = require('../../dd-trace')

--- a/packages/datadog-plugin-paperplane/test/index.spec.js
+++ b/packages/datadog-plugin-paperplane/test/index.spec.js
@@ -56,7 +56,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'paperplane')
+          return agent.load('paperplane')
         })
 
         after(() => {
@@ -452,7 +452,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load(plugin, 'paperplane', {
+          return agent.load('paperplane', {
             service: 'custom',
             validateStatus: code => code < 400,
             headers: ['User-Agent']

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -28,7 +28,7 @@ describe('Plugin', () => {
       Object.keys(clients).forEach(implementation => {
         describe(`when using ${implementation}.Client`, () => {
           before(() => {
-            return agent.load(plugin, 'pg')
+            return agent.load('pg')
           })
 
           after(() => {
@@ -135,7 +135,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load(plugin, 'pg', { service: 'custom' })
+          return agent.load('pg', { service: 'custom' })
         })
 
         after(() => {

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -29,7 +29,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'pino', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
-        return agent.load(plugin, 'pino')
+        return agent.load('pino')
       })
 
       afterEach(() => {

--- a/packages/datadog-plugin-redis/test/index.spec.js
+++ b/packages/datadog-plugin-redis/test/index.spec.js
@@ -26,7 +26,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'redis')
+          return agent.load('redis')
         })
 
         after(() => {
@@ -132,7 +132,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load(plugin, 'redis', { service: 'custom' })
+          return agent.load('redis', { service: 'custom' })
         })
 
         after(() => {

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -30,7 +30,7 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => agent.load(plugin, 'restify'))
+        before(() => agent.load('restify'))
         after(() => agent.close())
 
         it('should do automatic instrumentation', done => {

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -26,7 +26,7 @@ describe('Plugin', () => {
         })
 
         describe('without configuration', () => {
-          beforeEach(() => agent.load(plugin, 'rhea'))
+          beforeEach(() => agent.load('rhea'))
 
           beforeEach(done => {
             container = require(`../../../versions/rhea@${version}`).get()
@@ -111,7 +111,7 @@ describe('Plugin', () => {
         })
 
         describe('with configuration', () => {
-          beforeEach(() => agent.load(plugin, 'rhea', {
+          beforeEach(() => agent.load('rhea', {
             service: 'a_test_service'
           }))
 
@@ -176,7 +176,7 @@ describe('Plugin', () => {
         })
 
         describe('with defaults', () => {
-          beforeEach(() => agent.load(plugin, 'rhea'))
+          beforeEach(() => agent.load('rhea'))
 
           beforeEach(done => {
             const rhea = require(`../../../versions/rhea@${version}`).get()
@@ -277,7 +277,7 @@ describe('Plugin', () => {
         })
 
         describe('with pre-settled messages', () => {
-          beforeEach(() => agent.load(plugin, 'rhea'))
+          beforeEach(() => agent.load('rhea'))
 
           beforeEach(done => {
             const rhea = require(`../../../versions/rhea@${version}`).get()
@@ -346,7 +346,7 @@ describe('Plugin', () => {
         })
 
         describe('with manually settled messages', () => {
-          beforeEach(() => agent.load(plugin, 'rhea'))
+          beforeEach(() => agent.load('rhea'))
 
           beforeEach(done => {
             const rhea = require(`../../../versions/rhea@${version}`).get()
@@ -427,7 +427,7 @@ describe('Plugin', () => {
         })
 
         describe('on disconnect', () => {
-          beforeEach(() => agent.load(plugin, 'rhea'))
+          beforeEach(() => agent.load('rhea'))
 
           beforeEach(done => {
             const rhea = require(`../../../versions/rhea@${version}`).get()

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -43,7 +43,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          return agent.load(plugin, 'router')
+          return agent.load('router')
         })
 
         after(() => {

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -23,7 +23,7 @@ describe('Plugin', () => {
       let config
 
       beforeEach(() => {
-        return agent.load(plugin, 'tedious').then(() => {
+        return agent.load('tedious').then(() => {
           tds = require(`../../../versions/tedious@${version}`).get()
         })
       })

--- a/packages/datadog-plugin-winston/test/index.spec.js
+++ b/packages/datadog-plugin-winston/test/index.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
     withVersions(plugin, 'winston', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
-        return agent.load(plugin, 'winston')
+        return agent.load('winston')
       })
 
       afterEach(() => {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -16,7 +16,7 @@ let tracer = null
 
 module.exports = {
   // Load the plugin on the tracer with an optional config and start a mock agent.
-  load (plugin, pluginName, config) {
+  load (pluginName, config) {
     tracer = require('../..')
     agent = express()
     agent.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))

--- a/packages/dd-trace/test/plugins/promise.js
+++ b/packages/dd-trace/test/plugins/promise.js
@@ -21,7 +21,7 @@ module.exports = (name, factory, versionRange) => {
 
         describe('without configuration', () => {
           beforeEach(() => {
-            return agent.load(plugin, name)
+            return agent.load(name)
           })
 
           beforeEach(() => {

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -716,7 +716,7 @@ describe('plugins/util/web', () => {
     let http
 
     beforeEach(done => {
-      agent.load(null, 'express')
+      agent.load('express')
         .then(getPort)
         .then(_port => {
           port = _port


### PR DESCRIPTION
### What does this PR do?
the test agent's `agent.load` method no longer relies on the the `plugin` explicitly being passed in, removing this from specs and from the method itself

### Motivation
makes `agent.load` a little easier to grok

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
making this PR to make sure i didnt miss any tests
