### PR TITLE
export the tracer from implicit init file

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,3 +1,7 @@
 'use strict'
 
-require('.').init()
+const tracer = require('.')
+
+tracer.init()
+
+module.exports = tracer


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Export the tracer from implicit init file.

### Motivation
<!-- What inspired you to submit this pull request? -->

This allows using this file programmatically to ensure the tracer is initialized before everything else in cases where explicitly calling `init` in the entry point is not feasible.