### PR TITLE
add legacy dist tags and fix prerelease detection for docs

### DIFF
--- a/scripts/postpublish.js
+++ b/scripts/postpublish.js
@@ -4,8 +4,14 @@ const exec = require('./helpers/exec')
 
 const pkg = require('../package.json')
 
-const betaExpr = /\d+\.\d+\.\d+-beta\.\d+/
+const betaExpr = /\d+\.\d+\.\d+-.*/
+const legacyExpr = /0\.\d+\.\d+/
 
 if (!betaExpr.test(pkg.version)) {
+  if (legacyExpr.test(pkg.version)) {
+    exec(`yarn tag add dd-trace@${pkg.version} latest-node8`)
+    exec(`yarn tag add dd-trace@${pkg.version} latest-node10`)
+  }
+
   exec(`node scripts/publish_docs.js "v${pkg.version}"`)
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add legacy dist tags and fix prerelease detection for docs.

### Motivation
<!-- What inspired you to submit this pull request? -->

0.x releases should always be tagged with `latest-node8` and `latest-node10` to allow users of EOL versions of Node to install the latest supported version without having to worry about specific version numbers.