### PR TITLE
fix errors in web frameworks when using fake requests

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -408,9 +408,16 @@ function extractURL (req) {
   if (req.stream) {
     return `${headers[HTTP2_HEADER_SCHEME]}://${headers[HTTP2_HEADER_AUTHORITY]}${headers[HTTP2_HEADER_PATH]}`
   } else {
-    const protocol = req.socket.encrypted ? 'https' : 'http'
+    const protocol = getProtocol(req)
     return `${protocol}://${req.headers['host']}${req.originalUrl || req.url}`
   }
+}
+
+function getProtocol (req) {
+  if (req.socket && req.socket.encrypted) return 'https'
+  if (req.connection && req.connection.encrypted) return 'https'
+
+  return 'http'
 }
 
 function getHeadersToRecord (config) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix errors in web frameworks when using fake requests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some libraries like [hapi-io](https://www.npmjs.com/package/hapi-io) convert other protocols to fake HTTP request objects that may not contain some not widely used API. These objects would have very common properties like `method` and `url`, but not necessarily less common ones like `connection` or `socket`. This means that if these properties are objects we need to assume they may not exist.

Fixes #1435