### PR TITLE
remove the beta version limitation for log exporter in lambda

### DIFF
--- a/packages/dd-trace/src/platform/node/exporter.js
+++ b/packages/dd-trace/src/platform/node/exporter.js
@@ -4,11 +4,9 @@ const AgentExporter = require('../../exporters/agent')
 const LogExporter = require('../../exporters/log')
 const env = require('./env')
 const exporters = require('../../../../../ext/exporters')
-const version = require('../../../lib/version')
 
 module.exports = name => {
   const inAWSLambda = env('AWS_LAMBDA_FUNCTION_NAME') !== undefined
-  const isBeta = /^\d+\.\d+\.\d+-beta\.\d+$/.test(version) // TODO: remove when GA
 
   switch (name) {
     case exporters.LOG:
@@ -16,6 +14,6 @@ module.exports = name => {
     case exporters.AGENT:
       return AgentExporter
     default:
-      return inAWSLambda && isBeta ? LogExporter : AgentExporter
+      return inAWSLambda ? LogExporter : AgentExporter
   }
 }

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -688,32 +688,17 @@ describe('Platform', () => {
         expect(Exporter).to.be.equal(AgentExporter)
       })
 
-      it('should create an LogExporter when in Lambda environment with a beta', () => {
+      it('should create an LogExporter when in Lambda environment', () => {
         const Exporter = proxyquire('../src/platform/node/exporter', {
           './env': (key) => {
             if (key === 'AWS_LAMBDA_FUNCTION_NAME') {
               return 'my-func'
             }
             return undefined
-          },
-          '../../../lib/version': '0.16.0-beta.1'
+          }
         })()
 
         expect(Exporter).to.be.equal(LogExporter)
-      })
-
-      it('should create an AgentExporter when in Lambda environment without a beta', () => {
-        const Exporter = proxyquire('../src/platform/node/exporter', {
-          './env': (key) => {
-            if (key === 'AWS_LAMBDA_FUNCTION_NAME') {
-              return 'my-func'
-            }
-            return undefined
-          },
-          '../../../lib/version': '0.16.0'
-        })()
-
-        expect(Exporter).to.be.equal(AgentExporter)
       })
 
       it('should allow configuring the exporter', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the beta version limitation for log exporter in Lambda.

### Motivation
<!-- What inspired you to submit this pull request? -->

This feature is no longer beta. This is a breaking change but the old behavior can be restored by using configuring the exporter. This should not be necessary however since the forwarder should be used instead of the agent when running in Lambda.