### PR TITLE
update prepublish script to exclude nightly builds

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -62,6 +62,7 @@ function getPipeline () {
   return fetch(`project/github/DataDog/dd-trace-js/pipeline?branch=${branch}`)
     .then(response => {
       const pipeline = response.data.items
+        .filter(item => item.trigger.type !== 'schedule')
         .find(item => item.vcs.revision === revision)
 
       if (!pipeline) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update prepublish script to exclude nightly builds.

### Motivation
<!-- What inspired you to submit this pull request? -->

When trying to release from a commit that was not built the same day, the prepublish script uses the last pipeline, which may be the nightly build. Since this workflow doesn't include prebuilds, it has to be skipped by the script.