### PR TITLE
fix empty service name accepted as a valid value

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -13,13 +13,12 @@ class Config {
   constructor (options) {
     options = options || {}
 
-    const service = coalesce(
-      options.service,
-      platform.env('DD_SERVICE'),
-      platform.env('DD_SERVICE_NAME'),
-      platform.service(),
+    const service = options.service ||
+      platform.env('DD_SERVICE') ||
+      platform.env('DD_SERVICE_NAME') ||
+      platform.service() ||
       'node'
-    )
+
     const version = coalesce(
       options.version,
       platform.env('DD_VERSION'),

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -338,4 +338,14 @@ describe('Config', () => {
     expect(new Config({ sampleRate: 2 })).to.have.property('sampleRate', 1)
     expect(new Config({ sampleRate: NaN })).to.have.property('sampleRate', 1)
   })
+
+  it('should ignore empty service names', () => {
+    platform.env.withArgs('DD_SERVICE').returns('')
+
+    const config = new Config()
+
+    expect(config.tags).to.include({
+      service: 'node'
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix empty service name accepted as a valid value and instead use other sources or the fallback.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, one of the possible sources that are used to determine the service name can be set to an empty string. This should not be accepted since it's not a valid value for the service name, and can result in unexpected behaviors.

Relates to #850 and #851