### PR TITLE
pin codecov version

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "body-parser": "^1.18.2",
     "chai": "^4.2.0",
     "checksum": "^0.1.1",
-    "codecov": "^3.5.0",
+    "codecov": "3.5.0",
     "dotenv": "^8.2.0",
     "eslint": "^4.15.0",
     "eslint-config-standard": "^11.0.0-beta.0",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Pins the version of `codecov` to one that supports Node 8.

### Motivation
<!-- What inspired you to submit this pull request? -->
We have builds failing because of `teeny-request`, a dependency of `codecov`
that has recently dropped Node 8 support.

