### PR TITLE
update pubsub test to use a faster docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ jobs:
           - EXTRA_CORS_ALLOWED_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
           - EXTRA_CORS_EXPOSE_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
           - FORCE_NONINTERACTIVE=true
-          - START_WEB=0          
+          - START_WEB=0
 
   node-bluebird:
     <<: *node-plugin-base
@@ -389,7 +389,7 @@ jobs:
         environment:
           - SERVICES=google-cloud-pubsub
           - PLUGINS=google-cloud-pubsub
-      - image: kinok/google-pubsub-emulator
+      - image: knarz/pubsub-emulator
 
   node-graphql:
     <<: *node-plugin-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,9 @@ services:
     ports:
       - "127.0.0.1:9231:9231"
   google-cloud-pubsub:
-    image: kinok/google-pubsub-emulator
+    image: knarz/pubsub-emulator
     ports:
-      - "127.0.0.1:8042:8042"
+      - "127.0.0.1:8085:8085"
   localstack:
       image: localstack/localstack
       ports:

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -8,7 +8,7 @@ const id = require('../../dd-trace/src/id')
 wrapIt()
 
 // The roundtrip to the pubsub emulator takes time. Sometimes a *long* time.
-const TIMEOUT = 60000
+const TIMEOUT = 5000
 
 describe('Plugin', () => {
   let tracer
@@ -17,7 +17,7 @@ describe('Plugin', () => {
     this.timeout(TIMEOUT)
 
     before(() => {
-      process.env.PUBSUB_EMULATOR_HOST = 'localhost:8042'
+      process.env.PUBSUB_EMULATOR_HOST = 'localhost:8085'
     })
     after(() => {
       delete process.env.PUBSUB_EMULATOR_HOST

--- a/packages/dd-trace/test/setup/services/gpubsub.js
+++ b/packages/dd-trace/test/setup/services/gpubsub.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const RetryOperation = require('../operation')
-process.env.PUBSUB_EMULATOR_HOST = 'localhost:8042'
+process.env.PUBSUB_EMULATOR_HOST = 'localhost:8085'
 const { PubSub } = require('../../../../../versions/@google-cloud/pubsub').get()
 
 function waitForGpubsub () {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update pubsub test to use a faster docker image

### Motivation
<!-- What inspired you to submit this pull request? -->

The previous image was installing the emulator on startup, which was taking a very long time and was causing the tests to timeout. The new image boots almost instantly so the tests are no longer waiting.