### PR TITLE
ensure reading environment variables is always possible

### DIFF
--- a/packages/dd-trace/src/platform/index.js
+++ b/packages/dd-trace/src/platform/index.js
@@ -4,8 +4,9 @@ module.exports = {
   use (impl) {
     Object.assign(this, impl)
   },
-  env () {
+  env (name) {
     // need this stub for early config
+    return typeof window !== 'undefined' ? window[name] : process.env[name]
   },
   service () {
     // need this stub for early config


### PR DESCRIPTION
### What does this PR do?
This fixes a chicken and egg situation where config is loaded before
platform.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Without it, setting environment variables doesn't do anything.
