### PR TITLE
[ci-app] JUnit XML Upload – Fix `DD_ENV` to `CI`

### DIFF
--- a/scripts/junit_report.js
+++ b/scripts/junit_report.js
@@ -16,7 +16,7 @@ function uploadJUnitXMLReport () {
   execSync('yarn global add @datadog/datadog-ci@0.13.1', { stdio: 'inherit' })
   // we execute the upload command
   execSync(
-    `DD_ENV=test-env datadog-ci junit upload \
+    `DD_ENV=CI datadog-ci junit upload \
     --tags runtime.version:${process.version} \
     --service dd-trace-js-core-tests \
     ./core-test-results/mocha/test-results.xml`,

--- a/scripts/junit_report.js
+++ b/scripts/junit_report.js
@@ -16,7 +16,7 @@ function uploadJUnitXMLReport () {
   execSync('yarn global add @datadog/datadog-ci@0.13.1', { stdio: 'inherit' })
   // we execute the upload command
   execSync(
-    `datadog-ci junit upload \
+    `DD_ENV=test-env datadog-ci junit upload \
     --tags runtime.version:${process.version} \
     --service dd-trace-js-core-tests \
     ./core-test-results/mocha/test-results.xml`,


### PR DESCRIPTION
### What does this PR do?
* Fix `DD_ENV` to `CI` in JUnit XML Upload.

### Motivation
Make sure reported env is consistent.
