### PR TITLE
fix missing bulkBody info

### DIFF
--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -24,8 +24,8 @@ function createWrapRequest (tracer, config) {
         }
       })
 
-      if (params.body) {
-        span.setTag('elasticsearch.body', JSON.stringify(params.body))
+      if (params.body || params.bulkBody) {
+        span.setTag('elasticsearch.body', JSON.stringify(params.body || params.bulkBody))
       }
 
       analyticsSampler.sample(span, config.analytics)

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -72,6 +72,41 @@ describe('Plugin', () => {
           }, () => {})
         })
 
+        it('should set the correct tags on msearch', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property('db.type', 'elasticsearch')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].meta).to.have.property('elasticsearch.method', 'POST')
+              expect(traces[0][0].meta).to.have.property('elasticsearch.url', '/_msearch')
+              expect(traces[0][0].meta).to.have.property(
+                'elasticsearch.body',
+                '[{"index":"docs"},{"query":{"match_all":{}}},{"index":"docs2"},{"query":{"match_all":{}}}]'
+              )
+              expect(traces[0][0].meta).to.have.property('elasticsearch.params', '{"size":100}')
+            })
+            .then(done)
+            .catch(done)
+
+          client.msearch({
+            size: 100,
+            body: [
+              { index: 'docs' },
+              {
+                query: {
+                  match_all: {}
+                }
+              },
+              { index: 'docs2' },
+              {
+                query: {
+                  match_all: {}
+                }
+              }
+            ]
+          }, () => {})
+        })
+
         it('should skip tags for unavailable fields', done => {
           agent
             .use(traces => {


### PR DESCRIPTION
### What does this PR do?
Fix missing bulkBody info

### Motivation
The ability to see the bulk api request's body info

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
Based on [elasticsearch api util script](https://github.com/elastic/elasticsearch-js/blob/master/scripts/utils/generateApis.js#L432), it is always `body` or `bulkBody`
