### PR TITLE
add synchronous scope manager

### DIFF
--- a/ext/scopes.d.ts
+++ b/ext/scopes.d.ts
@@ -2,6 +2,7 @@ declare const scopes: {
   ASYNC_RESOURCE: 'async_resource',
   ASYNC_LOCAL_STORAGE: 'async_local_storage',
   ASYNC_HOOKS: 'async_hooks'
+  SYNC: 'sync'
   NOOP: 'noop'
 }
 

--- a/ext/scopes.js
+++ b/ext/scopes.js
@@ -4,5 +4,6 @@ module.exports = {
   ASYNC_RESOURCE: 'async_resource',
   ASYNC_LOCAL_STORAGE: 'async_local_storage',
   ASYNC_HOOKS: 'async_hooks',
+  SYNC: 'sync',
   NOOP: 'noop'
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -401,7 +401,7 @@ export declare interface TracerOptions {
    * implementation for the runtime. Only change this if you know what you are
    * doing.
    */
-  scope?: 'async_hooks' | 'async_local_storage' | 'async_resource' | 'noop'
+  scope?: 'async_hooks' | 'async_local_storage' | 'async_resource' | 'sync' | 'noop'
 
   /**
    * Whether to report the hostname of the service host. This is used when the agent is deployed on a different host and cannot determine the hostname automatically.

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -13,6 +13,8 @@ module.exports = name => {
 
   if (name === NOOP) {
     Scope = require('./scope/base')
+  } else if (name === scopes.SYNC) {
+    Scope = require('./scope/sync')
   } else if (name === scopes.ASYNC_LOCAL_STORAGE) {
     Scope = require('./scope/async_local_storage')
   } else if (name === scopes.ASYNC_RESOURCE || (!name && hasJavaScriptAsyncHooks)) {

--- a/packages/dd-trace/src/scope/sync.js
+++ b/packages/dd-trace/src/scope/sync.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const Base = require('./base')
+
+class Scope extends Base {
+  constructor () {
+    super()
+
+    this._stack = []
+    this._current = null
+  }
+
+  _active () {
+    return this._current || null
+  }
+
+  _activate (span, callback) {
+    this._stack.push(this._current)
+    this._current = span
+
+    try {
+      return callback()
+    } finally {
+      this._current = this._stack.pop()
+    }
+  }
+}
+
+module.exports = Scope

--- a/packages/dd-trace/test/scope/sync.spec.js
+++ b/packages/dd-trace/test/scope/sync.spec.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const Scope = require('../../src/scope/sync')
+const testScope = require('./test')
+
+describe('Scope (sync)', () => {
+  let scope
+
+  beforeEach(() => {
+    scope = new Scope()
+  })
+
+  testScope(() => scope, false)
+})

--- a/packages/dd-trace/test/scope/test.js
+++ b/packages/dd-trace/test/scope/test.js
@@ -2,7 +2,7 @@
 
 const Span = require('opentracing').Span
 
-module.exports = factory => {
+module.exports = (factory, supportsAsync = true) => {
   let scope
   let span
 
@@ -44,72 +44,74 @@ module.exports = factory => {
       expect(scope.active()).to.be.null
     })
 
-    it('should persist through setTimeout', done => {
-      scope.activate(span, () => {
-        setTimeout(() => {
-          expect(scope.active()).to.equal(span)
-          done()
-        }, 0)
-      })
-    })
-
-    it('should persist through setImmediate', done => {
-      scope.activate(span, () => {
-        setImmediate(() => {
-          expect(scope.active()).to.equal(span)
-          done()
-        }, 0)
-      })
-    })
-
-    it('should persist through setInterval', done => {
-      scope.activate(span, () => {
-        let shouldReturn = false
-
-        const timer = setInterval(() => {
-          expect(scope.active()).to.equal(span)
-
-          if (shouldReturn) {
-            clearInterval(timer)
-            return done()
-          }
-
-          shouldReturn = true
-        }, 0)
-      })
-    })
-
-    if (global.process && global.process.nextTick) {
-      it('should persist through process.nextTick', done => {
+    if (supportsAsync) {
+      it('should persist through setTimeout', done => {
         scope.activate(span, () => {
-          process.nextTick(() => {
+          setTimeout(() => {
             expect(scope.active()).to.equal(span)
             done()
           }, 0)
         })
       })
+
+      it('should persist through setImmediate', done => {
+        scope.activate(span, () => {
+          setImmediate(() => {
+            expect(scope.active()).to.equal(span)
+            done()
+          }, 0)
+        })
+      })
+
+      it('should persist through setInterval', done => {
+        scope.activate(span, () => {
+          let shouldReturn = false
+
+          const timer = setInterval(() => {
+            expect(scope.active()).to.equal(span)
+
+            if (shouldReturn) {
+              clearInterval(timer)
+              return done()
+            }
+
+            shouldReturn = true
+          }, 0)
+        })
+      })
+
+      if (global.process && global.process.nextTick) {
+        it('should persist through process.nextTick', done => {
+          scope.activate(span, () => {
+            process.nextTick(() => {
+              expect(scope.active()).to.equal(span)
+              done()
+            }, 0)
+          })
+        })
+      }
+
+      it('should persist through promises', () => {
+        const promise = Promise.resolve()
+
+        return scope.activate(span, () => {
+          return promise.then(() => {
+            expect(scope.active()).to.equal(span)
+          })
+        })
+      })
+
+      it('should handle concurrency', done => {
+        scope.activate(span, () => {
+          setImmediate(() => {
+            expect(scope.active()).to.equal(span)
+            done()
+          })
+        })
+
+        scope.activate(span, () => {})
+      })
     }
-
-    it('should persist through promises', () => {
-      const promise = Promise.resolve()
-
-      return scope.activate(span, () => {
-        return promise.then(() => {
-          expect(scope.active()).to.equal(span)
-        })
-      })
-    })
-
-    it('should handle concurrency', done => {
-      scope.activate(span, () => {
-        setImmediate(() => {
-          expect(scope.active()).to.equal(span)
-          done()
-        })
-      })
-
-      scope.activate(span, () => {})
-    })
 
     it('should handle errors', () => {
       const error = new Error('boom')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add synchronous scope manager.

### Motivation
<!-- What inspired you to submit this pull request? -->

Because of the [issue](https://github.com/DataDog/dd-trace-js/issues/1095) with `async_hooks`, there are cases where it's not possible to track the asynchronous context. However, our auto-instrumentation expects to always be able to get the parent span from the scope manager, which makes the it unusable when scope management is completely disabled. This new scope manager works around this issue by allowing to manually re-activate a span on a synchronous scope to make it available when the integration starts its own span.

For example:

```js
tracer.trace('parent', parent => {
  setImmediate(() => {
    // here `tracer.scope().active() is null instead of `parent`
    // calling for example `http.get` would result in a disconnected trace

    return tracer.scope().activate(parent, () => {
      // tracer.scope().active() is now `parent` so the `http` plugin will have access to it
      return http.get('some-url', res => {
        // here the correct scope is restored by the `http` plugin
      })
    })
  })
})
```

While the `async_hooks` issue should be fixed in a few months, in the meantime this allows to continue using auto-instrumentation by manually connecting spans from integrations together. The code is extremely simple so it also doesn't add unnecessary maintenance overhead after the fix will have landed.