### PR TITLE
chore: dep upgrade: read-pkg-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "protobufjs": "^6.9.0",
-    "read-pkg-up": "^8.0.0",
+    "read-pkg-up": "^7.0.0",
     "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
     "shimmer": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "protobufjs": "^6.9.0",
-    "read-pkg-up": "^7.0.0",
+    "read-pkg-up": "^6.0.0",
     "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
     "shimmer": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "protobufjs": "^6.9.0",
-    "read-pkg-up": "^3.0.0",
+    "read-pkg-up": "^8.0.0",
     "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
     "shimmer": "1.2.1",

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const readPkgUp = require('read-pkg-up')
+const { readPackageUpSync } = require('read-pkg-up')
 
 function findRoot () {
   return require.main && require.main.filename ? path.dirname(require.main.filename) : process.cwd()
@@ -9,7 +9,7 @@ function findRoot () {
 
 function findPkg () {
   const cwd = findRoot()
-  const up = readPkgUp.sync({ cwd })
+  const up = readPackageupSync({ cwd })
 
   return up && up.pkg ? up.pkg : {}
 }

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -9,7 +9,7 @@ function findRoot () {
 
 function findPkg () {
   const cwd = findRoot()
-  const up = readPackageupSync({ cwd })
+  const up = readPackageUpSync({ cwd })
 
   return up && up.pkg ? up.pkg : {}
 }

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const { readPackageUpSync } = require('read-pkg-up')
+const readPkgUp = require('read-pkg-up')
 
 function findRoot () {
   return require.main && require.main.filename ? path.dirname(require.main.filename) : process.cwd()
@@ -9,7 +9,7 @@ function findRoot () {
 
 function findPkg () {
   const cwd = findRoot()
-  const up = readPackageUpSync({ cwd })
+  const up = readPkgUp.sync({ cwd })
 
   return up && up.pkg ? up.pkg : {}
 }


### PR DESCRIPTION
Edit: read-pkg-up ^8.0.0 doesn't like earlier node versions, so going to use circle to test out different versions and see if I can't get those tests passing. Ignore this for now.



### What does this PR do?
Upgrades `read-pkg-up` in response to [Snyk flagging one of it's sub-dependencies for regex dos](https://snyk.io/test/npm/dd-trace/0.30.6). Note that the version in that Snyk advisory is an earlier version of dd-trace; but, it should be flagging the same advisory for the current version of dd-trace (and, at any rate, it _is_ in a private work repo).

### Motivation
Snyk flagged this in a private repo and it seemed like a fairly straightforward change. The `read-pkg-up` API only changes [slightly](https://www.npmjs.com/package/read-pkg-up).


[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
I couldn't run the tests for this. This is what `yarn test` (after spinning things up with docker compose) spits out a bunch of errors from a node native addon, couchbase. Here's a snippet from the end to show the version/culprit, but I can send over the full list if you want:

```
fatal error: too many errors emitted, stopping now [-ferror-limit=]
16 warnings and 20 errors generated.
make: *** [Release/obj.target/couchbase_impl/src/couchbase_impl.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/aaronarinder/.nvm/versions/node/v12.18.3/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:315:20)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
gyp ERR! System Darwin 19.6.0
gyp ERR! command "/Users/aaronarinder/.nvm/versions/node/v12.18.3/bin/node" "/Users/aaronarinder/.nvm/versions/node/v12.18.3/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/aaronarinder/external-code/pull-requests/dd-trace-js/versions/couchbase@2.4.2/node_modules/couchbase
```

The circleci cli spits this out:

```
Error:
CircleCI was unable to start the container because the container entrypoint or command failed to start.

This typically means that the passed entrypoint or command is not found or is not valid.  Try clearing the entrypoint/command values.
Original error: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: process_linux.go:459: container init caused: Running hook #0:: error running hook: exit status 1, stdout: , stderr: time="2021-03-30T16:52:09Z" level=fatal msg="no such file or directory": unknown

Step failed
Task failed
```


### Additional _Additional_ Notes
DataDog is awesome! We're enjoying the service where I work, to the point where I can't imagine doing without it. So, thanks!
