### PR TITLE
Add async_local_storage to available scopes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -373,7 +373,7 @@ export declare interface TracerOptions {
    * implementation for the runtime. Only change this if you know what you are
    * doing.
    */
-  scope?: 'async_hooks' | 'noop'
+  scope?: 'async_hooks' | 'async_local_storage' | 'noop'
 
   /**
    * Whether to report the hostname of the service host. This is used when the agent is deployed on a different host and cannot determine the hostname automatically.


### PR DESCRIPTION
### What does this PR do?

This PR adds `async_local_storage` to the Typescript types for `scopes`.

### Motivation

We're running Node 14 and trying out `async_local_storage` to try to work around performance issues we were experiencing with `dd-trace`. I noticed that Typescript was complaining that `async_local_storage` isn't a valid option, even though it's implemented and recommended in this issue: https://github.com/DataDog/dd-trace-js/issues/969#issuecomment-645682962
