### PR TITLE
Edit Tagger.js to support whitespace

### DIFF
--- a/packages/dd-trace/src/profiling/tagger.js
+++ b/packages/dd-trace/src/profiling/tagger.js
@@ -9,8 +9,8 @@ const tagger = {
         if (Array.isArray(tags)) {
           return tags.reduce((prev, next) => {
             const parts = next.split(':')
-            const key = parts.shift()
-            const value = parts.join(':')
+            const key = parts.shift().trim()
+            const value = parts.join(':').trim()
 
             if (!key || !value) return prev
 

--- a/packages/dd-trace/src/tagger.js
+++ b/packages/dd-trace/src/tagger.js
@@ -13,8 +13,8 @@ function add (carrier, keyValuePairs) {
         .filter(tag => tag.indexOf(':') !== -1)
         .reduce((prev, next) => {
           const tag = next.split(':')
-          const key = tag[0]
-          const value = tag.slice(1).join(':')
+          const key = tag[0].trim()
+          const value = tag.slice(1).join(':').trim()
 
           prev[key] = value
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -473,4 +473,12 @@ describe('Config', () => {
 
     expect(config.serviceMapping).to.deep.equal({})
   })
+  
+  it('should trim whitespace characters around keys', () => {
+    process.env.DD_TAGS = 'foo:bar, baz:qux'
+
+    const config = new Config()
+
+    expect(config.tags).to.include({ foo: 'foo', baz: 'qux' })
+  })
 })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -479,6 +479,6 @@ describe('Config', () => {
 
     const config = new Config()
 
-    expect(config.tags).to.include({ foo: 'foo', baz: 'qux' })
+    expect(config.tags).to.include({ foo: 'bar', baz: 'qux' })
   })
 })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -473,7 +473,7 @@ describe('Config', () => {
 
     expect(config.serviceMapping).to.deep.equal({})
   })
-  
+
   it('should trim whitespace characters around keys', () => {
     process.env.DD_TAGS = 'foo:bar, baz:qux'
 

--- a/packages/dd-trace/test/profiling/tagger.spec.js
+++ b/packages/dd-trace/test/profiling/tagger.spec.js
@@ -86,4 +86,14 @@ describe('tagger', () => {
 
     expect(parsed).to.deep.equal({})
   })
+
+  it('should trim whitespace around keys and values', () => {
+    const tags = 'foo:bar, fruit:banana'
+    const parsed = tagger.parse(tags)
+
+    expect(parsed).to.deep.equal({
+      foo: 'bar',
+      fruit: 'banana
+    })
+  })
 })

--- a/packages/dd-trace/test/profiling/tagger.spec.js
+++ b/packages/dd-trace/test/profiling/tagger.spec.js
@@ -93,7 +93,7 @@ describe('tagger', () => {
 
     expect(parsed).to.deep.equal({
       foo: 'bar',
-      fruit: 'banana
+      fruit: 'banana'
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Some customers are adding whitespace in their DD_TAGS Arguments

let /s = whitespace character
Ex: key1:val1,/skey2:val2, /skey3:val3

This causes an issue with span indexing in Datadog because we do not allow facets on whitespace characters https://a.cl.ly/4gun2LYy

Can we trim the data so it does not occur?

### Motivation
Customer Request

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
