### PR TITLE
use undici, for a faster HTTP implementation

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -28,6 +28,7 @@ require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,source-map,BSD-3-Clause,Copyright 2009-2011 Mozilla Foundation and contributors
 require,source-map-resolve,MIT,Copyright 2014-2020 Simon Lydell 2019 Jinxiang
 require,tar,ISC,Copyright Isaac Z. Schlueter and Contributors
+require,undici,MIT,Copyright Matteo Collina and Undici contributors
 require,url-parse,MIT,Copyright 2015 Unshift.io Arnout Kazemier the Contributors
 require,whatwg-fetch,MIT,Copyright 2014-2016 GitHub Inc.
 dev,@babel/core,MIT,Copyright 2014-present Sebastian McKenzie and other contributors

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "url-parse": "^1.4.3",
     "whatwg-fetch": "^3.0.0"
   },
+  "optionalDependencies": {
+    "undici": "^2.0.5"
+  },
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",
@@ -94,7 +97,7 @@
     "body-parser": "^1.18.2",
     "chai": "^4.2.0",
     "checksum": "^0.1.1",
-    "codecov": "^3.5.0",
+    "codecov": "3.5.0",
     "dotenv": "^8.2.0",
     "eslint": "^4.15.0",
     "eslint-config-standard": "^11.0.0-beta.0",

--- a/packages/dd-trace/src/platform/node/request.js
+++ b/packages/dd-trace/src/platform/node/request.js
@@ -1,21 +1,12 @@
 'use strict'
 
-const http = require('http')
-const https = require('https')
-const { Readable } = require('stream')
-const agents = require('./agents')
 const semver = require('semver')
 const containerInfo = require('container-info').sync() || {}
-
-let undici
-if (semver.satisfies(process.versions.node, '^10.16.0 || ^12.3.0 || ^14.0.0')) {
-  try {
-    undici = require('undici')
-  } catch (_e) { /* */ }
-}
+const platform = require('../../platform')
 
 const containerId = containerInfo.containerId
