### PR TITLE
Improve compatibility with ESBuild

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "no-var": 2,
     "no-console": 2,
     "prefer-const": 2,
-    "object-curly-spacing": [2, "always"]
+    "object-curly-spacing": [2, "always"],
+    "import/no-dynamic-require": 2
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,6 @@
     "no-var": 2,
     "no-console": 2,
     "prefer-const": 2,
-    "object-curly-spacing": [2, "always"],
-    "import/no-dynamic-require": 2
+    "object-curly-spacing": [2, "always"]
   }
 }

--- a/packages/datadog-plugin-aws-sdk/src/helpers.js
+++ b/packages/datadog-plugin-aws-sdk/src/helpers.js
@@ -3,18 +3,17 @@
 const Tags = require('opentracing').Tags
 
 const services = {
-  cloudwatchlogs: getService('cloudwatchlogs'),
-  dynamodb: getService('dynamodb'),
-  kinesis: getService('kinesis'),
-  lambda: getService('lambda'),
-  s3: getService('s3'),
-  redshift: getService('redshift'),
-  sns: getService('sns'),
-  sqs: getService('sqs')
-}
+  cloudwatchlogs: getService(require('./services/cloudwatchlogs')),
+  dynamodb: getService(require('./services/dynamodb')),
+  kinesis: getService(require('./services/kinesis')),
+  lambda: getService(require('./services/lambda')),
+  s3: getService(require('./services/s3')),
+  redshift: getService(require('./services/redshift')),
+  sns: getService(require('./services/sns')),
+  sqs: getService(require('./services/sqs')),
+};
 
-function getService (serviceName) {
-  const Service = require(`./services/${serviceName}`)
+function getService(Service) {
   return new Service()
 }
 

--- a/packages/datadog-plugin-aws-sdk/src/helpers.js
+++ b/packages/datadog-plugin-aws-sdk/src/helpers.js
@@ -10,10 +10,10 @@ const services = {
   s3: getService(require('./services/s3')),
   redshift: getService(require('./services/redshift')),
   sns: getService(require('./services/sns')),
-  sqs: getService(require('./services/sqs')),
-};
+  sqs: getService(require('./services/sqs'))
+}
 
-function getService(Service) {
+function getService (Service) {
   return new Service()
 }
 


### PR DESCRIPTION
### What does this PR do?
This makes the dynamic imports in `helpers.js` into static imports

### Motivation
Certain compilers (notably ESBuild) don't support dynamic imports and this really doesn't clean up the code too much (frankly seems a bit strange). This PR improves compatibility with other tooling by declaring the import directly instead of piecing it together with string concatenation

### Plugin Checklist
- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

### Additional Notes
Thanks in advance for your time reviewing this PR :)