### PR TITLE
fix aws-sdk tests not waiting for localstack to be ready

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
       - image: node:8
         environment:
           - PLUGINS=aws-sdk
-          - SERVICES=aws-sdk
+          - SERVICES=localstack
       - image: localstack/localstack:0.11.2
         environment:
           - LOCALSTACK_SERVICES=dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs

--- a/packages/dd-trace/test/setup/services/localstack.js
+++ b/packages/dd-trace/test/setup/services/localstack.js
@@ -21,6 +21,7 @@ function waitForAWS () {
     const snsEndpoint = new AWS.Endpoint('http://localhost:4575')
     const route53Endpoint = new AWS.Endpoint('http://localhost:4580')
     const redshiftEndpoint = new AWS.Endpoint('http://localhost:4577')
+    const lambdaEndpoint = new AWS.Endpoint('http://localhost:4566')
 
     const ddb = new AWS.DynamoDB({ endpoint: ddbEndpoint })
     const kinesis = new AWS.Kinesis({ endpoint: kinesisEndpoint })
@@ -29,6 +30,7 @@ function waitForAWS () {
     const sqs = new AWS.SQS({ endpoint: sqsEndpoint })
     const sns = new AWS.SNS({ endpoint: snsEndpoint })
     const redshift = new AWS.Redshift({ endpoint: redshiftEndpoint })
+    const lambda = new AWS.Lambda({ endpoint: lambdaEndpoint })
 
     operation.attempt(currentAttempt => {
       Promise.all([
@@ -38,7 +40,8 @@ function waitForAWS () {
         sqs.listQueues({}).promise(),
         sns.listTopics({}).promise(),
         route53.listHealthChecks({}).promise(),
-        redshift.describeClusters({}).promise()
+        redshift.describeClusters({}).promise(),
+        lambda.listFunctions({}).promise()
       ]).then(data => {
         resolve()
       }).catch(err => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `aws-sdk` tests not waiting for Localstack to be ready.

### Motivation
<!-- What inspired you to submit this pull request? -->

Build was constantly failing.