### PR TITLE
fix system functions sharing the same name in profiles

### DIFF
--- a/packages/dd-trace/src/profiling/mapper.js
+++ b/packages/dd-trace/src/profiling/mapper.js
@@ -14,8 +14,8 @@ class SourceMapper {
   }
 
   async getSource (callFrame) {
-    const { url, lineNumber, columnNumber } = callFrame
-    const key = `${url}:${lineNumber}:${columnNumber}`
+    const { url, lineNumber, columnNumber, functionName } = callFrame
+    const key = `${url}:${functionName}:${lineNumber}:${columnNumber}`
 
     if (!this._sources[key]) {
       this._sources[key] = await this._getMapping(callFrame)

--- a/packages/dd-trace/src/profiling/profilers/inspector/cpu.js
+++ b/packages/dd-trace/src/profiling/profilers/inspector/cpu.js
@@ -14,10 +14,6 @@ class InspectorCpuProfiler {
   start ({ mapper }) {
     this._mapper = mapper
 
-    if (process._startProfilerIdleNotifier) {
-      process._startProfilerIdleNotifier()
-    }
-
     session.connect()
     session.post('Profiler.enable')
     session.post('Profiler.setSamplingInterval', {

--- a/packages/dd-trace/test/profiling/mapper.spec.js
+++ b/packages/dd-trace/test/profiling/mapper.spec.js
@@ -79,4 +79,27 @@ describe('mapper', () => {
     expect(source).to.have.property('columnNumber', 17)
     expect(source).to.have.property('functionName', 'test')
   })
+
+  it('should map system functions with the correct name', async () => {
+    const url = ''
+
+    await mapper.getSource({
+      url,
+      lineNumber: -1,
+      columnNumber: -1,
+      functionName: 'invalid'
+    })
+
+    const source = await mapper.getSource({
+      url,
+      lineNumber: -1,
+      columnNumber: -1,
+      functionName: '(program)'
+    })
+
+    expect(source).to.have.property('url', url)
+    expect(source).to.have.property('lineNumber', -1)
+    expect(source).to.have.property('columnNumber', -1)
+    expect(source).to.have.property('functionName', '(program)')
+  })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix system functions sharing the same name in profiles.

### Motivation
<!-- What inspired you to submit this pull request? -->

The source mapper was using only the URL, line number and column number to do the mapping. The assumption was that a specific location in a file can never have multiple names, but the system functions all have an empty URL and a line/column of -1/-1, meaning they all ended up with the same name as the first system function that was called. By adding the function name to the key of the location in the mapper, we can differentiate between the different functions.

Support for `(idle)` has also been dropped in Node 14.5.0, so I removed it entirely from the profiler since we can rely on `(program)` instead which serves basically the same purpose.