### PR TITLE
add native addons support for node 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,6 +687,8 @@ jobs:
 
   linux-x64-14:
     <<: *prebuild-linux-base
+    docker:
+      - image: node:12.0.0
     environment:
       - ARCH=x64
       - NODE_VERSIONS=14 - 15
@@ -768,6 +770,8 @@ jobs:
 
   linux-ia32-14:
     <<: *prebuild-linux-ia32-base
+    docker:
+      - image: node:12.0.0
     environment:
       - ARCH=ia32
       - NODE_VERSIONS=14 - 15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1067,9 +1067,7 @@ workflows:
           requires:
             - linux-x64-8
       # Linux ia32
-      - linux-ia32-15:
-          <<: *prebuild-job
-      - linux-ia32-14:
+      - linux-ia32-13:
           <<: *prebuild-job
       - linux-ia32-12:
           <<: *prebuild-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ prebuild-job: &prebuild-job
         - master
         - /v\d+\.\d+/
         - /.*native.*/
+        - /^node-\d+/
 
 jobs:
   # Linting
@@ -246,6 +247,11 @@ jobs:
     <<: *node-core-base
     docker:
       - image: node:14
+
+  node-core-15:
+    <<: *node-core-base
+    docker:
+      - image: node:15
 
   node-core-latest:
     <<: *node-core-base
@@ -421,6 +427,13 @@ jobs:
     <<: *node-plugin-base
     docker:
       - image: node:14
+        environment:
+          - PLUGINS=fs
+
+  node-fs-15:
+    <<: *node-plugin-base
+    docker:
+      - image: node:15
         environment:
           - PLUGINS=fs
 
@@ -700,6 +713,11 @@ jobs:
 
   ## Tests
 
+  linux-x64-15-test:
+    <<: *test-prebuild-linux-base
+    docker:
+      - image: node:15
+
   linux-x64-14-test:
     <<: *test-prebuild-linux-base
     docker:
@@ -748,6 +766,12 @@ jobs:
 
   # Prebuilds (linux ia32)
 
+  linux-ia32-14:
+    <<: *prebuild-linux-ia32-base
+    environment:
+      - ARCH=ia32
+      - NODE_VERSIONS=14 - 15
+
   linux-ia32-12:
     <<: *prebuild-linux-ia32-base
     environment:
@@ -770,10 +794,15 @@ jobs:
 
   ## Tests
 
-  linux-ia32-13-test:
+  linux-ia32-15-test:
     <<: *test-prebuild-linux-base
     docker:
-      - image: i386/node:13-alpine
+      - image: i386/node:15-alpine
+
+  linux-ia32-14-test:
+    <<: *test-prebuild-linux-base
+    docker:
+      - image: i386/node:14-alpine
 
   linux-ia32-12-test:
     <<: *test-prebuild-linux-base
@@ -961,6 +990,7 @@ workflows:
       - node-core-10
       - node-core-12
       - node-core-14
+      - node-core-15
       - node-core-latest
       - node-core-windows
       - node-bench-latest
@@ -982,6 +1012,7 @@ workflows:
       - node-fs-10
       - node-fs-12
       - node-fs-14
+      - node-fs-15
       - node-fs-latest
       - node-generic-pool
       - node-google-cloud-pubsub
@@ -1021,6 +1052,9 @@ workflows:
           <<: *prebuild-job
       - linux-x64-8:
           <<: *prebuild-job
+      - linux-x64-15-test:
+          requires:
+            - linux-x64-14
       - linux-x64-14-test:
           requires:
             - linux-x64-14
@@ -1034,15 +1068,20 @@ workflows:
           requires:
             - linux-x64-8
       # Linux ia32
+      - linux-ia32-14:
+          <<: *prebuild-job
       - linux-ia32-12:
           <<: *prebuild-job
       - linux-ia32-10:
           <<: *prebuild-job
       - linux-ia32-8:
           <<: *prebuild-job
-      - linux-ia32-13-test:
+      - linux-ia32-15-test:
           requires:
-            - linux-ia32-12
+            - linux-ia32-14
+      - linux-ia32-14-test:
+          requires:
+            - linux-ia32-14
       - linux-ia32-12-test:
           requires:
             - linux-ia32-12
@@ -1101,7 +1140,8 @@ workflows:
             - linux-x64-12-test
             - linux-x64-10-test
             - linux-x64-8-test
-            - linux-ia32-13-test
+            - linux-ia32-15-test
+            - linux-ia32-14-test
             - linux-ia32-12-test
             - linux-ia32-10-test
             - linux-ia32-8-test
@@ -1138,6 +1178,7 @@ workflows:
       - node-core-10
       - node-core-12
       - node-core-14
+      - node-core-15
       - node-core-latest
       - node-core-windows
       - node-bench-latest
@@ -1159,6 +1200,7 @@ workflows:
       - node-fs-10
       - node-fs-12
       - node-fs-14
+      - node-fs-15
       - node-fs-latest
       - node-generic-pool
       - node-google-cloud-pubsub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1067,8 +1067,6 @@ workflows:
           requires:
             - linux-x64-8
       # Linux ia32
-      - linux-ia32-13:
-          <<: *prebuild-job
       - linux-ia32-12:
           <<: *prebuild-job
       - linux-ia32-10:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,20 +774,6 @@ jobs:
 
   # Prebuilds (linux ia32)
 
