### PR TITLE
remove dependency on require-in-the-middle

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -18,7 +18,6 @@ require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
 require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,protobufjs,BSD-3-Clause,Copyright 2016 Daniel Wirtz
-require,require-in-the-middle,MIT,Copyright 2016-2018 Thomas Watson Steen
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,source-map,BSD-3-Clause,Copyright 2009-2011 Mozilla Foundation and contributors
 require,source-map-resolve,MIT,Copyright 2014-2020 Simon Lydell 2019 Jinxiang

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "protobufjs": "^6.9.0",
-    "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
     "shimmer": "1.2.1",
     "source-map": "^0.7.3",

--- a/packages/dd-trace/src/loader.js
+++ b/packages/dd-trace/src/loader.js
@@ -26,7 +26,7 @@ class Loader {
     this._names = new Set(instrumentations
       .map(instrumentation => filename(instrumentation)))
 
-    hook(instrumentedModules, { internals: true }, this._hookModule.bind(this))
+    hook(instrumentedModules, this._hookModule.bind(this))
   }
 
   load (instrumentation, config) {

--- a/packages/dd-trace/src/loader.js
+++ b/packages/dd-trace/src/loader.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const semver = require('semver')
-const hook = require('require-in-the-middle')
+const hook = require('./ritm')
 const parse = require('module-details-from-path')
 const path = require('path')
 const uniq = require('lodash.uniq')

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const path = require('path')
+const Module = require('module')
+const parse = require('module-details-from-path')
+const log = require('./log')
+
+const orig = Module.prototype.require
+
+module.exports = function hook (modules, options, onrequire) {
+  if (typeof modules === 'function') return hook(null, {}, modules)
+  if (typeof options === 'function') return hook(modules, {}, options)
+
+  if (typeof Module._resolveFilename !== 'function') {
+    log.error('Expected Module._resolveFilename to be a function - aborting.')
+    return
+  }
+
+  options = options || {}
+
+  hook.cache = {}
+
+  const patching = {}
+
+  Module.prototype.require = function (request) {
+    const filename = Module._resolveFilename(request, this)
+    const core = filename.indexOf(path.sep) === -1
+    let name, basedir
+
+    // return known patched modules immediately
+    if (hook.cache.hasOwnProperty(filename)) {
+      return hook.cache[filename]
+    }
+
+    // Check if this module has a patcher in-progress already.
+    // Otherwise, mark this module as patching in-progress.
+    const patched = patching[filename]
+    if (!patched) {
+      patching[filename] = true
+    }
+
+    const exports = orig.apply(this, arguments)
+
+    // If it's already patched, just return it as-is.
+    if (patched) return exports
+
+    // The module has already been loaded,
+    // so the patching mark can be cleaned up.
+    delete patching[filename]
+
+    if (core) {
+      if (modules && modules.indexOf(filename) === -1) return exports // abort if module name isn't on whitelist
+      name = filename
+    } else {
+      const stat = parse(filename)
+      if (!stat) return exports // abort if filename could not be parsed
+      name = stat.name
+      basedir = stat.basedir
+
+      if (modules && modules.indexOf(name) === -1) return exports // abort if module name isn't on whitelist
+
+      // figure out if this is the main module file, or a file inside the module
+      let res
+      try {
+        res = Module._findPath(name, [basedir, ...Module._resolveLookupPaths(name, this, true)])
+      } catch (e) {
+        return exports // abort if module could not be resolved (e.g. no main in package.json and no index.js file)
+      }
+      if (res !== filename) {
+        // this is a module-internal file
+        if (options.internals) {
+          // use the module-relative path to the file, prefixed by original module name
+          name = name + path.sep + path.relative(basedir, filename)
+        } else return exports // abort if not main module file
+      }
+    }
+
+    // only call onrequire the first time a module is loaded
+    if (!hook.cache.hasOwnProperty(filename)) {
+      // ensure that the cache entry is assigned a value before calling
+      // onrequire, in case calling onrequire requires the same module.
+      hook.cache[filename] = exports
+      hook.cache[filename] = onrequire(exports, name, basedir)
+    }
+
+    return hook.cache[filename]
+  }
+}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove dependency on `require-in-the-middle`.

### Motivation
<!-- What inspired you to submit this pull request? -->

The library has dependencies that have security vulnerabilities, and these dependencies are not useful for our purpose. Using RITM 2.x also means that we break any existing hooks in the application code since that version doesn't support multiple hooks. Unfortunately, we also can't upgrade for now since newer versions break our tests which would require further investigation. For now I just copied the library as-is and refactored it to remove the dependency on `resolve` and use our logger. Later on when the instrumenter is rewritten this will be rewritten as well anyway.

Fixes #1214 #1356