### PR TITLE
[ci-app] Add HTTP Integrations Tests to Testing Frameworks Instrumentations

### DIFF
--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -52,6 +52,10 @@ function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot) {
           const promise = run.apply(this, arguments)
           promise.then(() => {
             setStatusFromResult(testSpan, this.getWorstStepResult(), TEST_STATUS)
+          }).finally(() => {
+            testSpan.context()._trace.started.forEach((span) => {
+              span.finish()
+            })
           })
           return promise
         }

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -8,7 +8,8 @@ const {
   TEST_SUITE,
   TEST_STATUS,
   CI_APP_ORIGIN,
-  getTestEnvironmentMetadata
+  getTestEnvironmentMetadata,
+  finishAllTraceSpans
 } = require('../../dd-trace/src/plugins/util/test')
 
 function setStatusFromResult (span, result, tag) {
@@ -53,9 +54,7 @@ function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot) {
           promise.then(() => {
             setStatusFromResult(testSpan, this.getWorstStepResult(), TEST_STATUS)
           }).finally(() => {
-            testSpan.context()._trace.started.forEach((span) => {
-              span.finish()
-            })
+            finishAllTraceSpans(testSpan)
           })
           return promise
         }

--- a/packages/datadog-plugin-cucumber/test/features/simple.feature
+++ b/packages/datadog-plugin-cucumber/test/features/simple.feature
@@ -18,3 +18,8 @@ Feature: Datadog integration
   @skip
   Scenario: skip scenario based on tag
     Given datadog
+
+  Scenario: integration scenario
+    Given datadog
+    When integration
+    Then pass

