### PR TITLE
fix tests failing for fastify 3

### DIFF
--- a/packages/datadog-plugin-fastify/src/fastify.js
+++ b/packages/datadog-plugin-fastify/src/fastify.js
@@ -102,11 +102,11 @@ function unwrapFastify (fastify) {
 }
 
 function getReq (request) {
-  return request && (request.req || request)
+  return request && (request.raw || request.req || request)
 }
 
 function getRes (reply) {
-  return reply && (reply.res || reply)
+  return reply && (reply.raw || reply.res || reply)
 }
 
 module.exports = [

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -2,6 +2,7 @@
 
 const axios = require('axios')
 const getPort = require('get-port')
+const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
 
@@ -34,6 +35,10 @@ describe('Plugin', () => {
         beforeEach(() => {
           fastify = require(`../../../versions/fastify@${version}`).get()
           app = fastify()
+
+          if (semver.intersects(version, '>=3')) {
+            return app.register(require('../../../versions/middie').get())
+          }
         })
 
         it('should do automatic instrumentation on the app routes', done => {

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -5,6 +5,12 @@
       "versions": [">=2.13.0"]
     }
   ],
+  "fastify": [
+    {
+      "name": "middie",
+      "versions": ["5.1.0"]
+    }
+  ],
   "generic-pool": [
     {
       "name": "generic-pool",

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon')
 const chai = require('chai')
 const sinonChai = require('sinon-chai')
+const os = require('os')
 const proxyquire = require('../proxyquire')
 const semver = require('semver')
 const platform = require('../../src/platform')
@@ -109,8 +110,8 @@ function withVersions (plugin, modules, range, cb) {
           before(() => {
             nodePath = process.env.NODE_PATH
             process.env.NODE_PATH = [process.env.NODE_PATH, versionPath]
-              .filter(x => x)
-              .join(';')
+              .filter(x => x && x !== 'undefined')
+              .join(os.platform() === 'win32' ? ';' : ':')
 
             require('module').Module._initPaths()
           })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix tests failing for Fastify 3.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests started failing since Fastify 3 was released because it now requires an explicit plugin to handle middleware. The existing logic for plugin test externals was also not working and was fixed since `middie` depends on `fastify`.