### PR TITLE
[ci-app] JUnit XML Upload – Bump `datadog-ci` version.

### DIFF
--- a/scripts/junit_report.js
+++ b/scripts/junit_report.js
@@ -13,7 +13,7 @@ function uploadJUnitXMLReport () {
     return
   }
   // we install @datadog/datadog-ci
-  execSync('yarn global add @datadog/datadog-ci@0.13.1', { stdio: 'inherit' })
+  execSync('yarn global add @datadog/datadog-ci@0.13.2', { stdio: 'inherit' })
   // we execute the upload command
   execSync(
     `DD_ENV=ci datadog-ci junit upload \


### PR DESCRIPTION
### What does this PR do?
* Bump version to install to `0.13.2`, that includes fix for CircleCI: https://github.com/DataDog/datadog-ci/releases/tag/v0.13.2.

### Motivation
* Report `ci.pipeline.url` correctly. 

