### PR TITLE
[ci-app] Fix Mocha Instrumentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,7 +627,6 @@ jobs:
         environment:
           - SERVICES=mssql
           - PLUGINS=tedious
-          - DD_TRACE_DISABLED_PLUGINS=mocha
       - image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
         environment:
           - "ACCEPT_EULA=Y"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,6 +627,7 @@ jobs:
         environment:
           - SERVICES=mssql
           - PLUGINS=tedious
+          - DD_TRACE_DISABLED_PLUGINS=mocha
       - image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
         environment:
           - "ACCEPT_EULA=Y"

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -64,10 +64,10 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
           let result
           try {
             result = await specFunction.call(context)
-            if (context.test.state === 'failed' && context.test.timedOut) {
-              activeSpan.setTag(TEST_STATUS, 'fail')
-            } else {
+            if (context.test.state !== 'failed' && !context.test.timedOut) {
               activeSpan.setTag(TEST_STATUS, 'pass')
+            } else {
+              activeSpan.setTag(TEST_STATUS, 'fail')
             }
           } catch (error) {
             activeSpan.setTag(TEST_STATUS, 'fail')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -38,7 +38,6 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
   return function wrapRunTest (runTest) {
     return async function runTestWithTrace () {
       let specFunction = this.test.fn
-      const context = this.test.ctx
       if (specFunction.length) {
         specFunction = promisify(specFunction)
         // otherwise you have to explicitly call done()
@@ -63,6 +62,7 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
           const activeSpan = tracer.scope().active()
           let result
           try {
+            const context = this.test.ctx
             result = await specFunction.call(context)
             if (context.test.state !== 'failed' && !context.test.timedOut) {
               activeSpan.setTag(TEST_STATUS, 'pass')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -59,7 +59,7 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
             ...testEnvironmentMetadata
           }
         },
-        async function () {
+        async () => {
           const activeSpan = tracer.scope().active()
           let result
           try {

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -66,6 +66,18 @@ const TESTS = [
     testName: 'can do failed async tests',
     root: 'mocha-test-async-fail',
     status: 'fail'
+  },
+  {
+    fileName: 'mocha-test-timeout-fail.js',
+    testName: 'times out',
+    root: 'mocha-test-timeout-fail',
+    status: 'fail'
+  },
+  {
+    fileName: 'mocha-test-timeout-pass.js',
+    testName: 'does not timeout',
+    root: 'mocha-test-timeout-pass',
+    status: 'pass'
   }
 ]
 
@@ -109,12 +121,12 @@ describe('Plugin', () => {
               expect(traces[0][0].type).to.equal('test')
               expect(traces[0][0].name).to.equal('mocha.test')
               expect(traces[0][0].resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
-            })
+            }).then(done, done)
           const mocha = new Mocha({
             reporter: function () {} // silent on internal tests
           })
           mocha.addFile(testFilePath)
-          mocha.run(() => done())
+          mocha.run()
         })
       })
     })

--- a/packages/datadog-plugin-mocha/test/mocha-test-timeout-fail.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-timeout-fail.js
@@ -1,0 +1,8 @@
+describe('mocha-test-timeout-fail', () => {
+  it('times out', function (done) {
+    this.timeout(100)
+    setTimeout(() => {
+      done()
+    }, 200)
+  })
+})

--- a/packages/datadog-plugin-mocha/test/mocha-test-timeout-pass.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-timeout-pass.js
@@ -1,0 +1,8 @@
+describe('mocha-test-timeout-pass', () => {
+  it('does not timeout', function (done) {
+    this.timeout(300)
+    setTimeout(() => {
+      done()
+    }, 200)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
* Fix bug where the spec function in `mocha` was not being called with the correct context. The fix is in https://github.com/DataDog/dd-trace-js/pull/1223/files#diff-3e917ea1366e30454d0aa44c11e64378545e1643def0c66baea963417518bc0dR66. 
* Add support for timeout errors (https://github.com/DataDog/dd-trace-js/pull/1223/files#diff-3e917ea1366e30454d0aa44c11e64378545e1643def0c66baea963417518bc0dR67-R71). These errors do not throw so we were not reporting them.
* Add tests. 

### Motivation
Fixed bug reported in https://github.com/DataDog/dd-trace-js/issues/1222

Fixes #1222 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

