### PR TITLE
[Issue-884] Implement hooks configuration for the GraphQL plugin

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -118,7 +118,7 @@ const graphqlOptions = {
   collapse: false,
   signature: false,
   hooks: {
-    execute: (span, args, res) => {},
+    execute: (span, context, res) => {},
   }
 };
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -118,10 +118,7 @@ const graphqlOptions = {
   collapse: false,
   signature: false,
   hooks: {
-    parse: (span, args) => {},
-    validate: (span, args) => {},
     execute: (span, args, res) => {},
-    resolve: (span, args) => {}
   }
 };
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -118,7 +118,7 @@ const graphqlOptions = {
   collapse: false,
   signature: false,
   hooks: {
-    execute: (span, context, res) => {},
+    execute: (span, args, res) => {},
   }
 };
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -116,7 +116,13 @@ const graphqlOptions = {
   depth: 2,
   variables: ({ foo, baz }) => ({ foo }),
   collapse: false,
-  signature: false
+  signature: false,
+  hooks: {
+    parse: (span, args) => {},
+    validate: (span, args) => {},
+    execute: (span, args, res) => {},
+    resolve: (span, args) => {}
+  }
 };
 
 const elasticsearchOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 import { ClientRequest, IncomingMessage, ServerResponse } from "http";
 import * as opentracing from "opentracing";
 import { SpanOptions } from "opentracing/lib/tracer";
-import { ExecutionArgs, ExecutionResult } from "graphql"
 
 export { SpanOptions };
 
