### PR TITLE
update api docs with the new and easier to use api

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -144,22 +144,6 @@ If you aren’t using supported library instrumentation (see [Compatibility](htt
 
 This can be done using the [tracer.trace()](./interfaces/tracer.html#trace) and the [tracer.wrap()](./interfaces/tracer.html#wrap) methods which handle the span lifecycle and scope management automatically. In some rare cases the scope needs to be handled manually as well in which case the [tracer.scope()](./interfaces/tracer.html#scope) method is provided.
 
-For example:
-
-```javascript
-const tracer = require('dd-trace').init()
-const app = require('./app')
-const { getUsers } = require('./db')
-
-app.get('/users', (req, res) => {
-  tracer.trace('web.request', () => {
-    getUsers()
-      .then(users => res.send(users))
-      .catch(() => res.status(500).send())
-  })
-})
-```
-
 The different ways to use the above methods are described below.
 
 <h3 id="tracer-trace">tracer.trace(name[, options], callback)</h3>

--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,133 @@ The module exported by this library is an instance of the [Tracer](./interfaces/
 This library instruments the most popular JavaScript modules out of the box.
 [](https://docs.datadoghq.com/tracing/setup/nodejs/#compatibility)
 
+
+<h3 id="integrations">Integrations</h3>
+
+APM provides out-of-the-box instrumentation for many popular frameworks and libraries by using a plugin system. By default all built-in plugins are enabled. Disabling plugins can cause unexpected side effects, so it is highly recommended to leave them enabled.
+
+Built-in plugins can be configured individually:
+
+```javascript
+const tracer = require('dd-trace').init()
+
+// enable and configure postgresql integration
+tracer.use('pg', {
+  service: 'pg-cluster'
+})
+```
+
+<h5 id="amqplib"></h5>
+<h5 id="amqplib-tags"></h5>
+<h5 id="amqplib-config"></h5>
+<h5 id="aws-sdk"></h5>
+<h5 id="aws-sdk-tags"></h5>
+<h5 id="aws-sdk-config"></h5>
+<h5 id="bunyan"></h5>
+<h5 id="couchbase"></h5>
+<h5 id="dns"></h5>
+<h5 id="elasticsearch"></h5>
+<h5 id="elasticsearch-tags"></h5>
+<h5 id="elasticsearch-config"></h5>
+<h5 id="express"></h5>
+<h5 id="express-tags"></h5>
+<h5 id="express-config"></h5>
+<h5 id="generic-pool"></h5>
+<h5 id="google-cloud-pubsub"></h5>
+<h5 id="fastify"></h5>
+<h5 id="fs"></h5>
+<h5 id="graphql"></h5>
+<h5 id="graphql-tags"></h5>
+<h5 id="graphql-config"></h5>
+<h5 id="grpc"></h5>
+<h5 id="hapi"></h5>
+<h5 id="hapi-tags"></h5>
+<h5 id="hapi-config"></h5>
+<h5 id="http"></h5>
+<h5 id="http-tags"></h5>
+<h5 id="http-config"></h5>
+<h5 id="ioredis"></h5>
+<h5 id="ioredis-tags"></h5>
+<h5 id="ioredis-config"></h5>
+<h5 id="koa"></h5>
+<h5 id="koa-tags"></h5>
+<h5 id="koa-config"></h5>
+<h5 id="limitd-client"></h5>
+<h5 id="memcached"></h5>
+<h5 id="memcached-tags"></h5>
+<h5 id="memcached-config"></h5>
+<h5 id="microgateway-core"></h5>
+<h5 id="mongodb-core"></h5>
+<h5 id="mongodb-core-tags"></h5>
+<h5 id="mongodb-core-config"></h5>
+<h5 id="mysql"></h5>
+<h5 id="mysql-tags"></h5>
+<h5 id="mysql-config"></h5>
+<h5 id="mysql2"></h5>
+<h5 id="mysql2-tags"></h5>
+<h5 id="mysql2-config"></h5>
+<h5 id="net"></h5>
+<h5 id="paperplane"></h5>
+<h5 id="paperplane-tags"></h5>
+<h5 id="paperplane-config"></h5>
+<h5 id="pino"></h5>
+<h5 id="pg"></h5>
+<h5 id="pg-tags"></h5>
+<h5 id="pg-config"></h5>
+<h5 id="redis"></h5>
+<h5 id="redis-tags"></h5>
+<h5 id="redis-config"></h5>
+<h5 id="restify"></h5>
+<h5 id="restify-tags"></h5>
+<h5 id="restify-config"></h5>
+<h5 id="tedious"></h5>
+<h5 id="when"></h5>
+<h5 id="winston"></h5>
+<h3 id="integrations-list">Available Plugins</h3>
+
+* [amqp10](./interfaces/plugins.amqp10.html)
+* [amqplib](./interfaces/plugins.amqplib.html)
+* [aws-sdk](./interfaces/plugins.aws_sdk.html)
+* [bluebird](./interfaces/plugins.bluebird.html)
+* [couchbase](./interfaces/plugins.couchbase.html)
+* [bunyan](./interfaces/plugins.bunyan.html)
+* [cassandra-driver](./interfaces/plugins.cassandra_driver.html)
+* [connect](./interfaces/plugins.connect.html)
+* [dns](./interfaces/plugins.dns.html)
+* [elasticsearch](./interfaces/plugins.elasticsearch.html)
+* [express](./interfaces/plugins.express.html)
+* [fastify](./interfaces/plugins.fastify.html)
+* [fs](./interfaces/plugins.fs.html)
+* [generic-pool](./interfaces/plugins.generic_pool.html)
+* [google-cloud-pubsub](./interfaces/plugins.google_cloud_pubsub.html)
+* [graphql](./interfaces/plugins.graphql.html)
+* [grpc](./interfaces/plugins.grpc.html)
+* [hapi](./interfaces/plugins.hapi.html)
+* [http](./interfaces/plugins.http.html)
+* [http2](./interfaces/plugins.http2.html)
+* [ioredis](./interfaces/plugins.ioredis.html)
+* [knex](./interfaces/plugins.knex.html)
+* [koa](./interfaces/plugins.koa.html)
+* [limitd-client](./interfaces/plugins.limitd_client.html)
+* [ioredis](./interfaces/plugins.ioredis.html)
+* [microgateway--core](./interfaces/plugins.microgateway_core.html)
+* [mongodb-core](./interfaces/plugins.mongodb_core.html)
+* [mysql](./interfaces/plugins.mysql.html)
+* [mysql2](./interfaces/plugins.mysql2.html)
+* [net](./interfaces/plugins.net.html)
+* [paperplane](./interfaces/plugins.paperplane.html)
+* [pino](./interfaces/plugins.pino.html)
+* [pg](./interfaces/plugins.pg.html)
+* [promise](./interfaces/plugins.promise.html)
+* [promise-js](./interfaces/plugins.promise_js.html)
+* [q](./interfaces/plugins.q.html)
+* [redis](./interfaces/plugins.redis.html)
+* [restify](./interfaces/plugins.restify.html)
+* [router](./interfaces/plugins.router.html)
+* [tedious](./interfaces/plugins.tedious.html)
+* [when](./interfaces/plugins.when.html)
+* [winston](./interfaces/plugins.winston.html)
+
 <h2 id="manual-instrumentation">Manual Instrumentation</h2>
 
 If you aren’t using supported library instrumentation (see [Compatibility](https://docs.datadoghq.com/tracing/setup/nodejs/#compatibility)), you may want to manually instrument your code.
@@ -39,7 +166,7 @@ The different ways to use the above methods are described below.
 
 This method allows you to trace a specific operation at the moment it is executed. It supports synchronous and asynchronous operations depending on how it's called.
 
-<h4 id="callback">Synchronous</h4>
+<h4 id="sync">Synchronous</h4>
 
 To trace synchronously, simply call `tracer.trace()` without passing a function to the callback.
 
@@ -300,132 +427,6 @@ The following tags are available to override Datadog specific options:
 * `resource.name`: The resource name to be used for this span. The operation name will be used if this is not provided.
 * `span.type`: The span type to be used for this span. Will fallback to `custom` if not provided.
 
-<h2 id="integrations">Integrations</h2>
-
-APM provides out-of-the-box instrumentation for many popular frameworks and libraries by using a plugin system. By default all built-in plugins are enabled. Disabling plugins can cause unexpected side effects, so it is highly recommended to leave them enabled.
-
-Built-in plugins can be configured individually:
-
-```javascript
-const tracer = require('dd-trace').init()
-
-// enable and configure postgresql integration
-tracer.use('pg', {
-  service: 'pg-cluster'
-})
-```
-
-<h5 id="amqplib"></h5>
-<h5 id="amqplib-tags"></h5>
-<h5 id="amqplib-config"></h5>
-<h5 id="aws-sdk"></h5>
-<h5 id="aws-sdk-tags"></h5>
-<h5 id="aws-sdk-config"></h5>
-<h5 id="bunyan"></h5>
-<h5 id="couchbase"></h5>
-<h5 id="dns"></h5>
-<h5 id="elasticsearch"></h5>
-<h5 id="elasticsearch-tags"></h5>
-<h5 id="elasticsearch-config"></h5>
-<h5 id="express"></h5>
-<h5 id="express-tags"></h5>
-<h5 id="express-config"></h5>
-<h5 id="generic-pool"></h5>
-<h5 id="google-cloud-pubsub"></h5>
-<h5 id="fastify"></h5>
-<h5 id="fs"></h5>
-<h5 id="graphql"></h5>
-<h5 id="graphql-tags"></h5>
-<h5 id="graphql-config"></h5>
-<h5 id="grpc"></h5>
-<h5 id="hapi"></h5>
-<h5 id="hapi-tags"></h5>
-<h5 id="hapi-config"></h5>
-<h5 id="http"></h5>
-<h5 id="http-tags"></h5>
-<h5 id="http-config"></h5>
-<h5 id="ioredis"></h5>
-<h5 id="ioredis-tags"></h5>
-<h5 id="ioredis-config"></h5>
-<h5 id="koa"></h5>
-<h5 id="koa-tags"></h5>
-<h5 id="koa-config"></h5>
-<h5 id="limitd-client"></h5>
-<h5 id="memcached"></h5>
-<h5 id="memcached-tags"></h5>
-<h5 id="memcached-config"></h5>
-<h5 id="microgateway-core"></h5>
-<h5 id="mongodb-core"></h5>
-<h5 id="mongodb-core-tags"></h5>
-<h5 id="mongodb-core-config"></h5>
-<h5 id="mysql"></h5>
-<h5 id="mysql-tags"></h5>
-<h5 id="mysql-config"></h5>
-<h5 id="mysql2"></h5>
-<h5 id="mysql2-tags"></h5>
-<h5 id="mysql2-config"></h5>
-<h5 id="net"></h5>
-<h5 id="paperplane"></h5>
-<h5 id="paperplane-tags"></h5>
-<h5 id="paperplane-config"></h5>
-<h5 id="pino"></h5>
-<h5 id="pg"></h5>
-<h5 id="pg-tags"></h5>
-<h5 id="pg-config"></h5>
-<h5 id="redis"></h5>
-<h5 id="redis-tags"></h5>
-<h5 id="redis-config"></h5>
-<h5 id="restify"></h5>
-<h5 id="restify-tags"></h5>
-<h5 id="restify-config"></h5>
-<h5 id="tedious"></h5>
-<h5 id="when"></h5>
-<h5 id="winston"></h5>
-<h3 id="integrations-list">Available Plugins</h3>
-
-* [amqp10](./interfaces/plugins.amqp10.html)
-* [amqplib](./interfaces/plugins.amqplib.html)
-* [aws-sdk](./interfaces/plugins.aws_sdk.html)
-* [bluebird](./interfaces/plugins.bluebird.html)
-* [couchbase](./interfaces/plugins.couchbase.html)
-* [bunyan](./interfaces/plugins.bunyan.html)
-* [cassandra-driver](./interfaces/plugins.cassandra_driver.html)
-* [connect](./interfaces/plugins.connect.html)
-* [dns](./interfaces/plugins.dns.html)
-* [elasticsearch](./interfaces/plugins.elasticsearch.html)
-* [express](./interfaces/plugins.express.html)
-* [fastify](./interfaces/plugins.fastify.html)
-* [fs](./interfaces/plugins.fs.html)
-* [generic-pool](./interfaces/plugins.generic_pool.html)
-* [google-cloud-pubsub](./interfaces/plugins.google_cloud_pubsub.html)
-* [graphql](./interfaces/plugins.graphql.html)
-* [grpc](./interfaces/plugins.grpc.html)
-* [hapi](./interfaces/plugins.hapi.html)
-* [http](./interfaces/plugins.http.html)
-* [http2](./interfaces/plugins.http2.html)
-* [ioredis](./interfaces/plugins.ioredis.html)
-* [knex](./interfaces/plugins.knex.html)
-* [koa](./interfaces/plugins.koa.html)
-* [limitd-client](./interfaces/plugins.limitd_client.html)
-* [ioredis](./interfaces/plugins.ioredis.html)
-* [microgateway--core](./interfaces/plugins.microgateway_core.html)
-* [mongodb-core](./interfaces/plugins.mongodb_core.html)
-* [mysql](./interfaces/plugins.mysql.html)
-* [mysql2](./interfaces/plugins.mysql2.html)
-* [net](./interfaces/plugins.net.html)
-* [paperplane](./interfaces/plugins.paperplane.html)
-* [pino](./interfaces/plugins.pino.html)
-* [pg](./interfaces/plugins.pg.html)
-* [promise](./interfaces/plugins.promise.html)
-* [promise-js](./interfaces/plugins.promise_js.html)
-* [q](./interfaces/plugins.q.html)
-* [redis](./interfaces/plugins.redis.html)
-* [restify](./interfaces/plugins.restify.html)
-* [router](./interfaces/plugins.router.html)
-* [tedious](./interfaces/plugins.tedious.html)
-* [when](./interfaces/plugins.when.html)
-* [winston](./interfaces/plugins.winston.html)
-
 <h2 id="advanced-configuration">Advanced Configuration</h2>
 
 <h3 id="tracer-settings">Tracer settings</h3>
@@ -477,3 +478,23 @@ const tracer = require('dd-trace').init({
   debug: true
 })
 ```
+
+<h3 id="span-hooks">Span Hooks</h3>
+
+In some cases, it's necessary to update the metadata of a span created by one of the built-in integrations. This is possible using span hooks registered by integration. Each hook provides the span as the first argument and other contextual objects as additional arguments.
+
+For example:
+
+```javascript
+const tracer = require('dd-trace').init()
+
+tracer.use('express', {
+  request: (span, req res) => {
+    span.setTag('customer.id', req.query.id)
+  }
+})
+```
+
+Right now this functionality is limited to Web frameworks.
+
+More information on which hooks are supported for each integration can be found in each individual [plugins](./modules/plugins.html).

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,12 +8,6 @@ The module exported by this library is an instance of the [Tracer](./interfaces/
 
 <h2 id="auto-instrumentation">Automatic Instrumentation</h2>
 
-This library instruments the most popular JavaScript modules out of the box.
-[](https://docs.datadoghq.com/tracing/setup/nodejs/#compatibility)
-
-
-<h3 id="integrations">Integrations</h3>
-
 APM provides out-of-the-box instrumentation for many popular frameworks and libraries by using a plugin system. By default all built-in plugins are enabled. Disabling plugins can cause unexpected side effects, so it is highly recommended to leave them enabled.
 
 Built-in plugins can be configured individually:

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,7 +15,7 @@ This library instruments the most popular JavaScript modules out of the box.
 
 If you aren’t using supported library instrumentation (see [Compatibility](https://docs.datadoghq.com/tracing/setup/nodejs/#compatibility)), you may want to manually instrument your code.
 
-This can be done using the [tracer.trace()](#opentracing-api) and the [tracer.wrap()](#scope-manager) methods. The span lifecycle and scope management is handled automatically by these methods.
+This can be done using the [tracer.trace()](./interfaces/tracer.html#trace) and the [tracer.wrap()](./interfaces/tracer.html#wrap) methods which handle the span lifecycle and scope management automatically. In some rare cases the scope needs to be handled manually as well in which case the [tracer.scope()](./interfaces/tracer.html#scope) method is provided.
 
 For example:
 
@@ -35,7 +35,7 @@ app.get('/users', (req, res) => {
 
 The different ways to use the above methods are described below.
 
-<h3 id="tracer-trace">tracer.trace()</h3>
+<h3 id="tracer-trace">tracer.trace(name[, options], callback)</h3>
 
 This method allows you to trace a specific operation at the moment it is executed. It supports synchronous and asynchronous operations depending on how it's called.
 
@@ -98,7 +98,7 @@ async function handle () {
 
 Any error from the awaited handler will automatically be added to the span.
 
-<h3 id="tracer-wrap">tracer.wrap()</h3>
+<h3 id="tracer-wrap">tracer.wrap(name[, options], fn)</h3>
 
 This method works very similarly to `tracer.trace()` except it wraps a function so that `tracer.trace()` is called automatically every time the function is called. This makes it easier to patch entire functions that have already been defined, or that are returned from code that cannot be edited easily.
 
@@ -123,11 +123,9 @@ function handle (a, b, c, callback) {
 const handleWithTrace = tracer.wrap('web.request', handle)
 ```
 
-<h3 id="scope-manager">Scope Manager</h3>
+<h3 id="scope-manager">tracer.scope()</h3>
 
-In order to provide context propagation, this library includes a scope manager.
-A scope is basically a wrapper around a span that can cross both synchronous and
-asynchronous contexts.
+In order to provide context propagation, this library includes a scope manager available with `tracer.scope()`. A scope is basically a wrapper around a span that can cross both synchronous and asynchronous contexts.
 
 In most cases, it's not necessary to interact with the scope manager since `tracer.trace()` activates the span on its scope, and uses the  active span on the current scope if available as its parent. This should only be used directly for edge cases, like an internal queue of functions that are executed on a timer for example in which case the scope is lost.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   "license": "BSD-3-Clause",
   "private": true,
   "devDependencies": {
-    "typedoc": "^0.14.2",
-    "typescript": "^3.3.3"
+    "typedoc": "^0.17.3",
+    "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update documentation to use the new and simpler API. Span hooks were also added the the docs and the sections were moved by order of importance.

### Motivation
<!-- What inspired you to submit this pull request? -->

While we are OpenTracing compliant, it's no longer the recommended API to use for the tracer as it's overly complex and the standard is deprecated.