### PR TITLE
Fix express api docs with invalid syntax

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -483,7 +483,7 @@ const tracer = require('dd-trace').init()
 
 tracer.use('express', {
   hooks: {
-    request: (span, req res) => {
+    request: (span, req, res) => {
       span.setTag('customer.id', req.query.id)
     }
   }


### PR DESCRIPTION
### What does this PR do?
Fix invalid syntax on `tracer.use('express', ...)` API docs
