### PR TITLE
fix invalid errors causing incorrect encoding

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -100,9 +100,9 @@ function extractError (trace, span) {
   const error = span.context()._tags['error']
 
   if (error instanceof Error) {
-    trace.meta['error.msg'] = error.message
-    trace.meta['error.type'] = error.name
-    trace.meta['error.stack'] = error.stack
+    addTag(trace.meta, trace.metrics, 'error.msg', error.message)
+    addTag(trace.meta, trace.metrics, 'error.type', error.name)
+    addTag(trace.meta, trace.metrics, 'error.stack', error.stack)
   }
 }
 

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -155,6 +155,19 @@ describe('format', () => {
       expect(trace.meta['error.stack']).to.equal(error.stack)
     })
 
+    it('should skip error properties without a value', () => {
+      const error = new Error('boom')
+
+      error.name = null
+      error.stack = null
+      spanContext._tags['error'] = error
+      trace = format(span)
+
+      expect(trace.meta['error.msg']).to.equal(error.message)
+      expect(trace.meta).to.not.have.property('error.type')
+      expect(trace.meta).to.not.have.property('error.stack')
+    })
+
     it('should extract the origin', () => {
       spanContext._trace.origin = 'synthetics'
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix invalid errors causing incorrect encoding.

### Motivation
<!-- What inspired you to submit this pull request? -->

There are cases where errors have been modified and are missing some properties, which caused the tracer to send `null` properties instead of strings, which causes decoding errors in the agent.