### PR TITLE
update postinstall script to skip building in development

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@
 !packages/*/src/**/*
 !packages/*/index.js
 !prebuilds/**/*
-!scripts/post_install.js
+!scripts/postinstall.js
 !CONTRIBUTING.md
 !LICENSE
 !LICENSE-3rdparty.csv

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "browser": "browser.js",
   "typings": "index.d.ts",
   "scripts": {
-    "install": "node-gyp-build",
+    "install": "node scripts/postinstall",
+    "install:rebuild": "node-gyp-build",
     "rebuild": "node-gyp rebuild",
     "prebuild": "node scripts/prebuild.js",
     "prebuilds": "node scripts/prebuilds.js",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,7 +3,8 @@
 /* eslint-disable no-console */
 
 const execSync = require('child_process').execSync
+const { INIT_CWD, PWD } = process.env
 
-if (__dirname.indexOf('/node_modules/') !== -1) {
+if (!INIT_CWD.includes(PWD)) {
   execSync('npm run install:rebuild --silent --scripts-prepend-node-path', { stdio: [0, 1, 2] })
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,9 @@
+'use strict'
+
+/* eslint-disable no-console */
+
+const execSync = require('child_process').execSync
+
+if (__dirname.indexOf('/node_modules/') !== -1) {
+  execSync('npm run install:rebuild --silent --scripts-prepend-node-path', { stdio: [0, 1, 2] })
+}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update postinstall script to skip building in development.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise the native addons would be built locally and in CI when not needed. We only need the build to run when installing as a dependency in another library.