### PR TITLE
fix fs tests breaking in node 15

### DIFF
--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1314,7 +1314,7 @@ describe('Plugin', () => {
               testHandleErrors(fs, 'dir.close', (_1, _2, _3, cb) => {
                 dir.closeSync()
                 try {
-                  dir.close()
+                  dir.close(cb)
                 } catch (e) {
                   cb(e)
                 }

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1311,12 +1311,12 @@ describe('Plugin', () => {
             })
 
             it('should handle errors', () =>
-              testHandleErrors(fs, 'dir.close', (_1, _2, _3, cb) => {
+              testHandleErrors(fs, 'dir.close', async (_1, _2, _3, cb) => {
                 dir.closeSync()
                 try {
-                  dir.close(cb) // Node >=15 passes error to callback
+                  await dir.close() // Node >=15.4 returns and rejects a promise
                 } catch (e) {
-                  cb(e) // Node <=14 throws
+                  cb(e) // Node <=15.3 throws
                 }
               }, [], agent))
 

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1314,9 +1314,9 @@ describe('Plugin', () => {
               testHandleErrors(fs, 'dir.close', (_1, _2, _3, cb) => {
                 dir.closeSync()
                 try {
-                  dir.close(cb)
+                  dir.close(cb) // Node 15 passes error to callback
                 } catch (e) {
-                  cb(e)
+                  cb(e) // Node <=14 throws
                 }
               }, [], agent))
 

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1314,9 +1314,10 @@ describe('Plugin', () => {
               testHandleErrors(fs, 'dir.close', async (_1, _2, _3, cb) => {
                 dir.closeSync()
                 try {
-                  await dir.close() // Node >=15.4 returns and rejects a promise
+                  // await for Node >=15.4 that returns and rejects a promise instead of throwing
+                  await dir.close()
                 } catch (e) {
-                  cb(e) // Node <=15.3 throws
+                  cb(e)
                 }
               }, [], agent))
 

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1314,7 +1314,7 @@ describe('Plugin', () => {
               testHandleErrors(fs, 'dir.close', (_1, _2, _3, cb) => {
                 dir.closeSync()
                 try {
-                  dir.close(cb) // Node 15 passes error to callback
+                  dir.close(cb) // Node >=15 passes error to callback
                 } catch (e) {
                   cb(e) // Node <=14 throws
                 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `fs` tests breaking in Node 15.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests have been failing in CI on Node 15 because `dir.close` no longer throws when called on an already closed dir. Using `dir.closeSync` instead fixes the test.