### PR TITLE
[ci-app] Improve Test Environment Metadata Extraction

### DIFF
--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1,3 +1,6 @@
+const { getGitMetadata, GIT_BRANCH, GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('./git')
+const { getCIMetadata } = require('./ci')
+
 const TEST_FRAMEWORK = 'test.framework'
 const TEST_TYPE = 'test.type'
 const TEST_NAME = 'test.name'
@@ -9,5 +12,24 @@ module.exports = {
   TEST_TYPE,
   TEST_NAME,
   TEST_SUITE,
-  TEST_STATUS
+  TEST_STATUS,
+  getTestEnvironmentMetadata
+}
+
+function getTestEnvironmentMetadata (testFramework) {
+  // TODO: eventually these will come from the tracer (generally available)
+  const ciMetadata = getCIMetadata()
+  const {
+    [GIT_COMMIT_SHA]: commitSHA,
+    [GIT_BRANCH]: branch,
+    [GIT_REPOSITORY_URL]: repositoryUrl
+  } = ciMetadata
+
+  const gitMetadata = getGitMetadata({ commitSHA, branch, repositoryUrl })
+
+  return {
+    [TEST_FRAMEWORK]: testFramework,
+    ...gitMetadata,
+    ...ciMetadata
+  }
 }


### PR DESCRIPTION
### What does this PR do?
* Extract `getTestEnvironmentMetadata` to a common util function in `test.js`.
* Use that function in `jest` and `mocha`.  

### Motivation
We had duplicated code in `mocha` and `jest` plugins for the git and ci metadata extraction. We were also missing some logic in `mocha` that was only updated in `jest` in https://github.com/DataDog/dd-trace-js/pull/1207. 
Through this PR we have a single place where we do this in the codebase. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
