### PR TITLE
add support for @grpc/grpc-js

### DIFF
--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -50,9 +50,7 @@ function wrapPackageDefinition (tracer, config, def) {
 function wrapClientConstructor (tracer, config, ServiceClient, methods) {
   const proto = ServiceClient.prototype
 
-  if (typeof methods !== 'object' || 'format' in methods) {
-    return ServiceClient
-  }
+  if (typeof methods !== 'object' || 'format' in methods) return
 
   Object.keys(methods)
     .forEach(name => {
@@ -70,8 +68,6 @@ function wrapClientConstructor (tracer, config, ServiceClient, methods) {
         proto[originalName] = wrapMethod(tracer, config, proto[originalName], path, methodKind)
       }
     })
-
-  return ServiceClient
 }
 
 function wrapMethod (tracer, config, method, path, methodKind) {

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -7,6 +7,8 @@ const kinds = require('./kinds')
 const { addMethodTags, addMetadataTags, getFilter } = require('./util')
 
 function createWrapLoadPackageDefinition (tracer, config) {
+  config = config.client || config
+
   return function wrapLoadPackageDefinition (loadPackageDefinition) {
     return function loadPackageDefinitionWithTrace (packageDef) {
       const result = loadPackageDefinition.apply(this, arguments)

--- a/packages/datadog-plugin-grpc/src/kinds.js
+++ b/packages/datadog-plugin-grpc/src/kinds.js
@@ -4,5 +4,7 @@ module.exports = {
   unary: 'unary',
   bidi: 'bidi_streaming',
   client_stream: 'client_streaming',
-  server_stream: 'server_streaming'
+  clientStream: 'client_streaming',
+  server_stream: 'server_streaming',
+  serverStream: 'server_streaming'
 }

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -25,7 +25,7 @@ function createWrapHandler (tracer, config, handler) {
 
     return function funcWithTrace (call, callback) {
       if (!isValid(this, arguments)) return func.apply(this, arguments)
-      // console.log(call.call)
+
       const metadata = call.metadata
       const type = this.type
       const isStream = type !== 'unary'

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -5,6 +5,9 @@ const getPort = require('get-port')
 const plugin = require('../src/client')
 const Readable = require('stream').Readable
 const kinds = require('../src/kinds')
+const loader = require('../../../versions/@grpc/proto-loader').get()
+const pkgs = ['grpc', '@grpc/grpc-js']
+// const pkgs = ['grpc']
 
 wrapIt()
 
@@ -13,7 +16,6 @@ describe('Plugin', () => {
   let port
   let server
   let tracer
-  let loader
 
   function buildClient (service, ClientService) {
     service = Object.assign({
@@ -23,20 +25,31 @@ describe('Plugin', () => {
       getUnary: () => {}
     }, service)
 
-    loader = require('../../../versions/@grpc/proto-loader').get()
-
     const definition = loader.loadSync(`${__dirname}/test.proto`)
     const TestService = grpc.loadPackageDefinition(definition).test.TestService
 
     server = new grpc.Server()
 
-    server.bind(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure())
-    server.addService(TestService.service, service)
-    server.start()
+    return new Promise((resolve, reject) => {
+      ClientService = ClientService || TestService
 
-    ClientService = ClientService || TestService
+      if (server.bindAsync) {
+        server.bindAsync(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure(), (err) => {
+          if (err) return reject(err)
 
-    return new ClientService(`localhost:${port}`, grpc.credentials.createInsecure())
+          server.addService(TestService.service, service)
+          server.start()
+
+          resolve(new ClientService(`localhost:${port}`, grpc.credentials.createInsecure()))
+        })
+      } else {
+        server.bind(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure())
+        server.addService(TestService.service, service)
+        server.start()
+
+        resolve(new ClientService(`localhost:${port}`, grpc.credentials.createInsecure()))
+      }
+    })
   }
 
   describe('grpc/client', () => {
@@ -50,531 +63,505 @@ describe('Plugin', () => {
       server.forceShutdown()
     })
 
-    withVersions(plugin, 'grpc', version => {
-      describe('without configuration', () => {
-        before(() => {
-          return agent.load('grpc', { server: false })
-            .then(() => {
-              tracer = require('../../dd-trace')
-              grpc = require(`../../../versions/grpc@${version}`).get()
-            })
-        })
-
-        after(() => {
-          return agent.close()
-        })
-
-        it('should handle `unary` calls', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
+    for (const pkg of pkgs) {
+      withVersions(plugin, pkg, version => {
+        describe('without configuration', () => {
+          before(() => {
+            return agent.load('grpc', { server: false })
+              .then(() => {
+                tracer = require('../../dd-trace')
+                grpc = require(`../../../versions/${pkg}@${version}`).get()
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test-grpc-client',
-                resource: '/test.TestService/getUnary'
-              })
-
-              expect(traces[0][0].meta).to.include({
-                'grpc.method.name': 'getUnary',
-                'grpc.method.service': 'TestService',
-                'grpc.method.package': 'test',
-                'grpc.method.path': '/test.TestService/getUnary',
-                'grpc.method.kind': kinds.unary,
-                'span.kind': 'client',
-                'component': 'grpc'
-              })
-
-              expect(traces[0][0].metrics).to.include({
-                'grpc.status.code': 0
-              })
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-
-        it('should handle `server_stream` calls', done => {
-          const client = buildClient({
-            getServerStream: stream => {
-              stream.end()
-            }
+          after(() => {
+            return agent.close()
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test-grpc-client',
-                resource: '/test.TestService/getServerStream'
-              })
-
-              expect(traces[0][0].meta).to.include({
-                'grpc.method.name': 'getServerStream',
-                'grpc.method.service': 'TestService',
-                'grpc.method.package': 'test',
-                'grpc.method.path': '/test.TestService/getServerStream',
-                'grpc.method.kind': kinds.server_stream,
-                'span.kind': 'client',
-                'component': 'grpc'
-              })
-
-              expect(traces[0][0].metrics).to.include({
-                'grpc.status.code': 0
-              })
+          it('should handle `unary` calls', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
             })
-            .then(done)
-            .catch(done)
 
-          const call = client.getServerStream({ first: 'foobar' })
+            client.getUnary({ first: 'foobar' }, () => {})
 
-          call.on('data', () => {})
-        })
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test-grpc-client',
+                  resource: '/test.TestService/getUnary'
+                })
 
-        it('should handle `client_stream` calls', done => {
-          const client = buildClient({
-            getClientStream: (_, callback) => {
-              callback()
-            }
+                expect(traces[0][0].meta).to.include({
+                  'grpc.method.name': 'getUnary',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.package': 'test',
+                  'grpc.method.path': '/test.TestService/getUnary',
+                  'grpc.method.kind': kinds.unary,
+                  'span.kind': 'client',
+                  'component': 'grpc'
+                })
+
+                expect(traces[0][0].metrics).to.include({
+                  'grpc.status.code': 0
+                })
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test-grpc-client',
-                resource: '/test.TestService/getClientStream'
-              })
-
-              expect(traces[0][0].meta).to.include({
-                'grpc.method.name': 'getClientStream',
-                'grpc.method.service': 'TestService',
-                'grpc.method.package': 'test',
-                'grpc.method.path': '/test.TestService/getClientStream',
-                'grpc.method.kind': kinds.client_stream,
-                'span.kind': 'client',
-                'component': 'grpc'
-              })
-
-              expect(traces[0][0].metrics).to.include({
-                'grpc.status.code': 0
-              })
-            })
-            .then(done)
-            .catch(done)
-
-          client.getClientStream(() => {})
-        })
-
-        it('should handle `bidi` calls', done => {
-          const client = buildClient({
-            getBidi: stream => stream.end()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test-grpc-client',
-                resource: '/test.TestService/get_Bidi'
-              })
-              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
-              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
-              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-            })
-            .then(done)
-            .catch(done)
-
-          const call = client.getBidi(new Readable())
-
-          call.on('data', () => {})
-        })
-
-        it('should handle cancelled `unary` calls', done => {
-          let call = null
-          const client = buildClient({
-            getUnary: () => call.cancel()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-            })
-            .then(done)
-            .catch(done)
-
-          call = client.getUnary({ first: 'foobar' }, () => {})
-        })
-
-        it('should handle cancelled `stream` calls', done => {
-          let call = null
-          const client = buildClient({
-            getServerStream: () => call.cancel()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-            })
-            .then(done)
-            .catch(done)
-
-          call = client.getServerStream({ first: 'foobar' })
-          call.on('data', () => {})
-          call.on('error', () => {})
-        })
-
-        it('should handle cancelled `bidi` calls', done => {
-          let call = null
-          const client = buildClient({
-            getBidi: () => call.cancel()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-            })
-            .then(done)
-            .catch(done)
-
-          call = client.getBidi(new Readable(), () => {})
-          call.on('data', () => {})
-          call.on('error', () => {})
-        })
-
-        it('should handle errors', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback(new Error('foobar'))
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
-              expect(traces[0][0].meta).to.include({
-                'error.msg': '2 UNKNOWN: foobar',
-                'error.type': 'Error',
-                'grpc.method.name': 'getUnary',
-                'grpc.method.service': 'TestService',
-                'grpc.method.package': 'test',
-                'grpc.method.path': '/test.TestService/getUnary',
-                'grpc.method.kind': kinds.unary,
-                'span.kind': 'client',
-                'component': 'grpc'
-              })
-              expect(traces[0][0].meta).to.have.property('error.stack')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 2)
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-
-        it('should handle protocol errors', done => {
-          const definition = loader.loadSync(`${__dirname}/invalid.proto`)
-          const test = grpc.loadPackageDefinition(definition).test
-          const client = buildClient({
-            getUnary: (_, callback) => callback(null)
-          }, test.TestService)
-
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
-              expect(traces[0][0].meta).to.include({
-                'error.msg': '13 INTERNAL: Failed to parse server response',
-                'error.type': 'Error',
-                'grpc.method.name': 'getUnary',
-                'grpc.method.service': 'TestService',
-                'grpc.method.package': 'test',
-                'grpc.method.path': '/test.TestService/getUnary',
-                'grpc.method.kind': kinds.unary,
-                'span.kind': 'client',
-                'component': 'grpc'
-              })
-              expect(traces[0][0].meta).to.have.property('error.stack')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 13)
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-
-        it('should handle a missing callback', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test-grpc-client',
-                resource: '/test.TestService/getUnary'
-              })
-
-              expect(traces[0][0].meta).to.include({
-                'grpc.method.name': 'getUnary',
-                'grpc.method.service': 'TestService',
-                'grpc.method.package': 'test',
-                'grpc.method.path': '/test.TestService/getUnary',
-                'grpc.method.kind': kinds.unary,
-                'span.kind': 'client',
-                'component': 'grpc'
-              })
-
-              expect(traces[0][0].metrics).to.deep.include({
-                'grpc.status.code': 0
-              })
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' })
-        })
-
-        it('should inject its parent span in the metadata', done => {
-          const client = buildClient({
-            getUnary: (call, callback) => {
-              const metadata = call.metadata.getMap()
-
-              callback(null, {})
-
-              try {
-                expect(metadata).to.have.property('foo', 'bar')
-                expect(metadata['x-datadog-trace-id']).to.be.a('string')
-                expect(metadata['x-datadog-parent-id']).to.be.a('string')
-
-                done()
-              } catch (e) {
-                done(e)
+          it('should handle `server_stream` calls', async () => {
+            const client = await buildClient({
+              getServerStream: stream => {
+                stream.end()
               }
-            }
-          })
-
-          const metadata = new grpc.Metadata()
-
-          metadata.set('foo', 'bar')
-
-          client.getUnary({ first: 'foobar' }, metadata, () => {})
-        })
-
-        it('should propagate the parent scope to the callback', done => {
-          const span = {}
-          const client = buildClient({
-            getUnary: (call, callback) => callback()
-          })
-
-          tracer.scope().activate(span, () => {
-            client.getUnary({ first: 'foobar' }, (err, response) => {
-              expect(tracer.scope().active()).to.equal(span)
-              done(err)
             })
+
+            const call = client.getServerStream({ first: 'foobar' })
+
+            call.on('data', () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test-grpc-client',
+                  resource: '/test.TestService/getServerStream'
+                })
+
+                expect(traces[0][0].meta).to.include({
+                  'grpc.method.name': 'getServerStream',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.package': 'test',
+                  'grpc.method.path': '/test.TestService/getServerStream',
+                  'grpc.method.kind': kinds.server_stream,
+                  'span.kind': 'client',
+                  'component': 'grpc'
+                })
+
+                expect(traces[0][0].metrics).to.include({
+                  'grpc.status.code': 0
+                })
+              })
           })
-        })
 
-        it('should propagate the parent scope to event listeners', done => {
-          const span = {}
-          const client = buildClient({
-            getServerStream: stream => {
-              stream.write('test')
-              stream.end()
-            }
-          })
-
-          const call = client.getServerStream({ first: 'foobar' })
-
-          tracer.scope().activate(span, () => {
-            call.on('data', () => {
-              expect(tracer.scope().active()).to.equal(span)
-              done()
+          it.only('should handle `client_stream` calls', async () => {
+            const client = await buildClient({
+              getClientStream: (_, callback) => {
+                setTimeout(callback, 40)
+              }
             })
+
+            client.getClientStream(() => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test-grpc-client',
+                  resource: '/test.TestService/getClientStream'
+                })
+
+                expect(traces[0][0].meta).to.include({
+                  'grpc.method.name': 'getClientStream',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.package': 'test',
+                  'grpc.method.path': '/test.TestService/getClientStream',
+                  'grpc.method.kind': kinds.client_stream,
+                  'span.kind': 'client',
+                  'component': 'grpc'
+                })
+
+                expect(traces[0][0].metrics).to.include({
+                  'grpc.status.code': 0
+                })
+              })
           })
-        })
-      })
 
-      describe('with service configuration', () => {
-        before(() => {
-          const config = {
-            client: {
-              service: 'custom'
-            },
-            server: false
-          }
-
-          return agent.load('grpc', config)
-            .then(() => {
-              grpc = require(`../../../versions/grpc@${version}`).get()
+          it('should handle `bidi` calls', async () => {
+            const client = await buildClient({
+              getBidi: stream => stream.end()
             })
-        })
 
-        after(() => {
-          return agent.close()
-        })
+            const call = client.getBidi(new Readable())
 
-        it('should be configured with the correct values', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
+            call.on('data', () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test-grpc-client',
+                  resource: '/test.TestService/get_Bidi'
+                })
+                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
+                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
+                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
+                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
+          it('should handle cancelled `unary` calls', async () => {
+            let call = null
+            const client = await buildClient({
+              getUnary: () => call.cancel()
+            })
+
+            call = client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+              })
+          })
+
+          it('should handle cancelled `stream` calls', async () => {
+            let call = null
+            const client = await buildClient({
+              getServerStream: () => call.cancel()
+            })
+
+            call = client.getServerStream({ first: 'foobar' })
+            call.on('data', () => {})
+            call.on('error', () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+              })
+          })
+
+          it('should handle cancelled `bidi` calls', async () => {
+            let call = null
+            const client = await buildClient({
+              getBidi: () => call.cancel()
+            })
+
+            call = client.getBidi(new Readable(), () => {})
+            call.on('data', () => {})
+            call.on('error', () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+              })
+          })
+
+          it('should handle errors', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback(new Error('foobar'))
+            })
+
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0].meta).to.include({
+                  'error.msg': '2 UNKNOWN: foobar',
+                  'error.type': 'Error',
+                  'grpc.method.name': 'getUnary',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.package': 'test',
+                  'grpc.method.path': '/test.TestService/getUnary',
+                  'grpc.method.kind': kinds.unary,
+                  'span.kind': 'client',
+                  'component': 'grpc'
+                })
+                expect(traces[0][0].meta).to.have.property('error.stack')
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 2)
+              })
+          })
+
+          it('should handle protocol errors', async () => {
+            const definition = loader.loadSync(`${__dirname}/invalid.proto`)
+            const test = grpc.loadPackageDefinition(definition).test
+            const client = await buildClient({
+              getUnary: (_, callback) => callback(null)
+            }, test.TestService)
+
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0].meta).to.include({
+                  'error.type': 'Error',
+                  'grpc.method.name': 'getUnary',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.package': 'test',
+                  'grpc.method.path': '/test.TestService/getUnary',
+                  'grpc.method.kind': kinds.unary,
+                  'span.kind': 'client',
+                  'component': 'grpc'
+                })
+                expect(traces[0][0].meta).to.have.property('error.stack')
+                expect(traces[0][0].meta['error.msg']).to.match(/^13 INTERNAL:.+$/)
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 13)
+              })
+          })
+
+          it('should handle a missing callback', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
+            })
+
+            client.getUnary({ first: 'foobar' })
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test-grpc-client',
+                  resource: '/test.TestService/getUnary'
+                })
+
+                expect(traces[0][0].meta).to.include({
+                  'grpc.method.name': 'getUnary',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.package': 'test',
+                  'grpc.method.path': '/test.TestService/getUnary',
+                  'grpc.method.kind': kinds.unary,
+                  'span.kind': 'client',
+                  'component': 'grpc'
+                })
+
+                expect(traces[0][0].metrics).to.deep.include({
+                  'grpc.status.code': 0
+                })
+              })
+          })
+
+          it('should inject its parent span in the metadata', done => {
+            buildClient({
+              getUnary: (call, callback) => {
+                const metadata = call.metadata.getMap()
+
+                callback(null, {})
+
+                try {
+                  expect(metadata).to.have.property('foo', 'bar')
+                  expect(metadata['x-datadog-trace-id']).to.be.a('string')
+                  expect(metadata['x-datadog-parent-id']).to.be.a('string')
+
+                  done()
+                } catch (e) {
+                  done(e)
+                }
+              }
+            }).then(client => {
+              const metadata = new grpc.Metadata()
+
+              metadata.set('foo', 'bar')
+
+              client.getUnary({ first: 'foobar' }, metadata, () => {})
+            }, done)
+          })
+
+          it('should propagate the parent scope to the callback', done => {
+            const span = {}
+
+            buildClient({
+              getUnary: (call, callback) => callback()
+            }).then(client => {
+              tracer.scope().activate(span, () => {
+                client.getUnary({ first: 'foobar' }, (err, response) => {
+                  expect(tracer.scope().active()).to.equal(span)
+                  done(err)
+                })
+              })
+            }, done)
+          })
+
+          it('should propagate the parent scope to event listeners', done => {
+            const span = {}
+
+            buildClient({
+              getServerStream: stream => {
+                stream.write('test')
+                stream.end()
+              }
+            }).then(client => {
+              const call = client.getServerStream({ first: 'foobar' })
+
+              tracer.scope().activate(span, () => {
+                call.on('data', () => {
+                  expect(tracer.scope().active()).to.equal(span)
+                  done()
+                })
+              })
+            }, done)
+          })
+        })
+
+        describe('with service configuration', () => {
+          before(() => {
+            const config = {
+              client: {
                 service: 'custom'
-              })
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-      })
-
-      describe('with a metadata function', () => {
-        before(() => {
-          const config = {
-            client: {
-              metadata: values => values
-            },
-            server: false
-          }
-
-          return agent.load('grpc', config)
-            .then(() => {
-              grpc = require(`../../../versions/grpc@${version}`).get()
-            })
-        })
-
-        after(() => {
-          return agent.close()
-        })
-
-        it('should handle request metadata', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
-            })
-            .then(done)
-            .catch(done)
-
-          const metadata = new grpc.Metadata()
-
-          metadata.set('foo', 'bar')
-
-          client.getUnary({ first: 'foobar' }, metadata, () => {})
-        })
-
-        it('should handle response metadata', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => {
-              const metadata = new grpc.Metadata()
-
-              metadata.set('foo', 'bar')
-
-              callback(null, {}, metadata)
+              },
+              server: false
             }
-          })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-      })
-
-      describe('with a metadata array', () => {
-        before(() => {
-          const config = {
-            client: {
-              metadata: ['foo']
-            },
-            server: false
-          }
-
-          return agent.load('grpc', config)
-            .then(() => {
-              grpc = require(`../../../versions/grpc@${version}`).get()
-            })
-        })
-
-        after(() => {
-          return agent.close()
-        })
-
-        it('should handle request metadata', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0].meta).to.deep.include({
-                'grpc.method.name': 'getUnary',
-                'grpc.method.service': 'TestService',
-                'grpc.method.path': '/test.TestService/getUnary',
-                'grpc.method.kind': 'unary',
-                'grpc.request.metadata.foo': 'bar',
-                'span.kind': 'client'
+            return agent.load('grpc', config)
+              .then(() => {
+                grpc = require(`../../../versions/${pkg}@${version}`).get()
               })
+          })
+
+          after(() => {
+            return agent.close()
+          })
+
+          it('should be configured with the correct values', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
             })
