### PR TITLE
Make profiler use normal enable option

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -32,9 +32,8 @@ class Config {
     )
     // Temporary disabled
     const DD_PROFILING_ENABLED = coalesce(
-      // options.profiling,
-      // process.env.DD_PROFILING_ENABLED,
-      process.env.DD_EXPERIMENTAL_PROFILING_ENABLED,
+      options.profiling,
+      process.env.DD_PROFILING_ENABLED,
       false
     )
     const DD_PROFILING_EXPORTERS = coalesce(


### PR DESCRIPTION
This makes the profiler use the standard config option to enable it, and makes it enabled by default.