### PR TITLE
Adding a request hook config for xmlhttprequest plugin

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -58,8 +58,8 @@ tracer.init({
   },
   hostname: 'agent',
   logger: {
-    error (message: string) {},
-    debug (message: string | Error) {}
+    error(message: string) { },
+    debug(message: string | Error) { }
   },
   plugins: false,
   port: 7777,
@@ -68,7 +68,7 @@ tracer.init({
     port: 8888
   },
   flushInterval: 1000,
-  lookup: () => {},
+  lookup: () => { },
   sampleRate: 0.1,
   service: 'test',
   tags: {
@@ -92,7 +92,7 @@ const httpOptions = {
 const httpServerOptions = {
   ...httpOptions,
   hooks: {
-    request: (span, req, res) => {}
+    request: (span, req, res) => { }
   }
 };
 
@@ -100,7 +100,7 @@ const httpClientOptions = {
   ...httpOptions,
   splitByDomain: true,
   hooks: {
-    request: (span, req, res) => {}
+    request: (span, req, res) => { }
   }
 };
 
@@ -120,21 +120,27 @@ const graphqlOptions = {
   collapse: false,
   signature: false,
   hooks: {
-    execute: (span, args, res) => {},
+    execute: (span, args, res) => { },
   }
 };
 
 const elasticsearchOptions = {
   service: 'test',
   hooks: {
-    query: (span, params) => {},
+    query: (span, params) => { },
   },
 };
 
 const awsSdkOptions = {
   service: 'test',
   hooks: {
-    request: (span, response) => {},
+    request: (span, response) => { },
+  }
+};
+
+const xmlhttprequestOptions = {
+  hooks: {
+    request: (span, xhr) => { },
   }
 };
 
@@ -208,6 +214,7 @@ tracer.use('redis');
 tracer.use('redis', redisOptions);
 tracer.use('restify');
 tracer.use('restify', httpServerOptions);
+tracer.use('xmlhttprequest', xmlhttprequestOptions);
 tracer.use('rhea');
 tracer.use('router');
 tracer.use('tedious');
@@ -230,18 +237,18 @@ span = tracer.startSpan('test', {
   }
 });
 
-tracer.trace('test', () => {})
-tracer.trace('test', { tags: { foo: 'bar' }}, () => {})
-tracer.trace('test', { service: 'foo', resource: 'bar', type: 'baz' }, () => {})
-tracer.trace('test', { analytics: true }, () => {})
-tracer.trace('test', { analytics: 0.5 }, () => {})
-tracer.trace('test', (span: Span) => {})
-tracer.trace('test', (span: Span, fn: () => void) => {})
-tracer.trace('test', (span: Span, fn: (err: Error) => string) => {})
+tracer.trace('test', () => { })
+tracer.trace('test', { tags: { foo: 'bar' } }, () => { })
+tracer.trace('test', { service: 'foo', resource: 'bar', type: 'baz' }, () => { })
+tracer.trace('test', { analytics: true }, () => { })
+tracer.trace('test', { analytics: 0.5 }, () => { })
+tracer.trace('test', (span: Span) => { })
+tracer.trace('test', (span: Span, fn: () => void) => { })
+tracer.trace('test', (span: Span, fn: (err: Error) => string) => { })
 
 promise = tracer.trace('test', () => Promise.resolve())
 
-tracer.wrap('test', () => {})
+tracer.wrap('test', () => { })
 tracer.wrap('test', (foo: string) => 'test')
 
 promise = tracer.wrap('test', () => Promise.resolve())()
@@ -259,10 +266,10 @@ const scope = tracer.scope()
 span = scope.active();
 
 const activateStringType: string = scope.activate(span, () => 'test');
-const activateVoidType: void = scope.activate(span, () => {});
+const activateVoidType: void = scope.activate(span, () => { });
 
 const bindFunctionStringType: (arg1: string, arg2: number) => string = scope.bind((arg1: string, arg2: number): string => 'test');
-const bindFunctionVoidType: (arg1: string, arg2: number) => void = scope.bind((arg1: string, arg2: number): void => {});
+const bindFunctionVoidType: (arg1: string, arg2: number) => void = scope.bind((arg1: string, arg2: number): void => { });
 const bindFunctionVoidTypeWithSpan: (arg1: string, arg2: number) => void = scope.bind((arg1: string, arg2: number): string => 'test', span);
 
 Promise.resolve();
@@ -271,18 +278,18 @@ scope.bind(promise);
 scope.bind(promise, span);
 
 const simpleEmitter = {
-  emit (eventName: string, arg1: boolean, arg2: number): void {}
+  emit(eventName: string, arg1: boolean, arg2: number): void { }
 };
 
 scope.bind(simpleEmitter);
 scope.bind(simpleEmitter, span);
 
 const emitter = {
-  emit (eventName: string, arg1: boolean, arg2: number): void {},
-  on (eventName: string, listener: (arg1: boolean, arg2: number) => void) {},
-  off (eventName: string, listener: (arg1: boolean, arg2: number) => void) {},
-  addListener (eventName: string, listener: (arg1: boolean, arg2: number) => void) {},
-  removeListener (eventName: string, listener: (arg1: boolean, arg2: number) => void) {}
+  emit(eventName: string, arg1: boolean, arg2: number): void { },
+  on(eventName: string, listener: (arg1: boolean, arg2: number) => void) { },
+  off(eventName: string, listener: (arg1: boolean, arg2: number) => void) { },
+  addListener(eventName: string, listener: (arg1: boolean, arg2: number) => void) { },
+  removeListener(eventName: string, listener: (arg1: boolean, arg2: number) => void) { }
 };
 
 scope.bind(emitter);

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["es2017"],
+    "lib": ["es2017", "DOM"],
     "moduleResolution": "node",
     "module": "commonjs",
     "baseUrl": "."
   },
-  "files": [
-    "../index.d.ts"
-  ]
+  "files": ["../index.d.ts"]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -306,7 +306,7 @@ export declare interface TracerOptions {
      * List of origins to whitelist for distributed tracing. This is used to determine whether to propagate context from the browser for CORS.
      * @default []
      */
-    distributedTracingOriginWhitelist?: (string|RegExp)[]
+    distributedTracingOriginWhitelist?: (string | RegExp)[]
 
     /**
      * Configuration of the priority sampler. Supports a global config and rules by span name or service name. The first matching rule is applied, and if no rule matches it falls back to the global config or on the rates provided by the agent if there is no global config.
@@ -484,6 +484,7 @@ interface Plugins {
   "tedious": plugins.tedious;
   "when": plugins.when;
   "winston": plugins.winston;
+  "xmlhttprequest": plugins.xmlhttprequest;
 }
 
 /** @hidden */
@@ -511,7 +512,7 @@ declare namespace plugins {
   }
 
   /** @hidden */
-  interface Instrumentation extends Integration, Analyzable {}
+  interface Instrumentation extends Integration, Analyzable { }
 
   /** @hidden */
   interface Http extends Instrumentation {
@@ -650,13 +651,13 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [amqp10](https://github.com/noodlefrenzy/node-amqp10) module.
    */
-  interface amqp10 extends Instrumentation {}
+  interface amqp10 extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [amqplib](https://github.com/squaremo/amqp.node) module.
    */
-  interface amqplib extends Instrumentation {}
+  interface amqplib extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
@@ -678,7 +679,7 @@ declare namespace plugins {
    * This plugin patches the [bluebird](https://github.com/petkaantonov/bluebird)
    * module to bind the promise callback the the caller context.
    */
-  interface bluebird extends Integration {}
+  interface bluebird extends Integration { }
 
   /**
    * This plugin patches the [bunyan](https://github.com/trentm/node-bunyan)
@@ -686,31 +687,31 @@ declare namespace plugins {
    * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
    * on the tracer.
    */
-  interface bunyan extends Integration {}
+  interface bunyan extends Integration { }
 
   /**
    * This plugin automatically instruments the
    * [cassandra-driver](https://github.com/datastax/nodejs-driver) module.
    */
-  interface cassandra_driver extends Instrumentation {}
+  interface cassandra_driver extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [connect](https://github.com/senchalabs/connect) module.
    */
-  interface connect extends HttpServer {}
+  interface connect extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
    * [couchbase](https://www.npmjs.com/package/couchbase) module.
    */
-  interface couchbase extends Instrumentation {}
+  interface couchbase extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [dns](https://nodejs.org/api/dns.html) module.
    */
-  interface dns extends Instrumentation {}
+  interface dns extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
@@ -732,31 +733,31 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [express](http://expressjs.com/) module.
    */
-  interface express extends HttpServer {}
+  interface express extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
    * [fastify](https://www.fastify.io/) module.
    */
-  interface fastify extends HttpServer {}
+  interface fastify extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
    * [fs](https://nodejs.org/api/fs.html) module.
    */
-  interface fs extends Instrumentation {}
+  interface fs extends Instrumentation { }
 
   /**
    * This plugin patches the [generic-pool](https://github.com/coopernurse/node-pool)
    * module to bind the callbacks the the caller context.
    */
-  interface generic_pool extends Integration {}
+  interface generic_pool extends Integration { }
 
   /**
    * This plugin automatically instruments the
    * [@google-cloud/pubsub](https://github.com/googleapis/nodejs-pubsub) module.
    */
-  interface google_cloud_pubsub extends Integration {}
+  interface google_cloud_pubsub extends Integration { }
 
   /** @hidden */
   interface ExecutionArgs {
@@ -858,7 +859,7 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [hapi](https://hapijs.com/) module.
    */
-  interface hapi extends HttpServer {}
+  interface hapi extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
@@ -939,67 +940,67 @@ declare namespace plugins {
    * This plugin patches the [knex](https://knexjs.org/)
    * module to bind the promise callback the the caller context.
    */
-  interface knex extends Integration {}
+  interface knex extends Integration { }
 
   /**
    * This plugin automatically instruments the
    * [koa](https://koajs.com/) module.
    */
-  interface koa extends HttpServer {}
+  interface koa extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
    * [limitd-client](https://github.com/limitd/node-client) module.
    */
-  interface limitd_client extends Integration {}
+  interface limitd_client extends Integration { }
 
   /**
    * This plugin automatically instruments the
    * [memcached](https://github.com/3rd-Eden/memcached) module.
    */
-  interface memcached extends Instrumentation {}
+  interface memcached extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [microgateway-core](https://github.com/apigee/microgateway-core) module.
    */
-  interface microgateway_core extends HttpServer {}
+  interface microgateway_core extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
    * [mongodb-core](https://github.com/mongodb-js/mongodb-core) module.
    */
-  interface mongodb_core extends Instrumentation {}
+  interface mongodb_core extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [mysql](https://github.com/mysqljs/mysql) module.
    */
-  interface mysql extends Instrumentation {}
+  interface mysql extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [mysql2](https://github.com/brianmario/mysql2) module.
    */
-  interface mysql2 extends Instrumentation {}
+  interface mysql2 extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [net](https://nodejs.org/api/net.html) module.
    */
-  interface net extends Instrumentation {}
+  interface net extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [paperplane](https://github.com/articulate/paperplane) module.
    */
-  interface paperplane extends HttpServer {}
+  interface paperplane extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
    * [pg](https://node-postgres.com/) module.
    */
-  interface pg extends Instrumentation {}
+  interface pg extends Instrumentation { }
 
   /**
    * This plugin patches the [pino](http://getpino.io)
@@ -1007,25 +1008,25 @@ declare namespace plugins {
    * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
    * on the tracer.
    */
-  interface pino extends Integration {}
+  interface pino extends Integration { }
 
   /**
    * This plugin patches the [promise-js](https://github.com/kevincennis/promise)
    * module to bind the promise callback the the caller context.
    */
-  interface promise_js extends Integration {}
+  interface promise_js extends Integration { }
 
   /**
    * This plugin patches the [promise](https://github.com/then/promise)
    * module to bind the promise callback the the caller context.
    */
-  interface promise extends Integration {}
+  interface promise extends Integration { }
 
   /**
    * This plugin patches the [q](https://github.com/kriskowal/q)
    * module to bind the promise callback the the caller context.
    */
-  interface q extends Integration {}
+  interface q extends Integration { }
 
   /**
    * This plugin automatically instruments the
@@ -1052,31 +1053,31 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [restify](http://restify.com/) module.
    */
-  interface restify extends HttpServer {}
+  interface restify extends HttpServer { }
 
   /**
    * This plugin automatically instruments the
    * [rhea](https://github.com/amqp/rhea) module.
    */
-  interface rhea extends Instrumentation {}
+  interface rhea extends Instrumentation { }
 
   /**
    * This plugin automatically instruments the
    * [router](https://github.com/pillarjs/router) module.
    */
-  interface router extends Integration {}
+  interface router extends Integration { }
 
   /**
    * This plugin automatically instruments the
    * [tedious](https://github.com/tediousjs/tedious/) module.
    */
-  interface tedious extends Instrumentation {}
+  interface tedious extends Instrumentation { }
 
   /**
    * This plugin patches the [when](https://github.com/cujojs/when)
    * module to bind the promise callback the the caller context.
    */
-  interface when extends Integration {}
+  interface when extends Integration { }
 
   /**
    * This plugin patches the [winston](https://github.com/winstonjs/winston)
@@ -1084,7 +1085,25 @@ declare namespace plugins {
    * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
    * on the tracer.
    */
-  interface winston extends Integration {}
+  interface winston extends Integration { }
+
+  /**
+   * This plugin instruments the browser
+   * [xmlhttprequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) module.
+   */
+  interface xmlhttprequest extends Integration {
+    /**
+     * Hooks to run before spans are finished.
+     */
+    hooks?: {
+      /**
+       * Hook to execute just before the request span finishes.
+       */
+      request?: (span?: opentracing.Span, xhr?: XMLHttpRequest & {
+        _datadog_method: string; _datadog_url: Partial<URL>;
+      }) => any;
+    };
+  }
 }
 
 /**

--- a/packages/datadog-plugin-xmlhttprequest/src/index.js
+++ b/packages/datadog-plugin-xmlhttprequest/src/index.js
@@ -48,18 +48,23 @@ function createWrapSend (tracer, config) {
 
       this.addEventListener('error', e => span.setTag('error', e))
       this.addEventListener('load', () => span.setTag('http.status', this.status))
-      this.addEventListener('loadend', () => span.finish())
+      this.addEventListener('loadend', () => finish(this, span, config))
 
       try {
         return tracer.scope().bind(send, span).apply(this, arguments)
       } catch (e) {
         span.setTag('error', e)
-        span.finish()
+        finish(this, span, config)
 
         throw e
       }
     }
   }
+}
+
+function finish (xhr, span, config) {
+  config.hooks.request(span, xhr)
+  span.finish()
 }
 
 function inject (xhr, tracer, span) {


### PR DESCRIPTION
### What does this PR do?
This PR adds the option to configure a `hooks.request` for the `datadog-plugin-xmlhttprequest`, similar to what has been done  before in `datadog-plugin-http`. 

### Motivation
<!-- What inspired you to submit this pull request? -->
We are using dd-trace-js along with [nextjs](https://github.com/vercel/next.js) and we saw that our tracing was only showing up with `resource.name` like `GET` and `POST` which we would like to override. The `datadog-plugin-http` provided a request hook to override this, however this didn't work from the browser. After some digging we realized that on the browser platform only the `datadog-plugin-fetch` and `datadog-plugin-xmlhttprequest` is loaded. We thereby extended `datadog-plugin-xmlhttprequest` to do the same as the `datadog-plugin-http` does. 

A sample hook can now be configured like this:
```ts
dataDogTracer.use('xmlhttprequest', {
    hooks: {
        request: (span, xhr) => {
            console.log({ span, xhr });
            span?.setTag(
                'resource.name',
                `${xhr?._datadog_method} ${xhr?._datadog_url?.href}`
            );
        },
    },
});
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests. *Comment* This plugin currently don't have any unit tests present.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3]. *Comment* Covered by existing section `Span hooks`
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
It would have been nice if the repo was shipped with prettier as it clutters up the changes. 
