### PR TITLE
fix error when initialized without the inspector module available

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/inspector/heap.js
+++ b/packages/dd-trace/src/profiling/profilers/inspector/heap.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const inspector = require('inspector')
 const { Profile } = require('../../profile')
-
-const session = new inspector.Session()
 
 class InspectorHeapProfiler {
   constructor (options = {}) {
@@ -12,19 +9,23 @@ class InspectorHeapProfiler {
   }
 
   start ({ mapper }) {
+    const { Session } = require('inspector')
+
     this._mapper = mapper
 
-    session.connect()
-    session.post('HeapProfiler.enable')
-    session.post('HeapProfiler.startSampling', {
+    this._session = new Session()
+    this._session.connect()
+    this._session.post('HeapProfiler.enable')
+    this._session.post('HeapProfiler.startSampling', {
       samplingInterval: this._samplingInterval
     })
   }
 
   stop () {
-    session.post('HeapProfiler.stopSampling')
-    session.post('HeapProfiler.disable')
-    session.disconnect()
+    this._session.post('HeapProfiler.stopSampling')
+    this._session.post('HeapProfiler.disable')
+    this._session.disconnect()
+    this._session = null
 
     this._mapper = null
   }
@@ -32,7 +33,7 @@ class InspectorHeapProfiler {
   profile () {
     let profile
 
-    session.post('HeapProfiler.getSamplingProfile', (err, params) => {
+    this._session.post('HeapProfiler.getSamplingProfile', (err, params) => {
       if (err) throw err
       profile = params.profile
     })

--- a/packages/dd-trace/test/profiling/profilers/inspector/cpu.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/inspector/cpu.spec.js
@@ -1,28 +1,47 @@
 'use strict'
 
 const { expect } = require('chai')
+const proxyquire = require('proxyquire')
 
 describe('profilers/inspector/cpu', () => {
   let InspectorCpuProfiler
   let profiler
   let mapper
 
-  beforeEach(() => {
-    InspectorCpuProfiler = require('../../../../src/profiling/profilers/inspector/cpu').InspectorCpuProfiler
+  describe('with the inspector module enabled', () => {
+    beforeEach(() => {
+      InspectorCpuProfiler = require('../../../../src/profiling/profilers/inspector/cpu').InspectorCpuProfiler
 
-    mapper = { getSource: callFrame => Promise.resolve(callFrame) }
-    profiler = new InspectorCpuProfiler()
+      mapper = { getSource: callFrame => Promise.resolve(callFrame) }
+      profiler = new InspectorCpuProfiler()
+    })
+
+    afterEach(() => {
+      profiler.stop()
+    })
+
+    it('should serialize profiles in the correct format', async () => {
+      profiler.start({ mapper })
+
+      const profile = await profiler.profile()
+
+      expect(profile).to.be.a.profile
+    })
   })
 
-  afterEach(() => {
-    profiler.stop()
-  })
+  describe('with the inspector module disabled', () => {
+    it('should throw when started', async () => {
+      expect(() => {
+        InspectorCpuProfiler = proxyquire('../../../../src/profiling/profilers/inspector/cpu', {
+          inspector: null
+        }).InspectorCpuProfiler
 
-  it('should serialize profiles in the correct format', async () => {
-    profiler.start({ mapper })
+        profiler = new InspectorCpuProfiler()
+      }).to.not.throw()
 
-    const profile = await profiler.profile()
-
-    expect(profile).to.be.a.profile
+      expect(() => {
+        profiler.start({ mapper })
+      }).to.throw()
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix error when initialized without the inspector module available by moving the import to the profiler `start` method instead of at the top of the file.

### Motivation
<!-- What inspired you to submit this pull request? -->

When Node is built with `--without-inspector` the module is not available so trying to import it fails.

Fixes #1037 