### PR TITLE
disable flaky aws-sdk tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -863,7 +863,7 @@ workflows:
       - node-bench-latest
       - node-amqplib
       - node-amqp10
-      - node-aws-sdk
+      # - node-aws-sdk
       - node-bluebird
       - node-bunyan
       - node-cassandra
@@ -1020,7 +1020,7 @@ workflows:
       - node-bench-latest
       - node-amqplib
       - node-amqp10
-      - node-aws-sdk
+      # - node-aws-sdk
       - node-bluebird
       - node-bunyan
       - node-cassandra


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable `aws-sdk` tests in CI.

### Motivation
<!-- What inspired you to submit this pull request? -->

They are currently unreliable and need to be redone.