### PR TITLE
fix ghost issue with router plugin

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -56,7 +56,8 @@ function wrapLayerHandle (layer, handle) {
     get: () => handle.stack,
     set: stack => {
       handle.stack = stack
-    }
+    },
+    configurable: true
   })
 
   return wrapCallHandle

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -50,15 +50,12 @@ function wrapLayerHandle (layer, handle) {
   // that contains the real handle function
   wrapCallHandle._datadog_orig = handle
 
-  // This is a workaround for `ghost`, which occaisionally iterates over this
-  // stack property without first checking that it exists.
-  Object.defineProperty(wrapCallHandle, 'stack', {
-    get: () => handle.stack,
-    set: stack => {
-      handle.stack = stack
-    },
-    configurable: true
-  })
+  // TODO(bengl) copying props like this when wrapping should be done in a centralized place.
+  const props = Object.getOwnPropertyDescriptors(handle)
+  for (const key in props) {
+    if (wrapCallHandle.hasOwnProperty(key)) delete props[key]
+  }
+  Object.defineProperties(wrapCallHandle, props)
 
   return wrapCallHandle
 }

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -50,6 +50,15 @@ function wrapLayerHandle (layer, handle) {
   // that contains the real handle function
   wrapCallHandle._datadog_orig = handle
 
+  // This is a workaround for `ghost`, which occaisionally iterates over this
+  // stack property without first checking that it exists.
+  Object.defineProperty(wrapCallHandle, 'stack', {
+    get: () => handle.stack,
+    set: stack => {
+      handle.stack = stack
+    }
+  })
+
   return wrapCallHandle
 }
 

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -65,6 +65,9 @@ describe('Plugin', () => {
 
           router.use('/parent', childRouter)
           expect(router.stack[0].handle.stack.length).to.equal(1)
+          // Next two lines are to test the setter.
+          router.stack[0].handle.stack = 5
+          expect(router.stack[0].handle.stack).to.equal(5)
         })
 
         it('should add the route to the request span', done => {

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -38,7 +38,7 @@ describe('Plugin', () => {
       })
 
       afterEach(() => {
-        appListener.close()
+        appListener && appListener.close()
       })
 
       describe('without configuration', () => {
@@ -52,6 +52,19 @@ describe('Plugin', () => {
 
         beforeEach(() => {
           Router = require(`../../../versions/router@${version}`).get()
+        })
+
+        it('should expose router handle properties', () => {
+          const router = Router()
+          const childRouter = Router()
+
+          childRouter.use('/child/:id', (req, res) => {
+            res.writeHead(200)
+            res.end()
+          })
+
+          router.use('/parent', childRouter)
+          expect(router.stack[0].handle.stack.length).to.equal(1)
         })
 
         it('should add the route to the request span', done => {


### PR DESCRIPTION
In some situations, the `stack` property on router handles is missing
due to us wrapping the router. This adds an accessor so the property is
always available.
