### PR TITLE
update post-publish script to not publish docs on legacy branches

### DIFF
--- a/scripts/postpublish.js
+++ b/scripts/postpublish.js
@@ -8,7 +8,7 @@ const betaExpr = /\d+\.\d+\.\d+-.*/
 const legacyExpr = /0\.\d+\.\d+/
 
 if (!betaExpr.test(pkg.version) && !legacyExpr.test(pkg.version)) {
-  const releaseBranches = exec.pipe('git branch | grep -E "v\\d+\\.x"')
+  const releaseBranches = exec.pipe('git fetch && git branch -a | grep -E "/v\\d+\\.x"')
     .trim()
     .split(/\s+/)
   const releaseMajors = releaseBranches

--- a/scripts/postpublish.js
+++ b/scripts/postpublish.js
@@ -5,7 +5,8 @@ const exec = require('./helpers/exec')
 const pkg = require('../package.json')
 
 const betaExpr = /\d+\.\d+\.\d+-.*/
+const legacyExpr = /0\.\d+\.\d+/
 
-if (!betaExpr.test(pkg.version)) {
+if (!betaExpr.test(pkg.version) && !legacyExpr.test(pkg.version)) {
   exec(`node scripts/publish_docs.js "v${pkg.version}"`)
 }

--- a/scripts/postpublish.js
+++ b/scripts/postpublish.js
@@ -8,5 +8,17 @@ const betaExpr = /\d+\.\d+\.\d+-.*/
 const legacyExpr = /0\.\d+\.\d+/
 
 if (!betaExpr.test(pkg.version) && !legacyExpr.test(pkg.version)) {
-  exec(`node scripts/publish_docs.js "v${pkg.version}"`)
+  const releaseBranches = exec.pipe('git branch | grep -E "v\\d+\\.x"')
+    .trim()
+    .split(/\s+/)
+  const releaseMajors = releaseBranches
+    .map(branch => parseInt(branch.replace(/[^0-9]/g, '')))
+    .sort()
+    .reverse()
+  const latestMajor = releaseMajors[0]
+  const currentMajor = parseInt(pkg.version.split('.')[0])
+
+  if (currentMajor === latestMajor) {
+    exec(`node scripts/publish_docs.js "v${pkg.version}"`)
+  }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update post-publish script to not publish docs on legacy branches.

### Motivation
<!-- What inspired you to submit this pull request? -->

Docs are currently only for 1.x and not 0.x.