### PR TITLE
[ci-app] Jest – Fix Instrumentation Snapshot Errors

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -10,7 +10,6 @@ const {
   TEST_SUITE,
   TEST_STATUS,
   ERROR_MESSAGE,
-  ERROR_STACK,
   ERROR_TYPE,
   TEST_PARAMETERS,
   CI_APP_ORIGIN,
@@ -154,10 +153,7 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
             suppressedErrors = context.expect.getState().suppressedErrors
           }
           if (suppressedErrors && suppressedErrors.length) {
-            const testError = suppressedErrors[0]
-            testSpan.setTag(ERROR_TYPE, testError.constructor ? testError.constructor.name : 'Error')
-            testSpan.setTag(ERROR_MESSAGE, testError.message)
-            testSpan.setTag(ERROR_STACK, testError.stack)
+            testSpan.setTag('error', suppressedErrors[0])
             testSpan.setTag(TEST_STATUS, 'fail')
           }
           if (!testSpan._spanContext._tags[TEST_STATUS]) {
@@ -165,9 +161,7 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
           }
         } catch (error) {
           testSpan.setTag(TEST_STATUS, 'fail')
-          testSpan.setTag(ERROR_TYPE, error.constructor ? error.constructor.name : error.name)
-          testSpan.setTag(ERROR_MESSAGE, error.message)
-          testSpan.setTag(ERROR_STACK, error.stack)
+          testSpan.setTag('error', error)
           throw error
         } finally {
           testSpan.context()._trace.started.forEach((span) => {

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -440,21 +440,18 @@ describe('Plugin', () => {
         datadogJestEnv.handleTestEvent(testStartEvent)
         testStartEvent.test.fn()
 
-        const agentPromises = [
-          agent.use(trace => {
-            expect(trace[0][0].meta).to.contain({
-              [TEST_STATUS]: 'fail',
-              [ERROR_TYPE]: 'Timeout',
-              [ERROR_MESSAGE]: 'Exceeded timeout of 100ms'
-            })
-          }),
-          agent.use(trace => {
-            expect(trace[0][0].meta).to.contain({
-              [TEST_STATUS]: 'pass'
-            })
+        agent.use(trace => {
+          const failedTest = trace[0].find(span => span.meta[TEST_STATUS] === 'fail')
+          const passedTest = trace[0].find(span => span.meta[TEST_STATUS] === 'pass')
+          expect(failedTest.meta).to.contain({
+            [TEST_STATUS]: 'fail',
+            [ERROR_TYPE]: 'Timeout',
+            [ERROR_MESSAGE]: 'Exceeded timeout of 100ms'
           })
-        ]
-        Promise.all(agentPromises).then(() => done()).catch(done)
+          expect(passedTest.meta).to.contain({
+            [TEST_STATUS]: 'pass'
+          })
+        }).then(() => done()).catch(done)
       })
 
       it('should not consider other errors as timeout', (done) => {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -10,9 +10,6 @@ const {
   TEST_SUITE,
   TEST_STATUS,
   TEST_PARAMETERS,
-  ERROR_MESSAGE,
-  ERROR_STACK,
-  ERROR_TYPE,
   CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
   getTestParametersString
@@ -83,9 +80,7 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
             }
           } catch (error) {
             activeSpan.setTag(TEST_STATUS, 'fail')
-            activeSpan.setTag(ERROR_TYPE, error.constructor ? error.constructor.name : error.name)
-            activeSpan.setTag(ERROR_MESSAGE, error.message)
-            activeSpan.setTag(ERROR_STACK, error.stack)
+            activeSpan.setTag('error', error)
             throw error
           } finally {
             activeSpan

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -4,6 +4,7 @@ const constants = require('./constants')
 const tags = require('../../../ext/tags')
 const log = require('./log')
 const id = require('./id')
+const { isError } = require('./util')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
 const ANALYTICS_KEY = constants.ANALYTICS_KEY
@@ -118,9 +119,7 @@ function extractRootTags (trace, span) {
 
 function extractError (trace, span) {
   const error = span.context()._tags['error']
-
-  // JestAssertionErrors are not instance of Error, so we need this extra check
-  if (error instanceof Error || (error && error.constructor && error.constructor.name === 'JestAssertionError')) {
+  if (isError(error)) {
     addTag(trace.meta, trace.metrics, 'error.msg', error.message)
     addTag(trace.meta, trace.metrics, 'error.type', error.name)
     addTag(trace.meta, trace.metrics, 'error.stack', error.stack)

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -119,7 +119,8 @@ function extractRootTags (trace, span) {
 function extractError (trace, span) {
   const error = span.context()._tags['error']
 
-  if (error instanceof Error) {
+  // JestAssertionErrors are not instance of Error, so we need this extra check
+  if (error instanceof Error || (error && error.constructor && error.constructor.name === 'JestAssertionError')) {
     addTag(trace.meta, trace.metrics, 'error.msg', error.message)
     addTag(trace.meta, trace.metrics, 'error.type', error.name)
     addTag(trace.meta, trace.metrics, 'error.stack', error.stack)

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -10,7 +10,7 @@ const TEST_STATUS = 'test.status'
 const TEST_PARAMETERS = 'test.parameters'
 
 const ERROR_TYPE = 'error.type'
-const ERROR_MESSAGE = 'error.message'
+const ERROR_MESSAGE = 'error.msg'
 const ERROR_STACK = 'error.stack'
 
 const CI_APP_ORIGIN = 'ciapp-test'

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -69,10 +69,9 @@ function getTestParametersString (parametersByTestName, testName) {
 }
 
 function finishAllTraceSpans (span) {
-  const spansToFinish = span.context()._trace.started.filter(traceSpan =>
-    !traceSpan.context()._isFinished && span !== traceSpan
-  )
-  spansToFinish.forEach(span => {
-    span.finish()
+  span.context()._trace.started.forEach(traceSpan => {
+    if (traceSpan !== span) {
+      traceSpan.finish()
+    }
   })
 }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -69,7 +69,10 @@ function getTestParametersString (parametersByTestName, testName) {
 }
 
 function finishAllTraceSpans (span) {
-  span.context()._trace.started.forEach((span) => {
+  const spansToFinish = span.context()._trace.started.filter(traceSpan =>
+    !traceSpan.context()._isFinished && span !== traceSpan
+  )
+  spansToFinish.forEach(span => {
     span.finish()
   })
 }

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -4,6 +4,7 @@ const Tracer = require('./opentracing/tracer')
 const tags = require('../../../ext/tags')
 const scopes = require('../../../ext/scopes')
 const getScope = require('./scope')
+const { isError } = require('./util')
 const { setStartupLogConfig } = require('./startup-log')
 
 const SPAN_TYPE = tags.SPAN_TYPE
@@ -128,7 +129,7 @@ class DatadogTracer extends Tracer {
 }
 
 function addError (span, error) {
-  if (error && error instanceof Error) {
+  if (isError(error)) {
     span.addTags({
       'error.type': error.name,
       'error.msg': error.message,

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -10,16 +10,14 @@ function isFalse (str) {
   return str === 'false' || str === '0'
 }
 
-// from https://github.com/facebook/jest/blob/d1882f2e6033186bd310240add41ffe50c2a9259/packages/expect/src/utils.ts#L350
 function isError (value) {
-  switch (Object.prototype.toString.call(value)) {
-    case '[object Error]':
-    case '[object Exception]':
-    case '[object DOMException]':
-      return true
-    default:
-      return value instanceof Error
+  if (value instanceof Error) {
+    return true
   }
+  if (value && value.constructor) {
+    return value.constructor.name === 'JestAssertionError' || value.constructor.name === 'Error'
+  }
+  return false
 }
 
 module.exports = {

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -10,7 +10,20 @@ function isFalse (str) {
   return str === 'false' || str === '0'
 }
 
+// from https://github.com/facebook/jest/blob/d1882f2e6033186bd310240add41ffe50c2a9259/packages/expect/src/utils.ts#L350
+function isError (value) {
+  switch (Object.prototype.toString.call(value)) {
+    case '[object Error]':
+    case '[object Exception]':
+    case '[object DOMException]':
+      return true
+    default:
+      return value instanceof Error
+  }
+}
+
 module.exports = {
   isTrue,
-  isFalse
+  isFalse,
+  isError
 }


### PR DESCRIPTION
### What does this PR do?
* Reads `snapshotState` before setting `test.status` and sets it to `fail` if there is an error.

### Motivation
Snapshot errors in jest do not throw, so we have to read the state manually and update the test span if there has been one.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
