### PR TITLE
fix profiler logger not mapping to the correct tracer logger methods

### DIFF
--- a/packages/dd-trace/src/platform/node/profiler.js
+++ b/packages/dd-trace/src/platform/node/profiler.js
@@ -12,7 +12,8 @@ module.exports = config => cached || (cached = {
     const exporter = new AgentExporter({ url, hostname, port })
     const logger = {
       debug: (message) => log.debug(message),
-      warn: (message) => log.debug(message),
+      info: (message) => log.info(message),
+      warn: (message) => log.warn(message),
       error: (message) => log.error(message)
     }
 

--- a/packages/dd-trace/src/profiling/loggers/console.js
+++ b/packages/dd-trace/src/profiling/loggers/console.js
@@ -6,6 +6,7 @@
 const mapping = {
   error: 3,
   warn: 4,
+  info: 6,
   debug: 7
 }
 
@@ -16,6 +17,10 @@ class ConsoleLogger {
 
   debug (message) {
     this._log('debug', message)
+  }
+
+  info (message) {
+    this._log('info', message)
   }
 
   warn (message) {

--- a/packages/dd-trace/test/profiling/loggers/console.spec.js
+++ b/packages/dd-trace/test/profiling/loggers/console.spec.js
@@ -9,6 +9,7 @@ describe('loggers/console', () => {
 
   beforeEach(() => {
     sinon.stub(console, 'debug')
+    sinon.stub(console, 'info')
     sinon.stub(console, 'warn')
     sinon.stub(console, 'error')
 
@@ -17,6 +18,7 @@ describe('loggers/console', () => {
 
   afterEach(() => {
     console.debug.restore()
+    console.info.restore()
     console.warn.restore()
     console.error.restore()
   })
@@ -26,11 +28,13 @@ describe('loggers/console', () => {
 
     logger.error('error')
     logger.warn('warn')
+    logger.info('info')
     logger.debug('debug')
 
     sinon.assert.calledOnce(console.error)
     sinon.assert.calledWith(console.error, 'error')
     sinon.assert.notCalled(console.debug)
+    sinon.assert.notCalled(console.info)
     sinon.assert.notCalled(console.warn)
   })
 
@@ -39,12 +43,31 @@ describe('loggers/console', () => {
 
     logger.error('error')
     logger.warn('warn')
+    logger.info('info')
     logger.debug('debug')
 
     sinon.assert.calledOnce(console.error)
     sinon.assert.calledWith(console.error, 'error')
     sinon.assert.calledOnce(console.warn)
     sinon.assert.calledWith(console.warn, 'warn')
+    sinon.assert.notCalled(console.info)
+    sinon.assert.notCalled(console.debug)
+  })
+
+  it('should call the underlying console for info', () => {
+    const logger = new ConsoleLogger({ level: 'info' })
+
+    logger.error('error')
+    logger.warn('warn')
+    logger.info('info')
+    logger.debug('debug')
+
+    sinon.assert.calledOnce(console.error)
+    sinon.assert.calledWith(console.error, 'error')
+    sinon.assert.calledOnce(console.warn)
+    sinon.assert.calledWith(console.warn, 'warn')
+    sinon.assert.calledOnce(console.info)
+    sinon.assert.calledWith(console.info, 'info')
     sinon.assert.notCalled(console.debug)
   })
 
@@ -53,12 +76,15 @@ describe('loggers/console', () => {
 
     logger.error('error')
     logger.warn('warn')
+    logger.info('info')
     logger.debug('debug')
 
     sinon.assert.calledOnce(console.error)
     sinon.assert.calledWith(console.error, 'error')
     sinon.assert.calledOnce(console.warn)
     sinon.assert.calledWith(console.warn, 'warn')
+    sinon.assert.calledOnce(console.info)
+    sinon.assert.calledWith(console.info, 'info')
     sinon.assert.calledOnce(console.debug)
     sinon.assert.calledWith(console.debug, 'debug')
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix profiler logger not mapping to the correct tracer logger methods.

### Motivation
<!-- What inspired you to submit this pull request? -->

The available methods changed when startup logs were added, but the profiler logger was not using the new methods.