### PR TITLE
fix error with masked internal modules

### DIFF
--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -60,7 +60,12 @@ module.exports = function hook (modules, onrequire) {
       if (modules && modules.indexOf(name) === -1) return exports // abort if module name isn't on whitelist
 
       // figure out if this is the main module file, or a file inside the module
-      const res = Module._findPath(name, [basedir, ...Module._resolveLookupPaths(name, this, true)])
+      const paths = Module._resolveLookupPaths(name, this, true)
+      if (!paths) {
+        // abort if _resolveLookupPaths return null
+        return exports
+      }
+      const res = Module._findPath(name, [basedir, ...paths])
       if (res !== filename) {
         // this is a module-internal file
         // use the module-relative path to the file, prefixed by original module name

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -203,6 +203,10 @@ describe('Instrumenter', () => {
 
         expect(integrations.other.patch).to.have.been.called
       })
+
+      it('should not interfere with userland modules masking core modules', () => {
+        expect(require('http2/foo.js')).to.equal('Hello, World!')
+      })
     })
 
     describe('enable', () => {

--- a/packages/dd-trace/test/node_modules/http2/foo.js
+++ b/packages/dd-trace/test/node_modules/http2/foo.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = 'Hello, World!'

--- a/packages/dd-trace/test/node_modules/http2/package.json
+++ b/packages/dd-trace/test/node_modules/http2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "http2",
+  "version": "4.0.0",
+  "license": "UNLICENSED",
+  "private": true
+}


### PR DESCRIPTION
### What does this PR do?
Aborts the hook if `_resolveLookupPaths` returns null.

### Motivation
`_resolveLookupPaths` can return null in some cases. One case in particular is when a userland module masks a builtin module, and files within it are required.

Fixes: #1450 