### PR TITLE
fix missing scripts for postinstall causing warnings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@
 !packages/*/src/**/*
 !packages/*/index.js
 !prebuilds/**/*
-!scripts/postinstall.js
+!scripts/**/*
 !CONTRIBUTING.md
 !LICENSE
 !LICENSE-3rdparty.csv


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing scripts for postinstall causing warnings.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `scripts` folder was missing because of the .npmignore configuration, which would show a warning and prevent rebuilding if needed after the installation.