### PR TITLE
fix kafkajs test setup timeout

### DIFF
--- a/packages/dd-trace/test/setup/services/kafka.js
+++ b/packages/dd-trace/test/setup/services/kafka.js
@@ -18,7 +18,7 @@ function waitForKafka () {
     operation.attempt(async currentAttempt => {
       try {
         await consumer.connect()
-        await consumer.subscribe({ topic })
+        await consumer.subscribe({ topic, fromBeginning: true })
         await consumer.run({
           eachMessage: () => {
             setTimeout(async () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `kafkajs` test setup timeout.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `kafkajs` tests have been randomly failing for a while with the setup script hanging forever and CircleCI eventually killing the job. I was able to reproduce locally, and it seems there is some weird race condition in Kafka itself when a consumer subscribes to a topic right before a producer sends a message for the same topic for a new consumer group, which the client doesn't handle properly. By forcing the consumer to subscribe from offset 0 with the `fromBeginning` option, the issue seems to be fixed as I wasn't able to reproduce when the option is `true`.