### PR TITLE
remove profiling documentation while the feature is disabled

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -428,7 +428,6 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | flushInterval  | -                              | `2000`         | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | lookup         | -                              | `dns.lookup()` | Custom function for DNS lookups when sending requests to the agent. |
 | runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED`   | `false`        | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
-| profiling      | `DD_PROFILING_ENABLED`         | `false`        | Whether to enable profiling. |
 | reportHostname | `DD_TRACE_REPORT_HOSTNAME`     | `false`        | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |
 | experimental   | -                              | `{}`           | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Please contact us to learn more about the available experimental features. |
 | plugins        | -                              | `true`         | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -222,11 +222,6 @@ export declare interface TracerOptions {
   port?: number | string;
 
   /**
-   * Whether to enable profiling.
-   */
-  profiling?: boolean
-
-  /**
    * Options specific for the Dogstatsd agent.
    */
   dogstatsd?: {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove profiling documentation while the feature is disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->

Profiling has been temporarily removed and should not be documented since the option has no effect.