### PR TITLE
fix incorrect protocol in http.url tag for https agent

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -38,7 +38,8 @@ function patch (http, methodName, tracer, config) {
       }
 
       const options = args.options
-      const protocol = options.protocol || 'http:'
+      const agent = options.agent || http.globalAgent
+      const protocol = options.protocol || agent.protocol || 'http:'
       const hostname = options.hostname || options.host || 'localhost'
       const host = options.port ? `${hostname}:${options.port}` : hostname
       const path = options.path ? options.path.split(/[?#]/)[0] : '/'

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -38,7 +38,7 @@ function patch (http, methodName, tracer, config) {
       }
 
       const options = args.options
-      const agent = options.agent || http.globalAgent
+      const agent = options.agent || options._defaultAgent || http.globalAgent
       const protocol = options.protocol || agent.protocol || 'http:'
       const hostname = options.hostname || options.host || 'localhost'
       const host = options.port ? `${hostname}:${options.port}` : hostname

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -640,6 +640,36 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it.only('should use the correct fallback protocol', done => {
+          const app = express()
+
+          app.get('/user', (req, res) => {
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+                expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(app, port, () => {
+              const req = http.request({
+                hostname: 'localhost',
+                port,
+                path: '/user?foo=bar'
+              }, res => {
+                res.on('data', () => {})
+              })
+
+              req.end()
+            })
+          })
+        })
       })
 
       describe('with service configuration', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix incorrect protocol in `http.url` tag for HTTPS agent.

### Motivation
<!-- What inspired you to submit this pull request? -->

When the protocol is not explicitly set, the default value would fallback to `http:` even for the HTTPS agent since the agent protocol was not used.