### PR TITLE
[ci-app] Fix Exception in Hooks Outside of Tests

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -99,6 +99,12 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
       event.name !== 'hook_failure') {
       return
     }
+    // for hook_failure events the test entry might not be defined, because the hook
+    // is not necessarily associated to a test:
+    if (!event.test) {
+      return
+    }
+
     const childOf = tracer.extract('text_map', {
       'x-datadog-trace-id': id().toString(10),
       'x-datadog-parent-id': '0000000000000000',

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -605,6 +605,15 @@ describe('Plugin', () => {
         datadogJestEnv.handleTestEvent(hookFailureEvent)
       })
 
+      it('does not crash when there is an error in a hook outside a test', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+        const hookFailureEvent = {
+          name: 'hook_failure'
+        }
+        datadogJestEnv.handleTestEvent(hookFailureEvent).then(done).catch(done)
+      })
+
       // TODO: allow the plugin consumer to define their own jest's `testEnvironment`
       it.skip('should allow the customer to use their own environment', (done) => {
         class CustomerCustomEnv extends DatadogJestEnvironment {


### PR DESCRIPTION
### What does this PR do?
* Fix bug in `jest` instrumentation.

### Motivation
We were attempting to access `event.test` for `hook_failure` events. This is fine as long as the hook is associated to a test (such as `beforeEach` and `afterEach`), but it isn't for hooks such as `beforeAll`. 

The entry for `test` is optional for this specific event: https://github.com/facebook/jest/blob/bc50e7f360ab1845abbaa0b3ad788caead0d3174/packages/jest-types/src/Circus.ts#L106 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
