### PR TITLE
fix graphql plugin error when using sampling

### DIFF
--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -342,7 +342,8 @@ function finishResolvers (contextValue) {
 }
 
 function updateField (field, error) {
-  field.finishTime = field.span._getTime()
+  // TODO: update this to also work with no-op spans without a hack
+  field.finishTime = field.span._getTime ? field.span._getTime() : 0
   field.error = field.error || error
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix GraphQL plugin error when using sampling. For now this is fixed in the plugin directly, but eventually a cleaner way to do handle this should be implemented.

### Motivation
<!-- What inspired you to submit this pull request? -->

The no-op implementation of `Span` doesn't have the `_getTime` private method which is used by the GraphQL plugin. Ideally this method should not be needed since it's private, but the way the GraphQL plugin works means it needs to be able to store the finish time when resolving arrays.

Fixes #1163 