### PR TITLE
update profiler to share the tracer http agent and add uds support

### DIFF
--- a/packages/dd-trace/src/platform/browser/client.js
+++ b/packages/dd-trace/src/platform/browser/client.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const axios = require('axios')
+
+module.exports = options => axios.create(options)

--- a/packages/dd-trace/src/platform/browser/index.js
+++ b/packages/dd-trace/src/platform/browser/index.js
@@ -11,6 +11,7 @@ const startupLog = require('./startup-log')
 const exporter = require('./exporter')
 const Loader = require('./loader')
 const Scope = require('../../scope/zone')
+const client = require('./client')
 
 const platform = {
   _config: {},
@@ -37,7 +38,8 @@ const platform = {
   profiler: () => ({
     start: () => {},
     stop: () => {}
-  })
+  }),
+  client
 }
 
 module.exports = platform

--- a/packages/dd-trace/src/platform/node/agents.js
+++ b/packages/dd-trace/src/platform/node/agents.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const http = require('http')
+const https = require('https')
+
+let agents
+
+module.exports = config => agents || (agents = {
+  httpAgent: new http.Agent({ keepAlive: true, lookup: config.lookup }),
+  httpsAgent: new https.Agent({ keepAlive: true, lookup: config.lookup })
+})

--- a/packages/dd-trace/src/platform/node/client.js
+++ b/packages/dd-trace/src/platform/node/client.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const axios = require('axios')
+const agents = require('./agents')
+
+module.exports = function (options) {
+  const platform = this
+  const { httpAgent, httpsAgent } = agents(platform._config)
+
+  return axios.create(Object.assign({
+    httpAgent,
+    httpsAgent
+  }, options))
+}

--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -16,6 +16,7 @@ const exporter = require('./exporter')
 const profiler = require('./profiler')
 const pkg = require('./pkg')
 const startupLog = require('./startup-log')
+const client = require('./client')
 
 const emitter = new EventEmitter()
 
@@ -49,7 +50,8 @@ const platform = {
   exporter,
   profiler () {
     return profiler(this._config)
-  }
+  },
+  client
 }
 
 process.once('beforeExit', () => emitter.emit('exit'))

--- a/packages/dd-trace/src/platform/node/request.js
+++ b/packages/dd-trace/src/platform/node/request.js
@@ -2,11 +2,14 @@
 
 const http = require('http')
 const https = require('https')
