### PR TITLE
Bump default build target to node >=12

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -15,10 +15,6 @@ const { NODE_VERSIONS = '>=12' } = process.env
 
 // https://nodejs.org/en/download/releases/
 const targets = [
-  { version: '8.0.0', abi: '57' },
-  { version: '9.0.0', abi: '59' },
-  { version: '10.0.0', abi: '64' },
-  { version: '11.0.0', abi: '67' },
   { version: '12.0.0', abi: '72' },
   { version: '13.0.0', abi: '79' },
   { version: '14.0.0', abi: '83' },

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -11,7 +11,7 @@ const checksum = require('checksum')
 const platform = os.platform()
 const arch = process.env.ARCH || os.arch()
 
-const { NODE_VERSIONS = '>=10' } = process.env
+const { NODE_VERSIONS = '>=12' } = process.env
 
 // https://nodejs.org/en/download/releases/
 const targets = [


### PR DESCRIPTION
### What does this PR do?
Bump the default build target to node >=12 and remove old build targets

### Motivation
We only support node >=12