### PR TITLE
implicit init

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -13,7 +13,7 @@ APM provides out-of-the-box instrumentation for many popular frameworks and libr
 Built-in plugins can be configured individually:
 
 ```javascript
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace')
 
 // enable and configure postgresql integration
 tracer.use('pg', {
@@ -249,7 +249,7 @@ provided function. Any asynchronous context created from whithin that function
 will also have the same scope.
 
 ```javascript
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace')
 const scope = tracer.scope()
 const log = console.log
 
@@ -303,7 +303,7 @@ already bound by default and don't need to be explicitly bound.
 <h6>Function binding</h6>
 
 ```javascript
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace')
 const scope = tracer.scope()
 const log = console.log
 
@@ -328,7 +328,7 @@ scope.activate(outerSpan, () => {
 <h6>Promise binding</h6>
 
 ```javascript
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace')
 const scope = tracer.scope()
 const log = console.log
 
@@ -359,7 +359,7 @@ wrapped by a function.
 <h6>Event emitter binding</h6>
 
 ```javascript
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace')
 const scope = tracer.scope()
 const log = console.log
 const EventEmitter = require('events').EventEmitter
@@ -395,7 +395,7 @@ See the [API documentation](./interfaces/scope.html) for more details.
 This library is OpenTracing compliant. Use the [OpenTracing API](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/) and the Datadog Tracer (dd-trace) library to measure execution times for specific pieces of code. In the following example, a Datadog Tracer is initialized and used as a global tracer:
 
 ```javascript
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace')
 const opentracing = require('opentracing')
 
 opentracing.initGlobalTracer(tracer)
@@ -456,7 +456,7 @@ const logger = bunyan.createLogger({
   level: 'trace'
 })
 
-const tracer = require('dd-trace').init({
+const tracer = require('dd-trace').configure({
   logger: {
     error: err => logger.error(err),
     warn: message => logger.warn(message),
@@ -474,7 +474,7 @@ In some cases, it's necessary to update the metadata of a span created by one of
 For example:
 
 ```javascript
-const tracer = require('dd-trace').init()
+const tracer = require('dd-trace')
 
 tracer.use('express', {
   hooks: {

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -31,8 +31,8 @@ let traceId: string;
 let spanId: string;
 let promise: Promise<void>;
 
-ddTrace.init();
-tracer.init({
+ddTrace.configure();
+tracer.configure({
   debug: true,
   enabled: true,
   logInjection: true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,9 +41,14 @@ export declare interface Tracer extends opentracing.Tracer {
   extract(format: string, carrier: any): SpanContext | null;
 
   /**
-   * Initializes the tracer. This should be called before importing other libraries.
+   * @deprecated Use configure instead.
    */
   init(options?: TracerOptions): this;
+
+  /**
+   * Configures the tracer.
+   */
+  configure(options?: TracerOptions): this;
 
   /**
    * Sets the URL for the trace agent. This should only be called _after_

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 'use strict'
 
 module.exports = require('./packages/dd-trace')
+module.exports.init()

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -7,7 +7,7 @@ const Uint64BE = require('int64-buffer').Uint64BE
 const msgpack = require('msgpack-lite')
 const codec = msgpack.createCodec({ int64: true })
 
-describe('dd-trace', () => {
+describe('dd-trace/index', () => {
   let tracer
   let agent
   let config
@@ -64,5 +64,19 @@ describe('dd-trace', () => {
     })
 
     span.finish()
+  })
+})
+
+describe('dd-trace', () => {
+  it('should call init, implicitly', () => {
+    const ddTrace = {
+      init: sinon.stub()
+    }
+
+    const required = proxyquire('../../..', {
+      './packages/dd-trace': ddTrace
+    })
+    expect(required).to.equal(ddTrace)
+    expect(ddTrace.init).to.have.been.calledOnce
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Calls `init()` immediately when the library is loaded, rather than waiting for
the user to do so. We can do this because config is dynamic, so users can call
`init` or `configure` later on to change any settings at will.

### Motivation
<!-- What inspired you to submit this pull request? -->
This way we have a higher probability of initializing the tracer (and thereby
instrumenting everything correctly) before instrumented code is loaded and
executed.
