### PR TITLE
update the agent exporter to use keep-alive for the connection

### DIFF
--- a/packages/dd-trace/src/platform/node/request.js
+++ b/packages/dd-trace/src/platform/node/request.js
@@ -14,14 +14,16 @@ function request (options, callback) {
   }, options)
 
   const data = [].concat(options.data)
+  const client = options.protocol === 'https:' ? https : http
+  const agent = new client.Agent({ keepAlive: true })
 
+  options.agent = agent
   options.headers['Content-Length'] = byteLength(data)
 
   if (containerId) {
     options.headers['Datadog-Container-ID'] = containerId
   }
 
-  const client = options.protocol === 'https:' ? https : http
   const req = client.request(options, res => {
     let data = ''
 

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -9,6 +9,7 @@ const express = require('express')
 const path = require('path')
 
 const handlers = new Set()
+let sockets = []
 let agent = null
 let server = null
 let listener = null
@@ -34,6 +35,7 @@ module.exports = {
     return getPort().then(port => {
       return new Promise((resolve, reject) => {
         server = http.createServer(agent)
+        server.on('connection', socket => sockets.push(socket))
 
         listener = server.listen(port, 'localhost', resolve)
 
@@ -127,6 +129,8 @@ module.exports = {
 
     listener.close()
     listener = null
+    sockets.forEach(socket => socket.end())
+    sockets = []
     agent = null
     handlers.clear()
     delete require.cache[require.resolve('../..')]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the agent exporter to use keep-alive for the connection.

### Motivation
<!-- What inspired you to submit this pull request? -->

Avoid creating a new connection to the agent on every flush which has unnecessary overhead.

Fixes #340