### PR TITLE
fix two errors from bad inputs

### DIFF
--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -338,7 +338,7 @@ function makeFSTags (resourceName, path, options, config, tracer) {
 
   switch (typeof path) {
     case 'object': {
-      if (path === null) return
+      if (path === null) return tags
       const src = 'src' in path ? path.src : null
       const dest = 'dest' in path ? path.dest : null
       if (src || dest) {

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -75,7 +75,7 @@ class DatadogTracer extends Tracer {
         optionsObj = optionsObj.apply(this, arguments)
       }
 
-      if (optionsObj.orphanable === false && !tracer.scope().active()) {
+      if (optionsObj && optionsObj.orphanable === false && !tracer.scope().active()) {
         return fn.apply(this, arguments)
       }
 

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -490,5 +490,19 @@ describe('Tracer', () => {
         })
       })
     })
+
+    describe('when the options object is a function returning a falsy value', () => {
+      it('should trace', () => {
+        const fn = tracer.wrap('name', () => false, () => {})
+
+        sinon.stub(tracer, 'trace').callsFake((_, options) => {
+          expect(options).to.equal(false)
+        })
+
+        fn()
+
+        expect(tracer.trace).to.have.been.called
+      })
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Fix: https://github.com/DataDog/dd-trace-js/issues/1338
Fix: https://github.com/DataDog/dd-trace-js/issues/1339

Testing for the `fs` inputs is covered by running the Node.js core tests for
`fs`. The tracer fix has a test.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

See the above issues.
