### PR TITLE
[ci-app] Add `_dd.origin` to CI App Spec

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci-app-spec.json
+++ b/packages/dd-trace/src/plugins/util/ci-app-spec.json
@@ -29,5 +29,6 @@
   "os.architecture",
   "runtime.name",
   "runtime.version",
-  "test.parameters"
+  "test.parameters",
+  "_dd.origin"
 ]


### PR DESCRIPTION
### What does this PR do?
Add `_dd.origin` to CI App Spec.

### Motivation
Keep feature tracking up to date.