-  linux-ia32-15:
-    <<: *prebuild-linux-ia32-base
-    docker:
-      - image: node:12.0.0
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=15
-
-  linux-ia32-14:
-    <<: *prebuild-linux-ia32-base
-    environment:
-      - ARCH=ia32
-      - NODE_VERSIONS=14
-
   linux-ia32-12:
     <<: *prebuild-linux-ia32-base
     environment:
@@ -810,15 +796,10 @@ jobs:
 
   ## Tests
 
-  linux-ia32-15-test:
+  linux-ia32-13-test:
     <<: *test-prebuild-linux-base
     docker:
-      - image: i386/node:15-alpine
-
-  linux-ia32-14-test:
-    <<: *test-prebuild-linux-base
-    docker:
-      - image: i386/node:14-alpine
+      - image: i386/node:13-alpine
 
   linux-ia32-12-test:
     <<: *test-prebuild-linux-base
@@ -1096,12 +1077,9 @@ workflows:
           <<: *prebuild-job
       - linux-ia32-8:
           <<: *prebuild-job
-      - linux-ia32-15-test:
+      - linux-ia32-13-test:
           requires:
-            - linux-ia32-15
-      - linux-ia32-14-test:
-          requires:
-            - linux-ia32-14
+            - linux-ia32-12
       - linux-ia32-12-test:
           requires:
             - linux-ia32-12
@@ -1161,8 +1139,7 @@ workflows:
             - linux-x64-12-test
             - linux-x64-10-test
             - linux-x64-8-test
-            - linux-ia32-15-test
-            - linux-ia32-14-test
+            - linux-ia32-13-test
             - linux-ia32-12-test
             - linux-ia32-10-test
             - linux-ia32-8-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -685,13 +685,19 @@ jobs:
 
   # Prebuilds (linux x64)
 
-  linux-x64-14:
+  linux-x64-15:
     <<: *prebuild-linux-base
     docker:
       - image: node:12.0.0
     environment:
       - ARCH=x64
-      - NODE_VERSIONS=14 - 15
+      - NODE_VERSIONS=15
+
+  linux-x64-14:
+    <<: *prebuild-linux-base
+    environment:
+      - ARCH=x64
+      - NODE_VERSIONS=14
 
   linux-x64-12:
     <<: *prebuild-linux-base
@@ -768,13 +774,19 @@ jobs:
 
   # Prebuilds (linux ia32)
 
-  linux-ia32-14:
+  linux-ia32-15:
     <<: *prebuild-linux-ia32-base
     docker:
       - image: node:12.0.0
     environment:
       - ARCH=ia32
-      - NODE_VERSIONS=14 - 15
+      - NODE_VERSIONS=15
+
+  linux-ia32-14:
+    <<: *prebuild-linux-ia32-base
+    environment:
+      - ARCH=ia32
+      - NODE_VERSIONS=14
 
   linux-ia32-12:
     <<: *prebuild-linux-ia32-base
@@ -1048,6 +1060,8 @@ workflows:
   prebuild:
     jobs:
       # Linux x64
+      - linux-x64-15:
+          <<: *prebuild-job
       - linux-x64-14:
           <<: *prebuild-job
       - linux-x64-12:
@@ -1058,7 +1072,7 @@ workflows:
           <<: *prebuild-job
       - linux-x64-15-test:
           requires:
-            - linux-x64-14
+            - linux-x64-15
       - linux-x64-14-test:
           requires:
             - linux-x64-14
@@ -1072,6 +1086,8 @@ workflows:
           requires:
             - linux-x64-8
       # Linux ia32
+      - linux-ia32-15:
+          <<: *prebuild-job
       - linux-ia32-14:
           <<: *prebuild-job
       - linux-ia32-12:
@@ -1082,7 +1098,7 @@ workflows:
           <<: *prebuild-job
       - linux-ia32-15-test:
           requires:
-            - linux-ia32-14
+            - linux-ia32-15
       - linux-ia32-14-test:
           requires:
             - linux-ia32-14
@@ -1140,6 +1156,7 @@ workflows:
       # Artifacts
       - prebuilds:
           requires:
+            - linux-x64-15-test
             - linux-x64-14-test
             - linux-x64-12-test
             - linux-x64-10-test

--- a/binding.gyp
+++ b/binding.gyp
@@ -33,9 +33,7 @@
           "-Wall",
           "-Werror"
         ],
-        "cflags_cc": [
-          "-Wno-cast-function-type"
-        ]
+        "cflags_cc": []
       }],
       ["OS == 'win'", {
         "cflags": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -33,7 +33,9 @@
           "-Wall",
           "-Werror"
         ],
-        "cflags_cc": []
+        "cflags_cc": [
+          "-Wno-cast-function-type"
+        ]
       }],
       ["OS == 'win'", {
         "cflags": [

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -21,7 +21,8 @@ const targets = [
   { version: '11.0.0', abi: '67' },
   { version: '12.0.0', abi: '72' },
   { version: '13.0.0', abi: '79' },
-  { version: '14.0.0', abi: '83' }
+  { version: '14.0.0', abi: '83' },
+  { version: '15.0.0', abi: '88' }
 ].filter(target => semver.satisfies(target.version, NODE_VERSIONS))
 
 prebuildify()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for Node 15.

### Motivation
<!-- What inspired you to submit this pull request? -->

Node 15 was released today. While not a stable version, it's still the latest so we should support it officially for the next 6 months until its end of life.