### PR TITLE
update prepublish script to only block for prebuilds

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -73,16 +73,14 @@ function getWorkflow (pipeline) {
     .then(response => {
       const workflows = response.data.items
         .sort((a, b) => (a.stopped_at < b.stopped_at) ? 1 : -1)
-      const running = workflows.find(workflow => !workflow.stopped_at)
-
-      if (running) {
-        throw new Error(`Workflow ${running.id} is still running for pipeline ${pipeline.id}.`)
-      }
-
       const workflow = workflows.find(workflow => workflow.name === 'prebuild')
 
       if (!workflow) {
         throw new Error(`Unable to find CircleCI workflow for pipeline ${pipeline.id}.`)
+      }
+
+      if (!workflow.stopped_at) {
+        throw new Error(`Workflow ${workflow.id} is still running for pipeline ${pipeline.id}.`)
       }
 
       if (workflow.status !== 'success') {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update prepublish script to only block for prebuilds.

### Motivation
<!-- What inspired you to submit this pull request? -->

Only the `prebuild` job is required to pass in order to release since otherwise the artifacts are not available for prebuilds. There is currently a bug in the script that waits for the entire pipeline even if the results are not checked.