### PR TITLE
Fix profiler url config

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -2,7 +2,6 @@
 
 const coalesce = require('koalas')
 const os = require('os')
-const { URL } = require('url')
 const { AgentExporter } = require('./exporters/agent')
 const { FileExporter } = require('./exporters/file')
 const { ConsoleLogger } = require('./loggers/console')
@@ -15,10 +14,7 @@ const {
   DD_ENV,
   DD_TAGS,
   DD_SERVICE,
-  DD_VERSION,
-  DD_TRACE_AGENT_URL,
-  DD_AGENT_HOST,
-  DD_TRACE_AGENT_PORT
+  DD_VERSION
 } = process.env
 
 class Config {
@@ -44,13 +40,8 @@ class Config {
     this.logger = ensureLogger(options.logger)
     this.flushInterval = flushInterval
 
-    const hostname = coalesce(options.hostname, DD_AGENT_HOST, 'localhost')
-    const port = coalesce(options.port, DD_TRACE_AGENT_PORT, 8126)
-    const url = new URL(coalesce(options.url, DD_TRACE_AGENT_URL,
-      `http://${hostname || 'localhost'}:${port || 8126}`))
-
     this.exporters = ensureExporters(options.exporters || [
-      new AgentExporter({ url })
+      new AgentExporter(options)
     ], options)
 
     this.profilers = options.profilers || [

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -1,11 +1,23 @@
 'use strict'
 
+const coalesce = require('koalas')
 const FormData = require('form-data')
 const { URL } = require('url')
 
+const {
+  DD_TRACE_AGENT_URL,
+  DD_AGENT_HOST,
+  DD_TRACE_AGENT_PORT
+} = process.env
+
 class AgentExporter {
-  constructor ({ url } = {}) {
-    this._url = typeof url === 'string' ? new URL(url) : url
+  constructor (options = {}) {
+    const hostname = coalesce(options.hostname, DD_AGENT_HOST, 'localhost')
+    const port = coalesce(options.port, DD_TRACE_AGENT_PORT, 8126)
+    const url = new URL(coalesce(options.url, DD_TRACE_AGENT_URL,
+      `http://${hostname || 'localhost'}:${port || 8126}`))
+
+    this._url = url
   }
 
   export ({ profiles, start, end, tags }) {

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -94,6 +94,14 @@ describe('profiler', () => {
     sinon.assert.calledOnce(heapProfiler.start)
   })
 
+  it('should allow configuring exporters by string name', () => {
+    profiler.start({ exporters: 'agent' })
+    expect(profiler._config.exporters[0].export).to.be.a('function')
+
+    profiler.start({ exporters: ['agent'] })
+    expect(profiler._config.exporters[0].export).to.be.a('function')
+  })
+
   it('should stop the internal profilers', () => {
     profiler.start({ profilers, exporters })
     profiler.stop()


### PR DESCRIPTION
The URL computing stuff needs to happen within `AgentExporter` for the string name config form of exporters work properly.