### PR TITLE
[ci-app] Add origin Tag Propagation for Testing Integrations

### DIFF
--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -7,6 +7,7 @@ const {
   TEST_NAME,
   TEST_SUITE,
   TEST_STATUS,
+  CI_APP_ORIGIN,
   getTestEnvironmentMetadata
 } = require('../../dd-trace/src/plugins/util/test')
 
@@ -46,10 +47,11 @@ function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot) {
           resource: testName,
           tags: commonSpanTags
         },
-        (span) => {
+        (testSpan) => {
+          testSpan.context()._trace.origin = CI_APP_ORIGIN
           const promise = run.apply(this, arguments)
           promise.then(() => {
-            setStatusFromResult(span, this.getWorstStepResult(), TEST_STATUS)
+            setStatusFromResult(testSpan, this.getWorstStepResult(), TEST_STATUS)
           })
           return promise
         }

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -429,8 +429,11 @@ describe('Plugin', () => {
             const testSpan = trace[0].find(span => span.type === 'test')
             const fsOperationSpans = trace[0].filter(span => span.name === 'fs.operation')
             expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.parent_id.toString()).to.equal('0')
             expect(fsOperationSpans.length > 1).to.equal(true)
             expect(fsOperationSpans.every(span => span.meta[ORIGIN_KEY] === CI_APP_ORIGIN)).to.equal(true)
+            const fsReadFileSyncSpan = trace[0].find(span => span.resource === 'readFileSync')
+            expect(fsReadFileSyncSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
           }).then(done).catch(done)
 
         const passingTestEvent = {

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -213,7 +213,7 @@ describe('Plugin', () => {
 
       it('should call startSpan and span finish on skipped tests', () => {
         if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
-        const span = { finish: sinon.spy(() => {}) }
+        const span = { finish: sinon.spy(() => {}), context: sinon.spy(() => ({ _trace: { origin: '' } })) }
         tracer._tracer.startSpan = sinon.spy(() => {
           return span
         })
@@ -229,6 +229,7 @@ describe('Plugin', () => {
         skippedTestEvent.test.fn()
         expect(tracer._tracer.startSpan).to.have.been.called
         expect(span.finish).to.have.been.called
+        expect(span.context).to.have.been.called
       })
 
       it('should call flush on teardown', async () => {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -13,6 +13,7 @@ const {
   ERROR_MESSAGE,
   ERROR_STACK,
   ERROR_TYPE,
+  CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
   getTestParametersString
 } = require('../../dd-trace/src/plugins/util/test')
@@ -70,6 +71,7 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
         },
         async () => {
           const activeSpan = tracer.scope().active()
+          activeSpan.context()._trace.origin = CI_APP_ORIGIN
           let result
           try {
             const context = this.test.ctx
@@ -134,7 +136,7 @@ function createWrapRunTests (tracer, testEnvironmentMetadata, sourceRoot) {
         test.__datadog_skipped = true
         const { childOf, resource, ...testSpanMetadata } = getTestSpanMetadata(tracer, test, sourceRoot)
 
-        tracer
+        const testSpan = tracer
           .startSpan('mocha.test', {
             childOf,
             tags: {
@@ -144,7 +146,9 @@ function createWrapRunTests (tracer, testEnvironmentMetadata, sourceRoot) {
               ...testEnvironmentMetadata
             }
           })
-          .finish()
+        testSpan.context()._trace.origin = CI_APP_ORIGIN
+
+        testSpan.finish()
       })
     }
   }

--- a/packages/datadog-plugin-mocha/test/mocha-test-integration.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-integration.js
@@ -1,0 +1,11 @@
+const { expect } = require('chai')
+const fs = require('fs')
+
+describe('mocha-test-integration', () => {
+  it('can do integration tests', (done) => {
+    fs.readFile('./package.json', () => {
+      expect(true).to.equal(true)
+      done()
+    })
+  })
+})

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -13,6 +13,8 @@ const ERROR_TYPE = 'error.type'
 const ERROR_MESSAGE = 'error.message'
 const ERROR_STACK = 'error.stack'
 
+const CI_APP_ORIGIN = 'ciapp-test'
+
 module.exports = {
   TEST_FRAMEWORK,
   TEST_TYPE,
@@ -23,6 +25,7 @@ module.exports = {
   ERROR_TYPE,
   ERROR_MESSAGE,
   ERROR_STACK,
+  CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
   getTestParametersString
 }


### PR DESCRIPTION
### What does this PR do?

* Set `_dd.origin` tag to `ciapp-test` to all testing instrumentation.
  * This way all children will have this tag set as well.
* Add tests. 

### Motivation
Be able to distinguish APM spans from CI App spans.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
