### PR TITLE
truncate IDs in encoder

### DIFF
--- a/packages/dd-trace/src/encode/index.js
+++ b/packages/dd-trace/src/encode/index.js
@@ -77,7 +77,7 @@ function encode (initBuffer, offset, trace, initWriter) {
     if (span.parent_id) {
       offset = copy(offset, fields.parent_id)
       offset = copy(offset, tokens.uint64)
-      offset = copy(offset, span.parent_id.toBuffer())
+      offset = writeId(buffer, offset, span.parent_id)
     }
 
     offset = copy(offset, fields.name)
@@ -122,12 +122,21 @@ function checkOffset (offset, length) {
 }
 
 function copyHeader (offset, span) {
-  headerBuffer.set(span.trace_id.toBuffer(), traceIdOffset)
-  headerBuffer.set(span.span_id.toBuffer(), spanIdOffset)
+  writeId(headerBuffer, traceIdOffset, span.trace_id)
+  writeId(headerBuffer, spanIdOffset, span.span_id)
   util.writeInt64(headerBuffer, span.start, startOffset)
   util.writeInt64(headerBuffer, span.duration, durationOffset)
   headerBuffer.set(tokens.int[span.error], errorOffset)
   return copy(offset, headerBuffer)
+}
+
+function writeId (buffer, offset, id) {
+  id = id.toBuffer()
+  if (id.length > 8) {
+    id = id.subarray(id.length - 8, id.length)
+  }
+  buffer.set(id, offset)
+  return offset + 8
 }
 
 function write (offset, val) {

--- a/packages/dd-trace/test/encode.spec.js
+++ b/packages/dd-trace/test/encode.spec.js
@@ -51,4 +51,35 @@ describe('encode', () => {
     expect(decoded[0].meta).to.deep.equal({ bar: 'baz' })
     expect(decoded[0].metrics).to.deep.equal({ example: 1 })
   })
+
+  it('should truncate long IDs', () => {
+    const data = [{
+      trace_id: id('ffffffffffffffff1234abcd1234abcd'),
+      span_id: id('ffffffffffffffff1234abcd1234abcd'),
+      parent_id: id('ffffffffffffffff1234abcd1234abcd'),
+      name: 'test',
+      resource: 'test-r',
+      service: 'test-s',
+      type: 'foo',
+      error: 0,
+      meta: {
+        bar: 'baz'
+      },
+      metrics: {
+        example: 1
+      },
+      start: 123,
+      duration: 456
+    }]
+
+    let buffer = Buffer.alloc(1024)
+    const offset = encode(buffer, 0, data)
+    buffer = buffer.slice(0, offset)
+
+    const decoded = msgpack.decode(buffer, { codec })
+
+    expect(decoded[0].trace_id.toString(16)).to.equal('1234abcd1234abcd')
+    expect(decoded[0].span_id.toString(16)).to.equal('1234abcd1234abcd')
+    expect(decoded[0].parent_id.toString(16)).to.equal('1234abcd1234abcd')
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Some users are using internals in a way that can have 128-bit IDs. This
truncates them as per:

https://www.w3.org/TR/trace-context/#handling-trace-id-for-compliant-platforms-with-shorter-internal-identifiers

<!-- A brief description of the change being made with this pull request. -->

### Motivation
https://github.com/DataDog/dd-trace-js/issues/970