### PR TITLE
[ci-app] Fix Test Names, Resource and Test Suite in Mocha

### DIFF
--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -29,7 +29,7 @@ function getCommonMetadata () {
   }
 }
 
-function getTestSpanMetadata (tracer, test) {
+function getTestSpanMetadata (tracer, test, sourceRoot) {
   const childOf = tracer.extract('text_map', {
     'x-datadog-trace-id': id().toString(10),
     'x-datadog-parent-id': '0000000000000000',
@@ -37,7 +37,7 @@ function getTestSpanMetadata (tracer, test) {
   })
   const { file: testSuite } = test
   const fullTestName = test.fullTitle()
-  const strippedTestSuite = testSuite ? testSuite.replace(`${process.cwd()}/`, '') : ''
+  const strippedTestSuite = testSuite ? testSuite.replace(`${sourceRoot}/`, '') : ''
 
   return {
     childOf,
@@ -51,7 +51,7 @@ function getTestSpanMetadata (tracer, test) {
   }
 }
 
-function createWrapRunTest (tracer, commonMetadata) {
+function createWrapRunTest (tracer, commonMetadata, sourceRoot) {
   return function wrapRunTest (runTest) {
     return async function runTestWithTrace () {
       let specFunction = this.test.fn
@@ -62,7 +62,7 @@ function createWrapRunTest (tracer, commonMetadata) {
         this.test.sync = true
       }
 
-      const { childOf, resource, ...testSpanMetadata } = getTestSpanMetadata(tracer, this.test)
+      const { childOf, resource, ...testSpanMetadata } = getTestSpanMetadata(tracer, this.test, sourceRoot)
 
       this.test.fn = tracer.wrap(
         'mocha.test',
@@ -100,7 +100,7 @@ function createWrapRunTest (tracer, commonMetadata) {
 }
 
 // Necessary to get the skipped tests, that do not go through runTest
-function createWrapRunTests (tracer, commonMetadata) {
+function createWrapRunTests (tracer, commonMetadata, sourceRoot) {
   return function wrapRunTests (runTests) {
     return function runTestsWithTrace () {
       runTests.apply(this, arguments)
@@ -109,7 +109,7 @@ function createWrapRunTests (tracer, commonMetadata) {
         if (!isSkipped) {
           return
         }
-        const { childOf, resource, ...testSpanMetadata } = getTestSpanMetadata(tracer, test)
+        const { childOf, resource, ...testSpanMetadata } = getTestSpanMetadata(tracer, test, sourceRoot)
 
         tracer
           .startSpan('mocha.test', {
@@ -134,8 +134,9 @@ module.exports = [
     file: 'lib/runner.js',
     patch (Runner, tracer) {
       const commonMetadata = getCommonMetadata()
-      this.wrap(Runner.prototype, 'runTests', createWrapRunTests(tracer, commonMetadata))
-      this.wrap(Runner.prototype, 'runTest', createWrapRunTest(tracer, commonMetadata))
+      const sourceRoot = process.cwd()
+      this.wrap(Runner.prototype, 'runTests', createWrapRunTests(tracer, commonMetadata, sourceRoot))
+      this.wrap(Runner.prototype, 'runTest', createWrapRunTest(tracer, commonMetadata, sourceRoot))
     },
     unpatch (Runner) {
       this.unwrap(Runner.prototype, 'runTests')


### PR DESCRIPTION
### What does this PR do?
* Strip source root from `testSuite`.
* Show full test name instead of just the description in the last `it()`.
* Align `resource` with `jest` instrumentation. 

### Motivation
While dogfooding the `mocha` instrumentation with `dd-trace-js` (https://app.datadoghq.com/ci/test-dashboard/dd-trace-js-tests?branch=master&end=1610535541779&env=testing-juan&index=citest&paused=false&query=%40test.service%3Add-trace-js-tests%20%40git.repository_url%3A%22git%40github.com%3ADataDog%2Fdd-trace-js.git%22%20env%3Atesting-juan%20%40git.branch%3Amaster&repoUrl=git%40github.com%3ADataDog%2Fdd-trace-js.git&start=1609930741779) I found a couple of inconsistencies between `jest` and `mocha` and minor bugs. This PR fixes them. 
