### PR TITLE
[ci-app] Fix `DD_ENV` in JUnit XML Upload

### DIFF
--- a/scripts/junit_report.js
+++ b/scripts/junit_report.js
@@ -16,7 +16,7 @@ function uploadJUnitXMLReport () {
   execSync('yarn global add @datadog/datadog-ci@0.13.1', { stdio: 'inherit' })
   // we execute the upload command
   execSync(
-    `DD_ENV=CI datadog-ci junit upload \
+    `DD_ENV=ci datadog-ci junit upload \
     --tags runtime.version:${process.version} \
     --service dd-trace-js-core-tests \
     ./core-test-results/mocha/test-results.xml`,


### PR DESCRIPTION
### What does this PR do?
Change the reported env from `CI` to `ci`.

### Motivation

I was under the impression the env was case insensitive but it isn't. We want to group this test service together with other test services reporting `env:ci`

