### PR TITLE
support context propagation through aws-sqsd

### DIFF
--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -191,6 +191,19 @@ describe('TextMapPropagator', () => {
       expect(spanContext._traceFlags).to.have.property('sampled', false)
     })
 
+    it('should extract from an aws-sqsd header', () => {
+      const carrier = {
+        'x-aws-sqsd-attr-_datadog': JSON.stringify(textMap)
+      }
+
+      const spanContext = propagator.extract(carrier)
+
+      expect(spanContext).to.deep.equal(new SpanContext({
+        traceId: id('123', 10),
+        spanId: id('-456', 10)
+      }))
+    })
+
     describe('with B3 propagation as multiple headers', () => {
       beforeEach(() => {
         config.experimental.b3 = true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Supports context propagation throught
[aws-sqsd](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html).

### Motivation
<!-- What inspired you to submit this pull request? -->
It's a common way to process SQS messages, and we want propagation to work here.
