### PR TITLE
remove internal services and replace analytics with measured

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
   oracledb:
     image: quillbuilduser/oracle-18-xe
     ports:
-      - '32118:1521'
-      - '35518:5500'
+      - '127.0.0.1:1521:1521'
+      - '127.0.0.1:5500:5500'
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
     environment:

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -4,7 +4,6 @@ import { BINARY, HTTP_HEADERS, LOG, TEXT_MAP } from '../ext/formats';
 import { SERVER, CLIENT, PRODUCER, CONSUMER } from '../ext/kinds'
 import { USER_REJECT, AUTO_REJECT, AUTO_KEEP, USER_KEEP } from '../ext/priority'
 import {
-  ANALYTICS,
   ERROR,
   HTTP_METHOD,
   HTTP_REQUEST_HEADERS,
@@ -37,7 +36,6 @@ tracer.init({
   enabled: true,
   logInjection: true,
   startupLogs: false,
-  analytics: true,
   env: 'test',
   version: '1.0.0',
   url: 'http://localhost',
@@ -238,7 +236,7 @@ tracer.use('winston');
 tracer.use('express', false)
 tracer.use('express', { enabled: false })
 tracer.use('express', { service: 'name' });
-tracer.use('express', { analytics: true });
+tracer.use('express', { measured: true });
 
 span = tracer.startSpan('test');
 span = tracer.startSpan('test', {});
@@ -254,8 +252,7 @@ span = tracer.startSpan('test', {
 tracer.trace('test', () => {})
 tracer.trace('test', { tags: { foo: 'bar' }}, () => {})
 tracer.trace('test', { service: 'foo', resource: 'bar', type: 'baz' }, () => {})
-tracer.trace('test', { analytics: true }, () => {})
-tracer.trace('test', { analytics: 0.5 }, () => {})
+tracer.trace('test', { measured: true }, () => {})
 tracer.trace('test', (span: Span) => {})
 tracer.trace('test', (span: Span, fn: () => void) => {})
 tracer.trace('test', (span: Span, fn: (err: Error) => string) => {})

--- a/index.d.ts
+++ b/index.d.ts
@@ -212,12 +212,6 @@ export declare interface TracerOptions {
   startupLogs?: boolean,
 
   /**
-   * Enable Trace Analytics.
-   * @default false
-   */
-  analytics?: boolean;
-
-  /**
    * The service name to be used for this program. If not set, the service name
    * will attempted to be inferred from package.json
    */
@@ -535,11 +529,10 @@ interface Plugins {
 /** @hidden */
 interface Analyzable {
   /**
-   * Whether to enable App Analytics. Can also be set to a number instead to
-   * control the sample rate, or to an key-value pair with span names as keys
-   * and booleans or sample rates as values for more granular control.
+   * Whether to measure the span. Can also be set to a key-value pair with span
+   * names as keys and booleans as values for more granular control.
    */
-  analytics?: boolean | number | { [key: string]: boolean | number };
+  measured?: boolean | { [key: string]: boolean };
 }
 
 declare namespace plugins {

--- a/packages/datadog-plugin-amqp10/src/index.js
+++ b/packages/datadog-plugin-amqp10/src/index.js
@@ -55,7 +55,7 @@ function startSendSpan (tracer, config, link) {
 
   addTags(tracer, config, span, link)
 
-  analyticsSampler.sample(span, config.analytics)
+  analyticsSampler.sample(span, config.measured)
 
   return span
 }
@@ -74,7 +74,7 @@ function startReceiveSpan (tracer, config, link) {
 
   addTags(tracer, config, span, link)
 
-  analyticsSampler.sample(span, config.analytics, true)
+  analyticsSampler.sample(span, config.measured, true)
 
   return span
 }

--- a/packages/datadog-plugin-amqplib/src/index.js
+++ b/packages/datadog-plugin-amqplib/src/index.js
@@ -30,7 +30,7 @@ function createWrapDispatchMessage (tracer, config) {
 
       addTags(this, tracer, config, span, 'basic.deliver', fields)
 
-      analyticsSampler.sample(span, config.analytics, true)
+      analyticsSampler.sample(span, config.measured, true)
 
       tracer.scope().activate(span, () => {
         try {
@@ -54,7 +54,7 @@ function sendWithTrace (send, channel, args, tracer, config, method, fields) {
   addTags(channel, tracer, config, span, method, fields)
   tracer.inject(span, TEXT_MAP, fields.headers)
 
-  analyticsSampler.sample(span, config.analytics)
+  analyticsSampler.sample(span, config.measured)
 
   return tracer.scope().activate(span, () => {
     try {

--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -40,7 +40,7 @@ function createWrapRequest (tracer, config) {
         awsHelpers.finish(span, response.error)
       })
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
 
       awsHelpers.requestInject(span, this, serviceIdentifier, tracer)
 

--- a/packages/datadog-plugin-cassandra-driver/src/index.js
+++ b/packages/datadog-plugin-cassandra-driver/src/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const tx = require('../../dd-trace/src/plugins/util/tx')
 
 function createWrapInnerExecute (tracer, config) {
@@ -132,6 +133,8 @@ function start (tracer, config, client = {}, query) {
       'cassandra.keyspace': client.keyspace
     }
   })
+
+  analyticsSampler.sample(span, config.measured)
 
   return span
 }

--- a/packages/datadog-plugin-couchbase/src/index.js
+++ b/packages/datadog-plugin-couchbase/src/index.js
@@ -17,7 +17,7 @@ function startSpan (tracer, config, operation, resource) {
     }
   })
 
-  analyticsSampler.sample(span, config.analytics)
+  analyticsSampler.sample(span, config.measured)
 
   return span
 }

--- a/packages/datadog-plugin-dns/src/index.js
+++ b/packages/datadog-plugin-dns/src/index.js
@@ -104,11 +104,12 @@ function startSpan (tracer, config, operation, tags) {
   const span = tracer.startSpan(operation, {
     childOf,
     tags: Object.assign({
-      'service.name': config.service || `${tracer._service}-dns`
+      'service.name': config.service || tracer._service,
+      'span.kind': 'client'
     }, tags)
   })
 
-  analyticsSampler.sample(span, config.analytics)
+  analyticsSampler.sample(span, config.measured)
 
   return span
 }

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -28,10 +28,11 @@ describe('Plugin', () => {
         .use(traces => {
           expect(traces[0][0]).to.deep.include({
             name: 'dns.lookup',
-            service: 'test-dns',
+            service: 'test',
             resource: 'localhost'
           })
           expect(traces[0][0].meta).to.deep.include({
+            'span.kind': 'client',
             'dns.hostname': 'localhost',
             'dns.address': '127.0.0.1'
           })
@@ -47,10 +48,11 @@ describe('Plugin', () => {
         .use(traces => {
           expect(traces[0][0]).to.deep.include({
             name: 'dns.lookup_service',
-            service: 'test-dns',
+            service: 'test',
             resource: '127.0.0.1:22'
           })
           expect(traces[0][0].meta).to.deep.include({
+            'span.kind': 'client',
             'dns.address': '127.0.0.1'
           })
           expect(traces[0][0].metrics).to.deep.include({
@@ -68,10 +70,11 @@ describe('Plugin', () => {
         .use(traces => {
           expect(traces[0][0]).to.deep.include({
             name: 'dns.resolve',
-            service: 'test-dns',
+            service: 'test',
             resource: 'A localhost'
           })
           expect(traces[0][0].meta).to.deep.include({
+            'span.kind': 'client',
             'dns.hostname': 'localhost',
             'dns.rrtype': 'A'
           })
@@ -87,10 +90,11 @@ describe('Plugin', () => {
         .use(traces => {
           expect(traces[0][0]).to.deep.include({
             name: 'dns.resolve',
-            service: 'test-dns',
+            service: 'test',
             resource: 'ANY localhost'
           })
           expect(traces[0][0].meta).to.deep.include({
+            'span.kind': 'client',
             'dns.hostname': 'localhost',
             'dns.rrtype': 'ANY'
           })
@@ -106,10 +110,11 @@ describe('Plugin', () => {
         .use(traces => {
           expect(traces[0][0]).to.deep.include({
             name: 'dns.reverse',
-            service: 'test-dns',
+            service: 'test',
             resource: '127.0.0.1'
           })
           expect(traces[0][0].meta).to.deep.include({
+            'span.kind': 'client',
             'dns.ip': '127.0.0.1'
           })
         })
@@ -150,10 +155,11 @@ describe('Plugin', () => {
           .use(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.resolve',
-              service: 'test-dns',
+              service: 'test',
               resource: 'A localhost'
             })
             expect(traces[0][0].meta).to.deep.include({
+              'span.kind': 'client',
               'dns.hostname': 'localhost',
               'dns.rrtype': 'A'
             })

--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -28,7 +28,7 @@ function createWrapRequest (tracer, config) {
         span.setTag('elasticsearch.body', JSON.stringify(params.body || params.bulkBody))
       }
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
 
       cb = request.length === 2 || typeof options === 'function'
         ? tracer.scope().bind(options, childOf)

--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -333,7 +333,7 @@ function makeFSTags (resourceName, path, options, config, tracer) {
     'component': 'fs',
     'span.kind': 'internal',
     'resource.name': resourceName,
-    'service.name': config.service || `${tracer._service}-fs`
+    'service.name': config.service || tracer._service
   }
 
   switch (typeof path) {

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1795,7 +1795,7 @@ function mkExpected (props) {
   const expected = Object.assign({
     name: 'fs.operation',
     error: 0,
-    service: 'test-fs'
+    service: 'test'
   }, props)
   expected.meta = meta
   return expected

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -224,7 +224,6 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
               expect(spans[0]).to.have.property('type', 'graphql')
-              expect(spans[0].meta).to.have.property('span.kind', 'server')
               expect(spans[0].meta).to.have.property('graphql.source', source)
               expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
               expect(spans[0].meta).to.have.property('graphql.operation.name', 'MyQuery')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -182,7 +182,7 @@ describe('Plugin', () => {
             .use(traces => {
               const span = traces[0][0]
 
-              expect(span).to.have.property('service', 'test-graphql')
+              expect(span).to.have.property('service', 'test')
               expect(span).to.have.property('name', 'graphql.parse')
               expect(span).to.have.property('resource', 'graphql.parse')
               expect(span).to.have.property('type', 'graphql')
@@ -201,7 +201,7 @@ describe('Plugin', () => {
             .use(traces => {
               const span = traces[0][0]
 
-              expect(span).to.have.property('service', 'test-graphql')
+              expect(span).to.have.property('service', 'test')
               expect(span).to.have.property('name', 'graphql.validate')
               expect(span).to.have.property('resource', 'graphql.validate')
               expect(span).to.have.property('type', 'graphql')
@@ -220,7 +220,7 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
               expect(spans[0]).to.have.property('type', 'graphql')
@@ -257,7 +257,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
-              expect(spans[1]).to.have.property('service', 'test-graphql')
+              expect(spans[1]).to.have.property('service', 'test')
               expect(spans[1]).to.have.property('name', 'graphql.resolve')
               expect(spans[1]).to.have.property('resource', 'hello:String')
               expect(spans[1]).to.have.property('type', 'graphql')
@@ -507,17 +507,17 @@ describe('Plugin', () => {
 
               expect(spans[0]).to.have.property('name', 'test.request')
 
-              expect(spans[1]).to.have.property('service', 'test-graphql')
+              expect(spans[1]).to.have.property('service', 'test')
               expect(spans[1]).to.have.property('name', 'graphql.parse')
 
-              expect(spans[2]).to.have.property('service', 'test-graphql')
+              expect(spans[2]).to.have.property('service', 'test')
               expect(spans[2]).to.have.property('name', 'graphql.validate')
 
-              expect(spans[3]).to.have.property('service', 'test-graphql')
+              expect(spans[3]).to.have.property('service', 'test')
               expect(spans[3]).to.have.property('name', 'graphql.execute')
               expect(spans[3]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
 
-              expect(spans[4]).to.have.property('service', 'test-graphql')
+              expect(spans[4]).to.have.property('service', 'test')
               expect(spans[4]).to.have.property('name', 'graphql.resolve')
               expect(spans[4]).to.have.property('resource', 'hello:String')
             })
@@ -632,7 +632,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
               expect(spans[0].meta).to.have.property('graphql.source', source)
@@ -651,7 +651,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.parse')
               expect(spans[0]).to.have.property('error', 1)
               expect(spans[0].meta).to.have.property('error.type', error.name)
@@ -676,7 +676,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.validate')
               expect(spans[0]).to.have.property('error', 1)
               expect(spans[0].meta).to.have.property('error.type', error.name)
@@ -702,7 +702,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.validate')
               expect(spans[0]).to.have.property('error', 1)
               expect(spans[0].meta).to.have.property('error.type', errors[0].name)
@@ -726,7 +726,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('error', 1)
               expect(spans[0].meta).to.have.property('error.type', error.name)
@@ -766,7 +766,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('error', 1)
               expect(spans[0].meta).to.have.property('error.type', error.name)
@@ -902,7 +902,7 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query SecondQuery{hello(name:"")}')
               expect(spans[0].meta).to.have.property('graphql.source', source)
@@ -933,7 +933,7 @@ describe('Plugin', () => {
 
               const resource = 'query WithFragments{human{...firstFields}}fragment firstFields on Human{name}'
 
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', resource)
               expect(spans[0].meta).to.have.property('graphql.source', source)
@@ -957,7 +957,7 @@ describe('Plugin', () => {
             .use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans[0]).to.have.property('service', 'test-graphql')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.parse')
               expect(spans[0]).to.have.property('resource', 'graphql.parse')
               expect(spans[0].meta).to.not.have.property('graphql.source')
@@ -978,7 +978,7 @@ describe('Plugin', () => {
         //       console.log(spans.map(span => `${span.name} | ${span.resource}`))
         //       const resource = 'query WithFragments{human{...firstFields}}fragment firstFields on Human{name}'
 
-        //       expect(spans[0]).to.have.property('service', 'test-graphql')
+        //       expect(spans[0]).to.have.property('service', 'test')
         //       expect(spans[0]).to.have.property('name', 'graphql.execute')
         //       expect(spans[0]).to.have.property('resource', resource)
         //       expect(spans[0].meta).to.have.property('graphql.source', source)

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const Tags = require('../../../ext/tags')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { ERROR } = require('../../../ext/tags')
@@ -178,6 +179,7 @@ function startSpan (tracer, config, path, methodKind) {
     }
   })
 
+  analyticsSampler.sample(span, config.measured)
   addMethodTags(span, path, methodKind)
 
   return span

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const Tags = require('../../../ext/tags')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { ERROR } = require('../../../ext/tags')
@@ -42,6 +43,7 @@ function createWrapHandler (tracer, config, handler) {
         }
       })
 
+      analyticsSampler.sample(span, config.measured, true)
       addMethodTags(span, handler, kinds[type])
       addMetadataTags(span, metadata, filter, 'request')
 

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -70,7 +70,7 @@ function patch (http, methodName, tracer, config) {
         tracer.inject(span, HTTP_HEADERS, options.headers)
       }
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
 
       callback = scope.bind(callback, childOf)
 

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -185,7 +185,7 @@ function startSpan (tracer, config, headers, sessionDetails) {
     tracer.inject(span, HTTP_HEADERS, headers)
   }
 
-  analyticsSampler.sample(span, config.analytics)
+  analyticsSampler.sample(span, config.measured)
   return span
 }
 

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -82,7 +82,7 @@ function instrumentStream (tracer, config, stream, headers, name, callback) {
     span.setTag(SERVICE_NAME, config.service)
   }
 
-  analyticsSampler.sample(span, config.analytics, true)
+  analyticsSampler.sample(span, config.measured, true)
 
   wrapStreamEnd(stream)
 

--- a/packages/datadog-plugin-memcached/src/index.js
+++ b/packages/datadog-plugin-memcached/src/index.js
@@ -16,7 +16,7 @@ function createWrapCommand (tracer, config) {
         }
       })
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
 
       queryCompiler = wrapQueryCompiler(queryCompiler, this, server, scope, span)
 

--- a/packages/datadog-plugin-mongodb-core/src/util.js
+++ b/packages/datadog-plugin-mongodb-core/src/util.js
@@ -12,7 +12,7 @@ function instrument (command, ctx, args, server, ns, ops, tracer, config, option
   const span = startSpan(tracer, config, ns, ops, server, name)
 
   if (name !== 'getMore' && name !== 'killCursors') {
-    analyticsSampler.sample(span, config.analytics)
+    analyticsSampler.sample(span, config.measured)
   }
 
   args[index] = wrapCallback(tracer, span, callback)

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -26,7 +26,7 @@ function createWrapQuery (tracer, config) {
         span.setTag('db.name', this.config.database)
       }
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
 
       const sequence = scope.bind(query, span).call(this, sql, values, cb)
 

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -42,7 +42,7 @@ function wrapExecute (tracer, config, execute) {
       }
     })
 
-    analyticsSampler.sample(span, config.analytics)
+    analyticsSampler.sample(span, config.measured)
 
     if (typeof this.onResult === 'function') {
       this.onResult = wrapCallback(tracer, span, childOf, this.onResult)

--- a/packages/datadog-plugin-net/src/index.js
+++ b/packages/datadog-plugin-net/src/index.js
@@ -21,7 +21,7 @@ function createWrapConnect (tracer, config) {
         ? wrapIpc(tracer, config, this, options)
         : wrapTcp(tracer, config, this, options)
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
 
       return scope.bind(connect, span).apply(this, arguments)
     }
@@ -64,7 +64,7 @@ function startSpan (tracer, config, protocol, tags) {
     childOf,
     tags: Object.assign({
       'span.kind': 'client',
-      'service.name': config.service || `${tracer._service}-${protocol}`
+      'service.name': config.service || tracer._service
     }, tags)
   })
 

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -61,7 +61,7 @@ describe('Plugin', () => {
     it('should instrument connect with a path', done => {
       expectSomeSpan(agent, {
         name: 'ipc.connect',
-        service: 'test-ipc',
+        service: 'test',
         resource: '/tmp/dd-trace.sock',
         meta: {
           'span.kind': 'client',
@@ -82,7 +82,7 @@ describe('Plugin', () => {
         socket.on('connect', () => {
           expectSomeSpan(agent, {
             name: 'tcp.connect',
-            service: 'test-tcp',
+            service: 'test',
             resource: `localhost:${port}`,
             meta: {
               'span.kind': 'client',
@@ -112,7 +112,7 @@ describe('Plugin', () => {
         socket.on('connect', () => {
           expectSomeSpan(agent, {
             name: 'tcp.connect',
-            service: 'test-tcp',
+            service: 'test',
             resource: `localhost:${port}`,
             meta: {
               'span.kind': 'client',
@@ -135,7 +135,7 @@ describe('Plugin', () => {
     it('should instrument connect with IPC options', done => {
       expectSomeSpan(agent, {
         name: 'ipc.connect',
-        service: 'test-ipc',
+        service: 'test',
         resource: '/tmp/dd-trace.sock',
         meta: {
           'span.kind': 'client',
@@ -160,7 +160,7 @@ describe('Plugin', () => {
         .use(traces => {
           expect(traces[0][0]).to.deep.include({
             name: 'tcp.connect',
-            service: 'test-tcp',
+            service: 'test',
             resource: `localhost:${port}`
           })
           expect(traces[0][0].meta).to.deep.include({

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -79,7 +79,7 @@ describe('Plugin', function () {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test-next')
+                expect(spans[0]).to.have.property('service', 'test')
                 expect(spans[0]).to.have.property('type', 'web')
                 expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
@@ -110,7 +110,7 @@ describe('Plugin', function () {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test-next')
+                expect(spans[0]).to.have.property('service', 'test')
                 expect(spans[0]).to.have.property('type', 'web')
                 expect(spans[0]).to.have.property('resource', 'GET /404')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
@@ -133,7 +133,7 @@ describe('Plugin', function () {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test-next')
+                expect(spans[0]).to.have.property('service', 'test')
                 expect(spans[0]).to.have.property('type', 'web')
                 expect(spans[0]).to.have.property('resource', 'GET /hello/[name]')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
@@ -154,7 +154,7 @@ describe('Plugin', function () {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test-next')
+                expect(spans[0]).to.have.property('service', 'test')
                 expect(spans[0]).to.have.property('type', 'web')
                 expect(spans[0]).to.have.property('resource', 'GET /404')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
@@ -188,7 +188,7 @@ describe('Plugin', function () {
               const spans = traces[0]
 
               expect(spans[0]).to.have.property('name', 'next.request')
-              expect(spans[0]).to.have.property('service', 'test-next')
+              expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('type', 'web')
               expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
               expect(spans[0].meta).to.have.property('span.kind', 'server')

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -20,11 +20,13 @@ function createWrapExecute (tracer, config) {
         'service.name': service
       }
 
-      return tracer.trace('oracle.query', { tags }, span => {
+      return tracer.wrap('oracle.query', { tags }, function (...args) {
+        const span = tracer.scope().active()
+
         analyticsSampler.sample(span, config.measured)
 
-        return execute.apply(this, arguments)
-      })
+        return execute.apply(this, args)
+      }).apply(this, arguments)
     }
   }
 }

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -23,7 +23,7 @@ function createWrapQuery (tracer, config) {
         }
       })
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
 
       const retval = scope.bind(query, span).apply(this, arguments)
       const queryQueue = this.queryQueue || this._queryQueue

--- a/packages/datadog-plugin-rhea/src/index.js
+++ b/packages/datadog-plugin-rhea/src/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
+
 const dd = Symbol('datadog')
 const circularBufferConstructor = Symbol('circularBufferConstructor')
 const inFlightDeliveries = Symbol('inFlightDeliveries')
@@ -25,6 +27,7 @@ function createWrapSend (tracer, config, instrumenter) {
           'out.port': port
         }
       }, (span, done) => {
+        analyticsSampler.sample(span, config.measured)
         addDeliveryAnnotations(msg, tracer, span)
         const delivery = send.apply(this, arguments)
         delivery[dd] = { done, span }
@@ -75,6 +78,7 @@ function createWrapReceiverDispatch (tracer, config, instrumenter) {
           },
           childOf
         }, (span, done) => {
+          analyticsSampler.sample(span, config.measured, true)
           if (msgObj.delivery) {
             msgObj.delivery[dd] = { done, span }
             msgObj.delivery.update = wrapDeliveryUpdate(msgObj.delivery.update)

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -35,7 +35,7 @@ function createWrapMakeRequest (tracer, config) {
       addDatabaseTags(span, connectionConfig)
       addProcIdTags(span, request)
 
-      analyticsSampler.sample(span, config.analytics)
+      analyticsSampler.sample(span, config.measured)
       request.callback = tx.wrap(span, request.callback)
 
       return scope.bind(makeRequest, span).apply(this, arguments)

--- a/packages/dd-trace/src/analytics_sampler.js
+++ b/packages/dd-trace/src/analytics_sampler.js
@@ -1,25 +1,13 @@
 'use strict'
 
-const ANALYTICS = require('../../../ext/tags').ANALYTICS
-
-let enabled = false
+const { MEASURED } = require('../../../ext/tags')
 
 module.exports = {
-  enable () {
-    enabled = true
-  },
-
-  disable () {
-    enabled = false
-  },
-
-  sample (span, rate, inherit) {
-    if (typeof rate === 'object') {
-      this.sample(span, rate[span.context()._name], inherit)
-    } else if (rate !== undefined) {
-      span.setTag(ANALYTICS, rate)
-    } else if (inherit && enabled) {
-      span.setTag(ANALYTICS, 1)
+  sample (span, measured, measuredByDefault) {
+    if (typeof measured === 'object') {
+      this.sample(span, measured[span.context()._name], measuredByDefault)
+    } else if (measured || measured !== undefined) {
+      span.setTag(MEASURED, !!measured)
     }
   }
 }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -24,12 +24,6 @@ class Config {
     tagger.add(this.tags, process.env.DD_TRACE_GLOBAL_TAGS)
     tagger.add(this.tags, options.tags)
 
-    const DD_TRACE_ANALYTICS_ENABLED = coalesce(
-      options.analytics,
-      process.env.DD_TRACE_ANALYTICS_ENABLED,
-      process.env.DD_TRACE_ANALYTICS,
-      false
-    )
     // Temporary disabled
     const DD_PROFILING_ENABLED = coalesce(
       // options.profiling,
@@ -162,7 +156,6 @@ class Config {
       DD_SERVICE_MAPPING.split(',').map(x => x.trim().split(':'))
     ) : {}
     this.version = DD_VERSION
-    this.analytics = isTrue(DD_TRACE_ANALYTICS_ENABLED)
     this.dogstatsd = {
       hostname: coalesce(dogstatsd.hostname, process.env.DD_DOGSTATSD_HOSTNAME, this.hostname),
       port: String(coalesce(dogstatsd.port, process.env.DD_DOGSTATSD_PORT, 8125))

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -7,11 +7,9 @@ const id = require('./id')
 const { isError } = require('./util')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
-const ANALYTICS_KEY = constants.ANALYTICS_KEY
 const SAMPLING_RULE_DECISION = constants.SAMPLING_RULE_DECISION
 const SAMPLING_LIMIT_DECISION = constants.SAMPLING_LIMIT_DECISION
 const SAMPLING_AGENT_DECISION = constants.SAMPLING_AGENT_DECISION
-const ANALYTICS = tags.ANALYTICS
 const MEASURED = tags.MEASURED
 const ORIGIN_KEY = constants.ORIGIN_KEY
 const HOSTNAME_KEY = constants.HOSTNAME_KEY
@@ -28,7 +26,6 @@ function format (span) {
   extractError(formatted, span)
   extractRootTags(formatted, span)
   extractTags(formatted, span)
-  extractAnalytics(formatted, span)
 
   return formatted
 }
@@ -74,8 +71,6 @@ function extractTags (trace, span) {
         addTag(trace.meta, {}, tag, tags[tag] && String(tags[tag]))
         break
       case HOSTNAME_KEY:
-      case ANALYTICS:
-        break
       case MEASURED:
         addTag({}, trace.metrics, tag, tags[tag] === undefined || tags[tag] ? 1 : 0)
         break
@@ -123,20 +118,6 @@ function extractError (trace, span) {
     addTag(trace.meta, trace.metrics, 'error.msg', error.message)
     addTag(trace.meta, trace.metrics, 'error.type', error.name)
     addTag(trace.meta, trace.metrics, 'error.stack', error.stack)
-  }
-}
-
-function extractAnalytics (trace, span) {
-  let analytics = span.context()._tags[ANALYTICS]
-
-  if (analytics === true) {
-    analytics = 1
-  } else {
-    analytics = parseFloat(analytics)
-  }
-
-  if (!isNaN(analytics)) {
-    trace.metrics[ANALYTICS_KEY] = Math.max(Math.min(analytics, 1), 0)
   }
 }
 

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -4,7 +4,7 @@ const shimmer = require('shimmer')
 const log = require('./log')
 const metrics = require('./metrics')
 const Loader = require('./loader')
-const { isTrue, isFalse } = require('./util')
+const { isTrue } = require('./util')
 const plugins = require('./plugins')
 
 shimmer({ logger: () => {} })
@@ -27,17 +27,6 @@ function getConfig (name, config = {}) {
   const enabled = cleanEnv(`${name}_ENABLED`)
   if (enabled !== undefined) {
     config.enabled = isTrue(enabled)
-  }
-
-  const analyticsEnabled = cleanEnv(`${name}_ANALYTICS_ENABLED`)
-  const analyticsSampleRate = Math.min(Math.max(cleanEnv(`${name}_ANALYTICS_SAMPLE_RATE`), 0), 1)
-
-  if (isFalse(analyticsEnabled)) {
-    config.analytics = false
-  } else if (!Number.isNaN(analyticsSampleRate)) {
-    config.analytics = analyticsSampleRate
-  } else if (isTrue(analyticsEnabled)) {
-    config.analytics = true
   }
 
   return config

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -36,7 +36,6 @@ class DatadogTracer extends Tracer {
     this._env = config.env
     this._tags = config.tags
     this._logInjection = config.logInjection
-    this._analytics = config.analytics
     this._debug = config.debug
     this._internalErrors = config.experimental.internalErrors
     this._prioritySampler = new PrioritySampler(config.env, config.experimental.sampler)

--- a/packages/dd-trace/src/plugins/util/redis.js
+++ b/packages/dd-trace/src/plugins/util/redis.js
@@ -33,7 +33,7 @@ const redis = {
 
     span.setTag('service.name', config.service || `${span.context()._tags['service.name']}-redis`)
 
-    analyticsSampler.sample(span, config.analytics)
+    analyticsSampler.sample(span, config.measured)
 
     return span
   }

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -62,7 +62,7 @@ const web = {
       span.setTag(SERVICE_NAME, config.service)
     }
 
-    analyticsSampler.sample(span, config.analytics, true)
+    analyticsSampler.sample(span, config.measured, true)
 
     if (!req._datadog.instrumented) {
       wrapEnd(req)
@@ -97,10 +97,13 @@ const web = {
 
     const tracer = req._datadog.tracer
     const childOf = this.active(req)
+    const config = req._datadog.config
 
-    if (req._datadog.config.middleware === false) return this.bindAndWrapMiddlewareErrors(fn, req, tracer, childOf)
+    if (config.middleware === false) return this.bindAndWrapMiddlewareErrors(fn, req, tracer, childOf)
 
     const span = tracer.startSpan(name, { childOf })
+
+    analyticsSampler.sample(span, config.measured)
 
     span.addTags({
       [RESOURCE_NAME]: middleware._name || middleware.name || '<anonymous>'

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -9,7 +9,6 @@ const metrics = require('./metrics')
 const profiler = require('./profiler')
 const log = require('./log')
 const { setStartupLogInstrumenter } = require('./startup-log')
-const analyticsSampler = require('./analytics_sampler')
 
 const noop = new NoopTracer()
 
@@ -38,10 +37,6 @@ class Tracer extends BaseTracer {
         if (config.enabled) {
           if (config.runtimeMetrics) {
             metrics.start(config)
-          }
-
-          if (config.analytics) {
-            analyticsSampler.enable()
           }
 
           this._tracer = new DatadogTracer(config)

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -29,17 +29,6 @@ function getIntegrationsAndAnalytics () {
     } else {
       integrations.add(plugin.name)
     }
-
-    const pluginData = instrumenter._plugins.get(plugin.name)
-    if (pluginData) {
-      const pluginConfig = pluginData.config
-      if (pluginConfig && pluginConfig.analytics) {
-        extras[`integration_${plugin.name}_analytics_enabled`] = true
-        if (typeof pluginConfig.analytics !== 'boolean') {
-          extras[`integration_${plugin.name}_sample_rate`] = pluginConfig.analytics
-        }
-      }
-    }
   }
   extras.integrations_loaded = Array.from(integrations)
   return extras
@@ -87,7 +76,6 @@ function startupLog ({ agentError } = {}) {
     out.agent_error = agentError.message
   }
   out.debug = !!config.debug
-  out.analytics_enabled = !!config.analytics
   out.sample_rate = config.sampleRate
   out.sampling_rules = samplingRules
   out.tags = config.tags

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -10,7 +10,7 @@ const { setStartupLogConfig } = require('./startup-log')
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
-const ANALYTICS = tags.ANALYTICS
+const MEASURED = tags.MEASURED
 const NOOP = scopes.NOOP
 
 class DatadogTracer extends Tracer {
@@ -145,7 +145,7 @@ function addTags (span, options) {
   if (options.service) tags[SERVICE_NAME] = options.service
   if (options.resource) tags[RESOURCE_NAME] = options.resource
 
-  tags[ANALYTICS] = options.analytics
+  tags[MEASURED] = options.measured
 
   span.addTags(tags)
 }

--- a/packages/dd-trace/test/analytics_sampler.spec.js
+++ b/packages/dd-trace/test/analytics_sampler.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ANALYTICS = require('../../../ext/tags').ANALYTICS
+const MEASURED = require('../../../ext/tags').MEASURED
 
 describe('analyticsSampler', () => {
   let sampler
@@ -20,43 +20,21 @@ describe('analyticsSampler', () => {
     it('should sample a span', () => {
       sampler.sample(span, true)
 
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS, true)
+      expect(span.setTag).to.have.been.calledWith(MEASURED, true)
     })
 
-    it('should sample a span with the provided rate', () => {
-      sampler.sample(span, 0)
-
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS, 0)
-    })
-
-    it('should sample a span with the provided rate by span name', () => {
+    it('should sample a span by span name', () => {
       sampler.sample(span, {
-        'web.request': 0.5
+        'web.request': 1
       })
 
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS, 0.5)
+      expect(span.setTag).to.have.been.calledWith(MEASURED, true)
     })
 
-    it('should not set a rate by default', () => {
+    it('should not sample by default', () => {
       sampler.sample(span, undefined)
 
       expect(span.setTag).to.not.have.been.called
-    })
-
-    it('should inherit from global setting when unset', () => {
-      sampler.enable()
-      sampler.sample(span, undefined, true)
-
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS, 1)
-    })
-
-    it('should inherit from global setting when span name is not matched', () => {
-      sampler.enable()
-      sampler.sample(span, {
-        'other.request': 0.5
-      }, true)
-
-      expect(span.setTag).to.have.been.calledWith(ANALYTICS, 1)
     })
   })
 })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -77,7 +77,6 @@ describe('Config', () => {
     process.env.DD_TRACE_ENABLED = 'false'
     process.env.DD_TRACE_DEBUG = 'true'
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.5'
-    process.env.DD_TRACE_ANALYTICS = 'true'
     process.env.DD_SERVICE = 'service'
     process.env.DD_VERSION = '1.0.0'
     process.env.DD_RUNTIME_METRICS_ENABLED = 'true'
@@ -97,7 +96,6 @@ describe('Config', () => {
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
     expect(config).to.have.property('protocolVersion', '0.5')
-    expect(config).to.have.property('analytics', true)
     expect(config).to.have.property('hostname', 'agent')
     expect(config).to.have.nested.property('dogstatsd.hostname', 'dsd-agent')
     expect(config).to.have.nested.property('dogstatsd.port', '5218')
@@ -119,14 +117,12 @@ describe('Config', () => {
   it('should read case-insensitive booleans from environment variables', () => {
     process.env.DD_TRACE_ENABLED = 'False'
     process.env.DD_TRACE_DEBUG = 'TRUE'
-    process.env.DD_TRACE_ANALYTICS = '1'
     process.env.DD_RUNTIME_METRICS_ENABLED = '0'
 
     const config = new Config()
 
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
-    expect(config).to.have.property('analytics', true)
     expect(config).to.have.property('runtimeMetrics', false)
   })
 
@@ -163,7 +159,6 @@ describe('Config', () => {
       enabled: false,
       debug: true,
       protocolVersion: '0.5',
-      analytics: true,
       site: 'datadoghq.eu',
       hostname: 'agent',
       port: 6218,
@@ -200,7 +195,6 @@ describe('Config', () => {
     expect(config).to.have.property('enabled', false)
     expect(config).to.have.property('debug', true)
     expect(config).to.have.property('protocolVersion', '0.5')
-    expect(config).to.have.property('analytics', true)
     expect(config).to.have.property('site', 'datadoghq.eu')
     expect(config).to.have.property('hostname', 'agent')
     expect(config).to.have.property('port', '6218')
@@ -289,7 +283,6 @@ describe('Config', () => {
     process.env.DD_TRACE_ENABLED = 'false'
     process.env.DD_TRACE_DEBUG = 'true'
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.4'
-    process.env.DD_TRACE_ANALYTICS = 'true'
     process.env.DD_SERVICE = 'service'
     process.env.DD_VERSION = '0.0.0'
     process.env.DD_RUNTIME_METRICS_ENABLED = 'true'
@@ -308,7 +301,6 @@ describe('Config', () => {
       enabled: true,
       debug: false,
       protocolVersion: '0.5',
-      analytics: false,
       protocol: 'https',
       site: 'datadoghq.com',
       hostname: 'server',
@@ -336,7 +328,6 @@ describe('Config', () => {
     expect(config).to.have.property('enabled', true)
     expect(config).to.have.property('debug', false)
     expect(config).to.have.property('protocolVersion', '0.5')
-    expect(config).to.have.property('analytics', false)
     expect(config).to.have.nested.property('url.protocol', 'https:')
     expect(config).to.have.nested.property('url.hostname', 'agent2')
     expect(config).to.have.nested.property('url.port', '6218')

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -5,8 +5,6 @@ const tags = require('../../../ext/tags')
 const id = require('../src/id')
 
 const SAMPLING_PRIORITY_KEY = constants.SAMPLING_PRIORITY_KEY
-const ANALYTICS_KEY = constants.ANALYTICS_KEY
-const ANALYTICS = tags.ANALYTICS
 const MEASURED = tags.MEASURED
 const ORIGIN_KEY = constants.ORIGIN_KEY
 const HOSTNAME_KEY = constants.HOSTNAME_KEY
@@ -488,42 +486,6 @@ describe('format', () => {
       trace = format(span)
 
       expect(trace.meta['circularTag']).to.equal('[object Object],[object Object]')
-    })
-
-    it('should include the analytics sample rate', () => {
-      spanContext._tags[ANALYTICS] = 0.5
-      trace = format(span)
-      expect(trace.metrics[ANALYTICS_KEY]).to.equal(0.5)
-    })
-
-    it('should limit the min analytics sample rate', () => {
-      spanContext._tags[ANALYTICS] = -1
-      trace = format(span)
-      expect(trace.metrics[ANALYTICS_KEY]).to.equal(0)
-    })
-
-    it('should limit the max analytics sample rate', () => {
-      spanContext._tags[ANALYTICS] = 2
-      trace = format(span)
-      expect(trace.metrics[ANALYTICS_KEY]).to.equal(1)
-    })
-
-    it('should accept boolean true for analytics', () => {
-      spanContext._tags[ANALYTICS] = true
-      trace = format(span)
-      expect(trace.metrics[ANALYTICS_KEY]).to.equal(1)
-    })
-
-    it('should accept boolean false for analytics', () => {
-      spanContext._tags[ANALYTICS] = false
-      trace = format(span)
-      expect(trace.metrics[ANALYTICS_KEY]).to.be.undefined
-    })
-
-    it('should accept strings for analytics', () => {
-      spanContext._tags[ANALYTICS] = '0.5'
-      trace = format(span)
-      expect(trace.metrics[ANALYTICS_KEY]).to.equal(0.5)
     })
 
     it('should accept a boolean for measured', () => {

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -477,8 +477,6 @@ describe('Instrumenter', () => {
 
     afterEach(() => {
       delete process.env.DD_TRACE_MYSQL_MOCK_ENABLED
-      delete process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_ENABLED
-      delete process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_SAMPLE_RATE
     })
 
     it('should use _ENABLED', () => {
@@ -488,44 +486,6 @@ describe('Instrumenter', () => {
       const plugins = [...instrumenter._plugins.values()]
       expect(plugins[0].name).to.equal('mysql-mock')
       expect(plugins[0].config.enabled).to.equal(false)
-    })
-
-    it('should use _ANALYTICS_ENABLED', () => {
-      instrumenter = new Instrumenter(tracer)
-      process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_ENABLED = false
-      instrumenter.enable()
-      const plugins = [...instrumenter._plugins.values()]
-      expect(plugins[0].name).to.equal('mysql-mock')
-      expect(plugins[0].config.analytics).to.equal(false)
-    })
-
-    it('should use _ANALYTICS_SAMPLE_RATE when _ANALYTICS_ENABLED is true', () => {
-      instrumenter = new Instrumenter(tracer)
-      process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_ENABLED = true
-      process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_SAMPLE_RATE = '0.25'
-      instrumenter.enable()
-      const plugins = [...instrumenter._plugins.values()]
-      expect(plugins[0].name).to.equal('mysql-mock')
-      expect(plugins[0].config.analytics).to.equal(0.25)
-    })
-
-    it('should not use _ANALYTICS_SAMPLE_RATE when _ANALYTICS_ENABLED is false', () => {
-      instrumenter = new Instrumenter(tracer)
-      process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_ENABLED = false
-      process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_SAMPLE_RATE = '0.25'
-      instrumenter.enable()
-      const plugins = [...instrumenter._plugins.values()]
-      expect(plugins[0].name).to.equal('mysql-mock')
-      expect(plugins[0].config.analytics).to.equal(false)
-    })
-
-    it('should use _ANALYTICS_SAMPLE_RATE', () => {
-      instrumenter = new Instrumenter(tracer)
-      process.env.DD_TRACE_MYSQL_MOCK_ANALYTICS_SAMPLE_RATE = '0.25'
-      instrumenter.enable()
-      const plugins = [...instrumenter._plugins.values()]
-      expect(plugins[0].name).to.equal('mysql-mock')
-      expect(plugins[0].config.analytics).to.equal(0.25)
     })
   })
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -12,7 +12,6 @@ describe('TracerProxy', () => {
   let Config
   let config
   let metrics
-  let analyticsSampler
   let log
   let profiler
 
@@ -68,10 +67,6 @@ describe('TracerProxy', () => {
       start: sinon.spy()
     }
 
-    analyticsSampler = {
-      enable: sinon.spy()
-    }
-
     profiler = {
       start: sinon.spy()
     }
@@ -81,7 +76,6 @@ describe('TracerProxy', () => {
       './noop/tracer': NoopTracer,
       './config': Config,
       './metrics': metrics,
-      './analytics_sampler': analyticsSampler,
       './instrumenter': Instrumenter,
       './log': log,
       './profiler': profiler
@@ -160,14 +154,6 @@ describe('TracerProxy', () => {
         proxy.init()
 
         expect(metrics.start).to.have.been.called
-      })
-
-      it('should enable the analytics sampler when configured', () => {
-        config.analytics = true
-
-        proxy.init()
-
-        expect(analyticsSampler.enable).to.have.been.called
       })
     })
 

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -76,10 +76,8 @@ describe('startup logging', () => {
       sample_rate: 1,
       dd_version: '1.2.3',
       log_injection_enabled: true,
-      runtime_metrics_enabled: true,
-      integration_semver_sample_rate: { a: 0.7 }
+      runtime_metrics_enabled: true
     })
-    expect(logObj.integration_semver_sample_rate).to.deep.equal({ a: 0.7 })
   })
 
   it('startupLog should correctly also output the diagnostic message', () => {

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -25,9 +25,9 @@ describe('startup logging', () => {
         }
       },
       _plugins: new Map([
-        ['fs', { config: { analytics: 0.5 } }],
-        ['http', { config: { analytics: true } }],
-        ['semver', { config: { analytics: { a: 0.7 } } }]
+        ['fs', { config: {} }],
+        ['http', { config: {} }],
+        ['semver', { config: {} }]
       ])
     })
     setStartupLogConfig({
@@ -38,7 +38,6 @@ describe('startup logging', () => {
       hostname: 'example.com',
       port: 4321,
       debug: true,
-      analytics: true,
       sampleRate: 1,
       tags: { version: '1.2.3' },
       logInjection: true,
@@ -74,15 +73,10 @@ describe('startup logging', () => {
       agent_url: 'http://example.com:4321',
       agent_error: 'Error: fake error',
       debug: true,
-      analytics_enabled: true,
       sample_rate: 1,
       dd_version: '1.2.3',
       log_injection_enabled: true,
       runtime_metrics_enabled: true,
-      integration_http_analytics_enabled: true,
-      integration_fs_analytics_enabled: true,
-      integration_fs_sample_rate: 0.5,
-      integration_semver_analytics_enabled: true,
       integration_semver_sample_rate: { a: 0.7 }
     })
     expect(logObj.integration_semver_sample_rate).to.deep.equal({ a: 0.7 })

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -7,7 +7,6 @@ const tags = require('../../../ext/tags')
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
-const ANALYTICS = tags.ANALYTICS
 
 wrapIt()
 
@@ -68,12 +67,6 @@ describe('Tracer', () => {
           [RESOURCE_NAME]: 'resource',
           [SPAN_TYPE]: 'type'
         })
-      })
-    })
-
-    it('should support analytics', () => {
-      tracer.trace('name', { analytics: 0.5 }, span => {
-        expect(span.context()._tags).to.have.property(ANALYTICS, 0.5)
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove internal services and replace analytics with measured.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now every integration creates a new service, which is confusing for a lot of users. Unfortunately, due to how the product works, it's not possible to rename everything to a single service name. However, for any external services like databases and message queues, the created services actually make sense in some contexts like the service map to represent a remote service that could not otherwise be instrumented. This is not true for internal spans like those generated for example by `fs` or `graphql`, so these should not create their own services.

With the change described above, some metrics would no longer be computed since we still need some of the internal spans to be measured and the agent relies on them having their own service to do this automatically. To avoid this, I've adjusted the existing analytics sampler to tag with `MEASURED` instead of `ANALYTICS` since the latter has been deprecated and replaced with Tracing without Limits for a long time. This will also allow users to configure the integrations to measure additional internal spans if needed since this was already supported by the analytics sampler.