### PR TITLE
[ci-app] Improve git Metadata

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -139,6 +139,7 @@ function extractAnalytics (trace, span) {
 function addTag (meta, metrics, key, value, seen) {
   switch (typeof value) {
     case 'string':
+      if (!value) break
       meta[key] = value
       break
     case 'number':

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -29,18 +29,6 @@ function parseUser (user) {
   return { name: user.replace(`<${email}>`, '').trim(), email }
 }
 
-function removeEmptyValues (tags) {
-  return Object.keys(tags).reduce((filteredTags, tag) => {
-    if (!tags[tag]) {
-      return filteredTags
-    }
-    return {
-      ...filteredTags,
-      [tag]: tags[tag]
-    }
-  }, {})
-}
-
 // If there is ciMetadata, it takes precedence.
 function getGitMetadata (ciMetadata) {
   const { commitSHA, branch, repositoryUrl, tag } = ciMetadata
@@ -87,7 +75,7 @@ function getGitMetadata (ciMetadata) {
     }
   }
 
-  const spanTags = {
+  return {
     // With stdio: 'pipe', errors in this command will not be output to the parent process,
     // so if `git` is not present in the env, we won't show a warning to the user.
     [GIT_REPOSITORY_URL]: repositoryUrl || sanitizedExec('git ls-remote --get-url', { stdio: 'pipe' }),
@@ -102,8 +90,6 @@ function getGitMetadata (ciMetadata) {
     [GIT_COMMIT_SHA]: coalesce(commitSHA, gitCommitSHA),
     [GIT_TAG]: coalesce(tag, gitTag)
   }
-
-  return removeEmptyValues(spanTags)
 }
 
 module.exports = {

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -33,34 +33,58 @@ function parseUser (user) {
 function getGitMetadata (ciMetadata) {
   const { commitSHA, branch, repositoryUrl, tag } = ciMetadata
 
-  const {
-    author,
-    committer,
-    authorDate,
-    committerDate,
-    commitMessage,
-    branch: gitBranch,
-    tag: gitTag,
-    sha: gitCommitSHA
-  } = getRepoInfo(process.cwd())
+  const repoInfo = getRepoInfo(process.cwd())
 
-  const { name: authorName, email: authorEmail } = parseUser(author)
-  const { name: committerName, email: committerEmail } = parseUser(committer)
+  let authorName
+  let authorEmail
+  let authorDate
+  let committerName
+  let committerEmail
+  let committerDate
+
+  const commitMessage = repoInfo.commitMessage
+  const gitBranch = repoInfo.branch
+  const gitTag = repoInfo.tag
+  const gitCommitSHA = repoInfo.sha
+
+  if (repoInfo.author && repoInfo.authorDate) {
+    const parsedUser = parseUser(repoInfo.author)
+    authorName = parsedUser.name
+    authorEmail = parsedUser.email
+    authorDate = repoInfo.authorDate
+  } else {
+    const author = sanitizedExec('git show -s --format=%an,%ae,%ad', { stdio: 'pipe' }).split(',')
+    authorName = author[0]
+    authorEmail = author[1]
+    authorDate = author[2]
+  }
+
+  if (repoInfo.committer && repoInfo.committerDate) {
+    const parsedUser = parseUser(repoInfo.committer)
+    committerName = parsedUser.name
+    committerEmail = parsedUser.email
+    committerDate = repoInfo.committerDate
+  } else {
+    const committer = sanitizedExec('git show -s --format=%cn,%ce,%cd', { stdio: 'pipe' }).split(',')
+    committerName = committer[0]
+    committerEmail = committer[1]
+    committerDate = committer[2]
+  }
 
   return {
     // With stdio: 'pipe', errors in this command will not be output to the parent process,
     // so if `git` is not present in the env, we won't show a warning to the user.
     [GIT_REPOSITORY_URL]: repositoryUrl || sanitizedExec('git ls-remote --get-url', { stdio: 'pipe' }),
-    [GIT_BRANCH]: coalesce(branch, gitBranch),
-    [GIT_COMMIT_SHA]: coalesce(commitSHA, gitCommitSHA),
-    [GIT_TAG]: coalesce(tag, gitTag),
-    [GIT_COMMIT_MESSAGE]: commitMessage,
+    [GIT_COMMIT_MESSAGE]: commitMessage || sanitizedExec('git show -s --format=%s', { stdio: 'pipe' }),
     [GIT_COMMIT_AUTHOR_DATE]: authorDate,
     [GIT_COMMIT_AUTHOR_NAME]: authorName,
     [GIT_COMMIT_AUTHOR_EMAIL]: authorEmail,
     [GIT_COMMIT_COMMITTER_DATE]: committerDate,
     [GIT_COMMIT_COMMITTER_NAME]: committerName,
-    [GIT_COMMIT_COMMITTER_EMAIL]: committerEmail
+    [GIT_COMMIT_COMMITTER_EMAIL]: committerEmail,
+    [GIT_BRANCH]: coalesce(branch, gitBranch),
+    [GIT_COMMIT_SHA]: coalesce(commitSHA, gitCommitSHA),
+    [GIT_TAG]: coalesce(tag, gitTag)
   }
 }
 

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -78,7 +78,7 @@ describe('git', () => {
     )
     expect(sanitizedExecStub).not.to.have.been.called
   })
-  it('does not crash badly shapen author', () => {
+  it('does not crash with badly shapen author', () => {
     gitRepoInfoStub.returns({
       author: 'author <>',
       committer: 'committer <committer@email.com>',
@@ -99,6 +99,7 @@ describe('git', () => {
         [GIT_COMMIT_COMMITTER_DATE]: '1971',
         [GIT_COMMIT_COMMITTER_EMAIL]: 'committer@email.com',
         [GIT_COMMIT_COMMITTER_NAME]: 'committer',
+        [GIT_COMMIT_AUTHOR_EMAIL]: '',
         [GIT_COMMIT_AUTHOR_DATE]: '1970',
         [GIT_COMMIT_AUTHOR_NAME]: 'author',
         [GIT_TAG]: 'gitTag',
@@ -199,6 +200,9 @@ describe('git', () => {
         [GIT_COMMIT_COMMITTER_DATE]: '1971',
         [GIT_COMMIT_COMMITTER_EMAIL]: 'committer@email.com',
         [GIT_COMMIT_COMMITTER_NAME]: 'committer',
+        [GIT_COMMIT_AUTHOR_DATE]: undefined,
+        [GIT_COMMIT_AUTHOR_EMAIL]: undefined,
+        [GIT_COMMIT_AUTHOR_NAME]: undefined,
         [GIT_TAG]: 'gitTag',
         [GIT_BRANCH]: 'gitBranch',
         [GIT_COMMIT_SHA]: 'gitSha',

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -100,7 +100,6 @@ describe('git', () => {
         [GIT_COMMIT_COMMITTER_EMAIL]: 'committer@email.com',
         [GIT_COMMIT_COMMITTER_NAME]: 'committer',
         [GIT_COMMIT_AUTHOR_DATE]: '1970',
-        [GIT_COMMIT_AUTHOR_EMAIL]: '',
         [GIT_COMMIT_AUTHOR_NAME]: 'author',
         [GIT_TAG]: 'gitTag',
         [GIT_BRANCH]: 'gitBranch',
@@ -170,6 +169,36 @@ describe('git', () => {
         [GIT_COMMIT_AUTHOR_DATE]: '1973',
         [GIT_COMMIT_AUTHOR_EMAIL]: 'git.author@email.com',
         [GIT_COMMIT_AUTHOR_NAME]: 'git author',
+        [GIT_TAG]: 'gitTag',
+        [GIT_BRANCH]: 'gitBranch',
+        [GIT_COMMIT_SHA]: 'gitSha',
+        [GIT_REPOSITORY_URL]: 'ciRepositoryUrl'
+      }
+    )
+  })
+
+  it('does not crash when git command is not available', () => {
+    gitRepoInfoStub.returns({
+      author: undefined,
+      committer: 'committer <committer@email.com>',
+      authorDate: '1970',
+      committerDate: '1971',
+      commitMessage: 'commit message',
+      branch: 'gitBranch',
+      tag: 'gitTag',
+      sha: 'gitSha'
+    })
+    sanitizedExecStub.returns('')
+    const ciMetadata = { repositoryUrl: 'ciRepositoryUrl' }
+    const metadata = getGitMetadata(ciMetadata)
+    expect(sanitizedExecStub).to.have.been.calledWith('git show -s --format=%an,%ae,%ad', { stdio: 'pipe' })
+
+    expect(metadata).to.eql(
+      {
+        [GIT_COMMIT_MESSAGE]: 'commit message',
+        [GIT_COMMIT_COMMITTER_DATE]: '1971',
+        [GIT_COMMIT_COMMITTER_EMAIL]: 'committer@email.com',
+        [GIT_COMMIT_COMMITTER_NAME]: 'committer',
         [GIT_TAG]: 'gitTag',
         [GIT_BRANCH]: 'gitBranch',
         [GIT_COMMIT_SHA]: 'gitSha',


### PR DESCRIPTION
### What does this PR do?

We attempt to read directly from the `.git` folder, but that sometimes fails: `git-repo-info` (the library we use to read) does not account for all the possible ways the commit info is encoded. 

What this PR does is to add a fallback to the `git` command if we can't successfully read from `.git` ourselves. 

### Motivation
Increase the odds of having `git` metadata.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
