### PR TITLE
fix elasticsearch tests failing because of node requirement bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,7 +479,7 @@ jobs:
   node-elasticsearch:
     <<: *node-plugin-base
     docker:
-      - image: node:8
+      - image: node:10
         environment:
           - SERVICES=elasticsearch
           - PLUGINS=elasticsearch


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `elasticsearch` tests failing because of Node requirement bump.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `elasticsearch` module no longer supports Node 8.