### PR TITLE
fix error in amqplib plugin when the message is null

### DIFF
--- a/packages/datadog-plugin-amqplib/src/index.js
+++ b/packages/datadog-plugin-amqplib/src/index.js
@@ -25,7 +25,7 @@ function createWrapSendMessage (tracer, config) {
 function createWrapDispatchMessage (tracer, config) {
   return function wrapDispatchMessage (dispatchMessage) {
     return function dispatchMessageWithTrace (fields, message) {
-      const childOf = tracer.extract(TEXT_MAP, message.properties.headers)
+      const childOf = extract(tracer, message)
       const span = tracer.startSpan('amqp.command', { childOf })
 
       addTags(this, tracer, config, span, 'basic.deliver', fields)
@@ -129,6 +129,12 @@ function addTags (channel, tracer, config, span, method, fields) {
   fieldNames.forEach(field => {
     fields[field] !== undefined && span.setTag(`amqp.${field}`, fields[field])
   })
+}
+
+function extract (tracer, message) {
+  return message
+    ? tracer.extract(TEXT_MAP, message.properties.headers)
+    : null
 }
 
 module.exports = [

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -221,6 +221,17 @@ describe('Plugin', () => {
                 }, {}, err => err && done(err))
               })
             })
+
+            it('should support null messages', done => {
+              channel.assertQueue('queue', {}, () => {
+                channel.consume('queue', (event) => {
+                  expect(event).to.be.null
+                  done()
+                }, {}, () => {
+                  channel.deleteQueue('queue')
+                })
+              })
+            })
           })
         })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix error in `amqplib` plugin when the message is `null`.

### Motivation
<!-- What inspired you to submit this pull request? -->

When a channel is closed unexpectedly, for example when a queue is removed from the broker, a `null` message is dispatched to the consumer which doesn't contain a `properties` field, thus causing an error when the plugin attempts to extract the headers from the properties.

Fixes #994 