### PR TITLE
fix instrumented functions missing symbols from the original

### DIFF
--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -2,6 +2,7 @@
 
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
+const { promisify } = require('util')
 
 wrapIt()
 
@@ -134,6 +135,15 @@ describe('Plugin', () => {
 
           done()
         })
+      })
+    })
+
+    it('should work with promisify', () => {
+      const lookup = promisify(dns.lookup)
+
+      return lookup('localhost', 4).then(({ address, family }) => {
+        expect(address).to.equal('127.0.0.1')
+        expect(family).to.equal(4)
       })
     })
 

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -117,9 +117,13 @@ class Instrumenter {
 
     shimmer.massWrap.call(this, nodules, names, function (original, name) {
       const wrapped = wrapper(original, name)
+      const props = Object.getOwnPropertyDescriptors(original)
+      const keys = Reflect.ownKeys(props)
 
-      for (const sym of Object.getOwnPropertySymbols(original)) {
-        wrapped[sym] = original[sym]
+      for (const key of keys) {
+        if (typeof key !== 'symbol' || wrapped.hasOwnProperty(key)) continue
+
+        Object.defineProperty(wrapped, key, props[key])
       }
 
       return wrapped

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -115,7 +115,15 @@ class Instrumenter {
       })
     })
 
-    shimmer.massWrap.call(this, nodules, names, wrapper)
+    shimmer.massWrap.call(this, nodules, names, function (original, name) {
+      const wrapped = wrapper(original, name)
+
+      for (const sym of Object.getOwnPropertySymbols(original)) {
+        wrapped[sym] = original[sym]
+      }
+
+      return wrapped
+    })
   }
 
   unwrap (nodules, names, wrapper) {

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -120,6 +120,7 @@ class Instrumenter {
       const props = Object.getOwnPropertyDescriptors(original)
       const keys = Reflect.ownKeys(props)
 
+      // https://github.com/othiym23/shimmer/issues/19
       for (const key of keys) {
         if (typeof key !== 'symbol' || wrapped.hasOwnProperty(key)) continue
 

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -10,7 +10,6 @@ describe('Instrumenter', () => {
   let instrumenter
   let integrations
   let tracer
-  // let shimmer
 
   beforeEach(() => {
     tracer = {
@@ -52,12 +51,7 @@ describe('Instrumenter', () => {
       }
     }
 
-    // shimmer = sinon.spy()
-    // shimmer.massWrap = sinon.stub().callsFake(())
-    // shimmer.massUnwrap = sinon.spy()
-
     Instrumenter = proxyquire('../src/instrumenter', {
-      // 'shimmer': shimmer,
       './platform': {
         plugins: {
           'http': integrations.http,

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -2,13 +2,15 @@
 
 const proxyquire = require('proxyquire')
 const path = require('path')
+const shimmer = require('shimmer')
+const { expect } = require('chai')
 
 describe('Instrumenter', () => {
   let Instrumenter
   let instrumenter
   let integrations
   let tracer
-  let shimmer
+  // let shimmer
 
   beforeEach(() => {
     tracer = {
@@ -50,12 +52,12 @@ describe('Instrumenter', () => {
       }
     }
 
-    shimmer = sinon.spy()
-    shimmer.massWrap = sinon.spy()
-    shimmer.massUnwrap = sinon.spy()
+    // shimmer = sinon.spy()
+    // shimmer.massWrap = sinon.stub().callsFake(())
+    // shimmer.massUnwrap = sinon.spy()
 
     Instrumenter = proxyquire('../src/instrumenter', {
-      'shimmer': shimmer,
+      // 'shimmer': shimmer,
       './platform': {
         plugins: {
           'http': integrations.http,
@@ -299,12 +301,26 @@ describe('Instrumenter', () => {
 
     describe('wrap', () => {
       it('should wrap the method on the object', () => {
-        const obj = { method: () => {} }
-        const wrapper = () => {}
+        const method = () => {}
+        const obj = { method }
+        const wrapper = sinon.stub().returns(() => 'test')
 
         instrumenter.wrap(obj, 'method', wrapper)
 
-        expect(shimmer.massWrap).to.have.been.calledWith([obj], ['method'], wrapper)
+        expect(wrapper).to.have.been.calledWith(method, 'method')
+        expect(obj.method()).to.equal('test')
+      })
+
+      it('should preserve symbols on the method', () => {
+        const sym = Symbol('foo')
+        const obj = { method: () => {} }
+        const wrapper = () => () => {}
+
+        obj.method[sym] = 'bar'
+
+        instrumenter.wrap(obj, 'method', wrapper)
+
+        expect(obj.method).to.have.property(sym, 'bar')
       })
 
       it('should throw if the method does not exist', () => {
@@ -317,11 +333,13 @@ describe('Instrumenter', () => {
 
     describe('unwrap', () => {
       it('should wrap the method on the object', () => {
-        const obj = { method: () => {} }
+        const obj = { method: () => 'foo' }
+        const wrapper = () => () => 'bar'
 
+        instrumenter.wrap(obj, 'method', wrapper)
         instrumenter.unwrap(obj, 'method')
 
-        expect(shimmer.massUnwrap).to.have.been.calledWith([obj], ['method'])
+        expect(obj.method()).to.equal('foo')
       })
     })
 

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -323,6 +323,20 @@ describe('Instrumenter', () => {
         expect(obj.method).to.have.property(sym, 'bar')
       })
 
+      it('should not override existing symbols on the shim', () => {
+        const sym = Symbol('foo')
+        const obj = { method: () => {} }
+        const shim = () => {}
+        const wrapper = () => shim
+
+        shim[sym] = 'invalid'
+        obj.method[sym] = 'bar'
+
+        instrumenter.wrap(obj, 'method', wrapper)
+
+        expect(obj.method).to.have.property(sym, 'invalid')
+      })
+
       it('should throw if the method does not exist', () => {
         const obj = {}
         const wrapper = () => {}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix instrumented functions missing symbols from the original.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix #1120. It's not the first time that there is a symbol missing on a shim from a plugin, so I did the fix directly on `Instrumenter`. This makes `wrap` significantly slower, but it should only be called when patching so that should't be an issue.

There might be the same issue in some cases for non-symbol properties, but that may have more implications so for now I preferred to focus only on symbols, especially given their prominence in Node core.