### PR TITLE
[ci-app] Add Error Handling for `beforeEach`/`afterEach` Hooks in Testing Frameworks

### DIFF
--- a/packages/datadog-plugin-cucumber/test/features/simple.feature
+++ b/packages/datadog-plugin-cucumber/test/features/simple.feature
@@ -23,3 +23,9 @@ Feature: Datadog integration
     Given datadog
     When integration
     Then pass
+
+  @hooks-fail
+  Scenario: hooks fail
+    Given datadog
+    When run
+    Then pass

--- a/packages/datadog-plugin-cucumber/test/features/simple.js
+++ b/packages/datadog-plugin-cucumber/test/features/simple.js
@@ -19,6 +19,11 @@ Given('datadog', function () {
   this.setTo('datadog')
 })
 
+Before('@hooks-fail', function () {
+  const unsafe = {}
+  unsafe.yeah.boom = 'crash'
+})
+
 When('run', () => {})
 
 When('integration', function () {

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -17,89 +17,6 @@ const {
   ERROR_MESSAGE
 } = require('../../dd-trace/src/plugins/util/test')
 
-const TESTS = [
-  {
-    featureName: 'simple.feature',
-    featureLineNumber: ':3',
-    requireName: 'simple.js',
-    testName: 'pass scenario',
-    testStatus: 'pass',
-    steps: [
-      { name: 'datadog', stepStatus: 'pass' },
-      { name: 'run', stepStatus: 'pass' },
-      { name: 'pass', stepStatus: 'pass' }
-    ],
-    success: true,
-    errors: []
-  },
-  {
-    featureName: 'simple.feature',
-    featureLineNumber: ':8',
-    requireName: 'simple.js',
-    testName: 'fail scenario',
-    testStatus: 'fail',
-    steps: [
-      { name: 'datadog', stepStatus: 'pass' },
-      { name: 'run', stepStatus: 'pass' },
-      { name: 'fail', stepStatus: 'fail' }
-    ],
-    success: false,
-    errors: [undefined, undefined, 'AssertionError', 'AssertionError']
-  },
-  {
-    featureName: 'simple.feature',
-    featureLineNumber: ':13',
-    requireName: 'simple.js',
-    testName: 'skip scenario',
-    testStatus: 'skip',
-    steps: [
-      { name: 'datadog', stepStatus: 'pass' },
-      { name: 'run', stepStatus: 'pass' },
-      { name: 'skip', stepStatus: 'skip' }
-    ],
-    success: true,
-    errors: [undefined, undefined, 'skipped', 'skipped']
-  },
-  {
-    featureName: 'simple.feature',
-    featureLineNumber: ':19',
-    requireName: 'simple.js',
-    testName: 'skip scenario based on tag',
-    testStatus: 'skip',
-    steps: [{ name: 'datadog', stepStatus: 'skip' }],
-    success: true,
-    errors: ['skipped', 'skipped']
-  },
-  {
-    featureName: 'simple.feature',
-    featureLineNumber: ':22',
-    requireName: 'simple.js',
-    testName: 'integration scenario',
-    testStatus: 'pass',
-    steps: [
-      { name: 'datadog', stepStatus: 'pass' },
-      { name: 'integration', stepStatus: 'pass' },
-      { name: 'pass', stepStatus: 'pass' }
-    ],
-    success: true,
-    errors: []
-  },
-  {
-    featureName: 'simple.feature',
-    featureLineNumber: ':28',
-    requireName: 'simple.js',
-    testName: 'hooks fail',
-    testStatus: 'fail',
-    steps: [
-      { name: 'datadog', stepStatus: 'skip' },
-      { name: 'run', stepStatus: 'skip' },
-      { name: 'pass', stepStatus: 'skip' }
-    ],
-    success: false,
-    errors: ['skipped', 'skipped', 'skipped']
-  }
-]
-
 wrapIt()
 
 const runCucumber = (version, Cucumber, requireName, featureName, featureLineNumber) => {
@@ -129,9 +46,7 @@ describe('Plugin', () => {
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache
       // before subsequent calls in whichever manner best suits your needs.
-      TESTS.forEach((test) => {
-        delete require.cache[require.resolve(path.join(__dirname, 'features', test.requireName))]
-      })
+      delete require.cache[require.resolve(path.join(__dirname, 'features', 'simple.js'))]
       return agent.close()
     })
     beforeEach(() => {
@@ -144,94 +59,377 @@ describe('Plugin', () => {
         Cucumber = require(`../../../versions/@cucumber/cucumber@${version}`).get()
       })
     })
+    const testFilePath = path.join(__dirname, 'features', 'simple.feature')
+    const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
 
     describe('cucumber', () => {
-      TESTS.forEach(test => {
-        const testFilePath = path.join(__dirname, 'features', test.featureName)
-        const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
-
-        const {
-          featureName,
-          featureLineNumber,
-          requireName,
-          testName,
-          testStatus,
-          steps,
-          success,
-          errors
-        } = test
-
-        describe(`for ${featureName}${featureLineNumber}`, () => {
-          it('should create a test span and spans for integrations', async function () {
-            const checkTraces = agent.use(traces => {
-              expect(traces.length).to.equal(1)
-              const testTrace = traces[0]
-              const isIntegrationTest = testName === 'integration scenario'
-              // number of tests + one test span + possibly one http span
-              const numExpectedSpans = steps.length + (isIntegrationTest ? 2 : 1)
-              expect(testTrace.length).to.equal(numExpectedSpans)
-              // take the test span
-              const testSpan = testTrace.find(span => span.name === 'cucumber.test')
-              // having no parent span means there is no span leak from other tests
-              expect(testSpan.parent_id.toString()).to.equal('0')
-              expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              expect(testSpan.meta).to.contain({
-                language: 'javascript',
-                service: 'test',
-                [TEST_NAME]: testName,
-                [TEST_TYPE]: 'test',
-                [TEST_FRAMEWORK]: 'cucumber',
-                [TEST_SUITE]: testSuite,
-                [TEST_STATUS]: testStatus
-              })
-              expect(testSpan.meta[TEST_SUITE].endsWith(featureName)).to.equal(true)
-              expect(testSpan.type).to.equal('test')
-              expect(testSpan.name).to.equal('cucumber.test')
-              expect(testSpan.resource).to.equal(testName)
-              if (isIntegrationTest) {
-                const httpSpan = testTrace.find(span => span.name === 'http.request')
-                expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-                expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
-                const parentCucumberStep = testTrace.find(span => span.meta['cucumber.step'] === 'integration')
-                expect(httpSpan.parent_id.toString()).to.equal(parentCucumberStep.span_id.toString())
-              }
-              if (testName === 'hooks fail') {
-                expect(testSpan.meta[ERROR_MESSAGE].startsWith(`TypeError: Cannot set property 'boom' of undefined`))
-                  .to.equal(true)
-              }
+      describe('passing test', () => {
+        it('should create a test span', async function () {
+          const checkTraces = agent.use(traces => {
+            expect(traces.length).to.equal(1)
+            const testTrace = traces[0]
+            expect(testTrace.length).to.equal(4)
+            // take the test span
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // having no parent span means there is no span leak from other tests
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'pass scenario',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'cucumber',
+              [TEST_SUITE]: testSuite,
+              [TEST_STATUS]: 'pass'
             })
-            const result = await runCucumber(version, Cucumber, requireName, featureName, featureLineNumber)
-            expect(result.success).to.equal(success)
-            await checkTraces
+            expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('cucumber.test')
+            expect(testSpan.resource).to.equal('pass scenario')
           })
-
-          it('should create spans for each cucumber step', async () => {
-            const checkTraces = agent.use(traces => {
-              const testTrace = traces[0]
-              const testSpan = testTrace.find(span => span.name === 'cucumber.test')
-              // step spans
-              const stepSpans = testTrace.filter(span => span.name === 'cucumber.step')
-              expect(stepSpans.length).to.equal(steps.length)
-              stepSpans.forEach((stepSpan, spanIndex) => {
-                // children spans should carry _dd.origin
-                expect(stepSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-                // all steps are children of the test span
-                expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
-                expect(stepSpan.meta['cucumber.step']).to.equal(steps[spanIndex].name)
-                expect(stepSpan.meta['step.status']).to.equal(steps[spanIndex].stepStatus)
-                expect(stepSpan.type).not.to.equal('test')
-              })
-              errors.forEach((msg, errorIndex) => {
-                expect(
-                  testTrace[errorIndex].meta[ERROR_MESSAGE],
-                  `error ${errorIndex} should start with "${msg}"`
-                ).to.satisfy(err => msg === undefined || err.startsWith(msg))
-              })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':3')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+        it('should create spans for each cucumber step', async () => {
+          const steps = [
+            { name: 'datadog', stepStatus: 'pass' },
+            { name: 'run', stepStatus: 'pass' },
+            { name: 'pass', stepStatus: 'pass' }
+          ]
+          const checkTraces = agent.use(traces => {
+            const testTrace = traces[0]
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // step spans
+            const stepSpans = testTrace.filter(span => span.name === 'cucumber.step')
+            expect(stepSpans.length).to.equal(steps.length)
+            stepSpans.forEach((stepSpan, spanIndex) => {
+              // children spans should carry _dd.origin
+              expect(stepSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              // all steps are children of the test span
+              expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              expect(stepSpan.meta['cucumber.step']).to.equal(steps[spanIndex].name)
+              expect(stepSpan.meta['step.status']).to.equal(steps[spanIndex].stepStatus)
+              expect(stepSpan.type).not.to.equal('test')
             })
-            const result = await runCucumber(version, Cucumber, requireName, featureName, featureLineNumber)
-            expect(result.success).to.equal(success)
-            await checkTraces
           })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':3')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+      })
+      describe('failing test', () => {
+        it('should create a test span', async function () {
+          const checkTraces = agent.use(traces => {
+            expect(traces.length).to.equal(1)
+            const testTrace = traces[0]
+            expect(testTrace.length).to.equal(4)
+            // take the test span
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // having no parent span means there is no span leak from other tests
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'fail scenario',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'cucumber',
+              [TEST_SUITE]: testSuite,
+              [TEST_STATUS]: 'fail'
+            })
+            expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('cucumber.test')
+            expect(testSpan.resource).to.equal('fail scenario')
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':8')
+          expect(result.success).to.equal(false)
+          await checkTraces
+        })
+        it('should create spans for each cucumber step', async () => {
+          const steps = [
+            { name: 'datadog', stepStatus: 'pass' },
+            { name: 'run', stepStatus: 'pass' },
+            { name: 'fail', stepStatus: 'fail' }
+          ]
+          const errors = [undefined, undefined, 'AssertionError', 'AssertionError']
+          const checkTraces = agent.use(traces => {
+            const testTrace = traces[0]
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // step spans
+            const stepSpans = testTrace.filter(span => span.name === 'cucumber.step')
+            expect(stepSpans.length).to.equal(steps.length)
+            stepSpans.forEach((stepSpan, spanIndex) => {
+              // children spans should carry _dd.origin
+              expect(stepSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              // all steps are children of the test span
+              expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              expect(stepSpan.meta['cucumber.step']).to.equal(steps[spanIndex].name)
+              expect(stepSpan.meta['step.status']).to.equal(steps[spanIndex].stepStatus)
+              expect(stepSpan.type).not.to.equal('test')
+            })
+            errors.forEach((msg, errorIndex) => {
+              expect(
+                testTrace[errorIndex].meta[ERROR_MESSAGE],
+                `error ${errorIndex} should start with "${msg}"`
+              ).to.satisfy(err => msg === undefined || err.startsWith(msg))
+            })
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':8')
+          expect(result.success).to.equal(false)
+          await checkTraces
+        })
+      })
+      describe('skipped test', () => {
+        it('should create a test span', async function () {
+          const checkTraces = agent.use(traces => {
+            expect(traces.length).to.equal(1)
+            const testTrace = traces[0]
+            expect(testTrace.length).to.equal(4)
+            // take the test span
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // having no parent span means there is no span leak from other tests
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'skip scenario',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'cucumber',
+              [TEST_SUITE]: testSuite,
+              [TEST_STATUS]: 'skip'
+            })
+            expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('cucumber.test')
+            expect(testSpan.resource).to.equal('skip scenario')
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':13')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+        it('should create spans for each cucumber step', async () => {
+          const steps = [
+            { name: 'datadog', stepStatus: 'pass' },
+            { name: 'run', stepStatus: 'pass' },
+            { name: 'skip', stepStatus: 'skip' }
+          ]
+          const errors = [undefined, undefined, 'skipped', 'skipped']
+          const checkTraces = agent.use(traces => {
+            const testTrace = traces[0]
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // step spans
+            const stepSpans = testTrace.filter(span => span.name === 'cucumber.step')
+            expect(stepSpans.length).to.equal(steps.length)
+            stepSpans.forEach((stepSpan, spanIndex) => {
+              // children spans should carry _dd.origin
+              expect(stepSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              // all steps are children of the test span
+              expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              expect(stepSpan.meta['cucumber.step']).to.equal(steps[spanIndex].name)
+              expect(stepSpan.meta['step.status']).to.equal(steps[spanIndex].stepStatus)
+              expect(stepSpan.type).not.to.equal('test')
+            })
+            errors.forEach((msg, errorIndex) => {
+              expect(
+                testTrace[errorIndex].meta[ERROR_MESSAGE],
+                `error ${errorIndex} should start with "${msg}"`
+              ).to.satisfy(err => msg === undefined || err.startsWith(msg))
+            })
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':13')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+      })
+      describe('skipped test based on tag', () => {
+        it('should create a test span', async function () {
+          const checkTraces = agent.use(traces => {
+            expect(traces.length).to.equal(1)
+            const testTrace = traces[0]
+            expect(testTrace.length).to.equal(2)
+            // take the test span
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // having no parent span means there is no span leak from other tests
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'skip scenario based on tag',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'cucumber',
+              [TEST_SUITE]: testSuite,
+              [TEST_STATUS]: 'skip'
+            })
+            expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('cucumber.test')
+            expect(testSpan.resource).to.equal('skip scenario based on tag')
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':19')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+        it('should create spans for each cucumber step', async () => {
+          const steps = [
+            { name: 'datadog', stepStatus: 'skip' }
+          ]
+          const errors = ['skipped', 'skipped']
+          const checkTraces = agent.use(traces => {
+            const testTrace = traces[0]
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // step spans
+            const stepSpans = testTrace.filter(span => span.name === 'cucumber.step')
+            expect(stepSpans.length).to.equal(steps.length)
+            stepSpans.forEach((stepSpan, spanIndex) => {
+              // children spans should carry _dd.origin
+              expect(stepSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              // all steps are children of the test span
+              expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              expect(stepSpan.meta['cucumber.step']).to.equal(steps[spanIndex].name)
+              expect(stepSpan.meta['step.status']).to.equal(steps[spanIndex].stepStatus)
+              expect(stepSpan.type).not.to.equal('test')
+            })
+            errors.forEach((msg, errorIndex) => {
+              expect(
+                testTrace[errorIndex].meta[ERROR_MESSAGE],
+                `error ${errorIndex} should start with "${msg}"`
+              ).to.satisfy(err => msg === undefined || err.startsWith(msg))
+            })
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':19')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+      })
+      describe('integration test', () => {
+        it('should create a test span and a span for the integration', async function () {
+          const checkTraces = agent.use(traces => {
+            expect(traces.length).to.equal(1)
+            const testTrace = traces[0]
+            expect(testTrace.length).to.equal(5)
+            // take the test span
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // having no parent span means there is no span leak from other tests
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'integration scenario',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'cucumber',
+              [TEST_SUITE]: testSuite,
+              [TEST_STATUS]: 'pass'
+            })
+            expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('cucumber.test')
+            expect(testSpan.resource).to.equal('integration scenario')
+            const httpSpan = testTrace.find(span => span.name === 'http.request')
+            expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
+            const parentCucumberStep = testTrace.find(span => span.meta['cucumber.step'] === 'integration')
+            expect(httpSpan.parent_id.toString()).to.equal(parentCucumberStep.span_id.toString())
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':22')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+        it('should create spans for each cucumber step', async () => {
+          const steps = [
+            { name: 'datadog', stepStatus: 'pass' },
+            { name: 'integration', stepStatus: 'pass' },
+            { name: 'pass', stepStatus: 'pass' }
+          ]
+          const checkTraces = agent.use(traces => {
+            const testTrace = traces[0]
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // step spans
+            const stepSpans = testTrace.filter(span => span.name === 'cucumber.step')
+            expect(stepSpans.length).to.equal(steps.length)
+            stepSpans.forEach((stepSpan, spanIndex) => {
+              // children spans should carry _dd.origin
+              expect(stepSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              // all steps are children of the test span
+              expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              expect(stepSpan.meta['cucumber.step']).to.equal(steps[spanIndex].name)
+              expect(stepSpan.meta['step.status']).to.equal(steps[spanIndex].stepStatus)
+              expect(stepSpan.type).not.to.equal('test')
+            })
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':22')
+          expect(result.success).to.equal(true)
+          await checkTraces
+        })
+      })
+      describe('hook fail', () => {
+        it('should create a test span', async function () {
+          const checkTraces = agent.use(traces => {
+            expect(traces.length).to.equal(1)
+            const testTrace = traces[0]
+            expect(testTrace.length).to.equal(4)
+            // take the test span
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // having no parent span means there is no span leak from other tests
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'hooks fail',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'cucumber',
+              [TEST_SUITE]: testSuite,
+              [TEST_STATUS]: 'fail'
+            })
+            expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('cucumber.test')
+            expect(testSpan.resource).to.equal('hooks fail')
+            expect(testSpan.meta[ERROR_MESSAGE].startsWith(`TypeError: Cannot set property 'boom' of undefined`))
+              .to.equal(true)
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':28')
+          expect(result.success).to.equal(false)
+          await checkTraces
+        })
+        it('should create spans for each cucumber step', async () => {
+          const steps = [
+            { name: 'datadog', stepStatus: 'skip' },
+            { name: 'run', stepStatus: 'skip' },
+            { name: 'pass', stepStatus: 'skip' }
+          ]
+          const errors = ['skipped', 'skipped', 'skipped']
+          const checkTraces = agent.use(traces => {
+            const testTrace = traces[0]
+            const testSpan = testTrace.find(span => span.name === 'cucumber.test')
+            // step spans
+            const stepSpans = testTrace.filter(span => span.name === 'cucumber.step')
+            expect(stepSpans.length).to.equal(steps.length)
+            stepSpans.forEach((stepSpan, spanIndex) => {
+              // children spans should carry _dd.origin
+              expect(stepSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              // all steps are children of the test span
+              expect(stepSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              expect(stepSpan.meta['cucumber.step']).to.equal(steps[spanIndex].name)
+              expect(stepSpan.meta['step.status']).to.equal(steps[spanIndex].stepStatus)
+              expect(stepSpan.type).not.to.equal('test')
+            })
+            errors.forEach((msg, errorIndex) => {
+              expect(
+                testTrace[errorIndex].meta[ERROR_MESSAGE],
+                `error ${errorIndex} should start with "${msg}"`
+              ).to.satisfy(err => msg === undefined || err.startsWith(msg))
+            })
+          })
+          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', ':28')
+          expect(result.success).to.equal(false)
+          await checkTraces
         })
       })
     })

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -272,7 +272,13 @@ describe('Plugin', () => {
             expect(testSpan.name).to.equal('cucumber.test')
             expect(testSpan.resource).to.equal('skip scenario based on tag')
           })
-          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', 'skip scenario based on tag')
+          const result = await runCucumber(
+            version,
+            Cucumber,
+            'simple.js',
+            'simple.feature',
+            'skip scenario based on tag'
+          )
           expect(result.success).to.equal(true)
           await checkTraces
         })
@@ -303,7 +309,13 @@ describe('Plugin', () => {
               ).to.satisfy(err => msg === undefined || err.startsWith(msg))
             })
           })
-          const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', 'skip scenario based on tag')
+          const result = await runCucumber(
+            version,
+            Cucumber,
+            'simple.js',
+            'simple.feature',
+            'skip scenario based on tag'
+          )
           expect(result.success).to.equal(true)
           await checkTraces
         })

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const path = require('path')
+const fs = require('fs')
 
 const nock = require('nock')
 
@@ -20,32 +21,7 @@ const {
   CI_APP_ORIGIN
 } = require('../../dd-trace/src/plugins/util/test')
 
-const TESTS = [
-  {
-    fileName: 'mocha-test-pass.js',
-    testNames: [
-      'mocha-test-pass can pass',
-      'mocha-test-pass can pass two',
-      'mocha-test-pass-two can pass',
-      'mocha-test-pass-two can pass two'
-    ],
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-fail.js',
-    testName: 'can fail',
-    root: 'mocha-test-fail',
-    status: 'fail'
-  },
-  {
-    fileName: 'mocha-test-skip.js',
-    testNames: [
-      'mocha-test-skip can skip',
-      'mocha-test-skip-different can skip too',
-      'mocha-test-skip-different can skip twice'
-    ],
-    status: 'skip'
-  },
+const ASYNC_TESTS = [
   {
     fileName: 'mocha-test-done-pass.js',
     testName: 'can do passed tests with done',
@@ -93,39 +69,6 @@ const TESTS = [
     testName: 'does not timeout',
     root: 'mocha-test-timeout-pass',
     status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-parameterized.js',
-    testName: 'can do parameterized',
-    root: 'mocha-parameterized',
-    status: 'pass',
-    extraSpanTags: {
-      [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
-    }
-  },
-  {
-    fileName: 'mocha-test-integration.js',
-    testName: 'can do integration tests',
-    root: 'mocha-test-integration',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-test-integration-http.js',
-    testName: 'can do integration http',
-    root: 'mocha-test-integration-http',
-    status: 'pass'
-  },
-  {
-    fileName: 'mocha-fail-hook-sync.js',
-    testName: 'will not run but be reported as failed',
-    root: 'mocha-fail-hook-sync',
-    status: 'fail'
-  },
-  {
-    fileName: 'mocha-fail-hook-async.js',
-    testName: 'will not run but be reported as failed',
-    root: 'mocha-fail-hook-async',
-    status: 'fail'
   }
 ]
 
@@ -137,8 +80,9 @@ describe('Plugin', () => {
       // https://github.com/mochajs/mocha/wiki/Using-Mocha-programmatically
       // > If you want to run tests multiple times, you may need to clear Node's require cache
       // before subsequent calls in whichever manner best suits your needs.
-      TESTS.forEach((test) => {
-        delete require.cache[require.resolve(path.join(__dirname, test.fileName))]
+      const mochaTestFiles = fs.readdirSync(__dirname).filter(name => name.startsWith('mocha-'))
+      mochaTestFiles.forEach((testFile) => {
+        delete require.cache[require.resolve(path.join(__dirname, testFile))]
       })
       return agent.close()
     })
@@ -153,101 +97,125 @@ describe('Plugin', () => {
       })
     })
     describe('mocha', () => {
-      TESTS.forEach(test => {
-        it(`should create a test span for ${test.fileName}`, (done) => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+      it('works with passing tests', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-test-pass.js')
+        const testNames = [
+          'mocha-test-pass can pass',
+          'mocha-test-pass can pass two',
+          'mocha-test-pass-two can pass',
+          'mocha-test-pass-two can pass two'
+        ]
+        const assertionPromises = testNames.map(testName => {
+          return agent.use(trace => {
+            const testSpan = trace[0][0]
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
+            expect(testSpan.meta[TEST_NAME]).to.equal(testName)
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+          })
+        })
+        Promise.all(assertionPromises)
+          .then(() => done())
+          .catch(done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
+      it('works with failing tests', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-test-fail.js')
+        const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
+        agent
+          .use(traces => {
+            const testSpan = traces[0][0]
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'mocha-test-fail can fail',
+              [TEST_STATUS]: 'fail',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'mocha',
+              [TEST_SUITE]: testSuite
+            })
+            expect(testSpan.meta).to.contain({
+              [ERROR_TYPE]: 'AssertionError',
+              [ERROR_MESSAGE]: 'expected true to equal false'
+            })
+            expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[TEST_SUITE].endsWith('mocha-test-fail.js')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('mocha.test')
+            expect(testSpan.resource).to.equal(`${testSuite}.mocha-test-fail can fail`)
+          }).then(done, done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
+      it('works with skipping tests', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-test-skip.js')
+        const testNames = [
+          'mocha-test-skip can skip',
+          'mocha-test-skip-different can skip too',
+          'mocha-test-skip-different can skip twice'
+        ]
+        const assertionPromises = testNames.map(testName => {
+          return agent.use(trace => {
+            const testSpan = trace[0][0]
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[TEST_STATUS]).to.equal('skip')
+            expect(testSpan.meta[TEST_NAME]).to.equal(testName)
+            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+          })
+        })
+        Promise.all(assertionPromises)
+          .then(() => done())
+          .catch(done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
+
+      ASYNC_TESTS.forEach(test => {
+        it(`works with async tests for ${test.fileName}`, (done) => {
           const testFilePath = path.join(__dirname, test.fileName)
           const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
-
-          if (test.fileName === 'mocha-test-skip.js' || test.fileName === 'mocha-test-pass.js') {
-            const assertionPromises = test.testNames.map(testName => {
-              return agent.use(trace => {
-                const testSpan = trace[0][0]
-                expect(testSpan.parent_id.toString()).to.equal('0')
-                expect(testSpan.meta[TEST_STATUS]).to.equal(test.status)
-                expect(testSpan.meta[TEST_NAME]).to.equal(testName)
-                expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              })
-            })
-            Promise.all(assertionPromises)
-              .then(() => done())
-              .catch(done)
-          } else if (test.fileName === 'mocha-test-integration.js') {
-            agent.use(trace => {
-              const testSpan = trace[0].find(span => span.type === 'test')
-              const fsOperationSpan = trace[0].find(span => span.name === 'fs.operation')
-              expect(testSpan.parent_id.toString()).to.equal('0')
-              expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
-              expect(testSpan.meta[TEST_NAME]).to.equal('mocha-test-integration can do integration tests')
-              expect(fsOperationSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
-              expect(fsOperationSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-            }).then(done, done)
-          } else if (test.fileName === 'mocha-test-integration-http.js') {
-            agent.use(trace => {
-              const httpSpan = trace[0].find(span => span.name === 'http.request')
-              const testSpan = trace[0].find(span => span.type === 'test')
-              expect(testSpan.parent_id.toString()).to.equal('0')
-              expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
-              expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+          agent
+            .use(traces => {
+              const testSpan = traces[0][0]
               expect(testSpan.meta).to.contain({
                 language: 'javascript',
                 service: 'test',
                 [TEST_NAME]: `${test.root} ${test.testName}`,
                 [TEST_STATUS]: test.status,
+                [TEST_TYPE]: 'test',
                 [TEST_FRAMEWORK]: 'mocha',
                 [TEST_SUITE]: testSuite
               })
-            }).then(done, done)
-          } else if (test.fileName === 'mocha-fail-hook-sync.js') {
-            agent.use(traces => {
-              const testSpan = traces[0][0]
-              expect(testSpan.meta).to.contain({
-                [ERROR_TYPE]: 'TypeError',
-                [ERROR_MESSAGE]: `"before each" hook for "will not run but be reported as failed": \
-Cannot set property 'error' of undefined`
-              })
-              expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
-            }).then(done, done)
-          } else if (test.fileName === 'mocha-fail-hook-async.js') {
-            agent.use(traces => {
-              const testSpan = traces[0][0]
-              expect(testSpan.meta[ERROR_MESSAGE].startsWith(
-                `"after each" hook for "will not run but be reported as failed": \
-Timeout of 100ms exceeded. For async tests and hooks, ensure "done()" is called;`)).to.equal(true)
-              expect(testSpan.meta[ERROR_TYPE]).to.equal('Error')
-              expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
-            }).then(done, done)
-          } else {
-            agent
-              .use(traces => {
-                const testSpan = traces[0][0]
+              if (test.fileName === 'mocha-test-fail.js') {
                 expect(testSpan.meta).to.contain({
-                  language: 'javascript',
-                  service: 'test',
-                  [TEST_NAME]: `${test.root} ${test.testName}`,
-                  [TEST_STATUS]: test.status,
-                  [TEST_TYPE]: 'test',
-                  [TEST_FRAMEWORK]: 'mocha',
-                  [TEST_SUITE]: testSuite,
-                  ...test.extraSpanTags
+                  [ERROR_TYPE]: 'AssertionError',
+                  [ERROR_MESSAGE]: 'expected true to equal false'
                 })
-                if (test.fileName === 'mocha-test-fail.js') {
-                  expect(testSpan.meta).to.contain({
-                    [ERROR_TYPE]: 'AssertionError',
-                    [ERROR_MESSAGE]: 'expected true to equal false'
-                  })
-                  expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
-                }
-                expect(testSpan.parent_id.toString()).to.equal('0')
-                expect(testSpan.meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
-                expect(testSpan.type).to.equal('test')
-                expect(testSpan.name).to.equal('mocha.test')
-                expect(testSpan.resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
-              }).then(done, done)
-          }
+                expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
+              }
+              expect(testSpan.parent_id.toString()).to.equal('0')
+              expect(testSpan.meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
+              expect(testSpan.type).to.equal('test')
+              expect(testSpan.name).to.equal('mocha.test')
+              expect(testSpan.resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
+            }).then(done, done)
 
           const mocha = new Mocha({
             reporter: function () {} // silent on internal tests
@@ -255,6 +223,130 @@ Timeout of 100ms exceeded. For async tests and hooks, ensure "done()" is called;
           mocha.addFile(testFilePath)
           mocha.run()
         })
+      })
+
+      it('works for parameterized tests', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-test-parameterized.js')
+        const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
+        agent
+          .use(traces => {
+            const testSpan = traces[0][0]
+            expect(testSpan.meta).to.contain({
+              language: 'javascript',
+              service: 'test',
+              [TEST_NAME]: 'mocha-parameterized can do parameterized',
+              [TEST_STATUS]: 'pass',
+              [TEST_TYPE]: 'test',
+              [TEST_FRAMEWORK]: 'mocha',
+              [TEST_SUITE]: testSuite,
+              [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
+            })
+            expect(testSpan.parent_id.toString()).to.equal('0')
+            expect(testSpan.meta[TEST_SUITE].endsWith('mocha-test-parameterized.js')).to.equal(true)
+            expect(testSpan.type).to.equal('test')
+            expect(testSpan.name).to.equal('mocha.test')
+            expect(testSpan.resource).to.equal(`${testSuite}.mocha-parameterized can do parameterized`)
+          }).then(done, done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
+
+      it('works with integrations', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-test-integration.js')
+
+        agent.use(trace => {
+          const testSpan = trace[0].find(span => span.type === 'test')
+          const fsOperationSpan = trace[0].find(span => span.name === 'fs.operation')
+          expect(testSpan.parent_id.toString()).to.equal('0')
+          expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+          expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
+          expect(testSpan.meta[TEST_NAME]).to.equal('mocha-test-integration can do integration tests')
+          expect(fsOperationSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+          expect(fsOperationSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+        }).then(done, done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
+
+      it('works with http integration', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-test-integration-http.js')
+        const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
+
+        agent.use(trace => {
+          const httpSpan = trace[0].find(span => span.name === 'http.request')
+          const testSpan = trace[0].find(span => span.type === 'test')
+          expect(testSpan.parent_id.toString()).to.equal('0')
+          expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+          expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+          expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
+          expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+          expect(testSpan.meta).to.contain({
+            language: 'javascript',
+            service: 'test',
+            [TEST_NAME]: 'mocha-test-integration-http can do integration http',
+            [TEST_STATUS]: 'pass',
+            [TEST_FRAMEWORK]: 'mocha',
+            [TEST_SUITE]: testSuite
+          })
+        }).then(done, done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
+
+      it('works with sync errors in the hooks', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-fail-hook-sync.js')
+
+        agent.use(traces => {
+          const testSpan = traces[0][0]
+          expect(testSpan.meta).to.contain({
+            [ERROR_TYPE]: 'TypeError',
+            [ERROR_MESSAGE]: `"before each" hook for "will not run but be reported as failed": \
+Cannot set property 'error' of undefined`
+          })
+          expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
+        }).then(done, done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
+
+      it('works with async errors in the hooks', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testFilePath = path.join(__dirname, 'mocha-fail-hook-async.js')
+
+        agent.use(traces => {
+          const testSpan = traces[0][0]
+          expect(testSpan.meta[ERROR_MESSAGE].startsWith(
+            `"after each" hook for "will not run but be reported as failed": \
+Timeout of 100ms exceeded. For async tests and hooks, ensure "done()" is called;`)).to.equal(true)
+          expect(testSpan.meta[ERROR_TYPE]).to.equal('Error')
+          expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
+        }).then(done, done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
       })
     })
   })

--- a/packages/datadog-plugin-mocha/test/mocha-fail-hook-async.js
+++ b/packages/datadog-plugin-mocha/test/mocha-fail-hook-async.js
@@ -1,0 +1,13 @@
+const { expect } = require('chai')
+
+describe('mocha-fail-hook-async', function () {
+  this.timeout(100)
+  afterEach((done) => {
+    setTimeout(() => {
+      done()
+    }, 200)
+  })
+  it('will not run but be reported as failed', () => {
+    expect(true).to.equal(true)
+  })
+})

--- a/packages/datadog-plugin-mocha/test/mocha-fail-hook-sync.js
+++ b/packages/datadog-plugin-mocha/test/mocha-fail-hook-sync.js
@@ -1,0 +1,11 @@
+const { expect } = require('chai')
+
+describe('mocha-fail-hook-sync', () => {
+  beforeEach(() => {
+    const value = ''
+    value.unsafe.error = ''
+  })
+  it('will not run but be reported as failed', () => {
+    expect(true).to.equal(true)
+  })
+})

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -15,7 +15,9 @@ function isError (value) {
     return true
   }
   if (value && value.constructor) {
-    return value.constructor.name === 'JestAssertionError' || value.constructor.name === 'Error'
+    return value.constructor.name === 'JestAssertionError' ||
+      value.constructor.name === 'Error' ||
+      value.constructor.name === 'ErrorWithStack'
   }
   return false
 }


### PR DESCRIPTION
### What does this PR do?
* Handle errors in hooks for `jest`, `mocha` and `cucumber`. 

### Motivation
If a test fails on its `beforeEach` or `afterEach`, we still want to have visibility over that error. This PR addresses just that.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
