### PR TITLE
move graphql to dependencies

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,6 +1,7 @@
 Component,Origin,License,Copyright
 require,@types/node,MIT,Copyright Authors
 require,form-data,MIT,Copyright 2012 Felix Geisendörfer and contributors
+require,graphql,MIT,Copyright 2015 Facebook Inc.
 require,hdr-histogram-js,BSD-2-Clause,Copyright 2016 Alexandre Victoor
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,limiter,MIT,Copyright 2011 John Hurliman
@@ -43,7 +44,6 @@ dev,mocha-multi-reporters,MIT,Copyright 2015 Stanley Ng 2019 Yousaf Nabi
 dev,express,MIT,Copyright 2009-2014 TJ Holowaychuk 2013-2014 Roman Shtylman 2014-2015 Douglas Christopher Wilson
 dev,get-port,MIT,Copyright Sindre Sorhus
 dev,glob,ISC,Copyright Isaac Z. Schlueter and Contributors
-dev,graphql,MIT,Copyright 2015 Facebook Inc.
 dev,int64-buffer,MIT,Copyright 2015-2016 Yusuke Kawasaki
 dev,jszip,MIT,Copyright 2015-2016 Stuart Knightley and contributors
 dev,mkdirp,MIT,Copyright 2010 James Halliday

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@types/node": "^10.12.18",
     "form-data": "^3.0.0",
+    "graphql": "0.13.2",
     "hdr-histogram-js": "^2.0.1",
     "koalas": "^1.0.2",
     "limiter": "^1.1.4",
@@ -99,7 +100,6 @@
     "express": "^4.16.2",
     "get-port": "^3.2.0",
     "glob": "^7.1.6",
-    "graphql": "0.13.2",
     "int64-buffer": "^0.1.9",
     "jszip": "^3.5.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
### What does this PR do?

This PR moves the graphql dependency in `package.json` from `devDependencies` to `dependencies`.

### Motivation

`graphql` was declared as a dev dependency, but it was used in production code.

This could cause issues when resolving packages using a bundler such as Rollup. #1467 
