### PR TITLE
[ci-app] Add Configuration Metadata

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci-app-spec.json
+++ b/packages/dd-trace/src/plugins/util/ci-app-spec.json
@@ -17,5 +17,10 @@
   "ci.stage.name",
   "git.commit.sha",
   "git.branch",
-  "git.tag"
+  "git.tag",
+  "os.platform",
+  "os.version",
+  "os.architecture",
+  "runtime.name",
+  "runtime.version"
 ]

--- a/packages/dd-trace/src/plugins/util/env.js
+++ b/packages/dd-trace/src/plugins/util/env.js
@@ -1,0 +1,26 @@
+const os = require('os')
+
+const OS_PLATFORM = 'os.platform'
+const OS_VERSION = 'os.version'
+const OS_ARCHITECTURE = 'os.architecture'
+const RUNTIME_NAME = 'runtime.name'
+const RUNTIME_VERSION = 'runtime.version'
+
+function getRuntimeAndOSMetadata () {
+  return {
+    [RUNTIME_VERSION]: process.version,
+    [OS_ARCHITECTURE]: process.arch,
+    [OS_PLATFORM]: process.platform,
+    [RUNTIME_NAME]: 'node',
+    [OS_VERSION]: os.release()
+  }
+}
+
+module.exports = {
+  getRuntimeAndOSMetadata,
+  OS_PLATFORM,
+  OS_VERSION,
+  OS_ARCHITECTURE,
+  RUNTIME_NAME,
+  RUNTIME_VERSION
+}

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1,5 +1,6 @@
 const { getGitMetadata, GIT_BRANCH, GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('./git')
 const { getCIMetadata } = require('./ci')
+const { getRuntimeAndOSMetadata } = require('./env')
 
 const TEST_FRAMEWORK = 'test.framework'
 const TEST_TYPE = 'test.type'
@@ -27,9 +28,12 @@ function getTestEnvironmentMetadata (testFramework) {
 
   const gitMetadata = getGitMetadata({ commitSHA, branch, repositoryUrl })
 
+  const runtimeAndOSMetadata = getRuntimeAndOSMetadata()
+
   return {
     [TEST_FRAMEWORK]: testFramework,
     ...gitMetadata,
-    ...ciMetadata
+    ...ciMetadata,
+    ...runtimeAndOSMetadata
   }
 }

--- a/packages/dd-trace/test/plugins/util/env.spec.js
+++ b/packages/dd-trace/test/plugins/util/env.spec.js
@@ -1,0 +1,25 @@
+const os = require('os')
+const {
+  getRuntimeAndOSMetadata,
+  OS_ARCHITECTURE,
+  OS_PLATFORM,
+  OS_VERSION,
+  RUNTIME_NAME,
+  RUNTIME_VERSION
+} = require('../../../src/plugins/util/env')
+
+describe('env', () => {
+  it('reads env data', () => {
+    const envMetadata = getRuntimeAndOSMetadata()
+
+    expect(envMetadata).to.eql(
+      {
+        [RUNTIME_VERSION]: process.version,
+        [OS_ARCHITECTURE]: process.arch,
+        [OS_PLATFORM]: process.platform,
+        [RUNTIME_NAME]: 'node',
+        [OS_VERSION]: os.release()
+      }
+    )
+  })
+})

--- a/packages/dd-trace/test/plugins/util/env.spec.js
+++ b/packages/dd-trace/test/plugins/util/env.spec.js
@@ -9,7 +9,7 @@ const {
 } = require('../../../src/plugins/util/env')
 
 describe('env', () => {
-  it('reads env data', () => {
+  it('reads runtime and OS metadata', () => {
     const envMetadata = getRuntimeAndOSMetadata()
 
     expect(envMetadata).to.eql(


### PR DESCRIPTION
### What does this PR do?

* Add environment (OS and runtime) metadata to test spans.

### Motivation
We want to be able to tell the users whether their tests failing is caused by their code or the underlying configuration used (say the OS or runtime used).

