### PR TITLE
fix graphql resolve span duration not accounting for wall time

### DIFF
--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -343,7 +343,7 @@ function finishResolvers (contextValue) {
 }
 
 function updateField (field, error) {
-  field.finishTime = platform.now()
+  field.finishTime = field.span.context()._trace.startTime + platform.now()
   field.error = field.error || error
 }
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -260,6 +260,7 @@ describe('Plugin', () => {
               expect(spans[1]).to.have.property('name', 'graphql.resolve')
               expect(spans[1]).to.have.property('resource', 'hello:String')
               expect(spans[1]).to.have.property('type', 'graphql')
+              expect(spans[1].duration.toNumber()).to.be.gt(0)
               expect(spans[1].meta).to.have.property('graphql.field.name', 'hello')
               expect(spans[1].meta).to.have.property('graphql.field.path', 'hello')
               expect(spans[1].meta).to.have.property('graphql.field.type', 'String')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `graphql` resolve span duration not accounting for wall time.

### Motivation
<!-- What inspired you to submit this pull request? -->

When the tracer was updated to use a trace-level monotonic clock, the behaviour of the `platform.now` util was also changed with the assumption that only the span was using this function, but it was also used by the `graphql`. The old implementation added the process uptime to `Date.now()` but the new implementation simply returns the uptime. This caused the plugin to use the process uptime as the finish time for the span, causing a negative duration.