### PR TITLE
fix thenable support and remove workaround in node >=14.5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -271,7 +271,7 @@ export declare interface TracerOptions {
   runtimeMetrics?: boolean
 
   /**
-   * Whether to track the scope of async functions. This is needed for async/await to work with non-native promises (thenables). Only disable this if you are sure only native promises are used with async/await.
+   * Whether to track the scope of async functions. This is needed for async/await to work with non-native promises (thenables). Only disable this if you are sure only native promises are used with async/await, or if you are using Node >=14.5 since the issue has been fixed in that version.
    * @default true
    */
   trackAsyncScope?: boolean

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -8,6 +8,9 @@ const semver = require('semver')
 // https://github.com/nodejs/node/issues/19859
 const hasKeepAliveBug = !semver.satisfies(process.version, '^8.13 || >=10.14.2')
 
+// fixed in https://github.com/nodejs/node/pull/33801
+const hasThenableBug = !semver.satisfies(process.version, '>=14.5')
+
 let singleton = null
 
 class Scope extends Base {
@@ -18,7 +21,7 @@ class Scope extends Base {
 
     singleton = this
 
-    this._trackAsyncScope = config.trackAsyncScope
+    this._trackAsyncScope = config.trackAsyncScope && hasThenableBug
     this._current = null
     this._spans = new Map()
     this._types = new Map()
@@ -30,8 +33,7 @@ class Scope extends Base {
       init: this._init.bind(this),
       before: this._before.bind(this),
       after: this._after.bind(this),
-      destroy: this._destroy.bind(this),
-      promiseResolve: this._destroy.bind(this)
+      destroy: this._destroy.bind(this)
     })
 
     this._enabled = true

--- a/packages/dd-trace/test/scope/async_hooks.spec.js
+++ b/packages/dd-trace/test/scope/async_hooks.spec.js
@@ -106,25 +106,30 @@ describe('Scope (async_hooks)', () => {
       expect(scope.active()).to.be.null
     })
 
-    it('should use the active span when using await', done => {
-      thenable.then = () => {
+    it('should use the active span when using await', () => {
+      thenable.then = onFulfill => {
         expect(scope.active()).to.equal(span)
-        done()
+        onFulfill()
       }
 
       scope.bind(thenable)
-      scope.activate(span, () => test())
+      return scope.activate(span, () => test())
     })
 
     it('should use the active span when using await in a timer', done => {
-      thenable.then = () => {
+      thenable.then = onFulfill => {
         expect(scope.active()).to.equal(span)
-        done()
+        onFulfill()
       }
 
       test = async () => {
         setTimeout(async () => {
-          await thenable
+          try {
+            await thenable
+            done()
+          } catch (e) {
+            done(e)
+          }
         })
       }
 
@@ -132,27 +137,15 @@ describe('Scope (async_hooks)', () => {
       scope.activate(span, () => test())
     })
 
-    it('should use the active span when using await in nested scopes', done => {
-      thenable.then = () => {
+    it('should use the active span when using await in nested scopes', () => {
+      thenable.then = onFulfill => {
         expect(scope.active()).to.equal(span)
-        done()
+        onFulfill()
       }
 
       scope.bind(thenable)
-      scope.activate({}, async () => {
-        scope.activate(span, () => test())
-      })
-    })
-
-    it('should use the active span when using await in nested scopes', done => {
-      thenable.then = () => {
-        expect(scope.active()).to.equal(span)
-        done()
-      }
-
-      scope.bind(thenable)
-      scope.activate({}, async () => {
-        scope.activate(span, () => test())
+      return scope.activate({}, async () => {
+        return scope.activate(span, () => test())
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix thenable support and remove workaround in Node >=14.5.

### Motivation
<!-- What inspired you to submit this pull request? -->

Now that Node properly tracks the async execution context of thenables with async/await, the resolving of the thenable wrapper promise would remove the span from the scope manager, resulting in an incorrect active span in the thenable handler. By relying only on `destroy` instead of `promiseResolve` to forget the span, we can solve the issue, and now that tracking works out of the box, we can remove the workaround as well.