### PR TITLE
add upstream tests for axios

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,13 @@ jobs:
           - LAMBDA_EXECUTOR=local
           - START_WEB=0
 
+  node-upstream-axios:
+    <<: *node-upstream-base
+    docker:
+      - image: node:12
+        environment:
+          - PLUGINS=axios
+
   node-bluebird:
     <<: *node-plugin-base
     docker:
@@ -1404,6 +1411,7 @@ workflows:
       # - node-upstream-node
       - node-upstream-amqp10
       - node-upstream-amqplib
+      - node-upstream-axios
       - node-upstream-bunyan
       - node-upstream-connect
       - node-upstream-graphql
@@ -1610,6 +1618,7 @@ workflows:
       # - node-upstream-node
       - node-upstream-amqp10
       - node-upstream-amqplib
+      - node-upstream-axios
       - node-upstream-bunyan
       - node-upstream-connect
       - node-upstream-graphql

--- a/packages/datadog-plugin-axios/test/suite.js
+++ b/packages/datadog-plugin-axios/test/suite.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const suiteTest = require('../../dd-trace/test/plugins/suite')
+
+suiteTest({
+  modName: 'axios',
+  repoUrl: 'axios/axios',
+  commitish: 'latest',
+  testCmd: 'node_modules/.bin/grunt mochaTest',
+  parallel: false
+})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add upstream tests for Axios.

### Motivation
<!-- What inspired you to submit this pull request? -->

Even though we don't support Axios, the way we used to patch event emitters ended up causing errors from the library in some cases which would have been caught by running Axios' own tests with the tracer.