### PR TITLE
[ci-app] Fix Jest Test Name Extraction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,7 +566,7 @@ jobs:
   node-jest:
     <<: *node-plugin-base
     docker:
-      - image: node:8
+      - image: node:10
         environment:
           - PLUGINS=jest
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -43,16 +43,21 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata) {
       'x-datadog-parent-id': '0000000000000000',
       'x-datadog-sampled': 1
     })
-    const { currentTestName } = this.getVmContext().expect.getState()
+    let testName = event.test.name
+    const context = this.getVmContext()
+    if (context) {
+      const { currentTestName } = context.expect.getState()
+      testName = currentTestName
+    }
     const commonSpanTags = {
       [TEST_TYPE]: 'test',
-      [TEST_NAME]: currentTestName,
+      [TEST_NAME]: testName,
       [TEST_SUITE]: this.testSuite,
       [SAMPLING_RULE_DECISION]: 1,
       [SAMPLING_PRIORITY]: AUTO_KEEP,
       ...testEnvironmentMetadata
     }
-    const resource = `${this.testSuite}.${currentTestName}`
+    const resource = `${this.testSuite}.${testName}`
     if (event.name === 'test_skip' || event.name === 'test_todo') {
       tracer.startSpan(
         'jest.test',

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -43,7 +43,7 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata) {
       'x-datadog-parent-id': '0000000000000000',
       'x-datadog-sampled': 1
     })
-    const { currentTestName } = this.context.expect.getState()
+    const { currentTestName } = this.getVmContext().expect.getState()
     const commonSpanTags = {
       [TEST_TYPE]: 'test',
       [TEST_NAME]: currentTestName,

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -12,23 +12,24 @@ describe('Plugin', () => {
   const TEST_SUITE = 'test-file.js'
   const BUILD_SOURCE_ROOT = '/source-root'
 
-  withVersions(plugin, 'jest-environment-node', version => {
+  withVersions(plugin, ['jest-environment-node', 'jest-environment-jsdom'], (version, moduleName) => {
     afterEach(() => {
       return agent.close()
     })
     beforeEach(() => {
       tracer = require('../../dd-trace')
       return agent.load('jest').then(() => {
-        DatadogJestEnvironment = require(`../../../versions/jest-environment-node@${version}`).get()
+        DatadogJestEnvironment = require(`../../../versions/${moduleName}@${version}`).get()
         datadogJestEnv = new DatadogJestEnvironment({ rootDir: BUILD_SOURCE_ROOT }, { testPath: TEST_SUITE })
         // TODO: avoid mocking expect once we instrument the runner instead of the environment
-        datadogJestEnv.context.expect = {
-          getState: () => {
-            return {
-              currentTestName: TEST_NAME
-            }
+        datadogJestEnv.getVmContext = () => ({
+          expect: {
+            getState: () =>
+              ({
+                currentTestName: TEST_NAME
+              })
           }
-        }
+        })
       })
     })
 


### PR DESCRIPTION
### What does this PR do?

In [#1190](https://github.com/DataDog/dd-trace-js/pull/1190/files#diff-76369ef968f888d26d7526855acc94b032e02899dcfef0fcefa452b584b84164R63) I changed the way the test name was extracted in `jest`. Sadly I relied on a field that appears _only_ in `jest-environment-node` and not `jest-environment-jsdom`. This means the instrumentation was broken for jsdom (ui) tests. 

As it can be seen here, `context` is in `jest-environment-node` but not in `jest-enviroment-jsdom`: 
* [`jest-environment-node`](https://github.com/facebook/jest/blob/master/packages/jest-environment-node/src/index.ts#L21-L22)
* [`jest-environment-jsdom`](https://github.com/facebook/jest/blob/master/packages/jest-environment-jsdom/src/index.ts#L25-L31)

What we do always have is `getVmContext`:
* [`getVmContext` in `jest-environment-node`, which simply returns `this.context`](https://github.com/facebook/jest/blob/master/packages/jest-environment-node/src/index.ts#L116-L118)
* [`getVmContext` in `jest-environment-jsdom`](https://github.com/facebook/jest/blob/master/packages/jest-environment-jsdom/src/index.ts#L135-L139)

I've made it so that we test both `jest-environment-node` and `jest-environment-jsdom` in the plugin tests. Sadly `expect` is added elsewhere (not in the env itself), so we still need to mock it in https://github.com/DataDog/dd-trace-js/pull/1230/files#diff-fd24cb8095a6c65c05bff556d3bab1e30e9b7d228ead358834dfd3cdfc25b3b3R25-R32. 

Since `getVmContext` can return `null` I've added a guard and fallback in https://github.com/DataDog/dd-trace-js/pull/1230/files#diff-76369ef968f888d26d7526855acc94b032e02899dcfef0fcefa452b584b84164R46-R51 and a corresponding unit test.

### Motivation

While dogfooding `jest` instrumentation with `web-ui` I found out about this bug. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
