### PR TITLE
Scope managers sirun test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,13 @@ jobs:
           - PLUGINS=q
           - SIRUN_TEST_DIR=plugin-q
 
+  node-bench-sirun-scope-latest:
+    <<: *node-bench-sirun-base
+    docker:
+      - image: node
+        environment:
+          - SIRUN_TEST_DIR=scope
+
   # Core tests
 
   node-core-8:
@@ -1261,6 +1268,7 @@ workflows:
       - node-bench-sirun-async-hooks
       - node-bench-sirun-encoders-latest
       - node-bench-sirun-plugin-q-latest
+      - node-bench-sirun-scope-latest
   prebuild:
     jobs:
       # Linux x64
@@ -1467,3 +1475,4 @@ workflows:
       - node-bench-sirun-async-hooks
       - node-bench-sirun-encoders-latest
       - node-bench-sirun-plugin-q-latest
+      - node-bench-sirun-scope-latest

--- a/benchmark/sirun/scope/README.md
+++ b/benchmark/sirun/scope/README.md
@@ -1,0 +1,2 @@
+This test creates a number (`COUNT`) of promises, awaits, setImmediates and
+setTimeouts which a given scope manager (`SCOPE_MANAGER`).

--- a/benchmark/sirun/scope/index.js
+++ b/benchmark/sirun/scope/index.js
@@ -1,0 +1,56 @@
+
+const {
+  SCOPE_MANAGER,
+  COUNT
+} = process.env
+
+if (SCOPE_MANAGER) {
+  const Scope = require(`../../../packages/dd-trace/src/scope/${SCOPE_MANAGER}`)
+  const scope = new Scope({
+    trackAsyncScope: true
+  })
+  if (scope.enable) {
+    scope.enable()
+  }
+}
+
+function promises (n, cb) {
+  let p = Promise.resolve()
+  for (let i = 1; i < n; i++) {
+    p = p.then(() => {})
+  }
+  p.then(cb)
+}
+
+function awaits (n, cb) {
+  (async () => {
+    for (let i = 0; i < n; i++) {
+      await 0
+    }
+  })().then(cb)
+}
+
+function immediates (n, cb) {
+  if (n === 0) {
+    cb()
+    return
+  }
+  setImmediate(immediates, n - 1, cb)
+}
+
+function timeouts (n, cb) {
+  if (n === 0) {
+    cb()
+    return
+  }
+  setTimeout(timeouts, 0, n - 1, cb)
+}
+
+promises(COUNT, () => {
+  awaits(COUNT, () => {
+    immediates(COUNT, () => {
+      timeouts(COUNT, () => {
+      })
+    })
+  })
+})

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -4,49 +4,25 @@
   "cachegrind": true,
   "iterations": 10,
   "variants": {
-    "base_1k": {
-      "env": {
-        "SCOPE_MANAGER": "base",
-        "COUNT": "1000"
-      }
-    },
-    "async_hooks_1k": {
-      "env": {
-        "SCOPE_MANAGER": "async_hooks",
-        "COUNT": "1000"
-      }
-    },
-    "async_local_storage_1k": {
-      "env": {
-        "SCOPE_MANAGER": "async_local_storage",
-        "COUNT": "1000"
-      }
-    },
-    "async_resource_1k": {
-      "env": {
-        "SCOPE_MANAGER": "async_resource",
-        "COUNT": "1000"
-      }
-    },
-    "base_10k": {
+    "base": {
       "env": {
         "SCOPE_MANAGER": "base",
         "COUNT": "10000"
       }
     },
-    "async_hooks_10k": {
+    "async_hooks": {
       "env": {
         "SCOPE_MANAGER": "async_hooks",
         "COUNT": "10000"
       }
     },
-    "async_local_storage_10k": {
+    "async_local_storage": {
       "env": {
         "SCOPE_MANAGER": "async_local_storage",
         "COUNT": "10000"
       }
     },
-    "async_resource_10k": {
+    "async_resource": {
       "env": {
         "SCOPE_MANAGER": "async_resource",
         "COUNT": "10000"

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -1,4 +1,5 @@
 {
+  "name": "scope-manager",
   "run": "node index.js",
   "cachegrind": true,
   "iterations": 10,

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -1,0 +1,55 @@
+{
+  "run": "node index.js",
+  "cachegrind": true,
+  "iterations": 10,
+  "variants": {
+    "base_1k": {
+      "env": {
+        "SCOPE_MANAGER": "base",
+        "COUNT": "1000"
+      }
+    },
+    "async_hooks_1k": {
+      "env": {
+        "SCOPE_MANAGER": "async_hooks",
+        "COUNT": "1000"
+      }
+    },
+    "async_local_storage_1k": {
+      "env": {
+        "SCOPE_MANAGER": "async_local_storage",
+        "COUNT": "1000"
+      }
+    },
+    "async_resource_1k": {
+      "env": {
+        "SCOPE_MANAGER": "async_resource",
+        "COUNT": "1000"
+      }
+    },
+    "base_10k": {
+      "env": {
+        "SCOPE_MANAGER": "base",
+        "COUNT": "10000"
+      }
+    },
+    "async_hooks_10k": {
+      "env": {
+        "SCOPE_MANAGER": "async_hooks",
+        "COUNT": "10000"
+      }
+    },
+    "async_local_storage_10k": {
+      "env": {
+        "SCOPE_MANAGER": "async_local_storage",
+        "COUNT": "10000"
+      }
+    },
+    "async_resource_10k": {
+      "env": {
+        "SCOPE_MANAGER": "async_resource",
+        "COUNT": "10000"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds a sirun test for specific scope managers.

### Motivation
The overhead of async_hooks depends on how its used, so it's useful to look at each of our supported scope managers.