-            .then(done)
-            .catch(done)
 
-          const metadata = new grpc.Metadata()
+            client.getUnary({ first: 'foobar' }, () => {})
 
-          metadata.set('foo', 'bar')
-          metadata.set('biz', 'baz')
-
-          client.getUnary({ first: 'foobar' }, metadata, () => {})
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  service: 'custom'
+                })
+              })
+          })
         })
 
-        it('should handle response metadata', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => {
-              const metadata = new grpc.Metadata()
-
-              metadata.set('foo', 'bar')
-              metadata.set('biz', 'baz')
-
-              callback(null, {}, metadata)
+        describe('with a metadata function', () => {
+          before(() => {
+            const config = {
+              client: {
+                metadata: values => values
+              },
+              server: false
             }
+
+            return agent.load('grpc', config)
+              .then(() => {
+                grpc = require(`../../../versions/${pkg}@${version}`).get()
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0].meta).to.deep.include({
-                'grpc.method.name': 'getUnary',
-                'grpc.method.service': 'TestService',
-                'grpc.method.path': '/test.TestService/getUnary',
-                'grpc.method.kind': 'unary',
-                'grpc.response.metadata.foo': 'bar',
-                'span.kind': 'client'
-              })
+          after(() => {
+            return agent.close()
+          })
 
-              expect(traces[0][0].metrics).to.deep.include({
-                'grpc.status.code': 0
-              })
+          it('should handle request metadata', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
             })
-            .then(done)
-            .catch(done)
 
-          client.getUnary({ first: 'foobar' }, () => {})
+            const metadata = new grpc.Metadata()
+
+            metadata.set('foo', 'bar')
+
+            client.getUnary({ first: 'foobar' }, metadata, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
+              })
+          })
+
+          it('should handle response metadata', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => {
+                const metadata = new grpc.Metadata()
+
+                metadata.set('foo', 'bar')
+
+                callback(null, {}, metadata)
+              }
+            })
+
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
+              })
+          })
+        })
+
+        describe('with a metadata array', () => {
+          before(() => {
+            const config = {
+              client: {
+                metadata: ['foo']
+              },
+              server: false
+            }
+
+            return agent.load('grpc', config)
+              .then(() => {
+                grpc = require(`../../../versions/${pkg}@${version}`).get()
+              })
+          })
+
+          after(() => {
+            return agent.close()
+          })
+
+          it('should handle request metadata', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
+            })
+
+            const metadata = new grpc.Metadata()
+
+            metadata.set('foo', 'bar')
+            metadata.set('biz', 'baz')
+
+            client.getUnary({ first: 'foobar' }, metadata, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.deep.include({
+                  'grpc.method.name': 'getUnary',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.path': '/test.TestService/getUnary',
+                  'grpc.method.kind': 'unary',
+                  'grpc.request.metadata.foo': 'bar',
+                  'span.kind': 'client'
+                })
+              })
+          })
+
+          it('should handle response metadata', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => {
+                const metadata = new grpc.Metadata()
+
+                metadata.set('foo', 'bar')
+                metadata.set('biz', 'baz')
+
+                callback(null, {}, metadata)
+              }
+            })
+
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.deep.include({
+                  'grpc.method.name': 'getUnary',
+                  'grpc.method.service': 'TestService',
+                  'grpc.method.path': '/test.TestService/getUnary',
+                  'grpc.method.kind': 'unary',
+                  'grpc.response.metadata.foo': 'bar',
+                  'span.kind': 'client'
+                })
+
+                expect(traces[0][0].metrics).to.deep.include({
+                  'grpc.status.code': 0
+                })
+              })
+          })
         })
       })
