### PR TITLE
fix memory leak in the async_local_storage scope manager

### DIFF
--- a/packages/dd-trace/src/scope/async_local_storage.js
+++ b/packages/dd-trace/src/scope/async_local_storage.js
@@ -22,9 +22,6 @@ class Scope extends Base {
   }
 
   _activate (span, callback) {
-    if (span === null) {
-      return this._storage.exit(callback)
-    }
     return this._storage.run(span, callback)
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix memory leak in the async_local_storage scope manager.

### Motivation
<!-- What inspired you to submit this pull request? -->

There is a bug in `AsyncLocalStorage` where `enterWith` may be called while in the callback of `exit`, causing the storage instance to be re-added to the internal storage list. This slows down the application continuously until it's no longer able to respond to requests. A fix will need to be done in Node, but in the meantime we can simply remove our call to `exit` since it was just an optimization that is unnecessary.

Fixes #1133 