### PR TITLE
add test for AsyncLocalStorage scope manager in Node 12

### DIFF
--- a/packages/dd-trace/test/scope/async_local_storage.spec.js
+++ b/packages/dd-trace/test/scope/async_local_storage.spec.js
@@ -12,7 +12,7 @@ const testScope = require('./test')
 wrapIt()
 
 // https://github.com/nodejs/node/commit/52d8afc07e005343390ebc8c6d9e1eec77acd16e#diff-0bb01a51b135a5f68d93540808bac801
-if (semver.gte(process.version, '12.17.0')) {
+if (semver.satisfies(process.version, '^12.17.0 || >=13.14.0')) {
   describe('Scope (AsyncLocalStorage)', test)
 } else {
   describe.skip('Scope (AsyncLocalStorage)', test)

--- a/packages/dd-trace/test/scope/async_local_storage.spec.js
+++ b/packages/dd-trace/test/scope/async_local_storage.spec.js
@@ -12,7 +12,7 @@ const testScope = require('./test')
 wrapIt()
 
 // https://github.com/nodejs/node/commit/52d8afc07e005343390ebc8c6d9e1eec77acd16e#diff-0bb01a51b135a5f68d93540808bac801
-if (semver.gte(process.version, '13.14.0')) {
+if (semver.gte(process.version, '12.17.0')) {
   describe('Scope (AsyncLocalStorage)', test)
 } else {
   describe.skip('Scope (AsyncLocalStorage)', test)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add test for `AsyncLocalStorage` scope manager in Node 12.

### Motivation
<!-- What inspired you to submit this pull request? -->

`AsyncLocalStorage` was backported to Node 12 and so we should test the corresponding scope manager in that version.