### PR TITLE
avoid DNS lookups when dogstatsd host is an IP address

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const dgram = require('dgram')
 const lookup = require('dns').lookup // cache to avoid instrumentation
+const dgram = require('dgram')
+const isIP = require('net').isIP
 const log = require('./log')
 
 const MAX_BUFFER_SIZE = 1024 // limit from the agent
@@ -11,6 +12,7 @@ class Client {
     options = options || {}
 
     this._host = options.host || 'localhost'
+    this.__family = isIP(this._host)
     this._port = options.port || 8125
     this._prefix = options.prefix || ''
     this._tags = options.tags || []
@@ -36,11 +38,17 @@ class Client {
 
     this._queue = []
 
-    lookup(this._host, (err, address, family) => {
-      if (err) return log.error(err)
+    const send = (address, family) =>
+      queue.forEach((buffer) => this._send(address, family, buffer));
 
-      queue.forEach(buffer => this._send(address, family, buffer))
-    })
+    if (this._family !== 0) {
+      send(this._host, this._family)
+    } else {
+      lookup(this._host, (err, address, family) => {
+        if (err) return log.error(err)
+        send(address, family)
+      })
+    }
   }
 
   _send (address, family, buffer) {

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -12,7 +12,7 @@ class Client {
     options = options || {}
 
     this._host = options.host || 'localhost'
-    this.__family = isIP(this._host)
+    this._family = isIP(this._host)
     this._port = options.port || 8125
     this._prefix = options.prefix || ''
     this._tags = options.tags || []
@@ -38,15 +38,12 @@ class Client {
 
     this._queue = []
 
-    const send = (address, family) =>
-      queue.forEach((buffer) => this._send(address, family, buffer));
-
     if (this._family !== 0) {
-      send(this._host, this._family)
+      this._sendAll(queue, this._host, this._family)
     } else {
       lookup(this._host, (err, address, family) => {
         if (err) return log.error(err)
-        send(address, family)
+        this._sendAll(queue, address, family)
       })
     }
   }
@@ -57,6 +54,10 @@ class Client {
     log.debug(`Sending to DogStatsD: ${buffer}`)
 
     socket.send(buffer, 0, buffer.length, this._port, address)
+  }
+
+  _sendAll (queue, address, family) {
+    queue.forEach((buffer) => this._send(address, family, buffer))
   }
 
   _add (stat, value, type, tags) {

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -134,8 +134,33 @@ describe('dogstatsd', () => {
     client.gauge('test.avg', 1)
     client.flush()
 
+    expect(dns.lookup).to.have.been.called
     expect(udp4.send).to.not.have.been.called
     expect(udp6.send).to.not.have.been.called
+  })
+
+  it('should not call DNS if the host is an IPv4 address', () => {
+    client = new Client({
+      host: '127.0.0.1'
+    })
+
+    client.gauge('test.avg', 1)
+    client.flush()
+
+    expect(udp4.send).to.have.been.called
+    expect(dns.lookup).to.not.have.been.called
+  })
+
+  it('should not call DNS if the host is an IPv6 address', () => {
+    client = new Client({
+      host: '2001:db8:3333:4444:5555:6666:7777:8888'
+    })
+
+    client.gauge('test.avg', 1)
+    client.flush()
+
+    expect(udp6.send).to.have.been.called
+    expect(dns.lookup).to.not.have.been.called
   })
 
   it('should support configuration', () => {


### PR DESCRIPTION
### What does this PR do?

This is an alternate solution to https://github.com/DataDog/dd-trace-js/pull/1187, which should prevent DNS lookups from the dogstatsd client from being performed or traced when the APM host is an IP address.

Note that it still seems possible that the dogstatsd DNS lookups _may_ still be traced if an actual hostname is provided.  However, regardless, this should provide a small performance bump for some folks.