### PR TITLE
update native addon build to run in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@1.0.0
+  win: circleci/windows@2.2.0
 
 node-core-base: &node-core-base
   resource_class: small
@@ -221,7 +221,9 @@ prebuild-darwin-base: &prebuild-darwin-base
     - *persist-prebuilds
 
 prebuild-win32-base: &prebuild-win32-base
-  executor: win/vs2019
+  executor:
+    name: win/default
+    size: medium
   working_directory: ~/dd-trace-js
   steps:
     - checkout
@@ -423,7 +425,9 @@ jobs:
   # Windows tests
 
   node-core-windows:
-    executor: win/vs2019
+    executor:
+      name: win/default
+      size: medium
     working_directory: ~/dd-trace-js
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "install": "(node scripts/should_rebuild && node-gyp-build) || exit 0",
-    "rebuild": "node-gyp rebuild",
+    "rebuild": "node-gyp rebuild --jobs=max",
     "prebuild": "node scripts/prebuild.js",
     "prebuilds": "node scripts/prebuilds.js",
     "protobuf": "pbjs -t static-module -w commonjs -o protobuf/profile.js protobuf/profile.proto && pbts -o protobuf/profile.d.ts protobuf/profile.js",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -42,6 +42,7 @@ function prebuildify () {
       `--target_arch=${arch}`,
       `--devdir=${cache}`,
       '--release',
+      '--jobs=max',
       '--build_v8_with_gn=false',
       '--v8_enable_pointer_compression=""',
       '--v8_enable_31bit_smis_on_64bit_arch=""',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update native addon build to run in parallel.

### Motivation
<!-- What inspired you to submit this pull request? -->

By default it runs sequentially. For Windows and Mac machines all cores will now be used when building native addons.