### PR TITLE
fix fastify error when handler is passed in the options

### DIFF
--- a/packages/datadog-plugin-fastify/src/fastify.js
+++ b/packages/datadog-plugin-fastify/src/fastify.js
@@ -77,13 +77,23 @@ function wrapMethod (method) {
   return function methodWithTrace (url, opts, handler) {
     const lastIndex = arguments.length - 1
 
-    arguments[lastIndex] = wrapHandler(arguments[lastIndex])
+    handler = arguments[lastIndex]
+
+    if (typeof handler === 'function') {
+      arguments[lastIndex] = wrapHandler(handler)
+    } else if (handler) {
+      arguments[lastIndex].handler = wrapHandler(handler.handler)
+    }
 
     return method.apply(this, arguments)
   }
 }
 
 function wrapHandler (handler) {
+  if (!handler || typeof handler !== 'function' || handler.name === 'handlerWithTrace') {
+    return handler
+  }
+
   return function handlerWithTrace (request, reply) {
     const req = getReq(request)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `fastify` error when handler is passed in the options.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix #1217