### PR TITLE
Improve profiler logging and behaviour when profilers fail to start

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -82,9 +82,14 @@ class AgentExporter {
       this._logger.debug(`Submitting agent report to: ${JSON.stringify(options)}`)
 
       form.submit(options, (err, res) => {
-        res.resume()
+        if (err || !res) return reject(err)
 
-        if (err) return reject(err)
+        const chunks = []
+        res.on('data', chunk => chunks.push(chunk))
+        res.on('end', () => {
+          this._logger.debug(`Agent export response: ${Buffer.concat(chunks)}`)
+        })
+
         if (res.statusCode >= 400) {
           return reject(new Error(`Error from the agent: ${res.statusCode}`))
         }

--- a/packages/dd-trace/src/profiling/profilers/heap.js
+++ b/packages/dd-trace/src/profiling/profilers/heap.js
@@ -5,34 +5,23 @@ class NativeHeapProfiler {
     this.type = 'space'
     this._samplingInterval = options.samplingInterval || 512 * 1024
     this._stackDepth = options.stackDepth || 64
-    this._logger = undefined
     this._pprof = undefined
   }
 
-  start ({ logger } = {}) {
-    this._logger = logger
-
-    try {
-      this._pprof = require('pprof')
-    } catch (err) {
-      if (this._logger) {
-        this._logger.error(err)
-      }
-    }
-
-    if (!this._pprof) return
-
+  start () {
+    this._pprof = require('pprof')
     this._pprof.heap.start(this._samplingInterval, this._stackDepth)
   }
 
   profile () {
-    if (!this._pprof) return
-    const profile = this._pprof.heap.profile()
+    return this._pprof.heap.profile()
+  }
+
+  encode (profile) {
     return this._pprof.encode(profile)
   }
 
   stop () {
-    if (!this._pprof) return
     this._pprof.heap.stop()
   }
 }

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -48,7 +48,8 @@ describe('profiler', () => {
       type: 'cpu',
       start: sinon.stub(),
       stop: sinon.stub(),
-      profile: sinon.stub().returns(cpuProfilePromise)
+      profile: sinon.stub().returns('profile'),
+      encode: sinon.stub().returns(cpuProfilePromise)
     }
 
     heapProfile = {}
@@ -57,7 +58,8 @@ describe('profiler', () => {
       type: 'heap',
       start: sinon.stub(),
       stop: sinon.stub(),
-      profile: sinon.stub().returns(heapProfilePromise)
+      profile: sinon.stub().returns('profile'),
+      encode: sinon.stub().returns(heapProfilePromise)
     }
 
     logger = consoleLogger
@@ -117,7 +119,7 @@ describe('profiler', () => {
 
   it('should stop when capturing failed', async () => {
     const rejected = Promise.reject(new Error('boom'))
-    cpuProfiler.profile.returns(rejected)
+    cpuProfiler.encode.returns(rejected)
 
     profiler.start({ profilers, exporters, logger })
 

--- a/packages/dd-trace/test/profiling/profilers/cpu.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/cpu.spec.js
@@ -58,11 +58,24 @@ describe('profilers/native/cpu', () => {
     const profiler = new NativeCpuProfiler()
 
     profiler.start()
-    profiler.profile(() => {})
 
-    sinon.assert.calledOnce(pprof.encode)
+    const profile = profiler.profile()
+
+    expect(profile).to.equal('profile')
 
     sinon.assert.calledOnce(stop)
     sinon.assert.calledTwice(pprof.time.start)
+  })
+
+  it('should encode profiles from the pprof time profiler', () => {
+    const profiler = new NativeCpuProfiler()
+
+    profiler.start()
+
+    const profile = profiler.profile()
+
+    profiler.encode(profile)
+
+    sinon.assert.calledOnce(pprof.encode)
   })
 })

--- a/packages/dd-trace/test/profiling/profilers/heap.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/heap.spec.js
@@ -55,11 +55,24 @@ describe('profilers/native/heap', () => {
     sinon.assert.calledOnce(pprof.heap.stop)
   })
 
-  it('should collect profiles from the internal heap profiler', () => {
+  it('should collect profiles from the pprof heap profiler', () => {
     const profiler = new NativeHeapProfiler()
 
     profiler.start()
-    profiler.profile(() => {})
+
+    pprof.heap.profile.returns('profile')
+
+    const profile = profiler.profile()
+
+    expect(profile).to.equal('profile')
+  })
+
+  it('should encode profiles from the pprof heap profiler', () => {
+    const profiler = new NativeHeapProfiler()
+
+    profiler.start()
+    const profile = profiler.profile()
+    profiler.encode(profile)
 
     sinon.assert.calledOnce(pprof.encode)
   })


### PR DESCRIPTION
This prevents individual profilers from failing silently, and ensures the profiler manager doesn't try to export if no profiles were captured. It also restores the split of profile capture from encoding, to some extent. This is mainly just to make it easier to log and inspect the profile contents.