### PR TITLE
temporarily disable profiling

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -27,9 +27,10 @@ class Config {
       platform.env('DD_TRACE_ANALYTICS'),
       false
     )
+    // Temporary disabled
     const DD_PROFILING_ENABLED = coalesce(
-      options.profiling,
-      platform.env('DD_PROFILING_ENABLED'),
+      // options.profiling,
+      // platform.env('DD_PROFILING_ENABLED'),
       false
     )
     const DD_PROFILING_EXPORTERS = coalesce(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Temporarily disable profiling.

### Motivation
<!-- What inspired you to submit this pull request? -->

There are currently performance issues which may impact the stability of applications where the profiler is enabled. To prevent issues in production, we are temporarily disabling the profiler completely until a future release.