### PR TITLE
fix http plugin url tag and agent requests being traced

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -37,8 +37,11 @@ function patch (http, methodName, tracer, config) {
         return request.apply(this, arguments)
       }
 
-      const uri = args.uri
       const options = args.options
+      const hostname = options.hostname || options.host || 'localhost'
+      const host = options.port ? `${hostname}:${options.port}` : hostname
+      const path = options.path ? options.path.split(/[?#]/)[0] : '/'
+      const uri = `${options.protocol}//${host}${path}`
 
       let callback = args.callback
 
@@ -188,7 +191,7 @@ function patch (http, methodName, tracer, config) {
         'localhost',
       hash: url.hash,
       search: url.search,
-      pathname: url.pathname || url.path || '/',
+      pathname: url.pathname,
       path: `${url.pathname || ''}${url.search || ''}`,
       href: url.href
     }

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -48,7 +48,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load('http')
+          return agent.load('http', { server: false })
             .then(() => {
               http = require(protocol)
               express = require('express')
@@ -131,7 +131,7 @@ describe('Plugin', () => {
               protocol: `${protocol}:`,
               hostname: 'localhost',
               port,
-              pathname: '/user'
+              path: '/user'
             }
 
             appListener = server(app, port, () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix http plugin url tag and agent requests being traced.

### Motivation
<!-- What inspired you to submit this pull request? -->

A bug was reported that the requests to the trace agent were being traced. After investigating the issue, the root cause was that the URL was not formatted properly by the `http` plugin. This caused the `http.url` tag to have an incorrect value, and also caused the filter on the agent endpoint to not match the URL.

The reason the tests were passing is that they were picking up the HTTP server span which had the correct tag value. This has also been fixed by disabling the server instrumentation in the client test.