### PR TITLE
fix prepublish failing when workflows are unexpectedly ordered

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -84,7 +84,7 @@ function getWorkflow (pipeline) {
         throw new Error(`Workflow ${running.id} is still running for pipeline ${pipeline.id}.`)
       }
 
-      const workflow = workflows[0]
+      const workflow = workflows.find(workflow => workflow.name === 'prebuild')
 
       if (!workflow) {
         throw new Error(`Unable to find CircleCI workflow for pipeline ${pipeline.id}.`)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix prepublish failing when workflows are unexpectedly ordered.

### Motivation
<!-- What inspired you to submit this pull request? -->

The first workflow is not always the `prebuild` workflow. This prevents releases when the order is unexpected.