### PR TITLE
update loader to accept pre-releases of instrumented modules

### DIFF
--- a/packages/dd-trace/src/platform/node/loader.js
+++ b/packages/dd-trace/src/platform/node/loader.js
@@ -135,7 +135,7 @@ function getBasedir (id) {
 }
 
 function matchVersion (version, ranges) {
-  return !version || (ranges && ranges.some(range => semver.satisfies(version, range)))
+  return !version || (ranges && ranges.some(range => semver.satisfies(semver.coerce(version), range)))
 }
 
 function getVersion (moduleBaseDir) {

--- a/packages/dd-trace/test/node_modules/other/package.json
+++ b/packages/dd-trace/test/node_modules/other/package.json
@@ -1,6 +1,6 @@
 {
   "name": "other",
-  "version": "1.0.0",
+  "version": "1.0.0-rc.1",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update loader to accept pre-releases of instrumented modules.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise any pre-releases are skipped by the plugins, making it impossible to update a dependency until a final release lands. Accepting them could result in the plugin failing, but that would only cause it to self-disable.