### PR TITLE
Fix get rum data

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "services": "node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services",
     "tdd": "node scripts/tdd.js",
     "test": "SERVICES=* yarn services && mocha --exit --expose-gc 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
-    "test:core": "mocha --exit --expose-gc --file packages/dd-trace/test/setup/core.js \"packages/dd-trace/test/**/*.spec.js\"",
+    "test:core": "nyc --include \"packages/dd-trace/src/**/*.js\" -- mocha --exit --expose-gc --file packages/dd-trace/test/setup/core.js \"packages/dd-trace/test/**/*.spec.js\"",
     "test:plugins": "yarn services && nyc --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- mocha --exit --file \"packages/dd-trace/test/setup/core.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
     "test:browser": "karma start --single-run",
     "test:browserstack": "BROWSERSTACK=true karma start --single-run",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "services": "node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services",
     "tdd": "node scripts/tdd.js",
     "test": "SERVICES=* yarn services && mocha --exit --expose-gc 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
-    "test:core": "nyc --include \"packages/dd-trace/src/**/*.js\" -- mocha --exit --expose-gc --file packages/dd-trace/test/setup/core.js \"packages/dd-trace/test/**/*.spec.js\"",
+    "test:core": "mocha --exit --expose-gc --file packages/dd-trace/test/setup/core.js \"packages/dd-trace/test/**/*.spec.js\"",
     "test:plugins": "yarn services && nyc --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- mocha --exit --file \"packages/dd-trace/test/setup/core.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
     "test:browser": "karma start --single-run",
     "test:browserstack": "BROWSERSTACK=true karma start --single-run",

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -42,6 +42,10 @@ class NoopTracer extends Tracer {
     return null
   }
 
+  getRumData () {
+    return ''
+  }
+
   _startSpan (name, options) {
     return this._span
   }

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -42,6 +42,7 @@ class DatadogTracer extends Tracer {
     this._url = this._exporter._url
     this._sampler = new Sampler(config.sampleRate)
     this._peers = config.experimental.peers
+    this._enableGetRumData = config.experimental.enableGetRumData
     this._propagators = {
       [formats.TEXT_MAP]: new TextMapPropagator(config),
       [formats.HTTP_HEADERS]: new HttpPropagator(config),

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -125,15 +125,7 @@ class Tracer extends BaseTracer {
   }
 
   getRumData () {
-    if (!this._tracer._config.experimental.enableGetRumData) {
-      return ''
-    }
-    const span = this.scope().active().context()
-    const traceId = span._traceId
-    const traceTime = Date.now()
-    return `\
-<meta name="dd-trace-id" content="${traceId}" />\
-<meta name="dd-trace-time" content="${traceTime}" />`
+    return this._tracer.getRumData.apply(this._tracer, arguments)
   }
 }
 

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -112,7 +112,7 @@ class DatadogTracer extends Tracer {
       return ''
     }
     const span = this.scope().active().context()
-    const traceId = span._traceId
+    const traceId = span.toTraceId()
     const traceTime = Date.now()
     return `\
 <meta name="dd-trace-id" content="${traceId}" />\

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -106,6 +106,18 @@ class DatadogTracer extends Tracer {
   currentSpan () {
     return this.scope().active()
   }
+
+  getRumData () {
+    if (!this._enableGetRumData) {
+      return ''
+    }
+    const span = this.scope().active().context()
+    const traceId = span._traceId
+    const traceTime = Date.now()
+    return `\
+<meta name="dd-trace-id" content="${traceId}" />\
+<meta name="dd-trace-time" content="${traceTime}" />`
+  }
 }
 
 function addError (span, error) {

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -358,35 +358,5 @@ describe('TracerProxy', () => {
         expect(returnValue).to.equal('scopeManager')
       })
     })
-
-    describe('getRumData', () => {
-      beforeEach(() => {
-        const now = Date.now()
-        sinon.stub(Date, 'now').returns(now)
-      })
-
-      afterEach(() => {
-        Date.now.restore()
-      })
-
-      it('should be disabled by default', () => {
-        tracer.trace('getRumData', () => {
-          expect(tracer.getRumData()).to.equal('')
-        })
-      })
-
-      it('should return correct string', () => {
-        config.experimental.enableGetRumData = true
-        tracer.trace('getRumData', () => {
-          const data = tracer.getRumData()
-          const time = Date.now()
-          const re = /<meta name="dd-trace-id" content="([\d\w]+)" \/><meta name="dd-trace-time" content="(\d+)" \/>/
-          const [, traceId, traceTime] = re.exec(data)
-          const span = tracer.scope().active().context()
-          expect(traceId).to.equal(span._traceId.toString())
-          expect(traceTime).to.equal(time.toString())
-        })
-      })
-    })
   })
 })

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -309,7 +309,7 @@ describe('Tracer', () => {
         const re = /<meta name="dd-trace-id" content="([\d\w]+)" \/><meta name="dd-trace-time" content="(\d+)" \/>/
         const [, traceId, traceTime] = re.exec(data)
         const span = tracer.scope().active().context()
-        expect(traceId).to.equal(span._traceId.toString())
+        expect(traceId).to.equal(span.toTraceId())
         expect(traceTime).to.equal(time.toString())
       })
     })

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -285,6 +285,36 @@ describe('Tracer', () => {
     })
   })
 
+  describe('getRumData', () => {
+    beforeEach(() => {
+      const now = Date.now()
+      sinon.stub(Date, 'now').returns(now)
+    })
+
+    afterEach(() => {
+      Date.now.restore()
+    })
+
+    it('should be disabled by default', () => {
+      tracer.trace('getRumData', {}, () => {
+        expect(tracer.getRumData()).to.equal('')
+      })
+    })
+
+    it('should return correct string', () => {
+      tracer._enableGetRumData = true
+      tracer.trace('getRumData', {}, () => {
+        const data = tracer.getRumData()
+        const time = Date.now()
+        const re = /<meta name="dd-trace-id" content="([\d\w]+)" \/><meta name="dd-trace-time" content="(\d+)" \/>/
+        const [, traceId, traceTime] = re.exec(data)
+        const span = tracer.scope().active().context()
+        expect(traceId).to.equal(span._traceId.toString())
+        expect(traceTime).to.equal(time.toString())
+      })
+    })
+  })
+
   describe('wrap', () => {
     it('should return a new function that automatically calls tracer.trace()', () => {
       const it = {}


### PR DESCRIPTION
### What does this PR do?
This fixes `getRumData()`, before it raised an exception, and also used the wrong format for the trace id


### Motivation
Was trying to get correlation working with RUM for the initial load

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
