### PR TITLE
fix encoding error when enabling debug logs

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -26,12 +26,19 @@ class AgentEncoder {
 
   encode (trace) {
     const bytes = this._traceBytes
+    const start = bytes.length
 
     this._traceCount++
 
     this._encode(bytes, trace)
 
-    log.debug(() => `Adding encoded trace to buffer: ${bytes.map(b => b.toString(16)).join(' ')}`)
+    const end = bytes.length
+
+    log.debug(() => {
+      const hex = bytes.buffer.subarray(start, end).toString('hex').match(/../g).join(' ')
+
+      return `Adding encoded trace to buffer: ${hex}`
+    })
 
     // we can go over the soft limit since the agent has a 50MB hard limit
     if (this._traceBytes.length > SOFT_LIMIT || this._stringBytes.length > SOFT_LIMIT) {
@@ -94,8 +101,6 @@ class AgentEncoder {
     this._stringCount = 0
     this._stringBytes.length = 0
     this._stringMap = {}
-    this._stringStarts = {}
-    this._stringEnds = {}
 
     this._cacheString('')
   }

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -8,10 +8,16 @@ const id = require('../../src/id')
 describe('encode', () => {
   let encoder
   let writer
+  let logger
   let data
 
   beforeEach(() => {
-    const { AgentEncoder } = require('../../src/encode/0.4')
+    logger = {
+      debug: sinon.stub()
+    }
+    const { AgentEncoder } = proxyquire('../src/encode/0.4', {
+      '../log': logger
+    })
     writer = { flush: sinon.spy() }
     encoder = new AgentEncoder(writer)
     data = [{
@@ -102,5 +108,13 @@ describe('encode', () => {
     expect(payload[2]).to.equal(0)
     expect(payload[3]).to.equal(0)
     expect(payload[4]).to.equal(0)
+  })
+
+  it('should log adding an encoded trace to the buffer', () => {
+    encoder.encode(data)
+
+    const message = logger.debug.firstCall.args[0]()
+
+    expect(message).to.match(/^Adding encoded trace to buffer:(\s[a-f\d]{2})+$/)
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix encoding error when enabling debug logs.

### Motivation
<!-- What inspired you to submit this pull request? -->

The debug logs of the 0.5 encoder were using a method that didn't exist on the msgpack chunk. This went unnoticed since we default to 0.4, but now that the code is shared between both the issue also started happening with 0.4. This regression was introduced in #1334.

Fixes #1349