### PR TITLE
fix socket connect callback not running in parent scope

### DIFF
--- a/packages/datadog-plugin-net/src/index.js
+++ b/packages/datadog-plugin-net/src/index.js
@@ -8,8 +8,14 @@ function createWrapConnect (tracer, config) {
     return function connectWithTrace () {
       const scope = tracer.scope()
       const options = getOptions(arguments)
+      const lastIndex = arguments.length - 1
+      const callback = arguments[lastIndex]
 
       if (!options) return connect.apply(this, arguments)
+
+      if (typeof callback === 'function') {
+        arguments[lastIndex] = scope.bind(callback)
+      }
 
       const span = options.path
         ? wrapIpc(tracer, config, this, options)

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -219,5 +219,17 @@ describe('Plugin', () => {
       socket.connect({ port })
       socket.destroy()
     })
+
+    it('should run the connection callback in the correct scope', done => {
+      const socket = new net.Socket()
+
+      tracer.scope().activate(parent, () => {
+        socket.connect({ port }, () => {
+          expect(tracer.scope().active()).to.equal(parent)
+          socket.destroy()
+          done()
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix socket connect callback not running in parent scope.

### Motivation
<!-- What inspired you to submit this pull request? -->

Callbacks that are run after an operation should always be in the scope of the parent and not the operation itself since it has ended at that point.