### PR TITLE
fix connect and fastify wrappers missing properties

### DIFF
--- a/packages/datadog-plugin-connect/src/index.js
+++ b/packages/datadog-plugin-connect/src/index.js
@@ -6,11 +6,7 @@ function createWrapConnect (tracer, config) {
   return function wrapConnect (connect) {
     if (typeof connect !== 'function') return connect
 
-    const connectWithTrace = function connectWithTrace () {
-      return connect._datadog_wrapper.apply(this, arguments)
-    }
-
-    connect._datadog_wrapper = function () {
+    return function connectWithTrace () {
       const app = connect()
 
       if (!app) return app
@@ -20,8 +16,6 @@ function createWrapConnect (tracer, config) {
 
       return app
     }
-
-    return connectWithTrace
   }
 }
 
@@ -58,10 +52,6 @@ function createWrapHandle (tracer, config) {
       })
     }
   }
-}
-
-function unwrapConnect (connect) {
-  connect._datadog_wrapper = connect
 }
 
 function wrapLayerHandle (layer) {
@@ -112,10 +102,10 @@ module.exports = [
     versions: ['>=3'],
     patch (connect, tracer, config) {
       // `connect` is a function so we return a wrapper that will replace its export.
-      return createWrapConnect(tracer, config)(connect)
+      return this.wrapExport(connect, createWrapConnect(tracer, config)(connect))
     },
     unpatch (connect) {
-      unwrapConnect(connect)
+      this.unwrapExport(connect)
     }
   },
   {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `connect` and `fastify` wrappers missing properties.

### Motivation
<!-- What inspired you to submit this pull request? -->

The existing code didn't copy the properties from the exported function in the wrapper. While the modules themselves don't have any properties, when the code is transpiled with Babel an additional `default` properly is added to every export which was missing, thus preventing usage of the default export from the transpiled code. The new methods on the instrumenter handle properties properly, so the code was updated to use the instrumenter.

Fixes #1058 