### PR TITLE
avoid C++ calls in some hot paths

### DIFF
--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -8,16 +8,8 @@ class NoopSpan extends Span {
   constructor (tracer, parent) {
     super()
 
-    // Avoid circular dependency
-    Object.defineProperties(this, {
-      _noopTracer: {
-        value: tracer
-      },
-
-      _noopContext: {
-        value: this._createContext(parent)
-      }
-    })
+    this._noopTracer = tracer
+    this._noopContext = this._createContext(parent)
   }
 
   _context () {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -154,15 +154,13 @@ const web = {
       return
     }
 
-    Object.defineProperty(req, '_datadog', {
-      value: {
-        span: null,
-        paths: [],
-        middleware: [],
-        beforeEnd: [],
-        config: {}
-      }
-    })
+    req._datadog = {
+      span: null,
+      paths: [],
+      middleware: [],
+      beforeEnd: [],
+      config: {}
+    }
   },
 
   // Return the request root span.
@@ -380,8 +378,7 @@ function addResourceTag (req) {
 
   if (tags['resource.name']) return
 
-  const resource = [req.method]
-    .concat(tags[HTTP_ROUTE])
+  const resource = [req.method, tags[HTTP_ROUTE]]
     .filter(val => val)
     .join(' ')
 


### PR DESCRIPTION
### What does this PR do?
Object.defineProperty and Object.defineProperties are implemented in
C++, and so we see the overhead of jumping to C++ in these cases.

The same happens with Array#concat.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
This should provide a slight improvement in performance, particularly when
traces aren't sampled.
