### PR TITLE
fix empty http protocol returning undefined

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -38,10 +38,11 @@ function patch (http, methodName, tracer, config) {
       }
 
       const options = args.options
+      const protocol = options.protocol || 'http:'
       const hostname = options.hostname || options.host || 'localhost'
       const host = options.port ? `${hostname}:${options.port}` : hostname
       const path = options.path ? options.path.split(/[?#]/)[0] : '/'
-      const uri = `${options.protocol}//${host}${path}`
+      const uri = `${protocol}//${host}${path}`
 
       let callback = args.callback
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix empty http protocol returning `undefined`.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, the protocol is not set on either the URL, options or agent provided to `http` when making a request. Right now this results in a URL like `undefined//localhost`.