### PR TITLE
run integration tests with packaged tarball after prebuilding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,32 @@ prebuild-job: &prebuild-job
         - /.*native.*/
         - /^node-\d+/
 
+
+packaged-integration-base: &packaged-integration-base
+  resource_class: small
+  working_directory: ~/dd-trace-js
+  steps:
+    - checkout
+    - *yarn-versions
+    - *restore-yarn-cache
+    - *yarn-install
+    - *save-yarn-cache
+    - run:
+        name: Yarn Prebuilds
+        command: yarn prebuilds
+    - run:
+        name: Npm Pack
+        command: npm pack
+    - run:
+        name: Install tarball in integration folder
+        working_directory: ~/dd-trace-js/integration-tests
+        command: npm i ../dd-trace*.tgz
+    - run:
+        name: Integration Tests
+        environment:
+          DD_TRACE_LIBRARY_REQUIRE: dd-trace
+        command: yarn test:integration
+
 jobs:
   # Linting
 
@@ -1034,6 +1060,38 @@ jobs:
       - store_artifacts:
           path: ./prebuilds.tgz.sha1
 
+  # Integration Tests with Built Artifacts
+
+  packaged-integration-8:
+    <<: *packaged-integration-base
+    docker:
+      - image: node:8
+
+  packaged-integration-10:
+    <<: *packaged-integration-base
+    docker:
+      - image: node:10
+
+  packaged-integration-12:
+    <<: *packaged-integration-base
+    docker:
+      - image: node:12
+
+  packaged-integration-14:
+    <<: *packaged-integration-base
+    docker:
+      - image: node:14
+
+  packaged-integration-15:
+    <<: *packaged-integration-base
+    docker:
+      - image: node:15
+
+  packaged-integration-latest:
+    <<: *packaged-integration-base
+    docker:
+      - image: node
+
   # Browser
 
   browser:
@@ -1258,6 +1316,25 @@ workflows:
             - win-ia32-12
             - win-ia32-10
             - win-ia32-8
+      # Packaged Integration Tests
+      - packaged-integration-8:
+          requires:
+            - prebuilds
+      - packaged-integration-10:
+          requires:
+            - prebuilds
+      - packaged-integration-12:
+          requires:
+            - prebuilds
+      - packaged-integration-14:
+          requires:
+            - prebuilds
+      - packaged-integration-15:
+          requires:
+            - prebuilds
+      - packaged-integration-latest:
+          requires:
+            - prebuilds
   nightly:
     triggers:
       - schedule:

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "integration-tests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "dependencies": {
+    "dd-trace": "file:../dd-trace-0.30.0.tgz"
+  }
+}

--- a/integration-tests/startup/index.js
+++ b/integration-tests/startup/index.js
@@ -10,7 +10,9 @@ if (process.env.AGENT_URL) {
   options.url = process.env.AGENT_URL
 }
 
-require('../..').init(options)
+const DD_TRACE_LIBRARY_REQUIRE = process.env.DD_TRACE_LIBRARY_REQUIRE || '../..'
+
+require(DD_TRACE_LIBRARY_REQUIRE).init(options)
 
 const http = require('http')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Allow the integration tests to be run against an arbitrary install of the
  library.
* Run integration tests against release-equivalent tarballs, whenever we do
  prebuilds.

### Motivation
<!-- What inspired you to submit this pull request? -->
Occaisionally we have errors resulting from packaged tarballs not containing
something that should have been there. This test should prevent that from
happening in a release.
