### PR TITLE
CI / Test Reorganization

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -1,87 +1,32 @@
+const { promisify } = require('util')
+
 const id = require('../../dd-trace/src/id')
 const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
 const { SAMPLING_PRIORITY } = require('../../../ext/tags')
 const { AUTO_KEEP } = require('../../../ext/priority')
 
-const { execSync } = require('child_process')
-const { promisify } = require('util')
-
-const GIT_COMMIT_SHA = 'git.commit.sha'
-// TODO: remove this once CI App's UI and backend are ready
-const DEPRECATED_GIT_COMMIT_SHA = 'git.commit_sha'
-const GIT_BRANCH = 'git.branch'
-const GIT_REPOSITORY_URL = 'git.repository_url'
-const BUILD_SOURCE_ROOT = 'build.source_root'
-const TEST_FRAMEWORK = 'test.framework'
-const TEST_TYPE = 'test.type'
-const TEST_NAME = 'test.name'
-const TEST_SUITE = 'test.suite'
-const TEST_STATUS = 'test.status'
-const CI_PIPELINE_URL = 'ci.pipeline.url'
-const CI_PIPELINE_ID = 'ci.pipeline.id'
-const CI_PIPELINE_NUMBER = 'ci.pipeline.number'
-const CI_WORKSPACE_PATH = 'ci.workspace_path'
-const CI_PROVIDER_NAME = 'ci.provider.name'
+const { getGitMetadata } = require('../../dd-trace/src/plugins/util/git')
+const { getCIMetadata } = require('../../dd-trace/src/plugins/util/ci')
+const {
+  TEST_FRAMEWORK,
+  TEST_TYPE,
+  TEST_NAME,
+  TEST_SUITE,
+  TEST_STATUS
+} = require('../../dd-trace/src/plugins/util/test')
 
 const SPAN_TYPE = 'span.type'
 const RESOURCE_NAME = 'resource.name'
