### PR TITLE
add option to mark internal spans on errors

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -59,7 +59,8 @@ tracer.init({
         { sampleRate: 0.5, service: 'foo', name: 'foo.request' },
         { sampleRate: 0.1, service: /foo/, name: /foo\.request/ }
       ]
-    }
+    },
+    internalErrors: true
   },
   hostname: 'agent',
   logger: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -371,6 +371,12 @@ export declare interface TracerOptions {
      * @default false
      */
     enableGetRumData?: boolean
+
+    /**
+     * Whether to set the error flag when an error occurs in an internal span.
+     * @default false
+     */
+    internalErrors?: boolean
   };
 
   /**

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -140,7 +140,8 @@ class Config {
       exporter: options.experimental && options.experimental.exporter,
       peers: (options.experimental && options.experimental.distributedTracingOriginWhitelist) || [],
       enableGetRumData: (options.experimental && !!options.experimental.enableGetRumData),
-      sampler
+      sampler,
+      internalErrors: options.experimental && options.experimental.internalErrors
     }
     this.reportHostname = isTrue(coalesce(options.reportHostname, platform.env('DD_TRACE_REPORT_HOSTNAME'), false))
     this.scope = isFalse(platform.env('DD_CONTEXT_PROPAGATION'))

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -51,6 +51,7 @@ function extractTags (trace, span) {
   const tags = context._tags
   const hostname = context._hostname
   const priority = context._sampling.priority
+  const internalErrors = span.tracer()._internalErrors
 
   for (const tag in tags) {
     switch (tag) {
@@ -70,7 +71,7 @@ function extractTags (trace, span) {
         addTag({}, trace.metrics, tag, tags[tag] === undefined || tags[tag] ? 1 : 0)
         break
       case 'error':
-        if (tags[tag] && tags['span.kind'] !== 'internal') {
+        if (tags[tag] && (tags['span.kind'] !== 'internal' || internalErrors)) {
           trace.error = 1
         }
         break
@@ -78,7 +79,7 @@ function extractTags (trace, span) {
       case 'error.msg':
       case 'error.stack':
         // HACK: remove when implemented in the backend
-        if (tags['span.kind'] !== 'internal') {
+        if (tags['span.kind'] !== 'internal' || internalErrors) {
           trace.error = 1
         }
       default: // eslint-disable-line no-fallthrough

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -36,6 +36,7 @@ class DatadogTracer extends Tracer {
     this._logInjection = config.logInjection
     this._analytics = config.analytics
     this._debug = config.debug
+    this._internalErrors = config.experimental.internalErrors
     this._prioritySampler = new PrioritySampler(config.env, config.experimental.sampler)
     this._exporter = new Exporter(config, this._prioritySampler)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add option to mark internal spans on errors.

### Motivation
<!-- What inspired you to submit this pull request? -->

While in general errors on internal spans are too noisy, there are cases where they might actually be needed. Ideally this should be more granular, but for now it will at least allow users to stop hiding internal errors.