### PR TITLE
update to calculate timing from a trace-level monotonic clock

### DIFF
--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1428,7 +1428,7 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans).to.have.length(2)
+              expect(spans).to.have.length(3)
 
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query MyQuery{hello}')
@@ -1436,6 +1436,9 @@ describe('Plugin', () => {
 
               expect(spans[1]).to.have.property('name', 'graphql.resolve')
               expect(spans[1]).to.have.property('resource', 'hello:String')
+
+              expect(spans[2]).to.have.property('name', 'graphql.validate')
+              expect(spans[2].meta).to.not.have.property('graphql.source')
             })
             .then(done)
             .catch(done)

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -72,11 +72,11 @@ class DatadogSpan extends Span {
         traceId: spanId,
         spanId
       })
-      spanContext._trace.startTime = Date.now()
-      spanContext._trace.ticks = platform.now()
     }
 
     spanContext._trace.started.push(this)
+    spanContext._trace.startTime = spanContext._trace.startTime || Date.now()
+    spanContext._trace.ticks = spanContext._trace.ticks || platform.now()
 
     return spanContext
   }

--- a/packages/dd-trace/src/platform/browser/now.js
+++ b/packages/dd-trace/src/platform/browser/now.js
@@ -1,7 +1,3 @@
 'use strict'
 
-const now = () => window.performance.now()
-const loadNs = now()
-const loadMs = Date.now()
-
-module.exports = () => loadMs + now() - loadNs
+module.exports = () => window.performance.now()

--- a/packages/dd-trace/src/platform/node/now.js
+++ b/packages/dd-trace/src/platform/node/now.js
@@ -1,7 +1,3 @@
 'use strict'
 
-const now = require('performance-now')
-const loadNs = now()
-const loadMs = Date.now()
-
-module.exports = () => loadMs + now() - loadNs
+module.exports = require('performance-now')

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const constants = require('../../src/constants')
-const SpanContext = require('../../src/opentracing/span_context')
 
 const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const constants = require('../../src/constants')
+const SpanContext = require('../../src/opentracing/span_context')
 
 const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 
@@ -17,8 +18,11 @@ describe('Span', () => {
   let tagger
 
   beforeEach(() => {
+    sinon.stub(Date, 'now').returns(1500000000000)
+
     handle = { finish: sinon.spy() }
     platform = {
+      now: sinon.stub().returns(0),
       metrics: sinon.stub().returns({
         track: sinon.stub().returns(handle)
       })
@@ -53,6 +57,10 @@ describe('Span', () => {
     })
   })
 
+  afterEach(() => {
+    Date.now.restore()
+  })
+
   it('should have a default context', () => {
     span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
 
@@ -64,6 +72,40 @@ describe('Span', () => {
     span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
 
     expect(span.context()._trace.started).to.deep.equal([span])
+  })
+
+  it('should calculate its start time and duration relative to the trace start', () => {
+    platform.now.onFirstCall().returns(100)
+    platform.now.onSecondCall().returns(300)
+    platform.now.onThirdCall().returns(700)
+
+    span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+    span.finish()
+
+    expect(Math.round(span._startTime)).to.equal(1500000000200)
+    expect(Math.round(span._duration)).to.equal(400)
+  })
+
+  it('should use the parent span to find the trace start', () => {
+    platform.now.onFirstCall().returns(100)
+    platform.now.onSecondCall().returns(100)
+
+    const parent = new Span(tracer, processor, sampler, prioritySampler, {
+      operationName: 'parent'
+    })
+
+    platform.now.resetHistory()
+    platform.now.onFirstCall().returns(300)
+    platform.now.onSecondCall().returns(700)
+
+    span = new Span(tracer, processor, sampler, prioritySampler, {
+      operationName: 'operation',
+      parent: parent.context()
+    })
+    span.finish()
+
+    expect(Math.round(span._startTime)).to.equal(1500000000200)
+    expect(Math.round(span._duration)).to.equal(400)
   })
 
   it('should use a parent context', () => {

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -113,7 +113,7 @@ describe('Platform', () => {
         })
       })
 
-      it('should return the current time in milliseconds with high resolution', () => {
+      it('should return the ticks since process start in milliseconds with high resolution', () => {
         expect(now()).to.equal(100.1111)
       })
     })

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -107,21 +107,14 @@ describe('Platform', () => {
       let performanceNow
 
       beforeEach(() => {
-        sinon.stub(Date, 'now').returns(1500000000000)
         performanceNow = sinon.stub().returns(100.1111)
         now = proxyquire('../src/platform/node/now', {
           'performance-now': performanceNow
         })
       })
 
-      afterEach(() => {
-        Date.now.restore()
-      })
-
       it('should return the current time in milliseconds with high resolution', () => {
-        performanceNow.returns(600.3333)
-
-        expect(now()).to.equal(1500000000500.2222)
+        expect(now()).to.equal(100.1111)
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update to calculate timing from a trace-level monotonic clock.

### Motivation
<!-- What inspired you to submit this pull request? -->

A process-level monotonic clock is subject to drifting when the system wall clock changes, or when the CPU is sleeping. Doing this at the trace level instead guarantees the timing will be consistent with the system clock, while avoiding clock skew within the trace. This also makes the tracer consistent with other languages which are already doing this at the trace level.

With this change, the `graphql` plugin could no longer compute its start time efficiently. Since this was actually hiding internal calls to `validate`, I simply removed the span creation condition instead of adding complexity.