### PR TITLE
add option to enable/disable tracing of individual aws services

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/helpers.js
+++ b/packages/datadog-plugin-aws-sdk/src/helpers.js
@@ -30,6 +30,18 @@ const helpers = {
     span.finish()
   },
 
+  isEnabled (serviceIdentifier, config, request) {
+    if (typeof config === 'boolean') {
+      return config
+    } else if (!config || typeof config !== 'object' || !services[serviceIdentifier]) {
+      return true
+    }
+
+    return services[serviceIdentifier].isEnabled
+      ? services[serviceIdentifier].isEnabled(config, request)
+      : true
+  },
+
   addResponseTags (span, response, serviceName, config) {
     if (!span) return
 

--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -12,6 +12,11 @@ function createWrapRequest (tracer, config) {
       if (!this.service) return send.apply(this, arguments)
 
       const serviceIdentifier = this.service.serviceIdentifier
+
+      if (!awsHelpers.isEnabled(serviceIdentifier, config[serviceIdentifier], this)) {
+        return send.apply(this, arguments)
+      }
+
       const serviceName = getServiceName(serviceIdentifier, tracer, config)
       const childOf = tracer.scope().active()
       const tags = {

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -3,6 +3,18 @@
 const log = require('../../../dd-trace/src/log')
 
 class Sqs {
+  isEnabled (config, request) {
+    switch (request.operation) {
+      case 'receiveMessage':
+        return config.consumer !== false
+      case 'sendMessage':
+      case 'sendMessageBatch':
+        return config.producer !== false
+      default:
+        return true
+    }
+  }
+
   generateTags (params, operation, response) {
     const tags = {}
 
@@ -14,6 +26,7 @@ class Sqs {
     })
 
     if (operation === 'receiveMessage') {
+      tags['span.type'] = 'worker'
       tags['span.type'] = 'worker'
     }
 

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -27,7 +27,6 @@ class Sqs {
 
     if (operation === 'receiveMessage') {
       tags['span.type'] = 'worker'
-      tags['span.type'] = 'worker'
     }
 
     return tags


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add option to enable/disable tracing of individual AWS services, and the producer and/or consumer of a service when applicable.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, auto-instrumentation doesn't work and manual instrumentation has to be used. Usually this is only needed for message queues, and in most cases only for the consumer. This PR allows disabling only the part that must be manually instrumented instead of the entire SDK.