### PR TITLE
add support for changing the pg service name based on connection params

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -204,6 +204,7 @@ tracer.use('net');
 tracer.use('paperplane');
 tracer.use('paperplane', httpServerOptions);
 tracer.use('pg');
+tracer.use('pg', { service: params => `${params.host}-${params.database}` });
 tracer.use('pino');
 tracer.use('promise-js');
 tracer.use('promise');

--- a/index.d.ts
+++ b/index.d.ts
@@ -524,7 +524,7 @@ declare namespace plugins {
     /**
      * The service name to be used for this plugin.
      */
-    service?: string;
+    service?: string | any;
 
     /** Whether to enable the plugin.
      * @default true
@@ -1027,7 +1027,12 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [pg](https://node-postgres.com/) module.
    */
-  interface pg extends Instrumentation {}
+  interface pg extends Instrumentation {
+    /**
+     * The service name to be used for this plugin. If a function is used, it will be passed the connection parameters and its return value will be used as the service name.
+     */
+    service?: string | ((params: any) => string);
+  }
 
   /**
    * This plugin patches the [pino](http://getpino.io)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for changing the `pg` service name based on connection params.

### Motivation
<!-- What inspired you to submit this pull request? -->

There are cases where an application may be using multiple Postgres instances where it would make sense to split by instance, user, database, or other connection parameters.

Closes #977