### PR TITLE
remove dependency on read-pkg-up

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -19,7 +19,6 @@ require,parent-module,MIT,Copyright Sindre Sorhus
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
 require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,protobufjs,BSD-3-Clause,Copyright 2016 Daniel Wirtz
-require,read-pkg-up,MIT,Copyright Sindre Sorhus
 require,require-in-the-middle,MIT,Copyright 2016-2018 Thomas Watson Steen
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,source-map,BSD-3-Clause,Copyright 2009-2011 Mozilla Foundation and contributors

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "protobufjs": "^6.9.0",
-    "read-pkg-up": "^3.0.0",
     "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
     "shimmer": "1.2.1",

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -14,17 +14,10 @@ function findPkg () {
   const filePath = findUp('package.json', cwd)
 
   try {
-    return readPkg(path.dirname(filePath))
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
   } catch (e) {
     return {}
   }
-}
-
-function readPkg (cwd) {
-  const filePath = path.resolve(cwd, 'package.json')
-  const json = JSON.parse(fs.readFileSync(filePath, 'utf8'))
-
-  return json
 }
 
 function findUp (name, cwd) {

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -1,17 +1,44 @@
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
-const readPkgUp = require('read-pkg-up')
 
 function findRoot () {
-  return require.main && require.main.filename ? path.dirname(require.main.filename) : process.cwd()
+  return require.main && require.main.filename
+    ? path.dirname(require.main.filename)
+    : process.cwd()
 }
 
 function findPkg () {
   const cwd = findRoot()
-  const up = readPkgUp.sync({ cwd })
+  const filePath = findUp('package.json', cwd)
 
-  return up && up.pkg ? up.pkg : {}
+  try {
+    return readPkg(path.dirname(filePath))
+  } catch (e) {
+    return {}
+  }
+}
+
+function readPkg (cwd) {
+  const filePath = path.resolve(cwd, 'package.json')
+  const json = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+
+  return json
+}
+
+function findUp (name, cwd) {
+  let directory = path.resolve(cwd)
+  const { root } = path.parse(directory)
+
+  while (true) {
+    const current = path.resolve(directory, name)
+
+    if (fs.existsSync(current)) return current
+    if (directory === root) return
+
+    directory = path.dirname(directory)
+  }
 }
 
 module.exports = findPkg()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove dependency on `read-pkg-up`.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `read-pkg-up` module has frequent breaking changes and recently dropped support for Node 8 which we still support for now.

Fixes #1294 #1319