### PR TITLE
[ci-app] Use Service Under Test as Service Name Fallback for `jest`

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -192,11 +192,11 @@ module.exports = [
   {
     name: 'jest-environment-node',
     versions: ['>=24.8.0'],
-    patch: function (NodeEnvironment, tracer) {
+    patch: function (NodeEnvironment, tracer, config) {
       const testEnvironmentMetadata = getTestEnvironmentMetadata('jest')
       // it if is the default service, we substitute it
       const serviceUnderTest = findPkg('package.json', process.cwd()).name
-      if (serviceUnderTest && (tracer._service === 'jest' || tracer._service === 'jest-worker')) {
+      if (serviceUnderTest && !config.service && (tracer._service === 'jest' || tracer._service === 'jest-worker')) {
         tracer._service = serviceUnderTest
         tracer._tags.service = serviceUnderTest
       }
@@ -216,9 +216,14 @@ module.exports = [
   {
     name: 'jest-environment-jsdom',
     versions: ['>=24.8.0'],
-    patch: function (JsdomEnvironment, tracer) {
+    patch: function (JsdomEnvironment, tracer, config) {
       const testEnvironmentMetadata = getTestEnvironmentMetadata('jest')
-
+      // it if is the default service, we substitute it
+      const serviceUnderTest = findPkg('package.json', process.cwd()).name
+      if (serviceUnderTest && !config.service && (tracer._service === 'jest' || tracer._service === 'jest-worker')) {
+        tracer._service = serviceUnderTest
+        tracer._tags.service = serviceUnderTest
+      }
       this.wrap(JsdomEnvironment.prototype, 'teardown', createWrapTeardown(tracer, this))
 
       const newHandleTestEvent = createHandleTestEvent(tracer, testEnvironmentMetadata, this)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const URL = require('url').URL
-const pkg = require('./pkg')
+const findPkg = require('./pkg')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
 const tagger = require('./tagger')
@@ -12,6 +12,8 @@ const runtimeId = `${id().toString()}${id().toString()}`
 
 const fromEntries = Object.fromEntries || (entries =>
   entries.reduce((obj, [k, v]) => Object.assign(obj, { [k]: v }), {}))
+
+const pkg = findPkg()
 
 class Config {
   constructor (options) {

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -9,8 +9,7 @@ function findRoot () {
     : process.cwd()
 }
 
-function findPkg () {
-  const cwd = findRoot()
+function findPkg (cwd = findRoot()) {
   const filePath = findUp('package.json', cwd)
 
   try {
@@ -34,4 +33,4 @@ function findUp (name, cwd) {
   }
 }
 
-module.exports = findPkg()
+module.exports = findPkg

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -17,7 +17,7 @@ describe('Config', () => {
     process.env = {}
 
     Config = proxyquire('../src/config', {
-      './pkg': pkg
+      './pkg': () => pkg
     })
   })
 

--- a/packages/dd-trace/test/pkg-loader.js
+++ b/packages/dd-trace/test/pkg-loader.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const pkg = require('../src/pkg.js')
+const findPkg = require('../src/pkg.js')
 
 // eslint-disable-next-line no-console
-console.log(JSON.stringify(pkg))
+console.log(JSON.stringify(findPkg()))

--- a/packages/dd-trace/test/pkg.spec.js
+++ b/packages/dd-trace/test/pkg.spec.js
@@ -20,7 +20,7 @@ describe('pkg', () => {
   }
 
   beforeEach(() => {
-    pkg = require('../src/pkg')
+    pkg = require('../src/pkg')()
   })
 
   it('should load the service name from the main module', () => {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -52,7 +52,7 @@ module.exports = {
         })
 
         tracer.init({
-          service: 'test',
+          service: process.env.DD_TEST_SERVICE || 'test',
           port,
           flushInterval: 0,
           plugins: false


### PR DESCRIPTION
### What does this PR do?
* Use the package name of the service under test for service name fallback for testing instrumentations. 

**Note**: this only includes `jest`. If we are OK with the approach I can move it to `mocha` and `cucumber`.

### Motivation
* Provide a better experience for CI App onboarding customers.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
