### PR TITLE
[serverless] add support for datadog extension

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -114,6 +114,9 @@ class Config {
       rateLimit: coalesce(ingestion.rateLimit, sampler.rateLimit, process.env.DD_TRACE_RATE_LIMIT)
     })
 
+    const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
+    const defaultFlushInterval = inAWSLambda ? 0 : 2000
+
     this.enabled = isTrue(DD_TRACE_ENABLED)
     this.debug = isTrue(DD_TRACE_DEBUG)
     this.logInjection = isTrue(DD_LOGS_INJECTION)
@@ -122,7 +125,7 @@ class Config {
     this.site = coalesce(options.site, process.env.DD_SITE, 'datadoghq.com')
     this.hostname = DD_AGENT_HOST || (this.url && this.url.hostname)
     this.port = String(DD_TRACE_AGENT_PORT || (this.url && this.url.port))
-    this.flushInterval = coalesce(parseInt(options.flushInterval, 10), 2000)
+    this.flushInterval = coalesce(parseInt(options.flushInterval, 10), defaultFlushInterval)
     this.sampleRate = coalesce(Math.min(Math.max(options.sampleRate, 0), 1), 1)
     this.logger = options.logger
     this.plugins = !!coalesce(options.plugins, true)

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -9,5 +9,6 @@ module.exports = {
   REFERENCE_NOOP: 'noop',
   SAMPLING_RULE_DECISION: '_dd.rule_psr',
   SAMPLING_LIMIT_DECISION: '_dd.limit_psr',
-  SAMPLING_AGENT_DECISION: '_dd.agent_psr'
+  SAMPLING_AGENT_DECISION: '_dd.agent_psr',
+  DATADOG_LAMBDA_EXTENSION_PATH: '/opt/extensions/datadog-agent'
 }

--- a/packages/dd-trace/src/exporter.js
+++ b/packages/dd-trace/src/exporter.js
@@ -3,9 +3,15 @@
 const AgentExporter = require('./exporters/agent')
 const LogExporter = require('./exporters/log')
 const exporters = require('../../../ext/exporters')
+const fs = require('fs')
+const constants = require('./constants')
 
 module.exports = name => {
   const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
+  let usingLambdaExtension = false
+  if (inAWSLambda) {
+    usingLambdaExtension = fs.existsSync(constants.DATADOG_LAMBDA_EXTENSION_PATH)
+  }
 
   switch (name) {
     case exporters.LOG:
@@ -13,6 +19,6 @@ module.exports = name => {
     case exporters.AGENT:
       return AgentExporter
     default:
-      return inAWSLambda ? LogExporter : AgentExporter
+      return inAWSLambda && !usingLambdaExtension ? LogExporter : AgentExporter
   }
 }

--- a/packages/dd-trace/src/exporter.js
+++ b/packages/dd-trace/src/exporter.js
@@ -8,10 +8,7 @@ const constants = require('./constants')
 
 module.exports = name => {
   const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
-  let usingLambdaExtension = false
-  if (inAWSLambda) {
-    usingLambdaExtension = fs.existsSync(constants.DATADOG_LAMBDA_EXTENSION_PATH)
-  }
+  const usingLambdaExtension = inAWSLambda && fs.existsSync(constants.DATADOG_LAMBDA_EXTENSION_PATH)
 
   switch (name) {
     case exporters.LOG:

--- a/packages/dd-trace/test/exporter.spec.js
+++ b/packages/dd-trace/test/exporter.spec.js
@@ -1,4 +1,5 @@
 'use strict'
+const fs = require('fs')
 
 const AgentExporter = require('../src/exporters/agent')
 const LogExporter = require('../src/exporters/log')
@@ -27,6 +28,17 @@ describe('exporter', () => {
     const Exporter = require('../src/exporter')()
 
     expect(Exporter).to.be.equal(LogExporter)
+  })
+
+  it('should create an AgentExporter when in Lambda environment with an extension', () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-func'
+    const stub = sinon.stub(fs, 'existsSync')
+    stub.withArgs('/opt/extensions/datadog-agent').returns(true)
+
+    const Exporter = require('../src/exporter')()
+
+    expect(Exporter).to.be.equal(AgentExporter)
+    stub.restore()
   })
 
   it('should allow configuring the exporter', () => {


### PR DESCRIPTION
### What does this PR do?
Adds support for submitting traces via the Datadog Lambda Extension. The Datadog Lambda Extension is a special flavor of the datadog agent, the hooks into the AWS Lambda runtime. Read the draft RFC on tracing with the extension [here](https://github.com/DataDog/architecture/blob/1721621a36e8ebcecc07ea90cabb4ea4f36173a0/rfcs/serverless/lambda-extension-tracing/rfc.md) for more context.

We also change the detection mechanism for the log exporter, only selecting it when we detect a serverless environment AND the extension isn't present. We use a hardcoded file system path to detect the extension, (due to the way the extension API works, the extension can only be at that path). When in serverless mode, we also modify the agent exporter so it flushes it immediately.

### Motivation
To supporting tracing via the Datadog Extension automatically

### Additional Notes