-const pools = {}
+const undiciWorks = semver.satisfies(process.versions.node, '^10.16.0 || ^12.3.0 || ^14.0.0')
+
 let requestImpl
 
 function request (options = {}, callback) {
@@ -34,125 +25,18 @@ function request (options = {}, callback) {
   if (containerId) {
     options.headers['Datadog-Container-ID'] = containerId
   }
+  if (!requestImpl) setRequestImpl()
   return requestImpl.call(this, options, callback)
 }
 
-function bufArrify (data) {
-  if (!data) return Buffer.alloc(0)
-  if (data instanceof Buffer) return data
-  if (Array.isArray(data)) {
-    if (data.length === 1) return bufArrify(data[0])
-    const strm = new Readable()
-    for (const chunk of data) {
-      strm.push(chunk)
-    }
-    strm.push(null)
-    return strm
+function setRequestImpl () {
+  if (
+    undiciWorks && platform._config.experimental.undici
+  ) {
+    requestImpl = require('./request/undici')
+  } else {
+    requestImpl = require('./request/http')
   }
-}
-
-function requestUndici (options, callback) {
-  let cb = function (err, data, statusCode) {
-    cb = () => undefined
-    callback(err, data, statusCode)
-  }
-
-  let data = ''
-  let rxStatusCode
-  getPool(options).dispatch({
-    path: options.path,
-    method: options.method,
-    headers: options.headers,
-    body: bufArrify(options.data),
-    requestTimeout: options.timeout || 2000
-  }, {
-    onConnect () {},
-    onHeaders (statusCode) {
-      if (statusCode < 200 || statusCode > 299) {
-        const error = new Error(`Error from the agent: ${statusCode} ${http.STATUS_CODES[statusCode]}`)
-        error.status = statusCode
-
-        cb(error, null, statusCode)
-      }
-      rxStatusCode = statusCode
-    },
-    onData (chunk) {
-      data += chunk
-    },
-    onComplete () {
-      cb(null, data, rxStatusCode)
-    },
-    onError: e => {
-      callback(new Error(`Network error trying to reach the agent: ${e.message}`))
-    }
-  })
-}
-
-function requestHttp (options, callback) {
-  const platform = this
-
-  options = Object.assign({
-    headers: {},
-    data: [],
-    timeout: 2000
-  }, options)
-
-  const data = [].concat(options.data)
-  const isSecure = options.protocol === 'https:'
-  const { httpAgent, httpsAgent } = agents(platform._config)
-  const client = isSecure ? https : http
-  const agent = isSecure ? httpsAgent : httpAgent
-
-  options.agent = agent
-  options.headers['Content-Length'] = byteLength(data)
-
-  const req = client.request(options, res => {
-    let data = ''
-
-    res.setTimeout(options.timeout)
-
-    res.on('data', chunk => { data += chunk })
-    res.on('end', () => {
-      if (res.statusCode >= 200 && res.statusCode <= 299) {
-        callback(null, data, res.statusCode)
-      } else {
-        const error = new Error(`Error from the agent: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`)
-        error.status = res.statusCode
-
-        callback(error, null, res.statusCode)
-      }
-    })
-  })
-
-  req.setTimeout(options.timeout, req.abort)
-  req.on('error', e => callback(new Error(`Network error trying to reach the agent: ${e.message}`)))
-
-  data.forEach(buffer => req.write(buffer))
-
-  req.end()
-}
-
-function getPool (options) {
-  const url = `${options.protocol}//${options.hostname}${options.port ? `:${options.port}` : ''}`
-  let pool = pools[url]
-  if (!pool) {
-    pool = new undici.Pool(url)
-  }
-  return pool
-}
-
-function byteLength (data) {
-  let len = 0
-  for (const item of data) {
-    len += item.length
-  }
-  return len
-}
-
-if (undici) {
-  requestImpl = requestUndici
-} else {
-  requestImpl = requestHttp
 }
 
 module.exports = request

--- a/packages/dd-trace/src/platform/node/request.js
+++ b/packages/dd-trace/src/platform/node/request.js
@@ -3,11 +3,86 @@
 const http = require('http')
 const https = require('https')
 const agents = require('./agents')
+const semver = require('semver')
 const containerInfo = require('container-info').sync() || {}
 
-const containerId = containerInfo.containerId
+let undici
+if (semver.satisfies(process.versions.node, '^10.16.0 || ^12.3.0 || ^14.0.0')) {
+  try {
+    undici = require('undici')
+  } catch (_e) { /* */ }
+}
 
-function request (options, callback) {
+const containerId = containerInfo.containerId
+const pools = {}
+let requestImpl
+
+function request (options = {}, callback) {
+  if (!options.headers) {
+    options.headers = {}
+  }
+  if (!options.protocol) {
+    options.protocol = 'http:'
+  }
+  if (!options.hostname) {
+    options.hostname = 'localhost'
+  }
+  if (!options.port) {
+    options.port = options.protocol === 'https:' ? 443 : 80
+  }
+  if (containerId) {
+    options.headers['Datadog-Container-ID'] = containerId
+  }
+  return requestImpl.call(this, options, callback)
+}
+
+function bufArrify (data) {
+  if (!data) return Buffer.alloc(0)
+  if (data instanceof Buffer) return data
+  if (Array.isArray(data)) {
+    if (data.length === 1) return data[0]
+    return Buffer.concat(data)
+  }
+}
+
+function requestUndici (options, callback) {
+  let cb = function (err, data, statusCode) {
+    cb = () => undefined
+    callback(err, data, statusCode)
+  }
+
+  let data = ''
+  let rxStatusCode
+  getPool(options).dispatch({
+    path: options.path,
+    method: options.method,
+    headers: options.headers,
+    body: bufArrify(options.data),
+    requestTimeout: options.timeout || 2000
+  }, {
+    onConnect () {},
+    onHeaders (statusCode) {
+      if (statusCode < 200 || statusCode > 299) {
+        const error = new Error(`Error from the agent: ${statusCode} ${http.STATUS_CODES[statusCode]}`)
+        error.status = statusCode
+
+        cb(error, null, statusCode)
+      }
+      rxStatusCode = statusCode
+    },
+    onData (chunk) {
+      data += chunk
+    },
+    onComplete () {
+      cb(null, data, rxStatusCode)
+    },
+    onError: e => {
+      callback(new Error(`Network error trying to reach the agent: ${e.message}`))
+    }
+  })
+}
+
+function requestHttp (options, callback) {
   const platform = this
 
   options = Object.assign({
@@ -24,10 +99,6 @@ function request (options, callback) {
 
   options.agent = agent
   options.headers['Content-Length'] = byteLength(data)
-
-  if (containerId) {
-    options.headers['Datadog-Container-ID'] = containerId
-  }
 
   const req = client.request(options, res => {
     let data = ''
@@ -55,8 +126,27 @@ function request (options, callback) {
   req.end()
 }
 
+function getPool (options) {
+  const url = `${options.protocol}//${options.hostname}${options.port ? `:${options.port}` : ''}`
+  let pool = pools[url]
+  if (!pool) {
+    pool = new undici.Pool(url)
+  }
+  return pool
+}
+
 function byteLength (data) {
-  return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
+  let len = 0
+  for (const item of data) {
+    len += item.length
+  }
+  return len
+}
+
+if (undici) {
+  requestImpl = requestUndici
+} else {
+  requestImpl = requestHttp
 }
 
 module.exports = request

--- a/packages/dd-trace/src/platform/node/request.js
+++ b/packages/dd-trace/src/platform/node/request.js
@@ -2,6 +2,7 @@
 
 const http = require('http')
 const https = require('https')
+const { Readable } = require('stream')
 const agents = require('./agents')
 const semver = require('semver')
 const containerInfo = require('container-info').sync() || {}
@@ -40,8 +41,13 @@ function bufArrify (data) {
   if (!data) return Buffer.alloc(0)
   if (data instanceof Buffer) return data
   if (Array.isArray(data)) {
-    if (data.length === 1) return data[0]
-    return Buffer.concat(data)
+    if (data.length === 1) return bufArrify(data[0])
+    const strm = new Readable()
+    for (const chunk of data) {
+      strm.push(chunk)
+    }
+    strm.push(null)
+    return strm
   }
 }
 

--- a/packages/dd-trace/src/platform/node/request/http.js
+++ b/packages/dd-trace/src/platform/node/request/http.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const http = require('http')
+const https = require('https')
+const agents = require('../agents')
+
+function requestHttp (options, callback) {
+  const platform = this
+
+  options = Object.assign({
+    headers: {},
+    data: [],
+    timeout: 2000
+  }, options)
+
+  const data = [].concat(options.data)
+  const isSecure = options.protocol === 'https:'
+  const { httpAgent, httpsAgent } = agents(platform._config)
+  const client = isSecure ? https : http
+  const agent = isSecure ? httpsAgent : httpAgent
+
+  options.agent = agent
+  options.headers['Content-Length'] = byteLength(data)
+
+  const req = client.request(options, res => {
+    let data = ''
+
+    res.setTimeout(options.timeout)
+
+    res.on('data', chunk => { data += chunk })
+    res.on('end', () => {
+      if (res.statusCode >= 200 && res.statusCode <= 299) {
+        callback(null, data, res.statusCode)
+      } else {
+        const error = new Error(`Error from the agent: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`)
+        error.status = res.statusCode
+
+        callback(error, null, res.statusCode)
+      }
+    })
+  })
+
+  req.setTimeout(options.timeout, req.abort)
+  req.on('error', e => callback(new Error(`Network error trying to reach the agent: ${e.message}`)))
+
+  data.forEach(buffer => req.write(buffer))
+
+  req.end()
+}
+
+function byteLength (data) {
+  let len = 0
+  for (const item of data) {
+    len += item.length
+  }
+  return len
+}
+
+module.exports = requestHttp

--- a/packages/dd-trace/src/platform/node/request/undici.js
+++ b/packages/dd-trace/src/platform/node/request/undici.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const undici = require('undici')
+const { STATUS_CODES } = require('http')
+const { Readable } = require('stream')
+const pools = {}
+
+function requestUndici (options, callback) {
+  let cb = function (err, data, statusCode) {
+    cb = () => undefined
+    callback(err, data, statusCode)
+  }
+
+  let data = ''
+  let rxStatusCode
+  getPool(options).dispatch({
+    path: options.path,
+    method: options.method,
+    headers: options.headers,
+    body: bufArrify(options.data),
+    requestTimeout: options.timeout || 2000
+  }, {
+    onConnect () {},
+    onHeaders (statusCode) {
+      if (statusCode < 200 || statusCode > 299) {
+        const error = new Error(`Error from the agent: ${statusCode} ${STATUS_CODES[statusCode]}`)
+        error.status = statusCode
+
+        cb(error, null, statusCode)
+      }
+      rxStatusCode = statusCode
+    },
+    onData (chunk) {
+      data += chunk
+    },
+    onComplete () {
+      cb(null, data, rxStatusCode)
+    },
+    onError: e => {
+      callback(new Error(`Network error trying to reach the agent: ${e.message}`))
+    }
+  })
+}
+
+function getPool (options) {
+  const url = `${options.protocol}//${options.hostname}${options.port ? `:${options.port}` : ''}`
+  let pool = pools[url]
+  if (!pool) {
+    pool = new undici.Pool(url)
+  }
+  return pool
+}
+
+function bufArrify (data) {
+  if (!data) return Buffer.alloc(0)
+  if (data instanceof Buffer) return data
+  if (Array.isArray(data)) {
+    if (data.length === 1) return bufArrify(data[0])
+    const strm = new Readable()
+    for (const chunk of data) {
+      strm.push(chunk)
+    }
+    strm.push(null)
+    return strm
+  }
+}
+
+module.exports = requestUndici

--- a/packages/dd-trace/test/setup/netmock.js
+++ b/packages/dd-trace/test/setup/netmock.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const nock = require('nock')
+const semver = require('semver')
+
+const net = require('net')
+const url = require('url')
+const http = require('http')
+
+const mocks = new Set()
+
+class NetMock {
+  constructor (theUrl, opts = {}) {
+    this.opts = opts
+    this.origConnect = net.connect
+    theUrl = url.parse(theUrl)
+    net.connect = (port, hostname) => {
+      if (Number(port) === Number(theUrl.port) && hostname === theUrl.hostname) {
+        port = this.mockServer.address().port
+        hostname = 'localhost'
+      }
+      return this.origConnect(port, hostname)
+    }
+  }
+
+  put (path, body) {
+    this.putPath = path
+    if (body) {
+      this.putBody = typeof body === 'string' ? body : JSON.stringify(body)
+    }
+    return this
+  }
+
+  socketDelay (delay) {
+    this.socketDelay = delay
+    return this
+  }
+
+  reply (status, body) {
+    if (!this.putPath) {
+      throw new Error('you must call `put` first')
+    }
+    this.mockServer = http.createServer((req, res) => {
+      const respond = (status, body) => {
+        res.statusCode = status
+        res.end(body)
+        this.destroy()
+      }
+      if (req.url !== this.putPath || req.method !== 'PUT') {
+        respond(404)
+        return
+      }
+      if (this.opts.reqheaders) {
+        for (const headerName in this.opts.reqheaders) {
+          if (req.headers[headerName] !== this.opts.reqheaders[headerName]) {
+            respond(404)
+          }
+        }
+      }
+      let data = ''
+      req.on('data', d => {
+        data += d
+      })
+      req.on('end', () => {
+        if (this.putBody && data !== this.putBody) {
+          respond(404)
+          return
+        }
+
+        if (this.socketDelay) {
+          setTimeout(respond, this.socketDelay, status, body)
+        } else {
+          respond(status, body)
+        }
+      })
+    })
+    this.mockServer.listen(0)
+    mocks.add(this)
+  }
+
+  destroy () {
+    net.connect = this.origConnect
+    this.mockServer.close()
+    mocks.delete(this)
+  }
+}
+
+function mock (theUrl, opts) {
+  return new NetMock(theUrl, opts)
+}
+
+mock.cleanAll = () => {
+  mocks.forEach(m => m.destroy())
+}
+
+// these two are for nock compat, but have no real need with this implementation
+mock.disableNetConnect = () => {}
+mock.enableNetConnect = () => {}
+mock.isNetMock = true
+
+const supportsUndici = semver.satisfies(process.versions.node, '^10.16.0 || ^12.3.0 || ^14.0.0')
+if (supportsUndici) {
+  module.exports = mock
+} else {
+  module.exports = nock
+}

--- a/packages/dd-trace/test/setup/netmock.js
+++ b/packages/dd-trace/test/setup/netmock.js
@@ -99,8 +99,7 @@ mock.enableNetConnect = () => {}
 mock.isNetMock = true
 
 const supportsUndici = semver.satisfies(process.versions.node, '^10.16.0 || ^12.3.0 || ^14.0.0')
-if (supportsUndici) {
-  module.exports = mock
-} else {
-  module.exports = nock
+
+module.exports = function getMock (useUndici) {
+  return supportsUndici && useUndici ? mock : nock
 }


### PR DESCRIPTION
### What does this PR do?
Uses `undici` instead of the regular node `http` API.


Before:

```
$ yarn bench:e2e -- --duration=300
avg latency overhead % 52.27722772277228
avg requests overhead % 47.5775574317691
avg throughput overhead % 47.564089591711856
```

After:

```
$ yarn bench:e2e -- --duration=300
avg latency overhead % 39.0928725701944
avg requests overhead % 35.334456624993926
avg throughput overhead % 35.315102625776994
```

Results may vary.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
Better performance.
<!-- What inspired you to submit this pull request? -->
