### PR TITLE
Add parse and validate hooks for graphql plugin:

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -126,7 +126,7 @@ const graphqlOptions = {
   hooks: {
     execute: (span, args, res) => {},
     validate: (span, document, errors) => {},
-    parse: (span, source, documents) => {}
+    parse: (span, source, document) => {}
   }
 };
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -125,6 +125,8 @@ const graphqlOptions = {
   signature: false,
   hooks: {
     execute: (span, args, res) => {},
+    validate: (span, document, errors) => {},
+    parse: (span, document, operation) => {}
   }
 };
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -126,7 +126,7 @@ const graphqlOptions = {
   hooks: {
     execute: (span, args, res) => {},
     validate: (span, document, errors) => {},
-    parse: (span, document, operation) => {}
+    parse: (span, source, documents) => {}
   }
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -912,7 +912,7 @@ declare namespace plugins {
     hooks?: {
       execute?: (span?: Span, args?: ExecutionArgs, res?: any) => void;
       validate?: (span?: Span, document?: any, errors?: any) => void;
-      parse?: (span?: Span, document?: any, operation?: any) => void;
+      parse?: (span?: Span, source?: any, document?: any) => void;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -911,6 +911,8 @@ declare namespace plugins {
      */
     hooks?: {
       execute?: (span?: Span, args?: ExecutionArgs, res?: any) => void;
+      validate?: (span?: Span, document?: any, errors?: any) => void;
+      parse?: (span?: Span, document?: any, operation?: any) => void;
     }
   }
 

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -51,10 +51,9 @@ function createWrapParse (tracer, config) {
       analyticsSampler.sample(span, config.measured, true)
 
       let document
-      let operation
       try {
         document = parse.apply(this, arguments)
-        operation = getOperation(document)
+        const operation = getOperation(document)
 
         if (!operation) return document // skip schema parsing
 
@@ -69,7 +68,7 @@ function createWrapParse (tracer, config) {
         setError(span, e)
         throw e
       } finally {
-        config.hooks.parse(span, document, operation)
+        config.hooks.parse(span, source, document)
         finish(span)
       }
     }

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -50,9 +50,11 @@ function createWrapParse (tracer, config) {
 
       analyticsSampler.sample(span, config.measured, true)
 
+      let document
+      let operation
       try {
-        const document = parse.apply(this, arguments)
-        const operation = getOperation(document)
+        document = parse.apply(this, arguments)
+        operation = getOperation(document)
 
         if (!operation) return document // skip schema parsing
 
@@ -67,6 +69,7 @@ function createWrapParse (tracer, config) {
         setError(span, e)
         throw e
       } finally {
+        config.hooks.parse(span, document, operation)
         finish(span)
       }
     }
@@ -85,8 +88,9 @@ function createWrapValidate (tracer, config) {
         addDocumentTags(span, document)
       }
 
+      let errors
       try {
-        const errors = validate.apply(this, arguments)
+        errors = validate.apply(this, arguments)
 
         setError(span, errors && errors[0])
 
@@ -95,6 +99,7 @@ function createWrapValidate (tracer, config) {
         setError(span, e)
         throw e
       } finally {
+        config.hooks.validate(span, document, errors)
         finish(span)
       }
     }
@@ -384,7 +389,7 @@ function getService (tracer, config) {
 
 function getOperation (document, operationName) {
   if (!document || !Array.isArray(document.definitions)) {
-    return
+    return null
   }
 
   const definitions = document.definitions.filter(def => def)
@@ -460,8 +465,10 @@ function pathToArray (path) {
 function getHooks (config) {
   const noop = () => {}
   const execute = (config.hooks && config.hooks.execute) || noop
+  const parse = (config.hooks && config.hooks.parse) || noop
+  const validate = (config.hooks && config.hooks.validate) || noop
 
-  return { execute }
+  return { execute, parse, validate }
 }
 
 module.exports = [

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -389,7 +389,7 @@ function getService (tracer, config) {
 
 function getOperation (document, operationName) {
   if (!document || !Array.isArray(document.definitions)) {
-    return null
+    return
   }
 
   const definitions = document.definitions.filter(def => def)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1403,7 +1403,8 @@ describe('Plugin', () => {
         })
 
         it('should run the validate hook before graphql.validate span is finished', done => {
-          graphql.parse(source)
+          const document = graphql.parse(source)
+
           agent
             .use(traces => {
               const spans = sort(traces[0])

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1439,14 +1439,13 @@ describe('Plugin', () => {
               expect(config.hooks.parse).to.have.been.calledOnce
 
               const span = config.hooks.parse.firstCall.args[0]
-              const hookDocument = config.hooks.parse.firstCall.args[1]
-              const operation = config.hooks.parse.firstCall.args[2]
+              const hookSource = config.hooks.parse.firstCall.args[1]
+              const hookDocument = config.hooks.parse.firstCall.args[2]
 
               expect(span.context()._name).to.equal('graphql.parse')
 
+              expect(hookSource).to.equal(source)
               expect(hookDocument).to.equal(document)
-              expect(operation.operation).to.equal('query')
-              expect(operation.name.value).to.equal('MyQuery')
             })
             .then(done)
             .catch(done)


### PR DESCRIPTION
### What does this PR do?

Adds implementation and tests to add parse and validate hooks to graphql plugin

### Motivation

Want more control on handling spans without messing with my business logic

### Plugin Checklist

- [x] Unit tests.
- [X] TypeScript [definitions][1].
- [X] TypeScript [tests][2].
- [ ] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [X] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

Decided with these args for the hooks:

    validate(span, document, errors)
    parse(span, source, document)
    