### PR TITLE
fix support for grpc custom client instances

### DIFF
--- a/packages/datadog-plugin-grpc/src/util.js
+++ b/packages/datadog-plugin-grpc/src/util.js
@@ -14,18 +14,22 @@ module.exports = {
 
     const methodParts = path.split('/')
 
-    if (methodParts.length < 2) return
+    if (methodParts.length > 2) {
+      const serviceParts = methodParts[1].split('.')
+      const name = methodParts[2]
+      const service = serviceParts.pop()
+      const pkg = serviceParts.join('.')
 
-    const serviceParts = methodParts[1].split('.')
-    const name = methodParts[2]
-    const service = serviceParts.pop()
-    const pkg = serviceParts.join('.')
-
-    span.addTags({
-      'grpc.method.name': name,
-      'grpc.method.service': service,
-      'grpc.method.package': pkg
-    })
+      span.addTags({
+        'grpc.method.name': name,
+        'grpc.method.service': service,
+        'grpc.method.package': pkg
+      })
+    } else {
+      span.addTags({
+        'grpc.method.name': methodParts[methodParts.length - 1]
+      })
+    }
   },
 
   addMetadataTags (span, metadata, filter, type) {

--- a/packages/datadog-plugin-grpc/test/invalid.proto
+++ b/packages/datadog-plugin-grpc/test/invalid.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package test;
 
 service TestService {
-  rpc get_Bidi (stream Request) returns (stream Response) {} // test rename support
+  rpc getBidi (stream Request) returns (stream Response) {} // test rename support
   rpc getServerStream (Request) returns (stream Response) {}
   rpc getClientStream (stream Request) returns (Response) {}
   rpc getUnary (Request) returns (Response) {}

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -139,12 +139,12 @@ describe('Plugin', () => {
               expect(traces[0][0]).to.deep.include({
                 name: 'grpc.request',
                 service: 'test',
-                resource: '/test.TestService/get_Bidi',
+                resource: '/test.TestService/getBidi',
                 type: 'web'
               })
-              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'get_Bidi')
+              expect(traces[0][0].meta).to.have.property('grpc.method.name', 'getBidi')
               expect(traces[0][0].meta).to.have.property('grpc.method.service', 'TestService')
-              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/get_Bidi')
+              expect(traces[0][0].meta).to.have.property('grpc.method.path', '/test.TestService/getBidi')
               expect(traces[0][0].meta).to.have.property('grpc.method.kind', kinds.bidi)
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
               expect(traces[0][0].metrics).to.have.property('grpc.status.code', 0)

--- a/packages/datadog-plugin-grpc/test/service.js
+++ b/packages/datadog-plugin-grpc/test/service.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const serialize = value => Buffer.from(JSON.stringify(value || ''))
+const deserialize = buffer => JSON.parse(buffer.toString())
+
+module.exports = grpc => {
+  class TestService extends grpc.Client {
+    getUnary (argument, ...more) {
+      return this.makeUnaryRequest(
+        '/test.TestService/getUnary',
+        serialize,
+        deserialize,
+        argument,
+        ...more
+      )
+    }
+
+    getBidi (argument, ...more) {
+      return this.makeBidiStreamRequest(
+        '/test.TestService/getBidi',
+        serialize,
+        deserialize,
+        argument,
+        ...more
+      )
+    }
+
+    getClientStream (argument, ...more) {
+      return this.makeClientStreamRequest(
+        '/test.TestService/getClientStream',
+        serialize,
+        deserialize,
+        argument,
+        ...more
+      )
+    }
+
+    getServerStream (argument, ...more) {
+      return this.makeServerStreamRequest(
+        '/test.TestService/getServerStream',
+        serialize,
+        deserialize,
+        argument,
+        ...more
+      )
+    }
+  }
+
+  TestService.service = {
+    getUnary: {
+      path: '/test.TestService/getUnary',
+      requestStream: false,
+      responseStream: false,
+      requestSerialize: serialize,
+      responseSerialize: serialize,
+      requestDeserialize: deserialize,
+      responseDeserialize: deserialize
+    },
+
+    getBidi: {
+      path: '/test.TestService/getBidi',
+      requestStream: true,
+      responseStream: true,
+      requestSerialize: serialize,
+      responseSerialize: serialize,
+      requestDeserialize: deserialize,
+      responseDeserialize: deserialize
+    },
+
+    getClientStream: {
+      path: '/test.TestService/getClientStream',
+      requestStream: true,
+      responseStream: false,
+      requestSerialize: serialize,
+      responseSerialize: serialize,
+      requestDeserialize: deserialize,
+      responseDeserialize: deserialize
+    },
+
+    getServerStream: {
+      path: '/test.TestService/getServerStream',
+      requestStream: false,
+      responseStream: true,
+      requestSerialize: serialize,
+      responseSerialize: serialize,
+      requestDeserialize: deserialize,
+      responseDeserialize: deserialize
+    }
+  }
+
+  return TestService
+}

--- a/packages/datadog-plugin-grpc/test/test.proto
+++ b/packages/datadog-plugin-grpc/test/test.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package test;
 
 service TestService {
-  rpc get_Bidi (stream Request) returns (stream Response) {} // test rename support
+  rpc getBidi (stream Request) returns (stream Response) {} // test rename support
   rpc getServerStream (Request) returns (stream Response) {}
   rpc getClientStream (stream Request) returns (Response) {}
   rpc getUnary (Request) returns (Response) {}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for grpc custom client instances.

### Motivation
<!-- What inspired you to submit this pull request? -->

With the current implementation, only clients created using a Protobuf package definition are instrumented. With this change, clients instantiated directly using the `Client` class will also be instrumented. This is useful when implementing clients that are not using Protobuf and instead rely for example on JSON.

Fixes #1376