### PR TITLE
Add `flush()` method to tracer

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -309,3 +309,5 @@ scope.bind(emitter, span);
 tracer.wrap('x', () => {
   const rumData: string = tracer.getRumData();
 })
+
+tracer.flush();

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,6 +108,12 @@ export declare interface Tracer extends opentracing.Tracer {
    * should not be cached.
    */
   getRumData(): string;
+
+  /**
+   * Flush all collected spans using the active exporter. Useful in cases
+   * where the application is shutting down.
+   */
+  flush (fn?: (error?: Error) => any): void;
 }
 
 export declare interface TraceOptions extends Analyzable {

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -48,6 +48,10 @@ class NoopTracer extends Tracer {
   setUrl () {
   }
 
+  flush (done) {
+    return done
+  }
+
   _startSpan (name, options) {
     return this._span
   }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -130,6 +130,10 @@ class Tracer extends BaseTracer {
   getRumData () {
     return this._tracer.getRumData.apply(this._tracer, arguments)
   }
+
+  flush () {
+    return this._tracer.flush.apply(this._tracer, arguments)
+  }
 }
 
 module.exports = Tracer

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -125,6 +125,10 @@ class DatadogTracer extends Tracer {
 <meta name="dd-trace-id" content="${traceId}" />\
 <meta name="dd-trace-time" content="${traceTime}" />`
   }
+
+  flush (done) {
+    return this._exporter._writer.flush(done)
+  }
 }
 
 function addError (span, error) {

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -103,6 +103,27 @@ function describeWriter (protocolVersion) {
       writer.flush(done)
     })
 
+    it('should enqueue flushes', (done) => {
+      encoder.count.returns(1)
+      request.onFirstCall().callsFake((options, fn) => setTimeout(fn, 1))
+
+      const spy1 = sinon.spy()
+      const spy2 = sinon.spy()
+
+      writer.flush(spy1)
+      writer.flush(spy2)
+
+      expect(spy1).not.to.have.been.called
+      expect(spy2).not.to.have.been.called
+
+      writer.flush(() => {
+        expect(spy1).to.have.been.called
+        expect(spy2).to.have.been.called
+
+        done()
+      })
+    })
+
     it('should flush its traces to the agent, and call callback', (done) => {
       const expectedData = Buffer.from('prefixed')
 

--- a/packages/dd-trace/test/noop.spec.js
+++ b/packages/dd-trace/test/noop.spec.js
@@ -41,6 +41,14 @@ describe('NoopTracer', () => {
     })
   })
 
+  describe('flush', () => {
+    it('should return the function', () => {
+      const fn = () => {}
+
+      expect(tracer.flush(fn)).to.equal(fn)
+    })
+  })
+
   describe('startSpan', () => {
     it('should return a span with a valid context', () => {
       const span = tracer.startSpan()

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -26,7 +26,8 @@ describe('TracerProxy', () => {
       extract: sinon.stub().returns('spanContext'),
       currentSpan: sinon.stub().returns('current'),
       scopeManager: sinon.stub().returns('scopeManager'),
-      setUrl: sinon.stub()
+      setUrl: sinon.stub(),
+      flush: sinon.stub().returns('flush')
     }
 
     noop = {
@@ -38,7 +39,8 @@ describe('TracerProxy', () => {
       extract: sinon.stub().returns('spanContext'),
       currentSpan: sinon.stub().returns('current'),
       scopeManager: sinon.stub().returns('scopeManager'),
-      setUrl: sinon.stub()
+      setUrl: sinon.stub(),
+      flush: sinon.stub().returns('flush')
     }
 
     log = {
@@ -273,6 +275,15 @@ describe('TracerProxy', () => {
         expect(returnValue).to.equal(proxy)
       })
     })
+
+    describe('flush', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.flush()
+
+        expect(noop.flush).to.have.been.calledWith()
+        expect(returnValue).to.equal('flush')
+      })
+    })
   })
 
   describe('initialized', () => {
@@ -376,6 +387,15 @@ describe('TracerProxy', () => {
 
         expect(tracer.setUrl).to.have.been.calledWith('http://example.com')
         expect(returnValue).to.equal(proxy)
+      })
+    })
+
+    describe('flush', () => {
+      it('should call the underlying DatadogTracer', () => {
+        const returnValue = proxy.flush('a', 'b', 'c')
+
+        expect(tracer.flush).to.have.been.calledWith('a', 'b', 'c')
+        expect(returnValue).to.equal('flush')
       })
     })
   })

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -491,4 +491,18 @@ describe('Tracer', () => {
       })
     })
   })
+
+  describe('flush', () => {
+    it('should flush the exporter', () => {
+      sinon.spy(tracer._exporter._writer, 'flush')
+
+      tracer.flush()
+
+      expect(tracer._exporter._writer.flush).to.have.been.called
+    })
+
+    it('should accept a callback', done => {
+      tracer.flush(done)
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Allows users to manually flush any collected spans to the exporter agent. Very useful in scenarios where the app manually calls `process.exit()` such as the one [described by @fredefox here](https://github.com/DataDog/dd-trace-js/issues/708#issuecomment-707024807):

```
const tracer = DD.init();
const res = await App.run(tracer)
await tracer.flush();
process.exit(res);
```

### Motivation
Was implementing an app that handles SIGTERM in order to do a clean shutdown, and dd-trace did not export the span that contained the error to Datadog.