### PR TITLE
fix ERR_INVALID_ARG_TYPE exception for webpack

### DIFF
--- a/packages/dd-trace/src/platform/node/pkg.js
+++ b/packages/dd-trace/src/platform/node/pkg.js
@@ -4,7 +4,7 @@ const path = require('path')
 const readPkgUp = require('read-pkg-up')
 
 function findRoot () {
-  return require.main ? path.dirname(require.main.filename) : process.cwd()
+  return require.main && require.main.filename ? path.dirname(require.main.filename) : process.cwd()
 }
 
 function findPkg () {


### PR DESCRIPTION
### What does this PR do?
This PR fixes the `ERR_INVALID_ARG_TYPE` exception when using webpack.

### Motivation
A customer got this error when upgrading from tracer `v0.19.0` to `v0.21.0`:

```
throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
at validateString (internal/validators.js:118:11)
at Object.dirname (path.js:1128:5)
at findRoot (webpack:///./node_modules/dd-trace/packages/dd-trace/src/platform/node/pkg.js?:7:62)
at findPkg (webpack:///./node_modules/dd-trace/packages/dd-trace/src/platform/node/pkg.js?:11:15)
at eval (webpack:///./node_modules/dd-trace/packages/dd-trace/src/platform/node/pkg.js?:17:18)
at Object../node_modules/dd-trace/packages/dd-trace/src/platform/node/pkg.js (/Users/mindaugasbujanauskas/Work/SeatGeek/hypernova/server.js:3525:1)
at __webpack_require__ (/Users/mindaugasbujanauskas/Work/SeatGeek/hypernova/server.js:21:30)
at eval (webpack:///./node_modules/dd-trace/packages/dd-trace/src/platform/node/index.js?:16:13)
at Object../node_modules/dd-trace/packages/dd-trace/src/platform/node/index.js (/Users/mindaugasbujanauskas/Work/SeatGeek/hypernova/server.js:3465:1)
at __webpack_require__ (/Users/mindaugasbujanauskas/Work/SeatGeek/hypernova/server.js:21:30) {
code: 'ERR_INVALID_ARG_TYPE'
}
```

The exception is due to the fact that webpack doesn't support `require.main.filename`. This PR checks the existence of `.filename` before returning any results.