### PR TITLE
fix fs tests randomly failing in build

### DIFF
--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -632,8 +632,9 @@ describe('Plugin', () => {
         beforeEach(() => {
           filename = path.join(tmpdir, 'createWriteStream')
         })
-        afterEach(() => {
-          realFS.unlinkSync(filename)
+        afterEach(done => {
+          // swallow errors since we're causing a race condition in one of the tests
+          realFS.unlink(filename, () => done())
         })
 
         it('should be instrumented', (done) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `fs` tests randomly failing in build.

### Motivation
<!-- What inspired you to submit this pull request? -->

Test was emitting 2 errors causing a race condition where `afterEach` would randomly not run in the correct sequence.