### PR TITLE
enable http2 plugin for clients

### DIFF
--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -255,5 +255,3 @@ module.exports = [
     }
   }
 ]
-
-module.exports = [] // temporarily disable HTTP2 client plugin

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -13,8 +13,6 @@ const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 wrapIt()
 
-const describe = () => {} // temporarily disable HTTP2 client plugin tests
-
 describe('Plugin', () => {
   let http2
   let appListener


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Enable the `http2` plugin, but only for clients.

### Motivation
<!-- What inspired you to submit this pull request? -->

The plugin was disabled because of technical limitations with how we currently handle Web frameworks. This limitation only affects servers, so there is not reason to keep the client disabled.