### PR TITLE
add a fast path in toArray for length-8 IDs

### DIFF
--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -37,6 +37,9 @@ class Identifier {
 
   // msgpack-lite compatibility
   toArray () {
+    if (this._buffer.length === 8) {
+      return this._buffer
+    }
     return this._buffer.subarray(-8)
   }
 


### PR DESCRIPTION
### What does this PR do?

`Id#toArray` uses `subarray` to ensure only the last 8 bytes of the ID buffer are
used. However, in normal usage, the buffer is exacltly 8 bytes.

This call to subarray turns out to be needlessly costly, and I found that it
contributed roughly 8% of `encode`'s time in the benchmarks for that function.

This commit adds a check for the length of the buffer, and if it's 8, it's
returned immediately.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Performance

