### PR TITLE
updates to get-results.js

### DIFF
--- a/benchmark/sirun/get-results.js
+++ b/benchmark/sirun/get-results.js
@@ -12,8 +12,8 @@ const circleHeaders = CIRCLE_TOKEN ? {
   'circle-token': CIRCLE_TOKEN
 } : {}
 
-const statusUrl = ref =>
-  `https://api.github.com/repos/DataDog/dd-trace-js/commits/${ref}/statuses?per_page=100`
+const statusUrl = (ref, page) =>
+  `https://api.github.com/repos/DataDog/dd-trace-js/commits/${ref}/statuses?per_page=100&page=${page}`
 const artifactsUrl = num =>
   `https://circleci.com/api/v1.1/project/github/DataDog/dd-trace-js/${num}/artifacts`
 
@@ -38,7 +38,14 @@ function get (url, headers) {
 }
 
 async function getBuildNumsFromGithub (ref) {
-  const results = JSON.parse(await get(statusUrl(ref)))
+  const results = []
+  let page = 1
+  let reply = JSON.parse(await get(statusUrl(ref, page)))
+  results.push(...reply)
+  while (reply.length === 100) {
+    reply = JSON.parse(await get(statusUrl(ref, ++page)))
+    results.push(...reply)
+  }
   const namesAndNums = {}
   for (const build of results.filter(s => s.context.includes('-sirun-'))) {
     const url = new URL(build.target_url)

--- a/benchmark/sirun/get-results.js
+++ b/benchmark/sirun/get-results.js
@@ -39,13 +39,12 @@ function get (url, headers) {
 
 async function getBuildNumsFromGithub (ref) {
   const results = []
-  let page = 1
-  let reply = JSON.parse(await get(statusUrl(ref, page)))
-  results.push(...reply)
-  while (reply.length === 100) {
+  let page = 0
+  let reply
+  do {
     reply = JSON.parse(await get(statusUrl(ref, ++page)))
     results.push(...reply)
-  }
+  } while (reply.length === 100)
   const namesAndNums = {}
   for (const build of results.filter(s => s.context.includes('-sirun-'))) {
     const url = new URL(build.target_url)

--- a/benchmark/sirun/get-results.js
+++ b/benchmark/sirun/get-results.js
@@ -78,7 +78,7 @@ function summary (iterations) {
   for (const [name, items] of Object.entries(stats)) {
     const m = mean(items)
     const s = stddev(m, items)
-    result[name] = { mean: m, stddev: s }
+    result[name] = { mean: m, stddev: s, min: Math.min(...items), max: Math.max(...items) }
   }
   return result
 }


### PR DESCRIPTION
### What does this PR do?
- support github's pagination in get-results.js
- add min and max to summaries in get-results.js

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Without pagination, we're not getting all the results from all the tests.
Min and max are useful summary statistics.

