### PR TITLE
Fix profiler config propagation

### DIFF
--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const log = require('./log')
-const { profiler, AgentExporter, FileExporter } = require('./profiling')
+const { profiler } = require('./profiling')
 
 module.exports = {
   start: config => {
-    const { service, version, env } = config
+    const { service, version, env, url, hostname, port } = config
     const { enabled, sourceMap, exporters } = config.profiling
     const logger = {
       debug: (message) => log.debug(message),
@@ -21,28 +21,14 @@ module.exports = {
       env,
       logger,
       sourceMap,
-      exporters: getExporters(exporters, config)
+      exporters,
+      url,
+      hostname,
+      port
     })
   },
 
   stop: () => {
     profiler.stop()
   }
-}
-
-function getExporters (names, { url, hostname, port }) {
-  const exporters = []
-
-  for (const name of names.split(',')) {
-    switch (name) {
-      case 'agent':
-        exporters.push(new AgentExporter({ url, hostname, port }))
-        break
-      case 'file':
-        exporters.push(new FileExporter())
-        break
-    }
-  }
-
-  return exporters
 }

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -2,7 +2,9 @@
 
 const coalesce = require('koalas')
 const os = require('os')
+const { URL } = require('url')
 const { AgentExporter } = require('./exporters/agent')
+const { FileExporter } = require('./exporters/file')
 const { InspectorCpuProfiler } = require('./profilers/inspector/cpu')
 const { InspectorHeapProfiler } = require('./profilers/inspector/heap')
 const { ConsoleLogger } = require('./loggers/console')
@@ -13,7 +15,10 @@ const {
   DD_ENV,
   DD_TAGS,
   DD_SERVICE,
-  DD_VERSION
+  DD_VERSION,
+  DD_TRACE_AGENT_URL,
+  DD_AGENT_HOST,
+  DD_TRACE_AGENT_PORT
 } = process.env
 
 class Config {
@@ -29,17 +34,25 @@ class Config {
     this.service = service
     this.env = env
     this.host = host
+
     this.version = version
     this.tags = Object.assign(
       tagger.parse(DD_TAGS),
       tagger.parse(options.tags),
       tagger.parse({ env, host, service, version })
     )
-    this.logger = options.logger || new ConsoleLogger()
+    this.logger = ensureLogger(options.logger)
     this.flushInterval = flushInterval
-    this.exporters = options.exporters || [
-      new AgentExporter()
-    ]
+
+    const hostname = coalesce(options.hostname, DD_AGENT_HOST, 'localhost')
+    const port = coalesce(options.port, DD_TRACE_AGENT_PORT, 8126)
+    const url = new URL(coalesce(options.url, DD_TRACE_AGENT_URL,
+      `http://${hostname || 'localhost'}:${port || 8126}`))
+
+    this.exporters = ensureExporters(options.exporters || [
+      new AgentExporter({ url })
+    ], options)
+
     this.profilers = options.profilers || [
       new InspectorCpuProfiler(),
       new InspectorHeapProfiler()
@@ -48,3 +61,39 @@ class Config {
 }
 
 module.exports = { Config }
+
+function getExporter (name, options) {
+  switch (name) {
+    case 'agent':
+      return new AgentExporter(options)
+    case 'file':
+      return new FileExporter(options)
+  }
+}
+
+function ensureExporters (exporters, options) {
+  if (typeof exporters === 'string') {
+    exporters = exporters.split(',')
+  }
+
+  for (let i = 0; i < exporters.length; i++) {
+    const exporter = exporters[i]
+    if (typeof exporter === 'string') {
+      exporters[i] = getExporter(exporter, options)
+    }
+  }
+
+  return exporters
+}
+
+function ensureLogger (logger) {
+  if (typeof logger !== 'object' ||
+    typeof logger.debug !== 'function' ||
+    typeof logger.info !== 'function' ||
+    typeof logger.warn !== 'function' ||
+    typeof logger.error !== 'function') {
+    return new ConsoleLogger()
+  }
+
+  return logger
+}

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -6,8 +6,8 @@ const { Encoder } = require('../encoders/pprof')
 const { eachOfSeries } = require('../util')
 
 class AgentExporter {
-  constructor ({ url, hostname, port } = {}) {
-    this._url = new URL(url || `http://${hostname || 'localhost'}:${port || 8126}`)
+  constructor ({ url } = {}) {
+    this._url = typeof url === 'string' ? new URL(url) : url
     this._encoder = new Encoder()
   }
 

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -39,14 +39,34 @@ describe('config', () => {
       enabled: false,
       service: 'test',
       version: '1.2.3-test.0',
-      logger: 'logger',
-      exporters: ['exporter'],
-      profilers: ['profiler']
+      logger: {
+        debug () {},
+        info () {},
+        warn () {},
+        error () {}
+      },
+      exporters: ['agent'],
+      profilers: [new InspectorCpuProfiler()],
+      url: 'http://localhost:1234/'
     }
 
     const config = new Config(options)
 
-    expect(config).to.deep.include(options)
+    expect(config.enabled).to.equal(options.enabled)
+    expect(config.service).to.equal(options.service)
+    expect(config.host).to.be.a('string')
+    expect(config.version).to.equal(options.version)
+    expect(config.tags).to.be.an('object')
+    expect(config.tags.host).to.be.a('string')
+    expect(config.tags.service).to.equal(options.service)
+    expect(config.tags.version).to.equal(options.version)
+    expect(config.flushInterval).to.equal(60 * 1000)
+    expect(config.exporters).to.be.an('array')
+    expect(config.exporters.length).to.equal(1)
+    expect(config.exporters[0]._url.toString()).to.equal(options.url)
+    expect(config.profilers).to.be.an('array')
+    expect(config.profilers.length).to.equal(1)
+    expect(config.profilers[0]).to.be.an.instanceOf(InspectorCpuProfiler)
   })
 
   it('should support tags', () => {

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -30,6 +30,9 @@ describe('profiler', () => {
       export: sinon.stub().yields()
     }
     consoleLogger = {
+      debug: sinon.spy(),
+      info: sinon.spy(),
+      warn: sinon.spy(),
       error: sinon.spy()
     }
 


### PR DESCRIPTION
The profiler configs are not currently propagated correctly, so it's impossible to use a non-localhost agent. This fixes that and better encapsulates config handling within the profiler rather than in tracer code.