### PR TITLE
[ci-app] Fix Timeout Errors in Retried Tests in `jest`

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -26,6 +26,7 @@ function wrapEnvironment (BaseEnvironment) {
       super(config, context)
       this.testSuite = context.testPath.replace(`${config.rootDir}/`, '')
       this.testSpansByTestName = {}
+      this.originalTestFnByTestName = {}
     }
   }
 }
@@ -53,6 +54,15 @@ const isTimeout = (event) => {
 
 function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
   return async function handleTestEventWithTrace (event) {
+    if (event.name === 'test_retry') {
+      const context = this.getVmContext()
+      const { currentTestName } = context.expect.getState()
+      // If it's a retry, we restore the original test function so that it is not wrapped again
+      if (this.originalTestFnByTestName[currentTestName]) {
+        event.test.fn = this.originalTestFnByTestName[currentTestName]
+      }
+      return
+    }
     if (event.name === 'test_fn_failure') {
       if (!isTimeout(event)) {
         return
@@ -60,13 +70,14 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
       const context = this.getVmContext()
       if (context) {
         const { currentTestName } = context.expect.getState()
-        const testSpan = this.testSpansByTestName[currentTestName]
+        const testSpan = this.testSpansByTestName[`${currentTestName}_${event.test.invocations}`]
         if (testSpan) {
           testSpan.setTag(ERROR_TYPE, 'Timeout')
           testSpan.setTag(ERROR_MESSAGE, event.error)
           testSpan.setTag(TEST_STATUS, 'fail')
         }
       }
+      return
     }
     if (event.name === 'setup') {
       instrumenter.wrap(this.global.test, 'each', function (original) {
@@ -80,6 +91,7 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
           }
         }
       })
+      return
     }
 
     if (event.name !== 'test_skip' && event.name !== 'test_todo' && event.name !== 'test_start') {
@@ -130,6 +142,8 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
     }
     // event.name === test_start at this point
     const environment = this
+    environment.originalTestFnByTestName[testName] = event.test.fn
+
     let specFunction = event.test.fn
     if (specFunction.length) {
       specFunction = promisify(specFunction)
@@ -144,12 +158,12 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
       async () => {
         let result
         const testSpan = tracer.scope().active()
-        environment.testSpansByTestName[testName] = testSpan
+        environment.testSpansByTestName[`${testName}_${event.test.invocations}`] = testSpan
         testSpan.context()._trace.origin = CI_APP_ORIGIN
         try {
           result = await specFunction()
           // it may have been set already if the test timed out
-          if (!testSpan._spanContext._tags['test.status']) {
+          if (!testSpan._spanContext._tags[TEST_STATUS]) {
             testSpan.setTag(TEST_STATUS, 'pass')
           }
         } catch (error) {


### PR DESCRIPTION
### What does this PR do?

What was happening: 
* The spec function (`event.test.fn`) was being called more than once for the same test. This mean that `environment.testSpansByTestName[testName] = testSpan` in [here](https://github.com/DataDog/dd-trace-js/compare/juan-fernandez/ci-app-fix-timeouts-retries?expand=1#diff-76369ef968f888d26d7526855acc94b032e02899dcfef0fcefa452b584b84164L147) was being overwritten. When the test span was being accessed in [here](https://github.com/DataDog/dd-trace-js/compare/juan-fernandez/ci-app-fix-timeouts-retries?expand=1#diff-76369ef968f888d26d7526855acc94b032e02899dcfef0fcefa452b584b84164L147), through `const testSpan = this.testSpansByTestName[currentTestName]`, an incorrect `testSpan` was being modified. 
* Since there were two `test_start` events being fired, `event.test.fn` was being wrapped twice (through `tracer.wrap`).


So the solution is:
* Take into account the retry attempt we are in when storing the `testSpan` in `environment.originalTestFnByTestName`.
* Do not wrap `event.test.fn` more than once, by restoring the original function in the `test_retry` event. 

### Motivation
Fix a bug where if a retriable test (through `jest.retryTimes`) timed out, we would set incorrect tags.

### Plugin Checklist
- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
