### PR TITLE
remove deprecated req.connection

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -408,7 +408,7 @@ function extractURL (req) {
   if (req.stream) {
     return `${headers[HTTP2_HEADER_SCHEME]}://${headers[HTTP2_HEADER_AUTHORITY]}${headers[HTTP2_HEADER_PATH]}`
   } else {
-    const protocol = req.connection.encrypted ? 'https' : 'http'
+    const protocol = req.socket.encrypted ? 'https' : 'http'
     return `${protocol}://${req.headers['host']}${req.originalUrl || req.url}`
   }
 }

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -39,7 +39,7 @@ describe('plugins/util/web', () => {
         'host': 'localhost',
         'date': 'now'
       },
-      connection: {}
+      socket: {}
     }
     end = sinon.stub()
     res = {


### PR DESCRIPTION
### What does this PR do?

Switches a reference from the deprecated `req.connection` to the non-deprecated
`req.socket`.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Fixes: https://github.com/DataDog/dd-trace-js/issues/1264
