### PR TITLE
update agent exporter to always use 0.4 endpoint by default

### DIFF
--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -1,7 +1,5 @@
 'use strict'
 
-process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = 'v0.4'
-
 const benchmark = require('./benchmark')
 const proxyquire = require('proxyquire')
 const platform = require('../packages/dd-trace/src/platform')

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = 'v0.4'
-
 const execSync = require('child_process').execSync
 const exec = cmd => execSync(cmd, { stdio: [0, 1, 2] })
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -411,30 +411,31 @@ The following tags are available to override Datadog specific options:
 
 Options can be configured as a parameter to the [init()](./interfaces/tracer.html#init) method or as environment variables.
 
-| Config         | Environment Variable           | Default     | Description |
-| -------------- | ------------------------------ | ----------- | ----------- |
-| enabled        | `DD_TRACE_ENABLED`             | `true`         | Whether to enable the tracer. |
-| debug          | `DD_TRACE_DEBUG`               | `false`        | Enable debug logging in the tracer. |
-| service        | `DD_SERVICE`                   | -              | The service name to be used for this program. Defaults to value of the `name` field in `package.json`. |
-| version        | `DD_VERSION`                   | -              | The version number of the application. Defaults to value of the `version` field in `package.json`. |
-| url            | `DD_TRACE_AGENT_URL`           | -              | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
-| hostname       | `DD_TRACE_AGENT_HOSTNAME`      | `localhost`    | The address of the agent that the tracer will submit to. |
-| port           | `DD_TRACE_AGENT_PORT`          | `8126`         | The port of the trace agent that the tracer will submit to. |
-| dogstatsd.port | `DD_DOGSTATSD_PORT`            | `8125`         | The port of the Dogstatsd agent that metrics will be submitted to. |
-| env            | `DD_ENV`                       | -              | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
-| logInjection   | `DD_LOGS_INJECTION`            | `false`        | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| tags           | `DD_TAGS`                      | `{}`           | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value,key:value` |
-| sampleRate     | -                              | `1`            | Percentage of spans to sample as a float between 0 and 1. |
-| flushInterval  | -                              | `2000`         | Interval in milliseconds at which the tracer will submit traces to the agent. |
-| lookup         | -                              | `dns.lookup()` | Custom function for DNS lookups when sending requests to the agent. |
-| runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED`   | `false`        | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
-| reportHostname | `DD_TRACE_REPORT_HOSTNAME`     | `false`        | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |
-| experimental   | -                              | `{}`           | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Please contact us to learn more about the available experimental features. |
-| plugins        | -                              | `true`         | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
-| -              | `DD_TRACE_DISABLED_PLUGINS`    | -              | A comma-separated string of integration names automatically disabled when tracer is initialized. Environment variable only e.g. `DD_TRACE_DISABLED_PLUGINS=express,dns`. |
-| clientToken    | `DD_CLIENT_TOKEN`              | -              | Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`. |
-| logLevel       | `DD_TRACE_LOG_LEVEL`           | `debug`        | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `'error'`, `'debug'`. |
-| startupLogs    | `DD_TRACE_STARTUP_LOGS`        | `true`         | Enable tracer startup configuration and diagnostic log. |
+| Config          | Environment Variable              | Default     | Description |
+| --------------- | --------------------------------- | ----------- | ----------- |
+| enabled         | `DD_TRACE_ENABLED`                | `true`         | Whether to enable the tracer. |
+| debug           | `DD_TRACE_DEBUG`                  | `false`        | Enable debug logging in the tracer. |
+| service         | `DD_SERVICE`                      | -              | The service name to be used for this program. Defaults to value of the `name` field in `package.json`. |
+| version         | `DD_VERSION`                      | -              | The version number of the application. Defaults to value of the `version` field in `package.json`. |
+| url             | `DD_TRACE_AGENT_URL`              | -              | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
+| hostname        | `DD_TRACE_AGENT_HOSTNAME`         | `localhost`    | The address of the agent that the tracer will submit to. |
+| port            | `DD_TRACE_AGENT_PORT`             | `8126`         | The port of the trace agent that the tracer will submit to. |
+| dogstatsd.port  | `DD_DOGSTATSD_PORT`               | `8125`         | The port of the Dogstatsd agent that metrics will be submitted to. |
+| env             | `DD_ENV`                          | -              | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
+| logInjection    | `DD_LOGS_INJECTION`               | `false`        | Enable automatic injection of trace IDs in logs for supported logging libraries. |
+| tags            | `DD_TAGS`                         | `{}`           | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value,key:value` |
+| sampleRate      | -                                 | `1`            | Percentage of spans to sample as a float between 0 and 1. |
+| flushInterval   | -                                 | `2000`         | Interval in milliseconds at which the tracer will submit traces to the agent. |
+| lookup          | -                                 | `dns.lookup()` | Custom function for DNS lookups when sending requests to the agent. |
+| protocolVersion | `DD_TRACE_AGENT_PROTOCOL_VERSION` | `0.4`          | Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped. |
+| runtimeMetrics  | `DD_RUNTIME_METRICS_ENABLED`      | `false`        | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
+| reportHostname  | `DD_TRACE_REPORT_HOSTNAME`        | `false`        | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |
+| experimental    | -                                 | `{}`           | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Please contact us to learn more about the available experimental features. |
+| plugins         | -                                 | `true`         | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
+| -               | `DD_TRACE_DISABLED_PLUGINS`       | -              | A comma-separated string of integration names automatically disabled when tracer is initialized. Environment variable only e.g. `DD_TRACE_DISABLED_PLUGINS=express,dns`. |
+| clientToken     | `DD_CLIENT_TOKEN`                 | -              | Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`. |
+| logLevel        | `DD_TRACE_LOG_LEVEL`              | `debug`        | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `'error'`, `'debug'`. |
+| startupLogs     | `DD_TRACE_STARTUP_LOGS`           | `true`         | Enable tracer startup configuration and diagnostic log. |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "typedoc",
     "pretest": "tsc test",
-    "test": "DD_TRACE_AGENT_PROTOCOL_VERSION=v0.4 node test"
+    "test": "node test"
   },
   "license": "BSD-3-Clause",
   "private": true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -292,6 +292,12 @@ export declare interface TracerOptions {
   lookup?: LookupFunction
 
   /**
+   * Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped.
+   * @default 0.4
+   */
+  protocolVersion?: string
+
+  /**
    * Experimental features can be enabled all at once by using true or individually using key / value pairs.
    * @default {}
    */

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -99,8 +99,9 @@ class Config {
       false
     )
     const DD_TRACE_AGENT_PROTOCOL_VERSION = coalesce(
+      options.protocolVersion,
       platform.env('DD_TRACE_AGENT_PROTOCOL_VERSION'),
-      null
+      '0.4'
     )
 
     const sampler = (options.experimental && options.experimental.sampler) || {}

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -5,9 +5,9 @@ const Writer = require('./writer')
 const Scheduler = require('./scheduler')
 
 class AgentExporter {
-  constructor ({ url, hostname, port, flushInterval, lookup }, prioritySampler) {
+  constructor ({ url, hostname, port, flushInterval, lookup, protocolVersion }, prioritySampler) {
     this._url = url || new URL(`http://${hostname || 'localhost'}:${port}`)
-    this._writer = new Writer(this._url, prioritySampler, lookup)
+    this._writer = new Writer({ url: this._url, prioritySampler, lookup, protocolVersion })
 
     if (flushInterval > 0) {
       this._scheduler = new Scheduler(() => this._writer.flush(), flushInterval)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -22,6 +22,7 @@ describe('Config', () => {
     expect(config).to.have.property('service', 'node')
     expect(config).to.have.property('enabled', true)
     expect(config).to.have.property('debug', false)
+    expect(config).to.have.property('protocolVersion', '0.4')
     expect(config).to.have.nested.property('dogstatsd.hostname', '127.0.0.1')
     expect(config).to.have.nested.property('dogstatsd.port', '8125')
     expect(config).to.have.property('flushInterval', 2000)
@@ -63,6 +64,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_DOGSTATSD_PORT').returns('5218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('DD_TRACE_AGENT_PROTOCOL_VERSION').returns('0.5')
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
     platform.env.withArgs('DD_SERVICE').returns('service')
     platform.env.withArgs('DD_VERSION').returns('1.0.0')
@@ -78,6 +80,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
+    expect(config).to.have.property('protocolVersion', '0.5')
     expect(config).to.have.property('analytics', true)
     expect(config).to.have.property('hostname', 'agent')
     expect(config).to.have.nested.property('dogstatsd.hostname', 'dsd-agent')
@@ -139,6 +142,7 @@ describe('Config', () => {
     const config = new Config({
       enabled: false,
       debug: true,
+      protocolVersion: '0.5',
       analytics: true,
       site: 'datadoghq.eu',
       hostname: 'agent',
@@ -173,6 +177,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
+    expect(config).to.have.property('protocolVersion', '0.5')
     expect(config).to.have.property('analytics', true)
     expect(config).to.have.property('site', 'datadoghq.eu')
     expect(config).to.have.property('hostname', 'agent')
@@ -259,6 +264,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_DOGSTATSD_PORT').returns('5218')
     platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
     platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('DD_TRACE_AGENT_PROTOCOL_VERSION').returns('0.4')
     platform.env.withArgs('DD_TRACE_ANALYTICS').returns('true')
     platform.env.withArgs('DD_SERVICE').returns('service')
     platform.env.withArgs('DD_VERSION').returns('0.0.0')
@@ -272,6 +278,7 @@ describe('Config', () => {
     const config = new Config({
       enabled: true,
       debug: false,
+      protocolVersion: '0.5',
       analytics: false,
       protocol: 'https',
       site: 'datadoghq.com',
@@ -293,6 +300,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('enabled', true)
     expect(config).to.have.property('debug', false)
+    expect(config).to.have.property('protocolVersion', '0.5')
     expect(config).to.have.property('analytics', false)
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent2')

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -112,7 +112,6 @@ function withVersions (plugin, modules, range, cb) {
             process.env.NODE_PATH = [process.env.NODE_PATH, versionPath]
               .filter(x => x && x !== 'undefined')
               .join(os.platform() === 'win32' ? ';' : ':')
-            process.env.DD_TRACE_AGENT_PROTOCOL_VERISON = 'v0.4'
 
             require('module').Module._initPaths()
           })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update agent exporter to always use 0.4 endpoint by default.

### Motivation
<!-- What inspired you to submit this pull request? -->

The current logic to detect the agent protocol version at the tracer initialization can cause the tracer to stop reporting traces completely if the version of the agent changes at runtime. It also relies on failures to detect the protocol version and is unable to determine the version without trying all of them in sequence. This is made even worse with load-balanced agents on a separate cluster which may use multiple versions at the same time.

We will revisit detecting this automatically when we have a better design, and in the meantime the version will need to be updated manually as needed on a case by case basis.