### PR TITLE
allow agent url to be a promise in config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -219,8 +219,10 @@ export declare interface TracerOptions {
   /**
    * The url of the trace agent that the tracer will submit to.
    * Takes priority over hostname and port, if set.
+   *
+   * If set to a promise, the promise must resolve within one second.
    */
-  url?: string;
+  url?: string | Promise<string>;
 
   /**
    * The address of the trace agent that the tracer will submit to.

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -160,6 +160,23 @@ function describeWriter (protocolVersion) {
         })
       })
     })
+
+    context('with a promise url', () => {
+      beforeEach(() => {
+        url = Promise.resolve('http://localhost:8126')
+        writer = new Writer({ url, protocolVersion })
+      })
+      it('should make a request to resolved url', async () => {
+        encoder.count.returns(1)
+        writer.flush()
+        url = new URL(await url)
+        expect(platform.request).to.have.been.calledWithMatch({
+          protocol: url.protocol,
+          hostname: url.hostname,
+          port: url.port
+        })
+      })
+    })
   })
 }
 


### PR DESCRIPTION
### What does this PR do?
This allows users to asynchronously set the agent URL, which is useful
in service discovery situations.

The user is given 1 second to fetch the agent URL and resolve the promise. (We
can change this if we want.)

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
In many situations, users want to get agent connection info from some sort of
service discovery mechanism.

For example: Often, then end up doing something like this (or something that
transpiles to something like this:

```js
const tracer = require('dd-trace')
const axios = require('axios')
axios.get('https://service-discovery.example.com/trace-agent-url').then(res => {
  // all this runs _after_ express is required!
  tracer.init({ url: res.data })
})

const express = require('express')
const app = express()
app.get('/', () => { /* ... */ })
// ...
```

This results in us not instrumenting things that should have been instrumented,
because `tracer.init()` is called _after_ all the user's code has loaded.

The goal here is to make it easier for users to call `init()` before any
application code is run/required. By allowing the `url` parameter to be a
Promise, the code above can be rewritten as follows:

```js
const tracer = require('dd-trace')
const axios = require('axios')
tracer.init({
  url: axios.get('https://service-discovery.example.com/trace-agent-url').then(res => res.data)
})

const express = require('express')
const app = express()
app.get('/', () => { /* ... */ })
// ...
```

Now, `init` is called before even `express` is required or invoked, which is
exactly what we want to happen.
