### PR TITLE
fix sqs message attributes quota reached when propagating

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "debug.node.autoAttach": "on"
+  "debug.node.autoAttach": "off"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "debug.node.autoAttach": "off"
+  "debug.node.autoAttach": "on"
 }

--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -82,6 +82,7 @@ function getHooks (config) {
   return { request }
 }
 
+// TODO: test splitByAwsService when the test suite is fixed
 function getServiceName (serviceIdentifier, tracer, config) {
   const service = config.service || tracer._service
 

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -44,6 +44,8 @@ class Sqs {
       }
       if (!request.params.MessageAttributes) {
         request.params.MessageAttributes = {}
+      } else if (Object.keys(request.params.MessageAttributes).length >=10) { // SQS quota
+        return
       }
       const ddInfo = {}
       tracer.inject(span, 'text_map', ddInfo)

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -44,7 +44,7 @@ class Sqs {
       }
       if (!request.params.MessageAttributes) {
         request.params.MessageAttributes = {}
-      } else if (Object.keys(request.params.MessageAttributes).length >=10) { // SQS quota
+      } else if (Object.keys(request.params.MessageAttributes).length >= 10) { // SQS quota
         return
       }
       const ddInfo = {}

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -45,6 +45,7 @@ class Sqs {
       if (!request.params.MessageAttributes) {
         request.params.MessageAttributes = {}
       } else if (Object.keys(request.params.MessageAttributes).length >= 10) { // SQS quota
+        // TODO: add test when the test suite is fixed
         return
       }
       const ddInfo = {}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix SQS message attributes quota reached when propagating.

### Motivation
<!-- What inspired you to submit this pull request? -->

SQS has a quota of 10 on the number of message attributes. This means that if there are already 10 attributes and we add the one we need for propagation, we go beyond the limit which results in an error. This means that unfortunately for now propagation can only be supported for less than 10 existing message attributes until we find another way to propagate.

Fixes #1094