### PR TITLE
fix incorrect line number when source mapping profiles

### DIFF
--- a/packages/dd-trace/src/profiling/profile.js
+++ b/packages/dd-trace/src/profiling/profile.js
@@ -74,7 +74,7 @@ class Profile {
       line: [
         new perftools.profiles.Line({
           functionId,
-          line: Math.max(lineNumber, 0)
+          line: lineNumber + 1 // Runtime.CallFrame is 0-based
         })
       ]
     })

--- a/packages/dd-trace/test/profiling/mapper.spec.js
+++ b/packages/dd-trace/test/profiling/mapper.spec.js
@@ -27,10 +27,10 @@ describe('mapper', () => {
     const filename = path.join(root, 'dist', `inline.js`)
     const url = pathToFileURL(filename).href
 
-    const source = await mapper.getSource({ url, lineNumber: 11, columnNumber: 17 })
+    const source = await mapper.getSource({ url, lineNumber: 10, columnNumber: 51 })
 
     expect(source).to.have.property('url', src)
-    expect(source).to.have.property('lineNumber', 2)
+    expect(source).to.have.property('lineNumber', 1)
     expect(source).to.have.property('columnNumber', 2)
     expect(source).to.have.property('functionName')
   })
@@ -39,10 +39,10 @@ describe('mapper', () => {
     const filename = path.join(root, 'dist', `url.js`)
     const url = pathToFileURL(filename).href
 
-    const source = await mapper.getSource({ url, lineNumber: 11, columnNumber: 17 })
+    const source = await mapper.getSource({ url, lineNumber: 10, columnNumber: 51 })
 
     expect(source).to.have.property('url', src)
-    expect(source).to.have.property('lineNumber', 2)
+    expect(source).to.have.property('lineNumber', 1)
     expect(source).to.have.property('columnNumber', 2)
     expect(source).to.have.property('functionName')
   })
@@ -53,14 +53,14 @@ describe('mapper', () => {
 
     const source = await mapper.getSource({
       url,
-      lineNumber: 11,
-      columnNumber: 17,
+      lineNumber: 10,
+      columnNumber: 51,
       functionName: 'test'
     })
 
     expect(source).to.have.property('url', url)
-    expect(source).to.have.property('lineNumber', 11)
-    expect(source).to.have.property('columnNumber', 17)
+    expect(source).to.have.property('lineNumber', 10)
+    expect(source).to.have.property('columnNumber', 51)
     expect(source).to.have.property('functionName', 'test')
   })
 
@@ -69,15 +69,26 @@ describe('mapper', () => {
 
     const source = await mapper.getSource({
       url,
-      lineNumber: 11,
-      columnNumber: 17,
+      lineNumber: 10,
+      columnNumber: 51,
       functionName: 'test'
     })
 
     expect(source).to.have.property('url', url)
-    expect(source).to.have.property('lineNumber', 11)
-    expect(source).to.have.property('columnNumber', 17)
+    expect(source).to.have.property('lineNumber', 10)
+    expect(source).to.have.property('columnNumber', 51)
     expect(source).to.have.property('functionName', 'test')
+  })
+
+  it('should fallback for invalid frames', async () => {
+    const filename = path.join(root, 'dist', `inline.js`)
+    const url = pathToFileURL(filename).href
+
+    const source = await mapper.getSource({ url, lineNumber: -1, columnNumber: -1 })
+
+    expect(source).to.have.property('url', url)
+    expect(source).to.have.property('lineNumber', -1)
+    expect(source).to.have.property('columnNumber', -1)
   })
 
   it('should map system functions with the correct name', async () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix incorrect line number when source mapping profiles.

### Motivation
<!-- What inspired you to submit this pull request? -->

Call frames from the inspector are 0-based for both CPU and heap profiles, but the `source-map` module is 1-based for line numbers. This causes incorrect mapping and can also cause errors when the line number is `0` since that's not supported by the `source-map`. I also updated the resulting profile to be 1-based since that's what stack traces use and it's more natural for the end user.

Fixes #1027 