### PR TITLE
[ci-app] Add Retry Mechanism to Requests

### DIFF
--- a/packages/dd-trace/src/exporters/agent/request.js
+++ b/packages/dd-trace/src/exporters/agent/request.js
@@ -67,6 +67,8 @@ function request (options, callback) {
 
   firstRequest.on('error', firstRequestErrorHandler)
   firstRequest.end()
+
+  return firstRequest
 }
 
 function byteLength (data) {

--- a/packages/dd-trace/src/exporters/agent/request.js
+++ b/packages/dd-trace/src/exporters/agent/request.js
@@ -61,7 +61,7 @@ function request (options, callback) {
       retriedReq.on('error', e => callback(new Error(`Network error trying to reach the agent: ${e.message}`)))
       retriedReq.end()
     } else {
-      callback(error)
+      callback(new Error(`Network error trying to reach the agent: ${error.message}`))
     }
   }
 

--- a/packages/dd-trace/src/exporters/agent/request.js
+++ b/packages/dd-trace/src/exporters/agent/request.js
@@ -55,7 +55,7 @@ function request (options, callback) {
   // The first request will be retried if it fails due to a socket connection close
   const firstRequestErrorHandler = error => {
     if (firstRequest.reusedSocket && (error.code === 'ECONNRESET' || error.code === 'EPIPE')) {
-      log.warn('Retrying request due to socket connection error')
+      log.debug('Retrying request due to socket connection error')
       const retriedReq = retriableRequest(options, callback, client, data)
       // The retried request will fail normally
       retriedReq.on('error', e => callback(new Error(`Network error trying to reach the agent: ${e.message}`)))

--- a/packages/dd-trace/src/exporters/agent/request.js
+++ b/packages/dd-trace/src/exporters/agent/request.js
@@ -46,11 +46,12 @@ function request (options, callback) {
   })
 
   req.setTimeout(options.timeout, req.abort)
-  req.on('error', e => callback(new Error(`Network error trying to reach the agent: ${e.message}`)))
+  req.on('error', callback)
 
   data.forEach(buffer => req.write(buffer))
 
   req.end()
+  return req
 }
 
 function byteLength (data) {

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -124,7 +124,11 @@ function makeRequest (version, data, count, url, lookup, needsStartupLog, cb) {
 
   log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)
 
-  request(Object.assign({ data }, options), (err, res, status) => {
+  const req = request(Object.assign({ data }, options), (err, res, status) => {
+    if (err && err.code === 'ECONNRESET' && req.reusedSocket) {
+      log.error('Retrying request to the agent')
+      return makeRequest(version, data, count, url, lookup, needsStartupLog, cb)
+    }
     if (needsStartupLog) {
       // Note that logging will only happen once, regardless of how many times this is called.
       startupLog({

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -124,11 +124,7 @@ function makeRequest (version, data, count, url, lookup, needsStartupLog, cb) {
 
   log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)
 
-  const req = request(Object.assign({ data }, options), (err, res, status) => {
-    if (err && err.code === 'ECONNRESET' && req.reusedSocket) {
-      log.error('Retrying request to the agent')
-      return makeRequest(version, data, count, url, lookup, needsStartupLog, cb)
-    }
+  request(Object.assign({ data }, options), (err, res, status) => {
     if (needsStartupLog) {
       // Note that logging will only happen once, regardless of how many times this is called.
       startupLog({


### PR DESCRIPTION
### What does this PR do?
* Add a single retry if the request to the agent fails due to a socket connection close.

### Motivation
From https://nodejs.org/api/http.html#http_request_reusedsocket:

> When sending request through a keep-alive enabled agent, the underlying socket might be reused. But if server closes connection at unfortunate time, client may run into a 'ECONNRESET' error.
