### PR TITLE
Support for service mapping

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -438,6 +438,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | clientToken     | `DD_CLIENT_TOKEN`                 | -              | Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`. |
 | logLevel        | `DD_TRACE_LOG_LEVEL`              | `debug`        | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `'error'`, `'debug'`. |
 | startupLogs     | `DD_TRACE_STARTUP_LOGS`           | `true`         | Enable tracer startup configuration and diagnostic log. |
+| serviceMapping     | `DD_SERVICE_MAPPING`           | `-`         | (Example: fs:my-fs-service-name, pg:my-postgres-service-name-db) Dynamically rename services via configuration. Useful for making databases have distinct names across different services. |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -438,7 +438,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | clientToken     | `DD_CLIENT_TOKEN`                 | -              | Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`. |
 | logLevel        | `DD_TRACE_LOG_LEVEL`              | `debug`        | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `'error'`, `'debug'`. |
 | startupLogs     | `DD_TRACE_STARTUP_LOGS`           | `true`         | Enable tracer startup configuration and diagnostic log. |
-| serviceMapping     | `DD_SERVICE_MAPPING`           | `-`         | (Example: fs:my-fs-service-name, pg:my-postgres-service-name-db) Dynamically rename services via configuration. Useful for making databases have distinct names across different services. |
+| serviceMapping     | `DD_SERVICE_MAPPING`           | `-`         | Dynamically rename plugins via configuration. (e.g.: `fs:my-service-name,pg:my-service-name`) |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -6,7 +6,7 @@ const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
 const tagger = require('./tagger')
 const id = require('./id')
-const { isTrue, isFalse } = require('./util')
+const { isTrue, isFalse, toKeyValuePairs } = require('./util')
 
 const runtimeId = `${id().toString()}${id().toString()}`
 
@@ -103,6 +103,10 @@ class Config {
       platform.env('DD_TRACE_AGENT_PROTOCOL_VERSION'),
       '0.4'
     )
+
+    this.serviceMapping = {}
+    Object.assign(this.serviceMapping, toKeyValuePairs(platform.env('DD_SERVICE_MAPPING')))
+    Object.assign(this.serviceMapping, options.serviceMapping || {})
 
     const sampler = (options.experimental && options.experimental.sampler) || {}
     const ingestion = options.ingestion || {}

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -81,7 +81,9 @@ class Instrumenter {
       Object.keys(plugins)
         .filter(name => !this._plugins.has(plugins[name]))
         .forEach(name => {
-          const options = config.serviceMapping[name] ? { service: config.serviceMapping[name] } : {}
+          const options = config.serviceMapping && config.serviceMapping[name]
+            ? { service: config.serviceMapping[name] }
+            : {}
           this._set(plugins[name], { name, config: getConfig(name, options) })
         })
     }
@@ -239,7 +241,9 @@ class Instrumenter {
     if (this._disabledPlugins.has(meta.name)) {
       log.debug(`Plugin "${meta.name}" was disabled via configuration option.`)
     } else {
-      this._plugins.set(plugin, meta)
+      const { config: oldConfig } = this._plugins.get(plugin) || {}
+      const { config: newConfig } = meta
+      this._plugins.set(plugin, { ...meta, config: { ...oldConfig, ...newConfig } })
       this.load(plugin, meta)
     }
   }

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -81,7 +81,8 @@ class Instrumenter {
       Object.keys(plugins)
         .filter(name => !this._plugins.has(plugins[name]))
         .forEach(name => {
-          this._set(plugins[name], { name, config: getConfig(name) })
+          const options = config.serviceMapping[name] ? { service: config.serviceMapping[name] } : {}
+          this._set(plugins[name], { name, config: getConfig(name, options) })
         })
     }
 

