### PR TITLE
fix tests for next 11

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -35,7 +35,14 @@ describe('Plugin', function () {
           // building in-process makes tests fail for an unknown reason
           execSync('node build', {
             cwd: __dirname,
-            env: { version },
+            env: {
+              version,
+              // needed for webpack 5
+              NODE_PATH: [
+                `${__dirname}/../../../versions/next@${version}/node_modules`,
+                `${__dirname}/../../../versions/node_modules`
+              ].join(':')
+            },
             stdio: ['pipe', 'ignore', 'pipe']
           })
 

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -5,6 +5,13 @@ module.exports = {
     ignoreDuringBuilds: true
   },
 
+  webpack5: false,
+
+  future: {
+    // legacy option
+    webpack5: false
+  },
+
   webpack: (config) => {
     const react = path.resolve(__dirname, '../../../versions/node_modules/react')
     const reactDom = path.resolve(__dirname, '../../../versions/node_modules/react-dom')
@@ -13,6 +20,12 @@ module.exports = {
       'react': `commonjs2 ${react}`,
       'react-dom': `commonjs2 ${reactDom}`
     }
+
+    // TODO: drop support for Next <10.1, enable webpack5 above, and uncomment:
+    // config.module.rules.push({
+    //   test: /\/dd-trace\/src\/native\/.+$/,
+    //   type: 'asset/source'
+    // })
 
     return config
   }

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -1,6 +1,10 @@
 const path = require('path')
 
 module.exports = {
+  eslint: {
+    ignoreDuringBuilds: true
+  },
+
   webpack: (config) => {
     const react = path.resolve(__dirname, '../../../versions/node_modules/react')
     const reactDom = path.resolve(__dirname, '../../../versions/node_modules/react-dom')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix tests for Next 11 by removing the new linter and downgrading to Webpack 4. I added support for Webpack 5, but the configuration is not compatible between Webpack 4 and 5, and Next <10.1 didn't support Webpack 5. Right now we can't test with multiple versions of Webpack, so we have to settle on v4 for now. Next 12 will drop support for Webpack 4 completely, so we should drop support for older versions as soon as we can to switch to Webpack 5.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests started failing in CI since the release of Next 11.

### Additional Notes

Was blocked by https://github.com/vercel/next.js/issues/26127 but I worked around the issue by switching to Webpack 4 for now.