### PR TITLE
Add prepatching mechanism

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -156,6 +156,10 @@ function cachedPathToRegExp (pattern) {
 module.exports = {
   name: 'router',
   versions: ['>=1'],
+  prepatch: (Router) => ({
+    object: Router.prototype,
+    methods: ['handle', 'use', 'route']
+  }),
   patch (Router, tracer, config) {
     this.wrap(Router.prototype, 'handle', createWrapHandle(tracer, config))
     this.wrap(Router.prototype, 'use', wrapRouterMethod)

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -50,7 +50,7 @@ function getPrepatchWrappedFunction (fn) {
       // eslint-disable-next-line new-cap
       return new fnToCall(...arguments)
     } else {
-      return fnToCall.call(this, arguments)
+      return fnToCall.apply(this, arguments)
     }
   }
 
@@ -159,7 +159,9 @@ class Instrumenter {
 
     nodules.forEach(nodule => {
       names.forEach(name => {
-        nodule[name] && delete nodule[name]._datadog_wrapped
+        if (nodule[name]) {
+          nodule[name]._datadog_wrapped = null
+        }
         shimmer.unwrap.call(this, nodule, name, wrapper)
         nodule[name] && delete nodule[name]._datadog_patched
       })

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -43,6 +43,22 @@ function getConfig (name, config = {}) {
   return config
 }
 
+function getPrepatchWrappedFunction (fn) {
+  const prepatchWrapped = function prepatchWrapped () {
+    const fnToCall = prepatchWrapped._datadog_wrapped || fn
+    if (new.target) {
+      // eslint-disable-next-line new-cap
+      return new fnToCall(...arguments)
+    } else {
+      return fnToCall.call(this, arguments)
+    }
+  }
+
+  // This will be an _actually_ wrapped function once this goes through Instrumenter#wrap
+  prepatchWrapped._datadog_wrapped = fn
+  return prepatchWrapped
+}
+
 class Instrumenter {
   constructor (tracer) {
     this._tracer = tracer
@@ -52,6 +68,7 @@ class Instrumenter {
     this._plugins = new Map()
     this._instrumented = new Map()
     this._disabledPlugins = collectDisabledPlugins()
+    this.preload()
   }
 
   use (name, config) {
@@ -113,6 +130,11 @@ class Instrumenter {
           configurable: true
         })
 
+        if (Reflect.ownKeys(nodule[name]).includes('_datadog_wrapped')) {
+          nodule[name]._datadog_wrapped = wrapper(nodule[name]._datadog_wrapped)
+          return
+        }
+
         shimmer.wrap.call(this, nodule, name, function (original, name) {
           const wrapped = wrapper(original, name)
           const props = Object.getOwnPropertyDescriptors(original)
@@ -137,6 +159,7 @@ class Instrumenter {
 
     nodules.forEach(nodule => {
       names.forEach(name => {
+        nodule[name] && delete nodule[name]._datadog_wrapped
         shimmer.unwrap.call(this, nodule, name, wrapper)
         nodule[name] && delete nodule[name]._datadog_patched
       })
@@ -203,6 +226,36 @@ class Instrumenter {
       this._plugins.delete(plugin)
 
       platform.metrics().boolean(`datadog.tracer.node.plugin.enabled.by.name`, false, `name:${meta.name}`)
+    }
+  }
+
+  preload () {
+    if (!this._loader.preload) {
+      return
+    }
+    const pluginsMap = new Map()
+    Object.keys(plugins)
+      .filter(name => !this._plugins.has(plugins[name]))
+      .forEach(name => {
+        pluginsMap.set(plugins[name], { name, config: getConfig(name) })
+      })
+    this._loader.preload(pluginsMap)
+  }
+
+  prepatch (instrumentation, moduleExports) {
+    if (!instrumentation.prepatch) {
+      return
+    }
+    const patches = [].concat(instrumentation.prepatch(moduleExports))
+    for (const { object, methods } of patches) {
+      for (const name of methods) {
+        this.wrap(object, name, getPrepatchWrappedFunction)
+        // While we're re-using wrap here for simplicity, we don't want to have
+        // the other code here assume that it has been pached in the sense that
+        // the _plugin's_ `patch` function has been called. We'ere adding a
+        // `_datadog_wrapped` property instead.
+        delete object[name]._datadog_patched
+      }
     }
   }
 

--- a/packages/dd-trace/src/platform/node/loader.js
+++ b/packages/dd-trace/src/platform/node/loader.js
@@ -113,8 +113,12 @@ class Loader {
             })
         } catch (e) {
           log.error(e)
-          this._instrumenter.unload(plugin)
-          log.debug(`Error while trying to patch ${meta.name}. The plugin has been disabled.`)
+          if (isPreload) {
+            log.debug(`Error while trying to prepatch ${meta.name}. Will rely on regular patching instead.`)
+          } else {
+            this._instrumenter.unload(plugin)
+            log.debug(`Error while trying to patch ${meta.name}. The plugin has been disabled.`)
+          }
         }
       })
 

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -127,6 +127,21 @@ describe('Instrumenter', () => {
 
       expect(foo()).to.equal('foo')
     })
+
+    it('should not disable plugin when prepatch throws', () => {
+      instrumenter.disable()
+
+      integrations.prepatchable.prepatch = () => {
+        throw new Error('bad')
+      }
+
+      instrumenter = new Instrumenter(tracer)
+      instrumenter.enable()
+
+      const { foo } = require('prepatchable')
+
+      expect(foo()).to.equal('bar')
+    })
   })
 
   describe('with integrations enabled', () => {

--- a/packages/dd-trace/test/node_modules/prepatchable/index.js
+++ b/packages/dd-trace/test/node_modules/prepatchable/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+exports.foo = function foo () {
+  return 'foo'
+}

--- a/packages/dd-trace/test/node_modules/prepatchable/package.json
+++ b/packages/dd-trace/test/node_modules/prepatchable/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "prepatchable",
+  "version": "4.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "private": true
+}


### PR DESCRIPTION


### What does this PR do?
This wraps all methods that we intend to patch on any module that's required
after we are, so that functions exported by those modules can be extracted from
those modules before our initialization happens.

This reduces the chances of having a load order issue impacting users, because
as long as `dd-trace` is required first, any plugin supporting prepatching will
work (and be instrumented) as intended once `init()` is called.

This is done by wrapping any function we _intend_ to instrument (assuming
everything would later be enabled) and passing through by default. If the plugin
is enabled, the pass-through is replaced by the instrumented version of the
function.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Load order issues are plentiful, and the sooner (in execution time) we can
insert a wrapper in place, the better support we can have for various use
cases.
<!-- What inspired you to submit this pull request? -->
