### PR TITLE
fix build error on alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ prebuild-job: &prebuild-job
       only:
         - master
         - /v\d+\.\d+/
+        - /.*native.*/
 
 jobs:
   # Linting

--- a/binding.gyp
+++ b/binding.gyp
@@ -32,6 +32,9 @@
           "-std=c++11",
           "-Wall",
           "-Werror"
+        ],
+        "cflags_cc": [
+          "-Wno-cast-function-type"
         ]
       }],
       ["OS == 'win'", {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix build error on alpine.

### Motivation
<!-- What inspired you to submit this pull request? -->

Build started failing on newer versions of GCC because of a new warning that was considered an error by our flags. The warning comes from `nan` and is not something they will be fixing according to [this](https://github.com/nodejs/nan/issues/807).