### PR TITLE
wrap end on prototype instead of instances

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -250,7 +250,6 @@ function finishMiddleware (req, res) {
 }
 
 function wrapEnd (req) {
-  const scope = req._datadog.tracer.scope()
   const res = req._datadog.res
   const end = res.end
 
@@ -270,15 +269,27 @@ function wrapEnd (req) {
     return returnValue
   }
 
-  Object.defineProperty(res, 'end', {
-    configurable: true,
-    get () {
-      return this._datadog_end
-    },
-    set (value) {
-      this._datadog_end = scope.bind(value, req._datadog.span)
-    }
-  })
+  res._datadog_req = req
+
+  if (!res._datadog_instrumented) {
+    const target = Reflect.getPrototypeOf(res)
+    Object.defineProperty(target, 'end', {
+      configurable: true,
+      get () {
+        return this._datadog_end || end
+      },
+      set (value) {
+        const req = this._datadog_req
+        if (req && req._datadog) {
+          const scope = req._datadog.tracer.scope()
+          this._datadog_end = scope.bind(value, req._datadog.span)
+        } else {
+          this._datadog_end = value
+        }
+      }
+    })
+    target._datadog_instrumented = true
+  }
 }
 
 function wrapWriteHead (req) {

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const http = require('http')
 const getPort = require('get-port')
 const agent = require('../agent')
 const types = require('../../../../../ext/types')
@@ -33,22 +34,22 @@ describe('plugins/util/web', () => {
   let tags
 
   beforeEach(() => {
-    req = {
+    req = Object.assign(Object.create(http.IncomingMessage.prototype), {
       method: 'GET',
       headers: {
         'host': 'localhost',
         'date': 'now'
       },
       connection: {}
-    }
+    })
     end = sinon.stub()
-    res = {
-      end,
+    const respProtoWithEnd = Object.assign(Object.create(http.ServerResponse.prototype), { end })
+    res = Object.assign(Object.create(respProtoWithEnd), {
       getHeader: sinon.stub(),
       getHeaders: sinon.stub().returns({}),
       setHeader: sinon.spy(),
       writeHead: () => {}
-    }
+    })
     res.getHeader.withArgs('server').returns('test')
     config = { hooks: {} }
 


### PR DESCRIPTION
### What does this PR do?
This avoids doing a costly Object.defineProperty on every single
instance of http.IncomingMessage passed to a server handler.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
Object.defineProperty is a costly performance hit, so it's better to avoid doing
it where we can.
<!-- What inspired you to submit this pull request? -->
