### PR TITLE
add fastify benchmark

### DIFF
--- a/benchmark/sirun/plugin-fastify/index.js
+++ b/benchmark/sirun/plugin-fastify/index.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const assert = require('assert')
+
+function run (task) {
+  const hasProfiler = process.env.PROFILER === 'true'
+  const hasTracer = process.env.TRACER === 'true'
+
+  if (!hasProfiler && !hasTracer) {
+    return task()
+  }
+
+  process.env.DD_EXPERIMENTAL_PROFILING_ENABLED = hasProfiler
+  process.env.DD_PROFILING_INTERVAL = '1000'
+
+  require('../../..').init({
+    url: 'http://localhost:8126',
+    profiling: hasProfiler,
+    enabled: hasTracer
+  })
+
+  let expectedRequests = (hasProfiler && hasTracer) ? 2 : 1
+
+  const http = require('http')
+
+  const server = http.createServer((req, res) => {
+    req.resume()
+    res.end()
+
+    if (hasProfiler && req.url === '/profiling/v1/input') {
+      expectedRequests--
+    } else if (hasTracer && /\/traces$/.test(req.url)) {
+      expectedRequests--
+    }
+
+    if (expectedRequests < 1) {
+      server.close()
+    }
+  })
+
+  server.listen(8126, task)
+}
+
+run(async () => {
+  const app = require('../../../versions/fastify/node_modules/fastify')()
+
+  app.get('/', (request, reply) => {
+    return { hello: 'world' }
+  })
+
+  try {
+    await app.listen(3000)
+
+    const { statusCode, body } = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    assert.strictEqual(statusCode, 200)
+    assert.strictEqual(body, '{"hello":"world"}')
+
+    await app.close()
+  } catch (err) {
+    app.log.error(err)
+    process.exit(1)
+  }
+})

--- a/benchmark/sirun/plugin-fastify/meta.json
+++ b/benchmark/sirun/plugin-fastify/meta.json
@@ -1,0 +1,32 @@
+{
+  "name": "fastify-overhead",
+  "run": "node -r ../monitor index.js",
+  "cachegrind": true,
+  "iterations": 10,
+  "variants": {
+    "control": {
+      "env": {
+        "PROFILER": "false",
+        "TRACER": "false"
+      }
+    },
+    "with-profiler": {
+      "env": {
+        "PROFILER": "true",
+        "TRACER": "false"
+      }
+    },
+    "with-tracer": {
+      "env": {
+        "PROFILER": "true",
+        "TRACER": "false"
+      }
+    },
+    "with-both": {
+      "env": {
+        "PROFILER": "true",
+        "TRACER": "true"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a simple benchmark to measure overhead of the profiler and tracer in a basic fastify app. We may want to make the request do something a bit more non-trivial,  but this gives a general idea of impact of future changes at the base framework level.