### PR TITLE
fix error when the execution async resource is undefined

### DIFF
--- a/packages/dd-trace/src/scope/async_resource.js
+++ b/packages/dd-trace/src/scope/async_resource.js
@@ -37,15 +37,19 @@ class Scope extends Base {
   _active () {
     if (!this._enabled) return null
 
-    const resource = executionAsyncResource()
+    const resource = this._activeResource()
 
     return resource[this._ddResourceStore] || null
+  }
+
+  _activeResource () {
+    return executionAsyncResource() || {}
   }
 
   _activate (span, callback) {
     if (!this._enabled) return callback()
 
-    const resource = executionAsyncResource()
+    const resource = this._activeResource()
 
     this._enter(span, resource)
 
@@ -66,7 +70,7 @@ class Scope extends Base {
   }
 
   _init (asyncId, type, triggerAsyncId, resource) {
-    const triggerResource = executionAsyncResource()
+    const triggerResource = this._activeResource()
     const span = triggerResource[this._ddResourceStore]
 
     if (span) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix error when the execution async resource is undefined.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was reported in #1384. Meteor use of fibers means the application will still be unstable, but at least with this change dd-trace will not be the cause of any crash. There are no tests for this since it's impossible that it happens when not using fibers.