### PR TITLE
set NAPI_VERSION to 1

### DIFF
--- a/packages/dd-trace/src/native/metrics/main.cc
+++ b/packages/dd-trace/src/native/metrics/main.cc
@@ -13,6 +13,7 @@
 
 #include <tdigest/TDigest.h>
 
+#define NAPI_VERSION 1
 #include <napi.h>
 #include <uv.h>
 #include <v8.h>


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This limits `NAPI_VERSION` to 1, which is used in Node.js v8.0.0

### Motivation
<!-- What inspired you to submit this pull request? -->

`node-addon-api` uses `NAPI_VERSION` to gate which wrapper apis it exposes. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
