### PR TITLE
add fs.realpath.native

### DIFF
--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -497,6 +497,8 @@ function unpatchDirFunctions (fs) {
 module.exports = {
   name: 'fs',
   patch (fs, tracer, config) {
+    const realpathNative = fs.realpath.native;
+    const realpathSyncNative = fs.realpathSync.native;
     patchClassicFunctions.call(this, fs, tracer, config)
     if (fs.promises) {
       patchFileHandle.call(this, fs, tracer, config)
@@ -509,6 +511,12 @@ module.exports = {
     this.wrap(fs, 'createWriteStream', createWrapCreateWriteStream(config, tracer))
     this.wrap(fs, 'existsSync', createWrap(tracer, config, 'existsSync', createPathTags))
     this.wrap(fs, 'exists', createWrapExists(config, tracer))
+    if (realpathNative) {
+      fs.realpath.native = createWrapCb(tracer, config, 'realpath.native', createPathTags)(realpathNative)
+    }
+    if (realpathSyncNative) {
+      fs.realpathSync.native = createWrap(tracer, config, 'realpath.native', createPathTags)(realpathSyncNative)
+    }
   },
   unpatch (fs) {
     unpatchClassicFunctions.call(this, fs)

--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -497,8 +497,8 @@ function unpatchDirFunctions (fs) {
 module.exports = {
   name: 'fs',
   patch (fs, tracer, config) {
-    const realpathNative = fs.realpath.native;
-    const realpathSyncNative = fs.realpathSync.native;
+    const realpathNative = fs.realpath.native
+    const realpathSyncNative = fs.realpathSync.native
     patchClassicFunctions.call(this, fs, tracer, config)
     if (fs.promises) {
       patchFileHandle.call(this, fs, tracer, config)

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -841,6 +841,23 @@ describe('Plugin', () => {
           testHandleErrors(fs, resource, tested, ['/badfilename'], agent))
       })
 
+      if (realFS.realpath.native) {
+        describeThreeWays('realpath.native', (resource, tested) => {
+          it('should be instrumented', (done) => {
+            expectOneSpan(agent, done, {
+              resource,
+              meta: {
+                'file.path': __filename
+              }
+            })
+            tested(fs, [__filename], done)
+          })
+
+          it('should handle errors', () =>
+            testHandleErrors(fs, resource, tested, ['/badfilename'], agent))
+        })
+      }
+
       describeThreeWays('readlink', (resource, tested) => {
         let link
         beforeEach(() => {
@@ -1716,7 +1733,8 @@ describe('Plugin', () => {
       }
 
       function describeThreeWays (name, fn) {
-        if (name in realFS) {
+        const reducer = (acc, cur) => acc[cur]
+        if (name.split('.').reduce(reducer, realFS)) {
           describe(name, () => {
             fn(name, (fs, args, done, withError) => {
               const span = {}
@@ -1728,7 +1746,8 @@ describe('Plugin', () => {
                     else done(err)
                   }
                 })
-                return fs[name].apply(fs, args)
+                const func = name.split('.').reduce((acc, cur) => acc[cur], fs)
+                return func.apply(fs, args)
               })
             })
           })


### PR DESCRIPTION
### What does this PR do?

Adds instrumentation for fs.realpath.native when it exists.

### Motivation

Fixes: https://github.com/DataDog/dd-trace-js/issues/1340


<!-- A brief description of the change being made with this pull request. -->

<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
