### PR TITLE
subtract baselines in diffserver view

### DIFF
--- a/benchmark/sirun/async_hooks/meta.json
+++ b/benchmark/sirun/async_hooks/meta.json
@@ -5,7 +5,13 @@
   "iterations": 5,
   "variants": {
     "no-hooks": { "env": { "ASYNC_HOOKS": "" } },
-    "init-only": { "env": { "ASYNC_HOOKS": "init" } },
-    "all-hooks": { "env": { "ASYNC_HOOKS": "init,before,after,destroy,promiseResolve" } }
+    "init-only": {
+      "baseline": "no-hooks",
+      "env": { "ASYNC_HOOKS": "init" }
+    },
+    "all-hooks": {
+      "baseline": "no-hooks",
+      "env": { "ASYNC_HOOKS": "init,before,after,destroy,promiseResolve" }
+    }
   }
 }

--- a/benchmark/sirun/plugin-bluebird/meta.json
+++ b/benchmark/sirun/plugin-bluebird/meta.json
@@ -11,6 +11,7 @@
       }
     },
     "with-tracer": {
+      "baseline": "control",
       "env": {
         "USE_TRACER": "1",
         "COUNT": "50000"

--- a/benchmark/sirun/plugin-http/meta.json
+++ b/benchmark/sirun/plugin-http/meta.json
@@ -13,6 +13,7 @@
     "client-with-tracer": {
       "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
       "run": "node client.js",
+      "baseline": "client-control",
       "env": {
         "CLIENT_USE_TRACER": "1"
       }
@@ -27,6 +28,7 @@
     "server-with-tracer": {
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
       "run": "node server.js",
+      "baseline": "server-control",
       "env": {
         "SERVER_USE_TRACER": "1"
       }

--- a/benchmark/sirun/plugin-net/meta.json
+++ b/benchmark/sirun/plugin-net/meta.json
@@ -8,7 +8,8 @@
       "run": "node client.js"
     },
     "with-tracer": {
-      "run": "node -r ../../../init.js client.js"
+      "run": "node -r ../../../init.js client.js",
+      "baseline": "control"
     }
   }
 }

--- a/benchmark/sirun/plugin-q/meta.json
+++ b/benchmark/sirun/plugin-q/meta.json
@@ -10,6 +10,7 @@
       }
     },
     "with-tracer": {
+      "baseline": "control",
       "env": {
         "USE_TRACER": "1"
       }

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -11,18 +11,21 @@
       }
     },
     "async_hooks": {
+      "baseline": "base",
       "env": {
         "SCOPE_MANAGER": "async_hooks",
         "COUNT": "10000"
       }
     },
     "async_local_storage": {
+      "baseline": "base",
       "env": {
         "SCOPE_MANAGER": "async_local_storage",
         "COUNT": "10000"
       }
     },
     "async_resource": {
+      "baseline": "base",
       "env": {
         "SCOPE_MANAGER": "async_resource",
         "COUNT": "10000"

--- a/benchmark/sirun/startup/meta.json
+++ b/benchmark/sirun/startup/meta.json
@@ -10,6 +10,7 @@
       }
     },
     "with-tracer": {
+      "baseline": "control",
       "env": {
         "USE_TRACER": "1"
       }


### PR DESCRIPTION
### What does this PR do?
In the diffserver view, simplify results interpretation by representing values as overheads over baselines.

### Motivation
<!-- What inspired you to submit this pull request? -->
Less data to look at, with the same information conveyed.
