### PR TITLE
fix stale module returned when require cache is overridden

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:core:ci": "nyc --include \"packages/dd-trace/src/**/*.js\" -- npm run test:core --  --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json",
     "test:plugins": "mocha --exit --file \"packages/dd-trace/test/setup/core.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
     "test:plugins:ci": "yarn services && nyc --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- npm run test:plugins",
+    "test:plugins:upstream": "node ./packages/dd-trace/test/plugins/suite.js",
     "test:integration": "mocha --timeout 30000 \"integration-tests/**/*.spec.js\"",
     "leak:core": "node ./scripts/install_plugin_modules && (cd packages/memwatch && yarn) && NODE_PATH=./packages/memwatch/node_modules node --no-warnings ./node_modules/.bin/tape 'packages/dd-trace/test/leak/**/*.js'",
     "leak:plugins": "yarn services && (cd packages/memwatch && yarn) && NODE_PATH=./packages/memwatch/node_modules node --no-warnings ./node_modules/.bin/tape \"packages/datadog-plugin-@($(echo $PLUGINS))/test/leak.js\"",

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -4,21 +4,32 @@ const path = require('path')
 const Module = require('module')
 const parse = require('module-details-from-path')
 
-const orig = Module.prototype.require
-
 module.exports = function hook (modules, onrequire) {
+  if (!hook.orig) {
+    hook.orig = Module.prototype.require
+
+    Module.prototype.require = function (request) {
+      return hook.require.apply(this, arguments)
+    }
+  }
+
   hook.cache = {}
 
   const patching = {}
 
-  Module.prototype.require = function (request) {
+  hook.require = function (request) {
     const filename = Module._resolveFilename(request, this)
     const core = filename.indexOf(path.sep) === -1
     let name, basedir
 
     // return known patched modules immediately
     if (hook.cache.hasOwnProperty(filename)) {
-      return hook.cache[filename]
+      // require.cache was potentially altered externally
+      if (require.cache[filename] && require.cache[filename].exports !== hook.cache[filename].original) {
+        return require.cache[filename].exports
+      }
+
+      return hook.cache[filename].exports
     }
 
     // Check if this module has a patcher in-progress already.
@@ -28,7 +39,7 @@ module.exports = function hook (modules, onrequire) {
       patching[filename] = true
     }
 
-    const exports = orig.apply(this, arguments)
+    const exports = hook.orig.apply(this, arguments)
 
     // If it's already patched, just return it as-is.
     if (patched) return exports
@@ -57,14 +68,12 @@ module.exports = function hook (modules, onrequire) {
       }
     }
 
-    // only call onrequire the first time a module is loaded
-    if (!hook.cache.hasOwnProperty(filename)) {
-      // ensure that the cache entry is assigned a value before calling
-      // onrequire, in case calling onrequire requires the same module.
-      hook.cache[filename] = exports
-      hook.cache[filename] = onrequire(exports, name, basedir)
-    }
+    // ensure that the cache entry is assigned a value before calling
+    // onrequire, in case calling onrequire requires the same module.
+    hook.cache[filename] = { exports }
+    hook.cache[filename].original = exports
+    hook.cache[filename].exports = onrequire(exports, name, basedir)
 
-    return hook.cache[filename]
+    return hook.cache[filename].exports
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix stale module returned when require cache is overridden by returning the export from the require cache directly in the instrumenter when it's different than the export that was patched.

### Motivation
<!-- What inspired you to submit this pull request? -->

Since patched modules are cached by the instrumenter, any direct changes to `require.cache` would be ignored and the patched module would still be returned by `require`. While this should not generally happen in an actual application, it does happen a lot in tests, and is currently the reason why the upstream Pino tests are failing.