### PR TITLE
Remove only from it, probably left in by accident

### DIFF
--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -641,7 +641,7 @@ describe('Plugin', () => {
           })
         })
 
-        it.only('should use the correct fallback protocol', done => {
+        it('should use the correct fallback protocol', done => {
           const app = express()
 
           app.get('/user', (req, res) => {


### PR DESCRIPTION
### What does this PR do?
Removes an `only` from a test that prevented the tests for the `http` plugin to run fully. It has been introduced in [this commit](https://github.com/vecerek/dd-trace-js/commit/4a46c211be5f61b768056ddd67f7db626bba8869) and left in there probably by accident.

### Motivation
<!-- What inspired you to submit this pull request? -->
I want to fiddle around with the `http` plugin and figured I can't even run all the tests locally 😄 