### PR TITLE
wrap emitter prototypes instead of instances where possible

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const web = require('../../dd-trace/src/plugins/util/web')
+const Scope = require('../../dd-trace/src/scope/base')
 
 function createWrapEmit (tracer, config) {
   config = web.normalizeConfig(config)
@@ -25,6 +26,9 @@ function plugin (name) {
       if (config.server === false) return
 
       this.wrap(http.Server.prototype, 'emit', createWrapEmit(tracer, config))
+      if (http.ServerResponse) { // not present on https
+        Scope._wrapEmitter(http.ServerResponse.prototype)
+      }
     },
     unpatch (http) {
       this.unwrap(http.Server.prototype, 'emit')


### PR DESCRIPTION
### What does this PR do?
We can wrap methods on prototypes of EventEmitter subclasses in order to more quickly bind their instances.

Right now, only doing this with ServerResponse, as it's always in a hot path.

Later on, we may do this for all EventEmitters.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
This boosts the performance of the `Scope#bind` operation, which happens, for
example, on every `req` and `res` object in HTTP server handlers.
