### PR TITLE
update log injection to include global tags outside of a trace

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/log.js
+++ b/packages/dd-trace/src/opentracing/propagation/log.js
@@ -11,9 +11,11 @@ class LogPropagator {
   inject (spanContext, carrier) {
     if (!carrier) return
 
-    carrier.dd = {
-      trace_id: spanContext.toTraceId(),
-      span_id: spanContext.toSpanId()
+    carrier.dd = {}
+
+    if (spanContext) {
+      carrier.dd.trace_id = spanContext.toTraceId()
+      carrier.dd.span_id = spanContext.toSpanId()
     }
 
     if (this._config.service) carrier.dd.service = this._config.service

--- a/packages/dd-trace/test/opentracing/propagation/log.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/log.spec.js
@@ -33,10 +33,18 @@ describe('LogPropagator', () => {
 
       propagator.inject(spanContext, carrier)
 
+      expect(carrier).to.have.property('dd')
+      expect(carrier.dd).to.have.property('trace_id', '123')
+      expect(carrier.dd).to.have.property('span_id', '18446744073709551160') // -456 casted to uint64
+    })
+
+    it('should inject the global context into the carrier', () => {
+      const carrier = {}
+
+      propagator.inject(null, carrier)
+
       expect(carrier).to.deep.include({
         dd: {
-          trace_id: '123',
-          span_id: '18446744073709551160', // -456 casted to uint64
           service: 'test',
           env: 'dev',
           version: '1.0.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update log injection to include global tags outside of a trace.

### Motivation
<!-- What inspired you to submit this pull request? -->

This will allow correlating the log record to its service/env/version even when there is no active trace.