### PR TITLE
fix support for mongodb 4.x

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/unified.js
+++ b/packages/datadog-plugin-mongodb-core/src/unified.js
@@ -5,7 +5,7 @@ const { instrument } = require('./util')
 function createWrapConnectionCommand (tracer, config, name) {
   return function wrapCommand (command) {
     return function commandWithTrace (ns, ops) {
-      const hostParts = this.address && this.address.split(':')
+      const hostParts = typeof this.address === 'string' ? this.address.split(':') : ''
       const options = hostParts.length === 2
         ? { host: hostParts[0], port: hostParts[1] }
         : {} // no port means the address is a random UUID so no host either

--- a/packages/datadog-plugin-mongodb-core/src/unified.js
+++ b/packages/datadog-plugin-mongodb-core/src/unified.js
@@ -2,6 +2,22 @@
 
 const { instrument } = require('./util')
 
+function createWrapConnectionCommand (tracer, config, name) {
+  return function wrapCommand (command) {
+    return function commandWithTrace (ns, ops) {
+      const hostParts = this.address && this.address.split(':')
+      const options = hostParts.length === 2
+        ? { host: hostParts[0], port: hostParts[1] }
+        : {} // no port means the address is a random UUID so no host either
+      const topology = { s: { options } }
+
+      ns = `${ns.db}.${ns.collection}`
+
+      return instrument(command, this, arguments, topology, ns, ops, tracer, config, { name })
+    }
+  }
+}
+
 function createWrapCommand (tracer, config, name) {
   return function wrapCommand (command) {
     return function commandWithTrace (server, ns, ops) {
@@ -30,6 +46,24 @@ function unpatch (wp) {
   this.unwrap(wp, 'killCursors')
 }
 
+function patchConnection ({ Connection }, tracer, config) {
+  const proto = Connection.prototype
+
+  this.wrap(proto, 'command', createWrapConnectionCommand(tracer, config))
+  this.wrap(proto, 'query', createWrapConnectionCommand(tracer, config))
+  this.wrap(proto, 'getMore', createWrapConnectionCommand(tracer, config, 'getMore'))
+  this.wrap(proto, 'killCursors', createWrapConnectionCommand(tracer, config, 'killCursors'))
+}
+
+function unpatchConnection ({ Connection }) {
+  const proto = Connection.prototype
+
+  this.unwrap(proto, 'command')
+  this.unwrap(proto, 'query')
+  this.unwrap(proto, 'getMore')
+  this.unwrap(proto, 'killCursors')
+}
+
 function patchClass (WireProtocol, tracer, config) {
   this.wrap(WireProtocol.prototype, 'command', createWrapCommand(tracer, config))
 }
@@ -41,7 +75,14 @@ function unpatchClass (WireProtocol) {
 module.exports = [
   {
     name: 'mongodb',
-    versions: ['>=3.3'],
+    versions: ['>=4'],
+    file: 'lib/cmap/connection.js',
+    patch: patchConnection,
+    unpatch: unpatchConnection
+  },
+  {
+    name: 'mongodb',
+    versions: ['>=3.3 <4'],
     file: 'lib/core/wireprotocol/index.js',
     patch,
     unpatch

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -7,7 +7,7 @@ const plugin = require('../src')
 wrapIt()
 
 const withTopologies = fn => {
-  withVersions(plugin, ['mongodb-core', 'mongodb'], (version, moduleName) => {
+  withVersions(plugin, ['mongodb-core', 'mongodb'], '<4', (version, moduleName) => {
     describe('using the server topology', () => {
       fn(() => {
         const { CoreServer, Server } = require(`../../../versions/${moduleName}@${version}`).get()

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
 
@@ -7,10 +8,10 @@ wrapIt()
 
 const withTopologies = fn => {
   withVersions(plugin, 'mongodb', (version, moduleName) => {
-    describe('using the server topology', () => {
+    describe('using the default topology', () => {
       fn(async () => {
         const { MongoClient } = require(`../../../versions/${moduleName}@${version}`).get()
-        const client = new MongoClient('mongodb://localhost:27017', { useUnifiedTopology: false })
+        const client = new MongoClient('mongodb://127.0.0.1:27017')
 
         await client.connect()
 
@@ -18,17 +19,20 @@ const withTopologies = fn => {
       })
     })
 
-    describe('using the unified topology', () => {
-      fn(async () => {
-        const { MongoClient, Server } = require(`../../../versions/${moduleName}@${version}`).get()
-        const server = new Server('localhost', 27017, { reconnect: false })
-        const client = new MongoClient(server, { useUnifiedTopology: true })
+    // unified topology is now the only topology and thus the default since 4.x
+    if (semver.intersects(version, '<4')) {
+      describe('using the unified topology', () => {
+        fn(async () => {
+          const { MongoClient, Server } = require(`../../../versions/${moduleName}@${version}`).get()
+          const server = new Server('127.0.0.1', 27017, { reconnect: false })
+          const client = new MongoClient(server, { useUnifiedTopology: true })
 
-        await client.connect()
+          await client.connect()
 
-        return client
+          return client
+        })
       })
-    })
+    }
   })
 }
 
@@ -81,7 +85,7 @@ describe('Plugin', () => {
                 expect(span).to.have.property('type', 'mongodb')
                 expect(span.meta).to.have.property('span.kind', 'client')
                 expect(span.meta).to.have.property('db.name', `test.${collectionName}`)
-                expect(span.meta).to.have.property('out.host', 'localhost')
+                expect(span.meta).to.have.property('out.host', '127.0.0.1')
               })
               .then(done)
               .catch(done)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix support for `mongodb` 4.x.

### Motivation
<!-- What inspired you to submit this pull request? -->

Version 4 of `mongodb` was released yesterday and broke compatibility with the tracer.