### PR TITLE
[CI-APP] Add Tests for CI Tags and Filter Sensitive Info

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -1,6 +1,5 @@
-const { GIT_BRANCH, GIT_COMMIT_SHA } = require('./git')
+const { GIT_BRANCH, GIT_COMMIT_SHA, DEPRECATED_GIT_COMMIT_SHA, GIT_TAG } = require('./git')
 
-const BUILD_SOURCE_ROOT = 'build.source_root'
 const CI_PIPELINE_ID = 'ci.pipeline.id'
 const CI_PIPELINE_NAME = 'ci.pipeline.name'
 const CI_PIPELINE_NUMBER = 'ci.pipeline.number'
@@ -8,9 +7,39 @@ const CI_PIPELINE_URL = 'ci.pipeline.url'
 const CI_PROVIDER_NAME = 'ci.provider.name'
 const CI_WORKSPACE_PATH = 'ci.workspace_path'
 const GIT_REPOSITORY_URL = 'git.repository_url'
+const CI_JOB_URL = 'ci.job.url'
+
+function normalizeRef (ref) {
+  if (!ref) {
+    return ref
+  }
+  return ref.replace(/origin\/|refs\/heads\/|tags\//gm, '')
+}
+
+function filterSensitiveInfoFromRepository (repositoryUrl) {
+  if (repositoryUrl.startsWith('git@')) {
+    return repositoryUrl
+  }
+  try {
+    const url = new URL(repositoryUrl)
+    return `${url.protocol}//${url.hostname}${url.pathname}`
+  } catch (e) {
+    return repositoryUrl
+  }
+}
+
+function resolveTilde (filePath) {
+  if (!filePath || typeof filePath !== 'string') {
+    return ''
+  }
+  // '~/folder/path' or '~'
+  if (filePath[0] === '~' && (filePath[1] === '/' || filePath.length === 1)) {
+    return filePath.replace('~', process.env.HOME)
+  }
+  return filePath
+}
 
 module.exports = {
-  BUILD_SOURCE_ROOT,
   CI_PIPELINE_ID,
   CI_PIPELINE_NAME,
   CI_PIPELINE_NUMBER,
@@ -29,20 +58,42 @@ module.exports = {
         BUILD_URL,
         GIT_BRANCH: JENKINS_GIT_BRANCH,
         GIT_COMMIT: JENKINS_GIT_COMMIT,
-        JENKINS_GIT_REPOSITORY_URL
+        GIT_URL: JENKINS_GIT_REPOSITORY_URL
       } = env
-      return {
-        [BUILD_SOURCE_ROOT]: WORKSPACE,
+
+      const isTag = JENKINS_GIT_BRANCH && JENKINS_GIT_BRANCH.includes('tags')
+      const finalRefKey = isTag ? GIT_TAG : GIT_BRANCH
+      const ref = normalizeRef(JENKINS_GIT_BRANCH)
+
+      let finalPipelineName = ''
+      if (JOB_NAME) {
+        const splittedPipelineName = JOB_NAME.split('/')
+        // There are parameters
+        if (splittedPipelineName.length > 1 && splittedPipelineName[1].includes('=')) {
+          finalPipelineName = splittedPipelineName[0]
+        } else {
+          finalPipelineName = JOB_NAME.replace(`/${ref}`, '')
+        }
+      }
+
+      const tags = {
         [CI_PIPELINE_ID]: BUILD_TAG,
-        [CI_PIPELINE_NAME]: JOB_NAME,
         [CI_PIPELINE_NUMBER]: BUILD_NUMBER,
         [CI_PIPELINE_URL]: BUILD_URL,
         [CI_PROVIDER_NAME]: 'jenkins',
-        [CI_WORKSPACE_PATH]: WORKSPACE,
-        [GIT_BRANCH]: JENKINS_GIT_BRANCH,
         [GIT_COMMIT_SHA]: JENKINS_GIT_COMMIT,
-        [GIT_REPOSITORY_URL]: JENKINS_GIT_REPOSITORY_URL
+        [DEPRECATED_GIT_COMMIT_SHA]: JENKINS_GIT_COMMIT,
+        [GIT_REPOSITORY_URL]: filterSensitiveInfoFromRepository(JENKINS_GIT_REPOSITORY_URL),
+        [finalRefKey]: ref
       }
+      if (WORKSPACE) {
+        tags[CI_WORKSPACE_PATH] = resolveTilde(WORKSPACE)
+      }
+      if (finalPipelineName) {
+        tags[CI_PIPELINE_NAME] = finalPipelineName
+      }
+
+      return tags
     }
 
     if (env.GITLAB_CI) {
@@ -50,24 +101,40 @@ module.exports = {
         CI_PIPELINE_ID: GITLAB_PIPELINE_ID,
         CI_PROJECT_PATH,
         CI_PIPELINE_IID,
-        CI_PIPELINE_URL,
+        CI_PIPELINE_URL: GITLAB_PIPELINE_URL,
         CI_PROJECT_DIR,
         CI_COMMIT_BRANCH,
+        CI_COMMIT_TAG,
         CI_COMMIT_SHA,
-        CI_REPOSITORY_URL
+        CI_REPOSITORY_URL,
+        CI_JOB_URL: GITLAB_CI_JOB_URL
       } = env
-      return {
-        [BUILD_SOURCE_ROOT]: CI_PROJECT_DIR,
+
+      const tags = {
         [CI_PIPELINE_ID]: GITLAB_PIPELINE_ID,
         [CI_PIPELINE_NAME]: CI_PROJECT_PATH,
         [CI_PIPELINE_NUMBER]: CI_PIPELINE_IID,
-        [CI_PIPELINE_URL]: `${(CI_PIPELINE_URL || '').replace('/-/pipelines/', '/pipelines/')}`,
         [CI_PROVIDER_NAME]: 'gitlab',
-        [CI_WORKSPACE_PATH]: CI_PROJECT_DIR,
-        [GIT_BRANCH]: CI_COMMIT_BRANCH,
         [GIT_COMMIT_SHA]: CI_COMMIT_SHA,
-        [GIT_REPOSITORY_URL]: CI_REPOSITORY_URL
+        [DEPRECATED_GIT_COMMIT_SHA]: CI_COMMIT_SHA,
+        [GIT_REPOSITORY_URL]: filterSensitiveInfoFromRepository(CI_REPOSITORY_URL),
+        [CI_JOB_URL]: GITLAB_CI_JOB_URL
       }
+
+      if (CI_COMMIT_TAG) {
+        tags[GIT_TAG] = normalizeRef(CI_COMMIT_TAG)
+      }
+      if (CI_COMMIT_BRANCH) {
+        tags[GIT_BRANCH] = normalizeRef(CI_COMMIT_BRANCH)
+      }
+      if (CI_PROJECT_DIR) {
+        tags[CI_WORKSPACE_PATH] = resolveTilde(CI_PROJECT_DIR)
+      }
+      if (GITLAB_PIPELINE_URL) {
+        tags[CI_PIPELINE_URL] = `${(GITLAB_PIPELINE_URL).replace('/-/pipelines/', '/pipelines/')}`
+      }
+
+      return tags
     }
 
     if (env.CIRCLECI) {
@@ -78,49 +145,74 @@ module.exports = {
         CIRCLE_BUILD_URL,
         CIRCLE_WORKING_DIRECTORY,
         CIRCLE_BRANCH,
+        CIRCLE_TAG,
         CIRCLE_SHA1,
         CIRCLE_REPOSITORY_URL
       } = env
-      return {
-        [BUILD_SOURCE_ROOT]: CIRCLE_WORKING_DIRECTORY,
+
+      const tags = {
         [CI_PIPELINE_ID]: CIRCLE_WORKFLOW_ID,
         [CI_PIPELINE_NAME]: CIRCLE_PROJECT_REPONAME,
         [CI_PIPELINE_NUMBER]: CIRCLE_BUILD_NUM,
         [CI_PIPELINE_URL]: CIRCLE_BUILD_URL,
         [CI_PROVIDER_NAME]: 'circleci',
-        [CI_WORKSPACE_PATH]: CIRCLE_WORKING_DIRECTORY,
-        [GIT_BRANCH]: CIRCLE_BRANCH,
         [GIT_COMMIT_SHA]: CIRCLE_SHA1,
-        [GIT_REPOSITORY_URL]: CIRCLE_REPOSITORY_URL
+        [DEPRECATED_GIT_COMMIT_SHA]: CIRCLE_SHA1,
+        [GIT_REPOSITORY_URL]: filterSensitiveInfoFromRepository(CIRCLE_REPOSITORY_URL)
       }
+
+      if (CIRCLE_TAG) {
+        tags[GIT_TAG] = normalizeRef(CIRCLE_TAG)
+      } else if (CIRCLE_BRANCH) {
+        tags[GIT_BRANCH] = normalizeRef(CIRCLE_BRANCH)
+      }
+      if (CIRCLE_WORKING_DIRECTORY) {
+        tags[CI_WORKSPACE_PATH] = resolveTilde(CIRCLE_WORKING_DIRECTORY)
+      }
+      if (CIRCLE_BUILD_URL) {
+        tags[CI_JOB_URL] = CIRCLE_BUILD_URL
+      }
+
+      return tags
     }
 
-    if (env.GITHUB_ACTIONS) {
+    if (env.GITHUB_ACTIONS || env.GITHUB_ACTION) {
       const {
         GITHUB_RUN_ID,
         GITHUB_WORKFLOW,
         GITHUB_RUN_NUMBER,
         GITHUB_WORKSPACE,
+        GITHUB_HEAD_REF,
         GITHUB_REF,
         GITHUB_SHA,
         GITHUB_REPOSITORY
       } = env
 
-      const repositoryURL = `https://github.com/${GITHUB_REPOSITORY}`
-      const pipelineURL = `${repositoryURL}/actions/runs/${GITHUB_RUN_ID}`
+      const repositoryURL = `https://github.com/${GITHUB_REPOSITORY}.git`
+      const pipelineURL = `https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}/checks`
 
-      return {
-        [BUILD_SOURCE_ROOT]: GITHUB_WORKSPACE,
+      const tags = {
         [CI_PIPELINE_ID]: GITHUB_RUN_ID,
         [CI_PIPELINE_NAME]: GITHUB_WORKFLOW,
         [CI_PIPELINE_NUMBER]: GITHUB_RUN_NUMBER,
         [CI_PIPELINE_URL]: pipelineURL,
         [CI_PROVIDER_NAME]: 'github',
-        [CI_WORKSPACE_PATH]: GITHUB_WORKSPACE,
-        [GIT_BRANCH]: GITHUB_REF,
         [GIT_COMMIT_SHA]: GITHUB_SHA,
-        [GIT_REPOSITORY_URL]: repositoryURL
+        [DEPRECATED_GIT_COMMIT_SHA]: GITHUB_SHA,
+        [GIT_REPOSITORY_URL]: repositoryURL,
+        [CI_JOB_URL]: pipelineURL
       }
+
+      const finalRef = GITHUB_HEAD_REF || GITHUB_REF || ''
+      const finalRefKey = finalRef.includes('tags') ? GIT_TAG : GIT_BRANCH
+
+      tags[finalRefKey] = normalizeRef(finalRef)
+
+      if (GITHUB_WORKSPACE) {
+        tags[CI_WORKSPACE_PATH] = resolveTilde(GITHUB_WORKSPACE)
+      }
+
+      return tags
     }
     return {}
   }

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -24,7 +24,17 @@ function filterSensitiveInfoFromRepository (repositoryUrl) {
     const url = new URL(repositoryUrl)
     return `${url.protocol}//${url.hostname}${url.pathname}`
   } catch (e) {
-    return repositoryUrl
+    try {
+      // support for node <=8
+      const url = require('url')
+      const parsedUrl = url.parse(repositoryUrl)
+      if (!parsedUrl.hostname || !parsedUrl.pathname || !parsedUrl.protocol) {
+        return repositoryUrl
+      }
+      return `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.pathname}`
+    } catch (e) {
+      return repositoryUrl
+    }
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -1,20 +1,16 @@
 const { sanitizedExec } = require('./exec')
 
 const GIT_COMMIT_SHA = 'git.commit.sha'
-// TODO: remove this once CI App's UI and backend are ready
-const DEPRECATED_GIT_COMMIT_SHA = 'git.commit_sha'
 const GIT_BRANCH = 'git.branch'
 const GIT_REPOSITORY_URL = 'git.repository_url'
 const GIT_TAG = 'git.tag'
 
 function getGitMetadata () {
-  const commitSha = sanitizedExec('git rev-parse HEAD')
   return {
     [GIT_REPOSITORY_URL]: sanitizedExec('git ls-remote --get-url'),
     [GIT_BRANCH]: sanitizedExec('git rev-parse --abbrev-ref HEAD'),
-    [GIT_COMMIT_SHA]: commitSha,
-    [DEPRECATED_GIT_COMMIT_SHA]: commitSha
+    [GIT_COMMIT_SHA]: sanitizedExec('git rev-parse HEAD')
   }
 }
 
-module.exports = { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL, DEPRECATED_GIT_COMMIT_SHA, GIT_TAG }
+module.exports = { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL, GIT_TAG }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -5,6 +5,7 @@ const GIT_COMMIT_SHA = 'git.commit.sha'
 const DEPRECATED_GIT_COMMIT_SHA = 'git.commit_sha'
 const GIT_BRANCH = 'git.branch'
 const GIT_REPOSITORY_URL = 'git.repository_url'
+const GIT_TAG = 'git.tag'
 
 function getGitMetadata () {
   const commitSha = sanitizedExec('git rev-parse HEAD')
@@ -16,4 +17,4 @@ function getGitMetadata () {
   }
 }
 
-module.exports = { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL }
+module.exports = { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL, DEPRECATED_GIT_COMMIT_SHA, GIT_TAG }

--- a/packages/dd-trace/test/plugins/util/ci-env/circleci.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/circleci.json
@@ -1,0 +1,556 @@
+[
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar~",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar~",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/~/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/~/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "CIRCLE_WORKING_DIRECTORY": "~/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "CIRCLE_WORKING_DIRECTORY": "~foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "~foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "CIRCLE_WORKING_DIRECTORY": "~",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/not-my-home",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "refs/heads/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "refs/heads/feature/one",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "feature/one",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/tags/0.1.0",
+      "CIRCLE_TAG": "origin/tags/0.1.0",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "refs/heads/tags/0.1.0",
+      "CIRCLE_TAG": "refs/heads/tags/0.1.0",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "http://hostname.com/repo.git",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "http://user@hostname.com/repo.git",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "http://user%E2%82%AC@hostname.com/repo.git",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "http://user:pwd@hostname.com/repo.git",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ],
+  [
+    {
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLE_REPOSITORY_URL": "git@hostname.com:org/repo.git",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLECI": "circleCI",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_SHA1": "circleci-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "git@hostname.com:org/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "circleci",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.job.url": "circleci-build-url",
+      "git.commit.sha": "circleci-git-commit",
+      "git.commit_sha": "circleci-git-commit"
+    }
+  ]
+]

--- a/packages/dd-trace/test/plugins/util/ci-env/circleci.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/circleci.json
@@ -21,8 +21,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -47,8 +46,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -73,8 +71,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -99,8 +96,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -125,8 +121,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -151,8 +146,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -177,8 +171,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -205,8 +198,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -233,8 +225,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -261,8 +252,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -287,8 +277,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -313,8 +302,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -340,8 +328,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -367,8 +354,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -393,8 +379,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -419,8 +404,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -445,8 +429,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -471,8 +454,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -497,8 +479,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -523,8 +504,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ],
   [
@@ -549,8 +529,7 @@
       "ci.pipeline.number": "circleci-pipeline-number",
       "ci.pipeline.url": "circleci-build-url",
       "ci.job.url": "circleci-build-url",
-      "git.commit.sha": "circleci-git-commit",
-      "git.commit_sha": "circleci-git-commit"
+      "git.commit.sha": "circleci-git-commit"
     }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/github.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/github.json
@@ -1,0 +1,411 @@
+[
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "foo/bar",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar~",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/~/bar",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "GITHUB_WORKSPACE": "~/foo/bar",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "GITHUB_WORKSPACE": "~foo/bar",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "GITHUB_WORKSPACE": "~",
+      "GITHUB_REF": "master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "origin/master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "refs/heads/master",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "refs/heads/feature/one",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "origin/tags/0.1.0",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "refs/heads/tags/0.1.0",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "origin/master",
+      "GITHUB_HEAD_REF": "origin/other",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "other",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "refs/heads/master",
+      "GITHUB_HEAD_REF": "refs/heads/other",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "other",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ],
+  [
+    {
+      "GITHUB_WORKSPACE": "/foo/bar",
+      "GITHUB_REF": "refs/heads/feature/one",
+      "GITHUB_HEAD_REF": "refs/heads/feature/other",
+      "GITHUB_ACTION": "run",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_SHA": "ghactions-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/other",
+      "ci.provider.name": "github",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.commit.sha": "ghactions-commit",
+      "git.commit_sha": "ghactions-commit"
+    }
+  ]
+]

--- a/packages/dd-trace/test/plugins/util/ci-env/github.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/github.json
@@ -20,8 +20,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -45,8 +44,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -70,8 +68,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -95,8 +92,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -120,8 +116,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -147,8 +142,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -174,8 +168,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -201,8 +194,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -226,8 +218,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -251,8 +242,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -276,8 +266,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -301,8 +290,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -326,8 +314,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -352,8 +339,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -378,8 +364,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ],
   [
@@ -404,8 +389,7 @@
       "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "git.repository_url": "https://github.com/ghactions-repo.git",
-      "git.commit.sha": "ghactions-commit",
-      "git.commit_sha": "ghactions-commit"
+      "git.commit.sha": "ghactions-commit"
     }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/gitlab.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/gitlab.json
@@ -20,8 +20,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -45,8 +44,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -72,8 +70,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -99,8 +96,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -126,8 +122,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -155,8 +150,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -184,8 +178,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -213,8 +206,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -240,8 +232,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -265,8 +256,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -290,8 +280,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -317,8 +306,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -344,8 +332,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -371,8 +358,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -398,8 +384,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -425,8 +410,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -452,8 +436,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -479,8 +462,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -506,8 +488,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -533,8 +514,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ],
   [
@@ -560,8 +540,7 @@
       "ci.pipeline.name": "gitlab-pipeline-name",
       "ci.pipeline.number": "gitlab-pipeline-number",
       "ci.job.url": "gitlab-job-url",
-      "git.commit.sha": "gitlab-git-commit",
-      "git.commit_sha": "gitlab-git-commit"
+      "git.commit.sha": "gitlab-git-commit"
     }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/gitlab.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/gitlab.json
@@ -1,0 +1,567 @@
+[
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar~",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar~",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/~/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "CI_PROJECT_DIR": "~/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "CI_PROJECT_DIR": "~foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "~foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "CI_PROJECT_DIR": "~",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/not-my-home",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "refs/heads/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_BRANCH": "refs/heads/feature/one",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "feature/one",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_TAG": "origin/tags/0.1.0",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_TAG": "refs/heads/tags/0.1.0",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "sample",
+      "CI_COMMIT_TAG": "0.1.0",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "http://hostname.com/repo.git",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "http://user@hostname.com/repo.git",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "http://user%E2%82%AC@hostname.com/repo.git",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "http://user:pwd@hostname.com/repo.git",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ],
+  [
+    {
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_REPOSITORY_URL": "git@hostname.com:org/repo.git",
+      "CI_COMMIT_BRANCH": "origin/master",
+      "GITLAB_CI": "gitlab",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_COMMIT_SHA": "gitlab-git-commit"
+    },
+    {
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "git@hostname.com:org/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "gitlab",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.job.url": "gitlab-job-url",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.commit_sha": "gitlab-git-commit"
+    }
+  ]
+]

