### PR TITLE
fix possible app crash in latest when used with meteor 2.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -415,7 +415,7 @@ export declare interface TracerOptions {
    * implementation for the runtime. Only change this if you know what you are
    * doing.
    */
-  scope?: 'async_hooks' | 'async_local_storage' | 'noop'
+  scope?: 'async_hooks' | 'async_local_storage' | 'async_resource' | 'noop'
 
   /**
    * Whether to report the hostname of the service host. This is used when the agent is deployed on a different host and cannot determine the hostname automatically.

--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -19,7 +19,8 @@ const semver = require('semver')
 
 const emitter = new EventEmitter()
 
-const hasSupportedAsyncLocalStorage = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
+// https://github.com/nodejs/node/pull/33801
+const hasJavaScriptAsyncHooks = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
 
 const platform = {
   _config: {},
@@ -44,7 +45,7 @@ const platform = {
   getScope (scope) {
     if (scope === scopes.ASYNC_LOCAL_STORAGE) {
       return require('../../scope/async_local_storage')
-    } else if (scope === scopes.ASYNC_RESOURCE || (!scope && hasSupportedAsyncLocalStorage)) {
+    } else if (scope === scopes.ASYNC_RESOURCE || (!scope && hasJavaScriptAsyncHooks)) {
       return require('../../scope/async_resource')
     } else {
       return require('../../scope/async_hooks')

--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -42,10 +42,10 @@ const platform = {
   off: emitter.removeListener.bind(emitter),
   Loader,
   getScope (scope) {
-    if (scope === scopes.ASYNC_RESOURCE) {
-      return require('../../scope/async_resource')
-    } else if (scope === scopes.ASYNC_LOCAL_STORAGE || (!scope && hasSupportedAsyncLocalStorage)) {
+    if (scope === scopes.ASYNC_LOCAL_STORAGE) {
       return require('../../scope/async_local_storage')
+    } else if (scope === scopes.ASYNC_RESOURCE || (!scope && hasSupportedAsyncLocalStorage)) {
+      return require('../../scope/async_resource')
     } else {
       return require('../../scope/async_hooks')
     }

--- a/packages/dd-trace/test/platform/node/index.spec.js
+++ b/packages/dd-trace/test/platform/node/index.spec.js
@@ -700,7 +700,7 @@ describe('Platform', () => {
     describe('getScope', () => {
       let platform
       let versionDescriptor
-      const ASYNC_LOCAL_STORAGE = { name: 'AsyncLocalStorage' }
+      const ASYNC_RESOURCE = { name: 'async_resource' }
       const ASYNC_HOOKS = { name: 'async_hooks' }
 
       beforeEach(() => {
@@ -711,17 +711,17 @@ describe('Platform', () => {
         Reflect.defineProperty(process.versions, 'node', versionDescriptor)
       })
 
-      it('should default to AsyncLocalStorage on supported versions, and async_hooks on unsupported versions', () => {
+      it('should default to async_resource on supported versions, and async_hooks on unsupported versions', () => {
         function assertVersion (version, als) {
           Reflect.defineProperty(process.versions, 'node', {
             value: version,
             configurable: true
           })
           platform = proxyquire('../src/platform/node/index', {
-            '../../scope/async_local_storage': ASYNC_LOCAL_STORAGE,
+            '../../scope/async_resource': ASYNC_RESOURCE,
             '../../scope/async_hooks': ASYNC_HOOKS
           })
-          expect(platform.getScope()).to.equal(als ? ASYNC_LOCAL_STORAGE : ASYNC_HOOKS)
+          expect(platform.getScope()).to.equal(als ? ASYNC_RESOURCE : ASYNC_HOOKS)
         }
         assertVersion('10.0.0', false)
         assertVersion('12.0.0', false)
@@ -739,7 +739,7 @@ describe('Platform', () => {
       })
 
       it('should go with user choice when scope is defined in options', () => {
-        expect(platform.getScope('async_local_storage')).to.equal(ASYNC_LOCAL_STORAGE)
+        expect(platform.getScope('async_resource')).to.equal(ASYNC_RESOURCE)
         expect(platform.getScope('async_hooks')).to.equal(ASYNC_HOOKS)
       })
     })

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -15,7 +15,7 @@ const agent = require('../plugins/agent')
 const externals = require('../plugins/externals.json')
 
 const defaultScope = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
-  ? 'async_local_storage'
+  ? 'async_resource'
   : 'async_hooks'
 
 const asyncHooksScope = new AsyncHooksScope({


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix possible app crash in latest when used with Meteor 2.0 by updating the tracer to default to the `async_resource` scope manager since the issue seems to be a bug in `AsyncLocalStorage`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Applications using Meteor 2.0 with the tracer are experiencing random C++ errors. While it's still unclear why this is happening, switching to the `executionAsyncResource` based scope manager seems to resolve the issue.

Fixes #1229