--- a/packages/datadog-plugin-cucumber/test/features/simple.js
+++ b/packages/datadog-plugin-cucumber/test/features/simple.js
@@ -21,6 +21,15 @@ Given('datadog', function () {
 
 When('run', () => {})
 
+When('integration', function () {
+  const http = require('http')
+  return new Promise(resolve => {
+    http.request('http://test:123', () => {
+      resolve()
+    }).end()
+  })
+})
+
 Then('pass', function () {
   expect(this.datadog).to.eql('datadog')
 })

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -148,7 +148,6 @@ describe('Plugin', () => {
 
         describe(`for ${featureName}${featureLineNumber}`, () => {
           it('should create a test span and spans for integrations', async function () {
-            this.timeout(200000)
             const checkTraces = agent.use(traces => {
               expect(traces.length).to.equal(1)
               const testTrace = traces[0]

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -131,7 +131,6 @@ describe('Plugin', () => {
     })
 
     describe('cucumber', () => {
-
       TESTS.forEach(test => {
         const testFilePath = path.join(__dirname, 'features', test.featureName)
         const testSuite = testFilePath.replace(`${process.cwd()}/`, '')

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -15,7 +15,8 @@ const {
   TEST_PARAMETERS,
   CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
-  getTestParametersString
+  getTestParametersString,
+  finishAllTraceSpans
 } = require('../../dd-trace/src/plugins/util/test')
 const { getFormattedJestTestParameters } = require('./util')
 
@@ -158,9 +159,7 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
           testSpan.setTag(ERROR_STACK, error.stack)
           throw error
         } finally {
-          testSpan.context()._trace.started.forEach((span) => {
-            span.finish()
-          })
+          finishAllTraceSpans(testSpan)
         }
         return result
       }

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -1,5 +1,4 @@
 'use strict'
-const { expect } = require('chai')
 const nock = require('nock')
 
 const { ORIGIN_KEY } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 const { expect } = require('chai')
+const nock = require('nock')
 
 const { ORIGIN_KEY } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -30,8 +31,13 @@ describe('Plugin', () => {
       return agent.close()
     })
     beforeEach(() => {
+      // for http integration tests
+      nock('http://test:123')
+        .get('/')
+        .reply(200, 'OK')
+
       tracer = require('../../dd-trace')
-      return agent.load(['jest', 'fs']).then(() => {
+      return agent.load(['jest', 'fs', 'http']).then(() => {
         DatadogJestEnvironment = require(`../../../versions/${moduleName}@${version}`).get()
         datadogJestEnv = new DatadogJestEnvironment({ rootDir: BUILD_SOURCE_ROOT }, { testPath: TEST_SUITE })
         // TODO: avoid mocking expect once we instrument the runner instead of the environment
@@ -183,6 +189,7 @@ describe('Plugin', () => {
 
       it('should call wrap on test_start event', () => {
         if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+        const originalWrap = tracer._tracer.wrap
         tracer._tracer.wrap = sinon.spy(() => {})
 
         const testEvent = {
@@ -198,10 +205,12 @@ describe('Plugin', () => {
         }
         datadogJestEnv.handleTestEvent(testEvent)
         expect(tracer._tracer.wrap).to.have.been.called
+        tracer._tracer.wrap = originalWrap
       })
 
       it('should not call wrap on events other than test_start or test_skip', () => {
         if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+        const originalWrap = tracer._tracer.wrap
         tracer._tracer.wrap = sinon.spy(() => {})
 
         const testFnStartEvent = {
@@ -209,6 +218,7 @@ describe('Plugin', () => {
         }
         datadogJestEnv.handleTestEvent(testFnStartEvent)
         expect(tracer._tracer.wrap).not.to.have.been.called
+        tracer._tracer.wrap = originalWrap
       })
 
       it('should call startSpan and span finish on skipped tests', () => {
@@ -443,6 +453,34 @@ describe('Plugin', () => {
             fn: () => {
               const fs = require('fs')
               fs.readFileSync('./package.json')
+            },
+            name: TEST_NAME
+          }
+        }
+
+        datadogJestEnv.handleTestEvent(passingTestEvent)
+        passingTestEvent.test.fn()
+      })
+
+      it('works with http integration', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        agent
+          .use(trace => {
+            const testSpan = trace[0].find(span => span.type === 'test')
+            const httpSpan = trace[0].find(span => span.name === 'http.request')
+            expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+          }).then(done).catch(done)
+
+        const passingTestEvent = {
+          name: 'test_start',
+          test: {
+            fn: () => {
+              const http = require('http')
+              http.request('http://test:123')
             },
             name: TEST_NAME
           }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -15,7 +15,8 @@ const {
   ERROR_TYPE,
   CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
-  getTestParametersString
+  getTestParametersString,
+  finishAllTraceSpans
 } = require('../../dd-trace/src/plugins/util/test')
 
 function getTestSpanMetadata (tracer, test, sourceRoot) {
@@ -88,11 +89,7 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
             activeSpan.setTag(ERROR_STACK, error.stack)
             throw error
           } finally {
-            activeSpan
-              .context()
-              ._trace.started.forEach((span) => {
-                span.finish()
-              })
+            finishAllTraceSpans(activeSpan)
           }
           return result
         }

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const path = require('path')
+
+const nock = require('nock')
+
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ORIGIN_KEY } = require('../../dd-trace/src/constants')
 const plugin = require('../src')
@@ -15,8 +19,6 @@ const {
   ERROR_STACK,
   CI_APP_ORIGIN
 } = require('../../dd-trace/src/plugins/util/test')
-const { expect } = require('chai')
-const path = require('path')
 
 const TESTS = [
   {
@@ -48,12 +50,6 @@ const TESTS = [
     fileName: 'mocha-test-done-pass.js',
     testName: 'can do passed tests with done',
     root: 'mocha-test-done-pass',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-integration.js',
-    testName: 'can do integration tests',
-    root: 'mocha-test-integration',
     status: 'pass'
   },
   {
@@ -106,6 +102,18 @@ const TESTS = [
     extraSpanTags: {
       [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
     }
+  },
+  {
+    fileName: 'mocha-test-integration.js',
+    testName: 'can do integration tests',
+    root: 'mocha-test-integration',
+    status: 'pass'
+  },
+  {
+    fileName: 'mocha-test-integration-http.js',
+    testName: 'can do integration http',
+    root: 'mocha-test-integration-http',
+    status: 'pass'
   }
 ]
 
@@ -123,11 +131,15 @@ describe('Plugin', () => {
       return agent.close()
     })
     beforeEach(() => {
-      return agent.load(['mocha', 'fs']).then(() => {
+      // for http integration tests
+      nock('http://test:123')
+        .get('/')
+        .reply(200, 'OK')
+
+      return agent.load(['mocha', 'fs', 'http']).then(() => {
         Mocha = require(`../../../versions/mocha@${version}`).get()
       })
     })
-
     describe('mocha', () => {
       TESTS.forEach(test => {
         it(`should create a test span for ${test.fileName}`, (done) => {
@@ -158,6 +170,23 @@ describe('Plugin', () => {
               expect(testSpan.meta[TEST_NAME]).to.equal('mocha-test-integration can do integration tests')
               expect(fsOperationSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
               expect(fsOperationSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            }).then(done, done)
+          } else if (test.fileName === 'mocha-test-integration-http.js') {
+            agent.use(trace => {
+              const httpSpan = trace[0].find(span => span.type === 'http')
+              const testSpan = trace[0].find(span => span.type === 'test')
+              expect(testSpan.parent_id.toString()).to.equal('0')
+              expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              expect(testSpan.meta).to.contain({
+                language: 'javascript',
+                service: 'test',
+                [TEST_NAME]: `${test.root} ${test.testName}`,
+                [TEST_STATUS]: test.status,
+                [TEST_FRAMEWORK]: 'mocha',
+                [TEST_SUITE]: testSuite
+              })
             }).then(done, done)
           } else {
             agent

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -173,11 +173,12 @@ describe('Plugin', () => {
             }).then(done, done)
           } else if (test.fileName === 'mocha-test-integration-http.js') {
             agent.use(trace => {
-              const httpSpan = trace[0].find(span => span.type === 'http')
+              const httpSpan = trace[0].find(span => span.name === 'http.request')
               const testSpan = trace[0].find(span => span.type === 'test')
               expect(testSpan.parent_id.toString()).to.equal('0')
               expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
               expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
               expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
               expect(testSpan.meta).to.contain({
                 language: 'javascript',

--- a/packages/datadog-plugin-mocha/test/mocha-test-integration-http.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-integration-http.js
@@ -1,0 +1,11 @@
+const http = require('http')
+
+describe('mocha-test-integration-http', () => {
+  it('can do integration http', (done) => {
+    const req = http.request('http://test:123', (res) => {
+      expect(res.statusCode).to.equal(200)
+      done()
+    })
+    req.end()
+  })
+})

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -27,7 +27,8 @@ module.exports = {
   ERROR_STACK,
   CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
-  getTestParametersString
+  getTestParametersString,
+  finishAllTraceSpans
 }
 
 function getTestEnvironmentMetadata (testFramework) {
@@ -65,4 +66,10 @@ function getTestParametersString (parametersByTestName, testName) {
     // so we ignore the test parameters and move on
     return ''
   }
+}
+
+function finishAllTraceSpans (span) {
+  span.context()._trace.started.forEach((span) => {
+    span.finish()
+  })
 }


### PR DESCRIPTION
### What does this PR do?
* Add `http` integration tests to `mocha`, `jest` and `cucumber`

### Motivation
* Improve confidence, as part of the production readiness efforts. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
