### PR TITLE
fix global tags missing from logs after span is finished

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/log.js
+++ b/packages/dd-trace/src/opentracing/propagation/log.js
@@ -4,19 +4,21 @@ const id = require('../../id')
 const DatadogSpanContext = require('../span_context')
 
 class LogPropagator {
+  constructor (config) {
+    this._config = config
+  }
+
   inject (spanContext, carrier) {
     if (!carrier) return
-
-    const tags = spanContext._tags
 
     carrier.dd = {
       trace_id: spanContext.toTraceId(),
       span_id: spanContext.toSpanId()
     }
 
-    if (tags.service) carrier.dd.service = tags.service
-    if (tags.version) carrier.dd.version = tags.version
-    if (tags.env) carrier.dd.env = tags.env
+    if (this._config.service) carrier.dd.service = this._config.service
+    if (this._config.version) carrier.dd.version = this._config.version
+    if (this._config.env) carrier.dd.env = this._config.env
   }
 
   extract (carrier) {

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -47,8 +47,8 @@ class DatadogTracer extends Tracer {
     this._propagators = {
       [formats.TEXT_MAP]: new TextMapPropagator(config),
       [formats.HTTP_HEADERS]: new HttpPropagator(config),
-      [formats.BINARY]: new BinaryPropagator(),
-      [formats.LOG]: new LogPropagator()
+      [formats.BINARY]: new BinaryPropagator(config),
+      [formats.LOG]: new LogPropagator(config)
     }
     if (config.reportHostname) {
       this._hostname = platform.hostname()

--- a/packages/dd-trace/test/opentracing/propagation/log.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/log.spec.js
@@ -10,7 +10,11 @@ describe('LogPropagator', () => {
 
   beforeEach(() => {
     LogPropagator = require('../../../src/opentracing/propagation/log')
-    propagator = new LogPropagator()
+    propagator = new LogPropagator({
+      service: 'test',
+      env: 'dev',
+      version: '1.0.0'
+    })
     log = {
       dd: {
         trace_id: '123',
@@ -24,12 +28,7 @@ describe('LogPropagator', () => {
       const carrier = {}
       const spanContext = new SpanContext({
         traceId: id('123', 10),
-        spanId: id('-456', 10),
-        tags: {
-          service: 'test',
-          env: 'dev',
-          version: '1.0.0'
-        }
+        spanId: id('-456', 10)
       })
 
       propagator.inject(spanContext, carrier)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix global tags missing from logs after span is finished.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, loggers wait until after a request is finished before logging. At that point, the span context metadata has been removed and is not longer available to log injection. By using the globally configured values instead, tags are always available regardless of the state of the trace.