### PR TITLE
fix missing error tags for hook exceptions

### DIFF
--- a/packages/datadog-plugin-fastify/src/fastify.js
+++ b/packages/datadog-plugin-fastify/src/fastify.js
@@ -57,9 +57,9 @@ function createWrapAddHook (tracer, config) {
             const promise = fn.apply(this, arguments)
 
             if (promise && typeof promise.catch === 'function') {
-              promise.catch(err => {
+              return promise.catch(err => {
                 web.addError(req, err)
-                return err
+                throw err
               })
             }
 

--- a/packages/datadog-plugin-fastify/src/fastify.js
+++ b/packages/datadog-plugin-fastify/src/fastify.js
@@ -17,6 +17,7 @@ function createWrapFastify (tracer, config) {
       if (typeof app.addHook === 'function') {
         app.addHook('onRequest', createOnRequest(tracer, config))
         app.addHook('preHandler', preHandler)
+        app.addHook = createWrapAddHook(tracer, config)(app.addHook)
       }
 
       methods.forEach(method => {
@@ -26,6 +27,51 @@ function createWrapFastify (tracer, config) {
       app.route = wrapRoute(app.route)
 
       return app
+    }
+  }
+}
+
+function createWrapAddHook (tracer, config) {
+  return function wrapAddHook (addHook) {
+    return function addHookWithTrace (name, fn) {
+      fn = arguments[arguments.length - 1]
+
+      if (typeof fn !== 'function') return addHook.apply(this, arguments)
+
+      arguments[arguments.length - 1] = function (request, reply, done) {
+        const req = getReq(request)
+
+        if (!req) return fn.apply(this, arguments)
+
+        done = arguments[arguments.length - 1]
+
+        try {
+          if (typeof done === 'function') {
+            arguments[arguments.length - 1] = function (err) {
+              web.addError(req, err)
+              return done.apply(this, arguments)
+            }
+
+            return fn.apply(this, arguments)
+          } else {
+            const promise = fn.apply(this, arguments)
+
+            if (promise && typeof promise.catch === 'function') {
+              promise.catch(err => {
+                web.addError(req, err)
+                return err
+              })
+            }
+
+            return promise
+          }
+        } catch (e) {
+          web.addError(req, e)
+          throw e
+        }
+      }
+
+      return addHook.apply(this, arguments)
     }
   }
 }

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -275,6 +275,142 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('should handle hook errors', done => {
+          let error
+
+          app.addHook('onRequest', (request, reply, next) => {
+            next(error = new Error('boom'))
+          })
+
+          app.get('/user', (request, reply) => {
+            reply.send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[0]).to.have.property('name', 'fastify.request')
+                expect(spans[0]).to.have.property('resource', 'GET /user')
+                expect(spans[0]).to.have.property('error', 1)
+                expect(spans[0].meta).to.have.property('error.type', error.name)
+                expect(spans[0].meta).to.have.property('error.msg', error.message)
+                expect(spans[0].meta).to.have.property('error.stack', error.stack)
+              })
+              .then(done)
+              .catch(done)
+
+            app.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(() => {})
+            })
+          })
+        })
+
+        // fastify crashes the process on reply exceptions in older versions
+        if (semver.intersects(version, '>=3')) {
+          it('should handle reply rejections', done => {
+            let error
+
+            app.get('/user', (request, reply) => {
+              return Promise.reject(error = new Error('boom'))
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  const spans = traces[0]
+
+                  expect(spans[0]).to.have.property('name', 'fastify.request')
+                  expect(spans[0]).to.have.property('resource', 'GET /user')
+                  expect(spans[0].meta).to.have.property('error.type', error.name)
+                  expect(spans[0].meta).to.have.property('error.msg', error.message)
+                  expect(spans[0].meta).to.have.property('error.stack', error.stack)
+                })
+                .then(done)
+                .catch(done)
+
+              app.listen(port, 'localhost', () => {
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
+              })
+            })
+          })
+
+          it('should handle reply exceptions', done => {
+            let error
+
+            app.setErrorHandler((error, request, reply) => {
+              reply.send()
+            })
+            app.get('/user', (request, reply) => {
+              throw (error = new Error('boom'))
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  const spans = traces[0]
+
+                  expect(spans[0]).to.have.property('name', 'fastify.request')
+                  expect(spans[0]).to.have.property('resource', 'GET /user')
+                  expect(spans[0].meta).to.have.property('error.type', error.name)
+                  expect(spans[0].meta).to.have.property('error.msg', error.message)
+                  expect(spans[0].meta).to.have.property('error.stack', error.stack)
+                })
+                .then(done)
+                .catch(done)
+
+              app.listen(port, 'localhost', () => {
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
+              })
+            })
+          })
+        }
+
+        // fastify crashes the process on hook exceptions in older versions
+        // which was fixed in https://github.com/fastify/fastify/pull/2695
+        if (semver.intersects(version, '>=3.9.2')) {
+          it('should handle hook exceptions', done => {
+            let error
+
+            app.addHook('onRequest', (request, reply, next) => {
+              throw (error = new Error('boom'))
+            })
+
+            app.get('/user', (request, reply) => {
+              reply.send()
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  const spans = traces[0]
+
+                  expect(spans[0]).to.have.property('name', 'fastify.request')
+                  expect(spans[0]).to.have.property('resource', 'GET /user')
+                  expect(spans[0]).to.have.property('error', 1)
+                  expect(spans[0].meta).to.have.property('error.type', error.name)
+                  expect(spans[0].meta).to.have.property('error.msg', error.message)
+                  expect(spans[0].meta).to.have.property('error.stack', error.stack)
+                })
+                .then(done)
+                .catch(done)
+
+              app.listen(port, 'localhost', () => {
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
+              })
+            })
+          })
+        }
       })
     })
   })

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -7,6 +7,10 @@
   ],
   "fastify": [
     {
+      "name": "fastify",
+      "versions": ["3.0.0", "3.9.2"]
+    },
+    {
       "name": "middie",
       "versions": ["5.1.0"]
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing error tags for hook exceptions.

### Motivation
<!-- What inspired you to submit this pull request? -->

Hooks have their own error handler that catches exceptions, so while the request would correctly be flagged as an error, the error itself wasn't available to the request span.

Fixes #1490