### PR TITLE
Prevent agent 502 errors

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -24,7 +24,8 @@ class Config {
     const service = options.service || DD_SERVICE || 'node'
     const host = os.hostname()
     const version = coalesce(options.version, DD_VERSION)
-    const flushInterval = coalesce(options.interval, 60 * 1000)
+    // Must be longer than one minute so pad with five seconds
+    const flushInterval = coalesce(options.interval, 65 * 1000)
 
     this.enabled = String(enabled) !== 'false'
     this.service = service

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -66,6 +66,8 @@ class AgentExporter {
       }
 
       form.submit(options, (err, res) => {
+        res.resume()
+
         if (err) return reject(err)
         if (res.statusCode >= 400) {
           return reject(new Error(`Error from the agent: ${res.statusCode}`))

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -20,7 +20,7 @@ describe('config', () => {
     expect(config).to.deep.include({
       enabled: true,
       service: 'node',
-      flushInterval: 60 * 1000
+      flushInterval: 65 * 1000
     })
 
     expect(config.tags).to.deep.equal({
@@ -60,7 +60,7 @@ describe('config', () => {
     expect(config.tags.host).to.be.a('string')
     expect(config.tags.service).to.equal(options.service)
     expect(config.tags.version).to.equal(options.version)
-    expect(config.flushInterval).to.equal(60 * 1000)
+    expect(config.flushInterval).to.equal(65 * 1000)
     expect(config.exporters).to.be.an('array')
     expect(config.exporters.length).to.equal(1)
     expect(config.exporters[0]._url.toString()).to.equal(options.url)

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect
 const sinon = require('sinon')
 const semver = require('semver')
 
-const INTERVAL = 60 * 1000
+const INTERVAL = 65 * 1000
 
 if (!semver.satisfies(process.version, '>=10.12')) {
   describe = describe.skip // eslint-disable-line no-global-assign
@@ -158,7 +158,7 @@ describe('profiler', () => {
     expect(profiles).to.have.property('heap', heapProfile)
     expect(start).to.be.a('date')
     expect(end).to.be.a('date')
-    expect(end - start).to.equal(60000)
+    expect(end - start).to.equal(65000)
     expect(tags).to.have.property('foo', 'foo')
   })
 


### PR DESCRIPTION
This should help to prevent the agent giving 502 proxy errors.