### PR TITLE
Only propagate baggage items to future causal descendents

### DIFF
--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -37,7 +37,7 @@ class NoopSpan extends Span {
         traceId: parent._traceId,
         spanId,
         parentId: parent._spanId,
-        baggageItems: parent._baggageItems
+        baggageItems: Object.assign({}, parent._baggageItems)
       })
     } else {
       return new NoopSpanContext({

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -63,7 +63,7 @@ class DatadogSpan extends Span {
         spanId: id(),
         parentId: parent._spanId,
         sampling: parent._sampling,
-        baggageItems: parent._baggageItems,
+        baggageItems: Object.assign({}, parent._baggageItems),
         trace: parent._trace
       })
     } else {

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -133,7 +133,25 @@ describe('Span', () => {
       span.setBaggageItem('foo', 'bar')
 
       expect(span.context()._baggageItems).to.have.property('foo', 'bar')
-      expect(parent._baggageItems).to.have.property('foo', 'bar')
+      expect(parent._baggageItems).to.not.have.property('foo', 'bar')
+    })
+
+    it('should pass baggage items to future causal spans', () => {
+      const parent = {
+        traceId: '123',
+        spanId: '456',
+        _baggageItems: {
+          'foo': 'bar'
+        },
+        _trace: {
+          started: ['span'],
+          finished: ['span']
+        }
+      }
+
+      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation', parent })
+
+      expect(span.context()._baggageItems).to.have.property('foo', 'bar')
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
Performs a shallow clone of `_baggageItems` from the parent.

### Motivation
Previously, all spans in a tree would share a single `_baggageItems`. The sharing caused baggage items to incorrectly be shared to ancestors and peers.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
