### PR TITLE
fix install script parentheses

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "browser.js",
   "typings": "index.d.ts",
   "scripts": {
-    "install": "node scripts/should_rebuild && node-gyp-build || exit 0",
+    "install": "(node scripts/should_rebuild && node-gyp-build) || exit 0",
     "rebuild": "node-gyp rebuild",
     "prebuild": "node scripts/prebuild.js",
     "prebuilds": "node scripts/prebuilds.js",


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the `install` script that breaks with Yarn v2 in `CI=true` environments, where the `should_rebuild` script exits with code 1 and `|| exit 0` does not handle the error as expected. Adding parentheses removes the ambiguity from the logic, and Yarn v2 handles the error correctly (by ignoring it).

### Motivation
https://github.com/DataDog/dd-trace-js/issues/1049

### Additional Notes
A potential workaround is to use `CI=false yarn`, but this may have unintended consequences when actually running in a CI environment.