### PR TITLE
default to AsyncLocalStorage on versions of node that support it

### DIFF
--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -16,8 +16,11 @@ const exporter = require('./exporter')
 const profiler = require('./profiler')
 const pkg = require('./pkg')
 const startupLog = require('./startup-log')
+const semver = require('semver')
 
 const emitter = new EventEmitter()
+
+const hasSupportedAsyncLocalStorage = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
 
 const platform = {
   _config: {},
@@ -41,10 +44,11 @@ const platform = {
   off: emitter.removeListener.bind(emitter),
   Loader,
   getScope (scope) {
-    if (scope === scopes.ASYNC_LOCAL_STORAGE) {
+    if (scope === scopes.ASYNC_LOCAL_STORAGE || (!scope && hasSupportedAsyncLocalStorage)) {
       return require('../../scope/async_local_storage')
+    } else {
+      return require('../../scope/async_hooks')
     }
-    return require('../../scope/async_hooks')
   },
   exporter,
   profiler () {

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -9,7 +9,7 @@ const semver = require('semver')
 const hasKeepAliveBug = !semver.satisfies(process.version, '^8.13 || >=10.14.2')
 
 // fixed in https://github.com/nodejs/node/pull/33801
-const hasThenableBug = !semver.satisfies(process.version, '>=14.5')
+const hasThenableBug = !semver.satisfies(process.version, '>=14.5 || ^12.19.0')
 
 let singleton = null
 

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -660,6 +660,53 @@ describe('Platform', () => {
       })
     })
 
+    describe('getScope', () => {
+      let platform
+      let versionDescriptor
+      const ASYNC_LOCAL_STORAGE = { name: 'AsyncLocalStorage' }
+      const ASYNC_HOOKS = { name: 'async_hooks' }
+
+      beforeEach(() => {
+        versionDescriptor = Reflect.getOwnPropertyDescriptor(process.versions, 'node')
+      })
+
+      afterEach(() => {
+        Reflect.defineProperty(process.versions, 'node', versionDescriptor)
+      })
+
+      it('should default to AsyncLocalStorage on supported versions, and async_hooks on unsupported versions', () => {
+        function assertVersion (version, als) {
+          Reflect.defineProperty(process.versions, 'node', {
+            value: version,
+            configurable: true
+          })
+          platform = proxyquire('../src/platform/node/index', {
+            '../../scope/async_local_storage': ASYNC_LOCAL_STORAGE,
+            '../../scope/async_hooks': ASYNC_HOOKS
+          })
+          expect(platform.getScope()).to.equal(als ? ASYNC_LOCAL_STORAGE : ASYNC_HOOKS)
+        }
+        assertVersion('10.0.0', false)
+        assertVersion('12.0.0', false)
+        assertVersion('12.18.99', false)
+        assertVersion('12.19.0', true)
+        assertVersion('13.0.0', false)
+        assertVersion('14.0.0', false)
+        assertVersion('14.4.99', false)
+        assertVersion('14.5.0', true)
+        assertVersion('14.5.1', true)
+        assertVersion('14.6.0', true)
+        assertVersion('15.0.0', true)
+        assertVersion('16.0.0', true)
+        assertVersion('17.0.0', true)
+      })
+
+      it('should go with user choice when scope is defined in options', () => {
+        expect(platform.getScope('async_local_storage')).to.equal(ASYNC_LOCAL_STORAGE)
+        expect(platform.getScope('async_hooks')).to.equal(ASYNC_HOOKS)
+      })
+    })
+
     describe('exporter', () => {
       it('should create an AgentExporter by default', () => {
         const Exporter = proxyquire('../src/platform/node/exporter', {

--- a/packages/dd-trace/test/scope/async_hooks.spec.js
+++ b/packages/dd-trace/test/scope/async_hooks.spec.js
@@ -7,7 +7,7 @@ const Span = require('opentracing').Span
 const platform = require('../../src/platform')
 const testScope = require('./test')
 
-wrapIt()
+wrapIt('async_hooks')
 
 describe('Scope (async_hooks)', () => {
   let scope

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -9,10 +9,18 @@ const semver = require('semver')
 const platform = require('../../src/platform')
 const node = require('../../src/platform/node')
 const AsyncHooksScope = require('../../src/scope/async_hooks')
+const AsyncLocalStorageScope = require('../../src/scope/async_local_storage')
 const agent = require('../plugins/agent')
 const externals = require('../plugins/externals.json')
 
+const defaultScope = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
+  ? 'async_local_storage'
+  : 'async_hooks'
+
 const asyncHooksScope = new AsyncHooksScope({
+  trackAsyncScope: true
+})
+const asyncLocalStorageScope = defaultScope === 'async_hooks' ? null : new AsyncLocalStorageScope({
   trackAsyncScope: true
 })
 
@@ -32,7 +40,11 @@ afterEach(() => {
   platform.metrics().stop()
 })
 
-function wrapIt () {
+function wrapIt (whichScope = defaultScope) {
+  const scope = {
+    async_hooks: asyncHooksScope,
+    async_local_storage: asyncLocalStorageScope
+  }[whichScope]
   const it = global.it
   const only = global.it.only
 
@@ -42,11 +54,11 @@ function wrapIt () {
 
       const length = fn.length
 
-      fn = asyncHooksScope.bind(fn, null)
+      fn = scope.bind(fn, null)
 
       if (length > 0) {
         return testFn.call(this, title, function (done) {
-          done = asyncHooksScope.bind(done, null)
+          done = scope.bind(done, null)
 
           return fn.call(this, done)
         })


### PR DESCRIPTION
### What does this PR do?
Enables using `AsyncLocalStorage` for tracking scope on versions of Node.js where we know it works.

### Motivation
It performs well.