-    })
+    }
   })
 })

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -7,7 +7,6 @@ const Readable = require('stream').Readable
 const kinds = require('../src/kinds')
 const loader = require('../../../versions/@grpc/proto-loader').get()
 const pkgs = ['grpc', '@grpc/grpc-js']
-// const pkgs = ['grpc']
 
 wrapIt()
 
@@ -63,505 +62,503 @@ describe('Plugin', () => {
       server.forceShutdown()
     })
 
-    for (const pkg of pkgs) {
-      withVersions(plugin, pkg, version => {
-        describe('without configuration', () => {
-          before(() => {
-            return agent.load('grpc', { server: false })
-              .then(() => {
-                tracer = require('../../dd-trace')
-                grpc = require(`../../../versions/${pkg}@${version}`).get()
-              })
-          })
-
-          after(() => {
-            return agent.close()
-          })
-
-          it('should handle `unary` calls', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
+    withVersions(plugin, pkgs, (version, pkg) => {
+      describe('without configuration', () => {
+        before(() => {
+          return agent.load('grpc', { server: false })
+            .then(() => {
+              tracer = require('../../dd-trace')
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
             })
+        })
 
-            client.getUnary({ first: 'foobar' }, () => {})
+        after(() => {
+          return agent.close()
+        })
 
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test-grpc-client',
-                  resource: '/test.TestService/getUnary'
-                })
-
-                expect(traces[0][0].meta).to.include({
-                  'grpc.method.name': 'getUnary',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.package': 'test',
-                  'grpc.method.path': '/test.TestService/getUnary',
-                  'grpc.method.kind': kinds.unary,
-                  'span.kind': 'client',
-                  'component': 'grpc'
-                })
-
-                expect(traces[0][0].metrics).to.include({
-                  'grpc.status.code': 0
-                })
-              })
+        it('should handle `unary` calls', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
           })
 
-          it('should handle `server_stream` calls', async () => {
-            const client = await buildClient({
-              getServerStream: stream => {
-                stream.end()
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test-grpc-client',
+                resource: '/test.TestService/getUnary'
+              })
+
+              expect(traces[0][0].meta).to.include({
+                'grpc.method.name': 'getUnary',
+                'grpc.method.service': 'TestService',
+                'grpc.method.package': 'test',
+                'grpc.method.path': '/test.TestService/getUnary',
+                'grpc.method.kind': kinds.unary,
+                'span.kind': 'client',
+                'component': 'grpc'
+              })
+
+              expect(traces[0][0].metrics).to.include({
+                'grpc.status.code': 0
+              })
+            })
+        })
+
+        it('should handle `server_stream` calls', async () => {
+          const client = await buildClient({
+            getServerStream: stream => {
+              stream.end()
+            }
+          })
+
+          const call = client.getServerStream({ first: 'foobar' })
+
+          call.on('data', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test-grpc-client',
+                resource: '/test.TestService/getServerStream'
+              })
+
+              expect(traces[0][0].meta).to.include({
+                'grpc.method.name': 'getServerStream',
+                'grpc.method.service': 'TestService',
+                'grpc.method.package': 'test',
+                'grpc.method.path': '/test.TestService/getServerStream',
+                'grpc.method.kind': kinds.server_stream,
+                'span.kind': 'client',
+                'component': 'grpc'
+              })
+
+              expect(traces[0][0].metrics).to.include({
+                'grpc.status.code': 0
+              })
+            })
+        })
+
+        it.only('should handle `client_stream` calls', async () => {
+          const client = await buildClient({
+            getClientStream: (_, callback) => {
+              setTimeout(callback, 40)
+            }
+          })
+
+          client.getClientStream(() => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test-grpc-client',
+                resource: '/test.TestService/getClientStream'
+              })
+
+              expect(traces[0][0].meta).to.include({
+                'grpc.method.name': 'getClientStream',
+                'grpc.method.service': 'TestService',
+                'grpc.method.package': 'test',
+                'grpc.method.path': '/test.TestService/getClientStream',
+                'grpc.method.kind': kinds.client_stream,
+                'span.kind': 'client',
+                'component': 'grpc'
+              })
+
+              expect(traces[0][0].metrics).to.include({
+                'grpc.status.code': 0
+              })
+            })
+        })
+
+        it('should handle `bidi` calls', async () => {
+          const client = await buildClient({
+            getBidi: stream => stream.end()
+          })
+
+          const call = client.getBidi(new Readable())
+
+          call.on('data', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test-grpc-client',
+                resource: '/test.TestService/get_Bidi'
+              })
+              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
+              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
+              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
+            })
+        })
+
+        it('should handle cancelled `unary` calls', async () => {
+          let call = null
+          const client = await buildClient({
+            getUnary: () => call.cancel()
+          })
+
+          call = client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+            })
+        })
+
+        it('should handle cancelled `stream` calls', async () => {
+          let call = null
+          const client = await buildClient({
+            getServerStream: () => call.cancel()
+          })
+
+          call = client.getServerStream({ first: 'foobar' })
+          call.on('data', () => {})
+          call.on('error', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+            })
+        })
+
+        it('should handle cancelled `bidi` calls', async () => {
+          let call = null
+          const client = await buildClient({
+            getBidi: () => call.cancel()
+          })
+
+          call = client.getBidi(new Readable(), () => {})
+          call.on('data', () => {})
+          call.on('error', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+            })
+        })
+
+        it('should handle errors', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback(new Error('foobar'))
+          })
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.include({
+                'error.msg': '2 UNKNOWN: foobar',
+                'error.type': 'Error',
+                'grpc.method.name': 'getUnary',
+                'grpc.method.service': 'TestService',
+                'grpc.method.package': 'test',
+                'grpc.method.path': '/test.TestService/getUnary',
+                'grpc.method.kind': kinds.unary,
+                'span.kind': 'client',
+                'component': 'grpc'
+              })
+              expect(traces[0][0].meta).to.have.property('error.stack')
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 2)
+            })
+        })
+
+        it('should handle protocol errors', async () => {
+          const definition = loader.loadSync(`${__dirname}/invalid.proto`)
+          const test = grpc.loadPackageDefinition(definition).test
+          const client = await buildClient({
+            getUnary: (_, callback) => callback(null)
+          }, test.TestService)
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.include({
+                'error.type': 'Error',
+                'grpc.method.name': 'getUnary',
+                'grpc.method.service': 'TestService',
+                'grpc.method.package': 'test',
+                'grpc.method.path': '/test.TestService/getUnary',
+                'grpc.method.kind': kinds.unary,
+                'span.kind': 'client',
+                'component': 'grpc'
+              })
+              expect(traces[0][0].meta).to.have.property('error.stack')
+              expect(traces[0][0].meta['error.msg']).to.match(/^13 INTERNAL:.+$/)
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 13)
+            })
+        })
+
+        it('should handle a missing callback', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
+          })
+
+          client.getUnary({ first: 'foobar' })
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test-grpc-client',
+                resource: '/test.TestService/getUnary'
+              })
+
+              expect(traces[0][0].meta).to.include({
+                'grpc.method.name': 'getUnary',
+                'grpc.method.service': 'TestService',
+                'grpc.method.package': 'test',
+                'grpc.method.path': '/test.TestService/getUnary',
+                'grpc.method.kind': kinds.unary,
+                'span.kind': 'client',
+                'component': 'grpc'
+              })
+
+              expect(traces[0][0].metrics).to.deep.include({
+                'grpc.status.code': 0
+              })
+            })
+        })
+
+        it('should inject its parent span in the metadata', done => {
+          buildClient({
+            getUnary: (call, callback) => {
+              const metadata = call.metadata.getMap()
+
+              callback(null, {})
+
+              try {
+                expect(metadata).to.have.property('foo', 'bar')
+                expect(metadata['x-datadog-trace-id']).to.be.a('string')
+                expect(metadata['x-datadog-parent-id']).to.be.a('string')
+
+                done()
+              } catch (e) {
+                done(e)
               }
-            })
+            }
+          }).then(client => {
+            const metadata = new grpc.Metadata()
 
+            metadata.set('foo', 'bar')
+
+            client.getUnary({ first: 'foobar' }, metadata, () => {})
+          }, done)
+        })
+
+        it('should propagate the parent scope to the callback', done => {
+          const span = {}
+
+          buildClient({
+            getUnary: (call, callback) => callback()
+          }).then(client => {
+            tracer.scope().activate(span, () => {
+              client.getUnary({ first: 'foobar' }, (err, response) => {
+                expect(tracer.scope().active()).to.equal(span)
+                done(err)
+              })
+            })
+          }, done)
+        })
+
+        it('should propagate the parent scope to event listeners', done => {
+          const span = {}
+
+          buildClient({
+            getServerStream: stream => {
+              stream.write('test')
+              stream.end()
+            }
+          }).then(client => {
             const call = client.getServerStream({ first: 'foobar' })
 
-            call.on('data', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test-grpc-client',
-                  resource: '/test.TestService/getServerStream'
-                })
-
-                expect(traces[0][0].meta).to.include({
-                  'grpc.method.name': 'getServerStream',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.package': 'test',
-                  'grpc.method.path': '/test.TestService/getServerStream',
-                  'grpc.method.kind': kinds.server_stream,
-                  'span.kind': 'client',
-                  'component': 'grpc'
-                })
-
-                expect(traces[0][0].metrics).to.include({
-                  'grpc.status.code': 0
-                })
+            tracer.scope().activate(span, () => {
+              call.on('data', () => {
+                expect(tracer.scope().active()).to.equal(span)
+                done()
               })
-          })
-
-          it.only('should handle `client_stream` calls', async () => {
-            const client = await buildClient({
-              getClientStream: (_, callback) => {
-                setTimeout(callback, 40)
-              }
             })
+          }, done)
+        })
+      })
 
