### PR TITLE
reduce log exporter chunk size

### DIFF
--- a/packages/dd-trace/src/exporters/log/index.js
+++ b/packages/dd-trace/src/exporters/log/index.js
@@ -2,7 +2,7 @@
 
 const log = require('../../log')
 
-const MAX_SIZE = 255 * 1024 // 255kb
+const MAX_SIZE = 50 * 1024 // 50kb
 
 class LogExporter {
   export (spans) {


### PR DESCRIPTION
### What does this PR do?
Reduces the chunk size of the log exporter to 50kb

### Motivation

The log exporter is mostly for use with AWS lambda/cloud watch logs. Although there is a documented limit of 255kb per cloudwatch log line, in practice logs get split at a much lower rate on node. From some practical testing, we found log lines getting split at around 65 kb on node on the lowest memory settings. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
