### PR TITLE
Expand profiler logging

### DIFF
--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -26,6 +26,8 @@ class Profiler extends EventEmitter {
     if (!semver.satisfies(process.version, '>=10.12')) {
       this._logger.error('Profiling could not be started because it requires Node >=10.12')
       return this
+    } else {
+      this._logger.debug('Profiling started')
     }
 
     this._enabled = true
@@ -39,6 +41,7 @@ class Profiler extends EventEmitter {
           logger: this._logger,
           mapper
         })
+        this._logger.debug(`Started ${profiler.type} profiler`)
       }
     } catch (e) {
       this._logger.error(e)
@@ -57,6 +60,7 @@ class Profiler extends EventEmitter {
 
     for (const profiler of this._config.profilers) {
       profiler.stop()
+      this._logger.debug(`Stopped ${profiler.type} profiler`)
     }
 
     clearTimeout(this._timer)
@@ -87,10 +91,12 @@ class Profiler extends EventEmitter {
         if (!profile) continue
 
         profiles[profiler.type] = profile
+        this._logger.debug(`Collected ${profiler.type} profile`)
       }
 
       this._capture(this._config.flushInterval)
       await this._submit(profiles, start, end)
+      this._logger.debug(`Submitted profiles`)
     } catch (err) {
       this._logger.error(err)
       this.stop()

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -97,6 +97,7 @@ function startupLog ({ agentError } = {}) {
 
   out.log_injection_enabled = !!config.logInjection
   out.runtime_metrics_enabled = !!config.runtimeMetrics
+  out.profiling_enabled = !!(config.profiling || {}).enabled
   Object.assign(out, getIntegrationsAndAnalytics())
 
   // // This next bunch is for features supported by other tracers, but not this

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -9,6 +9,7 @@ const getPort = require('get-port')
 const { gunzipSync } = require('zlib')
 const CpuProfiler = require('../../../src/profiling/profilers/cpu')
 const HeapProfiler = require('../../../src/profiling/profilers/heap')
+const logger = require('../../../src/log')
 const { perftools } = require('pprof/proto/profile')
 const semver = require('semver')
 
@@ -74,7 +75,7 @@ describe('exporters/agent', () => {
     })
 
     it('should send profiles as pprof to the intake', async () => {
-      const exporter = new AgentExporter({ url })
+      const exporter = new AgentExporter({ url, logger })
       const start = new Date()
       const end = new Date()
       const tags = { foo: 'bar' }
@@ -153,7 +154,7 @@ describe('exporters/agent', () => {
     })
 
     it('should support Unix domain sockets', async () => {
-      const exporter = new AgentExporter({ url: `unix://${url}` })
+      const exporter = new AgentExporter({ url: `unix://${url}`, logger })
       const start = new Date()
       const end = new Date()
       const tags = { foo: 'bar' }


### PR DESCRIPTION
I've made the profiler logging more verbose and helpful. The main changes are in the agent exporter which now should log everything in the form-data body to verify correctness of everything.