### PR TITLE
[ci-app] Fix Possible Missing `getVmContext`

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -203,9 +203,11 @@ function createHandleTestEvent (tracer, testEnvironmentMetadata, instrumenter) {
           result = await specFunction()
           // it may have been set already if the test timed out
           let suppressedErrors = []
-          const context = environment.getVmContext()
-          if (context) {
-            suppressedErrors = context.expect.getState().suppressedErrors
+          if (typeof environment.getVmContext === 'function') {
+            const context = environment.getVmContext()
+            if (context) {
+              suppressedErrors = context.expect.getState().suppressedErrors
+            }
           }
           if (suppressedErrors && suppressedErrors.length) {
             testSpan.setTag('error', suppressedErrors[0])

--- a/packages/datadog-plugin-jest/test/index.spec.js
+++ b/packages/datadog-plugin-jest/test/index.spec.js
@@ -614,6 +614,27 @@ describe('Plugin', () => {
         datadogJestEnv.handleTestEvent(hookFailureEvent).then(done).catch(done)
       })
 
+      it('should not crash when getVmContext is not a function', (done) => {
+        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        const testStartEvent = {
+          name: 'test_start',
+          test: {
+            fn: () => {},
+            name: TEST_NAME
+          }
+        }
+        datadogJestEnv.getVmContext = undefined
+
+        datadogJestEnv.handleTestEvent(testStartEvent)
+        testStartEvent.test.fn()
+
+        agent
+          .use(traces => {
+            expect(traces[0][0].meta[ERROR_TYPE]).to.be.undefined
+            expect(traces[0][0].meta[TEST_NAME_TAG]).to.equal(TEST_NAME)
+          }).then(done).catch(done)
+      })
+
       // TODO: allow the plugin consumer to define their own jest's `testEnvironment`
       it.skip('should allow the customer to use their own environment', (done) => {
         class CustomerCustomEnv extends DatadogJestEnvironment {


### PR DESCRIPTION
### What does this PR do?
Checks if `getVmContext` is a function before calling it.

### Motivation
Fixes https://github.com/DataDog/dd-trace-js/issues/1510

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
