### PR TITLE
fix pubsub tests failing because they dropped node 8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,7 @@ jobs:
   node-google-cloud-pubsub:
     <<: *node-plugin-base
     docker:
-      - image: node:8
+      - image: node:10
         environment:
           - SERVICES=google-cloud-pubsub
           - PLUGINS=google-cloud-pubsub


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `@google-cloud/pubsub` tests failing because they dropped Node 8 support.

### Motivation
<!-- What inspired you to submit this pull request? -->

Build started failing today.