### PR TITLE
disable debug metrics by default

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -11,7 +11,7 @@ const tagger = require('../tagger')
 const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 
 class DatadogSpan extends Span {
-  constructor (tracer, processor, sampler, prioritySampler, fields) {
+  constructor (tracer, processor, sampler, prioritySampler, fields, debug) {
     super()
 
     const operationName = fields.operationName
@@ -22,6 +22,7 @@ class DatadogSpan extends Span {
     const hostname = fields.hostname
 
     this._parentTracer = tracer
+    this._debug = debug
     this._sampler = sampler
     this._processor = processor
     this._prioritySampler = prioritySampler
@@ -33,7 +34,9 @@ class DatadogSpan extends Span {
 
     this._startTime = fields.startTime || this._getTime()
 
-    this._handle = platform.metrics().track(this)
+    if (debug) {
+      this._handle = platform.metrics().track(this)
+    }
   }
 
   toString () {
@@ -121,7 +124,11 @@ class DatadogSpan extends Span {
     this._duration = finishTime - this._startTime
     this._spanContext._trace.finished.push(this)
     this._spanContext._isFinished = true
-    this._handle.finish()
+
+    if (this._debug) {
+      this._handle.finish()
+    }
+
     this._processor.process(this)
   }
 }

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -35,6 +35,7 @@ class DatadogTracer extends Tracer {
     this._tags = config.tags
     this._logInjection = config.logInjection
     this._analytics = config.analytics
+    this._debug = config.debug
     this._prioritySampler = new PrioritySampler(config.env, config.experimental.sampler)
     this._exporter = new Exporter(config, this._prioritySampler)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)
@@ -71,7 +72,7 @@ class DatadogTracer extends Tracer {
       tags,
       startTime: fields.startTime,
       hostname: this._hostname
-    })
+    }, this._debug)
 
     span.addTags(this._tags)
     span.addTags(fields.tags)

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -21,7 +21,6 @@ class Scope extends Base {
 
     singleton = this
 
-    console.log(config)
     this._trackAsyncScope = config.trackAsyncScope && hasThenableBug
     this._debug = config.debug
     this._current = null

--- a/packages/dd-trace/src/scope/async_hooks.js
+++ b/packages/dd-trace/src/scope/async_hooks.js
@@ -21,7 +21,9 @@ class Scope extends Base {
 
     singleton = this
 
+    console.log(config)
     this._trackAsyncScope = config.trackAsyncScope && hasThenableBug
+    this._debug = config.debug
     this._current = null
     this._spans = new Map()
     this._types = new Map()
@@ -111,9 +113,11 @@ class Scope extends Base {
       this._weaks.set(resource, asyncId)
     }
 
-    const metrics = platform.metrics()
-    metrics.increment('runtime.node.async.resources')
-    metrics.increment('runtime.node.async.resources.by.type', `resource_type:${type}`)
+    if (this._debug) {
+      const metrics = platform.metrics()
+      metrics.increment('runtime.node.async.resources')
+      metrics.increment('runtime.node.async.resources.by.type', `resource_type:${type}`)
+    }
 
     if (this._trackAsyncScope && type === 'PROMISE') {
       this._initPromise()
@@ -132,7 +136,7 @@ class Scope extends Base {
   _destroy (asyncId) {
     const type = this._types.get(asyncId)
 
-    if (type) {
+    if (type && this._debug) {
       const metrics = platform.metrics()
       metrics.decrement('runtime.node.async.resources')
       metrics.decrement('runtime.node.async.resources.by.type', `resource_type:${type}`)

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -154,8 +154,8 @@ describe('Span', () => {
     expect(span.context()._tags).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
   })
 
-  it('should keep track of its memory lifecycle', () => {
-    span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+  it('should keep track of its memory lifecycle in debug mode', () => {
+    span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' }, true)
 
     expect(platform.metrics().track).to.have.been.calledWith(span)
 

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -74,7 +74,7 @@ describe('Tracer', () => {
       sampleRate: 0.5,
       logger: 'logger',
       tags: {},
-      debug: false,
+      debug: true,
       experimental: {}
     }
 
@@ -133,7 +133,7 @@ describe('Tracer', () => {
         },
         startTime: fields.startTime,
         hostname: undefined
-      })
+      }, true)
 
       expect(span.addTags).to.have.been.calledWith({
         'foo': 'bar'

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -13,7 +13,8 @@ const agent = require('../plugins/agent')
 const externals = require('../plugins/externals.json')
 
 const asyncHooksScope = new AsyncHooksScope({
-  trackAsyncScope: true
+  trackAsyncScope: true,
+  debug: true
 })
 
 chai.use(sinonChai)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable debug metrics by default.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some of the metrics we are reporting are always reported even though they are only used when debugging an issue with the tracer. Since these metrics are aggregated in hot paths (span start/finish and async hooks) they can cause unnecessary performance overhead and should be disabled by default.