### PR TITLE
[ci-app] Improve git Metadata Extraction Logic

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -5,7 +5,12 @@ const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
 const { SAMPLING_PRIORITY } = require('../../../ext/tags')
 const { AUTO_KEEP } = require('../../../ext/priority')
 
-const { getGitMetadata } = require('../../dd-trace/src/plugins/util/git')
+const {
+  getGitMetadata,
+  GIT_COMMIT_SHA,
+  GIT_BRANCH,
+  GIT_REPOSITORY_URL
+} = require('../../dd-trace/src/plugins/util/git')
 const { getCIMetadata } = require('../../dd-trace/src/plugins/util/ci')
 const {
   TEST_FRAMEWORK,
@@ -21,12 +26,18 @@ const RESOURCE_NAME = 'resource.name'
 function getTestMetadata () {
   // TODO: eventually these will come from the tracer (generally available)
   const ciMetadata = getCIMetadata()
-  const gitMetadata = getGitMetadata()
+  const {
+    [GIT_COMMIT_SHA]: commitSHA,
+    [GIT_BRANCH]: branch,
+    [GIT_REPOSITORY_URL]: repositoryUrl
+  } = ciMetadata
+
+  const gitMetadata = getGitMetadata({ commitSHA, branch, repositoryUrl })
 
   return {
     [TEST_FRAMEWORK]: 'jest',
-    ...ciMetadata,
-    ...gitMetadata
+    ...gitMetadata,
+    ...ciMetadata
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/exec.js
+++ b/packages/dd-trace/src/plugins/util/exec.js
@@ -1,8 +1,8 @@
 const { execSync } = require('child_process')
 
-const sanitizedExec = cmd => {
+const sanitizedExec = (cmd, options = {}) => {
   try {
-    return execSync(cmd).toString().replace(/(\r\n|\n|\r)/gm, '')
+    return execSync(cmd, options).toString().replace(/(\r\n|\n|\r)/gm, '')
   } catch (e) {
     return ''
   }

--- a/packages/dd-trace/src/plugins/util/exec.js
+++ b/packages/dd-trace/src/plugins/util/exec.js
@@ -1,6 +1,5 @@
-const { execSync } = require('child_process')
-
 const sanitizedExec = (cmd, options = {}) => {
+  const { execSync } = require('child_process')
   try {
     return execSync(cmd, options).toString().replace(/(\r\n|\n|\r)/gm, '')
   } catch (e) {

--- a/packages/dd-trace/src/plugins/util/exec.js
+++ b/packages/dd-trace/src/plugins/util/exec.js
@@ -1,5 +1,6 @@
+const { execSync } = require('child_process')
+
 const sanitizedExec = (cmd, options = {}) => {
-  const { execSync } = require('child_process')
   try {
     return execSync(cmd, options).toString().replace(/(\r\n|\n|\r)/gm, '')
   } catch (e) {

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -5,11 +5,17 @@ const GIT_BRANCH = 'git.branch'
 const GIT_REPOSITORY_URL = 'git.repository_url'
 const GIT_TAG = 'git.tag'
 
-function getGitMetadata () {
+// If there is ciMetadata, it takes precedence.
+function getGitMetadata (ciMetadata) {
+  const { commitSHA, branch, repositoryUrl } = ciMetadata
+  // With stdio: 'pipe', errors in this command will not be output to the parent process,
+  // so if `git` is not present in the env, we'll just fallback to the default
+  // and not show a warning to the user.
+  const execOptions = { stdio: 'pipe' }
   return {
-    [GIT_REPOSITORY_URL]: sanitizedExec('git ls-remote --get-url'),
-    [GIT_BRANCH]: sanitizedExec('git rev-parse --abbrev-ref HEAD'),
-    [GIT_COMMIT_SHA]: sanitizedExec('git rev-parse HEAD')
+    [GIT_REPOSITORY_URL]: repositoryUrl || sanitizedExec('git ls-remote --get-url', execOptions),
+    [GIT_BRANCH]: branch || sanitizedExec('git rev-parse --abbrev-ref HEAD', execOptions),
+    [GIT_COMMIT_SHA]: commitSHA || sanitizedExec('git rev-parse HEAD', execOptions)
   }
 }
 

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -22,13 +22,13 @@ describe('git', () => {
     const ciMetadata = { commitSHA: 'ciSHA', branch: 'ciBranch' }
     const metadata = getGitMetadata(ciMetadata)
 
-    expect(metadata).to.eql(
+    expect(metadata).to.include(
       {
         [GIT_COMMIT_SHA]: 'ciSHA',
-        [GIT_BRANCH]: 'ciBranch',
-        [GIT_REPOSITORY_URL]: 'git@github.com:DataDog/dd-trace-js.git'
+        [GIT_BRANCH]: 'ciBranch'
       }
     )
+    expect(metadata[GIT_REPOSITORY_URL]).not.to.equal('ciRepositoryUrl')
     expect(childProcess.execSync).to.have.been.calledWith('git ls-remote --get-url', { stdio: 'pipe' })
   })
 })

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -1,0 +1,34 @@
+const childProcess = require('child_process')
+
+const { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL } = require('../../../src/plugins/util/git')
+
+describe('git', () => {
+  beforeEach(() => {
+    sinon.spy(childProcess, 'execSync')
+  })
+  afterEach(() => {
+    childProcess.execSync.restore()
+  })
+  it('returns ci metadata if present and does not call git', () => {
+    const ciMetadata = { commitSHA: 'ciSHA', branch: 'ciBranch', repositoryUrl: 'ciRepositoryUrl' }
+    const metadata = getGitMetadata(ciMetadata)
+
+    expect(metadata).to.eql(
+      { [GIT_COMMIT_SHA]: 'ciSHA', [GIT_BRANCH]: 'ciBranch', [GIT_REPOSITORY_URL]: 'ciRepositoryUrl' }
+    )
+    expect(childProcess.execSync).not.to.have.been.called
+  })
+  it('calls git when some ci metadata is not present', () => {
+    const ciMetadata = { commitSHA: 'ciSHA', branch: 'ciBranch' }
+    const metadata = getGitMetadata(ciMetadata)
+
+    expect(metadata).to.eql(
+      {
+        [GIT_COMMIT_SHA]: 'ciSHA',
+        [GIT_BRANCH]: 'ciBranch',
+        [GIT_REPOSITORY_URL]: 'git@github.com:DataDog/dd-trace-js.git'
+      }
+    )
+    expect(childProcess.execSync).to.have.been.calledWith('git ls-remote --get-url', { stdio: 'pipe' })
+  })
+})

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -1,23 +1,18 @@
 const proxyquire = require('proxyquire')
 
-const { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL } = require('../../../src/plugins/util/git')
+const sanitizedExecStub = sinon.stub()
+const {
+  getGitMetadata,
+  GIT_COMMIT_SHA,
+  GIT_BRANCH,
+  GIT_REPOSITORY_URL
+} = proxyquire('../../../src/plugins/util/git', { './exec': {
+  'sanitizedExec': sanitizedExecStub
+} })
 
-describe('git', () => {
-  let childProcess
-  beforeEach(() => {
-    childProcess = proxyquire('child_process', { execSync: sinon.spy() })
-  })
+describe('gitt', () => {
   afterEach(() => {
-    childProcess.execSync.restore()
-  })
-  it('returns ci metadata if present and does not call git', () => {
-    const ciMetadata = { commitSHA: 'ciSHA', branch: 'ciBranch', repositoryUrl: 'ciRepositoryUrl' }
-    const metadata = getGitMetadata(ciMetadata)
-
-    expect(metadata).to.eql(
-      { [GIT_COMMIT_SHA]: 'ciSHA', [GIT_BRANCH]: 'ciBranch', [GIT_REPOSITORY_URL]: 'ciRepositoryUrl' }
-    )
-    expect(childProcess.execSync).not.to.have.been.called
+    sanitizedExecStub.reset()
   })
   it('calls git when some ci metadata is not present', () => {
     const ciMetadata = { commitSHA: 'ciSHA', branch: 'ciBranch' }
@@ -30,6 +25,15 @@ describe('git', () => {
       }
     )
     expect(metadata[GIT_REPOSITORY_URL]).not.to.equal('ciRepositoryUrl')
-    expect(childProcess.execSync).to.have.been.calledWith('git ls-remote --get-url', { stdio: 'pipe' })
+    expect(sanitizedExecStub).to.have.been.calledWith('git ls-remote --get-url', { stdio: 'pipe' })
+  })
+  it('returns ci metadata if present and does not call git', () => {
+    const ciMetadata = { commitSHA: 'ciSHA', branch: 'ciBranch', repositoryUrl: 'ciRepositoryUrl' }
+    const metadata = getGitMetadata(ciMetadata)
+
+    expect(metadata).to.eql(
+      { [GIT_COMMIT_SHA]: 'ciSHA', [GIT_BRANCH]: 'ciBranch', [GIT_REPOSITORY_URL]: 'ciRepositoryUrl' }
+    )
+    expect(sanitizedExecStub).not.to.have.been.called
   })
 })

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -1,10 +1,11 @@
-const childProcess = require('child_process')
+const proxyquire = require('proxyquire')
 
 const { getGitMetadata, GIT_COMMIT_SHA, GIT_BRANCH, GIT_REPOSITORY_URL } = require('../../../src/plugins/util/git')
 
 describe('git', () => {
+  let childProcess
   beforeEach(() => {
-    sinon.spy(childProcess, 'execSync')
+    childProcess = proxyquire('child_process', { execSync: sinon.spy() })
   })
   afterEach(() => {
     childProcess.execSync.restore()

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -10,7 +10,7 @@ const {
   'sanitizedExec': sanitizedExecStub
 } })
 
-describe('gitt', () => {
+describe('git', () => {
   afterEach(() => {
     sanitizedExecStub.reset()
   })


### PR DESCRIPTION
### What does this PR do?
* CI environment information takes precedence over `git` commands.
* `git` commands are not executed if CI env information is present.
* We don't show a warning to the user if `git` is not available. 

### Motivation
* Maximise the possibility of having meaningful git info and reduce chances of error states. 
