### PR TITLE
add support for measured spans

### DIFF
--- a/ext/tags.d.ts
+++ b/ext/tags.d.ts
@@ -8,6 +8,7 @@ declare const tags: {
   ERROR: 'error'
   MANUAL_KEEP: 'manual.keep'
   MANUAL_DROP: 'manual.drop'
+  MEASURED: '_dd.measured'
   HTTP_URL: 'http.url'
   HTTP_METHOD: 'http.method'
   HTTP_STATUS_CODE: 'http.status_code'

--- a/ext/tags.js
+++ b/ext/tags.js
@@ -11,6 +11,7 @@ const tags = {
   ERROR: 'error',
   MANUAL_KEEP: 'manual.keep',
   MANUAL_DROP: 'manual.drop',
+  MEASURED: '_dd.measured',
 
   // HTTP
   HTTP_URL: 'http.url',

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -8,6 +8,7 @@ const id = require('./id')
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY
 const ANALYTICS = tags.ANALYTICS
+const MEASURED = tags.MEASURED
 const ORIGIN_KEY = constants.ORIGIN_KEY
 const HOSTNAME_KEY = constants.HOSTNAME_KEY
 
@@ -64,6 +65,9 @@ function extractTags (trace, span) {
         break
       case HOSTNAME_KEY:
       case ANALYTICS:
+        break
+      case MEASURED:
+        addTag({}, trace.metrics, tag, tags[tag] === undefined || tags[tag] ? 1 : 0)
         break
       case 'error':
         if (tags[tag] && tags['span.kind'] !== 'internal') {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -7,6 +7,7 @@ const id = require('../src/id')
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY
 const ANALYTICS = tags.ANALYTICS
+const MEASURED = tags.MEASURED
 const ORIGIN_KEY = constants.ORIGIN_KEY
 const HOSTNAME_KEY = constants.HOSTNAME_KEY
 
@@ -481,6 +482,24 @@ describe('format', () => {
       spanContext._tags[ANALYTICS] = '0.5'
       trace = format(span)
       expect(trace.metrics[ANALYTICS_KEY]).to.equal(0.5)
+    })
+
+    it('should accept a boolean for measured', () => {
+      spanContext._tags[MEASURED] = true
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(1)
+    })
+
+    it('should accept a numeric value for measured', () => {
+      spanContext._tags[MEASURED] = 0
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(0)
+    })
+
+    it('should accept undefined for measured', () => {
+      spanContext._tags[MEASURED] = undefined
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(1)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for measured spans.

### Motivation
<!-- What inspired you to submit this pull request? -->

Allow picking which span should be measured in cases where the default doesn't fit the use case.