### PR TITLE
Add whitelist/blacklist filter to Redis plugin

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -136,6 +136,12 @@ const awsSdkOptions = {
   }
 };
 
+const redisOptions = {
+  service: 'test',
+  whitelist: ['info', /auth/i, command => true],
+  blacklist: ['info', /auth/i, command => true],
+};
+
 tracer.use('amqp10');
 tracer.use('amqplib');
 tracer.use('aws-sdk', awsSdkOptions);
@@ -178,6 +184,7 @@ tracer.use('http2', {
   client: http2ClientOptions
 });
 tracer.use('ioredis');
+tracer.use('ioredis', redisOptions);
 tracer.use('knex');
 tracer.use('koa');
 tracer.use('koa', httpServerOptions);
@@ -196,6 +203,7 @@ tracer.use('promise-js');
 tracer.use('promise');
 tracer.use('q');
 tracer.use('redis');
+tracer.use('redis', redisOptions);
 tracer.use('restify');
 tracer.use('restify', httpServerOptions);
 tracer.use('rhea');

--- a/index.d.ts
+++ b/index.d.ts
@@ -901,7 +901,22 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [ioredis](https://github.com/luin/ioredis) module.
    */
-  interface ioredis extends Instrumentation {}
+  interface ioredis extends Instrumentation {
+    /**
+     * List of commands that should be instrumented.
+     *
+     * @default /^.*$/
+     */
+    whitelist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+    /**
+     * List of commands that should not be instrumented. Takes precedence over
+     * whitelist if a command matches an entry in both.
+     *
+     * @default []
+     */
+    blacklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+  }
 
   /**
    * This plugin patches the [knex](https://knexjs.org/)
@@ -999,7 +1014,22 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [redis](https://github.com/NodeRedis/node_redis) module.
    */
-  interface redis extends Instrumentation {}
+  interface redis extends Instrumentation {
+    /**
+     * List of commands that should be instrumented.
+     *
+     * @default /^.*$/
+     */
+    whitelist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+    /**
+     * List of commands that should not be instrumented. Takes precedence over
+     * whitelist if a command matches an entry in both.
+     *
+     * @default []
+     */
+    blacklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+  }
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-plugin-ioredis/src/index.js
+++ b/packages/datadog-plugin-ioredis/src/index.js
@@ -5,7 +5,7 @@ const tx = require('../../dd-trace/src/plugins/util/redis')
 function createWrapSendCommand (tracer, config) {
   return function wrapSendCommand (sendCommand) {
     return function sendCommandWithTrace (command, stream) {
-      if (!command || !command.promise) return sendCommand.apply(this, arguments)
+      if (!command || !command.promise || !config.filter(command.name)) return sendCommand.apply(this, arguments)
 
       const options = this.options || {}
       const db = options.db
@@ -23,6 +23,7 @@ module.exports = {
   name: 'ioredis',
   versions: ['>=2'],
   patch (Redis, tracer, config) {
+    config = tx.normalizeConfig(config)
     this.wrap(Redis.prototype, 'sendCommand', createWrapSendCommand(tracer, config))
   },
   unpatch (Redis) {

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -82,13 +82,28 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        before(() => agent.load('ioredis', { service: 'custom' }))
+        before(() => agent.load('ioredis', {
+          service: 'custom',
+          whitelist: ['get']
+        }))
         after(() => agent.close())
 
         it('should be configured with the correct values', done => {
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
+            })
+            .then(done)
+            .catch(done)
+
+          redis.get('foo').catch(done)
+        })
+
+        it('should be able to filter commands', done => {
+          agent.use(() => {}) // wait for initial command
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('resource', 'get')
             })
             .then(done)
             .catch(done)

--- a/packages/datadog-plugin-redis/test/index.spec.js
+++ b/packages/datadog-plugin-redis/test/index.spec.js
@@ -132,7 +132,10 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load('redis', { service: 'custom' })
+          return agent.load('redis', {
+            service: 'custom',
+            whitelist: ['get']
+          })
         })
 
         after(() => {
@@ -152,7 +155,20 @@ describe('Plugin', () => {
             .then(done)
             .catch(done)
 
+          client.get('foo', () => {})
           client.on('error', done)
+        })
+
+        it('should be able to filter commands', done => {
+          agent.use(() => {}) // wait for initial command
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('resource', 'get')
+            })
+            .then(done)
+            .catch(done)
+
+          client.get('foo', () => {})
         })
       })
     })

--- a/packages/dd-trace/src/plugins/util/redis.js
+++ b/packages/dd-trace/src/plugins/util/redis.js
@@ -1,9 +1,19 @@
 'use strict'
 
 const analyticsSampler = require('../../analytics_sampler')
+const urlFilter = require('../util/urlfilter')
 const tx = require('./tx')
 
 const redis = {
+  // Ensure the configuration has the correct structure and defaults.
+  normalizeConfig (config) {
+    const filter = urlFilter.getFilter(config)
+
+    return Object.assign({}, config, {
+      filter
+    })
+  },
+
   // Start a span for a Redis command.
   instrument (tracer, config, db, command, args) {
     const childOf = tracer.scope().active()


### PR DESCRIPTION
### What does this PR do?

Similar to http instrumentation, this PR adds whitelist and blacklist configuration to redis commands.

### Motivation

`AUTH` commands are being captured by spans exposing secrets. This feature allows blacklisting this sensitive command (as well as noisy ones lint `PING`).

### Plugin Checklist

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

If there are other suggestions for ignoring sensitive data in spans, please let me know! Thanks!
