### PR TITLE
fix sampling priority using the wrong service name

### DIFF
--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -45,8 +45,10 @@ class PrioritySampler {
     if (!span) return
 
     const context = this._getContext(span)
+    const root = context._trace.started[0]
 
     if (context._sampling.priority !== undefined) return
+    if (!root) return // noop span
 
     const tag = this._getPriority(context._tags)
 
@@ -56,7 +58,7 @@ class PrioritySampler {
     }
 
     if (auto) {
-      context._sampling.priority = this.isSampled(span) ? AUTO_KEEP : AUTO_REJECT
+      context._sampling.priority = this.isSampled(root) ? AUTO_KEEP : AUTO_REJECT
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix sampling priority using the wrong service name.

### Motivation
<!-- What inspired you to submit this pull request? -->

Sampling priority should always be decided based on the service name and environment of the local root span and not the active span when the decision is taken.