### PR TITLE
fix bound emitters leaking when trying to remove all listeners

### DIFF
--- a/packages/dd-trace/src/scope/base.js
+++ b/packages/dd-trace/src/scope/base.js
@@ -188,7 +188,7 @@ function wrapRemoveListener (removeListener) {
 
     listeners.delete(listener)
 
-    return removeListener.call(this, eventName, listener)
+    return removeListener.apply(this, arguments)
   }
 }
 
@@ -202,7 +202,7 @@ function wrapRemoveAllListeners (removeAllListeners) {
       }
     }
 
-    return removeAllListeners.call(this, eventName)
+    return removeAllListeners.apply(this, arguments)
   }
 }
 

--- a/packages/dd-trace/test/scope/test.js
+++ b/packages/dd-trace/test/scope/test.js
@@ -300,6 +300,43 @@ module.exports = factory => {
 
         expect(spy).to.not.have.been.called
       })
+
+      it('should remove all listeners of a type', () => {
+        const spy = sinon.spy()
+        const spy2 = sinon.spy()
+
+        scope.bind(emitter)
+
+        scope.activate(span, () => {
+          emitter.once('test', spy)
+          emitter.once('test', spy2)
+          emitter.removeAllListeners('test')
+        })
+
+        emitter.emit('test')
+
+        expect(spy).to.not.have.been.called
+        expect(spy2).to.not.have.been.called
+      })
+
+      it('should remove all listeners', () => {
+        const spy = sinon.spy()
+        const spy2 = sinon.spy()
+
+        scope.bind(emitter)
+
+        scope.activate(span, () => {
+          emitter.once('test', spy)
+          emitter.once('test2', spy2)
+          emitter.removeAllListeners()
+        })
+
+        emitter.emit('test')
+        emitter.emit('test2')
+
+        expect(spy).to.not.have.been.called
+        expect(spy2).to.not.have.been.called
+      })
     })
 
     describe('with an unsupported target', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix bound emitters leaking when trying to remove all listeners.

### Motivation
<!-- What inspired you to submit this pull request? -->

The latest version of Axios bumped the version of their `follow-redirects` dependency which includes  https://github.com/follow-redirects/follow-redirects/commit/ad15f9bf42cbf5a3aa9425b961b94af45b52761e which relies on removing all event listeners from the underlying request. This caused the tracer to start crashing when used with Axios because the scope manager didn't properly handle calls to `removeAllListeners` without an actual event name, so all listeners were still attached to the emitter.

Fixes #1253 