### PR TITLE
do not trace "no-op" DNS lookups when hostname is an IP address

### DIFF
--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -3,6 +3,7 @@
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { promisify } = require('util')
+const { expect } = require('chai')
 
 wrapIt()
 
@@ -41,6 +42,23 @@ describe('Plugin', () => {
         .catch(done)
 
       dns.lookup('localhost', 4, (err, address, family) => err && done(err))
+    })
+    
+    it('should not record lookup traces when the hostname is an IP address', done => {
+      let traceRecorded = false
+      agent
+        .use((traces) => {
+          traceRecorded = true
+        })
+        .catch(done);
+      
+      dns.lookup('127.0.0.1', 4, (err, address, family) => {
+        if (err) return done(err)
+        setTimeout(() => {
+          expect(traceRecorded).to.be.false;
+          done();
+        }, 10)
+      })
     })
 
     it('should instrument lookupService', done => {


### PR DESCRIPTION
### What does this PR do?

When an IP address is provided as the `hostname` argument of Node's `dns.lookup()` function (which is called by the HTTP client, and basically anything else that opens an TCP socket), Node [does not actually perform a DNS lookup](https://github.com/nodejs/node/blob/2da36112d177efc19201f1610dcf51647378131c/lib/net.js#L1003-L1015), and instead immediately invokes the callback with the IP address on `process.nextTick()`.  

This PR prevents `dd-trace` from creating DNS spans for these "no-op" lookups.  

### Motivation

We'd like to remove some clutter from our traces.  

### Plugin Checklist

- [X] Unit tests.

(API contract has not changed)

### Additional Notes

`dd-trace-js` is actually (by far) the biggest contributor of these meaningless spans for us.  We connect to our DD agent via a Docker Host network (and its magic `172.17.0.1` IP address), and the agent records millions of meaningless `dns` APM traces for lookups to `172.17.0.1`.

The fact that the we're recording so many of these spans for the APM client to do its own work seems like it may be indicative of another issue (ie. request pooling may not be working as intended).

However, I think this is a meaningful improvement, regardless of other issues – these no-op DNS "lookups" aren't actually happening, and the performance metrics that are currently being generated from these spans are meaningless.