### PR TITLE
fix abruptly closed http client requests not tagged as error

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -83,14 +83,6 @@ function patch (http, methodName, tracer, config) {
 
             scope.bind(res)
 
-            span.setTag(HTTP_STATUS_CODE, res.statusCode)
-
-            addResponseHeaders(res, span, config)
-
-            if (!config.validateStatus(res.statusCode)) {
-              span.setTag('error', 1)
-            }
-
             res.on('end', () => finish(req, res, span, config))
 
             break
@@ -98,7 +90,7 @@ function patch (http, methodName, tracer, config) {
           case 'error':
             addError(span, arg)
           case 'abort': // eslint-disable-line no-fallthrough
-          case 'close': // eslint-disable-line no-fallthrough
+          case 'timeout': // eslint-disable-line no-fallthrough
             finish(req, null, span, config)
         }
 
@@ -112,6 +104,18 @@ function patch (http, methodName, tracer, config) {
   }
 
   function finish (req, res, span, config) {
+    if (res) {
+      span.setTag(HTTP_STATUS_CODE, res.statusCode)
+
+      if (!config.validateStatus(res.statusCode)) {
+        span.setTag('error', 1)
+      }
+
+      addResponseHeaders(res, span, config)
+    } else {
+      span.setTag('error', 1)
+    }
+
     addRequestHeaders(req, span, config)
 
     config.hooks.request(span, req, res)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix abruptly closed `http` client requests not tagged as error.

### Motivation
<!-- What inspired you to submit this pull request? -->

Requests that were aborted or that timed out without an explicit `error` event were not properly tagged as errors.