### PR TITLE
faster check for integer in encoding

### DIFF
--- a/packages/dd-trace/src/encode/notepack.js
+++ b/packages/dd-trace/src/encode/notepack.js
@@ -105,7 +105,7 @@ function _encode(bytes, defers, value) {
     case 'number':
       // TODO: encode to float 32?
 
-      if (Math.floor(value) !== value || !isFinite(value)) { // float 64
+      if (!Number.isInteger(value)) { // float 64
         bytes.push(0xcb);
         defers.push({ float: value, length: 8, offset: bytes.length });
         return 9;


### PR DESCRIPTION
### What does this PR do?

Notepack does not make use of the modern `Number.isInteger` function, which is
quite a bit faster than checking if the floored number is equal and then
checking with `isFinite`. `Number.isInteger` provides all of this in one
function call.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Performance
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
