### PR TITLE
Do not try to inject without span context on opentracing tracer

### DIFF
--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -81,10 +81,6 @@ class DatadogTracer extends Tracer {
   }
 
   _inject (spanContext, format, carrier) {
-    if (!spanContext) {
-      return this
-    }
-
     try {
       this._prioritySampler.sample(spanContext)
       this._propagators[format].inject(spanContext, carrier)

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -81,6 +81,10 @@ class DatadogTracer extends Tracer {
   }
 
   _inject (spanContext, format, carrier) {
+    if (!spanContext) {
+      return this
+    }
+
     try {
       this._prioritySampler.sample(spanContext)
       this._propagators[format].inject(spanContext, carrier)

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -42,6 +42,8 @@ class PrioritySampler {
   }
 
   sample (span) {
+    if (!span) return
+
     const context = this._getContext(span)
 
     if (context._sampling.priority !== undefined) return

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -365,12 +365,6 @@ describe('Tracer', () => {
       expect(log.error).to.have.been.calledOnce
     })
 
-    it('should ignore empty span', () => {
-      tracer = new Tracer(config)
-
-      expect(log.error).to.not.have.been.called
-    })
-
     it('should generate the sampling priority', () => {
       TextMapPropagator.returns(propagator)
 

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -80,7 +80,8 @@ describe('Tracer', () => {
 
     log = {
       use: sinon.spy(),
-      toggle: sinon.spy()
+      toggle: sinon.spy(),
+      error: sinon.spy()
     }
 
     platform = {
@@ -360,7 +361,14 @@ describe('Tracer', () => {
     it('should handle errors', () => {
       tracer = new Tracer(config)
 
-      expect(() => tracer.inject()).not.to.throw()
+      expect(() => tracer.inject({})).not.to.throw()
+      expect(log.error).to.have.been.calledOnce
+    })
+
+    it('should ignore empty span', () => {
+      tracer = new Tracer(config)
+
+      expect(log.error).to.not.have.been.called
     })
 
     it('should generate the sampling priority', () => {

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -285,6 +285,12 @@ describe('PrioritySampler', () => {
       expect(context._tags).to.have.property('_dd.rule_psr', 0.5)
       expect(context._tags).to.have.property('_dd.limit_psr', 1)
     })
+
+    it('should ignore empty span', () => {
+      prioritySampler.sample()
+
+      expect(context._sampling).to.not.have.property('priority')
+    })
   })
 
   describe('update', () => {


### PR DESCRIPTION
### Context

```
tracer.init({
  logInjection: true
})
```

Tested on Fastify application, some logs are sent before the first request, so we don't have active span yet.

### What does this PR do?

This PR fix the opentracing tracer `_inject` method in case first argument `spanContext` is null or undefined

### Motivation

In case that there is no active span and we need to send a log, an exception in the tracer injector is trhow, and the exception's catch try to do another logger.error() but this logger the tracer try to do an injection. So we loop here!
