### PR TITLE
fix handled fs exceptions being flagged as errors

### DIFF
--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -325,6 +325,7 @@ function makeFSTags (resourceName, path, options, config, tracer) {
   path = options && typeof options === 'object' && 'fd' in options ? options.fd : path
   const tags = {
     'component': 'fs',
+    'span.kind': 'internal',
     'resource.name': resourceName,
     'service.name': config.service || `${tracer._service}-fs`
   }

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -105,6 +105,7 @@ describe('Plugin', () => {
           fs.open(filename, 'r', (err) => {
             expectOneSpan(agent, done, {
               resource: 'open',
+              error: 0,
               meta: {
                 'file.flag': 'r',
                 'file.path': filename,
@@ -162,6 +163,7 @@ describe('Plugin', () => {
             fs.promises.open(filename, 'r').catch((err) => {
               expectOneSpan(agent, done, {
                 resource: 'promises.open',
+                error: 0,
                 meta: {
                   'file.flag': 'r',
                   'file.path': filename,
@@ -217,6 +219,7 @@ describe('Plugin', () => {
           } catch (err) {
             expectOneSpan(agent, done, {
               resource: 'openSync',
+              error: 0,
               meta: {
                 'file.flag': 'r',
                 'file.path': filename,

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1763,6 +1763,7 @@ function testHandleErrors (fs, name, tested, args, agent) {
     tested(fs, args, null, err => {
       expectOneSpan(agent, done, {
         resource: name,
+        error: 0,
         meta: {
           'error.type': err.name,
           'error.msg': err.message,

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -105,7 +105,6 @@ describe('Plugin', () => {
           fs.open(filename, 'r', (err) => {
             expectOneSpan(agent, done, {
               resource: 'open',
-              error: 1,
               meta: {
                 'file.flag': 'r',
                 'file.path': filename,
@@ -163,7 +162,6 @@ describe('Plugin', () => {
             fs.promises.open(filename, 'r').catch((err) => {
               expectOneSpan(agent, done, {
                 resource: 'promises.open',
-                error: 1,
                 meta: {
                   'file.flag': 'r',
                   'file.path': filename,
@@ -219,7 +217,6 @@ describe('Plugin', () => {
           } catch (err) {
             expectOneSpan(agent, done, {
               resource: 'openSync',
-              error: 1,
               meta: {
                 'file.flag': 'r',
                 'file.path': filename,
@@ -1763,7 +1760,6 @@ function testHandleErrors (fs, name, tested, args, agent) {
     tested(fs, args, null, err => {
       expectOneSpan(agent, done, {
         resource: name,
-        error: 1,
         meta: {
           'error.type': err.name,
           'error.msg': err.message,

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1739,7 +1739,7 @@ describe('Plugin', () => {
 })
 
 function mkExpected (props) {
-  const meta = Object.assign({ component: 'fs' }, props.meta)
+  const meta = Object.assign({ component: 'fs', 'span.kind': 'internal' }, props.meta)
   const expected = Object.assign({
     name: 'fs.operation',
     error: 0,

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -66,13 +66,14 @@ function extractTags (trace, span) {
       case ANALYTICS:
         break
       case 'error':
-        if (tags[tag] === true || tags[tag] === '1') {
+        if (tags[tag] && tags['span.kind'] !== 'internal') {
           trace.error = 1
         }
         break
       case 'error.type':
       case 'error.msg':
       case 'error.stack':
+        // HACK: remove when implemented in the backend
         if (tags['span.kind'] !== 'internal') {
           trace.error = 1
         }

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -66,7 +66,7 @@ function extractTags (trace, span) {
       case ANALYTICS:
         break
       case 'error':
-        if (tags[tag]) {
+        if (tags[tag] === true || tags[tag] === '1') {
           trace.error = 1
         }
         break

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -73,7 +73,9 @@ function extractTags (trace, span) {
       case 'error.type':
       case 'error.msg':
       case 'error.stack':
-        trace.error = 1
+        if (tags['span.kind'] !== 'internal') {
+          trace.error = 1
+        }
       default: // eslint-disable-line no-fallthrough
         addTag(trace.meta, trace.metrics, tag, tags[tag])
     }

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -253,6 +253,17 @@ describe('format', () => {
       expect(trace.error).to.equal(1)
     })
 
+    it('should not set the error flag for internal spans', () => {
+      spanContext._tags['error.type'] = 'Error'
+      spanContext._tags['error.msg'] = 'boom'
+      spanContext._tags['error.stack'] = ''
+      spanContext._tags['span.kind'] = 'internal'
+
+      trace = format(span)
+
+      expect(trace.error).to.equal(0)
+    })
+
     it('should sanitize the input', () => {
       spanContext._name = null
       spanContext._tags = {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -253,10 +253,19 @@ describe('format', () => {
       expect(trace.error).to.equal(1)
     })
 
-    it('should not set the error flag for internal spans', () => {
+    it('should not set the error flag for internal spans with error tags', () => {
       spanContext._tags['error.type'] = 'Error'
       spanContext._tags['error.msg'] = 'boom'
       spanContext._tags['error.stack'] = ''
+      spanContext._tags['span.kind'] = 'internal'
+
+      trace = format(span)
+
+      expect(trace.error).to.equal(0)
+    })
+
+    it('should not set the error flag for internal spans with error tag', () => {
+      spanContext._tags['error'] = new Error('boom')
       spanContext._tags['span.kind'] = 'internal'
 
       trace = format(span)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix handled `fs` exceptions being flagged as errors.

### Motivation
<!-- What inspired you to submit this pull request? -->

Errors need to be captured for any IO operations to identify that one end of the network resulted in a failure. For internal spans however, this behavior is confusing when the exception was handled by the surrounding code since it means nothing was impacted outside of the process. By introducing an `internal` span kind, we can identify the errors that should be ignored.

The worst offender for this is by far `fs` since it throws in a lot of cases that are not actual exceptions, which are usually handled right away. By marking `fs` as internal, these errors can be skipped. Eventually other internal spans should also get the same treatment.