### PR TITLE
Small perf wins in encoding

### DIFF
--- a/packages/dd-trace/src/encode/cache.js
+++ b/packages/dd-trace/src/encode/cache.js
@@ -4,10 +4,36 @@ const LRUCache = require('mnemonist/lru-cache')
 const tokens = require('./tokens')
 const util = require('./util')
 
+const fastCache = {};
+`
+service
+version
+language
+component
+span.kind
+error.type
+error.msg
+error.stack
+_sample_rate
+_sampling_priority_v1
+javascript
+
+`.trim().split('\n').forEach(str => {
+    const buffer = Buffer.from(str, 'utf-8')
+
+    fastCache[str] = Buffer.concat([
+      prefix(buffer.length),
+      buffer
+    ])
+  })
+
 function cache (max) {
   const cache = new LRUCache(max)
 
   return value => {
+    if (value in fastCache) {
+      return fastCache[value]
+    }
     let item = cache.get(value)
 
     if (!item) {

--- a/packages/dd-trace/src/encode/index.js
+++ b/packages/dd-trace/src/encode/index.js
@@ -121,9 +121,19 @@ function checkOffset (offset, length) {
   return offset
 }
 
+function lightCopyIdToHeader (src, offset) {
+  for (let i = 0; i < 8; i++) {
+    headerBuffer[offset + i] = src[i]
+  }
+}
+
 function copyHeader (offset, span) {
-  headerBuffer.set(span.trace_id.toBuffer(), traceIdOffset)
-  headerBuffer.set(span.span_id.toBuffer(), spanIdOffset)
+  const traceId = span.trace_id.toBuffer()
+  for (let i = 0; i < 8; i++) {
+    headerBuffer[traceIdOffset + i] = traceId[i]
+  }
+  lightCopyIdToHeader(span.trace_id.toBuffer(), traceIdOffset)
+  lightCopyIdToHeader(span.span_id.toBuffer(), spanIdOffset)
   util.writeInt64(headerBuffer, span.start, startOffset)
   util.writeInt64(headerBuffer, span.duration, durationOffset)
   headerBuffer.set(tokens.int[span.error], errorOffset)
@@ -145,7 +155,9 @@ function copy (offset, source) {
   const length = source.length
 
   offset = checkOffset(offset, length)
-  buffer.set(source, offset)
+  for (let i = 0; i < length; i++) {
+    buffer[offset + i] = source[i]
+  }
 
   return offset + length
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### fast string cache path for some well-used strings
These are commonly found in `metrics` and `meta`, so we'll pre-compute
them to avoid the slightly expensive cache lookup.

#### manual copy bytes instead of using `TypedArray#set`
In this particularly hot path, switching over to manual byte-copying
reduces overhead a bit, since `set` does additional typechecking, etc.,
behind the scenes.

### Motivation
<!-- What inspired you to submit this pull request? -->
Performance.
