### PR TITLE
fix primary tags being overridden with empty default values

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -13,21 +13,9 @@ class Config {
   constructor (options) {
     options = options || {}
 
-    const service = options.service ||
-      platform.env('DD_SERVICE') ||
-      platform.env('DD_SERVICE_NAME') ||
-      platform.service() ||
-      'node'
-
-    const version = coalesce(
-      options.version,
-      platform.env('DD_VERSION'),
-      platform.appVersion()
-    )
     const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
     const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
     const logInjection = coalesce(options.logInjection, platform.env('DD_LOGS_INJECTION'), false)
-    const env = coalesce(options.env, platform.env('DD_ENV'))
     const url = coalesce(options.url, platform.env('DD_TRACE_AGENT_URL'), platform.env('DD_TRACE_URL'), null)
     const site = coalesce(options.site, platform.env('DD_SITE'), 'datadoghq.com')
     const hostname = coalesce(
@@ -55,6 +43,23 @@ class Config {
     tagger.add(tags, platform.env('DD_TRACE_TAGS'))
     tagger.add(tags, platform.env('DD_TRACE_GLOBAL_TAGS'))
     tagger.add(tags, options.tags)
+
+    const service = options.service ||
+      platform.env('DD_SERVICE') ||
+      platform.env('DD_SERVICE_NAME') ||
+      tags.service ||
+      platform.service() ||
+      'node'
+
+    const version = coalesce(
+      options.version,
+      platform.env('DD_VERSION'),
+      tags.version,
+      platform.appVersion()
+    )
+
+    const env = coalesce(options.env, platform.env('DD_ENV'), tags.env)
+
     tagger.add(tags, { service, env, version })
 
     const sampler = (options.experimental && options.experimental.sampler) || {}

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -348,4 +348,18 @@ describe('Config', () => {
       service: 'node'
     })
   })
+
+  it('should support tags for setting primary fields', () => {
+    const config = new Config({
+      tags: {
+        service: 'service',
+        env: 'test',
+        version: '0.1.0'
+      }
+    })
+
+    expect(config).to.have.property('service', 'service')
+    expect(config).to.have.property('version', '0.1.0')
+    expect(config).to.have.property('env', 'test')
+  })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix primary tags being overridden with empty default values.

### Motivation
<!-- What inspired you to submit this pull request? -->

When primary tags are set but the corresponding configuration options are not, the empty values from the options override the values from the tags. The tracer should give priority to the options, but the tags should also be supported as a fallback to set both the options and the tags of the same names.

Fixes #1000 