### PR TITLE
fix boolean environment variables being case-sensitive

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -71,9 +71,9 @@ class Config {
       rateLimit: coalesce(sampler.rateLimit, platform.env('DD_TRACE_RATE_LIMIT'))
     })
 
-    this.enabled = String(enabled) === 'true'
-    this.debug = String(debug) === 'true'
-    this.logInjection = String(logInjection) === 'true'
+    this.enabled = isTrue(enabled)
+    this.debug = isTrue(debug)
+    this.logInjection = isTrue(logInjection)
     this.env = env
     this.url = url && new URL(url)
     this.site = site
@@ -85,13 +85,13 @@ class Config {
     this.plugins = !!plugins
     this.service = service
     this.version = version
-    this.analytics = String(analytics) === 'true'
+    this.analytics = isTrue(analytics)
     this.tags = tags
     this.dogstatsd = {
       hostname: coalesce(dogstatsd.hostname, platform.env(`DD_DOGSTATSD_HOSTNAME`), this.hostname),
       port: String(coalesce(dogstatsd.port, platform.env('DD_DOGSTATSD_PORT'), 8125))
     }
-    this.runtimeMetrics = String(runtimeMetrics) === 'true'
+    this.runtimeMetrics = isTrue(runtimeMetrics)
     this.trackAsyncScope = options.trackAsyncScope !== false
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
@@ -100,8 +100,8 @@ class Config {
       peers: (options.experimental && options.experimental.distributedTracingOriginWhitelist) || [],
       sampler
     }
-    this.reportHostname = String(reportHostname) === 'true'
-    this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope
+    this.reportHostname = isTrue(reportHostname)
+    this.scope = isFalse(platform.env('DD_CONTEXT_PROPAGATION')) ? scopes.NOOP : scope
     this.clientToken = clientToken
     this.logLevel = coalesce(
       options.logLevel,
@@ -109,10 +109,10 @@ class Config {
       'debug'
     )
     this.profiling = {
-      enabled: String(profilingEnabled) === 'true'
+      enabled: isTrue(profilingEnabled)
     }
     this.lookup = options.lookup
-    this.startupLogsEnabled = String(startupLogsEnabled) === 'true'
+    this.startupLogsEnabled = isTrue(startupLogsEnabled)
 
     if (this.experimental.runtimeId) {
       tagger.add(tags, {
@@ -120,6 +120,16 @@ class Config {
       })
     }
   }
+}
+
+function isTrue (str) {
+  str = String(str).toLowerCase()
+  return str === 'true' || str === '1'
+}
+
+function isFalse (str) {
+  str = String(str).toLowerCase()
+  return str === 'false' || str === '0'
 }
 
 module.exports = Config

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -93,6 +93,20 @@ describe('Config', () => {
     expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: '0.5', rateLimit: '-1' })
   })
 
+  it('should read case-insensitive booleans from environment variables', () => {
+    platform.env.withArgs('DD_TRACE_ENABLED').returns('False')
+    platform.env.withArgs('DD_TRACE_DEBUG').returns('TRUE')
+    platform.env.withArgs('DD_TRACE_ANALYTICS').returns('1')
+    platform.env.withArgs('DD_RUNTIME_METRICS_ENABLED').returns('0')
+
+    const config = new Config()
+
+    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('debug', true)
+    expect(config).to.have.property('analytics', true)
+    expect(config).to.have.property('runtimeMetrics', false)
+  })
+
   it('should initialize from environment variables with url taking precedence', () => {
     platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:7777')
     platform.env.withArgs('DD_SITE').returns('datadoghq.eu')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix boolean environment variables being case-sensitive.

### Motivation
<!-- What inspired you to submit this pull request? -->

There is no reason for these values to be case-sensitive, and it can be confusing to users when the environment variables are set by an external component that may use uppercase letters.