### PR TITLE
[ci-app] Handle Uncaught Async Errors in Mocha 

### DIFF
--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -351,7 +351,9 @@ Timeout of 100ms exceeded. For async tests and hooks, ensure "done()" is called;
 
       it('works with async tests with done fail', (done) => {
         if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
-        // necessary because we run mocha within mocha and mocha adds a handler for uncaughtExceptions
+        // necessary because we run mocha within mocha and mocha adds a handler for uncaughtExceptions.
+        // If we don't do this, the handler for the parent test (this test) will be called
+        // first and not the one for mocha-test-done-fail-badly.js (test we are testing).
         process.removeAllListeners('uncaughtException')
         const testFilePath = path.join(__dirname, 'mocha-test-done-fail-badly.js')
         agent.use(traces => {

--- a/packages/datadog-plugin-mocha/test/mocha-test-done-fail-badly.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-done-fail-badly.js
@@ -1,0 +1,10 @@
+const { expect } = require('chai')
+
+describe('mocha-test-done-fail', () => {
+  it('can do badly setup failed tests with done', (done) => {
+    setTimeout(() => {
+      expect(true).to.equal(false)
+      done()
+    }, 100)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
* Fix bug where uncaught async errors are not instrumented correctly. 

### Motivation
Be able to instrument errors that are uncaught, such as: 

```javascript
it('will fail asynchronously', (done) => {
  setTimeout(() => {
    expect(true).to.equal(false)
    done()
  }, 200)
})
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
