### PR TITLE
add e2e bench to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,19 @@ node-bench-base: &node-bench-base
         name: Benchmark Tracer
         command: yarn bench
 
+node-bench-e2e-base: &node-bench-e2e-base
+  resource_class: medium
+  working_directory: ~/dd-trace-js
+  steps:
+    - checkout
+    - *yarn-versions
+    - *restore-yarn-cache
+    - *yarn-install
+    - *save-yarn-cache
+    - run:
+        name: E2E Benchmark
+        command: yarn bench:e2e
+
 node-bench-profiler-base: &node-bench-profiler-base
   resource_class: small
   working_directory: ~/dd-trace-js
@@ -202,6 +215,15 @@ jobs:
     <<: *node-bench-profiler-base
     docker:
       - image: node
+
+  node-bench-e2e-latest:
+    <<: *node-bench-e2e-base
+    docker:
+      - image: node
+        environment:
+          - SERVICES=mongo
+          - PLUGINS=mongodb-core
+      - image: circleci/mongo
 
   # Core tests
 
@@ -943,6 +965,7 @@ workflows:
       - node-core-windows
       - node-bench-latest
       - node-bench-profiler-latest
+      - node-bench-e2e-latest
       - node-amqplib
       - node-amqp10
       # - node-aws-sdk
@@ -1119,6 +1142,7 @@ workflows:
       - node-core-windows
       - node-bench-latest
       - node-bench-profiler-latest
+      - node-bench-e2e-latest
       - node-amqplib
       - node-amqp10
       # - node-aws-sdk

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postpublish": "node scripts/postpublish.js",
     "bench": "node benchmark",
     "bench:profiler": "node benchmark/profiler",
-    "bench:e2e": "cd benchmark/e2e && node benchmark-run.js",
+    "bench:e2e": "SERVICES=mongo yarn services && cd benchmark/e2e && node benchmark-run.js --duration=30",
     "type:doc": "cd docs && yarn && yarn build",
     "type:test": "cd docs && yarn && yarn test",
     "lint": "node scripts/check_licenses.js && eslint .",


### PR DESCRIPTION
### What does this PR do?
Adds the e2e benchmark to CI

### Motivation
This way we have a repeatable and hopefully consistent way to smoke-test perf changes in CI.
