### PR TITLE
[ci-app] Add Database Integration Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -849,7 +849,12 @@ jobs:
     docker:
       - image: node
         environment:
+          - SERVICES=postgres
           - PLUGINS=mocha|pg
+          - image: node:8
+      - image: postgres:9.5
+        environment:
+          - POSTGRES_PASSWORD=postgres
 
   node-tedious:
     <<: *node-plugin-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -792,7 +792,12 @@ jobs:
     docker:
       - image: node:10
         environment:
+          - SERVICES=postgres
           - PLUGINS=jest
+          - TEST_DEPENDENCIES=pg
+      - image: postgres:9.5
+        environment:
+          - POSTGRES_PASSWORD=postgres
 
   node-knex:
     <<: *node-plugin-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,6 +851,7 @@ jobs:
         environment:
           - SERVICES=postgres
           - PLUGINS=mocha
+          - INTEGRATIONS=pg
           - image: node:8
       - image: postgres:9.5
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -850,7 +850,7 @@ jobs:
       - image: node
         environment:
           - SERVICES=postgres
-          - PLUGINS=mocha|pg
+          - PLUGINS=mocha
           - image: node:8
       - image: postgres:9.5
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -620,7 +620,12 @@ jobs:
     docker:
       - image: node:10
         environment:
+          - SERVICES=postgres
           - PLUGINS=cucumber
+          - TEST_DEPENDENCIES=pg
+      - image: postgres:9.5
+        environment:
+          - POSTGRES_PASSWORD=postgres
 
   node-couchbase:
     <<: *node-plugin-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,8 +851,7 @@ jobs:
         environment:
           - SERVICES=postgres
           - PLUGINS=mocha
-          - INTEGRATIONS=pg
-          - image: node:8
+          - TEST_DEPENDENCIES=pg
       - image: postgres:9.5
         environment:
           - POSTGRES_PASSWORD=postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -849,7 +849,7 @@ jobs:
     docker:
       - image: node
         environment:
-          - PLUGINS=mocha
+          - PLUGINS=mocha|pg
 
   node-tedious:
     <<: *node-plugin-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     image: postgres:9.5-alpine
     environment:
       - POSTGRES_PASSWORD=postgres
-      # - POSTGRES_USER=postgres
-      # - POSTGRES_DATABASE=postgres
     ports:
       - "127.0.0.1:5432:5432"
   mssql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     image: postgres:9.5-alpine
     environment:
       - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DATABASE=postgres
     ports:
       - "127.0.0.1:5432:5432"
   mssql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     image: postgres:9.5-alpine
     environment:
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DATABASE=postgres
+      # - POSTGRES_USER=postgres
+      # - POSTGRES_DATABASE=postgres
     ports:
       - "127.0.0.1:5432:5432"
   mssql:

--- a/packages/datadog-plugin-cucumber/test/features/simple.feature
+++ b/packages/datadog-plugin-cucumber/test/features/simple.feature
@@ -23,3 +23,8 @@ Feature: Datadog integration
     Given datadog
     When integration
     Then pass
+
+  Scenario: integration db scenario
+    Given datadog
+    When db
+    Then pass

--- a/packages/datadog-plugin-cucumber/test/features/simple.js
+++ b/packages/datadog-plugin-cucumber/test/features/simple.js
@@ -30,6 +30,18 @@ When('integration', function () {
   })
 })
 