-
-function getCIMetadata () {
-  const { env } = process
-  if (env.GITHUB_ACTIONS) {
-    const { GITHUB_REF, GITHUB_SHA, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_NUMBER, GITHUB_WORKSPACE } = env
-
-    const pipelineURL = `https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
-
-    return {
-      [CI_PIPELINE_URL]: pipelineURL,
-      [CI_PIPELINE_ID]: GITHUB_RUN_ID,
-      [CI_PROVIDER_NAME]: 'github',
-      [CI_PIPELINE_NUMBER]: GITHUB_RUN_NUMBER,
-      [CI_WORKSPACE_PATH]: GITHUB_WORKSPACE,
-      [GIT_BRANCH]: GITHUB_REF,
-      [GIT_COMMIT_SHA]: GITHUB_SHA,
-      [DEPRECATED_GIT_COMMIT_SHA]: GITHUB_SHA
-    }
-  }
-  return {}
-}
-
-const sanitizedRun = cmd => {
-  try {
-    return execSync(cmd).toString().replace(/(\r\n|\n|\r)/gm, '')
-  } catch (e) {
-    return ''
-  }
-}
-
-function getGitMetadata () {
-  const commitSha = sanitizedRun('git rev-parse HEAD')
-  return {
-    [GIT_REPOSITORY_URL]: sanitizedRun('git ls-remote --get-url'),
-    [GIT_BRANCH]: sanitizedRun('git branch --show-current'),
-    [GIT_COMMIT_SHA]: commitSha,
-    [DEPRECATED_GIT_COMMIT_SHA]: commitSha
-  }
-}
-
-function getEnvMetadata () {
-  return {
-    [BUILD_SOURCE_ROOT]: sanitizedRun('pwd')
-  }
-}
 
 function getTestMetadata () {
   // TODO: eventually these will come from the tracer (generally available)
   const ciMetadata = getCIMetadata()
   const gitMetadata = getGitMetadata()
-  const envMetadata = getEnvMetadata()
 
   return {
     [TEST_FRAMEWORK]: 'jest',
     ...ciMetadata,
-    ...gitMetadata,
-    ...envMetadata
+    ...gitMetadata
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -1,0 +1,86 @@
+const { GIT_BRANCH, GIT_COMMIT_SHA } = require('./git')
+
+const CI_PIPELINE_URL = 'ci.pipeline.url'
+const CI_PIPELINE_ID = 'ci.pipeline.id'
+const CI_PIPELINE_NUMBER = 'ci.pipeline.number'
+const CI_WORKSPACE_PATH = 'ci.workspace_path'
+const CI_PROVIDER_NAME = 'ci.provider.name'
+const BUILD_SOURCE_ROOT = 'build.source_root'
+
+module.exports = {
+  CI_PIPELINE_URL,
+  CI_PIPELINE_ID,
+  CI_PIPELINE_NUMBER,
+  CI_WORKSPACE_PATH,
+  CI_PROVIDER_NAME,
+  BUILD_SOURCE_ROOT,
+  getCIMetadata () {
+    const { env } = process
+
+    if (env.JENKINS_URL) {
+      const { BUILD_URL, GIT_COMMIT, GIT_BRANCH, BUILD_ID, BUILD_NUMBER, WORKSPACE } = env
+      return {
+        [CI_PIPELINE_URL]: BUILD_URL,
+        [CI_PIPELINE_ID]: BUILD_ID,
+        [CI_PROVIDER_NAME]: 'jenkins',
+        [CI_PIPELINE_NUMBER]: BUILD_NUMBER,
+        [CI_WORKSPACE_PATH]: WORKSPACE,
+        [GIT_BRANCH]: GIT_BRANCH,
+        [GIT_COMMIT_SHA]: GIT_COMMIT,
+        [BUILD_SOURCE_ROOT]: WORKSPACE
+      }
+    }
+
+    if (env.GITLAB_CI) {
+      const { CI_JOB_URL, CI_COMMIT_SHA, CI_COMMIT_BRANCH, CI_BUILD_ID, CI_PROJECT_PATH } = env
+      return {
+        [CI_PIPELINE_URL]: CI_JOB_URL,
+        [CI_PIPELINE_ID]: CI_BUILD_ID,
+        [CI_PROVIDER_NAME]: 'gitlab',
+        [CI_WORKSPACE_PATH]: CI_PROJECT_PATH,
+        [GIT_BRANCH]: CI_COMMIT_BRANCH,
+        [GIT_COMMIT_SHA]: CI_COMMIT_SHA,
+        [BUILD_SOURCE_ROOT]: CI_PROJECT_PATH
+      }
+    }
+
+    if (env.CIRCLECI) {
+      const {
+        CIRCLE_BUILD_URL,
+        CIRCLE_BUILD_NUM,
+        CIRCLE_WORKFLOW_ID,
+        CIRCLE_WORKING_DIRECTORY,
+        CIRCLE_SHA1,
+        CIRCLE_BRANCH
+      } = env
+      return {
+        [CI_PIPELINE_URL]: CIRCLE_BUILD_URL,
+        [CI_PIPELINE_ID]: CIRCLE_WORKFLOW_ID,
+        [CI_PROVIDER_NAME]: 'circleci',
+        [CI_PIPELINE_NUMBER]: CIRCLE_BUILD_NUM,
+        [CI_WORKSPACE_PATH]: CIRCLE_WORKING_DIRECTORY,
+        [GIT_BRANCH]: CIRCLE_BRANCH,
+        [GIT_COMMIT_SHA]: CIRCLE_SHA1,
+        [BUILD_SOURCE_ROOT]: CIRCLE_WORKING_DIRECTORY
+      }
+    }
+
+    if (env.GITHUB_ACTIONS) {
+      const { GITHUB_REF, GITHUB_SHA, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_NUMBER, GITHUB_WORKSPACE } = env
+
+      const pipelineURL = `https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
+
+      return {
+        [CI_PIPELINE_URL]: pipelineURL,
+        [CI_PIPELINE_ID]: GITHUB_RUN_ID,
+        [CI_PROVIDER_NAME]: 'github',
+        [CI_PIPELINE_NUMBER]: GITHUB_RUN_NUMBER,
+        [CI_WORKSPACE_PATH]: GITHUB_WORKSPACE,
+        [GIT_BRANCH]: GITHUB_REF,
+        [GIT_COMMIT_SHA]: GITHUB_SHA,
+        [BUILD_SOURCE_ROOT]: GITHUB_WORKSPACE
+      }
+    }
+    return {}
+  }
+}

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -1,84 +1,125 @@
 const { GIT_BRANCH, GIT_COMMIT_SHA } = require('./git')
 
-const CI_PIPELINE_URL = 'ci.pipeline.url'
-const CI_PIPELINE_ID = 'ci.pipeline.id'
-const CI_PIPELINE_NUMBER = 'ci.pipeline.number'
-const CI_WORKSPACE_PATH = 'ci.workspace_path'
-const CI_PROVIDER_NAME = 'ci.provider.name'
 const BUILD_SOURCE_ROOT = 'build.source_root'
