### PR TITLE
fix suffix incorrectly added to configured service name

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -89,11 +89,9 @@ function getHooks (config) {
 
 // TODO: test splitByAwsService when the test suite is fixed
 function getServiceName (serviceIdentifier, tracer, config) {
-  const service = config.service || tracer._service
-
-  return config.splitByAwsService
-    ? `${service}-aws-${serviceIdentifier}`
-    : service
+  return config.service
+    ? config.service
+    : `${tracer._service}-aws-${serviceIdentifier}`
 }
 
 // <2.1.35 has breaking changes for instrumentation

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -180,6 +180,7 @@ describe('Plugin', () => {
           tracer = require('../../dd-trace')
 
           return agent.load('aws-sdk', {
+            service: 'test',
             s3: false
           })
         })
@@ -196,7 +197,8 @@ describe('Plugin', () => {
 
             expect(span).to.include({
               name: 'aws.request',
-              resource: 'listBuckets'
+              resource: 'listBuckets',
+              service: 'test'
             })
 
             total++
@@ -207,7 +209,8 @@ describe('Plugin', () => {
 
             expect(span).to.include({
               name: 'aws.request',
-              resource: 'listQueues'
+              resource: 'listQueues',
+              service: 'test'
             })
 
             total++


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix suffix incorrectly added to configured service name for `aws-sdk`.

### Motivation
<!-- What inspired you to submit this pull request? -->

When a service name is configured, it should apply to any span created by the plugin which is not currently the case.