+const agents = require('./agents')
 const containerInfo = require('container-info').sync() || {}
 
 const containerId = containerInfo.containerId
 
 function request (options, callback) {
+  const platform = this
+
   options = Object.assign({
     headers: {},
     data: [],
@@ -14,8 +17,10 @@ function request (options, callback) {
   }, options)
 
   const data = [].concat(options.data)
-  const client = options.protocol === 'https:' ? https : http
-  const agent = new client.Agent({ keepAlive: true })
+  const isSecure = options.protocol === 'https:'
+  const { httpAgent, httpsAgent } = agents(platform._config)
+  const client = isSecure ? https : http
+  const agent = isSecure ? httpsAgent : httpAgent
 
   options.agent = agent
   options.headers['Content-Length'] = byteLength(data)

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const axios = require('axios')
 const FormData = require('form-data')
 const { URL } = require('url')
 const { Encoder } = require('../encoders/pprof')
@@ -10,12 +9,18 @@ class AgentExporter {
   constructor ({ url, hostname, port } = {}) {
     url = new URL(url || `http://${hostname || 'localhost'}:${port || 8126}`)
 
-    this._client = axios.create({
-      baseURL: `${url}profiling/v1/`,
+    const options = {
       timeout: 10 * 1000,
       validateStatus: code => code < 400
-    })
+    }
 
+    if (url.protocol === 'unix:') {
+      options.socketPath = url.pathname
+    } else {
+      options.baseURL = url.href
+    }
+
+    this._client = platform.client(options)
     this._encoder = new Encoder()
   }
 
@@ -53,7 +58,7 @@ class AgentExporter {
 
     const headers = form.getHeaders()
 
-    return this._client.post('input', form, { headers })
+    return this._client.post('/profiling/v1/input', form, { headers })
   }
 }
 

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -190,10 +190,11 @@ describe('Platform', () => {
         getContainerInfo = {
           sync: sinon.stub().returns({ containerId: 'abcd' })
         }
+        platform = require('../../../src/platform/node')
         request = proxyquire('../src/platform/node/request', {
           'container-info': getContainerInfo,
           '../../log': log
-        })
+        }).bind(platform)
       })
 
       afterEach(() => {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -22,6 +22,8 @@ const createProfile = (periodType) => {
   return profile
 }
 
+const describeOnUnix = os.platform() === 'win32' ? describe.skip : describe
+
 describe('exporters/agent', () => {
   let AgentExporter
   let sockets
@@ -104,7 +106,7 @@ describe('exporters/agent', () => {
     })
   })
 
-  describe('using UDS', () => {
+  describeOnUnix('using UDS', () => {
     let listener
 
     beforeEach(done => {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -3,6 +3,8 @@
 const expect = require('chai').expect
 const express = require('express')
 const upload = require('multer')()
+const os = require('os')
+const path = require('path')
 const getPort = require('get-port')
 const { gunzipSync } = require('zlib')
 const { perftools } = require('../../../../../protobuf/profile')
@@ -22,77 +24,152 @@ const createProfile = (periodType) => {
 
 describe('exporters/agent', () => {
   let AgentExporter
+  let sockets
   let url
   let listener
   let app
 
-  beforeEach(done => {
+  beforeEach(() => {
     AgentExporter = require('../../../src/profiling/exporters/agent').AgentExporter
-
+    sockets = []
     app = express()
+  })
 
-    getPort().then(port => {
-      url = `http://127.0.0.1:${port}`
-      listener = app.listen(port, '127.0.0.1', done)
+  describe('using HTTP', () => {
+    beforeEach(done => {
+      getPort().then(port => {
+        url = `http://127.0.0.1:${port}`
+
+        listener = app.listen(port, '127.0.0.1', done)
+        listener.on('connection', socket => sockets.push(socket))
+      })
     })
-  })
 
-  afterEach(done => {
-    listener.close(done)
-  })
+    afterEach(done => {
+      listener.close(done)
+      sockets.forEach(socket => socket.end())
+    })
 
-  it('should send profiles as pprof to the intake', done => {
-    const exporter = new AgentExporter({ url })
-    const start = new Date()
-    const end = new Date()
-    const tags = { foo: 'bar' }
-    const profiles = {
-      cpu: createProfile(['wall', 'microseconds']),
-      heap: createProfile(['space', 'bytes'])
-    }
-
-    app.post('/profiling/v1/input', upload.any(), (req, res) => {
-      try {
-        expect(true).to.be.true
-
-        expect(req.body).to.have.property('language', 'javascript')
-        expect(req.body).to.have.property('runtime', 'nodejs')
-        expect(req.body).to.have.property('format', 'pprof')
-        expect(req.body).to.have.deep.property('tags', [
-          'language:javascript',
-          'runtime:nodejs',
-          'format:pprof',
-          'foo:bar'
-        ])
-        expect(req.body).to.have.deep.property('types', ['cpu', 'heap'])
-        expect(req.body).to.have.property('recording-start', start.toISOString())
-        expect(req.body).to.have.property('recording-end', end.toISOString())
-
-        expect(req.files[0]).to.have.property('fieldname', 'data[0]')
-        expect(req.files[0]).to.have.property('originalname', 'cpu.pb.gz')
-        expect(req.files[0]).to.have.property('mimetype', 'application/octet-stream')
-        expect(req.files[0]).to.have.property('size', req.files[0].buffer.length)
-
-        expect(req.files[1]).to.have.property('fieldname', 'data[1]')
-        expect(req.files[1]).to.have.property('originalname', 'heap.pb.gz')
-        expect(req.files[1]).to.have.property('mimetype', 'application/octet-stream')
-        expect(req.files[1]).to.have.property('size', req.files[1].buffer.length)
-
-        const cpuProfile = decode(gunzipSync(req.files[0].buffer))
-        const heapProfile = decode(gunzipSync(req.files[1].buffer))
-
-        expect(cpuProfile).to.deep.equal(decode(encode(profiles.cpu).finish()))
-        expect(heapProfile).to.deep.equal(decode(encode(profiles.heap).finish()))
-
-        done()
-      } catch (e) {
-        done(e)
+    it('should send profiles as pprof to the intake', done => {
+      const exporter = new AgentExporter({ url })
+      const start = new Date()
+      const end = new Date()
+      const tags = { foo: 'bar' }
+      const profiles = {
+        cpu: createProfile(['wall', 'microseconds']),
+        heap: createProfile(['space', 'bytes'])
       }
 
-      res.send()
+      app.post('/profiling/v1/input', upload.any(), (req, res) => {
+        try {
+          expect(req.body).to.have.property('language', 'javascript')
+          expect(req.body).to.have.property('runtime', 'nodejs')
+          expect(req.body).to.have.property('format', 'pprof')
+          expect(req.body).to.have.deep.property('tags', [
+            'language:javascript',
+            'runtime:nodejs',
+            'format:pprof',
+            'foo:bar'
+          ])
+          expect(req.body).to.have.deep.property('types', ['cpu', 'heap'])
+          expect(req.body).to.have.property('recording-start', start.toISOString())
+          expect(req.body).to.have.property('recording-end', end.toISOString())
+
+          expect(req.files[0]).to.have.property('fieldname', 'data[0]')
+          expect(req.files[0]).to.have.property('originalname', 'cpu.pb.gz')
+          expect(req.files[0]).to.have.property('mimetype', 'application/octet-stream')
+          expect(req.files[0]).to.have.property('size', req.files[0].buffer.length)
+
+          expect(req.files[1]).to.have.property('fieldname', 'data[1]')
+          expect(req.files[1]).to.have.property('originalname', 'heap.pb.gz')
+          expect(req.files[1]).to.have.property('mimetype', 'application/octet-stream')
+          expect(req.files[1]).to.have.property('size', req.files[1].buffer.length)
+
+          const cpuProfile = decode(gunzipSync(req.files[0].buffer))
+          const heapProfile = decode(gunzipSync(req.files[1].buffer))
+
+          expect(cpuProfile).to.deep.equal(decode(encode(profiles.cpu).finish()))
+          expect(heapProfile).to.deep.equal(decode(encode(profiles.heap).finish()))
+
+          done()
+        } catch (e) {
+          done(e)
+        }
+
+        res.send()
+      })
+
+      exporter.export({ profiles, start, end, tags })
+        .catch(done)
+    })
+  })
+
+  describe('using UDS', () => {
+    let listener
+
+    beforeEach(done => {
+      url = `${path.join(os.tmpdir(), `dd-trace-profiler-test-${Date.now()}`)}.sock`
+
+      listener = app.listen(url, done)
+      listener.on('connection', socket => sockets.push(socket))
     })
 
-    exporter.export({ profiles, start, end, tags })
-      .catch(done)
+    afterEach(done => {
+      listener.close(done)
+      sockets.forEach(socket => socket.end())
+    })
+
+    it('should support Unix domain sockets', done => {
+      const exporter = new AgentExporter({ url: `unix://${url}` })
+      const start = new Date()
+      const end = new Date()
+      const tags = { foo: 'bar' }
+      const profiles = {
+        cpu: createProfile(['wall', 'microseconds']),
+        heap: createProfile(['space', 'bytes'])
+      }
+
+      app.post('/profiling/v1/input', upload.any(), (req, res) => {
+        try {
+          expect(req.body).to.have.property('language', 'javascript')
+          expect(req.body).to.have.property('runtime', 'nodejs')
+          expect(req.body).to.have.property('format', 'pprof')
+          expect(req.body).to.have.deep.property('tags', [
+            'language:javascript',
+            'runtime:nodejs',
+            'format:pprof',
+            'foo:bar'
+          ])
+          expect(req.body).to.have.deep.property('types', ['cpu', 'heap'])
+          expect(req.body).to.have.property('recording-start', start.toISOString())
+          expect(req.body).to.have.property('recording-end', end.toISOString())
+
+          expect(req.files[0]).to.have.property('fieldname', 'data[0]')
+          expect(req.files[0]).to.have.property('originalname', 'cpu.pb.gz')
+          expect(req.files[0]).to.have.property('mimetype', 'application/octet-stream')
+          expect(req.files[0]).to.have.property('size', req.files[0].buffer.length)
+
+          expect(req.files[1]).to.have.property('fieldname', 'data[1]')
+          expect(req.files[1]).to.have.property('originalname', 'heap.pb.gz')
+          expect(req.files[1]).to.have.property('mimetype', 'application/octet-stream')
+          expect(req.files[1]).to.have.property('size', req.files[1].buffer.length)
+
+          const cpuProfile = decode(gunzipSync(req.files[0].buffer))
+          const heapProfile = decode(gunzipSync(req.files[1].buffer))
+
+          expect(cpuProfile).to.deep.equal(decode(encode(profiles.cpu).finish()))
+          expect(heapProfile).to.deep.equal(decode(encode(profiles.heap).finish()))
+
+          done()
+        } catch (e) {
+          done(e)
+        }
+
+        res.send()
+      })
+
+      exporter.export({ profiles, start, end, tags })
+        .catch(done)
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update profiler to share the tracer HTTP agent and add UDS support.

### Motivation
<!-- What inspired you to submit this pull request? -->

The main idea was to add `keepAlive` and `lookup` configuration options to the profiler as well as UDS support, similar to the tracer. At that point I figured that they could both share the same connection, so I also added shared HTTP agents.