### PR TITLE
[ci-app] Better Test Name in Jest Instrumentation

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -60,15 +60,16 @@ function createHandleTestEvent (tracer, testMetadata) {
       'x-datadog-parent-id': '0000000000000000',
       'x-datadog-sampled': 1
     })
+    const { currentTestName } = this.context.expect.getState()
     const commonSpanTags = {
       [TEST_TYPE]: 'test',
-      [TEST_NAME]: event.test.name,
+      [TEST_NAME]: currentTestName,
       [TEST_SUITE]: this.testSuite,
       [SAMPLING_RULE_DECISION]: 1,
       [SAMPLING_PRIORITY]: AUTO_KEEP,
       ...testMetadata
     }
-    const resource = `${event.test.parent.name}.${event.test.name}`
+    const resource = `${this.testSuite}.${currentTestName}`
     if (event.name === 'test_skip' || event.name === 'test_todo') {
       tracer.startSpan(
         'jest.test',

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -21,6 +21,7 @@ describe('Plugin', () => {
       return agent.load('jest').then(() => {
         DatadogJestEnvironment = require(`../../../versions/jest-environment-node@${version}`).get()
         datadogJestEnv = new DatadogJestEnvironment({ rootDir: BUILD_SOURCE_ROOT }, { testPath: TEST_SUITE })
+        // TODO: avoid mocking expect once we instrument the runner instead of the environment
         datadogJestEnv.context.expect = {
           getState: () => {
             return {


### PR DESCRIPTION
### What does this PR do?

We can get test full name through `expect`, which is injected into the environment. So for tests such as:

```javascript
describe('utils', () => {
  describe('getSuites', () => {
    test('should get suites', () => {
    })
  })
```
we would get `utils getSuites should get suites` instead of `should get suites` as we got before. 

### Motivation
Improve naming of tests. I found this when the test name - test suite combination was not uniquely identifying tests in `datadog-ci`. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