@@ -806,7 +805,7 @@ declare namespace plugins {
      * @defaul {}
      */
     hooks?: {
-      execute?: (span: Span, args: ExecutionArgs, res: ExecutionResult) => void;
+      execute?: (span: Span, args: any, res: any) => void;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -741,6 +741,13 @@ declare namespace plugins {
    */
   interface google_cloud_pubsub extends Integration {}
 
+  /** @hidden */
+  interface ExecutionContext {
+    rootValue: any,
+    contextValue: any,
+    variableValues: any,
+  }
+
   /**
    * This plugin automatically instruments the
    * [graphql](https://github.com/graphql/graphql-js) module.
@@ -805,7 +812,7 @@ declare namespace plugins {
      * @default {}
      */
     hooks?: {
-      execute?: (span?: Span, context?: any, res?: any) => void;
+      execute?: (span?: Span, context?: ExecutionContext, res?: any) => void;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import { ClientRequest, IncomingMessage, ServerResponse } from "http";
 import * as opentracing from "opentracing";
 import { SpanOptions } from "opentracing/lib/tracer";
+import { ExecutionArgs, ExecutionResult } from "graphql"
 
 export { SpanOptions };
 
@@ -796,6 +797,20 @@ declare namespace plugins {
      * @default true
      */
     signature?: boolean;
+
+    /**
+     * An object of optional callbacks to be executed during the respective
+     * phase of a GraphQL operation. Undefined callbacks default to a noop
+     * function.
+     * 
+     * @defaul {}
+     */
+    hooks?: {
+      parse?: (span: Span, args: { source: string }) => void;
+      validate?: (span: Span, args: { source: string }) => void;
+      execute?: (span: Span, args: ExecutionArgs, res: ExecutionResult) => void;
+      resolve?: (span: Span, args: { field: string }) => void;
+    }
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -806,10 +806,7 @@ declare namespace plugins {
      * @defaul {}
      */
     hooks?: {
-      parse?: (span: Span, args: { source: string }) => void;
-      validate?: (span: Span, args: { source: string }) => void;
       execute?: (span: Span, args: ExecutionArgs, res: ExecutionResult) => void;
-      resolve?: (span: Span, args: { field: string }) => void;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -802,7 +802,7 @@ declare namespace plugins {
      * phase of a GraphQL operation. Undefined callbacks default to a noop
      * function.
      * 
-     * @defaul {}
+     * @default {}
      */
     hooks?: {
       execute?: (span: Span, args: any, res: any) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -742,10 +742,15 @@ declare namespace plugins {
   interface google_cloud_pubsub extends Integration {}
 
   /** @hidden */
-  interface ExecutionContext {
-    rootValue: any,
-    contextValue: any,
-    variableValues: any,
+  interface ExecutionArgs {
+    schema: any,
+    document: any,
+    rootValue?: any,
+    contextValue?: any,
+    variableValues?: any,
+    operationName?: string,
+    fieldResolver?: any,
+    typeResolver?: any,
   }
 
   /**
@@ -812,7 +817,7 @@ declare namespace plugins {
      * @default {}
      */
     hooks?: {
-      execute?: (span?: Span, context?: ExecutionContext, res?: any) => void;
+      execute?: (span?: Span, args?: ExecutionArgs, res?: any) => void;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -805,7 +805,7 @@ declare namespace plugins {
      * @default {}
      */
     hooks?: {
-      execute?: (span: Span, args: any, res: any) => void;
+      execute?: (span?: Span, context?: any, res?: any) => void;
     }
   }
 

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -37,7 +37,7 @@ function createWrapExecute (tracer, config, defaultFieldResolver) {
         finishResolvers(contextValue, config)
 
         setError(span, err || (res && res.errors && res.errors[0]))
-        config.hooks.execute(span, getExecutionContext(args), res)
+        config.hooks.execute(span, args, res)
         finish(span)
       })
     }
@@ -393,14 +393,6 @@ function getOperation (document, operationName) {
       .find(def => operationName === (def.name && def.name.value))
   } else {
     return definitions.find(def => types.indexOf(def.operation) !== -1)
-  }
-}
-
-function getExecutionContext (args) {
-  return {
-    rootValue: args.rootValue || {},
-    contextValue: args.contextValue,
-    variableValues: args.variableValues || {}
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -53,8 +53,6 @@ function createWrapParse (tracer, config) {
 
       analyticsSampler.sample(span, config.analytics)
 
-      const parseHook = (span) => config.hooks.parse(span, { source })
-
       try {
         const document = parse.apply(this, arguments)
         const operation = getOperation(document)
@@ -67,11 +65,11 @@ function createWrapParse (tracer, config) {
 
         addDocumentTags(span, document)
 
-        finish(null, span, undefined, parseHook)
+        finish(null, span)
 
         return document
       } catch (e) {
-        finish(e, span, undefined, parseHook)
+        finish(e, span)
         throw e
       }
     }
@@ -99,9 +97,7 @@ function createWrapValidate (tracer, config) {
           const span = startSpan(tracer, config, 'validate', { startTime })
           addDocumentTags(span, document)
           analyticsSampler.sample(span, config.analytics)
-          finish(error, span, undefined, (span) => config.hooks.validate(span, {
-            source: document && document._datadog_source
-          }))
+          finish(error, span)
         }
       }
     }
@@ -347,7 +343,7 @@ function finishResolvers (contextValue, config) {
   Object.keys(fields).reverse().forEach(key => {
     const field = fields[key]
 
-    finish(field.error, field.span, field.finishTime, (span) => config.hooks.resolve(span, { field: key }))
+    finish(field.error, field.span, field.finishTime)
   })
 }
 
@@ -463,12 +459,9 @@ function pathToArray (path) {
 
 function getHooks (config) {
   const noop = () => {}
-  const parse = (config.hooks && config.hooks.parse) || noop
-  const validate = (config.hooks && config.hooks.validate) || noop
   const execute = (config.hooks && config.hooks.execute) || noop
-  const resolve = (config.hooks && config.hooks.resolve) || noop
 
-  return { parse, validate, execute, resolve }
+  return { execute }
 }
 
 module.exports = [

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -37,7 +37,7 @@ function createWrapExecute (tracer, config, defaultFieldResolver) {
         finishResolvers(contextValue, config)
 
         setError(span, err || (res && res.errors && res.errors[0]))
-        config.hooks.execute(span, getExecutionContext(args, res), res)
+        config.hooks.execute(span, getExecutionContext(args), res)
         finish(span)
       })
     }
@@ -396,30 +396,11 @@ function getOperation (document, operationName) {
   }
 }
 
-function getFragments (document) {
-  if (!document || !Array.isArray(document.definitions)) {
-    return []
-  }
-
-  return document.definitions.reduce((acc, d) => {
-    if (d.kind !== 'FragmentDefinition') return acc
-    return {
-      ...acc,
-      [d.name.value]: d
-    }
-  }, {})
-}
-
-function getExecutionContext (args, res) {
+function getExecutionContext (args) {
   return {
-    schema: args.schema,
-    fragments: getFragments(args.document),
     rootValue: args.rootValue || {},
     contextValue: args.contextValue,
-    operation: getOperation(args.document, args.operationName),
-    variableValues: args.variableValues || {},
-    fieldResolver: args.fieldResolver,
-    errors: (res && res.errors) || []
+    variableValues: args.variableValues || {}
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -325,11 +325,7 @@ function startResolveSpan (tracer, config, childOf, path, info, contextValue) {
 
 function finish (error, span, finishTime, hook) {
   if (error) {
-    span.addTags({
-      'error.type': error.name,
-      'error.msg': error.message,
-      'error.stack': error.stack
-    })
+    span.setTag('error', error)
   }
 
   if (hook) hook(span)

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -16,7 +16,7 @@ function createWrapExecute (tracer, config, defaultFieldResolver) {
       const source = document && document._datadog_source
       const fieldResolver = args.fieldResolver || defaultFieldResolver
       const contextValue = args.contextValue = args.contextValue || {}
-      const operation = args.operation = getOperation(document, args.operationName)
+      const operation = getOperation(document, args.operationName)
 
       if (contextValue._datadog_graphql) {
         return execute.apply(this, arguments)
@@ -333,7 +333,7 @@ function finish (span, finishTime) {
   span.finish(finishTime)
 }
 
-function finishResolvers (contextValue, config) {
+function finishResolvers (contextValue) {
   const fields = contextValue._datadog_graphql.fields
 
   Object.keys(fields).reverse().forEach(key => {
@@ -416,7 +416,7 @@ function getExecutionContext (args, res) {
     fragments: getFragments(args.document),
     rootValue: args.rootValue || {},
     contextValue: args.contextValue,
-    operation: args.operation || getOperation(args.document, args.operationName),
+    operation: getOperation(args.document, args.operationName),
     variableValues: args.variableValues || {},
     fieldResolver: args.fieldResolver,
     errors: (res && res.errors) || []

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1351,20 +1351,11 @@ describe('Plugin', () => {
               const res = config.hooks.execute.firstCall.args[2]
 
               expect(span.context()._name).to.equal('graphql.execute')
-
               expect(context).to.include({
-                schema: params.schema,
                 rootValue: params.rootValue,
                 contextValue: params.contextValue,
-                variableValues: params.variableValues,
-                fieldResolver: params.fieldResolver
+                variableValues: params.variableValues
               })
-              expect(context).to.have.property('fragments')
-              expect(context.fragments).to.have.property('queryFields')
-              expect(context.operation.name.value).to.equal(params.operationName)
-              expect(context).to.have.property('errors')
-              expect(context.errors).to.be.deep.equal([])
-
               expect(res).to.equal(result)
             })
             .then(done)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1317,51 +1317,6 @@ describe('Plugin', () => {
 
         after(() => agent.close())
 
-        it('should run the parse hook before graphql.parse span is finished', done => {
-          const source = `query MyQuery { hello(name: "world") }`
-          graphql.parse(source)
-
-          agent
-            .use(traces => {
-              const spans = sort(traces[0])
-
-              expect(spans[0]).to.have.property('name', 'graphql.parse')
-              expect(config.hooks.parse).to.have.been.calledOnce
-
-              const span = config.hooks.parse.firstCall.args[0]
-              const args = config.hooks.parse.firstCall.args[1]
-
-              expect(span.context()._name).to.equal('graphql.parse')
-              expect(args.source).to.equal(source)
-            })
-            .then(done)
-            .catch(done)
-        })
-
-        it('should run the validate hook before graphql.validate span is finished', done => {
-          const source = `query MyQuery { hello(name: "world") }`
-          const document = graphql.parse(source)
-
-          agent
-            .use(traces => {
-              const spans = sort(traces[0])
-
-              expect(spans).to.have.length(1)
-              expect(spans[0]).to.have.property('name', 'graphql.validate')
-              expect(config.hooks.validate).to.have.been.calledOnce
-
-              const span = config.hooks.validate.firstCall.args[0]
-              const args = config.hooks.validate.firstCall.args[1]
-
-              expect(span.context()._name).to.equal('graphql.validate')
-              expect(args.source).to.equal(source)
-            })
-            .then(done)
-            .catch(done)
-
-          graphql.validate(schema, document)
-        })
-
         it('should run the execute hook before graphql.execute span is finished', done => {
           const source = `query MyQuery { hello(name: "world") }`
           const document = graphql.parse(source)
@@ -1404,31 +1359,6 @@ describe('Plugin', () => {
             .then(res => {
               result = res
             })
-        })
-
-        it('should run the resolve hook before graphql.resolve span is finished', done => {
-          const source = `query MyQuery { hello(name: "world") }`
-          const document = graphql.parse(source)
-          graphql.validate(schema, document)
-
-          agent
-            .use(traces => {
-              const spans = sort(traces[0])
-
-              expect(spans).to.have.length(2)
-              expect(spans[1]).to.have.property('name', 'graphql.resolve')
-              expect(config.hooks.resolve).to.have.been.calledOnce
-
-              const span = config.hooks.resolve.firstCall.args[0]
-              const args = config.hooks.resolve.firstCall.args[1]
-
-              expect(span.context()._name).to.equal('graphql.resolve')
-              expect(args.field).to.equal('hello')
-            })
-            .then(done)
-            .catch(done)
-
-          graphql.execute({ schema, document })
         })
       })
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1333,7 +1333,8 @@ describe('Plugin', () => {
             contextValue: {},
             variableValues: { who: 'world' },
             operationName: 'MyQuery',
-            fieldResolver: (source, args, contextValue, info) => args.name
+            fieldResolver: (source, args, contextValue, info) => args.name,
+            typeResolver: (value, context, info, abstractType) => 'Query'
           }
 
           let result
@@ -1347,14 +1348,19 @@ describe('Plugin', () => {
               expect(config.hooks.execute).to.have.been.calledOnce
 
               const span = config.hooks.execute.firstCall.args[0]
-              const context = config.hooks.execute.firstCall.args[1]
+              const args = config.hooks.execute.firstCall.args[1]
               const res = config.hooks.execute.firstCall.args[2]
 
               expect(span.context()._name).to.equal('graphql.execute')
-              expect(context).to.include({
+              expect(args).to.include({
+                schema: params.schema,
+                document: params.document,
                 rootValue: params.rootValue,
                 contextValue: params.contextValue,
-                variableValues: params.variableValues
+                variableValues: params.variableValues,
+                operationName: params.operationName,
+                fieldResolver: params.fieldResolver,
+                typeResolver: params.typeResolver
               })
               expect(res).to.equal(result)
             })

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1293,10 +1293,7 @@ describe('Plugin', () => {
       describe('with hooks configuration', () => {
         const config = {
           hooks: {
-            parse: sinon.spy((span, args) => {}),
-            validate: sinon.spy((span, args) => {}),
-            execute: sinon.spy((span, args, res) => {}),
-            resolve: sinon.spy((span, args) => {})
+            execute: sinon.spy((span, context, res) => {})
           }
         }
 


### PR DESCRIPTION
### What does this PR do?
This PR implements the execute hook for the graphql plugin based on #884. Its signature is the following:

```ts
type ExecuteHook = (span?: Span, context?: ExecutionContext, res?: ExecutionResult) => void
```

Links to definitions:

- [ExecutionContext](https://github.com/graphql/graphql-js/blob/c9850c1dab8811086e6fd8383508384e538b31fd/src/execution/execute.js#L89-L105)
- [ExecutionResult](https://github.com/graphql/graphql-js/blob/c9850c1dab8811086e6fd8383508384e538b31fd/src/execution/execute.js#L113)

cc: @rochdev

### Motivation

- #884 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].
- [x] CircleCI [jobs/workflows][4]. (Not Applicable)
- [x] Plugin is [exported][5]. (Not Applicable)

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I wasn't able to update the API documentation for the plugin. It also serves a 404 page: https://github.com/DataDog/dd-trace-js/blob/master/docs/interfaces/plugins.graphql.html.