### PR TITLE
Fix for #992

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/helpers.js
+++ b/packages/datadog-plugin-aws-sdk/src/helpers.js
@@ -78,9 +78,9 @@ const helpers = {
           childOf: maybeChildOf,
           tags: Object.assign({}, tags, { [Tags.SPAN_KIND]: 'server' })
         }
-        return tracer.wrap('aws.response', options, cb).call(request, err, resp)
+        return tracer.wrap('aws.response', options, cb).call(this, err, resp)
       } else {
-        return tracer.scope().bind(cb, childOf).call(request, err, resp)
+        return tracer.scope().bind(cb, childOf).call(this, err, resp)
       }
     }
   }

--- a/packages/datadog-plugin-aws-sdk/test/index.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/index.spec.js
@@ -231,7 +231,8 @@ describe('Plugin', () => {
               serviceName, klass, s3Params, key, metadata)
           })
 
-          it('upload works (regression test for #992)', (done) => {
+          // Regression test for https://github.com/DataDog/dd-trace-js/issues/992
+          it('upload should not be broken', (done) => {
             s3.upload({
               Bucket: s3Params.Bucket,
               Key: 'testupload',

--- a/packages/datadog-plugin-aws-sdk/test/index.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/index.spec.js
@@ -230,6 +230,14 @@ describe('Plugin', () => {
             helpers.baseSpecs(semver, version, agent, getService, operation,
               serviceName, klass, s3Params, key, metadata)
           })
+
+          it('upload works (regression test for #992)', (done) => {
+            s3.upload({
+              Bucket: s3Params.Bucket,
+              Key: 'testupload',
+              Body: 'some body'
+            }, done)
+          })
         })
 
         describe('with configuration', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes #992 by using the local `this` instead of using one passed along the call
chain.

### Motivation
<!-- What inspired you to submit this pull request? -->
A bug was introduced by making the assumption of what a `this` object always
ought to be. This lead to the issues faced by users in #992.
