### PR TITLE
add path of current test version to node path

### DIFF
--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -114,7 +114,27 @@ function withVersions (plugin, modules, range, cb) {
       .sort(v => v[0].localeCompare(v[0]))
       .map(v => Object.assign({}, v[1], { version: v[0] }))
       .forEach(v => {
-        describe(`with ${moduleName} ${v.range} (${v.version})`, () => cb(v.test, moduleName))
+        const versionPath = `${__dirname}/../../../../versions/${moduleName}@${v.test}/node_modules`
+
+        describe(`with ${moduleName} ${v.range} (${v.version})`, () => {
+          let nodePath
+
+          before(() => {
+            nodePath = process.env.NODE_PATH
+            process.env.NODE_PATH = [process.env.NODE_PATH, versionPath]
+              .filter(x => x)
+              .join(';')
+
+            require('module').Module._initPaths()
+          })
+
+          cb(v.test, moduleName)
+
+          after(() => {
+            process.env.NODE_PATH = nodePath
+            require('module').Module._initPaths()
+          })
+        })
       })
 
     agent.wipe()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add path of current test version to `NODE_PATH`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Supersede #901 by automatically add the test version path to the `NODE_PATH` implicitly for every test that uses `withVersion`. This allows any inner `withVersion` to require the module from an outer `withVersion` even if it doesn't explicitly depend on it and thus doesn't have it available in its own path.