### PR TITLE
preinstall script to check version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "scripts": {
+    "preinstall": "node scripts/preinstall.js",
     "install": "(node scripts/should_rebuild && node-gyp-build) || exit 0",
     "rebuild": "node-gyp rebuild --jobs=max",
     "prebuild": "node scripts/prebuild.js",
@@ -51,8 +52,8 @@
     "url": "https://github.com/DataDog/dd-trace-js/issues"
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
-  "engines": {
-    "node": ">=12"
+  "dd-trace": {
+    "nodejsVersions": [8, 9, 10, 11, 12, 13, 14, 15, 16]
   },
   "dependencies": {
     "@types/node": "^10.12.18",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "url": "https://github.com/DataDog/dd-trace-js/issues"
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
-  "dd-trace": {
-    "nodejsVersions": [8, 9, 10, 11, 12, 13, 14, 15, 16]
+  "engines": {
+    "node": ">=12"
   },
   "dependencies": {
     "@types/node": "^10.12.18",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,0 +1,81 @@
+'use strict'
+
+/* eslint-disable no-console */
+
+const fs = require('fs')
+const path = require('path')
+
+const nodeMajor = Number(process.versions.node.split('.')[0])
+
+const range = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+)['dd-trace'].nodejsVersions
+
+;(() => {
+  if (nodeMajor < 8) {
+    process.exitCode = 1
+    console.error('\n' + `
+You're using Node.js v${process.versions.node}, which is not supported by
+dd-trace.
+
+Please upgrade to a more recent version of Node.js.
+    `.trim() + '\n')
+    return
+  }
+
+  if (nodeMajor % 2 === 1 && range.includes(nodeMajor)) {
+    oddVersion()
+  }
+
+  if (!range.includes(nodeMajor)) {
+    process.exitCode = 1
+    // eslint-disable-next-line no-console
+    console.error(incompatMessage())
+  }
+})()
+
+function incompatMessage () {
+  return '\n' + `
+The version of dd-trace you're attempting to install is incompatible with the
+version of Node.js you're using.
+
+Please use the following to switch to a compatible dd-trace version:
+
+${versionInstall()}
+  `.trim() + '\n'
+}
+
+function versionInstall () {
+  const output = {
+    npm () {
+      return `npm rm dd-trace; npm install dd-trace@node${nodeMajor}`
+    },
+    yarn () {
+      return `yarn remove dd-trace; yarn add dd-trace@node${nodeMajor}`
+    },
+    pnpm () {
+      return `pnpm rm dd-trace; pnpm install dd-trace@node${nodeMajor}`
+    }
+  }
+
+  let packageManager = process.env.npm_execpath
+    ? path.basename(process.env.npm_execpath)
+    : 'npm'
+
+  if (!(packageManager in output)) {
+    packageManager = 'npm'
+  }
+
+  return '    ' + output[packageManager]()
+}
+
+function oddVersion () {
+  console.error('\n' + `
+You're using Node.js v${process.versions.node}.
+Odd-numbered release lines of Node.js do not receive long-term support from
+Node.js or from dd-trace. Support for dd-trace with this version of Node.js is
+limited.
+
+Please consider switching to an even-numbered release line of Node.js.
+`.trim() + '\n')
+}

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -4,78 +4,20 @@
 
 const fs = require('fs')
 const path = require('path')
+const semver = require('semver')
 
-const nodeMajor = Number(process.versions.node.split('.')[0])
+const nodeVersion = process.versions.node
 
 const range = JSON.parse(
   fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
-)['dd-trace'].nodejsVersions
+).engines.node
 
-;(() => {
-  if (nodeMajor < 8) {
-    process.exitCode = 1
-    console.error('\n' + `
+if (!semver.satisfies(nodeVersion, range)) {
+  process.exitCode = 1
+  console.error('\n' + `
 You're using Node.js v${process.versions.node}, which is not supported by
 dd-trace.
 
 Please upgrade to a more recent version of Node.js.
-    `.trim() + '\n')
-    return
-  }
-
-  if (nodeMajor % 2 === 1 && range.includes(nodeMajor)) {
-    oddVersion()
-  }
-
-  if (!range.includes(nodeMajor)) {
-    process.exitCode = 1
-    // eslint-disable-next-line no-console
-    console.error(incompatMessage())
-  }
-})()
-
-function incompatMessage () {
-  return '\n' + `
-The version of dd-trace you're attempting to install is incompatible with the
-version of Node.js you're using.
-
-Please use the following to switch to a compatible dd-trace version:
-
-${versionInstall()}
-  `.trim() + '\n'
-}
-
-function versionInstall () {
-  const output = {
-    npm () {
-      return `npm rm dd-trace; npm install dd-trace@node${nodeMajor}`
-    },
-    yarn () {
-      return `yarn remove dd-trace; yarn add dd-trace@node${nodeMajor}`
-    },
-    pnpm () {
-      return `pnpm rm dd-trace; pnpm install dd-trace@node${nodeMajor}`
-    }
-  }
-
-  let packageManager = process.env.npm_execpath
-    ? path.basename(process.env.npm_execpath)
-    : 'npm'
-
-  if (!(packageManager in output)) {
-    packageManager = 'npm'
-  }
-
-  return '    ' + output[packageManager]()
-}
-
-function oddVersion () {
-  console.error('\n' + `
-You're using Node.js v${process.versions.node}.
-Odd-numbered release lines of Node.js do not receive long-term support from
-Node.js or from dd-trace. Support for dd-trace with this version of Node.js is
-limited.
-
-Please consider switching to an even-numbered release line of Node.js.
-`.trim() + '\n')
+  `.trim() + '\n')
 }

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -2,17 +2,14 @@
 
 /* eslint-disable no-console */
 
-const fs = require('fs')
 const path = require('path')
-const semver = require('semver')
+const requirePackageJson = require('../packages/dd-trace/src/require-package-json.js')
 
-const nodeVersion = process.versions.node
+const nodeMajor = Number(process.versions.node.split('.')[0])
 
-const range = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
-).engines.node
+const min = Number(requirePackageJson(path.join(__dirname, '..')).engines.node.match(/\d+/)[0])
 
-if (!semver.satisfies(nodeVersion, range)) {
+if (nodeMajor < min) {
   process.exitCode = 1
   console.error('\n' + `
 You're using Node.js v${process.versions.node}, which is not supported by


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a preinstall script that checks version ranges.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want a better experience for users who install `dd-trace` with versions of Node.js that are not supported.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This relies on `dist-tag` entries for each supported Node.js major version. Those need to be set up before merging this.
