### PR TITLE
fix grpc unary call when metadata is undefined

### DIFF
--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -180,7 +180,7 @@ function ensureMetadata (client, args) {
     normalized.push(new client._datadog.grpc.Metadata())
   }
 
-  for (let i = 1; i < args.length; i++) {
+  for (let i = typeof args[1] == 'undefined' ? 2 : 1; i < args.length; i++) {
     normalized.push(args[i])
   }
 

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -180,7 +180,11 @@ function ensureMetadata (client, args) {
     normalized.push(new client._datadog.grpc.Metadata())
   }
 
-  for (let i = typeof args[1] == 'undefined' ? 2 : 1; i < args.length; i++) {
+  if (args[1]) {
+    normalized.push(args[1])
+  }
+
+  for (let i = 2; i < args.length; i++) {
     normalized.push(args[i])
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
When the `metadata` parameter of a grpc call is `undefined`, but present, we
should replace it with our metadata object, rather than splicing it in.

### Motivation
<!-- What inspired you to submit this pull request? -->
The incorrect behaviour was reported by a user adding the undefined argument.

