### PR TITLE
split headless browser tests from browserstack tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -867,6 +867,7 @@ workflows:
       - lint
       - typescript
       - browser
+      - browserstack
       - node-core-8
       - node-core-10
       - node-core-12
@@ -1024,6 +1025,7 @@ workflows:
                 - master
     jobs:
       - browser
+      - browserstack
       - node-core-8
       - node-core-10
       - node-core-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,6 +845,21 @@ jobs:
           name: Integration tests
           command: yarn test:browser
 
+  browserstack:
+    docker:
+      - image: circleci/node:10-browsers
+    resource_class: small
+    working_directory: ~/dd-trace-js
+    steps:
+      - checkout
+      - *yarn-versions
+      - *restore-yarn-cache
+      - *yarn-install
+      - *save-yarn-cache
+      - run:
+          name: Integration tests
+          command: yarn test:browserstack
+
 workflows:
   version: 2
   build:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -104,7 +104,7 @@ module.exports = function (config) {
       }
     }
 
-    opts.reporters = 'BrowserStack'
+    opts.reporters = ['BrowserStack']
 
     for (const browser in opts.customLaunchers) {
       opts.browsers.push(browser)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -64,7 +64,7 @@ module.exports = function (config) {
     webpack: webpackConfig.find(entry => entry.mode === 'development')
   }
 
-  if (process.env.CI === 'true') {
+  if (process.env.BROWSERSTACK === 'true') {
     // https://github.com/karma-runner/karma-browserstack-launcher
     opts.browserStack = {
       project: 'dd-trace-js'
@@ -104,7 +104,7 @@ module.exports = function (config) {
       }
     }
 
-    opts.reporters.push('BrowserStack')
+    opts.reporters = 'BrowserStack'
 
     for (const browser in opts.customLaunchers) {
       opts.browsers.push(browser)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:core": "nyc --include \"packages/dd-trace/src/**/*.js\" -- mocha --exit --expose-gc --file packages/dd-trace/test/setup/core.js \"packages/dd-trace/test/**/*.spec.js\"",
     "test:plugins": "yarn services && nyc --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- mocha --exit --file \"packages/dd-trace/test/setup/core.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
     "test:browser": "karma start --single-run",
+    "test:browserstack": "BROWSERSTACK=true karma start --single-run",
     "leak:core": "node ./scripts/install_plugin_modules && (cd packages/memwatch && yarn) && NODE_PATH=./packages/memwatch/node_modules node --no-warnings ./node_modules/.bin/tape 'packages/dd-trace/test/leak/**/*.js'",
     "leak:plugins": "yarn services && (cd packages/memwatch && yarn) && NODE_PATH=./packages/memwatch/node_modules node --no-warnings ./node_modules/.bin/tape \"packages/datadog-plugin-@($(echo $PLUGINS))/test/leak.js\"",
     "codecov": "codecov"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split headless browser tests from BrowserStack tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Browser tests are always failing in forks because CircleCI doesn't provide the API keys in them for security reasons. This can hide when browser tests start failing in forks since they are expected to fail. By splitting the headless tests from the BrowserStack tests, it's easier to figure out the real reason for tests failing.