### PR TITLE
fix ingestion rate limiter drifting on interval change

### DIFF
--- a/packages/dd-trace/src/rate_limiter.js
+++ b/packages/dd-trace/src/rate_limiter.js
@@ -7,29 +7,35 @@ class RateLimiter {
     this._rateLimit = parseInt(rateLimit)
     this._limiter = new limiter.RateLimiter(this._rateLimit, 'second')
     this._tokensRequested = 0
-    this._prevWindowRate = null
+    this._prevIntervalTokens = 0
+    this._prevTokensRequested = 0
   }
 
   isAllowed () {
     const curIntervalStart = this._limiter.curIntervalStart
+    const curIntervalTokens = this._limiter.tokensThisInterval
     const allowed = this._isAllowed()
 
     if (curIntervalStart !== this._limiter.curIntervalStart) {
-      this._prevWindowRate = this._currentWindowRate()
-      this._tokensRequested = 0
+      this._prevIntervalTokens = curIntervalTokens
+      this._prevTokensRequested = this._tokensRequested
+      this._tokensRequested = 1
+    } else {
+      this._tokensRequested++
     }
-
-    this._tokensRequested++
 
     return allowed
   }
 
   effectiveRate () {
-    const currentWindowRate = this._currentWindowRate()
+    if (this._rateLimit < 0) return 1
+    if (this._rateLimit === 0) return 0
+    if (this._tokensRequested === 0) return 1
 
-    if (this._prevWindowRate === null) return currentWindowRate
+    const allowed = this._prevIntervalTokens + this._limiter.tokensThisInterval
+    const requested = this._prevTokensRequested + this._tokensRequested
 
-    return (currentWindowRate + this._prevWindowRate) / 2
+    return allowed / requested
   }
 
   _isAllowed () {

--- a/packages/dd-trace/test/rate_limiter.spec.js
+++ b/packages/dd-trace/test/rate_limiter.spec.js
@@ -65,7 +65,25 @@ describe('RateLimiter', () => {
   })
 
   it('should average its effective rate with the previous rate', () => {
-    rateLimiter = new RateLimiter(1)
+    rateLimiter = new RateLimiter(2)
+
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+
+    clock.tick(1000)
+
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+
+    expect(rateLimiter.effectiveRate()).to.equal(0.5)
+  })
+
+  it('should properly reset the counters at each interval', () => {
+    rateLimiter = new RateLimiter(2)
 
     rateLimiter.isAllowed()
     rateLimiter.isAllowed()
@@ -73,8 +91,39 @@ describe('RateLimiter', () => {
     clock.tick(1000)
 
     rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
 
-    expect(rateLimiter.effectiveRate()).to.equal(0.75)
+    clock.tick(1000)
+
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+
+    expect(rateLimiter.effectiveRate()).to.equal(1)
+  })
+
+  it('should use 2 intervals to calculate the effective rate', () => {
+    rateLimiter = new RateLimiter(2)
+
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+
+    clock.tick(1000)
+
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+
+    clock.tick(1000)
+
+    rateLimiter.isAllowed()
+    rateLimiter.isAllowed()
+
+    expect(rateLimiter.effectiveRate()).to.equal(1)
   })
 
   it('should always have an effective rate of 0 when limit is 0', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix ingestion rate limiter drifting on interval change.

### Motivation
<!-- What inspired you to submit this pull request? -->

The current time and the number of requested tokens were not calculated in the correct order, leading to incorrect values used on an interval change.