### PR TITLE
add support for next

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -763,6 +763,13 @@ jobs:
         environment:
           - PLUGINS=net
 
+  node-next:
+    <<: *node-plugin-base
+    docker:
+      - image: node:12
+        environment:
+          - PLUGINS=next
+
   node-paperplane:
     <<: *node-plugin-base
     docker:
@@ -1205,6 +1212,7 @@ workflows:
       - node-mongoose
       - node-mysql
       - node-net
+      - node-next
       - node-paperplane
       - node-pino
       - node-postgres
@@ -1262,6 +1270,7 @@ workflows:
             - node-mongoose
             - node-mysql
             - node-net
+            - node-next
             - node-paperplane
             - node-pino
             - node-postgres
@@ -1464,6 +1473,7 @@ workflows:
       - node-mongoose
       - node-mysql
       - node-net
+      - node-next
       - node-paperplane
       - node-pino
       - node-postgres

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ typings/
 
 # End of https://www.gitignore.io/api/node,macos,visualstudiocode
 
+.next
 package-lock.json
 yarn.lock
 out

--- a/docs/API.md
+++ b/docs/API.md
@@ -72,6 +72,7 @@ tracer.use('pg', {
 <h5 id="mysql2-tags"></h5>
 <h5 id="mysql2-config"></h5>
 <h5 id="net"></h5>
+<h5 id="next"></h5>
 <h5 id="paperplane"></h5>
 <h5 id="paperplane-tags"></h5>
 <h5 id="paperplane-config"></h5>
@@ -121,6 +122,7 @@ tracer.use('pg', {
 * [mysql](./interfaces/plugins.mysql.html)
 * [mysql2](./interfaces/plugins.mysql2.html)
 * [net](./interfaces/plugins.net.html)
+* [next](./interfaces/plugins.next.html)
 * [paperplane](./interfaces/plugins.paperplane.html)
 * [pino](./interfaces/plugins.pino.html)
 * [pg](./interfaces/plugins.pg.html)

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -214,6 +214,7 @@ tracer.use('mongoose');
 tracer.use('mysql');
 tracer.use('mysql2');
 tracer.use('net');
+tracer.use('next');
 tracer.use('paperplane');
 tracer.use('paperplane', httpServerOptions);
 tracer.use('pg');

--- a/index.d.ts
+++ b/index.d.ts
@@ -514,6 +514,7 @@ interface Plugins {
   "mysql": plugins.mysql;
   "mysql2": plugins.mysql2;
   "net": plugins.net;
+  "next": plugins.next;
   "paperplane": plugins.paperplane;
   "pg": plugins.pg;
   "pino": plugins.pino;
@@ -1113,9 +1114,26 @@ declare namespace plugins {
 
   /**
    * This plugin automatically instruments the
+   * [next](https://nextjs.org/) module.
+   */
+  interface next extends Instrumentation {
+    /**
+     * Hooks to run before spans are finished.
+     */
+     hooks?: {
+      /**
+       * Hook to execute just before the request span finishes.
+       */
+      request?: (span?: opentracing.Span, req?: IncomingMessage, res?: ServerResponse) => any;
+    };
+  }
+
+  /**
+   * This plugin automatically instruments the
    * [paperplane](https://github.com/articulate/paperplane) module.
    */
-  interface paperplane extends HttpServer {}
+   interface paperplane extends HttpServer {}
+
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -1,0 +1,132 @@
+'use strict'
+
+function createWrapHandleRequest (tracer, config) {
+  return function wrapHandleRequest (handleRequest) {
+    return function handleRequestWithTrace (req, res, pathname, query) {
+      return trace(tracer, config, req, res, () => handleRequest.apply(this, arguments))
+    }
+  }
+}
+
+function createWrapHandleApiRequest (tracer, config) {
+  return function wrapHandleApiRequest (handleApiRequest) {
+    return function handleApiRequestWithTrace (req, res, pathname, query) {
+      return trace(tracer, config, req, res, () => {
+        const promise = handleApiRequest.apply(this, arguments)
+
+        promise.then(handled => {
+          if (!handled) return
+
+          const page = getPageFromPath(pathname, this.dynamicRoutes)
+
+          addPage(req, page)
+        })
+
+        return promise
+      })
+    }
+  }
+}
+
+function createWrapRenderToHTML (tracer, config) {
+  return function wrapRenderToHTML (renderToHTML) {
+    return function renderToHTMLWithTrace (req, res, pathname, query, parsedUrl) {
+      return trace(tracer, config, req, res, () => renderToHTML.apply(this, arguments))
+    }
+  }
+}
+
+function createWrapRenderToHTMLWithComponents (tracer, config) {
+  return function wrapHandleRenderToHTMLWithComponents (renderToHTMLWithComponents) {
+    return function renderToHTMLWithComponentsWithTrace (req, res, page) {
+      addPage(req, page)
+
+      return renderToHTMLWithComponents.apply(this, arguments)
+    }
+  }
+}
+
+function getPageFromPath (page, dynamicRoutes = []) {
+  for (const dynamicRoute of dynamicRoutes) {
+    if (dynamicRoute.page.startsWith('/api') && dynamicRoute.match(page)) {
+      return dynamicRoute.page
+    }
+  }
+
+  return page
+}
+
+function trace (tracer, config, req, res, handler) {
+  const scope = tracer.scope()
+
+  if (req._datadog_next) return scope.activate(req._datadog_next.span, handler)
+
+  const childOf = scope.active()
+  const tags = {
+    'service.name': config.service || `${tracer._service}-next`,
+    'resource.name': req.method,
+    'span.type': 'web',
+    'span.kind': 'server',
+    'http.status_code': res.statusCode,
+    'http.method': req.method
+  }
+  const span = tracer.startSpan('next.request', { childOf, tags })
+
+  req._datadog_next = { span }
+
+  const promise = scope.activate(span, handler)
+
+  promise.then(() => finish(span, config, req, res), err => {
+    span.setTag('error', err)
+    finish(span, config, req, res)
+  })
+
+  return promise
+}
+
+function addPage (req, page) {
+  req._datadog_next.span.addTags({
+    'resource.name': `${req.method} ${page}`,
+    'next.page': page
+  })
+}
+
+function finish (span, config, req, res) {
+  config.hooks.request(span, req, res)
+  span.finish()
+}
+
+function normalizeConfig (config) {
+  const hooks = getHooks(config)
+
+  return Object.assign({}, config, { hooks })
+}
+
+function getHooks (config) {
+  const noop = () => {}
+  const request = (config.hooks && config.hooks.request) || noop
+
+  return { request }
+}
+
+module.exports = [
+  {
+    name: 'next',
+    versions: ['>=9.5'],
+    file: 'dist/next-server/server/next-server.js',
+    patch ({ default: Server }, tracer, config) {
+      config = normalizeConfig(config)
+
+      this.wrap(Server.prototype, 'handleRequest', createWrapHandleRequest(tracer, config))
+      this.wrap(Server.prototype, 'handleApiRequest', createWrapHandleApiRequest(tracer, config))
+      this.wrap(Server.prototype, 'renderToHTML', createWrapRenderToHTML(tracer, config))
+      this.wrap(Server.prototype, 'renderToHTMLWithComponents', createWrapRenderToHTMLWithComponents(tracer, config))
+    },
+    unpatch ({ default: Server }) {
+      this.unwrap(Server.prototype, 'handleRequest')
+      this.unwrap(Server.prototype, 'handleApiRequest')
+      this.unwrap(Server.prototype, 'renderToHTML')
+      this.unwrap(Server.prototype, 'renderToHTMLWithComponents')
+    }
+  }
+]

--- a/packages/datadog-plugin-next/test/build.js
+++ b/packages/datadog-plugin-next/test/build.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { version } = process.env
+
+const build = require(`../../../versions/next@${version}`).get('next/dist/build').default
+
+build(__dirname)

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -1,0 +1,159 @@
+'use strict'
+
+const axios = require('axios')
+const getPort = require('get-port')
+const { execSync } = require('child_process')
+const { parse } = require('url')
+const agent = require('../../dd-trace/test/plugins/agent')
+const plugin = require('../src')
+
+wrapIt()
+
+describe('Plugin', function () {
+  this.timeout(30000) // Webpack builds on every test run
+
+  let next
+  let app
+  let listener
+  let port
+
+  describe('next', () => {
+    withVersions(plugin, 'next', version => {
+      const setup = config => {
+        before(() => {
+          return agent.load('next', config)
+        })
+
+        after(() => {
+          listener.close()
+          return agent.close()
+        })
+
+        before(async () => {
+          const { createServer } = require('http')
+
+          // building in-process makes tests fail for an unknown reason
+          execSync('node build', {
+            cwd: __dirname,
+            env: { version },
+            stdio: ['pipe', 'ignore', 'pipe']
+          })
+
+          next = require(`../../../versions/next@${version}`).get()
+          app = next({ dir: __dirname, dev: false, quiet: true })
+
+          const handle = app.getRequestHandler()
+
+          await app.prepare()
+
+          listener = createServer((req, res) => {
+            const parsedUrl = parse(req.url, true)
+
+            handle(req, res, parsedUrl)
+          })
+        })
+
+        before(done => {
+          getPort()
+            .then(_port => {
+              port = _port
+              listener.listen(port, 'localhost', () => done())
+            })
+        })
+      }
+
+      describe('without configuration', () => {
+        setup()
+
+        describe('for api routes', () => {
+          it('should do automatic instrumentation', done => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[0]).to.have.property('name', 'next.request')
+                expect(spans[0]).to.have.property('service', 'test-next')
+                expect(spans[0]).to.have.property('type', 'web')
+                expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
+                expect(spans[0].meta).to.have.property('span.kind', 'server')
+                expect(spans[0].meta).to.have.property('http.method', 'GET')
+                expect(spans[0].meta).to.have.property('http.status_code', '200')
+              })
+              .then(done)
+              .catch(done)
+
+            axios
+              .get(`http://localhost:${port}/api/hello/world`)
+              .catch(done)
+          })
+
+          it('should propagate context', done => {
+            axios
+              .get(`http://localhost:${port}/api/hello/world`)
+              .then(res => {
+                expect(res.data.name).to.equal('next.request')
+                done()
+              })
+              .catch(done)
+          })
+        })
+
+        describe('for pages', () => {
+          it('should do automatic instrumentation', done => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[0]).to.have.property('name', 'next.request')
+                expect(spans[0]).to.have.property('service', 'test-next')
+                expect(spans[0]).to.have.property('type', 'web')
+                expect(spans[0]).to.have.property('resource', 'GET /hello/[name]')
+                expect(spans[0].meta).to.have.property('span.kind', 'server')
+                expect(spans[0].meta).to.have.property('http.method', 'GET')
+                expect(spans[0].meta).to.have.property('http.status_code', '200')
+              })
+              .then(done)
+              .catch(done)
+
+            axios
+              .get(`http://localhost:${port}/hello/world`)
+              .catch(done)
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        const config = {}
+
+        before(() => {
+          config.hooks = {
+            request: sinon.spy()
+          }
+        })
+
+        setup(config)
+
+        it('should execute the hook', done => {
+          agent
+            .use(traces => {
+              const spans = traces[0]
+
+              expect(spans[0]).to.have.property('name', 'next.request')
+              expect(spans[0]).to.have.property('service', 'test-next')
+              expect(spans[0]).to.have.property('type', 'web')
+              expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
+              expect(spans[0].meta).to.have.property('span.kind', 'server')
+              expect(spans[0].meta).to.have.property('http.method', 'GET')
+              expect(spans[0].meta).to.have.property('http.status_code', '200')
+            })
+            .then(done)
+            .catch(done)
+
+          axios
+            .get(`http://localhost:${port}/api/hello/world`)
+            .catch(done)
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -1,0 +1,15 @@
+const path = require('path')
+
+module.exports = {
+  webpack: (config) => {
+    const react = path.resolve(__dirname, '../../../versions/node_modules/react')
+    const reactDom = path.resolve(__dirname, '../../../versions/node_modules/react-dom')
+
+    config.externals = {
+      'react': `commonjs2 ${react}`,
+      'react-dom': `commonjs2 ${reactDom}`
+    }
+
+    return config
+  }
+}

--- a/packages/datadog-plugin-next/test/package.json
+++ b/packages/datadog-plugin-next/test/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "my-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "10.1.3",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/packages/datadog-plugin-next/test/pages/api/hello/[name].js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/[name].js
@@ -1,0 +1,9 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+  const tracer = require('../../../../../dd-trace')
+  const span = tracer.scope().active()
+  const name = span && span.context()._name
+
+  res.status(200).json({ name })
+}

--- a/packages/datadog-plugin-next/test/pages/hello/[name].js
+++ b/packages/datadog-plugin-next/test/pages/hello/[name].js
@@ -1,0 +1,7 @@
+export default function Home () {
+  return (
+    <div>
+      Hello World!
+    </div>
+  )
+}

--- a/packages/dd-trace/index.js
+++ b/packages/dd-trace/index.js
@@ -1,7 +1,11 @@
 'use strict'
 
-const TracerProxy = require('./src/proxy')
+if (!global.ddtrace) {
+  const TracerProxy = require('./src/proxy')
 
-module.exports = new TracerProxy()
-module.exports.default = module.exports
-module.exports.tracer = module.exports
+  global.ddtrace = new TracerProxy()
+  global.ddtrace.default = global.ddtrace
+  global.ddtrace.tracer = global.ddtrace
+}
+
+module.exports = global.ddtrace

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -35,6 +35,7 @@ module.exports = {
   'mysql': require('../../../datadog-plugin-mysql/src'),
   'mysql2': require('../../../datadog-plugin-mysql2/src'),
   'net': require('../../../datadog-plugin-net/src'),
+  'next': require('../../../datadog-plugin-next/src'),
   'paperplane': require('../../../datadog-plugin-paperplane/src'),
   'pg': require('../../../datadog-plugin-pg/src'),
   'pino': require('../../../datadog-plugin-pino/src'),

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -31,6 +31,7 @@ describe('dd-trace', () => {
   afterEach(() => {
     listener.close()
     delete require.cache[require.resolve('../')]
+    delete global.ddtrace
   })
 
   it('should record and send a trace to the agent', (done) => {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -138,6 +138,7 @@ module.exports = {
     agent = null
     handlers.clear()
     delete require.cache[require.resolve('../..')]
+    delete global.ddtrace
 
     return new Promise((resolve, reject) => {
       server.on('close', () => {

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -81,6 +81,16 @@
       "versions": ["3.2.7"]
     }
   ],
+  "next": [
+    {
+      "name": "react",
+      "versions": ["17.0.2"]
+    },
+    {
+      "name": "react-dom",
+      "versions": ["17.0.2"]
+    }
+  ],
   "pg": [
     {
       "name": "pg-native",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for Next. It also updated the tracer export to use a global variable to hold the tracer so that the same tracer is always returned, even if exported using different names because of a bundler which would otherwise result in different instances. This is useful for Next since it uses Webpack by default which causes that issue.

### Motivation
<!-- What inspired you to submit this pull request? -->

Closes #1259 