### PR TITLE
[ci-app] Remove `ci.job.id` from CircleCI Env Var Extraction

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -12,7 +12,6 @@ const GIT_REPOSITORY_URL = 'git.repository_url'
 const CI_JOB_URL = 'ci.job.url'
 const CI_JOB_NAME = 'ci.job.name'
 const CI_STAGE_NAME = 'ci.stage.name'
-const CI_JOB_ID = 'ci.job.id'
 
 function removeEmptyValues (tags) {
   return Object.keys(tags).reduce((filteredTags, tag) => {
@@ -154,7 +153,6 @@ module.exports = {
       const {
         CIRCLE_WORKFLOW_ID,
         CIRCLE_PROJECT_REPONAME,
-        CIRCLE_BUILD_NUM,
         CIRCLE_BUILD_URL,
         CIRCLE_WORKING_DIRECTORY,
         CIRCLE_BRANCH,
@@ -171,7 +169,6 @@ module.exports = {
         [CI_PIPELINE_NAME]: CIRCLE_PROJECT_REPONAME,
         [CI_PIPELINE_URL]: pipelineUrl,
         [CI_JOB_NAME]: CIRCLE_JOB,
-        [CI_JOB_ID]: CIRCLE_BUILD_NUM,
         [CI_PROVIDER_NAME]: 'circleci',
         [GIT_COMMIT_SHA]: CIRCLE_SHA1,
         [GIT_REPOSITORY_URL]: CIRCLE_REPOSITORY_URL,

--- a/packages/dd-trace/test/plugins/util/ci-env/circleci.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/circleci.json
@@ -13,7 +13,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -40,7 +39,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -67,7 +65,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -94,7 +91,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -121,7 +117,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -148,7 +143,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -175,7 +169,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -204,7 +197,6 @@
       "USERPROFILE": "/not-my-home"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -233,7 +225,6 @@
       "USERPROFILE": "/not-my-home"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -262,7 +253,6 @@
       "USERPROFILE": "/not-my-home"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -289,7 +279,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -316,7 +305,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -344,7 +332,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -372,7 +359,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -399,7 +385,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -426,7 +411,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -453,7 +437,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -480,7 +463,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -507,7 +489,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -534,7 +515,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -561,7 +541,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",


### PR DESCRIPTION
### What does this PR do?
In https://github.com/DataDog/dd-trace-js/pull/1378 I added `ci.job.id`, but we didn't want it: it is only available in CircleCI and we are not using it anywhere, so it makes no sense to keep it. 

### Motivation
Keep up to date to datadog ci app spec.

