### PR TITLE
Add option for AsyncLocalStorage for scope management

### DIFF
--- a/ext/scopes.d.ts
+++ b/ext/scopes.d.ts
@@ -1,4 +1,5 @@
 declare const scopes: {
+  ASYNC_LOCAL_STORAGE: 'async_local_storage',
   ASYNC_HOOKS: 'async_hooks'
   NOOP: 'noop'
 }

--- a/ext/scopes.js
+++ b/ext/scopes.js
@@ -1,6 +1,7 @@
 'use strict'
 
 module.exports = {
+  ASYNC_LOCAL_STORAGE: 'async_local_storage',
   ASYNC_HOOKS: 'async_hooks',
   NOOP: 'noop'
 }

--- a/packages/dd-trace/src/platform/browser/index.js
+++ b/packages/dd-trace/src/platform/browser/index.js
@@ -30,7 +30,7 @@ const platform = {
   on: () => {}, // TODO: add event listener
   off: () => {}, // TODO: add event listener
   Loader,
-  Scope,
+  getScope: () => Scope,
   exporter
 }
 

--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -11,7 +11,7 @@ const metrics = require('./metrics')
 const plugins = require('../../plugins')
 const hostname = require('./hostname')
 const Loader = require('./loader')
-const Scope = require('../../scope/async_hooks')
+const scopes = require('../../../../../ext/scopes')
 const exporter = require('./exporter')
 const pkg = require('./pkg')
 
@@ -37,7 +37,12 @@ const platform = {
   on: emitter.on.bind(emitter),
   off: emitter.removeListener.bind(emitter),
   Loader,
-  Scope,
+  getScope (scope) {
+    if (scope === scopes.ASYNC_LOCAL_STORAGE) {
+      return require('../../scope/async_local_storage')
+    }
+    return require('../../scope/async_hooks')
+  },
   exporter
 }
 

--- a/packages/dd-trace/src/scope/async_local_storage.js
+++ b/packages/dd-trace/src/scope/async_local_storage.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { AsyncLocalStorage } = require('async_hooks')
+const Base = require('./base')
+
+let singleton = null
+
+class Scope extends Base {
+  constructor () {
+    if (singleton) return singleton
+
+    super()
+
+    singleton = this
+
+    this._storage = new AsyncLocalStorage()
+  }
+
+  _active () {
+    const store = this._storage.getStore()
+    return typeof store === 'undefined' ? null : store
+  }
+
+  _activate (span, callback) {
+    if (span === null) {
+      return this._storage.exit(callback)
+    }
+    return this._storage.run(span, callback)
+  }
+}
+
+module.exports = Scope

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -146,7 +146,7 @@ function getScope (config) {
   if (config.scope === NOOP) {
     Scope = require('./scope/base')
   } else {
-    Scope = platform.Scope
+    Scope = platform.getScope(config.scope)
   }
 
   return new Scope(config)

--- a/packages/dd-trace/test/scope/async_local_storage.spec.js
+++ b/packages/dd-trace/test/scope/async_local_storage.spec.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const {
+  AsyncLocalStorage,
+  AsyncResource,
+  executionAsyncId
+} = require('async_hooks')
+const Scope = require('../../src/scope/async_local_storage')
+const Span = require('opentracing').Span
+const testScope = require('./test')
+
+wrapIt()
+
+if (AsyncLocalStorage) {
+  describe('Scope (AsyncLocalStorage)', test)
+} else {
+  describe.skip('Scope (AsyncLocalStorage)', test)
+}
+
+function test () {
+  let scope
+  let span
+
+  beforeEach(() => {
+    scope = new Scope()
+    span = new Span()
+  })
+
+  it('should not break propagation for nested resources', done => {
+    scope.activate(span, () => {
+      const asyncResource = new AsyncResource(
+        'TEST', { triggerAsyncId: executionAsyncId(), requireManualDestroy: false }
+      )
+
+      asyncResource.runInAsyncScope(() => {})
+
+      expect(scope.active()).to.equal(span)
+
+      // AsyncLocalStorage context persists through `done()` unless we tell it
+      // not to. Without this, the following tests will run inside this scope.
+      scope._storage.exit(done)
+    })
+  })
+
+  testScope(() => scope)
+}


### PR DESCRIPTION
I've added support for using the new `AsyncLocalStorage` class in Node.js 14+ as a simpler and faster scope manager.

Note the comment in the test: this is a bit more aggressive at maintaining the context than the existing scope manager so it may be necessary to expose the `storage.exit(...)` method for some cases where you don't want the context propagated.