### PR TITLE
fix loopback timing out in express plugin tests

### DIFF
--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -824,7 +824,9 @@ describe('Plugin', () => {
         withVersions(plugin, 'loopback', loopbackVersion => {
           let loopback
 
-          beforeEach(() => {
+          beforeEach(function () {
+            this.timeout(5000)
+
             loopback = require(`../../../versions/loopback@${loopbackVersion}`).get()
           })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix loopback timing out in express plugin tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Loopback is a large framework and is very slow to load, sometimes taking over 2 seconds and failing the tests because of the default timeout being too short.