### PR TITLE
[ci-app] Fix Jest Flaky Test Setup and Use More Supported Branch Extraction

### DIFF
--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -13,7 +13,7 @@ describe('Plugin', () => {
     })
     beforeEach(() => {
       tracer = require('../../dd-trace')
-      agent.load('jest').then(() => {
+      return agent.load('jest').then(() => {
         DatadogJestEnvironment = require(`../../../versions/jest-environment-node@${version}`).get()
       })
     })

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -10,7 +10,7 @@ function getGitMetadata () {
   const commitSha = sanitizedExec('git rev-parse HEAD')
   return {
     [GIT_REPOSITORY_URL]: sanitizedExec('git ls-remote --get-url'),
-    [GIT_BRANCH]: sanitizedExec('git branch --show-current'),
+    [GIT_BRANCH]: sanitizedExec('git rev-parse --abbrev-ref HEAD'),
     [GIT_COMMIT_SHA]: commitSha,
     [DEPRECATED_GIT_COMMIT_SHA]: commitSha
   }


### PR DESCRIPTION
### What does this PR do?
The tests were flaky due to a race condition: sometimes `DatadogJestEnvironment` at https://github.com/DataDog/dd-trace-js/compare/juan-fernandez/ci-app-fix-jest-tests-and-different-branch-extraction?expand=1#diff-fd24cb8095a6c65c05bff556d3bab1e30e9b7d228ead358834dfd3cdfc25b3b3L17 was being initialized correctly and sometimes it was not. Returning the promise makes `mocha` wait for the `beforeEach` to end.

It also changes the way the `branch` is extracted for a more general support. Error seen in: https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/2132/workflows/5027c0f7-ba3a-45b0-b8dd-0411d9f7ca48/jobs/169932 
```
error: unknown option `show-current'
```

### Motivation
Fix flaky tests at `jest` plugin. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
