### PR TITLE
Support for ShareDB (datadog-plugin-sharedb)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -527,6 +527,7 @@ interface Plugins {
   "restify": plugins.restify;
   "rhea": plugins.rhea;
   "router": plugins.router;
+  "sharedb": plugins.sharedb;
   "tedious": plugins.tedious;
   "when": plugins.when;
   "winston": plugins.winston;
@@ -631,7 +632,7 @@ declare namespace plugins {
     };
 
     /**
-     * Whether to enable instrumention of <plugin>.middleware spans
+     * Whether to enable instrumentation of <plugin>.middleware spans
      *
      * @default true
      */
@@ -1244,6 +1245,22 @@ declare namespace plugins {
    * [router](https://github.com/pillarjs/router) module.
    */
   interface router extends Integration {}
+
+  /**
+   * This plugin automatically instruments the
+   * [sharedb](https://github.com/share/sharedb) module.
+   */
+  interface sharedb extends Integration {
+    /**
+     * Hooks to run before spans are finished.
+     */
+    hooks?: {
+      /**
+       * Hook to execute just when the span is created.
+       */
+      receive?: (span?: opentracing.Span, shareDBAgent?: any, shareDBTriggerContext?: any) => any;
+    };
+  }
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-plugin-sharedb/src/index.js
+++ b/packages/datadog-plugin-sharedb/src/index.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const MessagesAwaitingResponse = new WeakMap();
+const READABLE_ACTION_NAMES = {
+  hs: 'handshake',
+  qf: 'query-fetch',
+  qs: 'query-subscribe',
+  qu: 'query-unsubscribe',
+  bf: 'bulk-fetch',
+  bs: 'bulk-subscribe',
+  bu: 'bulk-unsubscribe',
+  f: 'fetch',
+  s: 'subscribe',
+  u: 'unsubscribe',
+  op: 'op',
+  nf: 'snapshot-fetch',
+  nt: 'snapshot-fetch-by-ts',
+  p: 'presence-broadcast',
+  pr: 'presence-request',
+  ps: 'presence-subscribe',
+  pu: 'presence-unsubscribe'
+};
+
+function createTraceName(action, collection) {
+  let actionName = READABLE_ACTION_NAMES[action];
+  if (actionName === undefined) {
+    actionName = action;
+  }
+  let traceName = 'sharedb-request/' + actionName;
+  if (collection) {
+    traceName += '/' + collection;
+  }
+  return traceName;
+}
+
+function createWrapHandle(tracer, config) { // called once
+  return function wrapTrigger(triggerFn) { // called once
+    return function handleMessageWithTrace(action, agent, triggerContext, callback) { // called for each trigger
+      /**
+       * What we're doing here is tying ourselves into the ShareDB Backend middleware.
+       * This allows us to create traces for all events that have triggers, like receiving a message and replying
+       * to it. The benefit of doing this over wrapping the connection class is that both the receive and reply
+       * triggers have access to a reference of the original request object. This allows us to use a WeakMap to
+       * store the span call backs to help prevent memory leaks.
+       *
+       */
+      switch (action) {
+        case 'receive':
+          if (triggerContext.data && triggerContext.data.a) {
+            const scope = tracer.scope();
+            const childOf = scope.active();
+            return triggerFn.call(this, action, agent, triggerContext, function wrappedCallback(err) {
+              tracer.trace(
+                createTraceName(triggerContext.data.a, triggerContext.data.c),
+                { childOf },
+                (span, spanDoneCb) => {
+                  if (config.hooks && config.hooks.receive) {
+                    config.hooks.receive(span, agent, triggerContext);
+                  }
+                  if (span) {
+                    MessagesAwaitingResponse.set(triggerContext.data, spanDoneCb);
+                  }
+                  callback(err);
+                });
+            });
+          } else {
+            return triggerFn.apply(this, arguments);
+          }
+        case 'reply':
+          const replySpanCallBack = MessagesAwaitingResponse.get(triggerContext.request);
+          if (replySpanCallBack) {
+            replySpanCallBack();
+            MessagesAwaitingResponse.delete(triggerContext.request);
+          }
+          return triggerFn.apply(this, arguments);
+        case 'send':
+          const sendSpanCallBack = MessagesAwaitingResponse.get(triggerContext);
+          if (sendSpanCallBack) {
+            sendSpanCallBack();
+            MessagesAwaitingResponse.delete(triggerContext);
+          }
+          return triggerFn.apply(this, arguments);
+        default:
+          return triggerFn.apply(this, arguments);
+      }
+    };
+  };
+}
+
+module.exports = {
+  name: 'sharedb',
+  versions: ['>=1'],
+  file: 'lib/backend.js',
+  patch(Backend, tracer, config) {
+    this.wrap(Backend.prototype, 'trigger', createWrapHandle(tracer, config));
+  },
+  unpatch(Backend) {
+    this.unwrap(Backend.prototype, 'trigger');
+  }
+};

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -48,6 +48,7 @@ module.exports = {
   'restify': require('../../../datadog-plugin-restify/src'),
   'rhea': require('../../../datadog-plugin-rhea/src'),
   'router': require('../../../datadog-plugin-router/src'),
+  'sharedb': require('../../../datadog-plugin-sharedb/src'),
   'tedious': require('../../../datadog-plugin-tedious/src'),
   'when': require('../../../datadog-plugin-when/src'),
   'winston': require('../../../datadog-plugin-winston/src')


### PR DESCRIPTION
Could someone please approve this approach, before I invest in writing the tests? 🥳 

### What does this PR do?
Adding support for ShareDB.

### Motivation
At Lever, we use ShareDB extensively. We've created our own datadog plugin internally - however it would be preferred if this was just part of dd-trace-js.

### Plugin Checklist
Will add tests once approach approved.

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
ShareDB does not provide a normal request-response flow with callbacks. It uses long-lived connections, so to properly complete spans we have to store a reference to the request object, and then resolve the span on response by looking for that reference. For this we use a WeakMap to prevent memory leaks.
