### PR TITLE
fix express plugin loopback test failing on node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ jobs:
   node-express:
     <<: *node-plugin-base
     docker:
-      - image: node:8
+      - image: node:10
         environment:
           - PLUGINS=express
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `express` plugin `loopback` test failing on Node 8.

### Motivation
<!-- What inspired you to submit this pull request? -->

A transitive dependency of Loopback is not longer compatible with Node 8, so I moved the test to Node 10.