### PR TITLE
add option to disable splitting aws-sdk service names by aws service

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -135,6 +135,7 @@ const elasticsearchOptions = {
 
 const awsSdkOptions = {
   service: 'test',
+  splitByAwsService: false,
   hooks: {
     request: (span, response) => {},
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -668,6 +668,12 @@ declare namespace plugins {
    */
   interface aws_sdk extends Instrumentation {
     /**
+     * Whether to add a suffix to the service name so that each AWS service has its own service name.
+     * @default true
+     */
+    splitByAwsService?: boolean;
+
+    /**
      * Hooks to run before spans are finished.
      */
     hooks?: {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add option to disable splitting `aws-sdk` service names by AWS service.

### Motivation
<!-- What inspired you to submit this pull request? -->

There are cases where users prefer to combine everything under the actual name of the service.