### PR TITLE
[ci-app] Add support for cucumber.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,6 +557,13 @@ jobs:
         environment:
           - PLUGINS=connect
 
+  node-cucumber:
+    <<: *node-plugin-base
+    docker:
+      - image: node:10
+        environment:
+          - PLUGINS=cucumber
+
   node-couchbase:
     <<: *node-plugin-base
     docker:
@@ -1273,6 +1280,7 @@ workflows:
       - node-cassandra
       - node-connect
       - node-couchbase
+      - node-cucumber
       - node-dns
       - node-elasticsearch
       - node-express
@@ -1552,6 +1560,7 @@ workflows:
       - node-cassandra
       - node-connect
       - node-couchbase
+      - node-cucumber
       - node-dns
       - node-elasticsearch
       - node-express

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,7 +923,7 @@ jobs:
           command: yarn type:doc
       - store_artifacts:
           path: ./docs/out
-  
+
   # Node upstream tests
 
   node-upstream-node:
@@ -1338,6 +1338,7 @@ workflows:
             - node-cassandra
             - node-connect
             - node-couchbase
+            - node-cucumber
             - node-dns
             - node-elasticsearch
             - node-express

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,7 @@ tracer.use('pg', {
 <h5 id="aws-sdk-config"></h5>
 <h5 id="bunyan"></h5>
 <h5 id="couchbase"></h5>
+<h5 id="cucumber"></h5>
 <h5 id="dns"></h5>
 <h5 id="elasticsearch"></h5>
 <h5 id="elasticsearch-tags"></h5>
@@ -95,6 +96,7 @@ tracer.use('pg', {
 * [aws-sdk](./interfaces/plugins.aws_sdk.html)
 * [bluebird](./interfaces/plugins.bluebird.html)
 * [couchbase](./interfaces/plugins.couchbase.html)
+* [cucumber](./interfaces/plugins.cucumber.html)
 * [bunyan](./interfaces/plugins.bunyan.html)
 * [cassandra-driver](./interfaces/plugins.cassandra_driver.html)
 * [connect](./interfaces/plugins.connect.html)

--- a/index.d.ts
+++ b/index.d.ts
@@ -783,6 +783,12 @@ declare namespace plugins {
 
   /**
    * This plugin automatically instruments the
+   * [cucumber](https://www.npmjs.com/package/@cucumber/cucumber) module.
+   */
+  interface cucumber extends Instrumentation {}
+
+  /**
+   * This plugin automatically instruments the
    * [dns](https://nodejs.org/api/dns.html) module.
    */
   interface dns extends Instrumentation {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -488,6 +488,7 @@ interface Plugins {
   "cassandra-driver": plugins.cassandra_driver;
   "connect": plugins.connect;
   "couchbase": plugins.couchbase;
+  "cucumber": plugins.cucumber;
   "dns": plugins.dns;
   "elasticsearch": plugins.elasticsearch;
   "express": plugins.express;

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -27,7 +27,7 @@ function setStatusFromResult (span, result) {
 
 function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot) {
   return function wrapRun (run) {
-    return async function handleRun (...args) {
+    return async function handleRun () {
       const testName = this.pickle.name
       const testSuite = relative(sourceRoot, this.pickle.uri)
 
@@ -47,7 +47,7 @@ function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot) {
           tags: commonSpanTags
         },
         async (span) => {
-          const runResult = await run.apply(this, args)
+          const runResult = await run.apply(this, arguments)
           setStatusFromResult(span, this.getWorstStepResult())
           return runResult
         }
@@ -59,13 +59,13 @@ function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot) {
 
 function createWrapRunStep (tracer) {
   return function wrapRunStep (runStep) {
-    return async function handleRunStep (...args) {
-      const resource = args[0].isHook ? 'hook' : args[0].pickleStep.text
+    return async function handleRunStep () {
+      const resource = arguments[0].isHook ? 'hook' : arguments[0].pickleStep.text
       return tracer.trace(
         'cucumber.step',
         { type: 'test', resource: resource },
         async (span) => {
-          const result = await runStep.apply(this, args)
+          const result = await runStep.apply(this, arguments)
           setStatusFromResult(span, result)
           return result
         }

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -46,7 +46,7 @@ function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot) {
           resource: testName,
           tags: commonSpanTags
         },
-        async (span) => {
+        (span) => {
           const promise = run.apply(this, arguments)
           promise.then(() => {
             setStatusFromResult(span, this.getWorstStepResult())
@@ -65,7 +65,7 @@ function createWrapRunStep (tracer) {
       return tracer.trace(
         'cucumber.step',
         { type: 'test', resource: resource },
-        async (span) => {
+        (span) => {
           const promise = runStep.apply(this, arguments)
           promise.then((result) => {
             setStatusFromResult(span, result)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -1,0 +1,99 @@
+const { relative } = require('path')
+const { promisify } = require('util')
+
+const id = require('../../dd-trace/src/id')
+const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
+const { SAMPLING_PRIORITY, SPAN_TYPE, RESOURCE_NAME } = require('../../../ext/tags')
+const { AUTO_KEEP } = require('../../../ext/priority')
+
+const {
+  TEST_TYPE,
+  TEST_NAME,
+  TEST_SUITE,
+  TEST_STATUS,
+  getTestEnvironmentMetadata
+} = require('../../dd-trace/src/plugins/util/test')
+
+function setStatusFromResult(span, result) {
+  if (result.status == 1) {
+    span.setTag(TEST_STATUS, "pass")
+  } else if (result.status == 2) {
+    span.setTag(TEST_STATUS, "skip")
+    span.setTag("error.msg", "skipped")
+  } else if (result.status == 4) {
+    span.setTag(TEST_STATUS, "skip")
+    span.setTag("error.msg", "not implemented")
+  } else {
+    span.setTag(TEST_STATUS, "fail")
+    span.setTag("error.msg", result.message)
+  }
+}
+
+function createWrapRun(tracer, testEnvironmentMetadata, sourceRoot) {
+  return function wrapRun(run) {
+    return async function handleRun(...args) {
+      const testName = this.pickle.name
+      const testSuite = relative(sourceRoot, this.pickle.uri)
+
+      const commonSpanTags = {
+        [TEST_TYPE]: "test",
+        [TEST_NAME]: testName,
+        [TEST_SUITE]: testSuite,
+        [SAMPLING_RULE_DECISION]: 1,
+        ...testEnvironmentMetadata,
+      }
+
+      let result = await tracer.trace(
+        "cucumber.test",
+        {
+          type: "test",
+          resource: testName,
+          tags: commonSpanTags,
+        },
+        async (span) => {
+          const runResult = await run.apply(this, args)
+          setStatusFromResult(span, this.getWorstStepResult())
+          return runResult
+        }
+      )
+      return result
+    }
+  }
+}
+
+function createWrapRunStep(tracer) {
+  return function wrapRunStep(runStep) {
+    return async function handleRunStep(...args) {
+      const resource = args[0].isHook ? "hook" : args[0].pickleStep?.text
+      return await tracer.trace(
+        "cucumber.step",
+        { type: "test", resource: resource },
+        async (span) => {
+          const result = await runStep.apply(this, args)
+          setStatusFromResult(span, result)
+          return result
+        }
+      )
+    }
+  }
+}
+
+module.exports = [
+  {
+    name: '@cucumber/cucumber',
+    versions: ['>=7.0.0'],
+    file: 'lib/runtime/pickle_runner.js',
+    patch(PickleRunner, tracer) {
+      const testEnvironmentMetadata = getTestEnvironmentMetadata('cucumber')
+      const sourceRoot = process.cwd()
+      let pl = PickleRunner.default
+      this.wrap(pl.prototype, 'run', createWrapRun(tracer, testEnvironmentMetadata, sourceRoot))
+      this.wrap(pl.prototype, 'runStep', createWrapRunStep(tracer))
+    },
+    unpatch(PickleRunner) {
+      let pl = PickleRunner.default
+      this.unwrap(pl.prototype, 'run')
+      this.unwrap(pl.prototype, 'runStep')
+    }
+  }
+]

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -64,7 +64,7 @@ function createWrapRun(tracer, testEnvironmentMetadata, sourceRoot) {
 function createWrapRunStep(tracer) {
   return function wrapRunStep(runStep) {
     return async function handleRunStep(...args) {
-      const resource = args[0].isHook ? "hook" : args[0].pickleStep?.text
+      const resource = args[0].isHook ? "hook" : args[0].pickleStep.text
       return await tracer.trace(
         "cucumber.step",
         { type: "test", resource: resource },

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -67,8 +67,8 @@ function createWrapRunStep (tracer) {
         { type: 'test', resource: resource },
         async (span) => {
           const promise = runStep.apply(this, arguments)
-          promise.then(() => {
-            setStatusFromResult(span, this)
+          promise.then((result) => {
+            setStatusFromResult(span, result)
           })
           return promise
         }

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -64,7 +64,7 @@ function createWrapRunStep (tracer) {
       const resource = arguments[0].isHook ? 'hook' : arguments[0].pickleStep.text
       return tracer.trace(
         'cucumber.step',
-        { type: 'test', resource: resource, tags: { 'cucumber.step': resource } },
+        { resource, tags: { 'cucumber.step': resource } },
         (span) => {
           const promise = runStep.apply(this, arguments)
           promise.then((result) => {

--- a/packages/datadog-plugin-cucumber/test/features/simple.feature
+++ b/packages/datadog-plugin-cucumber/test/features/simple.feature
@@ -1,0 +1,20 @@
+Feature: Datadog integration
+
+  Scenario: pass scenario
+    Given datadog
+    When run
+    Then pass
+
+  Scenario: fail scenario
+    Given datadog
+    When run
+    Then fail
+
+  Scenario: skip scenario
+    Given datadog
+    When run
+    Then skip
+
+  @skip
+  Scenario: skip scenario based on tag
+    Given datadog

--- a/packages/datadog-plugin-cucumber/test/features/simple.js
+++ b/packages/datadog-plugin-cucumber/test/features/simple.js
@@ -1,0 +1,34 @@
+const { Before, Given, When, Then, setWorldConstructor } = require('@cucumber/cucumber')
+const { expect } = require('chai')
+
+var CustomWorld = function() {
+  this.datadog = 0;
+};
+
+CustomWorld.prototype.setTo = function(value) {
+  this.datadog = value;
+};
+
+setWorldConstructor(CustomWorld);
+
+Before('@skip', function() {
+  return 'skipped'
+})
+
+Given('datadog', function() {
+  this.setTo('datadog');
+});
+
+When('run', () => {});
+
+Then('pass', function() {
+  expect(this.datadog).to.eql('datadog')
+});
+
+Then('fail', function() {
+  expect(this.datadog).to.eql('godatad')
+});
+
+Then('skip', function() {
+  return 'skipped'
+});

--- a/packages/datadog-plugin-cucumber/test/features/simple.js
+++ b/packages/datadog-plugin-cucumber/test/features/simple.js
@@ -1,34 +1,34 @@
 const { Before, Given, When, Then, setWorldConstructor } = require('@cucumber/cucumber')
 const { expect } = require('chai')
 
-var CustomWorld = function() {
-  this.datadog = 0;
-};
+const CustomWorld = function () {
+  this.datadog = 0
+}
 
-CustomWorld.prototype.setTo = function(value) {
-  this.datadog = value;
-};
+CustomWorld.prototype.setTo = function (value) {
+  this.datadog = value
+}
 
-setWorldConstructor(CustomWorld);
+setWorldConstructor(CustomWorld)
 
-Before('@skip', function() {
+Before('@skip', function () {
   return 'skipped'
 })
 
-Given('datadog', function() {
-  this.setTo('datadog');
-});
+Given('datadog', function () {
+  this.setTo('datadog')
+})
 
-When('run', () => {});
+When('run', () => {})
 
-Then('pass', function() {
+Then('pass', function () {
   expect(this.datadog).to.eql('datadog')
-});
+})
 
-Then('fail', function() {
+Then('fail', function () {
   expect(this.datadog).to.eql('godatad')
-});
+})
 
-Then('skip', function() {
+Then('skip', function () {
   return 'skipped'
-});
+})

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -108,7 +108,7 @@ describe('Plugin', () => {
             argv, cwd, stdout
           })
 
-          let result = await cli.run()
+          const result = await cli.run()
           expect(result.success).to.equal(test.success)
           await checkTraces
         })

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -47,7 +47,7 @@ const TESTS = [
     requireName: 'simple.js',
     testName: 'skip scenario based on tag',
     success: true,
-    statuses: ['skip', 'skip'],  // includes first step and marks it as skipped
+    statuses: ['skip', 'skip'], // includes first step and marks it as skipped
     errors: ['skipped', 'skipped']
   }
 ]
@@ -84,7 +84,10 @@ describe('Plugin', () => {
               expect(traces[0].map(s => s.meta[TEST_STATUS])).to.have.members(test.statuses)
               if (test.errors !== undefined) {
                 test.errors.forEach((msg, i) => {
-                  expect(traces[0][i].meta['error.msg'], `item ${i} should start with "${msg}"`).to.satisfy(err => msg === undefined || err.startsWith(msg))
+                  expect(
+                    traces[0][i].meta['error.msg'],
+                    `item ${i} should start with "${msg}"`
+                  ).to.satisfy(err => msg === undefined || err.startsWith(msg))
                 })
               }
               // take the last top level trace

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -1,0 +1,120 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const plugin = require('../src')
+
+
+const {
+  TEST_FRAMEWORK,
+  TEST_TYPE,
+  TEST_NAME,
+  TEST_SUITE,
+  TEST_STATUS
+} = require('../../dd-trace/src/plugins/util/test')
+const { expect } = require('chai')
+const path = require('path')
+const { PassThrough } = require('stream')
+
+const TESTS = [
+  {
+    featureName: 'simple.feature',
+    featureSuffix: ':3',
+    requireName: 'simple.js',
+    testName: 'pass scenario',
+    status: 'pass',
+    success: true
+  },
+  {
+    featureName: 'simple.feature',
+    featureSuffix: ':8',
+    requireName: 'simple.js',
+    testName: 'fail scenario',
+    status: 'fail',
+    success: false
+  },
+  {
+    featureName: 'simple.feature',
+    featureSuffix: ':13',
+    requireName: 'simple.js',
+    testName: 'skip scenario',
+    status: 'skip',
+    success: true
+  },
+  {
+    featureName: 'simple.feature',
+    featureSuffix: ':19',
+    requireName: 'simple.js',
+    testName: 'skip scenario based on tag',
+    status: 'skip',
+    success: true
+  }
+]
+
+wrapIt()
+
+describe('Plugin', () => {
+  let Cucumber
+
+  withVersions(plugin, '@cucumber/cucumber', version => {
+    afterEach(() => {
+      // > If you want to run tests multiple times, you may need to clear Node's require cache
+      // before subsequent calls in whichever manner best suits your needs.
+      TESTS.forEach((test) => {
+        delete require.cache[require.resolve(path.join(__dirname, 'features', test.requireName))]
+      })
+      return agent.close()
+    })
+    beforeEach(() => {
+      return agent.load('cucumber').then(() => {
+        Cucumber = require(`../../../versions/@cucumber/cucumber@${version}`).get()
+      })
+    })
+
+    describe('cucumber', () => {
+      TESTS.forEach(test => {
+        it(`should create a test span for ${test.featureName}${test.featureSuffix || ''}`, function (done) {
+          this.timeout(20000)
+          const testFilePath = path.join(__dirname, 'features', test.featureName)
+          const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
+          agent
+            .use(traces => {
+              // take the last top level trace
+              const trace = traces[0][traces[0].length-1]
+              expect(traces[0][traces[0].length-1].meta).to.contain({
+                language: 'javascript',
+                service: 'test',
+                [TEST_NAME]: test.testName,
+                [TEST_STATUS]: test.status,
+                [TEST_TYPE]: 'test',
+                [TEST_FRAMEWORK]: 'cucumber',
+                [TEST_SUITE]: testSuite
+              })
+              expect(trace.meta[TEST_SUITE].endsWith(test.featureName)).to.equal(true)
+              expect(trace.type).to.equal('test')
+              expect(trace.name).to.equal('cucumber.test')
+              expect(trace.resource).to.equal(`${test.testName}`)
+            }).then(done, done)
+
+          const stdout = new PassThrough()
+          const cwd = path.resolve(path.join(__dirname, `../../../versions/@cucumber/cucumber@${version}`))
+          const cucumber_js = `${cwd}/node-modules/.bin/cucumber-js`;
+          const argv = [
+            'node',
+            cucumber_js,
+            '--require', __dirname + '/features/' + test.requireName,
+            __dirname + '/features/' + test.featureName + test.featureSuffix
+          ]
+          const cli = new Cucumber.Cli({
+            argv, cwd, stdout
+          });
+
+          cli.run().then(result => {
+            expect(result.success).to.equal(test.success)
+          }, reason => {
+            throw reason
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -3,7 +3,6 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
 
-
 const {
   TEST_FRAMEWORK,
   TEST_TYPE,
@@ -79,8 +78,8 @@ describe('Plugin', () => {
           agent
             .use(traces => {
               // take the last top level trace
-              const trace = traces[0][traces[0].length-1]
-              expect(traces[0][traces[0].length-1].meta).to.contain({
+              const trace = traces[0][traces[0].length - 1]
+              expect(traces[0][traces[0].length - 1].meta).to.contain({
                 language: 'javascript',
                 service: 'test',
                 [TEST_NAME]: test.testName,
@@ -97,16 +96,17 @@ describe('Plugin', () => {
 
           const stdout = new PassThrough()
           const cwd = path.resolve(path.join(__dirname, `../../../versions/@cucumber/cucumber@${version}`))
-          const cucumber_js = `${cwd}/node-modules/.bin/cucumber-js`;
+          const cucumberJs = `${cwd}/node-modules/.bin/cucumber-js`
           const argv = [
             'node',
-            cucumber_js,
-            '--require', __dirname + '/features/' + test.requireName,
-            __dirname + '/features/' + test.featureName + test.featureSuffix
+            cucumberJs,
+            '--require',
+            path.join(__dirname, 'features', test.requireName),
+            path.join(__dirname, 'features', `${test.featureName}${test.featureSuffix}`)
           ]
           const cli = new Cucumber.Cli({
             argv, cwd, stdout
-          });
+          })
 
           cli.run().then(result => {
             expect(result.success).to.equal(test.success)

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -108,7 +108,10 @@ describe('Plugin', () => {
               }
               // take the test span
               const testSpan = traces[0][traces[0].length - 1]
-              expect(traces[0][traces[0].length - 1].meta).to.contain({
+
+              // having no parent span means there is no span leak from other tests
+              expect(testSpan.parent_id.toString()).to.equal('0')
+              expect(testSpan.meta).to.contain({
                 language: 'javascript',
                 service: 'test',
                 [TEST_NAME]: test.testName,

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -96,6 +96,8 @@ describe('Plugin', () => {
           const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
           const checkTraces = agent
             .use(traces => {
+              // number of tests + one test span
+              expect(traces[0].length).to.equal(test.steps.length + 1)
               if (test.errors !== undefined) {
                 test.errors.forEach((msg, i) => {
                   expect(

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -129,6 +129,7 @@ describe('Plugin', () => {
                 expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
                 expect(stepSpan.meta['cucumber.step']).to.equal(test.steps[index].name)
                 expect(stepSpan.meta['step.status']).to.equal(test.steps[index].stepStatus)
+                expect(stepSpan.type).not.to.equal('test')
               })
             })
 

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -9,6 +9,7 @@ module.exports = {
   'cassandra-driver': require('../../../datadog-plugin-cassandra-driver/src'),
   'connect': require('../../../datadog-plugin-connect/src'),
   'couchbase': require('../../../datadog-plugin-couchbase/src'),
+  'cucumber': require('../../../datadog-plugin-cucumber/src'),
   'dns': require('../../../datadog-plugin-dns/src'),
   'elasticsearch': require('../../../datadog-plugin-elasticsearch/src'),
   'express': require('../../../datadog-plugin-express/src'),


### PR DESCRIPTION
### What does this PR do?

Adds support for tracing features and steps executed by cucumber.js.

### Motivation

Tracking BDD scenarios in CI App.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] ~API [documentation][3].~
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

Run as usual with loaded `dd-trace`:
```console
$ cucumber-js --require-module dd-trace/init ...
```

