### PR TITLE
option to ignore branches when preparing release commits

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -18,13 +18,15 @@ title(`Bumping version to v${version} in a new branch`)
 
 pkg.version = version
 
-if (isNewBranch) {
-  exec(`git checkout master`)
-  exec(`git pull`)
-  exec(`git checkout -b ${branch}`)
-} else {
-  exec(`git checkout ${branch}`)
-  exec('git pull')
+if (process.argv[3] !== 'ignore-branch') {
+  if (isNewBranch) {
+    exec(`git checkout master`)
+    exec(`git pull`)
+    exec(`git checkout -b ${branch}`)
+  } else {
+    exec(`git checkout ${branch}`)
+    exec('git pull')
+  }
 }
 
 write('package.json', JSON.stringify(pkg, null, 2) + '\n')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allows the version script (`scripts/version.js`) to completely ignore branches.

### Motivation
<!-- What inspired you to submit this pull request? -->
The branch strategy is changing, and we still need to make releases. This is a temporary measure until we've come up with a more thought-out set of release scripts.