### PR TITLE
increase max listeners for config

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -18,6 +18,7 @@ function pluginEnv (name) {
 class Config extends EventEmitter {
   constructor (options) {
     super()
+    this.setMaxListeners(1024)
     this._hasEmitted = {}
     this.configure(options)
   }

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -14,10 +14,12 @@ describe('Config', () => {
     Config = proxyquire('../src/config', {
       './platform': platform
     }).constructor
+    sinon.stub(Config.prototype, 'setMaxListeners')
   })
 
   it('should initialize with the correct defaults', () => {
     const config = new Config()
+    expect(Config.prototype.setMaxListeners).to.have.been.calledWith(1024)
 
     expect(config).to.have.property('service', 'node')
     expect(config).to.have.property('enabled', true)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Sets the max listeners for the config EVentEmitter to 1024, which should be
enough for all the files that are adding listeners, and still small enough to
detect any actual leaks.

### Motivation
<!-- What inspired you to submit this pull request? -->
\#1202