+const CI_PIPELINE_ID = 'ci.pipeline.id'
+const CI_PIPELINE_NAME = 'ci.pipeline.name'
+const CI_PIPELINE_NUMBER = 'ci.pipeline.number'
+const CI_PIPELINE_URL = 'ci.pipeline.url'
+const CI_PROVIDER_NAME = 'ci.provider.name'
+const CI_WORKSPACE_PATH = 'ci.workspace_path'
+const GIT_REPOSITORY_URL = 'git.repository_url'
 
 module.exports = {
-  CI_PIPELINE_URL,
-  CI_PIPELINE_ID,
-  CI_PIPELINE_NUMBER,
-  CI_WORKSPACE_PATH,
-  CI_PROVIDER_NAME,
   BUILD_SOURCE_ROOT,
+  CI_PIPELINE_ID,
+  CI_PIPELINE_NAME,
+  CI_PIPELINE_NUMBER,
+  CI_PIPELINE_URL,
+  CI_PROVIDER_NAME,
+  CI_WORKSPACE_PATH,
   getCIMetadata () {
     const { env } = process
 
     if (env.JENKINS_URL) {
-      const { BUILD_URL, GIT_COMMIT, GIT_BRANCH, BUILD_ID, BUILD_NUMBER, WORKSPACE } = env
+      const {
+        WORKSPACE,
+        BUILD_TAG,
+        JOB_NAME,
+        BUILD_NUMBER,
+        BUILD_URL,
+        GIT_BRANCH: JENKINS_GIT_BRANCH,
+        GIT_COMMIT: JENKINS_GIT_COMMIT,
+        JENKINS_GIT_REPOSITORY_URL
+      } = env
       return {
-        [CI_PIPELINE_URL]: BUILD_URL,
-        [CI_PIPELINE_ID]: BUILD_ID,
-        [CI_PROVIDER_NAME]: 'jenkins',
+        [BUILD_SOURCE_ROOT]: WORKSPACE,
+        [CI_PIPELINE_ID]: BUILD_TAG,
+        [CI_PIPELINE_NAME]: JOB_NAME,
         [CI_PIPELINE_NUMBER]: BUILD_NUMBER,
+        [CI_PIPELINE_URL]: BUILD_URL,
+        [CI_PROVIDER_NAME]: 'jenkins',
         [CI_WORKSPACE_PATH]: WORKSPACE,
-        [GIT_BRANCH]: GIT_BRANCH,
-        [GIT_COMMIT_SHA]: GIT_COMMIT,
-        [BUILD_SOURCE_ROOT]: WORKSPACE
+        [GIT_BRANCH]: JENKINS_GIT_BRANCH,
+        [GIT_COMMIT_SHA]: JENKINS_GIT_COMMIT,
+        [GIT_REPOSITORY_URL]: JENKINS_GIT_REPOSITORY_URL
       }
     }
 
     if (env.GITLAB_CI) {
-      const { CI_JOB_URL, CI_COMMIT_SHA, CI_COMMIT_BRANCH, CI_BUILD_ID, CI_PROJECT_PATH } = env
+      const {
+        CI_PIPELINE_ID: GITLAB_PIPELINE_ID,
+        CI_PROJECT_PATH,
+        CI_PIPELINE_IID,
+        CI_PIPELINE_URL,
+        CI_PROJECT_DIR,
+        CI_COMMIT_BRANCH,
+        CI_COMMIT_SHA,
+        CI_REPOSITORY_URL
+      } = env
       return {
-        [CI_PIPELINE_URL]: CI_JOB_URL,
-        [CI_PIPELINE_ID]: CI_BUILD_ID,
+        [BUILD_SOURCE_ROOT]: CI_PROJECT_DIR,
+        [CI_PIPELINE_ID]: GITLAB_PIPELINE_ID,
+        [CI_PIPELINE_NAME]: CI_PROJECT_PATH,
+        [CI_PIPELINE_NUMBER]: CI_PIPELINE_IID,
+        [CI_PIPELINE_URL]: `${(CI_PIPELINE_URL || '').replace('/-/pipelines/', '/pipelines/')}`,
         [CI_PROVIDER_NAME]: 'gitlab',
-        [CI_WORKSPACE_PATH]: CI_PROJECT_PATH,
+        [CI_WORKSPACE_PATH]: CI_PROJECT_DIR,
         [GIT_BRANCH]: CI_COMMIT_BRANCH,
         [GIT_COMMIT_SHA]: CI_COMMIT_SHA,
-        [BUILD_SOURCE_ROOT]: CI_PROJECT_PATH
+        [GIT_REPOSITORY_URL]: CI_REPOSITORY_URL
       }
     }
 
     if (env.CIRCLECI) {
       const {
-        CIRCLE_BUILD_URL,
-        CIRCLE_BUILD_NUM,
         CIRCLE_WORKFLOW_ID,
+        CIRCLE_PROJECT_REPONAME,
+        CIRCLE_BUILD_NUM,
+        CIRCLE_BUILD_URL,
         CIRCLE_WORKING_DIRECTORY,
+        CIRCLE_BRANCH,
         CIRCLE_SHA1,
-        CIRCLE_BRANCH
+        CIRCLE_REPOSITORY_URL
       } = env
       return {
-        [CI_PIPELINE_URL]: CIRCLE_BUILD_URL,
+        [BUILD_SOURCE_ROOT]: CIRCLE_WORKING_DIRECTORY,
         [CI_PIPELINE_ID]: CIRCLE_WORKFLOW_ID,
-        [CI_PROVIDER_NAME]: 'circleci',
+        [CI_PIPELINE_NAME]: CIRCLE_PROJECT_REPONAME,
         [CI_PIPELINE_NUMBER]: CIRCLE_BUILD_NUM,
+        [CI_PIPELINE_URL]: CIRCLE_BUILD_URL,
+        [CI_PROVIDER_NAME]: 'circleci',
         [CI_WORKSPACE_PATH]: CIRCLE_WORKING_DIRECTORY,
         [GIT_BRANCH]: CIRCLE_BRANCH,
         [GIT_COMMIT_SHA]: CIRCLE_SHA1,
-        [BUILD_SOURCE_ROOT]: CIRCLE_WORKING_DIRECTORY
+        [GIT_REPOSITORY_URL]: CIRCLE_REPOSITORY_URL
       }
     }
 
     if (env.GITHUB_ACTIONS) {
-      const { GITHUB_REF, GITHUB_SHA, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_NUMBER, GITHUB_WORKSPACE } = env
+      const {
+        GITHUB_RUN_ID,
+        GITHUB_WORKFLOW,
+        GITHUB_RUN_NUMBER,
+        GITHUB_WORKSPACE,
+        GITHUB_REF,
+        GITHUB_SHA,
+        GITHUB_REPOSITORY
+      } = env
 
-      const pipelineURL = `https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
+      const repositoryURL = `https://github.com/${GITHUB_REPOSITORY}`
+      const pipelineURL = `${repositoryURL}/actions/runs/${GITHUB_RUN_ID}`
 
       return {
-        [CI_PIPELINE_URL]: pipelineURL,
+        [BUILD_SOURCE_ROOT]: GITHUB_WORKSPACE,
         [CI_PIPELINE_ID]: GITHUB_RUN_ID,
-        [CI_PROVIDER_NAME]: 'github',
+        [CI_PIPELINE_NAME]: GITHUB_WORKFLOW,
         [CI_PIPELINE_NUMBER]: GITHUB_RUN_NUMBER,
+        [CI_PIPELINE_URL]: pipelineURL,
+        [CI_PROVIDER_NAME]: 'github',
         [CI_WORKSPACE_PATH]: GITHUB_WORKSPACE,
         [GIT_BRANCH]: GITHUB_REF,
         [GIT_COMMIT_SHA]: GITHUB_SHA,
-        [BUILD_SOURCE_ROOT]: GITHUB_WORKSPACE
+        [GIT_REPOSITORY_URL]: repositoryURL
       }
     }
     return {}

--- a/packages/dd-trace/src/plugins/util/exec.js
+++ b/packages/dd-trace/src/plugins/util/exec.js
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process')
+
+const sanitizedExec = cmd => {
+  try {
+    return execSync(cmd).toString().replace(/(\r\n|\n|\r)/gm, '')
+  } catch (e) {
+    return ''
+  }
+}
+
+module.exports = { sanitizedExec }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -1,0 +1,19 @@
+const { sanitizedExec } = require('./exec')
+
+const GIT_COMMIT_SHA = 'git.commit.sha'
+// TODO: remove this once CI App's UI and backend are ready
+const DEPRECATED_GIT_COMMIT_SHA = 'git.commit_sha'
+const GIT_BRANCH = 'git.branch'
+const GIT_REPOSITORY_URL = 'git.repository_url'
+
+function getGitMetadata () {
+  const commitSha = sanitizedExec('git rev-parse HEAD')
+  return {
+    [GIT_REPOSITORY_URL]: sanitizedExec('git ls-remote --get-url'),
+    [GIT_BRANCH]: sanitizedExec('git branch --show-current'),
+    [GIT_COMMIT_SHA]: commitSha,
+    [DEPRECATED_GIT_COMMIT_SHA]: commitSha
+  }
+}
+
+module.exports = { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1,0 +1,13 @@
+const TEST_FRAMEWORK = 'test.framework'
+const TEST_TYPE = 'test.type'
+const TEST_NAME = 'test.name'
+const TEST_SUITE = 'test.suite'
+const TEST_STATUS = 'test.status'
+
+module.exports = {
+  TEST_FRAMEWORK,
+  TEST_TYPE,
+  TEST_NAME,
+  TEST_SUITE,
+  TEST_STATUS
+}


### PR DESCRIPTION
### What does this PR do?

* Move test and ci logic to common folder.
* Add support for Circle CI, Gitlab and Jenkins as CIs. 

### Motivation
When instrumenting `mocha`, a lot of the logic is the same as in `jest`, so this PR makes it easier to reuse the utility functions.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
