### PR TITLE
add encodings sirun test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,13 @@ jobs:
         environment:
           - SIRUN_TEST_DIR=async_hooks
 
+  node-bench-sirun-encoders-latest:
+    <<: *node-bench-sirun-base
+    docker:
+      - image: node
+        environment:
+          - SIRUN_TEST_DIR=encoding
+
   # Core tests
 
   node-core-8:
@@ -1133,6 +1140,7 @@ workflows:
       - node-bench-e2e-latest
       - node-bench-sirun-startup-latest
       - node-bench-sirun-async-hooks
+      - node-bench-sirun-encoders-latest
       - node-amqplib
       - node-amqp10
       - node-aws-sdk
@@ -1385,6 +1393,7 @@ workflows:
       - node-bench-e2e-latest
       - node-bench-sirun-startup-latest
       - node-bench-sirun-async-hooks
+      - node-bench-sirun-encoders-latest
       - node-amqplib
       - node-amqp10
       - node-aws-sdk

--- a/benchmark/sirun/encoding/README.md
+++ b/benchmark/sirun/encoding/README.md
@@ -1,0 +1,9 @@
+This test sends a single trace 10000 times to the encoder. Each trace is
+pre-formatted (as the encoder requires) and consists of 30 spans with the same
+content in each of them. The IDs are all randomized. A null writer is provided
+to the encoder, so writing operations are not included here.
+
+The span content contains three metas, three metrics, and reasonable values for
+everything else.
+
+The two variants correspond to the v0.4 and v0.5 encoders.

--- a/benchmark/sirun/encoding/index.js
+++ b/benchmark/sirun/encoding/index.js
@@ -1,0 +1,47 @@
+const {
+  ENCODER_VERSION
+} = process.env
+
+const { AgentEncoder } = require(`../../../packages/dd-trace/src/encode/${ENCODER_VERSION}`)
+const id = require('../../../packages/dd-trace/src/id')
+
+const writer = {
+  flush: () => {}
+}
+
+function createSpan (parent) {
+  const spanId = id()
+  return {
+    trace_id: parent ? parent.trace_id : spanId,
+    span_id: spanId,
+    parent_id: parent ? parent.parent_id : id(0),
+    name: 'this is a name',
+    resource: 'this is a resource',
+    error: 0,
+    start: 1415926535897,
+    duration: 100,
+    meta: {
+      a: 'b',
+      hello: 'world',
+      and: 'this is a longer string, just because we want to test some longer strongs, got it? okay'
+    },
+    metrics: {
+      b: 45,
+      something: 98764389,
+      afloaty: 203987465.756754
+    }
+  }
+}
+
+const trace = []
+for (let parent = null, i = 0; i < 30; i++) {
+  const span = createSpan(parent)
+  trace.push(span)
+  parent = span
+}
+
+const encoder = new AgentEncoder(writer)
+
+for (let j = 0; j < 10000; j++) {
+  encoder.encode(trace)
+}

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "encoders",
+  "run": "node index.js",
+  "cachegrind": true,
+  "iterations": 10,
+  "variants": {
+    "0.4": { "env": { "ENCODER_VERSION": "0.4" } },
+    "0.5": { "env": { "ENCODER_VERSION": "0.5" } }
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds a test of the encoders for each of the protocol version in the sirun benchmarks.

### Motivation
<!-- What inspired you to submit this pull request? -->
Encoding is a source of overhead.
