### PR TITLE
add option to split ioredis service name by instance

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -196,6 +196,7 @@ tracer.use('http2', {
 });
 tracer.use('ioredis');
 tracer.use('ioredis', redisOptions);
+tracer.use('ioredis', { splitByInstance: true });
 tracer.use('jest');
 tracer.use('kafkajs');
 tracer.use('knex');

--- a/index.d.ts
+++ b/index.d.ts
@@ -993,6 +993,14 @@ declare namespace plugins {
      * @default []
      */
     blacklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+    /**
+     * Whether to use a different service name for each Redis instance based
+     * on the configured connection name of the client.
+     *
+     * @default false
+     */
+    splitByInstance?: boolean;
   }
 
   /**
@@ -1014,7 +1022,7 @@ declare namespace plugins {
   interface koa extends HttpServer {}
 
   /**
-   * This plugin automatically instruments the 
+   * This plugin automatically instruments the
    * [kafkajs](https://kafka.js.org/) module.
    */
   interface kafkajs extends Instrumentation {}

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -15,7 +15,7 @@ describe('Plugin', () => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
         Redis = require(`../../../versions/ioredis@${version}`).get()
-        redis = new Redis()
+        redis = new Redis({ connectionName: 'test' })
       })
 
       afterEach(() => {
@@ -84,6 +84,7 @@ describe('Plugin', () => {
       describe('with configuration', () => {
         before(() => agent.load('ioredis', {
           service: 'custom',
+          splitByInstance: true,
           whitelist: ['get']
         }))
         after(() => agent.close())
@@ -91,7 +92,7 @@ describe('Plugin', () => {
         it('should be configured with the correct values', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+              expect(traces[0][0]).to.have.property('service', 'custom-test')
             })
             .then(done)
             .catch(done)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add option to split `ioredis` service name by instance.

### Motivation
<!-- What inspired you to submit this pull request? -->

This has been requested a lot for Redis and `ioredis` provides an option to configure the name of each connections.