### PR TITLE
update minimum version of pubsub in the plugin to 1.2

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/src/index.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/index.js
@@ -70,7 +70,7 @@ function getTopic (cfg) {
 module.exports = [
   {
     name: '@google-cloud/pubsub',
-    versions: ['>=1.1'],
+    versions: ['>=1.2'],
     patch ({ PubSub, Subscription }, tracer, config) {
       this.wrap(PubSub.prototype, 'request', createWrapRequest(tracer, config))
       this.wrap(Subscription.prototype, 'emit', createWrapSubscriptionEmit(tracer, config))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update minimum version of `pubsub` in the plugin to 1.2.

### Motivation
<!-- What inspired you to submit this pull request? -->

Olders versions of the module depend on a version of `grpc-js` with known issues that prevent testing.