### PR TITLE
fix runtime metrics not working when hostname was not configured

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -88,7 +88,7 @@ class Config {
     this.analytics = String(analytics) === 'true'
     this.tags = tags
     this.dogstatsd = {
-      hostname: String(coalesce(dogstatsd.hostname, platform.env(`DD_DOGSTATSD_HOSTNAME`), this.hostname)),
+      hostname: coalesce(dogstatsd.hostname, platform.env(`DD_DOGSTATSD_HOSTNAME`), this.hostname),
       port: String(coalesce(dogstatsd.port, platform.env('DD_DOGSTATSD_PORT'), 8125))
     }
     this.runtimeMetrics = String(runtimeMetrics) === 'true'

--- a/packages/dd-trace/src/platform/node/dogstatsd.js
+++ b/packages/dd-trace/src/platform/node/dogstatsd.js
@@ -37,9 +37,9 @@ class Client {
     this._queue = []
 
     lookup(this._host, (err, address, family) => {
-      if (err === null) {
-        queue.forEach(buffer => this._send(address, family, buffer))
-      }
+      if (err) return log.error(err)
+
+      queue.forEach(buffer => this._send(address, family, buffer))
     })
   }
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -22,6 +22,7 @@ describe('Config', () => {
     expect(config).to.have.property('service', 'node')
     expect(config).to.have.property('enabled', true)
     expect(config).to.have.property('debug', false)
+    expect(config).to.have.nested.property('dogstatsd.hostname', null)
     expect(config).to.have.nested.property('dogstatsd.port', '8125')
     expect(config).to.have.property('flushInterval', 2000)
     expect(config).to.have.property('sampleRate', 1)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix runtime metrics not working when hostname was not configured.

### Motivation
<!-- What inspired you to submit this pull request? -->

Value of the configuration option was stringified so it ended up being the string `"null"`.

Fixes #1029 