+When('db', () => {
+  const { Client } = require('../../../../versions/pg').get()
+  const client = new Client({
+    user: 'postgres',
+    password: 'postgres',
+    database: 'postgres'
+  })
+  return client.connect().then(() => {
+    return client.query('SELECT $1::text as message', ['Hello world!'])
+  })
+})
+
 Then('pass', function () {
   expect(this.datadog).to.eql('datadog')
 })

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -78,6 +78,7 @@ const TESTS = [
     steps: [
       { name: 'datadog', stepStatus: 'pass' },
       { name: 'integration', stepStatus: 'pass' },
+      { name: 'pass', stepStatus: 'pass' }
     ],
     success: true,
     errors: []

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -472,7 +472,8 @@ describe('Plugin', () => {
             expect(testSpan.parent_id.toString()).to.equal('0')
             expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
           }).then(done).catch(done)
-        const passingTestEvent = {
+
+        const httpTestEvent = {
           name: 'test_start',
           test: {
             fn: () => {
@@ -482,8 +483,8 @@ describe('Plugin', () => {
             name: TEST_NAME
           }
         }
-        datadogJestEnv.handleTestEvent(passingTestEvent)
-        passingTestEvent.test.fn()
+        datadogJestEnv.handleTestEvent(httpTestEvent)
+        httpTestEvent.test.fn()
       })
 
       it('works with database integration', (done) => {
@@ -501,7 +502,7 @@ describe('Plugin', () => {
             expect(databaseSpan.resource).to.equal('SELECT $1::text as message')
           }).then(done).catch(done)
 
-        const passingTestEvent = {
+        const databaseTestEvent = {
           name: 'test_start',
           test: {
             fn: async () => {
@@ -518,8 +519,8 @@ describe('Plugin', () => {
           }
         }
 
-        datadogJestEnv.handleTestEvent(passingTestEvent)
-        passingTestEvent.test.fn()
+        datadogJestEnv.handleTestEvent(databaseTestEvent)
+        databaseTestEvent.test.fn()
       })
 
       // TODO: allow the plugin consumer to define their own jest's `testEnvironment`

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -200,11 +200,9 @@ describe('Plugin', () => {
               const testSpan = trace[0].find(span => span.type === 'test')
               const databaseSpan = trace[0].find(span => span.name === 'pg.query')
 
-              console.log('testSpan.meta', testSpan.meta)
-
               expect(testSpan.parent_id.toString()).to.equal('0')
               expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              // expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
+              expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
               expect(testSpan.meta[TEST_NAME]).to.equal('mocha-test-integration-db can do integration tests with db')
               expect(databaseSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
               expect(databaseSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -200,9 +200,11 @@ describe('Plugin', () => {
               const testSpan = trace[0].find(span => span.type === 'test')
               const databaseSpan = trace[0].find(span => span.name === 'pg.query')
 
+              console.log('testSpan.meta', testSpan.meta)
+
               expect(testSpan.parent_id.toString()).to.equal('0')
               expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
+              // expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
               expect(testSpan.meta[TEST_NAME]).to.equal('mocha-test-integration-db can do integration tests with db')
               expect(databaseSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
               expect(databaseSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)

--- a/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const { Client } = require('../../../versions/pg').get()
+const { Client } = require('../../../versions/pg@>=4').get()
 
 describe('mocha-test-integration-db', () => {
   it('can do integration tests with db', async () => {

--- a/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai')
+const { Client } = require('../../../versions/pg').get()
+
+describe('mocha-test-integration-db', () => {
+  it('can do integration tests with db', async () => {
+    const client = new Client({
+      user: 'postgres',
+      password: 'postgres',
+      database: 'postgres',
+      application_name: 'test'
+    })
+    await client.connect()
+    const res = await client.query('SELECT $1::text as message', ['Hello world!'])
+    expect(res.rows[0]).not.to.equal(null)
+    await client.end()
+  })
+})

--- a/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const { Client } = require('../../../versions/pg@>=4').get()
+const { Client } = require('../../../versions/pg@4.0.0').get()
 
 describe('mocha-test-integration-db', () => {
   it('can do integration tests with db', async () => {

--- a/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-integration-db.js
@@ -1,13 +1,12 @@
 const { expect } = require('chai')
-const { Client } = require('../../../versions/pg@4.0.0').get()
+const { Client } = require('../../../versions/pg').get()
 
 describe('mocha-test-integration-db', () => {
   it('can do integration tests with db', async () => {
     const client = new Client({
       user: 'postgres',
       password: 'postgres',
-      database: 'postgres',
-      application_name: 'test'
+      database: 'postgres'
     })
     await client.connect()
     const res = await client.query('SELECT $1::text as message', ['Hello world!'])

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -28,6 +28,11 @@ function assertVersions () {
     names = names.filter(name => ~filter.indexOf(name))
   }
 
+  if (process.env.hasOwnProperty('INTEGRATIONS')) {
+    const integrations = process.env.INTEGRATIONS.split('|')
+    names = names.concat(integrations)
+  }
+
   const internals = names
     .map(key => plugins[key])
     .reduce((prev, next) => prev.concat(next), [])

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -28,9 +28,9 @@ function assertVersions () {
     names = names.filter(name => ~filter.indexOf(name))
   }
 
-  if (process.env.hasOwnProperty('INTEGRATIONS')) {
-    const integrations = process.env.INTEGRATIONS.split('|')
-    names = names.concat(integrations)
+  if (process.env.hasOwnProperty('TEST_DEPENDENCIES')) {
+    const testDependencies = process.env.TEST_DEPENDENCIES.split('|')
+    names = names.concat(testDependencies)
   }
 
   const internals = names


### PR DESCRIPTION
### What does this PR do?
* Add `pg` integration tests to `mocha`, `jest` and `cucumber`

### Motivation
* Improve confidence on the testing frameworks instrumentation, as part of the production readiness efforts. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