--- a/packages/dd-trace/test/plugins/util/ci-env/jenkins.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/jenkins.json
@@ -1,0 +1,546 @@
+[
+  [
+    {
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar~",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar~",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/~/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "WORKSPACE": "~/foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "WORKSPACE": "~foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "~foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home",
+      "WORKSPACE": "~",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/not-my-home",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName/master",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "refs/heads/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName/another",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "refs/heads/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName/another",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName/feature/one",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "refs/heads/feature/one",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "feature/one",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName/KEY1=VALUE1,KEY2=VALUE2",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "refs/heads/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName/KEY1=VALUE1,KEY2=VALUE2/master",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "refs/heads/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "origin/tags/0.1.0",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "GIT_URL": "sample",
+      "GIT_BRANCH": "refs/heads/tags/0.1.0",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "http://hostname.com/repo.git",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "http://user@hostname.com/repo.git",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "http://user%E2%82%AC@hostname.com/repo.git",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "http://user:pwd@hostname.com/repo.git",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ],
+  [
+    {
+      "WORKSPACE": "/foo/bar",
+      "JOB_NAME": "jobName",
+      "GIT_URL": "git@hostname.com:org/repo.git",
+      "GIT_BRANCH": "origin/master",
+      "JENKINS_URL": "jenkins",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "JOB_URL": "jenkins-job-url",
+      "GIT_COMMIT": "jenkins-git-commit"
+    },
+    {
+      "ci.pipeline.name": "jobName",
+      "ci.workspace_path": "/foo/bar",
+      "git.repository_url": "git@hostname.com:org/repo.git",
+      "git.branch": "master",
+      "ci.provider.name": "jenkins",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.commit_sha": "jenkins-git-commit"
+    }
+  ]
+]

--- a/packages/dd-trace/test/plugins/util/ci-env/jenkins.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/jenkins.json
@@ -19,8 +19,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -43,8 +42,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -69,8 +67,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -95,8 +92,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -121,8 +117,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -149,8 +144,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -177,8 +171,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -205,8 +198,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -231,8 +223,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -257,8 +248,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -283,8 +273,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -309,8 +298,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -335,8 +323,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -361,8 +348,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -385,8 +371,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -409,8 +394,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -435,8 +419,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -461,8 +444,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -487,8 +469,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -513,8 +494,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ],
   [
@@ -539,8 +519,7 @@
       "ci.pipeline.id": "jenkins-pipeline-id",
       "ci.pipeline.number": "jenkins-pipeline-number",
       "ci.pipeline.url": "jenkins-pipeline-url",
-      "git.commit.sha": "jenkins-git-commit",
-      "git.commit_sha": "jenkins-git-commit"
+      "git.commit.sha": "jenkins-git-commit"
     }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci.spec.js
