### PR TITLE
fix postinstall script in older versions of package managers

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,6 +5,7 @@
 const execSync = require('child_process').execSync
 const { INIT_CWD, PWD } = process.env
 
-if (!INIT_CWD.includes(PWD)) {
+// skip for local development or very old package managers without INIT_CWD
+if (INIT_CWD && !INIT_CWD.includes(PWD)) {
   execSync('npm run install:rebuild --silent --scripts-prepend-node-path', { stdio: [0, 1, 2] })
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix postinstall script in older versions of package managers by skipping the build if not set.

### Motivation
<!-- What inspired you to submit this pull request? -->

Old package managers didn't set the `INIT_CWD` environment variable. The chance of one of these being used at the same time as a platform we don't support is very unlikely, and even then it would be possible to just `npm rebuild` as a workaround if any issue arises.