### PR TITLE
Format Overhaul

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -3,7 +3,6 @@
 const constants = require('./constants')
 const tags = require('../../../ext/tags')
 const log = require('./log')
-const id = require('./id')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY
@@ -20,7 +19,7 @@ const map = {
 function format (span) {
   const formatted = formatSpan(span)
 
-  extractError(formatted, span)
+  extractError(formatted, span.context()._tags)
   extractTags(formatted, span)
   extractAnalytics(formatted, span)
 
@@ -90,8 +89,8 @@ function extractTags (trace, span) {
   addTag(trace.meta, trace.metrics, HOSTNAME_KEY, hostname)
 }
 
-function extractError (trace, span) {
-  const error = span.context()._tags['error']
+function extractError (trace, tags) {
+  const error = tags['error']
 
   if (error instanceof Error) {
     trace.meta['error.msg'] = error.message

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -30,18 +30,13 @@ function format (span) {
 function formatSpan (span) {
   const spanContext = span.context()
 
-  return {
-    trace_id: spanContext._traceId,
-    span_id: spanContext._spanId,
-    parent_id: spanContext._parentId || id('0'),
-    name: serialize(spanContext._name),
-    resource: serialize(spanContext._name),
-    error: 0,
-    meta: {},
-    metrics: {},
-    start: Math.round(span._startTime * 1e6),
-    duration: Math.round(span._duration * 1e6)
-  }
+  const spanData = spanContext._spanData
+  console.log(spanData)
+
+  spanData.name = serialize(spanContext._name)
+  spanData.resource = serialize(spanContext._name)
+
+  return spanData
 }
 
 function extractTags (trace, span) {

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -3,6 +3,7 @@
 const constants = require('./constants')
 const tags = require('../../../ext/tags')
 const log = require('./log')
+const id = require('./id')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY
@@ -33,9 +34,13 @@ function formatSpan (span) {
   const spanContext = span.context()
 
   const spanData = spanContext._spanData
+  if (spanData.parent_id === null) {
+    spanData.parent_id = id('0000000000000000')
+  }
 
-  spanData.name = serialize(spanContext._name)
-  spanData.resource = serialize(spanContext._name)
+  spanData.name = serialize(spanData.name)
+  spanData.resource = serialize(spanData.resource || spanData.name)
+  spanData.error = spanData.error || 0
 
   return spanData
 }
@@ -54,7 +59,7 @@ function extractJustTags (trace, tags) {
         addTag(trace.meta, {}, tag, tags[tag] && String(tags[tag]))
         break
       case HOSTNAME_KEY:
-      case ANALYTICS:
+      // case ANALYTICS: // XXX TODO (bengl) what is this line for??
         break
       case 'error':
         if (tags[tag]) {

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -27,11 +27,13 @@ function format (span) {
   return formatted
 }
 
+format.extractJustTags = extractJustTags
+format.extractError = extractError
+
 function formatSpan (span) {
   const spanContext = span.context()
 
   const spanData = spanContext._spanData
-  console.log(spanData)
 
   spanData.name = serialize(spanContext._name)
   spanData.resource = serialize(spanContext._name)
@@ -39,13 +41,8 @@ function formatSpan (span) {
   return spanData
 }
 
-function extractTags (trace, span) {
-  const context = span.context()
-  const origin = context._trace.origin
-  const tags = context._tags
-  const hostname = context._hostname
-  const priority = context._sampling.priority
-
+// trace here is actually a spanData
+function extractJustTags (trace, tags) {
   for (const tag in tags) {
     switch (tag) {
       case 'service.name':
@@ -73,6 +70,16 @@ function extractTags (trace, span) {
         addTag(trace.meta, trace.metrics, tag, tags[tag])
     }
   }
+}
+
+function extractTags (trace, span) {
+  const context = span.context()
+  const origin = context._trace.origin
+  const tags = context._tags
+  const hostname = context._hostname
+  const priority = context._sampling.priority
+
+  extractJustTags(trace, tags)
 
   if (span.tracer()._service === tags['service.name']) {
     addTag(trace.meta, trace.metrics, 'language', 'javascript')

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -30,7 +30,6 @@ class DatadogSpan extends Span {
     this._spanContext = this._createContext(parent)
     this._spanContext._name = operationName
     // this._spanContext._tags = tags
-    debugger; // eslint-disable-line
     this._addTags(tags)
     this._spanContext._hostname = hostname
 
@@ -53,8 +52,9 @@ class DatadogSpan extends Span {
   }
 
   toString () {
+    return ''
     const spanContext = this.context()
-    const resourceName = spanContext._tags['resource.name']
+    const resourceName = spanContext._resource
     const resource = resourceName.length > 100
       ? `${resourceName.substring(0, 97)}...`
       : resourceName
@@ -62,7 +62,7 @@ class DatadogSpan extends Span {
       traceId: spanContext._traceId,
       spanId: spanContext._spanId,
       parentId: spanContext._parentId,
-      service: spanContext._tags['service.name'],
+      service: spanContext._service,
       name: spanContext._name,
       resource
     })

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -29,7 +29,9 @@ class DatadogSpan extends Span {
 
     this._spanContext = this._createContext(parent)
     this._spanContext._name = operationName
-    this._spanContext._tags = tags
+    // this._spanContext._tags = tags
+    debugger; // eslint-disable-line
+    this._addTags(tags)
     this._spanContext._hostname = hostname
 
     this._startTime = startTime

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -26,14 +26,28 @@ class DatadogSpan extends Span {
     this._sampler = sampler
     this._processor = processor
     this._prioritySampler = prioritySampler
-    this._startTime = startTime
 
     this._spanContext = this._createContext(parent)
     this._spanContext._name = operationName
     this._spanContext._tags = tags
     this._spanContext._hostname = hostname
 
+    this._startTime = startTime
+
     this._handle = platform.metrics().track(this)
+  }
+
+  set _startTime (val) {
+    this._spanContext._spanData.start = Math.round(val * 1e6)
+  }
+  get _startTime () {
+    return this._spanContext._spanData.start
+  }
+  set _duration (val) {
+    this._spanContext._spanData.duration = Math.round(val * 1e6)
+  }
+  get _duration () {
+    return this._spanContext._spanData.duration
   }
 
   toString () {

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -114,7 +114,7 @@ class DatadogSpan extends Span {
   }
 
   _addTags (keyValuePairs) {
-    tagger.add(this._spanContext._tags, keyValuePairs)
+    tagger.addToSpanContext(this._spanContext, keyValuePairs)
   }
 
   _finish (finishTime) {

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -10,6 +10,7 @@ class DatadogSpanContext extends SpanContext {
 
     props = props || {}
 
+    console.log(props)
     this._spanData = {
       name: props.name,
       trace_id: props.traceId,

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -46,6 +46,8 @@ aliasToData('_traceId', 'trace_id')
 aliasToData('_spanId', 'span_id')
 aliasToData('_parentId', 'parent_id')
 aliasToData('_name', 'name')
+aliasToData('_service', 'service')
+aliasToData('_resource', 'resource')
 
 module.exports = DatadogSpanContext
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -10,7 +10,6 @@ class DatadogSpanContext extends SpanContext {
 
     props = props || {}
 
-    console.log(props)
     this._spanData = {
       name: props.name,
       trace_id: props.traceId,

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -2,16 +2,23 @@
 
 const SpanContext = require('opentracing').SpanContext
 
+const id = require('../id')
+
 class DatadogSpanContext extends SpanContext {
   constructor (props) {
     super()
 
     props = props || {}
 
-    this._traceId = props.traceId
-    this._spanId = props.spanId
-    this._parentId = props.parentId || null
-    this._name = props.name
+    this._spanData = {
+      name: props.name,
+      trace_id: props.traceId,
+      span_id: props.spanId,
+      parent_id: props.parentId || id(0),
+      error: 0,
+      metrics: {},
+      meta: {}
+    }
     this._isFinished = props.isFinished || false
     this._tags = props.tags || {}
     this._sampling = props.sampling || {}
@@ -35,4 +42,22 @@ class DatadogSpanContext extends SpanContext {
   }
 }
 
+aliasToData('_traceId', 'trace_id')
+aliasToData('_spanId', 'span_id')
+aliasToData('_parentId', 'parent_id')
+aliasToData('_name', 'name')
+
 module.exports = DatadogSpanContext
+
+function aliasToData (propName, dataPropName) {
+  Reflect.defineProperty(DatadogSpanContext.prototype, propName, {
+    get () {
+      return this._spanData[dataPropName]
+    },
+    set (val) {
+      this._spanData[dataPropName] = val
+    },
+    enumerable: true,
+    configurable: true
+  })
+}

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -2,8 +2,6 @@
 
 const SpanContext = require('opentracing').SpanContext
 
-const id = require('../id')
-
 class DatadogSpanContext extends SpanContext {
   constructor (props) {
     super()
@@ -14,7 +12,7 @@ class DatadogSpanContext extends SpanContext {
       name: props.name,
       trace_id: props.traceId,
       span_id: props.spanId,
-      parent_id: props.parentId || id(0),
+      parent_id: props.parentId || null,
       error: 0,
       metrics: {},
       meta: {}

--- a/packages/dd-trace/src/plugins/util/redis.js
+++ b/packages/dd-trace/src/plugins/util/redis.js
@@ -21,7 +21,7 @@ const redis = {
       }
     })
 
-    span.setTag('service.name', config.service || `${span.context()._tags['service.name']}-redis`)
+    span.setTag('service.name', config.service || `${span.context()._spanData.service}-redis`)
 
     analyticsSampler.sample(span, config.analytics)
 

--- a/packages/dd-trace/src/plugins/util/tx.js
+++ b/packages/dd-trace/src/plugins/util/tx.js
@@ -41,11 +41,7 @@ function wrapPromise (span, promise) {
 
 function finish (span, error) {
   if (error) {
-    span.addTags({
-      'error.type': error.name,
-      'error.msg': error.message,
-      'error.stack': error.stack
-    })
+    span.addTags({ error })
   }
 
   span.finish()

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -384,7 +384,10 @@ function addResourceTag (req) {
     .filter(val => val)
     .join(' ')
 
+  console.log('before', span.context()._spanData)
+  console.log(RESOURCE_NAME, resource)
   span.setTag(RESOURCE_NAME, resource)
+  console.log('after', span.context()._spanData)
 }
 
 function addHeaders (req) {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -184,7 +184,7 @@ const web = {
     const error = req._datadog.error
 
     if (!req._datadog.config.validateStatus(statusCode)) {
-      span.setTag(ERROR, error || true)
+      span.addTags({ error: error || 1 })
     }
   },
 
@@ -376,7 +376,7 @@ function addResourceTag (req) {
   if (context._resource) return
 
   const resource = [req.method]
-    .concat(tags[HTTP_ROUTE])
+    .concat(context._spanData.meta[HTTP_ROUTE])
     .filter(val => val)
     .join(' ')
 

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -375,9 +375,9 @@ function addResponseTags (req) {
 
 function addResourceTag (req) {
   const span = req._datadog.span
-  const tags = span.context()._tags
+  const context = span.context()
 
-  if (tags['resource.name']) return
+  if (context._resource) return
 
   const resource = [req.method]
     .concat(tags[HTTP_ROUTE])

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -125,11 +125,7 @@ const web = {
 
     if (span) {
       if (error) {
-        span.addTags({
-          'error.type': error.name,
-          'error.msg': error.message,
-          'error.stack': error.stack
-        })
+        span.addTags({ error })
       }
 
       span.finish()
@@ -384,10 +380,7 @@ function addResourceTag (req) {
     .filter(val => val)
     .join(' ')
 
-  console.log('before', span.context()._spanData)
-  console.log(RESOURCE_NAME, resource)
   span.setTag(RESOURCE_NAME, resource)
-  console.log('after', span.context()._spanData)
 }
 
 function addHeaders (req) {

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -85,13 +85,13 @@ class PrioritySampler {
 
   _getPriority (spanData) {
     if (
-      (spanData.metrics.hasOwnProperty(MANUAL_KEEP) && spanData.metrics[MANUAL_KEEP]) ||
-      (spanData.meta.hasOwnProperty(MANUAL_KEEP) && spanData.meta[MANUAL_KEEP])
+      (spanData.metrics.hasOwnProperty(MANUAL_KEEP) && spanData.metrics[MANUAL_KEEP] !== false) ||
+      (spanData.meta.hasOwnProperty(MANUAL_KEEP) && spanData.meta[MANUAL_KEEP] !== false)
     ) {
       return USER_KEEP
     } else if (
-      (spanData.metrics.hasOwnProperty(MANUAL_DROP) && spanData.metrics[MANUAL_DROP]) ||
-      (spanData.meta.hasOwnProperty(MANUAL_DROP) && spanData.meta[MANUAL_DROP])
+      (spanData.metrics.hasOwnProperty(MANUAL_DROP) && spanData.metrics[MANUAL_DROP] !== false) ||
+      (spanData.meta.hasOwnProperty(MANUAL_DROP) && spanData.meta[MANUAL_DROP] !== false)
     ) {
       return USER_REJECT
     } else {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -29,7 +29,7 @@ class SpanProcessor {
   _erase (trace) {
     trace.finished.forEach(span => {
       span.context()._tags = {}
-      span.context()._spanData = {}
+      // span.context()._spanData = {}
     })
 
     trace.started = []

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -29,6 +29,7 @@ class SpanProcessor {
   _erase (trace) {
     trace.finished.forEach(span => {
       span.context()._tags = {}
+      span.context()._spanData = {}
     })
 
     trace.started = []

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -108,11 +108,7 @@ class DatadogTracer extends Tracer {
 
 function addError (span, error) {
   if (error && error instanceof Error) {
-    span.addTags({
-      'error.type': error.name,
-      'error.msg': error.message,
-      'error.stack': error.stack
-    })
+    span.addTags({ error })
   }
 }
 

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -46,7 +46,7 @@ describe('dd-trace', () => {
 
       const payload = msgpack.decode(req.body, { codec })
 
-      expect(payload[0][0].trace_id.toString()).to.equal(span.context()._traceId.toString(10))
+      expect(payload[0][0].trace_id.toString()).to.equal(span.context()._spanData.trace_id.toString(10))
       expect(payload[0][0].span_id.toString()).to.equal(span.context()._spanId.toString(10))
       expect(payload[0][0].service).to.equal('test')
       expect(payload[0][0].name).to.equal('hello')

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -44,19 +44,23 @@ describe('dd-trace', () => {
     agent.put('/v0.4/traces', (req, res) => {
       if (req.body.length === 0) return res.status(200).send()
 
-      const payload = msgpack.decode(req.body, { codec })
+      try {
+        const payload = msgpack.decode(req.body, { codec })
 
-      expect(payload[0][0].trace_id.toString()).to.equal(span.context()._spanData.trace_id.toString(10))
-      expect(payload[0][0].span_id.toString()).to.equal(span.context()._spanId.toString(10))
-      expect(payload[0][0].service).to.equal('test')
-      expect(payload[0][0].name).to.equal('hello')
-      expect(payload[0][0].resource).to.equal('/hello/:name')
-      expect(payload[0][0].start).to.be.instanceof(Int64BE)
-      expect(payload[0][0].duration).to.be.instanceof(Int64BE)
+        expect(payload[0][0].trace_id.toString()).to.equal(span.context()._spanData.trace_id.toString(10))
+        expect(payload[0][0].span_id.toString()).to.equal(span.context()._spanId.toString(10))
+        expect(payload[0][0].service).to.equal('test')
+        expect(payload[0][0].name).to.equal('hello')
+        expect(payload[0][0].resource).to.equal('/hello/:name')
+        expect(payload[0][0].start).to.be.instanceof(Int64BE)
+        expect(payload[0][0].duration).to.be.instanceof(Int64BE)
 
-      res.status(200).send('OK')
+        res.status(200).send('OK')
 
-      done()
+        done()
+      } catch (e) {
+        done(e)
+      }
     })
 
     span.finish()

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -21,23 +21,27 @@ describe('format', () => {
 
   beforeEach(() => {
     spanContext = {
-      _traceId: spanId,
-      _spanId: spanId,
-      _parentId: spanId,
       _tags: {},
+      _spanData: {
+        trace_id: spanId,
+        span_id: spanId,
+        parent_id: spanId,
+        name: 'operation',
+        metrics: {},
+        meta: {},
+        start: 1500000000000.123456,
+        duration: 100
+      },
       _metrics: {},
       _sampling: {},
-      _trace: {},
-      _name: 'operation'
+      _trace: {}
     }
 
     span = {
       context: sinon.stub().returns(spanContext),
       tracer: sinon.stub().returns({
         _service: 'test'
-      }),
-      _startTime: 1500000000000.123456,
-      _duration: 100
+      })
     }
 
     platform = {
@@ -53,29 +57,29 @@ describe('format', () => {
     it('should convert a span to the correct trace format', () => {
       trace = format(span)
 
-      expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
-      expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
-      expect(trace.parent_id.toString()).to.equal(span.context()._parentId.toString())
-      expect(trace.name).to.equal(span.context()._name)
-      expect(trace.resource).to.equal(span.context()._name)
+      expect(trace.trace_id.toString()).to.equal(span.context()._spanData.trace_id.toString())
+      expect(trace.span_id.toString()).to.equal(span.context()._spanData.span_id.toString())
+      expect(trace.parent_id.toString()).to.equal(span.context()._spanData.parent_id.toString())
+      expect(trace.name).to.equal(span.context()._spanData.name)
+      expect(trace.resource).to.equal(span.context()._spanData.name)
       expect(trace.error).to.equal(0)
-      expect(trace.start).to.equal(span._startTime * 1e6)
-      expect(trace.duration).to.equal(span._duration * 1e6)
+      expect(trace.start).to.equal(span.context()._spanData.start)
+      expect(trace.duration).to.equal(span.context()._spanData.duration)
     })
 
     it('should always set a parent ID', () => {
-      span.context()._parentId = null
+      span.context()._spanData.parent_id = null
 
       trace = format(span)
 
-      expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
-      expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
+      expect(trace.trace_id.toString()).to.equal(span.context()._spanData.trace_id.toString())
+      expect(trace.span_id.toString()).to.equal(span.context()._spanData.span_id.toString())
       expect(trace.parent_id.toString()).to.equal('0000000000000000')
-      expect(trace.name).to.equal(span.context()._name)
-      expect(trace.resource).to.equal(span.context()._name)
-      expect(trace.error).to.equal(0)
-      expect(trace.start).to.equal(span._startTime * 1e6)
-      expect(trace.duration).to.equal(span._duration * 1e6)
+      expect(trace.name).to.equal(span.context()._spanData.name)
+      expect(trace.resource).to.equal(span.context()._spanData.name)
+      expect(trace.error).to.equal(1)
+      expect(trace.start).to.equal(span.context()._spanData.start)
+      expect(trace.duration).to.equal(span.context()._spanData.duration)
     })
 
     it('should extract Datadog specific tags', () => {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -150,7 +150,7 @@ describe('format', () => {
     it('should extract errors', () => {
       const error = new Error('boom')
 
-      spanContext._tags['error'] = error
+      spanContext._spanData.error = error
       trace = format(span)
 
       expect(trace.meta['error.msg']).to.equal(error.message)

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -77,7 +77,7 @@ describe('format', () => {
       expect(trace.parent_id.toString()).to.equal('0000000000000000')
       expect(trace.name).to.equal(span.context()._spanData.name)
       expect(trace.resource).to.equal(span.context()._spanData.name)
-      expect(trace.error).to.equal(1)
+      expect(trace.error).to.equal(0)
       expect(trace.start).to.equal(span.context()._spanData.start)
       expect(trace.duration).to.equal(span.context()._spanData.duration)
     })
@@ -258,7 +258,7 @@ describe('format', () => {
     })
 
     it('should sanitize the input', () => {
-      spanContext._name = null
+      spanContext._spanData.name = null
       spanContext._tags = {
         'foo.bar': null,
         'baz.qux': undefined

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -43,7 +43,8 @@ describe('Span', () => {
     }
 
     tagger = {
-      add: sinon.spy()
+      add: sinon.spy(),
+      addToSpanContext: sinon.spy()
     }
 
     Span = proxyquire('../src/opentracing/span', {
@@ -87,7 +88,7 @@ describe('Span', () => {
   })
 
   it('should set the sample rate metric from the sampler', () => {
-    expect(span.context()._tags).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
+    expect(span.context()._spanData.metrics).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
   })
 
   it('should keep track of its memory lifecycle', () => {
@@ -151,7 +152,7 @@ describe('Span', () => {
       span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
       span.setTag('foo', 'bar')
 
-      expect(tagger.add).to.have.been.calledWith(span.context()._tags, { foo: 'bar' })
+      expect(tagger.addToSpanContext).to.have.been.calledWith(span.context(), { foo: 'bar' })
     })
   })
 
@@ -165,7 +166,7 @@ describe('Span', () => {
 
       span.addTags(tags)
 
-      expect(tagger.add).to.have.been.calledWith(span.context()._tags, tags)
+      expect(tagger.addToSpanContext).to.have.been.calledWith(span.context(), tags)
     })
   })
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -43,7 +43,6 @@ describe('Span', () => {
     }
 
     tagger = {
-      add: sinon.spy(),
       addToSpanContext: sinon.spy()
     }
 
@@ -85,10 +84,7 @@ describe('Span', () => {
     expect(span.context()._parentId).to.deep.equal('456')
     expect(span.context()._baggageItems).to.deep.equal({ foo: 'bar' })
     expect(span.context()._trace).to.equal(parent._trace)
-  })
-
-  it('should set the sample rate metric from the sampler', () => {
-    expect(span.context()._spanData.metrics).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
+    expect(tagger.addToSpanContext).to.have.been.calledWith(span.context(), { [SAMPLE_RATE_METRIC_KEY]: 1 })
   })
 
   it('should keep track of its memory lifecycle', () => {

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -34,12 +34,18 @@ describe('SpanContext', () => {
     const spanContext = new SpanContext(props)
 
     expect(spanContext).to.deep.equal({
-      _traceId: '123',
-      _spanId: '456',
-      _parentId: '789',
-      _name: 'test',
+      __proto__: SpanContext.prototype,
       _isFinished: true,
       _tags: {},
+      _spanData: {
+        error: 0,
+        meta: {},
+        metrics: {},
+        name: 'test',
+        parent_id: '789',
+        span_id: '456',
+        trace_id: '123'
+      },
       _sampling: { priority: 2 },
       _baggageItems: { foo: 'bar' },
       _traceFlags: {
@@ -61,12 +67,20 @@ describe('SpanContext', () => {
     })
 
     expect(spanContext).to.deep.equal({
-      _traceId: '123',
-      _spanId: '456',
-      _parentId: null,
-      _name: undefined,
+      __proto__: SpanContext.prototype,
       _isFinished: false,
       _tags: {},
+      _spanData: {
+        error: 0,
+        meta: {},
+        metrics: {},
+        name: undefined,
+        parent_id: {
+          _buffer: spanContext._spanData.parent_id._buffer
+        },
+        span_id: '456',
+        trace_id: '123'
+      },
       _sampling: {},
       _baggageItems: {},
       _traceFlags: {

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -75,9 +75,7 @@ describe('SpanContext', () => {
         meta: {},
         metrics: {},
         name: undefined,
-        parent_id: {
-          _buffer: spanContext._spanData.parent_id._buffer
-        },
+        parent_id: null,
         span_id: '456',
         trace_id: '123'
       },

--- a/packages/dd-trace/test/plugins/util/tx.spec.js
+++ b/packages/dd-trace/test/plugins/util/tx.spec.js
@@ -21,8 +21,8 @@ describe('plugins/util/tx', () => {
     it('should set the out.host and out.port tags', () => {
       tx.setHost(span, 'example.com', '1234')
 
-      expect(span.context()._tags).to.have.property('out.host', 'example.com')
-      expect(span.context()._tags).to.have.property('out.port', '1234')
+      expect(span.context()._spanData.meta).to.have.property('out.host', 'example.com')
+      expect(span.context()._spanData.meta).to.have.property('out.port', '1234')
     })
   })
 
@@ -42,7 +42,7 @@ describe('plugins/util/tx', () => {
         const callback = sinon.spy()
         const error = new Error('boom')
         const wrapper = tx.wrap(span, callback)
-        const tags = span.context()._tags
+        const tags = span.context()._spanData.meta
 
         wrapper(error)
 
@@ -83,7 +83,7 @@ describe('plugins/util/tx', () => {
       it('should set the error tags when the promise is rejected', () => {
         const error = new Error('boom')
         const promise = Promise.reject(error)
-        const tags = span.context()._tags
+        const tags = span.context()._spanData.meta
 
         tx.wrap(span, promise)
 

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -417,7 +417,7 @@ describe('plugins/util/web', () => {
 
         expect(tags).to.include({
           resource: 'GET',
-          [HTTP_STATUS_CODE]: 200
+          [HTTP_STATUS_CODE]: '200'
         })
       })
 

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -21,7 +21,10 @@ describe('PrioritySampler', () => {
 
   beforeEach(() => {
     context = {
-      _tags: {},
+      _spanData: {
+        metrics: {},
+        meta: {}
+      },
       _sampling: {}
     }
 
@@ -87,7 +90,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should set the priority from the corresponding tag', () => {
-      context._tags[SAMPLING_PRIORITY] = `${USER_KEEP}`
+      context._spanData.metrics[SAMPLING_PRIORITY] = `${USER_KEEP}`
 
       prioritySampler.sample(span)
 
@@ -97,7 +100,7 @@ describe('PrioritySampler', () => {
     it('should freeze the sampling priority once set', () => {
       prioritySampler.sample(span)
 
-      context._tags[SAMPLING_PRIORITY] = `${USER_KEEP}`
+      context._spanData.metrics[SAMPLING_PRIORITY] = `${USER_KEEP}`
 
       prioritySampler.sample(span)
 
@@ -111,7 +114,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should support manual keep', () => {
-      context._tags[MANUAL_KEEP] = undefined
+      context._spanData.metrics[MANUAL_KEEP] = undefined
 
       prioritySampler.sample(context)
 
@@ -119,7 +122,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should support manual drop', () => {
-      context._tags[MANUAL_DROP] = undefined
+      context._spanData.metrics[MANUAL_DROP] = undefined
 
       prioritySampler.sample(context)
 
@@ -127,7 +130,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should support opentracing keep', () => {
-      context._tags['sampling.priority'] = 1
+      context._spanData.metrics['sampling.priority'] = 1
 
       prioritySampler.sample(context)
 
@@ -135,7 +138,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should support opentracing drop', () => {
-      context._tags['sampling.priority'] = 0
+      context._spanData.metrics['sampling.priority'] = 0
 
       prioritySampler.sample(context)
 
@@ -156,7 +159,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should support a sample rate from a rule on service as string', () => {
-      context._tags['service.name'] = 'test'
+      context._spanData.metrics['service.name'] = 'test'
 
       prioritySampler = new PrioritySampler('test', {
         rules: [
@@ -170,7 +173,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should support a sample rate from a rule on service as string as regex', () => {
-      context._tags['service.name'] = 'test'
+      context._spanData.metrics['service.name'] = 'test'
 
       prioritySampler = new PrioritySampler('test', {
         rules: [
@@ -185,7 +188,7 @@ describe('PrioritySampler', () => {
 
     it('should support a sample rate from a rule on name as string', () => {
       context._name = 'foo'
-      context._tags['service.name'] = 'test'
+      context._spanData.metrics['service.name'] = 'test'
 
       prioritySampler = new PrioritySampler('test', {
         rules: [
@@ -200,7 +203,7 @@ describe('PrioritySampler', () => {
 
     it('should support a sample rate from a rule on name as regex', () => {
       context._name = 'foo'
-      context._tags['service.name'] = 'test'
+      context._spanData.metrics['service.name'] = 'test'
 
       prioritySampler = new PrioritySampler('test', {
         rules: [
@@ -262,7 +265,7 @@ describe('PrioritySampler', () => {
     it('should add metrics for agent sample rate', () => {
       prioritySampler.sample(span)
 
-      expect(context._tags).to.have.property('_dd.agent_psr', 1)
+      expect(context._spanData.metrics).to.have.property('_dd.agent_psr', 1)
     })
 
     it('should add metrics for rule sample rate', () => {
@@ -271,8 +274,8 @@ describe('PrioritySampler', () => {
       })
       prioritySampler.sample(span)
 
-      expect(context._tags).to.have.property('_dd.rule_psr', 0)
-      expect(context._tags).to.not.have.property('_dd.limit_psr')
+      expect(context._spanData.metrics).to.have.property('_dd.rule_psr', 0)
+      expect(context._spanData.metrics).to.not.have.property('_dd.limit_psr')
     })
 
     it('should add metrics for rate limiter sample rate', () => {
@@ -282,8 +285,8 @@ describe('PrioritySampler', () => {
       })
       prioritySampler.sample(span)
 
-      expect(context._tags).to.have.property('_dd.rule_psr', 0.5)
-      expect(context._tags).to.have.property('_dd.limit_psr', 1)
+      expect(context._spanData.metrics).to.have.property('_dd.rule_psr', 0.5)
+      expect(context._spanData.metrics).to.have.property('_dd.limit_psr', 1)
     })
   })
 
@@ -299,7 +302,7 @@ describe('PrioritySampler', () => {
     })
 
     it('should update service rates', () => {
-      context._tags[SERVICE_NAME] = 'hello'
+      context._spanData.service = 'hello'
 
       prioritySampler.update({
         'service:hello,env:test': AUTO_REJECT

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -59,7 +59,7 @@ describe('Tracer', () => {
         expect(tags).to.include({
           service: 'service',
           resource: 'resource',
-          [SPAN_TYPE]: 'type'
+          type: 'type'
         })
       })
     })
@@ -116,18 +116,16 @@ describe('Tracer', () => {
 
     it('should handle exceptions', () => {
       let span
-      let tags
 
       try {
         tracer.trace('name', {}, _span => {
           span = _span
-          tags = span.context()._tags
           sinon.spy(span, 'finish')
           throw new Error('boom')
         })
       } catch (e) {
         expect(span.finish).to.have.been.called
-        expect(tags).to.include({
+        expect(flatTags(span)).to.include({
           'error.type': e.name,
           'error.msg': e.message,
           'error.stack': e.stack
@@ -156,12 +154,10 @@ describe('Tracer', () => {
       it('should handle errors', () => {
         const error = new Error('boom')
         let span
-        let tags
         let done
 
         tracer.trace('name', {}, (_span, _done) => {
           span = _span
-          tags = flatTags(span)
           sinon.spy(span, 'finish')
           done = _done
         })
@@ -169,7 +165,7 @@ describe('Tracer', () => {
         done(error)
 
         expect(span.finish).to.have.been.called
-        expect(tags).to.include({
+        expect(flatTags(span)).to.include({
           'error.type': error.name,
           'error.msg': error.message,
           'error.stack': error.stack


### PR DESCRIPTION
### What does this PR do?
Moves the formatting process to whenever tags are added, so that we never have to convert an entire tags object into the intended "formatted"/pre-msgpack format.

### Motivation
This should reduce memory and CPU overhead (and hopefully latency).

### Additional Notes
There are a few tests still failing, but this should be alright for at least an initial review pass.