### PR TITLE
fix double-routing in restify

### DIFF
--- a/packages/datadog-plugin-fastify/src/find-my-way.js
+++ b/packages/datadog-plugin-fastify/src/find-my-way.js
@@ -10,7 +10,7 @@ function createWrapOn () {
       const wrapper = function (req) {
         web.patch(req)
         web.enterRoute(req, path)
-        req._datadog._dd_path_added_by_find_my_way = true
+        req._datadog._dd_route_entered = true
 
         return handler.apply(this, arguments)
       }

--- a/packages/datadog-plugin-fastify/src/find-my-way.js
+++ b/packages/datadog-plugin-fastify/src/find-my-way.js
@@ -10,6 +10,7 @@ function createWrapOn () {
       const wrapper = function (req) {
         web.patch(req)
         web.enterRoute(req, path)
+        req._datadog._dd_path_added_by_find_my_way = true
 
         return handler.apply(this, arguments)
       }

--- a/packages/datadog-plugin-fastify/src/find-my-way.js
+++ b/packages/datadog-plugin-fastify/src/find-my-way.js
@@ -10,7 +10,7 @@ function createWrapOn () {
       const wrapper = function (req) {
         web.patch(req)
         web.enterRoute(req, path)
-        req._datadog._dd_route_entered = true
+        req._datadog.routeEntered = true
 
         return handler.apply(this, arguments)
       }

--- a/packages/datadog-plugin-fastify/src/index.js
+++ b/packages/datadog-plugin-fastify/src/index.js
@@ -2,5 +2,5 @@
 
 module.exports = [].concat(
   require('./fastify'),
-  require('./find-my-way')
+  require('./find-my-way') // TODO make this its own plugin, since restify uses it too
 )

--- a/packages/datadog-plugin-restify/src/index.js
+++ b/packages/datadog-plugin-restify/src/index.js
@@ -11,7 +11,7 @@ function createWrapSetupRequest (tracer, config) {
     return function setupRequestWithTrace (req, res) {
       return web.instrument(tracer, config, req, res, 'restify.request', () => {
         web.beforeEnd(req, () => {
-          if (req.route) {
+          if (req.route && !req._datadog._dd_path_added_by_find_my_way) {
             web.enterRoute(req, req.route.path)
           }
         })

--- a/packages/datadog-plugin-restify/src/index.js
+++ b/packages/datadog-plugin-restify/src/index.js
@@ -11,7 +11,7 @@ function createWrapSetupRequest (tracer, config) {
     return function setupRequestWithTrace (req, res) {
       return web.instrument(tracer, config, req, res, 'restify.request', () => {
         web.beforeEnd(req, () => {
-          if (req.route && !req._datadog._dd_path_added_by_find_my_way) {
+          if (req.route && !req._datadog._dd_route_entered) {
             web.enterRoute(req, req.route.path)
           }
         })

--- a/packages/datadog-plugin-restify/src/index.js
+++ b/packages/datadog-plugin-restify/src/index.js
@@ -11,7 +11,7 @@ function createWrapSetupRequest (tracer, config) {
     return function setupRequestWithTrace (req, res) {
       return web.instrument(tracer, config, req, res, 'restify.request', () => {
         web.beforeEnd(req, () => {
-          if (req.route && !req._datadog._dd_route_entered) {
+          if (req.route && !req._datadog.routeEntered) {
             web.enterRoute(req, req.route.path)
           }
         })

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -30,7 +30,9 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => agent.load('restify'))
+        // We're loading the fastify plugin here because it includes `find-my-way` which is also
+        // used by restify.
+        before(() => agent.load(['restify', 'fastify']))
         after(() => agent.close())
 
         it('should do automatic instrumentation', done => {


### PR DESCRIPTION
### What does this PR do?
Newer versions of `restify` use `find-my-way`, which we also have
instrumentation for. This was resulting in the route being added twice.
This change signals the `restify` plugin when `find-my-way` is used, so
that there's no need to add the route.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
Some folks were seeing their routes doubled up.
<!-- What inspired you to submit this pull request? -->

