### PR TITLE
remove dependency on url-parse

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -23,7 +23,6 @@ require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,source-map,BSD-3-Clause,Copyright 2009-2011 Mozilla Foundation and contributors
 require,source-map-resolve,MIT,Copyright 2014-2020 Simon Lydell 2019 Jinxiang
 require,tar,ISC,Copyright Isaac Z. Schlueter and Contributors
-require,url-parse,MIT,Copyright 2015 Unshift.io Arnout Kazemier the Contributors
 dev,autocannon,MIT,Copyright 2016 Matteo Collina
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie
 dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David Dalton

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "semver": "^5.5.0",
     "shimmer": "1.2.1",
     "source-map": "^0.7.3",
-    "source-map-resolve": "^0.6.0",
-    "url-parse": "^1.4.3"
+    "source-map-resolve": "^0.6.0"
   },
   "devDependencies": {
     "autocannon": "^4.5.2",

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const URL = require('url-parse')
+const URL = require('url').URL
 const pkg = require('./pkg')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const URL = require('url-parse')
+const URL = require('url').URL
 const log = require('../../log')
 const Writer = require('./writer')
 const Scheduler = require('./scheduler')

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -1,4 +1,4 @@
-const Url = require('url-parse')
+const URL = require('url').URL
 
 const { GIT_BRANCH, GIT_COMMIT_SHA, GIT_TAG } = require('./git')
 
@@ -42,7 +42,7 @@ function filterSensitiveInfoFromRepository (repositoryUrl) {
   if (repositoryUrl.startsWith('git@')) {
     return repositoryUrl
   }
-  const { protocol, hostname, pathname } = new Url(repositoryUrl)
+  const { protocol, hostname, pathname } = new URL(repositoryUrl)
   if (!protocol || !hostname) {
     return repositoryUrl
   }

--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -42,11 +42,14 @@ function filterSensitiveInfoFromRepository (repositoryUrl) {
   if (repositoryUrl.startsWith('git@')) {
     return repositoryUrl
   }
-  const { protocol, hostname, pathname } = new URL(repositoryUrl)
-  if (!protocol || !hostname) {
+
+  try {
+    const { protocol, hostname, pathname } = new URL(repositoryUrl)
+
+    return `${protocol}//${hostname}${pathname}`
+  } catch (e) {
     return repositoryUrl
   }
-  return `${protocol}//${hostname}${pathname}`
 }
 
 function resolveTilde (filePath) {

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const URL = require('url-parse')
+const URL = require('url').URL
 
 describe('Exporter', () => {
   let url

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const URL = require('url-parse')
+const URL = require('url').URL
 
 function describeWriter (protocolVersion) {
   let Writer


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove dependency on `url-parse`.

### Motivation
<!-- What inspired you to submit this pull request? -->

This library is only useful in older versions of Node which we no longer support, and for the browser which we now support with RUM instead.

Fixes #1355 