+++ b/packages/dd-trace/test/plugins/util/ci.spec.js
@@ -6,6 +6,7 @@ const githubEnv = require('./ci-env/github.json')
 
 describe('ci tags', () => {
   it('returns an empty object if the CI is not supported', () => {
+    process.env = {}
     expect(getCIMetadata()).to.eql({})
   })
   describe('jenkins', () => {

--- a/packages/dd-trace/test/plugins/util/ci.spec.js
+++ b/packages/dd-trace/test/plugins/util/ci.spec.js
@@ -1,0 +1,43 @@
+const { getCIMetadata } = require('../../../src/plugins/util/ci')
+const jenkinsEnv = require('./ci-env/jenkins.json')
+const gitlabEnv = require('./ci-env/gitlab.json')
+const circleciEnv = require('./ci-env/circleci.json')
+const githubEnv = require('./ci-env/github.json')
+
+describe('ci tags', () => {
+  it('returns an empty object if the CI is not supported', () => {
+    expect(getCIMetadata()).to.eql({})
+  })
+  describe('jenkins', () => {
+    jenkinsEnv.forEach(([env, expectedSpanTags], index) => {
+      it(`reads env info from jenkins ${index}`, () => {
+        process.env = env
+        expect(getCIMetadata()).to.eql(expectedSpanTags)
+      })
+    })
+  })
+  describe('gitlab', () => {
+    gitlabEnv.forEach(([env, expectedSpanTags], index) => {
+      it(`reads env info from gitlab ${index}`, () => {
+        process.env = env
+        expect(getCIMetadata()).to.eql(expectedSpanTags)
+      })
+    })
+  })
+  describe('circleci', () => {
+    circleciEnv.forEach(([env, expectedSpanTags], index) => {
+      it(`reads env info from circleci ${index}`, () => {
+        process.env = env
+        expect(getCIMetadata()).to.eql(expectedSpanTags)
+      })
+    })
+  })
+  describe('githubEnv', () => {
+    githubEnv.forEach(([env, expectedSpanTags], index) => {
+      it(`reads env info from github ${index}`, () => {
+        process.env = env
+        expect(getCIMetadata()).to.eql(expectedSpanTags)
+      })
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
* Add unit tests to the ci tags extraction logic.
* Filter out sensitive information like credentials within repository urls. 

### Motivation
We want all the testing instrumentation across tracer languages to be consistent. For this reason we have created a repository: https://github.com/DataDog/datadog-ci-spec/tree/main/tests that tracks the CI tags (among other stuff). 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