-            client.getClientStream(() => {})
+      describe('with service configuration', () => {
+        before(() => {
+          const config = {
+            client: {
+              service: 'custom'
+            },
+            server: false
+          }
 
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test-grpc-client',
-                  resource: '/test.TestService/getClientStream'
-                })
-
-                expect(traces[0][0].meta).to.include({
-                  'grpc.method.name': 'getClientStream',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.package': 'test',
-                  'grpc.method.path': '/test.TestService/getClientStream',
-                  'grpc.method.kind': kinds.client_stream,
-                  'span.kind': 'client',
-                  'component': 'grpc'
-                })
-
-                expect(traces[0][0].metrics).to.include({
-                  'grpc.status.code': 0
-                })
-              })
-          })
-
-          it('should handle `bidi` calls', async () => {
-            const client = await buildClient({
-              getBidi: stream => stream.end()
+          return agent.load('grpc', config)
+            .then(() => {
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
             })
+        })
 
-            const call = client.getBidi(new Readable())
+        after(() => {
+          return agent.close()
+        })
 
-            call.on('data', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test-grpc-client',
-                  resource: '/test.TestService/get_Bidi'
-                })
-                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
-                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
-                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
-                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-              })
+        it('should be configured with the correct values', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
           })
 
-          it('should handle cancelled `unary` calls', async () => {
-            let call = null
-            const client = await buildClient({
-              getUnary: () => call.cancel()
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                service: 'custom'
+              })
             })
+        })
+      })
 
