### PR TITLE
Fix header parsing for kafkajs consumer distributed tracing

### DIFF
--- a/packages/datadog-plugin-kafkajs/src/index.js
+++ b/packages/datadog-plugin-kafkajs/src/index.js
@@ -87,7 +87,11 @@ function extract (tracer, bufferMap) {
   const textMap = {}
 
   for (const key of Object.keys(bufferMap)) {
-    textMap[key] = bufferMap[key].toString()
+    // Even though the values in `bufferMap` appear to be Buffers, it seems
+    // necessary to parse them as a Buffer again in order to obtain the correct
+    // values - this would have no impact if they were in fact actual Buffers
+    // to begin with, so is safe to do either way
+    textMap[key] = Buffer.from(bufferMap[key]).toString("utf-8")
   }
 
   return tracer.extract('text_map', textMap)

--- a/packages/datadog-plugin-kafkajs/src/index.js
+++ b/packages/datadog-plugin-kafkajs/src/index.js
@@ -91,7 +91,7 @@ function extract (tracer, bufferMap) {
     // necessary to parse them as a Buffer again in order to obtain the correct
     // values - this would have no impact if they were in fact actual Buffers
     // to begin with, so is safe to do either way
-    textMap[key] = Buffer.from(bufferMap[key]).toString("utf-8")
+    textMap[key] = Buffer.from(bufferMap[key]).toString('utf-8')
   }
 
   return tracer.extract('text_map', textMap)


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where headers were not extracted correctly from each kafka message. Instead of extracting a trace ID that should look like `3723113666305865006`, a 2-digit number was being extracted instead, which led me to realise that it was only extracting the first octet of what looks like a Buffer, but must actually be coming through as an array of some sort. Since these headers are used to create the `childOf` property of the `kafka.consume` trace, the traces were being unintentionally stitched together with other traces.

By parsing the header value as a Buffer using `Buffer.from(...)` we can ensure that it is, in fact, a Buffer, and then running a `toString()` on it like before gives us the expected result. If for some reason the headers change in the future to be actual Buffers (not just arrays that look like Buffers) compatibility is preserved since creating a Buffer from a Buffer is effectively a no-op.

### Motivation

My team uses a forked version of the kafkajs plugin for processing messages in batches (not using the `eachMessage` function) and we have patched it internally - now contributing this upstream.

### Plugin Checklist

NOTE: I was unable to run tests locally due to an issue building the `grpc` dependency - happy to write a test for this if I can get a hand setting it up. Thinking an assertion on the `childOf` field would be easy enough to do?

- [ ] Unit tests.
- [x] ~TypeScript [definitions][1].~
- [x] ~TypeScript [tests][2].~
- [x] ~API [documentation][3].~
- [x] ~CircleCI [jobs/workflows][4].~
- [x] ~Plugin is [exported][5].~

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
