### PR TITLE
fix duplicate path on errors in express plugin

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -14,29 +14,6 @@ function createWrapHandle (tracer, config) {
   }
 }
 
-function createWrapProcessParams (tracer, config) {
-  return function wrapProcessParams (processParams) {
-    return function processParamsWithTrace (layer, called, req, res, done) {
-      const matchers = layer._datadog_matchers
-
-      req = done ? req : called
-
-      if (web.active(req) && matchers) {
-        // Try to guess which path actually matched
-        for (let i = 0; i < matchers.length; i++) {
-          if (matchers[i].test(layer)) {
-            web.enterRoute(req, matchers[i].path)
-
-            break
-          }
-        }
-      }
-
-      return processParams.apply(this, arguments)
-    }
-  }
-}
-
 function wrapRouterMethod (original) {
   return function methodWithTrace (fn) {
     const offset = this.stack ? [].concat(this.stack).length : 0
@@ -113,6 +90,19 @@ function wrapNext (layer, req, next) {
 }
 
 function callHandle (layer, handle, req, args) {
+  const matchers = layer._datadog_matchers
+
+  if (web.active(req) && matchers) {
+    // Try to guess which path actually matched
+    for (let i = 0; i < matchers.length; i++) {
+      if (matchers[i].test(layer)) {
+        web.enterRoute(req, matchers[i].path)
+
+        break
+      }
+    }
+  }
+
   return web.wrapMiddleware(req, handle, 'express.middleware', () => {
     return handle.apply(layer, args)
   })
@@ -156,13 +146,11 @@ module.exports = {
   versions: ['>=1'],
   patch (Router, tracer, config) {
     this.wrap(Router.prototype, 'handle', createWrapHandle(tracer, config))
-    this.wrap(Router.prototype, 'process_params', createWrapProcessParams(tracer, config))
     this.wrap(Router.prototype, 'use', wrapRouterMethod)
     this.wrap(Router.prototype, 'route', wrapRouterMethod)
   },
   unpatch (Router) {
     this.unwrap(Router.prototype, 'handle')
-    this.unwrap(Router.prototype, 'process_params')
     this.unwrap(Router.prototype, 'use')
     this.unwrap(Router.prototype, 'route')
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix duplicate path on errors in express plugin.

### Motivation
<!-- What inspired you to submit this pull request? -->

When multiple middleware are registered on the same route and one throw an error, it would result in the path being duplicated.