### PR TITLE
fix stack overflow when cloning http res and overriding res.end

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -67,9 +67,9 @@ const web = {
     if (!req._datadog.instrumented) {
       wrapEnd(req)
       wrapEvents(req)
-    }
 
-    req._datadog.instrumented = true
+      req._datadog.instrumented = true
+    }
 
     return callback && tracer.scope().activate(span, () => callback(span))
   },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix stack overflow when cloning http `res` and overriding `res.end`.

### Motivation
<!-- What inspired you to submit this pull request? -->

We redefine the `res.end` property to be a setter and use a local variable within the wrapper to store the original function. When cloning `res`, both the clone and the original `res` object end up sharing the same local variable since they refer to the same setter. This means that when the clone tries to call the original by calling `res.end.apply(res, arguments)` it results in a stack overflow since it ends up calling itself.

By storing the original on the object itself instead, we can make sure that each clone has its own internal original function.

Fixes #927 