### PR TITLE
Fix GraphQL span finishTime calculation

### DIFF
--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const pick = require('lodash.pick')
-const platform = require('../../dd-trace/src/platform')
 const log = require('../../dd-trace/src/log')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 
@@ -343,7 +342,7 @@ function finishResolvers (contextValue) {
 }
 
 function updateField (field, error) {
-  field.finishTime = field.span.context()._trace.startTime + platform.now()
+  field.finishTime = field.span._getTime()
   field.error = field.error || error
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the calculation of finishTime span value for GraphQL.

### Motivation
We are using dd-trace-js to monitor a GraphQL API and we noticed that the span times were not accurate. They were directly affected by the uptime of the node.js process (the longer the process was alive, the bigger the span times). 

### Additional Notes
Screenshots of the traces same GraphQL API call:
<img width="1177" alt="Screenshot 2020-10-26 at 16 48 44" src="https://user-images.githubusercontent.com/135173/97204478-09237880-17ae-11eb-94d8-5cdeca27e9a3.png">
Just after starting the server (notice also that the root span does not encompass the child-spans).


<img width="1175" alt="Screenshot 2020-10-26 at 16 55 10" src="https://user-images.githubusercontent.com/135173/97204564-222c2980-17ae-11eb-9db1-a5c6c1f7d979.png">
Approx 7 min after starting the server. 


<img width="1178" alt="Screenshot 2020-10-26 at 17 16 27" src="https://user-images.githubusercontent.com/135173/97205192-09704380-17af-11eb-8719-1d81bbfb8229.png">
After the fix.