### PR TITLE
output every minute in sirun tests to avoid timeout

### DIFF
--- a/benchmark/sirun/run-all-variants.js
+++ b/benchmark/sirun/run-all-variants.js
@@ -19,10 +19,9 @@ const interval = setInterval(() => {
   // eslint-disable-next-line no-console
   console.error('This test is still running one minute later...')
 }, 60000)
-const clear = () => clearInterval(interval)
 
-if (metaJson.variants) {
-  (async () => {
+;(async () => {
+  if (metaJson.variants) {
     const variants = metaJson.variants
     const len = Object.keys(variants).length
     let count = 0
@@ -30,10 +29,11 @@ if (metaJson.variants) {
       const variantEnv = Object.assign({}, env, { SIRUN_VARIANT: variant })
       await exec('sirun', ['meta.json'], { env: variantEnv, stdio: 'inherit' })
       if (++count === len) {
-        clear()
+        clearInterval(interval)
       }
     }
-  })()
-} else {
-  childProcess.exec('sirun', ['meta.json'], { env, stdio: 'inherit' }).on('exit', clear)
-}
+  } else {
+    await exec('sirun', ['meta.json'], { env, stdio: 'inherit' })
+    clearInterval(interval)
+  }
+})()

--- a/benchmark/sirun/run-all-variants.js
+++ b/benchmark/sirun/run-all-variants.js
@@ -7,12 +7,18 @@ const metaJson = require(path.join(process.cwd(), 'meta.json'))
 
 const env = Object.assign({}, process.env, { SIRUN_NO_STDIO: '1' })
 
+const interval = setInterval(() => {
+  // esline-ignore-next-line no-console
+  console.error('This test is still running one minute later...')
+}, 60000)
+const clear = () => clearInterval(interval)
+
 if (metaJson.variants) {
   const variants = metaJson.variants
   for (const variant in variants) {
     const variantEnv = Object.assign({}, env, { SIRUN_VARIANT: variant })
-    childProcess.execSync(`sirun meta.json`, { env: variantEnv, stdio: 'inherit' })
+    childProcess.exec(`sirun meta.json`, { env: variantEnv, stdio: 'inherit' }, clear)
   }
 } else {
-  childProcess.exec(`sirun meta.json`, { env, stdio: 'inherit' })
+  childProcess.exec(`sirun meta.json`, { env, stdio: 'inherit' }, clear)
 }

--- a/benchmark/sirun/run-all-variants.js
+++ b/benchmark/sirun/run-all-variants.js
@@ -8,16 +8,22 @@ const metaJson = require(path.join(process.cwd(), 'meta.json'))
 const env = Object.assign({}, process.env, { SIRUN_NO_STDIO: '1' })
 
 const interval = setInterval(() => {
-  // esline-ignore-next-line no-console
+  // eslint-disable-next-line no-console
   console.error('This test is still running one minute later...')
 }, 60000)
 const clear = () => clearInterval(interval)
 
 if (metaJson.variants) {
   const variants = metaJson.variants
+  const len = Object.keys(variants).length
+  let count = 0
   for (const variant in variants) {
     const variantEnv = Object.assign({}, env, { SIRUN_VARIANT: variant })
-    childProcess.exec(`sirun meta.json`, { env: variantEnv, stdio: 'inherit' }, clear)
+    childProcess.exec(`sirun meta.json`, { env: variantEnv, stdio: 'inherit' }, () => {
+      if (++count === len) {
+        clear()
+      }
+    })
   }
 } else {
   childProcess.exec(`sirun meta.json`, { env, stdio: 'inherit' }, clear)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Once a minute in sirun tests, put some text on stderr to avoid timing out tests
in CircleCI.

### Motivation
<!-- What inspired you to submit this pull request? -->
Tests were timing out due to no output.
