### PR TITLE
enable manually triggering reliablity environment deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ copy_to_s3:
       when: on_success
     - if: '$CI_COMMIT_BRANCH == "testing"'
       when: on_success
+    - when: manual
   script:
     - export ACCESS_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-js.secret_key_id --with-decryption --query "Parameter.Value" --out text)
     - export SECRET_ACCESS_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-js.secret_sec_key_id --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
### What does this PR do?
Enables an option to deploy to S3 manually when we want to.

### Motivation
This enables us to test arbitrary changes in the reliability environment.