### PR TITLE
fix old versions of mongoose losing the asynchronous context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,6 +559,15 @@ jobs:
           - PLUGINS=mongodb-core
       - image: circleci/mongo
 
+  node-mongoose:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - SERVICES=mongo
+          - PLUGINS=mongoose
+      - image: circleci/mongo
+
   node-net:
     <<: *node-plugin-base
     docker:
@@ -996,6 +1005,7 @@ workflows:
       - node-memcached
       - node-microgateway-core
       - node-mongodb-core
+      - node-mongoose
       - node-mysql
       - node-net
       - node-paperplane
@@ -1173,6 +1183,7 @@ workflows:
       - node-memcached
       - node-microgateway-core
       - node-mongodb-core
+      - node-mongoose
       - node-mysql
       - node-net
       - node-paperplane

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -198,6 +198,7 @@ tracer.use('limitd-client');
 tracer.use('memcached');
 tracer.use('microgateway-core', httpServerOptions);
 tracer.use('mongodb-core');
+tracer.use('mongoose');
 tracer.use('mysql');
 tracer.use('mysql2');
 tracer.use('net');

--- a/index.d.ts
+++ b/index.d.ts
@@ -490,6 +490,7 @@ interface Plugins {
   "memcached": plugins.memcached;
   "microgateway-core": plugins.microgateway_core;
   "mongodb-core": plugins.mongodb_core;
+  "mongoose": plugins.mongoose;
   "mysql": plugins.mysql;
   "mysql2": plugins.mysql2;
   "net": plugins.net;
@@ -998,6 +999,12 @@ declare namespace plugins {
    * [mongodb-core](https://github.com/mongodb-js/mongodb-core) module.
    */
   interface mongodb_core extends Instrumentation {}
+
+  /**
+   * This plugin automatically instruments the
+   * [mongoose](https://mongoosejs.com/) module.
+   */
+  interface mongoose extends Instrumentation {}
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-plugin-mongoose/src/index.js
+++ b/packages/datadog-plugin-mongoose/src/index.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const tx = require('../../dd-trace/src/plugins/util/promise')
+
+function createWrapCollectionAddQueue (tracer, config) {
+  return function wrapAddQueue (addQueue) {
+    return function addQueueWithTrace (name) {
+      const scope = tracer.scope()
+
+      if (typeof name === 'function') {
+        arguments[0] = scope.bind(name)
+      } else if (typeof this[name] === 'function') {
+        arguments[0] = scope.bind((...args) => this[name](...args))
+      }
+
+      return addQueue.apply(this, arguments)
+    }
+  }
+}
+
+module.exports = [
+  {
+    name: 'mongoose',
+    versions: ['>=4.6.4'],
+    patch (mongoose, tracer, config) {
+      if (mongoose.Promise !== global.Promise) {
+        this.wrap(mongoose.Promise.prototype, 'then', tx.createWrapThen(tracer, config))
+      }
+
+      this.wrap(mongoose.Collection.prototype, 'addQueue', createWrapCollectionAddQueue(tracer, config))
+    },
+    unpatch (mongoose) {
+      if (mongoose.Promise !== global.Promise) {
+        this.unwrap(mongoose.Promise.prototype, 'then')
+      }
+
+      this.unwrap(mongoose.Collection.prototype, 'addQueue')
+    }
+  }
+]

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const plugin = require('../src')
+
+wrapIt()
+
+describe('Plugin', () => {
+  let id
+  let tracer
+  let collection
+
+  describe('mongoose', () => {
+    withVersions(plugin, ['mongoose'], (version) => {
+      let mongoose
+
+      beforeEach(() => {
+        id = require('../../dd-trace/src/id')
+        tracer = require('../../dd-trace')
+
+        collection = id().toString()
+
+        mongoose = require(`../../../versions/mongoose@${version}`).get()
+        mongoose.connect(`mongodb://localhost:27017/${collection}`, { useNewUrlParser: true, useUnifiedTopology: true })
+
+        return agent.load(['mongoose', 'mongodb-core'])
+      })
+
+      afterEach(() => {
+        return agent.close()
+      })
+
+      it('should propagate context with write operations', () => {
+        const Cat = mongoose.model('Cat', { name: String })
+
+        const span = {}
+        const kitty = new Cat({ name: 'Zildjian' })
+
+        return tracer.scope().activate(span, () => {
+          return kitty.save().then(() => {
+            expect(tracer.scope().active()).to.equal(span)
+          })
+        })
+      })
+
+      it('should propagate context with queries', () => {
+        const Cat = mongoose.model('Cat', { name: String })
+
+        const span = {}
+
+        return tracer.scope().activate(span, () => {
+          Cat.find({ name: 'Zildjian' }).exec(() => {
+            expect(tracer.scope().active()).to.equal(span)
+          })
+        })
+      })
+
+      it('should propagate context with aggregations', () => {
+        const Cat = mongoose.model('Cat', { name: String })
+
+        const span = {}
+
+        return tracer.scope().activate(span, () => {
+          Cat.aggregate([{ $match: { name: 'Zildjian' } }]).then(() => {
+            expect(tracer.scope().active()).to.equal(span)
+          })
+        })
+      })
+
+      it('should propagate context with promises', () => {
+        if (!mongoose.Promise.ES6) return // native promises
+
+        const promise = new mongoose.Promise.ES6((resolve) => {
+          setImmediate(resolve)
+        })
+
+        const span = {}
+
+        return tracer.scope().activate(span, () => {
+          return promise.then(() => {
+            expect(tracer.scope().active()).to.equal(span)
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -28,6 +28,7 @@ module.exports = {
   'memcached': require('../../../datadog-plugin-memcached/src'),
   'microgateway-core': require('../../../datadog-plugin-microgateway-core/src'),
   'mongodb-core': require('../../../datadog-plugin-mongodb-core/src'),
+  'mongoose': require('../../../datadog-plugin-mongoose/src'),
   'mysql': require('../../../datadog-plugin-mysql/src'),
   'mysql2': require('../../../datadog-plugin-mysql2/src'),
   'net': require('../../../datadog-plugin-net/src'),

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -59,6 +59,12 @@
       "versions": ["4.0.0"]
     }
   ],
+  "mongoose": [
+    {
+      "name": "mongodb-core",
+      "versions": ["3.2.7"]
+    }
+  ],
   "pg": [
     {
       "name": "pg-native",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix old versions of mongoose losing the asynchronous context.

Add
### Motivation
<!-- What inspired you to submit this pull request? -->

Context propagation is otherwise broken in Mongoose 4.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js