### PR TITLE
Always Finalize GraphQL Datadog Span

### DIFF
--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -63,13 +63,12 @@ function createWrapParse (tracer, config) {
 
         addDocumentTags(span, document)
 
-        finish(span)
-
         return document
       } catch (e) {
         setError(span, e)
-        finish(span)
         throw e
+      } finally {
+        finish(span)
       }
     }
   }

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -944,6 +944,30 @@ describe('Plugin', () => {
           graphql.graphql(schema, source).catch(done)
         })
 
+        it('should handle single fragment definitions', done => {
+          const source = `
+            fragment firstFields on Human {
+              name
+            }
+          `
+
+          agent
+            .use(traces => {
+              const spans = sort(traces[0])
+
+              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('name', 'graphql.parse')
+              expect(spans[0]).to.have.property('resource', 'graphql.parse')
+              expect(spans[0].meta).to.not.have.property('graphql.source')
+              expect(spans[0].meta).to.not.have.property('graphql.operation.type')
+              expect(spans[0].meta).to.not.have.property('graphql.operation.name')
+            })
+            .then(done)
+            .catch(done)
+
+          graphql.graphql(schema, source).catch(done)
+        })
+
         // it('should not disable signature with invalid arguments', done => {
         //   agent
         //     .use(traces => {


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where spans in the `graphql` plugin may not be marked as finished if the query only contains fragment definitions which prevents traces from being sent to the agent. 

### Motivation

See https://github.com/DataDog/dd-trace-js/issues/951

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js