### PR TITLE
fix aws-sdk auto-instrumentation breaking with custom promises

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
@@ -110,6 +110,15 @@ const helpers = {
           this.baseSpecPromise(done, agent, getService(), operation,
             serviceName, klass, fixture, key, metadata)
         })
+
+        it('should instrument service methods using promise() with custom promises', (done) => {
+          const AWS = require(`../../../versions/aws-sdk@${version}`).get()
+
+          AWS.config.setPromisesDependency(null)
+
+          this.baseSpecPromise(done, agent, getService(), operation,
+            serviceName, klass, fixture, key, metadata)
+        })
       }
 
       it('should bind callbacks to the correct active span', (done) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `aws-sdk` auto-instrumentation breaking with custom promises.

### Motivation
<!-- What inspired you to submit this pull request? -->

When `AWS.config.setPromisesDependency()` is called, the `promise` method on the `Request` class prototype is overwritten with an unpatched version. Instrumenting `setPromisesDependency` ensures that the prototype is patched again when it's called.