### PR TITLE
fix container tagging support for ecs and fargate

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,6 +1,5 @@
 Component,Origin,License,Copyright
 require,@types/node,MIT,Copyright Authors
-require,container-info,MIT,Copyright 2018 Stephen Belanger
 require,core-js,MIT,Copyright 2014-2020 Denis Pushkarev
 require,form-data,MIT,Copyright 2012 Felix Geisendörfer and contributors
 require,hdr-histogram-js,BSD-2-Clause,Copyright 2016 Alexandre Victoor

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "@types/node": "^10.12.18",
     "axios": "^0.21.1",
-    "container-info": "^1.0.1",
     "core-js": "^3.6.0",
     "form-data": "^3.0.0",
     "hdr-histogram-js": "^1.1.4",

--- a/packages/dd-trace/src/platform/node/docker.js
+++ b/packages/dd-trace/src/platform/node/docker.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const fs = require('fs')
+
+const uuidSource = '[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}'
+const containerSource = '[0-9a-f]{64}'
+const taskSource = '[0-9a-f]{32}-\\d+'
+const entityReg = new RegExp(`/(${uuidSource}|${containerSource}|${taskSource})(?:.scope)?$`, 'm')
+
+const entityId = getEntityId()
+
+function getEntityId () {
+  const cgroup = readControlGroup() || ''
+  const match = cgroup.trim().match(entityReg) || []
+
+  return match[1]
+}
+
+function readControlGroup () {
+  try {
+    return fs.readFileSync('/proc/self/cgroup').toString()
+  } catch (err) {
+    // ignore
+  }
+}
+
+module.exports = {
+  // can be the container ID but not always depending on the orchestrator
+  id () {
+    return entityId
+  }
+}

--- a/packages/dd-trace/src/platform/node/request.js
+++ b/packages/dd-trace/src/platform/node/request.js
@@ -3,9 +3,9 @@
 const http = require('http')
 const https = require('https')
 const agents = require('./agents')
-const containerInfo = require('container-info').sync() || {}
+const docker = require('./docker')
 
-const containerId = containerInfo.containerId
+const containerId = docker.id()
 
 function request (options, callback) {
   const platform = this

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -169,10 +169,84 @@ describe('Platform', () => {
       })
     })
 
+    describe('docker', () => {
+      let docker
+      let fs
+
+      beforeEach(() => {
+        fs = {
+          readFileSync: sinon.stub()
+        }
+      })
+
+      it('should return an empty ID when the cgroup cannot be read', () => {
+        docker = proxyquire('../src/platform/node/docker', { fs })
+
+        expect(docker.id()).to.be.undefined
+      })
+
+      it('should support IDs with long format', () => {
+        const cgroup = [
+          '1:name=systemd:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376'
+        ].join('\n')
+
+        fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+        docker = proxyquire('../src/platform/node/docker', { fs })
+
+        expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376')
+      })
+
+      it('should support IDs with UUID format', () => {
+        const cgroup = [
+          '1:name=systemd:/uuid/34dc0b5e-626f-2c5c-4c51-70e34b10e765'
+        ].join('\n')
+
+        fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+        docker = proxyquire('../src/platform/node/docker', { fs })
+
+        expect(docker.id()).to.equal('34dc0b5e-626f-2c5c-4c51-70e34b10e765')
+      })
+
+      it('should support IDs with ECS task format', () => {
+        const cgroup = [
+          '1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890'
+        ].join('\n')
+
+        fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+        docker = proxyquire('../src/platform/node/docker', { fs })
+
+        expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e765-1234567890')
+      })
+
+      it('should support IDs with scope suffix', () => {
+        const cgroup = [
+          '1:name=systemd:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376.scope'
+        ].join('\n')
+
+        fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+        docker = proxyquire('../src/platform/node/docker', { fs })
+
+        expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376')
+      })
+
+      it('should support finding IDs on any line of the cgroup', () => {
+        const cgroup = [
+          '1:name=systemd:/nope',
+          '2:pids:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+          '3:cpu:/invalid'
+        ].join('\n')
+
+        fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+        docker = proxyquire('../src/platform/node/docker', { fs })
+
+        expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376')
+      })
+    })
+
     describe('request', () => {
       let request
       let log
-      let getContainerInfo
+      let docker
 
       beforeEach(() => {
         nock.disableNetConnect()
@@ -180,12 +254,12 @@ describe('Platform', () => {
         log = {
           error: sinon.spy()
         }
-        getContainerInfo = {
-          sync: sinon.stub().returns({ containerId: 'abcd' })
+        docker = {
+          id: sinon.stub().returns('abcd')
         }
         platform = require('../../../src/platform/node')
         request = proxyquire('../src/platform/node/request', {
-          'container-info': getContainerInfo,
+          './docker': docker,
           '../../log': log
         }).bind(platform)
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix container tagging support for ECS and Fargate.

### Motivation
<!-- What inspired you to submit this pull request? -->

ECS recently changed their cgroup format to use the task instance ID (AKA Docker ID) instead of the container ID. Since the agent already uses the Docker ID in these environments, we can simply add support for it and send it as the "container" ID.

Since what we need is not exactly the same use case as `container-info`, the dependency was removed and the functionality was moved to the tracer.

Fixes #1145 