-            call = client.getUnary({ first: 'foobar' }, () => {})
+      describe('with a metadata function', () => {
+        before(() => {
+          const config = {
+            client: {
+              metadata: values => values
+            },
+            server: false
+          }
 
-            return agent
-              .use(traces => {
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-              })
-          })
-
-          it('should handle cancelled `stream` calls', async () => {
-            let call = null
-            const client = await buildClient({
-              getServerStream: () => call.cancel()
+          return agent.load('grpc', config)
+            .then(() => {
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
             })
+        })
 
-            call = client.getServerStream({ first: 'foobar' })
-            call.on('data', () => {})
-            call.on('error', () => {})
+        after(() => {
+          return agent.close()
+        })
 
-            return agent
-              .use(traces => {
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-              })
+        it('should handle request metadata', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
           })
 
-          it('should handle cancelled `bidi` calls', async () => {
-            let call = null
-            const client = await buildClient({
-              getBidi: () => call.cancel()
+          const metadata = new grpc.Metadata()
+
+          metadata.set('foo', 'bar')
+
+          client.getUnary({ first: 'foobar' }, metadata, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
             })
+        })
 
-            call = client.getBidi(new Readable(), () => {})
-            call.on('data', () => {})
-            call.on('error', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-              })
-          })
-
-          it('should handle errors', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback(new Error('foobar'))
-            })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
-                expect(traces[0][0].meta).to.include({
-                  'error.msg': '2 UNKNOWN: foobar',
-                  'error.type': 'Error',
-                  'grpc.method.name': 'getUnary',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.package': 'test',
-                  'grpc.method.path': '/test.TestService/getUnary',
-                  'grpc.method.kind': kinds.unary,
-                  'span.kind': 'client',
-                  'component': 'grpc'
-                })
-                expect(traces[0][0].meta).to.have.property('error.stack')
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 2)
-              })
-          })
-
-          it('should handle protocol errors', async () => {
-            const definition = loader.loadSync(`${__dirname}/invalid.proto`)
-            const test = grpc.loadPackageDefinition(definition).test
-            const client = await buildClient({
-              getUnary: (_, callback) => callback(null)
-            }, test.TestService)
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
-                expect(traces[0][0].meta).to.include({
-                  'error.type': 'Error',
-                  'grpc.method.name': 'getUnary',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.package': 'test',
-                  'grpc.method.path': '/test.TestService/getUnary',
-                  'grpc.method.kind': kinds.unary,
-                  'span.kind': 'client',
-                  'component': 'grpc'
-                })
-                expect(traces[0][0].meta).to.have.property('error.stack')
-                expect(traces[0][0].meta['error.msg']).to.match(/^13 INTERNAL:.+$/)
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 13)
-              })
-          })
-
-          it('should handle a missing callback', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
-            })
-
-            client.getUnary({ first: 'foobar' })
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test-grpc-client',
-                  resource: '/test.TestService/getUnary'
-                })
-
-                expect(traces[0][0].meta).to.include({
-                  'grpc.method.name': 'getUnary',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.package': 'test',
-                  'grpc.method.path': '/test.TestService/getUnary',
-                  'grpc.method.kind': kinds.unary,
-                  'span.kind': 'client',
-                  'component': 'grpc'
-                })
-
-                expect(traces[0][0].metrics).to.deep.include({
-                  'grpc.status.code': 0
-                })
-              })
-          })
-
-          it('should inject its parent span in the metadata', done => {
-            buildClient({
-              getUnary: (call, callback) => {
-                const metadata = call.metadata.getMap()
-
-                callback(null, {})
-
-                try {
-                  expect(metadata).to.have.property('foo', 'bar')
-                  expect(metadata['x-datadog-trace-id']).to.be.a('string')
-                  expect(metadata['x-datadog-parent-id']).to.be.a('string')
-
-                  done()
-                } catch (e) {
-                  done(e)
-                }
-              }
-            }).then(client => {
+        it('should handle response metadata', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => {
               const metadata = new grpc.Metadata()
 
               metadata.set('foo', 'bar')
 
-              client.getUnary({ first: 'foobar' }, metadata, () => {})
-            }, done)
-          })
-
-          it('should propagate the parent scope to the callback', done => {
-            const span = {}
-
-            buildClient({
-              getUnary: (call, callback) => callback()
-            }).then(client => {
-              tracer.scope().activate(span, () => {
-                client.getUnary({ first: 'foobar' }, (err, response) => {
-                  expect(tracer.scope().active()).to.equal(span)
-                  done(err)
-                })
-              })
-            }, done)
-          })
-
-          it('should propagate the parent scope to event listeners', done => {
-            const span = {}
-
-            buildClient({
-              getServerStream: stream => {
-                stream.write('test')
-                stream.end()
-              }
-            }).then(client => {
-              const call = client.getServerStream({ first: 'foobar' })
-
-              tracer.scope().activate(span, () => {
-                call.on('data', () => {
-                  expect(tracer.scope().active()).to.equal(span)
-                  done()
-                })
-              })
-            }, done)
-          })
-        })
-
-        describe('with service configuration', () => {
-          before(() => {
-            const config = {
-              client: {
-                service: 'custom'
-              },
-              server: false
+              callback(null, {}, metadata)
             }
-
-            return agent.load('grpc', config)
-              .then(() => {
-                grpc = require(`../../../versions/${pkg}@${version}`).get()
-              })
           })
 
-          after(() => {
-            return agent.close()
-          })
+          client.getUnary({ first: 'foobar' }, () => {})
 
-          it('should be configured with the correct values', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
+          return agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
             })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  service: 'custom'
-                })
-              })
-          })
-        })
-
-        describe('with a metadata function', () => {
-          before(() => {
-            const config = {
-              client: {
-                metadata: values => values
-              },
-              server: false
-            }
-
-            return agent.load('grpc', config)
-              .then(() => {
-                grpc = require(`../../../versions/${pkg}@${version}`).get()
-              })
-          })
-
-          after(() => {
-            return agent.close()
-          })
-
-          it('should handle request metadata', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
-            })
-
-            const metadata = new grpc.Metadata()
-
-            metadata.set('foo', 'bar')
-
-            client.getUnary({ first: 'foobar' }, metadata, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
-              })
-          })
-
-          it('should handle response metadata', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => {
-                const metadata = new grpc.Metadata()
-
-                metadata.set('foo', 'bar')
-
-                callback(null, {}, metadata)
-              }
-            })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
-              })
-          })
-        })
-
-        describe('with a metadata array', () => {
-          before(() => {
-            const config = {
-              client: {
-                metadata: ['foo']
-              },
-              server: false
-            }
-
-            return agent.load('grpc', config)
-              .then(() => {
-                grpc = require(`../../../versions/${pkg}@${version}`).get()
-              })
-          })
-
-          after(() => {
-            return agent.close()
-          })
-
-          it('should handle request metadata', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
-            })
-
-            const metadata = new grpc.Metadata()
-
-            metadata.set('foo', 'bar')
-            metadata.set('biz', 'baz')
-
-            client.getUnary({ first: 'foobar' }, metadata, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.deep.include({
-                  'grpc.method.name': 'getUnary',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.path': '/test.TestService/getUnary',
-                  'grpc.method.kind': 'unary',
-                  'grpc.request.metadata.foo': 'bar',
-                  'span.kind': 'client'
-                })
-              })
-          })
-
-          it('should handle response metadata', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => {
-                const metadata = new grpc.Metadata()
-
-                metadata.set('foo', 'bar')
-                metadata.set('biz', 'baz')
-
-                callback(null, {}, metadata)
-              }
-            })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.deep.include({
-                  'grpc.method.name': 'getUnary',
-                  'grpc.method.service': 'TestService',
-                  'grpc.method.path': '/test.TestService/getUnary',
-                  'grpc.method.kind': 'unary',
-                  'grpc.response.metadata.foo': 'bar',
-                  'span.kind': 'client'
-                })
-
-                expect(traces[0][0].metrics).to.deep.include({
-                  'grpc.status.code': 0
-                })
-              })
-          })
         })
       })
-    }
+
+      describe('with a metadata array', () => {
+        before(() => {
+          const config = {
+            client: {
+              metadata: ['foo']
+            },
+            server: false
+          }
+
+          return agent.load('grpc', config)
+            .then(() => {
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
+            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        it('should handle request metadata', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
+          })
+
+          const metadata = new grpc.Metadata()
+
+          metadata.set('foo', 'bar')
+          metadata.set('biz', 'baz')
+
+          client.getUnary({ first: 'foobar' }, metadata, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.deep.include({
+                'grpc.method.name': 'getUnary',
+                'grpc.method.service': 'TestService',
+                'grpc.method.path': '/test.TestService/getUnary',
+                'grpc.method.kind': 'unary',
+                'grpc.request.metadata.foo': 'bar',
+                'span.kind': 'client'
+              })
+            })
+        })
+
+        it('should handle response metadata', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => {
+              const metadata = new grpc.Metadata()
+
+              metadata.set('foo', 'bar')
+              metadata.set('biz', 'baz')
+
+              callback(null, {}, metadata)
+            }
+          })
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.deep.include({
+                'grpc.method.name': 'getUnary',
+                'grpc.method.service': 'TestService',
+                'grpc.method.path': '/test.TestService/getUnary',
+                'grpc.method.kind': 'unary',
+                'grpc.response.metadata.foo': 'bar',
+                'span.kind': 'client'
+              })
+
+              expect(traces[0][0].metrics).to.deep.include({
+                'grpc.status.code': 0
+              })
+            })
+        })
+      })
+    })
   })
 })

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -142,7 +142,7 @@ describe('Plugin', () => {
             })
         })
 
