### PR TITLE
update codecov dependency to a fixed version with node 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "chai": "^4.2.0",
     "checksum": "^0.1.1",
     "codecov": "3.8.1",
-    "dotenv": "^8.2.0",
+    "dotenv": "8.2.0",
     "eslint": "^4.15.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-import": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "body-parser": "^1.18.2",
     "chai": "^4.2.0",
     "checksum": "^0.1.1",
-    "codecov": "^3.8.1",
+    "codecov": "3.8.1",
     "dotenv": "^8.2.0",
     "eslint": "^4.15.0",
     "eslint-config-standard": "^11.0.0-beta.0",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update `codecov` dependency to a fixed version with Node 8 support.

### Motivation
<!-- What inspired you to submit this pull request? -->

Node 8 support was dropped in 3.8.2.