### PR TITLE
fix pino-pretty test check for invalid string on the record

### DIFF
--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -66,7 +66,6 @@ describe('Plugin', () => {
 
               const record = stream.write.firstCall.args[0].toString()
 
-              expect(record).to.not.include('dd')
               expect(record).to.not.include('trace_id')
               expect(record).to.not.include('span_id')
               expect(record).to.include('message')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `pino-pretty` test check for invalid string on the record.

### Motivation
<!-- What inspired you to submit this pull request? -->

This check is not needed for strings, only for JSON, and it makes the test intermittent because the string contains hexadecimal which can match `dd`.