### PR TITLE
fix version script not using the correct branches and suffixes

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -15,15 +15,20 @@ title(`Bumping version to v${version}.`)
 const currentBranch = exec.pipe(`git branch --show-current`)
 
 if (currentBranch === 'master') {
-  exec(`git checkout -b v${semver.major(pkg.version)}.x`)
-  exec(`git push -u origin HEAD`)
-
+  const major = semver.major(pkg.version)
   const nextMajor = semver.major(pkg.version) + 1
 
-  bump(`v${nextMajor}.0.0-pre`)
+  exec(`git checkout -b v${major}.x`)
+  exec(`git push -u origin HEAD`)
+
+  bump(`${nextMajor}.0.0-pre`)
+
+  exec(`git checkout v${major}.x`)
 }
 
 bump(version)
+
+exec(`git checkout ${currentBranch}`)
 
 function bump (newVersion) {
   pkg.version = newVersion


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix version script not using the correct branches and suffixes.

### Motivation
<!-- What inspired you to submit this pull request? -->

It would otherwise result in a branch with 2 suffixes like `vv2.0.0-pre` and add both version commits to the new version branch.