### PR TITLE
Prevent next failures on profiler branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,6 @@ node-bench-sirun-base: &node-bench-sirun-base
         paths:
           - benchmark/sirun/*-sirun-output.ndjson
 
-
 node-integration-base: &node-integration-base
   resource_class: small
   working_directory: ~/dd-trace-js

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -38,6 +38,7 @@ describe('Plugin', function () {
           execSync('node build', {
             cwd: __dirname,
             env: {
+              ...process.env,
               version,
               // needed for webpack 5
               NODE_PATH: [

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -18,7 +18,8 @@ module.exports = {
 
     config.externals = {
       'react': `commonjs2 ${react}`,
-      'react-dom': `commonjs2 ${reactDom}`
+      'react-dom': `commonjs2 ${reactDom}`,
+      '@mapbox/node-pre-gyp': '@mapbox/node-pre-gyp'
     }
 
     // TODO: drop support for Next <10.1, enable webpack5 above, and uncomment:

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -93,6 +93,10 @@
     {
       "name": "react-dom",
       "versions": ["17.0.2"]
+    },
+    {
+      "name": "@mapbox/node-pre-gyp",
+      "versions": [">=1"]
     }
   ],
   "pg": [


### PR DESCRIPTION
Turns out the `node-pre-gyp` dependency in the `pprof` module is the cause of `next` failures on the profiler branch. This fixes the issue.