### PR TITLE
allow setting agent url after initialization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,13 @@ export declare interface Tracer extends opentracing.Tracer {
   init(options?: TracerOptions): this;
 
   /**
+   * Sets the URL for the trace agent. This should only be called _after_
+   * init() is called, only in cases where the URL needs to be set after
+   * initialization.
+   */
+  setUrl(url: string): this;
+
+  /**
    * Enable and optionally configure a plugin.
    * @param plugin The name of a built-in plugin.
    * @param config Configuration options. Can also be `false` to disable the plugin.

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const URL = require('url-parse')
+const log = require('../../log')
 const Writer = require('./writer')
 const Scheduler = require('./scheduler')
 
@@ -13,6 +14,16 @@ class AgentExporter {
       this._scheduler = new Scheduler(() => this._writer.flush(), flushInterval)
     }
     this._scheduler && this._scheduler.start()
+  }
+
+  setUrl (url) {
+    try {
+      url = new URL(url)
+      this._url = url
+      this._writer.setUrl(url)
+    } catch (e) {
+      log.warn(e.stack)
+    }
   }
 
   export (spans) {

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -56,6 +56,10 @@ class Writer {
     })
   }
 
+  setUrl (url) {
+    this._url = url
+  }
+
   _encode (trace) {
     this._encoderForVersion.encode(trace)
   }

--- a/packages/dd-trace/src/exporters/browser/index.js
+++ b/packages/dd-trace/src/exporters/browser/index.js
@@ -37,6 +37,10 @@ class BrowserExporter {
     this._queue.push(json)
   }
 
+  setUrl (url) {
+    this._url = url
+  }
+
   _flush () {
     if (this._queue.length === 0) return
 

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -46,6 +46,9 @@ class NoopTracer extends Tracer {
     return ''
   }
 
+  setUrl () {
+  }
+
   _startSpan (name, options) {
     return this._span
   }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -89,6 +89,11 @@ class Tracer extends BaseTracer {
     return this._tracer.wrap(name, options, fn)
   }
 
+  setUrl () {
+    this._tracer.setUrl.apply(this._tracer, arguments)
+    return this
+  }
+
   startSpan () {
     return this._tracer.startSpan.apply(this._tracer, arguments)
   }

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -95,6 +95,10 @@ class DatadogTracer extends Tracer {
     }
   }
 
+  setUrl (url) {
+    this._exporter.setUrl(url)
+  }
+
   scopeManager () {
     return this._scopeManager
   }

--- a/packages/dd-trace/test/browser.test.js
+++ b/packages/dd-trace/test/browser.test.js
@@ -59,4 +59,11 @@ describe('dd-trace', () => {
 
     window.fetch && expect(fetch).to.have.been.called
   })
+
+  context('setUrl', () => {
+    it('should set the URL on the exporter', () => {
+      tracer.setUrl('http://example.com')
+      expect(tracer._tracer._exporter._url).to.equal('http://example.com')
+    })
+  })
 })

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const URL = require('url-parse')
+
 describe('Exporter', () => {
   let url
   let flushInterval
@@ -22,7 +24,8 @@ describe('Exporter', () => {
     }
     writer = {
       append: sinon.spy(),
-      flush: sinon.spy()
+      flush: sinon.spy(),
+      setUrl: sinon.spy()
     }
     prioritySampler = {}
     Scheduler = sinon.stub().returns(scheduler)
@@ -70,6 +73,18 @@ describe('Exporter', () => {
     it('should flush right away when interval is set to 0', () => {
       exporter.export([span])
       expect(writer.flush).to.have.been.called
+    })
+  })
+
+  describe('setUrl', () => {
+    beforeEach(() => {
+      exporter = new Exporter({ url })
+    })
+    it('should set the URL on self and writer', () => {
+      exporter.setUrl('http://example2.com')
+      const url = new URL('http://example2.com')
+      expect(exporter._url).to.deep.equal(url)
+      expect(writer.setUrl).to.have.been.calledWith(url)
     })
   })
 })

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -76,6 +76,22 @@ function describeWriter (protocolVersion) {
     })
   })
 
+  describe('setUrl', () => {
+    it('should set the URL used in the flush', () => {
+      const url = new URL('http://example.com:1234')
+      writer.setUrl(url)
+      writer.append([span])
+      encoder.count.returns(2)
+      encoder.makePayload.returns([Buffer.alloc(0)])
+      writer.flush()
+      expect(platform.request).to.have.been.calledWithMatch({
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port
+      })
+    })
+  })
+
   describe('flush', () => {
     it('should skip flushing if empty', () => {
       writer.flush()

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -24,7 +24,8 @@ describe('TracerProxy', () => {
       inject: sinon.stub().returns('tracer'),
       extract: sinon.stub().returns('spanContext'),
       currentSpan: sinon.stub().returns('current'),
-      scopeManager: sinon.stub().returns('scopeManager')
+      scopeManager: sinon.stub().returns('scopeManager'),
+      setUrl: sinon.stub()
     }
 
     noop = {
@@ -35,7 +36,8 @@ describe('TracerProxy', () => {
       inject: sinon.stub().returns('noop'),
       extract: sinon.stub().returns('spanContext'),
       currentSpan: sinon.stub().returns('current'),
-      scopeManager: sinon.stub().returns('scopeManager')
+      scopeManager: sinon.stub().returns('scopeManager'),
+      setUrl: sinon.stub()
     }
 
     log = {
@@ -262,6 +264,15 @@ describe('TracerProxy', () => {
         expect(returnValue).to.equal('scopeManager')
       })
     })
+
+    describe('setUrl', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.setUrl('http://example.com')
+
+        expect(noop.setUrl).to.have.been.calledWith('http://example.com')
+        expect(returnValue).to.equal(proxy)
+      })
+    })
   })
 
   describe('initialized', () => {
@@ -356,6 +367,15 @@ describe('TracerProxy', () => {
 
         expect(tracer.scopeManager).to.have.been.called
         expect(returnValue).to.equal('scopeManager')
+      })
+    })
+
+    describe('setUrl', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.setUrl('http://example.com')
+
+        expect(tracer.setUrl).to.have.been.calledWith('http://example.com')
+        expect(returnValue).to.equal(proxy)
       })
     })
   })

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -32,6 +32,14 @@ describe('Tracer', () => {
     })
 
     tracer = new Tracer(config)
+    tracer._exporter.setUrl = sinon.stub()
+  })
+
+  describe('setUrl', () => {
+    it('should pass the setUrl call to the exporter', () => {
+      tracer.setUrl('http://example.com')
+      expect(tracer._exporter.setUrl).to.have.been.calledWith('http://example.com')
+    })
   })
 
   describe('trace', () => {


### PR DESCRIPTION
### What does this PR do?
Enables re-setting the URL for the agent at any point after
initialization, to enable service discovery situations.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
In situations where users have to grab the agent URL from some service discovery
endpoint, we want them to be able re-set the URL once they have this information
available, so that they don't have to wait to initialize.
