### PR TITLE
Fixes #1240 properly spread callback args

### DIFF
--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -58,14 +58,8 @@ function wrapExecute (tracer, config, execute) {
 
 function wrapCallback (tracer, span, parent, done) {
   return tracer.scope().bind((...args) => {
-    const [ err ] = args;
-    if (err) {
-      span.addTags({
-        'error.type': err.name,
-        'error.msg': err.message,
-        'error.stack': err.stack
-      })
-    }
+    const [ error ] = args
+    span.addTags({ error })
 
     span.finish()
 

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -57,11 +57,19 @@ function wrapExecute (tracer, config, execute) {
 }
 
 function wrapCallback (tracer, span, parent, done) {
-  return tracer.scope().bind((error, res) => {
-    span.addTags({ error })
+  return tracer.scope().bind((...args) => {
+    const [ err ] = args;
+    if (err) {
+      span.addTags({
+        'error.type': err.name,
+        'error.msg': err.message,
+        'error.stack': err.stack
+      })
+    }
+
     span.finish()
 
-    done(error, res)
+    done(...args)
   }, parent)
 }
 

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -5,7 +5,7 @@ const plugin = require('../src')
 
 wrapIt()
 
-describe('Plugin', () => {
+describe.only('Plugin', () => {
   let mysql2
   let tracer
 
@@ -42,7 +42,7 @@ describe('Plugin', () => {
           connection.end(done)
         })
 
-        it('should propagate context to callbacks', done => {
+        it('should propagate context to callbacks, with correct callback args', done => {
           if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
 
           const span = tracer.startSpan('test')
@@ -50,7 +50,9 @@ describe('Plugin', () => {
           tracer.scope().activate(span, () => {
             const span = tracer.scope().active()
 
-            connection.query('SELECT 1 + 1 AS solution', () => {
+            connection.query('SELECT 1 + 1 AS solution', (err, results, fields) => {
+              expect(results).to.not.be.null
+              expect(fields).to.not.be.null
               expect(tracer.scope().active()).to.equal(span)
               done()
             })

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -5,7 +5,7 @@ const plugin = require('../src')
 
 wrapIt()
 
-describe.only('Plugin', () => {
+describe('Plugin', () => {
   let mysql2
   let tracer
 


### PR DESCRIPTION
### What does this PR do?
This properly spreads the callback args to fix #1240 

### Motivation
I want mysql2 support and use fields in my code

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
I updated a test, but can't get tests to run locally. 
