### PR TITLE
[ci-app] Fix `mocha` Skipped Tests

### DIFF
--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -123,6 +123,11 @@ function createWrapRunTests (tracer, testEnvironmentMetadata, sourceRoot) {
       const tests = getAllTestsInSuite(suite)
       tests.forEach(test => {
         const { pending: isSkipped } = test
+        // We call `getAllTestsInSuite` with the root suite so every skipped test
+        // should already have an associated test span.
+        // This function is called with every suite, so we need a way to mark
+        // the test as already accounted for. We do this through `__datadog_skipped`.
+        // If the test is already marked as skipped, we don't create an additional test span.
         if (!isSkipped || test.__datadog_skipped) {
           return
         }

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -17,81 +17,81 @@ const { expect } = require('chai')
 const path = require('path')
 
 const TESTS = [
-  {
-    fileName: 'mocha-test-pass.js',
-    testName: 'can pass',
-    root: 'mocha-test-pass',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-fail.js',
-    testName: 'can fail',
-    root: 'mocha-test-fail',
-    status: 'fail'
-  },
+  // {
+  //   fileName: 'mocha-test-pass.js',
+  //   testName: 'can pass',
+  //   root: 'mocha-test-pass',
+  //   status: 'pass'
+  // },
+  // {
+  //   fileName: 'mocha-test-fail.js',
+  //   testName: 'can fail',
+  //   root: 'mocha-test-fail',
+  //   status: 'fail'
+  // },
   {
     fileName: 'mocha-test-skip.js',
     testName: 'can skip',
     root: 'mocha-test-skip',
     status: 'skip'
   },
-  {
-    fileName: 'mocha-test-done-pass.js',
-    testName: 'can do passed tests with done',
-    root: 'mocha-test-done-pass',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-done-fail.js',
-    testName: 'can do failed tests with done',
-    root: 'mocha-test-done-fail',
-    status: 'fail'
-  },
-  {
-    fileName: 'mocha-test-promise-pass.js',
-    testName: 'can do passed promise tests',
-    root: 'mocha-test-promise-pass',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-promise-fail.js',
-    testName: 'can do failed promise tests',
-    root: 'mocha-test-promise-fail',
-    status: 'fail'
-  },
-  {
-    fileName: 'mocha-test-async-pass.js',
-    testName: 'can do passed async tests',
-    root: 'mocha-test-async-pass',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-async-fail.js',
-    testName: 'can do failed async tests',
-    root: 'mocha-test-async-fail',
-    status: 'fail'
-  },
-  {
-    fileName: 'mocha-test-timeout-fail.js',
-    testName: 'times out',
-    root: 'mocha-test-timeout-fail',
-    status: 'fail'
-  },
-  {
-    fileName: 'mocha-test-timeout-pass.js',
-    testName: 'does not timeout',
-    root: 'mocha-test-timeout-pass',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-parameterized.js',
-    testName: 'can do parameterized',
-    root: 'mocha-parameterized',
-    status: 'pass',
-    extraSpanTags: {
-      [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
-    }
-  }
+  // {
+  //   fileName: 'mocha-test-done-pass.js',
+  //   testName: 'can do passed tests with done',
+  //   root: 'mocha-test-done-pass',
+  //   status: 'pass'
+  // },
+  // {
+  //   fileName: 'mocha-test-done-fail.js',
+  //   testName: 'can do failed tests with done',
+  //   root: 'mocha-test-done-fail',
+  //   status: 'fail'
+  // },
+  // {
+  //   fileName: 'mocha-test-promise-pass.js',
+  //   testName: 'can do passed promise tests',
+  //   root: 'mocha-test-promise-pass',
+  //   status: 'pass'
+  // },
+  // {
+  //   fileName: 'mocha-test-promise-fail.js',
+  //   testName: 'can do failed promise tests',
+  //   root: 'mocha-test-promise-fail',
+  //   status: 'fail'
+  // },
+  // {
+  //   fileName: 'mocha-test-async-pass.js',
+  //   testName: 'can do passed async tests',
+  //   root: 'mocha-test-async-pass',
+  //   status: 'pass'
+  // },
+  // {
+  //   fileName: 'mocha-test-async-fail.js',
+  //   testName: 'can do failed async tests',
+  //   root: 'mocha-test-async-fail',
+  //   status: 'fail'
+  // },
+  // {
+  //   fileName: 'mocha-test-timeout-fail.js',
+  //   testName: 'times out',
+  //   root: 'mocha-test-timeout-fail',
+  //   status: 'fail'
+  // },
+  // {
+  //   fileName: 'mocha-test-timeout-pass.js',
+  //   testName: 'does not timeout',
+  //   root: 'mocha-test-timeout-pass',
+  //   status: 'pass'
+  // },
+  // {
+  //   fileName: 'mocha-test-parameterized.js',
+  //   testName: 'can do parameterized',
+  //   root: 'mocha-parameterized',
+  //   status: 'pass',
+  //   extraSpanTags: {
+  //     [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
+  //   }
+  // }
 ]
 
 describe('Plugin', () => {
@@ -108,7 +108,8 @@ describe('Plugin', () => {
       return agent.close()
     })
     beforeEach(() => {
-      return agent.load('mocha').then(() => {
+      debugger
+      return agent.load('mocha', {}, { flushInterval: 100000000 }).then(() => {
         Mocha = require(`../../../versions/mocha@${version}`).get()
       })
     })
@@ -121,33 +122,37 @@ describe('Plugin', () => {
           const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
           agent
             .use(traces => {
-              expect(traces[0][0].meta).to.contain({
-                language: 'javascript',
-                service: 'test',
-                [TEST_NAME]: `${test.root} ${test.testName}`,
-                [TEST_STATUS]: test.status,
-                [TEST_TYPE]: 'test',
-                [TEST_FRAMEWORK]: 'mocha',
-                [TEST_SUITE]: testSuite,
-                ...test.extraSpanTags
-              })
-              if (test.fileName === 'mocha-test-fail.js') {
-                expect(traces[0][0].meta).to.contain({
-                  [ERROR_TYPE]: 'AssertionError',
-                  [ERROR_MESSAGE]: 'expected true to equal false'
-                })
-                expect(traces[0][0].meta[ERROR_STACK]).not.to.be.undefined
-              }
-              expect(traces[0][0].meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
-              expect(traces[0][0].type).to.equal('test')
-              expect(traces[0][0].name).to.equal('mocha.test')
-              expect(traces[0][0].resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
+              expect(traces.length).to.equal(3)
+              // expect(traces[0][0].meta).to.contain({
+              //   language: 'javascript',
+              //   service: 'test',
+              //   [TEST_NAME]: `${test.root} ${test.testName}`,
+              //   [TEST_STATUS]: test.status,
+              //   [TEST_TYPE]: 'test',
+              //   [TEST_FRAMEWORK]: 'mocha',
+              //   [TEST_SUITE]: testSuite,
+              //   ...test.extraSpanTags
+              // })
+              // if (test.fileName === 'mocha-test-fail.js') {
+              //   expect(traces[0][0].meta).to.contain({
+              //     [ERROR_TYPE]: 'AssertionError',
+              //     [ERROR_MESSAGE]: 'expected true to equal false'
+              //   })
+              //   expect(traces[0][0].meta[ERROR_STACK]).not.to.be.undefined
+              // }
+              // expect(traces[0][0].meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
+              // expect(traces[0][0].type).to.equal('test')
+              // expect(traces[0][0].name).to.equal('mocha.test')
+              // expect(traces[0][0].resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
             }).then(done, done)
+
           const mocha = new Mocha({
             reporter: function () {} // silent on internal tests
           })
           mocha.addFile(testFilePath)
-          mocha.run()
+          mocha.run(() => {
+            agent.flush()
+          })
         })
       })
     })

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -17,18 +17,22 @@ const { expect } = require('chai')
 const path = require('path')
 
 const TESTS = [
-  // {
-  //   fileName: 'mocha-test-pass.js',
-  //   testName: 'can pass',
-  //   root: 'mocha-test-pass',
-  //   status: 'pass'
-  // },
-  // {
-  //   fileName: 'mocha-test-fail.js',
-  //   testName: 'can fail',
-  //   root: 'mocha-test-fail',
-  //   status: 'fail'
-  // },
+  {
+    fileName: 'mocha-test-pass.js',
+    testNames: [
+      'mocha-test-pass can pass',
+      'mocha-test-pass can pass two',
+      'mocha-test-pass-two can pass',
+      'mocha-test-pass-two can pass two'
+    ],
+    status: 'pass'
+  },
+  {
+    fileName: 'mocha-test-fail.js',
+    testName: 'can fail',
+    root: 'mocha-test-fail',
+    status: 'fail'
+  },
   {
     fileName: 'mocha-test-skip.js',
     testNames: [
@@ -38,63 +42,63 @@ const TESTS = [
     ],
     status: 'skip'
   },
-  // {
-  //   fileName: 'mocha-test-done-pass.js',
-  //   testName: 'can do passed tests with done',
-  //   root: 'mocha-test-done-pass',
-  //   status: 'pass'
-  // },
-  // {
-  //   fileName: 'mocha-test-done-fail.js',
-  //   testName: 'can do failed tests with done',
-  //   root: 'mocha-test-done-fail',
-  //   status: 'fail'
-  // },
-  // {
-  //   fileName: 'mocha-test-promise-pass.js',
-  //   testName: 'can do passed promise tests',
-  //   root: 'mocha-test-promise-pass',
-  //   status: 'pass'
-  // },
-  // {
-  //   fileName: 'mocha-test-promise-fail.js',
-  //   testName: 'can do failed promise tests',
-  //   root: 'mocha-test-promise-fail',
-  //   status: 'fail'
-  // },
-  // {
-  //   fileName: 'mocha-test-async-pass.js',
-  //   testName: 'can do passed async tests',
-  //   root: 'mocha-test-async-pass',
-  //   status: 'pass'
-  // },
-  // {
-  //   fileName: 'mocha-test-async-fail.js',
-  //   testName: 'can do failed async tests',
-  //   root: 'mocha-test-async-fail',
-  //   status: 'fail'
-  // },
-  // {
-  //   fileName: 'mocha-test-timeout-fail.js',
-  //   testName: 'times out',
-  //   root: 'mocha-test-timeout-fail',
-  //   status: 'fail'
-  // },
-  // {
-  //   fileName: 'mocha-test-timeout-pass.js',
-  //   testName: 'does not timeout',
-  //   root: 'mocha-test-timeout-pass',
-  //   status: 'pass'
-  // },
-  // {
-  //   fileName: 'mocha-test-parameterized.js',
-  //   testName: 'can do parameterized',
-  //   root: 'mocha-parameterized',
-  //   status: 'pass',
-  //   extraSpanTags: {
-  //     [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
-  //   }
-  // }
+  {
+    fileName: 'mocha-test-done-pass.js',
+    testName: 'can do passed tests with done',
+    root: 'mocha-test-done-pass',
+    status: 'pass'
+  },
+  {
+    fileName: 'mocha-test-done-fail.js',
+    testName: 'can do failed tests with done',
+    root: 'mocha-test-done-fail',
+    status: 'fail'
+  },
+  {
+    fileName: 'mocha-test-promise-pass.js',
+    testName: 'can do passed promise tests',
+    root: 'mocha-test-promise-pass',
+    status: 'pass'
+  },
+  {
+    fileName: 'mocha-test-promise-fail.js',
+    testName: 'can do failed promise tests',
+    root: 'mocha-test-promise-fail',
+    status: 'fail'
+  },
+  {
+    fileName: 'mocha-test-async-pass.js',
+    testName: 'can do passed async tests',
+    root: 'mocha-test-async-pass',
+    status: 'pass'
+  },
+  {
+    fileName: 'mocha-test-async-fail.js',
+    testName: 'can do failed async tests',
+    root: 'mocha-test-async-fail',
+    status: 'fail'
+  },
+  {
+    fileName: 'mocha-test-timeout-fail.js',
+    testName: 'times out',
+    root: 'mocha-test-timeout-fail',
+    status: 'fail'
+  },
+  {
+    fileName: 'mocha-test-timeout-pass.js',
+    testName: 'does not timeout',
+    root: 'mocha-test-timeout-pass',
+    status: 'pass'
+  },
+  {
+    fileName: 'mocha-test-parameterized.js',
+    testName: 'can do parameterized',
+    root: 'mocha-parameterized',
+    status: 'pass',
+    extraSpanTags: {
+      [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
+    }
+  }
 ]
 
 describe('Plugin', () => {
@@ -123,11 +127,13 @@ describe('Plugin', () => {
           const testFilePath = path.join(__dirname, test.fileName)
           const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
 
-          if (test.fileName === 'mocha-test-skip.js') {
+          if (test.fileName === 'mocha-test-skip.js' || test.fileName === 'mocha-test-pass.js') {
             const assertionPromises = test.testNames.map(testName => {
-              return agent.use(traces => {
-                expect(traces[0][0].meta[TEST_STATUS]).to.equal('skip')
-                expect(traces[0][0].meta[TEST_NAME]).to.equal(testName)
+              return agent.use(trace => {
+                const testSpan = trace[0][0]
+                expect(testSpan.parent_id.toString()).to.equal('0')
+                expect(testSpan.meta[TEST_STATUS]).to.equal(test.status)
+                expect(testSpan.meta[TEST_NAME]).to.equal(testName)
               })
             })
             Promise.all(assertionPromises)
@@ -136,8 +142,8 @@ describe('Plugin', () => {
           } else {
             agent
               .use(traces => {
-                expect(traces.length).to.equal(3)
-                expect(traces[0][0].meta).to.contain({
+                const testSpan = traces[0][0]
+                expect(testSpan.meta).to.contain({
                   language: 'javascript',
                   service: 'test',
                   [TEST_NAME]: `${test.root} ${test.testName}`,
@@ -148,16 +154,17 @@ describe('Plugin', () => {
                   ...test.extraSpanTags
                 })
                 if (test.fileName === 'mocha-test-fail.js') {
-                  expect(traces[0][0].meta).to.contain({
+                  expect(testSpan.meta).to.contain({
                     [ERROR_TYPE]: 'AssertionError',
                     [ERROR_MESSAGE]: 'expected true to equal false'
                   })
-                  expect(traces[0][0].meta[ERROR_STACK]).not.to.be.undefined
+                  expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
                 }
-                expect(traces[0][0].meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
-                expect(traces[0][0].type).to.equal('test')
-                expect(traces[0][0].name).to.equal('mocha.test')
-                expect(traces[0][0].resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
+                expect(testSpan.parent_id.toString()).to.equal('0')
+                expect(testSpan.meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
+                expect(testSpan.type).to.equal('test')
+                expect(testSpan.name).to.equal('mocha.test')
+                expect(testSpan.resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
               }).then(done, done)
           }
 

--- a/packages/datadog-plugin-mocha/test/mocha-test-pass.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-pass.js
@@ -4,4 +4,16 @@ describe('mocha-test-pass', () => {
   it('can pass', () => {
     expect(true).to.equal(true)
   })
+  it('can pass two', () => {
+    expect(true).to.equal(true)
+  })
+})
+
+describe('mocha-test-pass-two', () => {
+  it('can pass', () => {
+    expect(true).to.equal(true)
+  })
+  it('can pass two', () => {
+    expect(true).to.equal(true)
+  })
 })

--- a/packages/datadog-plugin-mocha/test/mocha-test-skip.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-skip.js
@@ -5,3 +5,12 @@ describe('mocha-test-skip', () => {
     expect(true).to.equal(false)
   })
 })
+
+describe('mocha-test-skip-different', () => {
+  it.skip('can skip too', () => {
+    expect(true).to.equal(false)
+  })
+  it.skip('can skip twice', () => {
+    expect(true).to.equal(false)
+  })
+})

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -16,8 +16,11 @@ let listener = null
 let tracer = null
 
 module.exports = {
+  flush (done) {
+    tracer._tracer._exporter._writer.flush(done)
+  },
   // Load the plugin on the tracer with an optional config and start a mock agent.
-  load (pluginName, config) {
+  load (pluginName, config, tracerConfig) {
     tracer = require('../..')
     agent = express()
     agent.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
@@ -54,7 +57,7 @@ module.exports = {
         tracer.init({
           service: 'test',
           port,
-          flushInterval: 0,
+          flushInterval: tracerConfig && tracerConfig.flushInterval ? tracerConfig.flushInterval : 0,
           plugins: false
         })
 

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -16,11 +16,8 @@ let listener = null
 let tracer = null
 
 module.exports = {
-  flush (done) {
-    tracer._tracer._exporter._writer.flush(done)
-  },
   // Load the plugin on the tracer with an optional config and start a mock agent.
-  load (pluginName, config, tracerConfig) {
+  load (pluginName, config) {
     tracer = require('../..')
     agent = express()
     agent.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
@@ -57,7 +54,7 @@ module.exports = {
         tracer.init({
           service: 'test',
           port,
-          flushInterval: tracerConfig && tracerConfig.flushInterval ? tracerConfig.flushInterval : 0,
+          flushInterval: 0,
           plugins: false
         })
 


### PR DESCRIPTION
### What does this PR do?
To get the skipped tests we are wrapping `runTests` and then we were using `this.suite.tests.forEach` to loop through the different tests. This *didn't work*, as suites can include suites recursively. 

This PR fixes this and adds unit tests to check the solution.

Additionally, we've improved the unit tests for other statuses: 
* Have multiple describe blocks in https://github.com/DataDog/dd-trace-js/compare/juan-fernandez/mocha-skipped-tests#diff-f82096dcddaddb4447d5644b6b9f1f934304362fce9abd30f99cbcfa55864efdR7-R18
* Check test spans' `parent_id` for cases where the test runner calls the next test explicitly. 


### Motivation
Fix skipped tests instrumentation in mocha. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
