### PR TITLE
allow subclasses of router

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -50,12 +50,8 @@ function wrapLayerHandle (layer, handle) {
   // that contains the real handle function
   wrapCallHandle._datadog_orig = handle
 
-  // TODO(bengl) copying props like this when wrapping should be done in a centralized place.
-  const props = Object.getOwnPropertyDescriptors(handle)
-  for (const key in props) {
-    if (wrapCallHandle.hasOwnProperty(key)) delete props[key]
-  }
-  Object.defineProperties(wrapCallHandle, props)
+  // TODO(bengl) assigning prototypes like this when wrapping should be done in a centralized place.
+  Object.setPrototypeOf(wrapCallHandle, handle)
 
   return wrapCallHandle
 }

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -54,9 +54,15 @@ describe('Plugin', () => {
           Router = require(`../../../versions/router@${version}`).get()
         })
 
-        it('should expose router handle properties', () => {
+        it('should copy custom prototypes on routers', () => {
           const router = Router()
-          const childRouter = Router()
+          class ChildRouter extends Router {
+            get foo () {
+              return 'bar'
+            }
+          }
+          const childRouter = new ChildRouter()
+          childRouter.hello = 'goodbye'
 
           childRouter.use('/child/:id', (req, res) => {
             res.writeHead(200)
@@ -64,10 +70,8 @@ describe('Plugin', () => {
           })
 
           router.use('/parent', childRouter)
-          expect(router.stack[0].handle.stack.length).to.equal(1)
-          // Next two lines are to test the setter.
-          router.stack[0].handle.stack = 5
-          expect(router.stack[0].handle.stack).to.equal(5)
+          expect(router.stack[0].handle.hello).to.equal('goodbye')
+          expect(router.stack[0].handle.foo).to.equal('bar')
         })
 
         it('should add the route to the request span', done => {


### PR DESCRIPTION
### What does this PR do?
In router plugin, allow subclasses of router to behave as expected in the router stacks.

### Motivation
<!-- What inspired you to submit this pull request? -->
This was breaking Ghost.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js