### PR TITLE
respect --ignore-engines in scripts/preinstall.js

### DIFF
--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -2,6 +2,10 @@
 
 /* eslint-disable no-console */
 
+const npmArgv = process.env.npm_config_argv
+  ? JSON.parse(process.env.npm_config_argv)
+  : { original: [] }
+
 const path = require('path')
 const requirePackageJson = require('../packages/dd-trace/src/require-package-json.js')
 
@@ -9,7 +13,7 @@ const nodeMajor = Number(process.versions.node.split('.')[0])
 
 const min = Number(requirePackageJson(path.join(__dirname, '..')).engines.node.match(/\d+/)[0])
 
-if (nodeMajor < min) {
+if (nodeMajor < min && !npmArgv.includes('--ignore-engines')) {
   process.exitCode = 1
   console.error('\n' + `
 You're using Node.js v${process.versions.node}, which is not supported by


### PR DESCRIPTION
### What does this PR do?
See title.

### Motivation
Unblocks prebuilds

