### PR TITLE
Bump node-tedious node image 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,7 +627,6 @@ jobs:
         environment:
           - SERVICES=mssql
           - PLUGINS=tedious
-          - DD_TRACE_DISABLED_PLUGINS=mocha
       - image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
         environment:
           - "ACCEPT_EULA=Y"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,7 +623,7 @@ jobs:
   node-tedious:
     <<: *node-plugin-base
     docker:
-      - image: node:8
+      - image: node:10
         environment:
           - SERVICES=mssql
           - PLUGINS=tedious

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,6 +627,7 @@ jobs:
         environment:
           - SERVICES=mssql
           - PLUGINS=tedious
+          - DD_TRACE_DISABLED_PLUGINS=mocha
       - image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
         environment:
           - "ACCEPT_EULA=Y"

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -54,7 +54,8 @@ describe('Plugin', () => {
         }
 
         connection = new tds.Connection(config)
-          .connect(done)
+
+        connection.connect(done)
       })
 
       afterEach(() => {

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -54,7 +54,7 @@ describe('Plugin', () => {
         }
 
         connection = new tds.Connection(config)
-          .on('connect', done)
+          .connect(done)
       })
 
       afterEach(() => {


### PR DESCRIPTION
### What does this PR do?
https://github.com/tediousjs/tedious/releases/tag/v11.0.0 support for `node:8` has been dropped.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
