### PR TITLE
fix consumer span not waiting for message ack before finishing

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/src/index.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/index.js
@@ -51,6 +51,7 @@ function createWrapSubscriptionEmit (tracer, config) {
           return emit.apply(this, arguments)
         } catch (e) {
           span.setTag('error', e)
+          throw e
         }
       })
     }

--- a/packages/datadog-plugin-google-cloud-pubsub/src/index.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/index.js
@@ -57,9 +57,9 @@ function createWrapSubscriptionEmit (tracer, config) {
   }
 }
 
-function createWrapLeaseAdd (tracer, config) {
-  return function wrapAdd (add) {
-    return function addWithTrace (message) {
+function createWrapLeaseDispense (tracer, config) {
+  return function wrapDispense (dispense) {
+    return function dispenseWithTrace (message) {
       const subscription = message._subscriber._subscription
       const topic = subscription.metadata && subscription.metadata.topic
       const tags = {
@@ -76,7 +76,7 @@ function createWrapLeaseAdd (tracer, config) {
 
       message._datadog_span = span
 
-      return add.apply(this, arguments)
+      return dispense.apply(this, arguments)
     }
   }
 }
@@ -136,12 +136,12 @@ module.exports = [
     versions: ['>=1.2'],
     file: 'build/src/lease-manager.js',
     patch ({ LeaseManager }, tracer, config) {
-      this.wrap(LeaseManager.prototype, 'add', createWrapLeaseAdd(tracer, config))
+      this.wrap(LeaseManager.prototype, '_dispense', createWrapLeaseDispense(tracer, config))
       this.wrap(LeaseManager.prototype, 'remove', createWrapLeaseRemove(tracer, config))
       this.wrap(LeaseManager.prototype, 'clear', createWrapLeaseClear(tracer, config))
     },
     unpatch ({ LeaseManager }) {
-      this.unwrap(LeaseManager.prototype, 'add')
+      this.unwrap(LeaseManager.prototype, '_dispense')
       this.unwrap(LeaseManager.prototype, 'remove')
       this.unwrap(LeaseManager.prototype, 'clear')
     }

--- a/packages/datadog-plugin-google-cloud-pubsub/src/index.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/index.js
@@ -40,23 +40,65 @@ function createWrapRequest (tracer, config) {
 function createWrapSubscriptionEmit (tracer, config) {
   return function wrapSubscriptionEmit (emit) {
     return function emitWithTrace (eventName, message) {
-      if (eventName !== 'message' || !message) {
+      if (eventName !== 'message' || !message || !message._datadog_span) {
         return emit.apply(this, arguments)
       }
 
-      const topic = this.metadata && this.metadata.topic
+      const span = message._datadog_span
+
+      return tracer.scope().activate(span, () => {
+        try {
+          return emit.apply(this, arguments)
+        } catch (e) {
+          span.setTag('error', e)
+        }
+      })
+    }
+  }
+}
+
+function createWrapLeaseAdd (tracer, config) {
+  return function wrapAdd (add) {
+    return function addWithTrace (message) {
+      const subscription = message._subscriber._subscription
+      const topic = subscription.metadata && subscription.metadata.topic
       const tags = {
         component: '@google-cloud/pubsub',
         'resource.name': topic,
         'service.name': config.service || tracer._service,
-        'gcloud.project_id': this.pubsub.projectId,
+        'gcloud.project_id': subscription.pubsub.projectId,
         'pubsub.topic': topic,
         'span.kind': 'consumer'
       }
+
       const childOf = tracer.extract('text_map', message.attributes)
-      return tracer.trace('pubsub.receive', { tags, childOf }, (span) => {
-        return emit.apply(this, arguments)
-      })
+      const span = tracer.startSpan('pubsub.receive', { tags, childOf })
+
+      message._datadog_span = span
+
+      return add.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapLeaseRemove (tracer, config) {
+  return function wrapRemove (remove) {
+    return function removeWithTrace (message) {
+      finish(message)
+
+      return remove.apply(this, arguments)
+    }
+  }
+}
+
+function createWrapLeaseClear (tracer, config) {
+  return function wrapClear (clear) {
+    return function clearWithTrace () {
+      for (const message of this._messages) {
+        finish(message)
+      }
+
+      return clear.apply(this, arguments)
     }
   }
 }
@@ -65,6 +107,15 @@ function getTopic (cfg) {
   if (cfg.reqOpts) {
     return cfg.reqOpts[cfg.method === 'createTopic' ? 'name' : 'topic']
   }
+}
+
+function finish (message) {
+  const span = message._datadog_span
+
+  if (!span) return
+
+  span.setTag('pubsub.ack', message._handled ? 1 : 0)
+  span.finish()
 }
 
 module.exports = [
@@ -78,6 +129,21 @@ module.exports = [
     unpatch ({ PubSub, Subscription }) {
       this.unwrap(PubSub.prototype, 'request')
       this.unwrap(Subscription.prototype, 'emit')
+    }
+  },
+  {
+    name: '@google-cloud/pubsub',
+    versions: ['>=1.2'],
+    file: 'build/src/lease-manager.js',
+    patch ({ LeaseManager }, tracer, config) {
+      this.wrap(LeaseManager.prototype, 'add', createWrapLeaseAdd(tracer, config))
+      this.wrap(LeaseManager.prototype, 'remove', createWrapLeaseRemove(tracer, config))
+      this.wrap(LeaseManager.prototype, 'clear', createWrapLeaseClear(tracer, config))
+    },
+    unpatch ({ LeaseManager }) {
+      this.unwrap(LeaseManager.prototype, 'add')
+      this.unwrap(LeaseManager.prototype, 'remove')
+      this.unwrap(LeaseManager.prototype, 'clear')
     }
   }
 ]

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -8,7 +8,7 @@ const id = require('../../dd-trace/src/id')
 wrapIt()
 
 // The roundtrip to the pubsub emulator takes time. Sometimes a *long* time.
-const TIMEOUT = 5000
+const TIMEOUT = 30000
 
 describe('Plugin', () => {
   let tracer
@@ -140,11 +140,16 @@ describe('Plugin', () => {
           it('should be instrumented', async () => {
             const expectedSpanPromise = expectSpanWithDefaults({
               name: 'pubsub.receive',
-              meta: { 'span.kind': 'consumer' }
+              meta: {
+                'span.kind': 'consumer'
+              },
+              metrics: {
+                'pubsub.ack': 1
+              }
             })
             const [topic] = await pubsub.createTopic(topicName)
             const [sub] = await topic.createSubscription('foo')
-            sub.on('message', () => {})
+            sub.on('message', msg => msg.ack())
             await publish(topic, { data: Buffer.from('hello') })
             return expectedSpanPromise
           })
@@ -157,11 +162,12 @@ describe('Plugin', () => {
             const [topic] = await pubsub.createTopic(topicName)
             const [sub] = await topic.createSubscription('foo')
             const rxPromise = new Promise((resolve, reject) => {
-              sub.on('message', () => {
+              sub.on('message', msg => {
                 const receiverSpanContext = tracer.scope().active()._spanContext
                 try {
                   expect(receiverSpanContext._parentId).to.be.an('object')
                   resolve()
+                  msg.ack()
                 } catch (e) {
                   reject(e)
                 }
@@ -193,8 +199,12 @@ describe('Plugin', () => {
                 // this is just to prevent mocha from crashing
               }
             }
-            sub.on('message', () => {
-              throw error
+            sub.on('message', msg => {
+              try {
+                throw error
+              } finally {
+                msg.ack()
+              }
             })
             await publish(topic, { data: Buffer.from('hello') })
             return expectedSpanPromise

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -192,11 +192,17 @@ describe('Plugin', () => {
             const [topic] = await pubsub.createTopic(topicName)
             const [sub] = await topic.createSubscription('foo')
             const emit = sub.emit
-            sub.emit = function emitWrapped () {
+            sub.emit = function emitWrapped (name) {
+              let err
+
               try {
                 return emit.apply(this, arguments)
               } catch (e) {
-                // this is just to prevent mocha from crashing
+                err = e
+              } finally {
+                if (name === 'message') {
+                  expect(err).to.equal(error)
+                }
               }
             }
             sub.on('message', msg => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix consumer span not waiting for message ack before finishing.

### Motivation
<!-- What inspired you to submit this pull request? -->

A message has only been handled after it has been acknowledged. The library handles messages that are not acknowledged in time with a deadline system so it's guaranteed that the message will eventually be acknowledged even if there is a bug in the user code that never calls ack/nack.

Closes #964