### PR TITLE
[ci-app] Bump shimmer

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "read-pkg-up": "^3.0.0",
     "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
-    "shimmer": "^1.2.0",
+    "shimmer": "1.2.1",
     "source-map": "^0.7.3",
     "source-map-resolve": "^0.6.0",
     "url-parse": "^1.4.3"


### PR DESCRIPTION
### What does this PR do?
* Bump `shimmer` to `1.2.1` (`latest`)

### Motivation
The `isFunction` util function within `shimmer` didn't work for async functions. The fix was release in `1.2.1` but we're still in `1.2.0`: 
https://github.com/othiym23/shimmer/compare/v1.2.0...master 

Specifically in this commit:
https://github.com/othiym23/shimmer/commit/ec15ba2bf2cffc25622fca0d277ea68f0ae2d8ee

This was making the `teardown` not run in the `jest` instrumentation (https://github.com/DataDog/dd-trace-js/blob/master/packages/datadog-plugin-jest/src/index.js#L25-L34), which provoked that failed tests were missing.

The caret in `^1.2.0` should make it so that we get future patch releases, but apparently it is failing sometimes. In any case, pinning to `1.2.1` should be safer. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
