### PR TITLE
[ci-app] Add Errors to Jest and Mocha Instrumentation 

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -10,6 +10,9 @@ const {
   TEST_NAME,
   TEST_SUITE,
   TEST_STATUS,
+  ERROR_MESSAGE,
+  ERROR_STACK,
+  ERROR_TYPE,
   getTestEnvironmentMetadata
 } = require('../../dd-trace/src/plugins/util/test')
 
@@ -92,6 +95,9 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata) {
           tracer.scope().active().setTag(TEST_STATUS, 'pass')
         } catch (error) {
           tracer.scope().active().setTag(TEST_STATUS, 'fail')
+          tracer.scope().active().setTag(ERROR_TYPE, error.constructor ? error.constructor.name : error.name)
+          tracer.scope().active().setTag(ERROR_MESSAGE, error.message)
+          tracer.scope().active().setTag(ERROR_STACK, error.stack)
           throw error
         } finally {
           tracer

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -3,6 +3,16 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
 const { expect } = require('chai')
+const {
+  TEST_FRAMEWORK,
+  TEST_TYPE,
+  TEST_NAME: TEST_NAME_TAG,
+  TEST_SUITE: TEST_SUITE_TAG,
+  TEST_STATUS,
+  ERROR_TYPE,
+  ERROR_MESSAGE,
+  ERROR_STACK
+} = require('../../dd-trace/src/plugins/util/test')
 
 describe('Plugin', () => {
   let tracer
@@ -41,10 +51,11 @@ describe('Plugin', () => {
             expect(traces[0][0].meta).to.contain({
               language: 'javascript',
               service: 'test',
-              'test.name': TEST_NAME,
-              'test.status': 'pass',
-              'test.suite': TEST_SUITE,
-              'test.type': 'test'
+              [TEST_FRAMEWORK]: 'jest',
+              [TEST_NAME_TAG]: TEST_NAME,
+              [TEST_STATUS]: 'pass',
+              [TEST_SUITE_TAG]: TEST_SUITE,
+              [TEST_TYPE]: 'test'
             })
             expect(traces[0][0].type).to.equal('test')
             expect(traces[0][0].name).to.equal('jest.test')
@@ -73,11 +84,15 @@ describe('Plugin', () => {
             expect(traces[0][0].meta).to.contain({
               language: 'javascript',
               service: 'test',
-              'test.name': TEST_NAME,
-              'test.status': 'fail',
-              'test.suite': TEST_SUITE,
-              'test.type': 'test'
+              [TEST_FRAMEWORK]: 'jest',
+              [TEST_NAME_TAG]: TEST_NAME,
+              [TEST_STATUS]: 'fail',
+              [TEST_SUITE_TAG]: TEST_SUITE,
+              [TEST_TYPE]: 'test',
+              [ERROR_TYPE]: 'Error',
+              [ERROR_MESSAGE]: 'custom error message'
             })
+            expect(traces[0][0].meta[ERROR_STACK]).not.to.be.undefined
             expect(traces[0][0].type).to.equal('test')
             expect(traces[0][0].name).to.equal('jest.test')
             expect(traces[0][0].resource).to.equal(`${TEST_SUITE}.${TEST_NAME}`)
@@ -87,7 +102,7 @@ describe('Plugin', () => {
           name: 'test_start',
           test: {
             fn: () => {
-              throw Error
+              throw Error('custom error message')
             },
             name: TEST_NAME
           }
@@ -104,10 +119,11 @@ describe('Plugin', () => {
             expect(traces[0][0].meta).to.contain({
               language: 'javascript',
               service: 'test',
-              'test.name': TEST_NAME,
-              'test.status': 'skip',
-              'test.suite': TEST_SUITE,
-              'test.type': 'test'
+              [TEST_FRAMEWORK]: 'jest',
+              [TEST_NAME_TAG]: TEST_NAME,
+              [TEST_STATUS]: 'skip',
+              [TEST_SUITE_TAG]: TEST_SUITE,
+              [TEST_TYPE]: 'test'
             })
             expect(traces[0][0].type).to.equal('test')
             expect(traces[0][0].name).to.equal('jest.test')
@@ -133,10 +149,11 @@ describe('Plugin', () => {
             expect(traces[0][0].meta).to.contain({
               language: 'javascript',
               service: 'test',
-              'test.name': TEST_NAME,
-              'test.status': 'pass',
-              'test.suite': TEST_SUITE,
-              'test.type': 'test'
+              [TEST_FRAMEWORK]: 'jest',
+              [TEST_NAME_TAG]: TEST_NAME,
+              [TEST_STATUS]: 'pass',
+              [TEST_SUITE_TAG]: TEST_SUITE,
+              [TEST_TYPE]: 'test'
             })
             expect(traces[0][0].type).to.equal('test')
             expect(traces[0][0].name).to.equal('jest.test')
@@ -231,10 +248,11 @@ describe('Plugin', () => {
             expect(traces[0][0].meta).to.contain({
               language: 'javascript',
               service: 'test',
-              'test.name': TEST_NAME_FROM_EVENT,
-              'test.status': 'pass',
-              'test.suite': TEST_SUITE,
-              'test.type': 'test'
+              [TEST_FRAMEWORK]: 'jest',
+              [TEST_NAME_TAG]: TEST_NAME_FROM_EVENT,
+              [TEST_STATUS]: 'pass',
+              [TEST_SUITE_TAG]: TEST_SUITE,
+              [TEST_TYPE]: 'test'
             })
             expect(traces[0][0].type).to.equal('test')
             expect(traces[0][0].name).to.equal('jest.test')
@@ -269,10 +287,11 @@ describe('Plugin', () => {
             expect(traces[0][0].meta).to.contain({
               language: 'javascript',
               service: 'test',
-              'test.name': TEST_NAME,
-              'test.status': 'fail',
-              'test.suite': TEST_SUITE,
-              'test.type': 'test'
+              [TEST_FRAMEWORK]: 'jest',
+              [TEST_NAME_TAG]: TEST_NAME,
+              [TEST_STATUS]: 'fail',
+              [TEST_SUITE_TAG]: TEST_SUITE,
+              [TEST_TYPE]: 'test'
             })
             expect(traces[0][0].type).to.equal('test')
             expect(traces[0][0].name).to.equal('jest.test')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -9,6 +9,9 @@ const {
   TEST_NAME,
   TEST_SUITE,
   TEST_STATUS,
+  ERROR_MESSAGE,
+  ERROR_STACK,
+  ERROR_TYPE,
   getTestEnvironmentMetadata
 } = require('../../dd-trace/src/plugins/util/test')
 
@@ -71,6 +74,9 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
             }
           } catch (error) {
             activeSpan.setTag(TEST_STATUS, 'fail')
+            activeSpan.setTag(ERROR_TYPE, error.constructor ? error.constructor.name : error.name)
+            activeSpan.setTag(ERROR_MESSAGE, error.message)
+            activeSpan.setTag(ERROR_STACK, error.stack)
             throw error
           } finally {
             activeSpan

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -84,7 +84,7 @@ const TESTS = [
   }
 ]
 
-describe('mocha', () => {
+describe('Plugin', () => {
   let Mocha
   withVersions(plugin, 'mocha', version => {
     afterEach(() => {

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -7,7 +7,10 @@ const {
   TEST_TYPE,
   TEST_NAME,
   TEST_SUITE,
-  TEST_STATUS
+  TEST_STATUS,
+  ERROR_TYPE,
+  ERROR_MESSAGE,
+  ERROR_STACK
 } = require('../../dd-trace/src/plugins/util/test')
 const { expect } = require('chai')
 const path = require('path')
@@ -81,7 +84,7 @@ const TESTS = [
   }
 ]
 
-describe('Plugin', () => {
+describe('mocha', () => {
   let Mocha
   withVersions(plugin, 'mocha', version => {
     afterEach(() => {
@@ -117,6 +120,13 @@ describe('Plugin', () => {
                 [TEST_FRAMEWORK]: 'mocha',
                 [TEST_SUITE]: testSuite
               })
+              if (test.fileName === 'mocha-test-fail.js') {
+                expect(traces[0][0].meta).to.contain({
+                  [ERROR_TYPE]: 'AssertionError',
+                  [ERROR_MESSAGE]: 'expected true to equal false'
+                })
+                expect(traces[0][0].meta[ERROR_STACK]).not.to.be.undefined
+              }
               expect(traces[0][0].meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
               expect(traces[0][0].type).to.equal('test')
               expect(traces[0][0].name).to.equal('mocha.test')

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -8,12 +8,19 @@ const TEST_NAME = 'test.name'
 const TEST_SUITE = 'test.suite'
 const TEST_STATUS = 'test.status'
 
+const ERROR_TYPE = 'error.type'
+const ERROR_MESSAGE = 'error.message'
+const ERROR_STACK = 'error.stack'
+
 module.exports = {
   TEST_FRAMEWORK,
   TEST_TYPE,
   TEST_NAME,
   TEST_SUITE,
   TEST_STATUS,
+  ERROR_TYPE,
+  ERROR_MESSAGE,
+  ERROR_STACK,
   getTestEnvironmentMetadata
 }
 


### PR DESCRIPTION
### What does this PR do?
* Add errors to jest and mocha instrumentation.

### Motivation
Be able to debug your failed tests. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
