### PR TITLE
Allow benchmarking arbitrary e2e apps

### DIFF
--- a/benchmark/e2e/benchmark-run.js
+++ b/benchmark/e2e/benchmark-run.js
@@ -110,9 +110,9 @@ async function withFakeAgent (fn) {
   subProcess.kill()
 }
 
-async function testBoth ({ url, duration, prof, testAsyncHooks }) {
+async function testBoth ({ url, duration, prof, testAsyncHooks, appDir }) {
   // TODO We should have ways of invoking the individual tests in isolation
-  cd(path.join(__dirname, 'acmeair-nodejs'))
+  cd(path.join(__dirname, appDir))
   const results = {}
   await withFakeAgent(async () => {
     console.log(' # Running with the tracer ...')
@@ -183,7 +183,8 @@ function getOpts () {
   const argv = process.argv.slice(2)
   const opts = {
     duration: 10,
-    url: 'http://localhost:9080/rest/api/config/countCustomers'
+    url: 'http://localhost:9080/rest/api/config/countCustomers',
+    appDir: 'acmeair-nodejs'
   }
   for (const arg of argv) {
     if (arg === '--prof') {
@@ -192,6 +193,8 @@ function getOpts () {
       opts.testAsyncHooks = true
     } else if (arg.startsWith('--duration=')) {
       opts.duration = Number(arg.substr(11))
+    } else if (arg.startsWith('--appdir=')) {
+      opts.appDir = arg.substr(9)
     } else {
       opts.url = arg
     }

--- a/benchmark/e2e/express-helloworld-manyroutes/app.js
+++ b/benchmark/e2e/express-helloworld-manyroutes/app.js
@@ -1,0 +1,10 @@
+
+const crypto = require('crypto')
+const app = require('express')()
+
+for (let i = 0; i < 100; i++) {
+  app.get(`/${crypto.randomBytes(8).toString('hex')}`, (req, res) => res.end(''))
+}
+
+app.get('/hello', (req, res) => res.end('hello world'))
+app.listen(3000)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the ability to run from an arbitrary benchmarking app directory. Also adds
a simple express hello world with 100 random routes added.

### Motivation
<!-- What inspired you to submit this pull request? -->
We need to be able to test apps other than acme air.