-        it.only('should handle `client_stream` calls', async () => {
+        it('should handle `client_stream` calls', async () => {
           const client = await buildClient({
             getClientStream: (_, callback) => {
               setTimeout(callback, 40)

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -2,9 +2,10 @@
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const getPort = require('get-port')
-const plugin = require('../src/client')
+const plugin = require('../src/server')
 const Readable = require('stream').Readable
 const kinds = require('../src/kinds')
+const pkgs = ['grpc', '@grpc/grpc-js']
 
 wrapIt()
 
@@ -13,8 +14,9 @@ describe('Plugin', () => {
   let port
   let server
   let tracer
+  let call
 
-  function buildClient (service) {
+  function buildClient (service, callback) {
     service = Object.assign({
       getBidi: () => {},
       getServerStream: () => {},
@@ -28,15 +30,29 @@ describe('Plugin', () => {
 
     server = new grpc.Server()
 
-    server.bind(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure())
-    server.addService(TestService.service, service)
-    server.start()
+    return new Promise((resolve, reject) => {
+      if (server.bindAsync) {
+        server.bindAsync(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure(), (err) => {
+          if (err) return reject(err)
 
-    return new TestService(`localhost:${port}`, grpc.credentials.createInsecure())
+          server.addService(TestService.service, service)
+          server.start()
+
+          resolve(new TestService(`localhost:${port}`, grpc.credentials.createInsecure()))
+        })
+      } else {
+        server.bind(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure())
+        server.addService(TestService.service, service)
+        server.start()
+
+        resolve(new TestService(`localhost:${port}`, grpc.credentials.createInsecure()))
+      }
+    })
   }
 
   describe('grpc/server', () => {
     beforeEach(() => {
+      call = null
       return getPort().then(newPort => {
         port = newPort
       })
@@ -46,381 +62,361 @@ describe('Plugin', () => {
       server.forceShutdown()
     })
 
-    withVersions(plugin, 'grpc', version => {
-      describe('without configuration', () => {
-        before(() => {
-          return agent.load('grpc', { client: false })
-            .then(() => {
-              tracer = require('../../dd-trace')
-              grpc = require(`../../../versions/grpc@${version}`).get()
-            })
-        })
-
-        after(() => {
-          return agent.close()
-        })
-
-        it('should handle `unary` calls', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test',
-                resource: '/test.TestService/getUnary'
+    for (const pkg of pkgs) {
+      withVersions(plugin, pkg, version => {
+        describe('without configuration', () => {
+          before(() => {
+            return agent.load('grpc', { client: false })
+              .then(() => {
+                tracer = require('../../dd-trace')
+                grpc = require(`../../../versions/${pkg}@${version}`).get()
               })
-              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getUnary')
-              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-              expect(traces[0][0].meta).to.have.property('grpc.method.package', 'test')
-              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getUnary')
-              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.unary)
-              expect(traces[0][0].meta).to.have.property('span.kind', 'server')
-              expect(traces[0][0].meta).to.have.property('component', 'grpc')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-
-        it('should handle `stream` calls', done => {
-          const client = buildClient({
-            getServerStream: stream => stream.end()
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test',
-                resource: '/test.TestService/getServerStream'
+          after(() => {
+            return agent.close()
+          })
+
+          it('should handle `unary` calls', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
+            })
+
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test',
+                  resource: '/test.TestService/getUnary'
+                })
+                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getUnary')
+                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+                expect(traces[0][0].meta).to.have.property('grpc.method.package', 'test')
+                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getUnary')
+                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.unary)
+                expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+                expect(traces[0][0].meta).to.have.property('component', 'grpc')
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
               })
-              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getServerStream')
-              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getServerStream')
-              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.server_stream)
-              expect(traces[0][0].meta).to.have.property('span.kind', 'server')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-            })
-            .then(done)
-            .catch(done)
-
-          client.getServerStream({ first: 'foobar' }, () => {})
-        })
-
-        it('should handle `bidi` calls', done => {
-          const client = buildClient({
-            getBidi: stream => stream.end()
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
-                service: 'test',
-                resource: '/test.TestService/get_Bidi'
+          it('should handle `stream` calls', async () => {
+            const client = await buildClient({
+              getServerStream: stream => stream.end()
+            })
+
+            client.getServerStream({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test',
+                  resource: '/test.TestService/getServerStream'
+                })
+                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getServerStream')
+                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getServerStream')
+                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.server_stream)
+                expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
               })
-              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
-              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
-              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
-              expect(traces[0][0].meta).to.have.property('span.kind', 'server')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-            })
-            .then(done)
-            .catch(done)
-
-          client.getBidi(new Readable(), () => {})
-        })
-
-        it('should handle cancelled `unary` calls', done => {
-          let call = null
-          const client = buildClient({
-            getUnary: () => call.cancel()
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+          it('should handle `bidi` calls', async () => {
+            const client = await buildClient({
+              getBidi: stream => stream.end()
             })
-            .then(done)
-            .catch(done)
 
-          call = client.getUnary({ first: 'foobar' }, () => {})
-        })
+            call = client.getBidi(new Readable(), () => {})
+            call.on('error', () => {})
 
-        it('should handle cancelled `stream` calls', done => {
-          let call = null
-          const client = buildClient({
-            getServerStream: () => call.cancel()
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  name: 'grpc.request',
+                  service: 'test',
+                  resource: '/test.TestService/get_Bidi'
+                })
+                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
+                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
+                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
+                expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+          it('should handle cancelled `unary` calls', async () => {
+            let call = null
+            const client = await buildClient({
+              getUnary: () => call.cancel()
             })
-            .then(done)
-            .catch(done)
 
-          call = client.getServerStream({ first: 'foobar' }, () => {})
-        })
+            call = client.getUnary({ first: 'foobar' }, () => {})
+            call.on('error', () => {})
 
-        it('should handle cancelled `bidi` calls', done => {
-          let call = null
-          const client = buildClient({
-            getBidi: () => call.cancel()
+            return agent
+              .use(traces => {
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+          it('should handle cancelled `stream` calls', async () => {
+            let call = null
+            const client = await buildClient({
+              getServerStream: () => call.cancel()
             })
-            .then(done)
-            .catch(done)
 
-          call = client.getBidi(new Readable(), () => {})
-        })
+            call = client.getServerStream({ first: 'foobar' }, () => {})
+            call.on('error', () => {})
 
-        it('should handle errors without `code`', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => {
-              const metadata = new grpc.Metadata()
-
-              metadata.set('extra', 'information')
-
-              callback(new Error('foobar'), {}, metadata)
-            }
+            return agent
+              .use(traces => {
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
-              expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
-              expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-              expect(traces[0][0].meta).to.not.have.property('grpc.status.code')
+          it('should handle cancelled `bidi` calls', async () => {
+            const client = await buildClient({
+              getBidi: () => call.cancel()
             })
-            .then(done)
-            .catch(done)
 
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
+            call = client.getBidi(new Readable(), () => {})
+            call.on('error', () => {})
 
-        it('should handle errors with `code`', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => {
-              const metadata = new grpc.Metadata()
-
-              metadata.set('extra', 'information')
-
-              const error = new Error('foobar')
-
-              error.code = grpc.status.NOT_FOUND
-
-              callback(error, {}, metadata)
-            }
+            return agent
+              .use(traces => {
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
-              expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
-              expect(traces[0][0].meta['error.stack']).to.match(/^Error: foobar\n {4}at Object.getUnary.*/)
-              expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
-            })
-            .then(done)
-            .catch(done)
+          it('should handle errors without `code`', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => {
+                const metadata = new grpc.Metadata()
 
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
+                metadata.set('extra', 'information')
 
-        it('should handle stream errors', done => {
-          let error = null
-
-          const client = buildClient({
-            getBidi: (stream) => {
-              error = new Error('foobar')
-              error.code = grpc.status.NOT_FOUND
-
-              stream.emit('error', error)
-            }
-          })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
-              expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
-              expect(traces[0][0].meta['error.stack']).to.equal(error.stack)
-              expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
-            })
-            .then(done)
-            .catch(done)
-
-          client.getBidi(new Readable(), () => {})
-        })
-
-        it('should run the handler in the scope of the request', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => {
-              try {
-                callback()
-                expect(tracer.scope().active()).to.not.be.null
-                done()
-              } catch (e) {
-                done(e)
+                callback(new Error('foobar'), {}, metadata)
               }
-            }
-          })
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-
-        it('should run the emitter in the scope of the caller', done => {
-          let emitter = null
-
-          const client = buildClient({
-            getUnary: (call, callback) => {
-              const span = tracer.scope().active()
-
-              emitter = call
-              emitter.on('test', () => {
-                expect(tracer.scope().active()).to.equal(span)
-                expect(span).to.not.be.null
-                done()
-              })
-
-              callback(null, {})
-            }
-          })
-
-          client.getUnary({ first: 'foobar' }, () => {
-            emitter.emit('test')
-          })
-        })
-      })
-
-      describe('with service configuration', () => {
-        before(() => {
-          const config = {
-            server: {
-              service: 'custom'
-            },
-            client: false
-          }
-
-          return agent.load('grpc', config)
-            .then(() => {
-              grpc = require(`../../../versions/grpc@${version}`).get()
             })
-        })
 
-        after(() => {
-          return agent.close()
-        })
+            client.getUnary({ first: 'foobar' }, () => {})
 
-        it('should be configured with the correct values', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
+                expect(traces[0][0].meta).to.have.property('error.type', 'Error')
+                expect(traces[0][0].meta).to.not.have.property('grpc.status.code')
+              })
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.deep.include({
+          it('should handle errors with `code`', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => {
+                const metadata = new grpc.Metadata()
+
+                metadata.set('extra', 'information')
+
+                const error = new Error('foobar')
+
+                error.code = grpc.status.NOT_FOUND
+
+                callback(error, {}, metadata)
+              }
+            })
+
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
+                expect(traces[0][0].meta['error.stack']).to.match(/^Error: foobar\n {4}at Object.getUnary.*/)
+                expect(traces[0][0].meta).to.have.property('error.type', 'Error')
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
+              })
+          })
+
+          it('should handle stream errors', async () => {
+            let error = null
+
+            const client = await buildClient({
+              getBidi: (stream) => {
+                error = new Error('foobar')
+                error.code = grpc.status.NOT_FOUND
+
+                stream.emit('error', error)
+              }
+            })
+
+            call = client.getBidi(new Readable(), () => {})
+            call.on('error', () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
+                expect(traces[0][0].meta['error.stack']).to.equal(error.stack)
+                expect(traces[0][0].meta).to.have.property('error.type', 'Error')
+                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
+              })
+          })
+
+          it('should run the handler in the scope of the request', done => {
+            buildClient({
+              getUnary: (_, callback) => {
+                try {
+                  callback()
+                  expect(tracer.scope().active()).to.not.be.null
+                  done()
+                } catch (e) {
+                  done(e)
+                }
+              }
+            }).then(client => client.getUnary({ first: 'foobar' }, () => {}), done)
+          })
+
+          it('should run the emitter in the scope of the caller', done => {
+            let emitter = null
+
+            buildClient({
+              getUnary: (call, callback) => {
+                const span = tracer.scope().active()
+
+                emitter = call
+                emitter.on('test', () => {
+                  expect(tracer.scope().active()).to.equal(span)
+                  expect(span).to.not.be.null
+                  done()
+                })
+
+                callback(null, {})
+              }
+            }).then(client => {
+              client.getUnary({ first: 'foobar' }, () => {
+                emitter.emit('test')
+              })
+            }, done)
+          })
+        })
+
+        describe('with service configuration', () => {
+          before(() => {
+            const config = {
+              server: {
                 service: 'custom'
+              },
+              client: false
+            }
+
+            return agent.load('grpc', config)
+              .then(() => {
+                grpc = require(`../../../versions/${pkg}@${version}`).get()
               })
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-      })
-
-      describe('with metadata configuration', () => {
-        before(() => {
-          const config = {
-            server: {
-              metadata: values => values
-            },
-            client: false
-          }
-
-          return agent.load('grpc', config)
-            .then(() => {
-              grpc = require(`../../../versions/grpc@${version}`).get()
-            })
-        })
-
-        after(() => {
-          return agent.close()
-        })
-
-        it('should handle request metadata', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => callback()
           })
 
-          agent
-            .use(traces => {
-              expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
+          after(() => {
+            return agent.close()
+          })
+
+          it('should be configured with the correct values', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
             })
-            .then(done)
-            .catch(done)
 
-          const metadata = new grpc.Metadata()
+            client.getUnary({ first: 'foobar' }, () => {})
 
-          metadata.set('foo', 'bar')
-
-          client.getUnary({ first: 'foobar' }, metadata, () => {})
+            return agent
+              .use(traces => {
+                expect(traces[0][0]).to.deep.include({
+                  service: 'custom'
+                })
+              })
+          })
         })
 
-        it('should handle response metadata', done => {
-          const client = buildClient({
-            getUnary: (_, callback) => {
+        describe('with metadata configuration', () => {
+          before(() => {
+            const config = {
+              server: {
+                metadata: values => values
+              },
+              client: false
+            }
+
+            return agent.load('grpc', config)
+              .then(() => {
+                grpc = require(`../../../versions/${pkg}@${version}`).get()
+              })
+          })
+
+          after(() => {
+            return agent.close()
+          })
+
+          it('should handle request metadata', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
+            })
+
+            const metadata = new grpc.Metadata()
+
+            metadata.set('foo', 'bar')
+
+            client.getUnary({ first: 'foobar' }, metadata, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
+              })
+          })
+
+          it('should handle response metadata', async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => {
+                const metadata = new grpc.Metadata()
+
+                metadata.set('foo', 'bar')
+
+                callback(null, {}, metadata)
+              }
+            })
+
+            client.getUnary({ first: 'foobar' }, () => {})
+
+            return agent
+              .use(traces => {
+                expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
+              })
+          })
+
+          it('should not alter the request metadata', done => {
+            buildClient({
+              getUnary: (call, callback) => {
+                callback(null, {})
+
+                try {
+                  expect(call.metadata.getMap()).to.have.property('foo', 'bar')
+                  done()
+                } catch (e) {
+                  done(e)
+                }
+              }
+            }).then(client => {
               const metadata = new grpc.Metadata()
 
               metadata.set('foo', 'bar')
 
-              callback(null, {}, metadata)
-            }
+              client.getUnary({ first: 'foobar' }, metadata, () => {})
+            }, done)
           })
-
-          agent
-            .use(traces => {
-              expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
-            })
-            .then(done)
-            .catch(done)
-
-          client.getUnary({ first: 'foobar' }, () => {})
-        })
-
-        it('should not alter the request metadata', done => {
-          const client = buildClient({
-            getUnary: (call, callback) => {
-              callback(null, {})
-
-              try {
-                expect(call.metadata.getMap()).to.have.property('foo', 'bar')
-                done()
-              } catch (e) {
-                done(e)
-              }
-            }
-          })
-
-          const metadata = new grpc.Metadata()
-
-          metadata.set('foo', 'bar')
-
-          client.getUnary({ first: 'foobar' }, metadata, () => {})
         })
       })
-    })
+    }
   })
 })

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -62,361 +62,359 @@ describe('Plugin', () => {
       server.forceShutdown()
     })
 
-    for (const pkg of pkgs) {
-      withVersions(plugin, pkg, version => {
-        describe('without configuration', () => {
-          before(() => {
-            return agent.load('grpc', { client: false })
-              .then(() => {
-                tracer = require('../../dd-trace')
-                grpc = require(`../../../versions/${pkg}@${version}`).get()
-              })
-          })
-
-          after(() => {
-            return agent.close()
-          })
-
-          it('should handle `unary` calls', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
+    withVersions(plugin, pkgs, (version, pkg) => {
+      describe('without configuration', () => {
+        before(() => {
+          return agent.load('grpc', { client: false })
+            .then(() => {
+              tracer = require('../../dd-trace')
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
             })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test',
-                  resource: '/test.TestService/getUnary'
-                })
-                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getUnary')
-                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-                expect(traces[0][0].meta).to.have.property('grpc.method.package', 'test')
-                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getUnary')
-                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.unary)
-                expect(traces[0][0].meta).to.have.property('span.kind', 'server')
-                expect(traces[0][0].meta).to.have.property('component', 'grpc')
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-              })
-          })
-
-          it('should handle `stream` calls', async () => {
-            const client = await buildClient({
-              getServerStream: stream => stream.end()
-            })
-
-            client.getServerStream({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test',
-                  resource: '/test.TestService/getServerStream'
-                })
-                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getServerStream')
-                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getServerStream')
-                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.server_stream)
-                expect(traces[0][0].meta).to.have.property('span.kind', 'server')
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-              })
-          })
-
-          it('should handle `bidi` calls', async () => {
-            const client = await buildClient({
-              getBidi: stream => stream.end()
-            })
-
-            call = client.getBidi(new Readable(), () => {})
-            call.on('error', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  name: 'grpc.request',
-                  service: 'test',
-                  resource: '/test.TestService/get_Bidi'
-                })
-                expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
-                expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-                expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
-                expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
-                expect(traces[0][0].meta).to.have.property('span.kind', 'server')
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
-              })
-          })
-
-          it('should handle cancelled `unary` calls', async () => {
-            let call = null
-            const client = await buildClient({
-              getUnary: () => call.cancel()
-            })
-
-            call = client.getUnary({ first: 'foobar' }, () => {})
-            call.on('error', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-              })
-          })
-
-          it('should handle cancelled `stream` calls', async () => {
-            let call = null
-            const client = await buildClient({
-              getServerStream: () => call.cancel()
-            })
-
-            call = client.getServerStream({ first: 'foobar' }, () => {})
-            call.on('error', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-              })
-          })
-
-          it('should handle cancelled `bidi` calls', async () => {
-            const client = await buildClient({
-              getBidi: () => call.cancel()
-            })
-
-            call = client.getBidi(new Readable(), () => {})
-            call.on('error', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
-              })
-          })
-
-          it('should handle errors without `code`', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => {
-                const metadata = new grpc.Metadata()
-
-                metadata.set('extra', 'information')
-
-                callback(new Error('foobar'), {}, metadata)
-              }
-            })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
-                expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
-                expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-                expect(traces[0][0].meta).to.not.have.property('grpc.status.code')
-              })
-          })
-
-          it('should handle errors with `code`', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => {
-                const metadata = new grpc.Metadata()
-
-                metadata.set('extra', 'information')
-
-                const error = new Error('foobar')
-
-                error.code = grpc.status.NOT_FOUND
-
-                callback(error, {}, metadata)
-              }
-            })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
-                expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
-                expect(traces[0][0].meta['error.stack']).to.match(/^Error: foobar\n {4}at Object.getUnary.*/)
-                expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
-              })
-          })
-
-          it('should handle stream errors', async () => {
-            let error = null
-
-            const client = await buildClient({
-              getBidi: (stream) => {
-                error = new Error('foobar')
-                error.code = grpc.status.NOT_FOUND
-
-                stream.emit('error', error)
-              }
-            })
-
-            call = client.getBidi(new Readable(), () => {})
-            call.on('error', () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
-                expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
-                expect(traces[0][0].meta['error.stack']).to.equal(error.stack)
-                expect(traces[0][0].meta).to.have.property('error.type', 'Error')
-                expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
-              })
-          })
-
-          it('should run the handler in the scope of the request', done => {
-            buildClient({
-              getUnary: (_, callback) => {
-                try {
-                  callback()
-                  expect(tracer.scope().active()).to.not.be.null
-                  done()
-                } catch (e) {
-                  done(e)
-                }
-              }
-            }).then(client => client.getUnary({ first: 'foobar' }, () => {}), done)
-          })
-
-          it('should run the emitter in the scope of the caller', done => {
-            let emitter = null
-
-            buildClient({
-              getUnary: (call, callback) => {
-                const span = tracer.scope().active()
-
-                emitter = call
-                emitter.on('test', () => {
-                  expect(tracer.scope().active()).to.equal(span)
-                  expect(span).to.not.be.null
-                  done()
-                })
-
-                callback(null, {})
-              }
-            }).then(client => {
-              client.getUnary({ first: 'foobar' }, () => {
-                emitter.emit('test')
-              })
-            }, done)
-          })
         })
 
-        describe('with service configuration', () => {
-          before(() => {
-            const config = {
-              server: {
+        after(() => {
+          return agent.close()
+        })
+
+        it('should handle `unary` calls', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
+          })
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test',
+                resource: '/test.TestService/getUnary'
+              })
+              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getUnary')
+              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+              expect(traces[0][0].meta).to.have.property('grpc.method.package', 'test')
+              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getUnary')
+              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.unary)
+              expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+              expect(traces[0][0].meta).to.have.property('component', 'grpc')
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
+            })
+        })
+
+        it('should handle `stream` calls', async () => {
+          const client = await buildClient({
+            getServerStream: stream => stream.end()
+          })
+
+          client.getServerStream({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test',
+                resource: '/test.TestService/getServerStream'
+              })
+              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getServerStream')
+              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getServerStream')
+              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.server_stream)
+              expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
+            })
+        })
+
+        it('should handle `bidi` calls', async () => {
+          const client = await buildClient({
+            getBidi: stream => stream.end()
+          })
+
+          call = client.getBidi(new Readable(), () => {})
+          call.on('error', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
+                name: 'grpc.request',
+                service: 'test',
+                resource: '/test.TestService/get_Bidi'
+              })
+              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
+              expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
+              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
+              expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
+              expect(traces[0][0].meta).to.have.property('span.kind', 'server')
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)
+            })
+        })
+
+        it('should handle cancelled `unary` calls', async () => {
+          let call = null
+          const client = await buildClient({
+            getUnary: () => call.cancel()
+          })
+
+          call = client.getUnary({ first: 'foobar' }, () => {})
+          call.on('error', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+            })
+        })
+
+        it('should handle cancelled `stream` calls', async () => {
+          let call = null
+          const client = await buildClient({
+            getServerStream: () => call.cancel()
+          })
+
+          call = client.getServerStream({ first: 'foobar' }, () => {})
+          call.on('error', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+            })
+        })
+
+        it('should handle cancelled `bidi` calls', async () => {
+          const client = await buildClient({
+            getBidi: () => call.cancel()
+          })
+
+          call = client.getBidi(new Readable(), () => {})
+          call.on('error', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
+            })
+        })
+
+        it('should handle errors without `code`', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => {
+              const metadata = new grpc.Metadata()
+
+              metadata.set('extra', 'information')
+
+              callback(new Error('foobar'), {}, metadata)
+            }
+          })
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
+              expect(traces[0][0].meta).to.have.property('error.type', 'Error')
+              expect(traces[0][0].meta).to.not.have.property('grpc.status.code')
+            })
+        })
+
+        it('should handle errors with `code`', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => {
+              const metadata = new grpc.Metadata()
+
+              metadata.set('extra', 'information')
+
+              const error = new Error('foobar')
+
+              error.code = grpc.status.NOT_FOUND
+
+              callback(error, {}, metadata)
+            }
+          })
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
+              expect(traces[0][0].meta['error.stack']).to.match(/^Error: foobar\n {4}at Object.getUnary.*/)
+              expect(traces[0][0].meta).to.have.property('error.type', 'Error')
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
+            })
+        })
+
+        it('should handle stream errors', async () => {
+          let error = null
+
+          const client = await buildClient({
+            getBidi: (stream) => {
+              error = new Error('foobar')
+              error.code = grpc.status.NOT_FOUND
+
+              stream.emit('error', error)
+            }
+          })
+
+          call = client.getBidi(new Readable(), () => {})
+          call.on('error', () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.have.property('error.msg', 'foobar')
+              expect(traces[0][0].meta['error.stack']).to.equal(error.stack)
+              expect(traces[0][0].meta).to.have.property('error.type', 'Error')
+              expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
+            })
+        })
+
+        it('should run the handler in the scope of the request', done => {
+          buildClient({
+            getUnary: (_, callback) => {
+              try {
+                callback()
+                expect(tracer.scope().active()).to.not.be.null
+                done()
+              } catch (e) {
+                done(e)
+              }
+            }
+          }).then(client => client.getUnary({ first: 'foobar' }, () => {}), done)
+        })
+
+        it('should run the emitter in the scope of the caller', done => {
+          let emitter = null
+
+          buildClient({
+            getUnary: (call, callback) => {
+              const span = tracer.scope().active()
+
+              emitter = call
+              emitter.on('test', () => {
+                expect(tracer.scope().active()).to.equal(span)
+                expect(span).to.not.be.null
+                done()
+              })
+
+              callback(null, {})
+            }
+          }).then(client => {
+            client.getUnary({ first: 'foobar' }, () => {
+              emitter.emit('test')
+            })
+          }, done)
+        })
+      })
+
+      describe('with service configuration', () => {
+        before(() => {
+          const config = {
+            server: {
+              service: 'custom'
+            },
+            client: false
+          }
+
+          return agent.load('grpc', config)
+            .then(() => {
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
+            })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        it('should be configured with the correct values', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
+          })
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0]).to.deep.include({
                 service: 'custom'
-              },
-              client: false
-            }
-
-            return agent.load('grpc', config)
-              .then(() => {
-                grpc = require(`../../../versions/${pkg}@${version}`).get()
               })
-          })
-
-          after(() => {
-            return agent.close()
-          })
-
-          it('should be configured with the correct values', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
             })
