### PR TITLE
fix typo in aws-sdk plugin unpatch

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -118,7 +118,7 @@ module.exports = [
       this.wrap(AWS.Request.prototype, 'send', createWrapRequest(tracer, config))
     },
     unpatch (AWS) {
-      this.wrap(AWS.Request.prototype, 'send')
+      this.unwrap(AWS.Request.prototype, 'send')
     }
   }
 ]


### PR DESCRIPTION
### What does this PR do?
Fix a typo

I also checked all other `unpatch` calls, and I found no others.