### PR TITLE
improve compatibility with graphql-tools 

### DIFF
--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -101,6 +101,7 @@ function createWrapValidate (tracer, config) {
         setError(span, e)
         throw e
       } finally {
+        config.hooks.validate(span, document, errors)
         finish(span)
       }
     }

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -17,10 +17,8 @@ function createWrapExecute (tracer, config, defaultFieldResolver) {
       const contextValue = args.contextValue = args.contextValue || {}
       const operation = getOperation(document, args.operationName)
 
-      args.fieldResolver = args.fieldResolver || wrappedDefaultFieldResolver
-      if (!args.fieldResolver._datadog_patched) {
-        args.fieldResolver = wrapResolve(args.fieldResolver, tracer, config)
-      }
+      args.fieldResolver = wrapResolve(args.fieldResolver, tracer, config) ||
+        wrappedDefaultFieldResolver
 
       if (schema) {
         wrapFields(schema._queryType, tracer, config)
@@ -142,7 +140,9 @@ function wrapFieldType (field, tracer, config) {
 }
 
 function wrapResolve (resolve, tracer, config) {
-  if (resolve._datadog_patched || typeof resolve !== 'function') return resolve
+  if (!resolve || resolve._datadog_patched || typeof resolve !== 'function') {
+    return resolve
+  }
 
   const responsePathAsArray = config.collapse
     ? withCollapse(pathToArray)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1502,7 +1502,7 @@ describe('Plugin', () => {
 
               expect(spans[2]).to.have.property('name', 'graphql.validate')
               expect(spans[2].meta).to.not.have.property('graphql.source')
-            })
+            }, { raiseLastError: true })
             .then(done)
             .catch(done)
 
@@ -1609,7 +1609,7 @@ describe('Plugin', () => {
             expect(spans[6]).to.have.property('resource', 'findFancyWord')
             expect(spans[6].duration.toNumber()).gte(40 * 1e6)
             expect(spans[6].meta).to.not.have.property('graphql.source')
-          })
+          }, { raiseLastError: true })
           .catch(done)
           .then(done)
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -161,7 +161,6 @@ describe('Plugin', () => {
     })
 
     withVersions(plugin, 'graphql', version => {
-
       describe('without configuration', () => {
         before(() => {
           return agent.load('graphql')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1543,122 +1543,118 @@ describe('Plugin', () => {
           runQuery(params)
             .catch(done)
         })
-      })
-    })
 
-    withVersions(plugin, 'graphql', '>10.0.0', toolsVersion => {
-      let runQuery
-      let makeExecutableSchema
-      let wrapSchema
-      let FilterTypes
+        withVersions(plugin, 'graphql-tools', '>7.0.0', (gqlToolsVersion) => {
+          let runQuery
+          let makeExecutableSchema
+          let wrapSchema
+          let FilterTypes
 
-      before(() => {
-        tracer = require('../../dd-trace')
+          before(() => {
+            tracer = require('../../dd-trace')
 
-        return agent.load('graphql')
-          .then(() => {
-            graphql = require(`../../../versions/graphql@15.5.1`).get()
+            return agent.load('graphql')
+              .then(() => {
+                graphql = require(`../../../versions/graphql@${version}`).get()
 
-            const apolloCore = require(`../../../versions/apollo-server-core@1.3.6`).get()
-            const graphqlTools = require(`../../../versions/graphql-tools@7.0.4`).get()
+                const apolloCore = require(`../../../versions/apollo-server-core@1.3.6`).get()
+                const graphqlTools = require(`../../../versions/graphql-tools@${gqlToolsVersion}`).get()
 
-            runQuery = apolloCore.runQuery
-            makeExecutableSchema = graphqlTools.makeExecutableSchema
-            wrapSchema = graphqlTools.wrapSchema
-            FilterTypes = graphqlTools.FilterTypes
+                runQuery = apolloCore.runQuery
+                makeExecutableSchema = graphqlTools.makeExecutableSchema
+                wrapSchema = graphqlTools.wrapSchema
+                FilterTypes = graphqlTools.FilterTypes
+              })
           })
-      })
 
-      after(() => {
-        return agent.close()
-      })
+          it('should support graphql-tools wrapSchema', done => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+                expect(spans).to.have.length(7)
 
-      it('should support graphql-tools wrapSchema', done => {
-        agent
-          .use(traces => {
-            const spans = sort(traces[0])
-            expect(spans).to.have.length(7)
+                // TODO: Make these durations match the actual timeouts.
+                // For some reason, they occasionally come up slightly short.
 
-            // TODO: Make these durations match the actual timeouts.
-            // For some reason, they occasionally come up slightly short.
+                expect(spans[0]).to.have.property('name', 'graphql.execute')
+                expect(spans[0]).to.have.property('resource', 'query MyQuery{parent{child{fancyWord word}}}')
+                expect(spans[0].duration.toNumber()).gte(60 * 1e6)
+                expect(spans[0].meta).to.not.have.property('graphql.source')
 
-            expect(spans[0]).to.have.property('name', 'graphql.execute')
-            expect(spans[0]).to.have.property('resource', 'query MyQuery{parent{child{fancyWord word}}}')
-            expect(spans[0].duration.toNumber()).gte(60 * 1e6)
-            expect(spans[0].meta).to.not.have.property('graphql.source')
+                expect(spans[1]).to.have.property('name', 'graphql.resolve')
+                expect(spans[1]).to.have.property('resource', 'parent:Parent')
+                expect(spans[1].duration.toNumber()).gte(9 * 1e6)
+                expect(spans[1].meta).to.not.have.property('graphql.source')
 
-            expect(spans[1]).to.have.property('name', 'graphql.resolve')
-            expect(spans[1]).to.have.property('resource', 'parent:Parent')
-            expect(spans[1].duration.toNumber()).gte(9 * 1e6)
-            expect(spans[1].meta).to.not.have.property('graphql.source')
+                expect(spans[3]).to.have.property('name', 'graphql.resolve')
+                expect(spans[3]).to.have.property('resource', 'child:Child')
+                expect(spans[3].duration.toNumber()).gte(9 * 1e6)
+                expect(spans[3].meta).to.not.have.property('graphql.source')
 
-            expect(spans[3]).to.have.property('name', 'graphql.resolve')
-            expect(spans[3]).to.have.property('resource', 'child:Child')
-            expect(spans[3].duration.toNumber()).gte(9 * 1e6)
-            expect(spans[3].meta).to.not.have.property('graphql.source')
+                expect(spans[4]).to.have.property('name', 'graphql.resolve')
+                expect(spans[4]).to.have.property('resource', 'word:String')
+                expect(spans[4].duration.toNumber()).gte(9 * 1e6)
+                expect(spans[4].meta).to.not.have.property('graphql.source')
 
-            expect(spans[4]).to.have.property('name', 'graphql.resolve')
-            expect(spans[4]).to.have.property('resource', 'word:String')
-            expect(spans[4].duration.toNumber()).gte(9 * 1e6)
-            expect(spans[4].meta).to.not.have.property('graphql.source')
+                expect(spans[5]).to.have.property('name', 'graphql.resolve')
+                expect(spans[5]).to.have.property('resource', 'fancyWord:String')
+                expect(spans[5].duration.toNumber()).gte(18 * 1e6)
+                expect(spans[5].meta).to.not.have.property('graphql.source')
 
-            expect(spans[5]).to.have.property('name', 'graphql.resolve')
-            expect(spans[5]).to.have.property('resource', 'fancyWord:String')
-            expect(spans[5].duration.toNumber()).gte(18 * 1e6)
-            expect(spans[5].meta).to.not.have.property('graphql.source')
+                expect(spans[6]).to.have.property('name', 'findFancyWord')
+                expect(spans[6]).to.have.property('resource', 'findFancyWord')
+                expect(spans[6].duration.toNumber()).gte(36 * 1e6)
+                expect(spans[6].meta).to.not.have.property('graphql.source')
+              }, { raiseLastError: true })
+              .catch(done)
+              .then(done)
 
-            expect(spans[6]).to.have.property('name', 'findFancyWord')
-            expect(spans[6]).to.have.property('resource', 'findFancyWord')
-            expect(spans[6].duration.toNumber()).gte(36 * 1e6)
-            expect(spans[6].meta).to.not.have.property('graphql.source')
-          }, { raiseLastError: true })
-          .catch(done)
-          .then(done)
-
-        schema = makeExecutableSchema({
-          typeDefs: `
-            type Query {
-              parent: Parent
-            }
-            type Parent {
-              child: Child
-            }
-            type Child {
-              word: String
-              fancyWord: String
-            }
-          `,
-          resolvers: {
-            Query: {
-              parent: () => new Promise((resolve) => setTimeout(() => resolve({}), 10))
-            },
-            Parent: {
-              child: () => new Promise((resolve) => setTimeout(() => resolve({}), 10))
-            },
-            Child: {
-              word: () => new Promise((resolve) => setTimeout(() => resolve('hello'), 20)),
-              fancyWord: async () => {
-                await tracer.trace('findFancyWord', () =>
-                  new Promise((resolve) => setTimeout(() => resolve('world'), 40))
-                )
+            schema = makeExecutableSchema({
+              typeDefs: `
+                type Query {
+                  parent: Parent
+                }
+                type Parent {
+                  child: Child
+                }
+                type Child {
+                  word: String
+                  fancyWord: String
+                }
+              `,
+              resolvers: {
+                Query: {
+                  parent: () => new Promise((resolve) => setTimeout(() => resolve({}), 10))
+                },
+                Parent: {
+                  child: () => new Promise((resolve) => setTimeout(() => resolve({}), 10))
+                },
+                Child: {
+                  word: () => new Promise((resolve) => setTimeout(() => resolve('hello'), 20)),
+                  fancyWord: async () => {
+                    await tracer.trace('findFancyWord', () =>
+                      new Promise((resolve) => setTimeout(() => resolve('world'), 40))
+                    )
+                  }
+                }
               }
+            })
+
+            const wrappedSchema = wrapSchema({
+              schema,
+              transforms: [ new FilterTypes(() => true) ]
+            })
+
+            const params = {
+              schema: wrappedSchema,
+              query: 'query MyQuery { parent { child { word fancyWord } } }',
+              operationName: 'MyQuery'
             }
-          }
+
+            runQuery(params)
+              .catch(done)
+          })
         })
-
-        const wrappedSchema = wrapSchema({
-          schema,
-          transforms: [ new FilterTypes(() => true) ]
-        })
-
-        const params = {
-          schema: wrappedSchema,
-          query: 'query MyQuery { parent { child { word fancyWord } } }',
-          operationName: 'MyQuery'
-        }
-
-        runQuery(params)
-          .catch(done)
       })
     })
   })

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1579,6 +1579,9 @@ describe('Plugin', () => {
             const spans = sort(traces[0])
             expect(spans).to.have.length(7)
 
+            // TODO: Make these durations match the actual timeouts.
+            // For some reason, they occasionally come up slightly short.
+
             expect(spans[0]).to.have.property('name', 'graphql.execute')
             expect(spans[0]).to.have.property('resource', 'query MyQuery{parent{child{fancyWord word}}}')
             expect(spans[0].duration.toNumber()).gte(60 * 1e6)
@@ -1586,27 +1589,27 @@ describe('Plugin', () => {
 
             expect(spans[1]).to.have.property('name', 'graphql.resolve')
             expect(spans[1]).to.have.property('resource', 'parent:Parent')
-            expect(spans[1].duration.toNumber()).gte(10 * 1e6)
+            expect(spans[1].duration.toNumber()).gte(9 * 1e6)
             expect(spans[1].meta).to.not.have.property('graphql.source')
 
             expect(spans[3]).to.have.property('name', 'graphql.resolve')
             expect(spans[3]).to.have.property('resource', 'child:Child')
-            expect(spans[3].duration.toNumber()).gte(10 * 1e6)
+            expect(spans[3].duration.toNumber()).gte(9 * 1e6)
             expect(spans[3].meta).to.not.have.property('graphql.source')
 
             expect(spans[4]).to.have.property('name', 'graphql.resolve')
             expect(spans[4]).to.have.property('resource', 'word:String')
-            expect(spans[4].duration.toNumber()).gte(10 * 1e6)
+            expect(spans[4].duration.toNumber()).gte(9 * 1e6)
             expect(spans[4].meta).to.not.have.property('graphql.source')
 
             expect(spans[5]).to.have.property('name', 'graphql.resolve')
             expect(spans[5]).to.have.property('resource', 'fancyWord:String')
-            expect(spans[5].duration.toNumber()).gte(20 * 1e6)
+            expect(spans[5].duration.toNumber()).gte(18 * 1e6)
             expect(spans[5].meta).to.not.have.property('graphql.source')
 
             expect(spans[6]).to.have.property('name', 'findFancyWord')
             expect(spans[6]).to.have.property('resource', 'findFancyWord')
-            expect(spans[6].duration.toNumber()).gte(40 * 1e6)
+            expect(spans[6].duration.toNumber()).gte(36 * 1e6)
             expect(spans[6].meta).to.not.have.property('graphql.source')
           }, { raiseLastError: true })
           .catch(done)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -159,6 +159,7 @@ describe('Plugin', () => {
         return a.start.toString() >= b.start.toString() ? 1 : -1
       })
     })
+
     withVersions(plugin, 'graphql', version => {
 
       describe('without configuration', () => {
@@ -1635,7 +1636,9 @@ describe('Plugin', () => {
             Child: {
               word: () => new Promise((resolve) => setTimeout(() => resolve('hello'), 20)),
               fancyWord: async () => {
-                await tracer.trace('findFancyWord', () => new Promise((resolve) => setTimeout(() => resolve('world'), 40)))
+                await tracer.trace('findFancyWord', () =>
+                  new Promise((resolve) => setTimeout(() => resolve('world'), 40))
+                )
               }
             }
           }
@@ -1654,7 +1657,6 @@ describe('Plugin', () => {
 
         runQuery(params)
           .catch(done)
-
       })
     })
   })

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -74,6 +74,7 @@ module.exports = {
     })
 
     const timeoutMs = options && typeof options === 'object' && options.timeoutMs ? options.timeoutMs : 1000
+    const raiseLastError = options && typeof options === 'object' && options.raiseLastError
 
     const timeout = setTimeout(() => {
       if (error) {
@@ -90,7 +91,7 @@ module.exports = {
         clearTimeout(timeout)
         deferred.resolve()
       } catch (e) {
-        error = error || e
+        error = raiseLastError ? (e || error) : (error || e)
       }
     }
 

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -23,12 +23,16 @@
   ],
   "graphql": [
     {
+      "name": "graphql",
+      "versions": ["0.13.2", "15.5.1"]
+    },
+    {
       "name": "apollo-server-core",
       "versions": ["1.3.6"]
     },
     {
       "name": "graphql-tools",
-      "versions": ["3.1.1"]
+      "versions": ["4.0.7", "7.0.4"]
     }
   ],
   "grpc": [


### PR DESCRIPTION
### What does this PR do?

This PR improves compatibility with graphql servers that use [graphql-tools](https://www.graphql-tools.com/) to transform their schemas.  This will ensure that resolver span timings are correctly recorded for anybody who uses `graphql-tools` (or any other implementation that makes multiple calls to `graphql.execute()` within a single request).  

---

After a server calls the `execute` function from `graphql-js`, `graphql-tools` will internally make additional calls to `execute`, often supplying a modified/transformed version of the original schema.  

Unfortunately, the current implementation of `dd-trace-js` assumes that `execute` will only be called once per trace, and will always supply the same schema object on subsequent calls.  This is not a safe assumption, and the existence of `contextValue._datadog_graphql` should not necessarily imply that the schema/resolvers have already been wrapped.

Fixes https://github.com/DataDog/dd-trace-js/issues/1068

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.

### Additional Notes

I'm not entirely sure how to write unit tests here, as this is a workaround for a fairly specific implementation quirk/detail of `graphql-tools`. 