### PR TITLE
fix logging of dropped traces not including the trace

### DIFF
--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -15,7 +15,7 @@ class SpanProcessor {
       this._prioritySampler.sample(spanContext)
 
       if (spanContext._traceFlags.sampled === false) {
-        log.debug(() => `Dropping trace due to user configured filtering: ${trace}`)
+        log.debug(() => `Dropping trace due to user configured filtering: ${trace.started}`)
         this._erase(trace)
         return
       }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix logging of dropped traces not including the trace.

### Motivation
<!-- What inspired you to submit this pull request? -->

The message logged included `[object Object]` instead of the trace because of an incorrect reference.