### PR TITLE
Use forked pprof module with prebuilds

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,6 @@ dist
 docs
 out
 node_modules
-protobuf
 versions
 acmeair-nodejs
 vendor

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@
 !packages/*/src/**/*
 !packages/*/index.js
 !prebuilds/**/*
-!protobuf/**/*
 !scripts/**/*
 !vendor/**/*
 !CONTRIBUTING.md

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,4 +1,5 @@
 Component,Origin,License,Copyright
+require,@datadog/pprof,Apache license 2.0,Copyright 2019 Google Inc.
 require,@types/node,MIT,Copyright Authors
 require,form-data,MIT,Copyright 2012 Felix Geisendörfer and contributors
 require,hdr-histogram-js,BSD-2-Clause,Copyright 2016 Alexandre Victoor
@@ -16,7 +17,6 @@ require,node-gyp-build,MIT,Copyright 2017 Mathias Buus
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
 require,performance-now,MIT,Copyright 2013 Braveg1rl
-require,pprof,Apache license 2.0,Copyright 2019 Google Inc.
 require,resolve,MIT,Copyright 2012 James Halliday
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "rebuild": "node-gyp rebuild --jobs=max",
     "prebuild": "node scripts/prebuild.js",
     "prebuilds": "node scripts/prebuilds.js",
-    "protobuf": "pbjs -t static-module -w commonjs -o protobuf/profile.js protobuf/profile.proto && pbts -o protobuf/profile.d.ts protobuf/profile.js",
     "prepublishOnly": "node scripts/prepublish.js",
     "postpublish": "node scripts/postpublish.js",
     "bench": "node benchmark",
@@ -60,6 +59,7 @@
     "node": ">=12"
   },
   "dependencies": {
+    "@datadog/pprof": "^0.1.3",
     "@types/node": "^10.12.18",
     "form-data": "^3.0.0",
     "hdr-histogram-js": "^2.0.1",
@@ -77,7 +77,6 @@
     "opentracing": ">=0.12.1",
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
-    "pprof": "^3.0.0",
     "resolve": "^1.20.0",
     "semver": "^5.5.0",
     "shimmer": "1.2.1",

--- a/packages/dd-trace/src/profiling/profilers/cpu.js
+++ b/packages/dd-trace/src/profiling/profilers/cpu.js
@@ -10,7 +10,7 @@ class NativeCpuProfiler {
 
   start ({ mapper } = {}) {
     this._mapper = mapper
-    this._pprof = require('pprof')
+    this._pprof = require('@datadog/pprof')
 
     // pprof otherwise crashes in worker threads
     if (!process._startProfilerIdleNotifier) {

--- a/packages/dd-trace/src/profiling/profilers/heap.js
+++ b/packages/dd-trace/src/profiling/profilers/heap.js
@@ -9,7 +9,7 @@ class NativeHeapProfiler {
   }
 
   start () {
-    this._pprof = require('pprof')
+    this._pprof = require('@datadog/pprof')
     this._pprof.heap.start(this._samplingInterval, this._stackDepth)
   }
 

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -10,7 +10,7 @@ const { gunzipSync } = require('zlib')
 const CpuProfiler = require('../../../src/profiling/profilers/cpu')
 const HeapProfiler = require('../../../src/profiling/profilers/heap')
 const logger = require('../../../src/log')
-const { perftools } = require('pprof/proto/profile')
+const { perftools } = require('@datadog/pprof/proto/profile')
 const semver = require('semver')
 
 if (!semver.satisfies(process.version, '>=10.12')) {

--- a/packages/dd-trace/test/profiling/profilers/cpu.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/cpu.spec.js
@@ -23,7 +23,7 @@ describe('profilers/native/cpu', () => {
     }
 
     NativeCpuProfiler = proxyquire('../../../src/profiling/profilers/cpu', {
-      'pprof': pprof
+      '@datadog/pprof': pprof
     })
   })
 

--- a/packages/dd-trace/test/profiling/profilers/heap.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/heap.spec.js
@@ -23,7 +23,7 @@ describe('profilers/native/heap', () => {
     }
 
     NativeHeapProfiler = proxyquire('../../../src/profiling/profilers/heap', {
-      'pprof': pprof
+      '@datadog/pprof': pprof
     })
   })
 


### PR DESCRIPTION
With this, the profiler will use our forked version of the pprof module with our prebuilds included.