### PR TITLE
add debug logs when sending runtime metrics to dogstatsd

### DIFF
--- a/packages/dd-trace/src/platform/node/dogstatsd.js
+++ b/packages/dd-trace/src/platform/node/dogstatsd.js
@@ -2,6 +2,7 @@
 
 const dgram = require('dgram')
 const lookup = require('dns').lookup // cache to avoid instrumentation
+const log = require('../../log')
 
 const MAX_BUFFER_SIZE = 1024 // limit from the agent
 
@@ -44,6 +45,8 @@ class Client {
 
   _send (address, family, buffer) {
     const socket = family === 6 ? this._udp6 : this._udp4
+
+    log.debug(`Sending to DogStatsD: ${buffer}`)
 
     socket.send(buffer, 0, buffer.length, this._port, address)
   }

--- a/packages/dd-trace/test/platform/node/dogstatsd.spec.js
+++ b/packages/dd-trace/test/platform/node/dogstatsd.spec.js
@@ -118,19 +118,6 @@ describe('Platform', () => {
         expect(udp4.send).to.have.been.calledTwice
       })
 
-      it('should buffer metrics', () => {
-        const value = new Array(1000).map(() => 'a').join()
-        const tags = [`foo:${value}`]
-
-        client = new Client()
-
-        client.gauge('test.avg', 1, tags)
-        client.gauge('test.avg', 1, tags)
-        client.flush()
-
-        expect(udp4.send).to.have.been.calledTwice
-      })
-
       it('should not flush if the queue is empty', () => {
         client = new Client()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add debug logs when sending runtime metrics to DogStatsD. Also removed a duplicate test that I noticed while doing this.

### Motivation
<!-- What inspired you to submit this pull request? -->

It can be difficult to know if runtime metrics are reported properly when debugging an issue.