### PR TITLE
support SQS propagation

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/helpers.js
+++ b/packages/datadog-plugin-aws-sdk/src/helpers.js
@@ -50,6 +50,21 @@ const helpers = {
     }, extraTags)
 
     span.addTags(tags)
+  },
+
+  responseExtract (serviceName, request, response, tracer) {
+    if (services[serviceName] && services[serviceName].responseExtract) {
+      const params = request.params
+      const operation = request.operation
+      return services[serviceName].responseExtract(params, operation, response, tracer)
+    }
+  },
+
+  requestInject (span, request, serviceName, tracer) {
+    if (!span) return
+
+    const inject = services[serviceName] && services[serviceName].requestInject
+    if (inject) inject(span, request, tracer)
   }
 }
 

--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -45,18 +45,7 @@ function createWrapRequest (tracer, config) {
       return tracer.scope().activate(span, () => {
         let boundCb
         if (typeof cb === 'function') {
-          boundCb = function wrappedCb (err, resp) {
-            const maybeChildOf = awsHelpers.responseExtract(serviceName, request, resp, tracer)
-            if (maybeChildOf) {
-              const options = {
-                childOf: maybeChildOf,
-                tags: Object.assign({}, tags, { [Tags.SPAN_KIND]: 'server' })
-              }
-              boundCb = tracer.wrap('aws.response', options, cb).call(this, err, resp)
-            } else {
-              boundCb = tracer.scope().bind(cb, childOf).call(this, err, resp)
-            }
-          }
+          boundCb = awsHelpers.wrapCb(cb, serviceName, tags, request, tracer, childOf)
         } else {
           boundCb = cb
         }

--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -29,18 +29,37 @@ function createWrapRequest (tracer, config) {
         tags
       })
 
-      const boundCb = typeof cb === 'function' ? tracer.scope().bind(cb, childOf) : cb
-
       this.on('complete', response => {
         if (!span) return
 
-        awsHelpers.addResponseTags(span, response, serviceName, config)
+        awsHelpers.addResponseTags(span, response, serviceName, config, tracer)
         awsHelpers.finish(span, response.error)
       })
 
       analyticsSampler.sample(span, config.analytics)
 
+      awsHelpers.requestInject(span, this, serviceName, tracer)
+
+      const request = this
+
       return tracer.scope().activate(span, () => {
+        let boundCb
+        if (typeof cb === 'function') {
+          boundCb = function wrappedCb (err, resp) {
+            const maybeChildOf = awsHelpers.responseExtract(serviceName, request, resp, tracer)
+            if (maybeChildOf) {
+              const options = {
+                childOf: maybeChildOf,
+                tags: Object.assign({}, tags, { [Tags.SPAN_KIND]: 'server' })
+              }
+              boundCb = tracer.wrap('aws.response', options, cb).call(this, err, resp)
+            } else {
+              boundCb = tracer.scope().bind(cb, childOf).call(this, err, resp)
+            }
+          }
+        } else {
+          boundCb = cb
+        }
         return send.call(this, boundCb)
       })
     }

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -11,6 +11,38 @@ class Sqs {
       'aws.sqs.queue_name': params.QueueName || params.QueueUrl
     })
   }
+
+  responseExtract (params, operation, response, tracer) {
+    if (operation === 'receiveMessage') {
+      if (
+        (!params.MaxNumberOfMessages || params.MaxNumberOfMessages === 1) &&
+        response &&
+        response.Messages &&
+        response.Messages[0]
+      ) {
+        const msg = response.Messages[0]
+        return tracer.extract('text_map', JSON.parse(msg.MessageAttributes._datadog.StringValue))
+      }
+    }
+  }
+
+  requestInject (span, request, tracer) {
+    const operation = request.operation
+    if (operation === 'sendMessage') {
+      if (!request.params) {
+        request.params = {}
+      }
+      if (!request.params.MessageAttributes) {
+        request.params.MessageAttributes = {}
+      }
+      const ddInfo = {}
+      tracer.inject(span, 'text_map', ddInfo)
+      request.params.MessageAttributes._datadog = {
+        DataType: 'String',
+        StringValue: JSON.stringify(ddInfo)
+      }
+    }
+  }
 }
 
 module.exports = Sqs

--- a/packages/datadog-plugin-aws-sdk/test/fixtures/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/test/fixtures/sqs.js
@@ -5,7 +5,6 @@ const sqs = {}
 sqs['create'] = {
   QueueName: 'SQS_QUEUE_NAME',
   Attributes: {
-    // 'DelaySeconds': '60',
     'MessageRetentionPeriod': '86400'
   }
 }

--- a/packages/datadog-plugin-aws-sdk/test/fixtures/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/test/fixtures/sqs.js
@@ -5,7 +5,7 @@ const sqs = {}
 sqs['create'] = {
   QueueName: 'SQS_QUEUE_NAME',
   Attributes: {
-    'DelaySeconds': '60',
+    // 'DelaySeconds': '60',
     'MessageRetentionPeriod': '86400'
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adds support for propagation through SQS MessageAttributes.

### Motivation
Users need propagation through SQS.

### Additional Notes
This only supports the case where there's only one message in `receiveMessage` response, which is the default.

Tests aren't currently running for `aws-sdk` in CircleCI, so either that needs to be fixed, or reviewers should run the tests locally.