+        })
+      })
 
-            client.getUnary({ first: 'foobar' }, () => {})
+      describe('with metadata configuration', () => {
+        before(() => {
+          const config = {
+            server: {
+              metadata: values => values
+            },
+            client: false
+          }
 
-            return agent
-              .use(traces => {
-                expect(traces[0][0]).to.deep.include({
-                  service: 'custom'
-                })
-              })
-          })
+          return agent.load('grpc', config)
+            .then(() => {
+              grpc = require(`../../../versions/${pkg}@${version}`).get()
+            })
         })
 
-        describe('with metadata configuration', () => {
-          before(() => {
-            const config = {
-              server: {
-                metadata: values => values
-              },
-              client: false
-            }
+        after(() => {
+          return agent.close()
+        })
 
-            return agent.load('grpc', config)
-              .then(() => {
-                grpc = require(`../../../versions/${pkg}@${version}`).get()
-              })
+        it('should handle request metadata', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => callback()
           })
 
-          after(() => {
-            return agent.close()
-          })
+          const metadata = new grpc.Metadata()
 
-          it('should handle request metadata', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => callback()
+          metadata.set('foo', 'bar')
+
+          client.getUnary({ first: 'foobar' }, metadata, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
             })
+        })
 
+        it('should handle response metadata', async () => {
+          const client = await buildClient({
+            getUnary: (_, callback) => {
+              const metadata = new grpc.Metadata()
+
+              metadata.set('foo', 'bar')
+
+              callback(null, {}, metadata)
+            }
+          })
+
+          client.getUnary({ first: 'foobar' }, () => {})
+
+          return agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
+            })
+        })
+
+        it('should not alter the request metadata', done => {
+          buildClient({
+            getUnary: (call, callback) => {
+              callback(null, {})
+
+              try {
+                expect(call.metadata.getMap()).to.have.property('foo', 'bar')
+                done()
+              } catch (e) {
+                done(e)
+              }
+            }
+          }).then(client => {
             const metadata = new grpc.Metadata()
 
             metadata.set('foo', 'bar')
 
             client.getUnary({ first: 'foobar' }, metadata, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
-              })
-          })
-
-          it('should handle response metadata', async () => {
-            const client = await buildClient({
-              getUnary: (_, callback) => {
-                const metadata = new grpc.Metadata()
-
-                metadata.set('foo', 'bar')
-
-                callback(null, {}, metadata)
-              }
-            })
-
-            client.getUnary({ first: 'foobar' }, () => {})
-
-            return agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
-              })
-          })
-
-          it('should not alter the request metadata', done => {
-            buildClient({
-              getUnary: (call, callback) => {
-                callback(null, {})
-
-                try {
-                  expect(call.metadata.getMap()).to.have.property('foo', 'bar')
-                  done()
-                } catch (e) {
-                  done(e)
-                }
-              }
-            }).then(client => {
-              const metadata = new grpc.Metadata()
-
-              metadata.set('foo', 'bar')
-
-              client.getUnary({ first: 'foobar' }, metadata, () => {})
-            }, done)
-          })
+          }, done)
         })
       })
-    }
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for `@grpc/grpc-js`.

### Motivation
<!-- What inspired you to submit this pull request? -->

The current `grpc` plugin only instruments `grpc` which is deprecated in favor of `@grpc/grpc-js`.

Closes #981