### PR TITLE
Fix `platform/node/pkg.js` for pre-requires.

### DIFF
--- a/packages/dd-trace/src/platform/node/pkg.js
+++ b/packages/dd-trace/src/platform/node/pkg.js
@@ -4,7 +4,7 @@ const path = require('path')
 const readPkgUp = require('read-pkg-up')
 
 function findRoot () {
-  return path.dirname(require.main.filename)
+  return require.main ? path.dirname(require.main.filename) : process.cwd()
 }
 
 function findPkg () {

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -2,6 +2,7 @@
 
 const nock = require('nock')
 const semver = require('semver')
+const { execSync } = require('child_process')
 
 const AgentExporter = require('../../../src/exporters/agent')
 const LogExporter = require('../../../src/exporters/log')
@@ -11,6 +12,15 @@ wrapIt()
 describe('Platform', () => {
   describe('Node', () => {
     let platform
+
+    describe('in pre-require', () => {
+      it('should load the package.json correctly', () => {
+        const pkg = JSON.parse(execSync(`node --require ./pkg-loader.js -e ""`, {
+          cwd: __dirname
+        }).toString())
+        expect(pkg.name).to.equal('dd-trace')
+      })
+    })
 
     describe('name', () => {
       beforeEach(() => {

--- a/packages/dd-trace/test/platform/node/pkg-loader.js
+++ b/packages/dd-trace/test/platform/node/pkg-loader.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const pkg = require('../../../src/platform/node/pkg.js')
+
+// eslint-disable-next-line no-console
+console.log(JSON.stringify(pkg))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pult. -->
Fixes the loading of the tracer from pre-requires (i.e. `pre.js` in `node -r
./pre.js myapp.js`). Which had previously worked

### Motivation
<!-- What inspired you to submit this pull request? -->
We use this in our performance testing, which prior to this is broken on master.