--- a/packages/dd-trace/src/tagger.js
+++ b/packages/dd-trace/src/tagger.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const log = require('./log')
+const { toKeyValuePairs } = require('./util')
 
 function add (carrier, keyValuePairs) {
   if (!carrier || !keyValuePairs) return
@@ -8,18 +9,7 @@ function add (carrier, keyValuePairs) {
   if (typeof keyValuePairs === 'string') {
     return add(
       carrier,
-      keyValuePairs
-        .split(',')
-        .filter(tag => tag.indexOf(':') !== -1)
-        .reduce((prev, next) => {
-          const tag = next.split(':')
-          const key = tag[0]
-          const value = tag.slice(1).join(':')
-
-          prev[key] = value
-
-          return prev
-        }, {})
+      toKeyValuePairs(keyValuePairs)
     )
   }
 

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -10,7 +10,20 @@ function isFalse (str) {
   return str === 'false' || str === '0'
 }
 
+function toKeyValuePairs (str) {
+  return (str || '').split(',')
+    .filter(tag => tag.indexOf(':') !== -1)
+    .reduce((prev, next) => {
+      const tag = next.split(':')
+      const key = tag[0]
+      const value = tag.slice(1).join(':')
+      prev[key] = value
+      return prev
+    }, {})
+}
+
 module.exports = {
   isTrue,
-  isFalse
+  isFalse,
+  toKeyValuePairs
 }

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -15,8 +15,8 @@ function toKeyValuePairs (str) {
     .filter(tag => tag.indexOf(':') !== -1)
     .reduce((prev, next) => {
       const tag = next.split(':')
-      const key = tag[0]
-      const value = tag.slice(1).join(':')
+      const key = tag[0].trim()
+      const value = tag.slice(1).join(':').trim()
       prev[key] = value
       return prev
     }, {})

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -75,6 +75,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_TRACE_GLOBAL_TAGS').returns('foo:bar,baz:qux')
     platform.env.withArgs('DD_TRACE_SAMPLE_RATE').returns('0.5')
     platform.env.withArgs('DD_TRACE_RATE_LIMIT').returns('-1')
+    platform.env.withArgs('DD_SERVICE_MAPPING').returns('quux:quuz,corge:grault')
 
     const config = new Config()
 
@@ -94,6 +95,7 @@ describe('Config', () => {
     expect(config.tags).to.include({ foo: 'bar', baz: 'qux' })
     expect(config.tags).to.include({ service: 'service', 'version': '1.0.0', 'env': 'test' })
     expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: '0.5', rateLimit: '-1' })
+    expect(config.serviceMapping).to.include({ quux: 'quuz', corge: 'grault' })
   })
 
   it('should read case-insensitive booleans from environment variables', () => {
@@ -274,6 +276,7 @@ describe('Config', () => {
     platform.env.withArgs('DD_API_KEY').returns('123')
     platform.env.withArgs('DD_APP_KEY').returns('456')
     platform.env.withArgs('DD_TRACE_GLOBAL_TAGS').returns('foo:bar,baz:qux')
+    platform.env.withArgs('DD_SERVICE_MAPPING').returns('quux:quuz,corge:grault')
 
     const config = new Config({
       enabled: true,
@@ -295,6 +298,10 @@ describe('Config', () => {
       clientToken: '789',
       tags: {
         foo: 'foo'
+      },
+      serviceMapping: {
+        quux: 'thud',
+        garply: 'waldo'
       }
     })
 
@@ -316,6 +323,7 @@ describe('Config', () => {
     expect(config).to.have.property('clientToken', '789')
     expect(config.tags).to.include({ foo: 'foo', baz: 'qux' })
     expect(config.tags).to.include({ service: 'test', version: '1.0.0', env: 'development' })
+    expect(config.serviceMapping).to.include({ quux: 'thud', corge: 'grault', garply: 'waldo' })
   })
 
   it('should give priority to non-experimental options', () => {

--- a/packages/dd-trace/test/util.spec.js
+++ b/packages/dd-trace/test/util.spec.js
@@ -49,5 +49,8 @@ describe('util', () => {
     expect(toKeyValuePairs('key:value')).to.deep.equal({ key: 'value' })
     expect(toKeyValuePairs('key1:value1,key2:value2')).to.deep.equal({ key1: 'value1', key2: 'value2' })
     expect(toKeyValuePairs('string1,key2:value2,string3')).to.deep.equal({ key2: 'value2' })
+    expect(toKeyValuePairs('  key1 :  value1, key2 :  value2 ')).to.deep.equal({ key1: 'value1', key2: 'value2' })
+    expect(toKeyValuePairs('key1:value1,key2:value2,')).to.deep.equal({ key1: 'value1', key2: 'value2' })
+    expect(toKeyValuePairs('key1:value1,key2:value2,key1:value3')).to.deep.equal({ key1: 'value3', key2: 'value2' })
   })
 })

--- a/packages/dd-trace/test/util.spec.js
+++ b/packages/dd-trace/test/util.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isTrue, isFalse } = require('../src/util')
+const { isTrue, isFalse, toKeyValuePairs } = require('../src/util')
 
 const TRUES = [
   1,
@@ -38,5 +38,16 @@ describe('util', () => {
       expect(isFalse(v)).to.equal(false)
       expect(isFalse(String(v))).to.equal(false)
     })
+  })
+
+  it('toKeyValuePairs works', () => {
+    expect(toKeyValuePairs(undefined)).to.deep.equal({})
+    expect(toKeyValuePairs(null)).to.deep.equal({})
+    expect(toKeyValuePairs('')).to.deep.equal({})
+    expect(toKeyValuePairs('string')).to.deep.equal({})
+    expect(toKeyValuePairs('string1,string2')).to.deep.equal({})
+    expect(toKeyValuePairs('key:value')).to.deep.equal({ key: 'value' })
+    expect(toKeyValuePairs('key1:value1,key2:value2')).to.deep.equal({ key1: 'value1', key2: 'value2' })
+    expect(toKeyValuePairs('string1,key2:value2,string3')).to.deep.equal({ key2: 'value2' })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds support for `options.serviceMapping` and `DD_SERVICE_MAPPING`

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to ensure all spans (web or db) originating from a microservice to be tracked in a single service dashboard. To achieve this we are using `DD_SERVICE_MAPPING` for java services. 
Unfortunately to achieve the same in nodejs applications, it required code change in multiple services. Having this option avoid boilerplate code by making it configureable via environment variables.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [x] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
