### PR TITLE
Fix TypeScript type definitions for logger config

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -454,8 +454,10 @@ const logger = bunyan.createLogger({
 
 const tracer = require('dd-trace').init({
   logger: {
+    error: err => logger.error(err),
+    warn: message => logger.warn(message),
+    info: message => logger.info(message),
     debug: message => logger.trace(message),
-    error: err => logger.error(err)
   },
   debug: true
 })

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -58,8 +58,10 @@ tracer.init({
   },
   hostname: 'agent',
   logger: {
-    error (message: string) {},
-    debug (message: string | Error) {}
+    error (message: string | Error) {},
+    warn (message: string) {},
+    info (message: string) {},
+    debug (message: string) {}
   },
   plugins: false,
   port: 7777,

--- a/index.d.ts
+++ b/index.d.ts
@@ -339,12 +339,14 @@ export declare interface TracerOptions {
 
   /**
    * Custom logger to be used by the tracer (if debug = true),
-   * should support debug() and error() methods
+   * should support error(), warn(), info(), and debug() methods
    * see https://datadog.github.io/dd-trace-js/#custom-logging
    */
   logger?: {
-    debug: (message: string) => void;
     error: (err: Error | string) => void;
+    warn: (message: string) => void;
+    info: (message: string) => void;
+    debug: (message: string) => void;
   };
 
   /**


### PR DESCRIPTION
### What does this PR do?

PR #999 added startup logging. In doing so it added support for additional logging methods.

### Motivation

While integrating dd-trace into my project I saw some nice debugging messages in the console. When I provided my own logger, these messages disappeared. After digging through the code I figured out that these new startup logging messages are being sent to logger methods I wasn't providing because they are undocumented, and the TypeScript types do not recognize them.

This patch makes it so those new methods are a known part of the logger object shape.

### Plugin Checklist

- [ ] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
