### PR TITLE
fix tedious invalid stored procedure tag

### DIFF
--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -5,8 +5,6 @@ const Kinds = require('../../../ext/kinds')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const tx = require('../../dd-trace/src/plugins/util/tx')
 
-const procnameRegex = /^sp_[a-z]+$/
-
 function createWrapMakeRequest (tracer, config) {
   return function wrapMakeRequest (makeRequest) {
     return function makeRequestWithTrace (request) {
@@ -33,7 +31,6 @@ function createWrapMakeRequest (tracer, config) {
 
       addConnectionTags(span, connectionConfig)
       addDatabaseTags(span, connectionConfig)
-      addProcIdTags(span, request)
 
       analyticsSampler.sample(span, config.measured)
       request.callback = tx.wrap(span, request.callback)
@@ -75,11 +72,6 @@ function addDatabaseTags (span, connectionConfig) {
   span.setTag('db.user', connectionConfig.userName || connectionConfig.authentication.options.userName)
   span.setTag('db.name', connectionConfig.options.database)
   span.setTag('db.instance', connectionConfig.options.instanceName)
-}
-
-function addProcIdTags (span, request) {
-  if (!procnameRegex.test(request.sqlTextOrProcedure)) return
-  span.setTag('tds.proc.name', request.sqlTextOrProcedure)
 }
 
 module.exports = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `tedious` invalid stored procedure tag. Additionally, fix race conditions in tests that would result in random failures when the connection is closed before the request is finished, which happens more often with the latest version.

### Motivation
<!-- What inspired you to submit this pull request? -->

The tag was originally added to capture the stored procedure name, but the internals of the library were changed in a way where we can no longer capture `sp_*` stored procedures, and other stored procedures can have any name so we can't differentiate them, meaning the tag actually doesn't capture what it's supposed to capture. Removing the tag is thus the only solution here since it doesn't work as advised.