### PR TITLE
update tedious ci tests to run on node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,7 +637,7 @@ jobs:
   node-tedious:
     <<: *node-plugin-base
     docker:
-      - image: node:8
+      - image: node:10
         environment:
           - SERVICES=mssql
           - PLUGINS=tedious


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update `tedious` CI tests to run on Node 10.

### Motivation
<!-- What inspired you to submit this pull request? -->

`tedious` no longer supports Node 8.