### PR TITLE
update encoder to reuse memory between encodes

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -29,7 +29,7 @@ class AgentEncoder {
   }
 
   makePayload () {
-    const prefix = Buffer.alloc(5)
+    const prefix = Buffer.allocUnsafe(5)
 
     prefix[0] = 0xdd
     prefix.writeUInt32BE(this._traces.length, 1)

--- a/packages/dd-trace/src/encode/0.5.js
+++ b/packages/dd-trace/src/encode/0.5.js
@@ -121,11 +121,11 @@ class AgentEncoder {
     } else if (value < 0x100000000) { // uint 32
       bytes.push(0xce, value >> 24, value >> 16, value >> 8, value)
     } else {
-      this._encodeBigInt(bytes, value)
+      this._encodeLong(bytes, value)
     }
   }
 
-  _encodeBigInt (bytes, value) {
+  _encodeLong (bytes, value) {
     const hi = (value / Math.pow(2, 32)) >> 0
     const lo = value >>> 0
 

--- a/packages/dd-trace/src/encode/chunk.js
+++ b/packages/dd-trace/src/encode/chunk.js
@@ -2,6 +2,11 @@
 
 const DEFAULT_MIN_SIZE = 2 * 1024 * 1024 // 2MB
 
+/**
+ * Represents a chunk of a Msgpack payload. Exposes a subset of Array and Buffer
+ * interfaces so that it can be used seamlessly by any encoder code that expects
+ * either.
+ */
 class Chunk {
   constructor (minSize = DEFAULT_MIN_SIZE) {
     this.buffer = Buffer.allocUnsafe(minSize)

--- a/packages/dd-trace/src/encode/chunk.js
+++ b/packages/dd-trace/src/encode/chunk.js
@@ -1,0 +1,53 @@
+'use strict'
+
+class Chunk {
+  constructor (minSize = 1024 * 1024) {
+    this.buffer = Buffer.allocUnsafe(minSize)
+    this.length = 0
+    this._minSize = minSize
+  }
+
+  push (...bytes) {
+    this._reserve(bytes.length)
+
+    for (const byte of bytes) {
+      this.buffer[this.length++] = byte
+    }
+  }
+
+  write (value) {
+    const length = Buffer.byteLength(value)
+
+    if (length < 0x20) { // fixstr
+      this.push(length | 0xa0)
+    } else if (length < 0x100) { // str 8
+      this.push(0xd9, length)
+    } else if (length < 0x10000) { // str 16
+      this.push(0xda, length >> 8, length)
+    } else if (length < 0x100000000) { // str 32
+      this.push(0xdb, length >> 24, length >> 16, length >> 8, length)
+    } else {
+      throw new Error('String too long')
+    }
+
+    this._reserve(length)
+
+    this.length += this.buffer.utf8Write(value, this.length, length)
+  }
+
+  _reserve (size) {
+    if (this.length + size > this.buffer.length) {
+      this._resize(this._minSize * Math.ceil((this.length + size) / this._minSize))
+    }
+  }
+
+  _resize (size) {
+    const oldBuffer = this.buffer
+
+    this.buffer = Buffer.allocUnsafe(size)
+
+    oldBuffer.copy(this.buffer, 0, 0, this.length)
+  }
+}
+
+module.exports = Chunk

--- a/packages/dd-trace/src/encode/chunk.js
+++ b/packages/dd-trace/src/encode/chunk.js
@@ -1,7 +1,9 @@
 'use strict'
 
+const DEFAULT_MIN_SIZE = 2 * 1024 * 1024 // 2MB
+
 class Chunk {
-  constructor (minSize = 1024 * 1024) {
+  constructor (minSize = DEFAULT_MIN_SIZE) {
     this.buffer = Buffer.allocUnsafe(minSize)
     this.length = 0
     this._minSize = minSize


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update encoder to reuse memory between encodes.

### Motivation
<!-- What inspired you to submit this pull request? -->

Reusing buffers to encode data is 2x faster and 2-10x more memory efficient than constantly allocating new arrays under heavy load. I also verified that there was no regression under very light load.

#### Before

`encode (0.5) x 759,535 ops/sec ±5.68% (50 runs sampled)`

Memory usage rapidly moving between 100MB and 400MB. (realworld, max reqs/sec)

#### After

`encode (0.5) x 1,704,048 ops/sec ±2.23% (50 runs sampled)`

Memory usage stable around 55MB. (realworld, max reqs/sec)