### PR TITLE
check against both params.body and params.bulkBody

### DIFF
--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -24,8 +24,8 @@ function createWrapRequest (tracer, config) {
         }
       })
 
-      if (params.body) {
-        span.setTag('elasticsearch.body', JSON.stringify(params.body))
+      if (params.body || params.bulkBody) {
+        span.setTag('elasticsearch.body', JSON.stringify(params.body || params.bulkBody))
       }
 
       analyticsSampler.sample(span, config.analytics)


### PR DESCRIPTION
### What does this PR do?
This PR will allow tracer to log bulkBody when it's a bulk request to endpoint like '/msearch' 

### Motivation
Since we switched the way to do multi-index search, we lose query.body in the dd log.

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
In the later elasticsearch-js client, bulk request body is in bulkBody key:
https://github.com/elastic/elasticsearch-js/blob/883ef386e34c25f933835977328d8ae174b97a2a/api/api/msearch.js#L54
