### PR TITLE
add support for peer dependencies in test versions

### DIFF
--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -87,6 +87,16 @@ function withVersions (plugin, modules, range, cb) {
       .forEach(instrumentation => {
         instrumentation.versions
           .forEach(version => {
+            const nodePath = process.env.NODE_PATH
+
+            if (instrumentation.peers) {
+              instrumentation.peers.forEach(peer => {
+                process.env.NODE_PATH = `${__dirname}/../../../../versions/${peer}/node_modules`
+              })
+
+              require('module').Module._initPaths()
+            }
+
             try {
               const min = semver.coerce(version).version
               require(`../../../../versions/${moduleName}@${min}`).get()
@@ -106,6 +116,11 @@ function withVersions (plugin, modules, range, cb) {
             }
 
             agent.wipe()
+
+            if (instrumentation.peers) {
+              process.env.NODE_PATH = nodePath
+              require('module').Module._initPaths()
+            }
           })
       })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for peer dependencies in test versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some supported modules can have peer dependencies that are not in the same folder when installed using the script to install test versions. Fixing this completely would need a significant change to how the versions are installed. By explicitly defining peer dependencies at the instrumentation level, it's possible to add them to the `NODE_PATH` and work around the issue, while also allowing to specify a different version than the ones tested.

Unblocks #861