### PR TITLE
fix wrong minimum node version for AsyncLocalStorage failing tests

### DIFF
--- a/packages/dd-trace/test/scope/async_local_storage.spec.js
+++ b/packages/dd-trace/test/scope/async_local_storage.spec.js
@@ -12,7 +12,7 @@ const testScope = require('./test')
 wrapIt()
 
 // https://github.com/nodejs/node/commit/52d8afc07e005343390ebc8c6d9e1eec77acd16e#diff-0bb01a51b135a5f68d93540808bac801
-if (semver.gte(process.version, '13.14')) {
+if (semver.gte(process.version, '13.14.0')) {
   describe('Scope (AsyncLocalStorage)', test)
 } else {
   describe.skip('Scope (AsyncLocalStorage)', test)

--- a/packages/dd-trace/test/scope/async_local_storage.spec.js
+++ b/packages/dd-trace/test/scope/async_local_storage.spec.js
@@ -1,17 +1,18 @@
 'use strict'
 
 const {
-  AsyncLocalStorage,
   AsyncResource,
   executionAsyncId
 } = require('async_hooks')
 const Scope = require('../../src/scope/async_local_storage')
 const Span = require('opentracing').Span
+const semver = require('semver')
 const testScope = require('./test')
 
 wrapIt()
 
-if (AsyncLocalStorage) {
+// https://github.com/nodejs/node/commit/52d8afc07e005343390ebc8c6d9e1eec77acd16e#diff-0bb01a51b135a5f68d93540808bac801
+if (semver.gte(process.version, '13.14')) {
   describe('Scope (AsyncLocalStorage)', test)
 } else {
   describe.skip('Scope (AsyncLocalStorage)', test)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix wrong minimum Node version for `AsyncLocalStorage` failing tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Relying on the presence of `AsyncLocalStorage` is not enough since the API changed in 13.14 and we rely on the new API in the tests.