### PR TITLE
add a noop span around logging

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -30,7 +30,7 @@ class Tracer extends BaseTracer {
         const config = new Config(options)
 
         log.use(config.logger)
-        log.toggle(config.debug, config.logLevel)
+        log.toggle(config.debug, config.logLevel, this)
 
         platform.configure(config)
         platform.profiler().start()

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -264,4 +264,31 @@ describe('log', () => {
       expect(console.error).to.have.been.calledOnce
     })
   })
+
+  describe('tracing', () => {
+    it('should be disabled inside logging', (done) => {
+      let onceDone = () => {
+        onceDone = () => {}
+        done()
+      }
+      const tracer = require('../../dd-trace').init({
+        debug: true,
+        plugins: false,
+        service: 'test',
+        logger: {
+          debug: () => {
+            expect(!!tracer.scope().active().context()._noop).to.equal(true)
+            onceDone()
+          },
+          info: () => {},
+          warn: () => {},
+          error: () => {}
+        }
+      })
+      tracer.trace('testing.testing', () => {
+        expect(!!tracer.scope().active().context()._noop).to.equal(false)
+        log.debug()
+      })
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Does all internal logging within a NoopSpan, preventing instrumentation of
anything logging related.

### Motivation

In debug mode, when logging spans/traces, it's possible to use a logger that
calls instrumented code. This can result in infinite recursions or otherwise
loopy code flow. Surrounding the call with a NoopSpan prevents creating new
spans for logging.