### PR TITLE
[ci-app] Fix `cucumber` Test Suite Extraction

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -17,7 +17,6 @@ require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
 require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,protobufjs,BSD-3-Clause,Copyright 2016 Daniel Wirtz
-require,resolve,MIT,Copyright 2012 James Halliday
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,source-map,BSD-3-Clause,Copyright 2009-2011 Mozilla Foundation and contributors

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "protobufjs": "^6.9.0",
-    "resolve": "^1.20.0",
     "semver": "^5.5.0",
     "shimmer": "1.2.1",
     "source-map": "^0.7.3",

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -1,5 +1,4 @@
 const { relative } = require('path')
-const resolve = require('resolve')
 
 const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
 
@@ -132,7 +131,7 @@ module.exports = [
       const testEnvironmentMetadata = getTestEnvironmentMetadata('cucumber')
       const sourceRoot = process.cwd()
       const getTestSuiteName = (pickleUri) => {
-        return relative(sourceRoot, resolve.sync(pickleUri, { basedir: __dirname }))
+        return relative(sourceRoot, pickleUri)
       }
       const pl = TestCaseRunner.default
       this.wrap(

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -61,8 +61,6 @@ describe('Plugin', () => {
         Cucumber = require(`../../../versions/@cucumber/cucumber@${version}`).get()
       })
     })
-    const testFilePath = path.join(__dirname, 'features', 'simple.feature')
-    const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
 
     describe('cucumber', () => {
       describe('passing test', () => {
@@ -82,7 +80,6 @@ describe('Plugin', () => {
               [TEST_NAME]: 'pass scenario',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_SUITE]: testSuite,
               [TEST_STATUS]: 'pass'
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
@@ -138,7 +135,6 @@ describe('Plugin', () => {
               [TEST_NAME]: 'fail scenario',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_SUITE]: testSuite,
               [TEST_STATUS]: 'fail'
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
@@ -201,7 +197,6 @@ describe('Plugin', () => {
               [TEST_NAME]: 'skip scenario',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_SUITE]: testSuite,
               [TEST_STATUS]: 'skip'
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
@@ -264,7 +259,6 @@ describe('Plugin', () => {
               [TEST_NAME]: 'skip scenario based on tag',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_SUITE]: testSuite,
               [TEST_STATUS]: 'skip'
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
@@ -337,7 +331,6 @@ describe('Plugin', () => {
               [TEST_NAME]: 'integration scenario',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_SUITE]: testSuite,
               [TEST_STATUS]: 'pass'
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
@@ -398,7 +391,6 @@ describe('Plugin', () => {
               [TEST_NAME]: 'hooks fail',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_SUITE]: testSuite,
               [TEST_STATUS]: 'fail'
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)


### PR DESCRIPTION
### What does this PR do?
Fix test suite extraction logic in `cucumber` plugin. 

### Motivation
Fix issue with latest version of `cucumber`, where we would try to extract the feature file name from `__dirname` within the cucumber plugin, which raised an exception. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
