### PR TITLE
Lazy-load hdr-histogram

### DIFF
--- a/packages/dd-trace/src/metrics.js
+++ b/packages/dd-trace/src/metrics.js
@@ -7,11 +7,11 @@ const path = require('path')
 const os = require('os')
 const Client = require('./dogstatsd')
 const log = require('./log')
-const Histogram = require('./histogram')
 
 const INTERVAL = 10 * 1000
 
 let nativeMetrics = null
+let Histogram = null
 
 let interval
 let client
@@ -38,10 +38,12 @@ module.exports = {
 
     try {
       nativeMetrics = require('node-gyp-build')(path.join(__dirname, '..', '..', '..'))
+      Histogram = require('./histogram')
       nativeMetrics.start()
     } catch (e) {
       log.error(e)
       nativeMetrics = null
+      Histogram = null
     }
 
     client = new Client({
@@ -98,7 +100,7 @@ module.exports = {
   },
 
   histogram (name, value, tag) {
-    if (!client) return
+    if (!client || !Histogram) return
 
     histograms[name] = histograms[name] || new Map()
 

--- a/packages/dd-trace/test/metrics.spec.js
+++ b/packages/dd-trace/test/metrics.spec.js
@@ -149,7 +149,7 @@ describe('metrics', () => {
       expect(client.increment).to.have.been.calledWith('test.count', 3)
     })
 
-    it('should fail to add a record to a histogram since lazy loading has failed', () => {
+    it('does not add a record to a histogram when lazy loading has failed', () => {
       metrics = proxyquire('../src/metrics', {
         './dogstatsd': Client,
         './histogram': null // make histogram lazy-loading fail

--- a/packages/dd-trace/test/metrics.spec.js
+++ b/packages/dd-trace/test/metrics.spec.js
@@ -148,6 +148,23 @@ describe('metrics', () => {
       expect(client.gauge).to.have.been.calledWith('test.95percentile', 3)
       expect(client.increment).to.have.been.calledWith('test.count', 3)
     })
+
+    it('should fail to add a record to a histogram since lazy loading has failed', () => {
+      metrics = proxyquire('../src/metrics', {
+        './dogstatsd': Client,
+        './histogram': null // make histogram lazy-loading fail
+      })
+
+      metrics.start(config)
+
+      metrics.histogram('test', 1)
+      metrics.histogram('test', 2)
+      metrics.histogram('test', 3)
+
+      clock.tick(10000)
+
+      expect(client.gauge).not.have.been.calledWith('test.max', 3)
+    })
   })
 
   describe('increment', () => {


### PR DESCRIPTION
### What does this PR do?

Lazy-load ./histogram file (which loads hdr-histogram-js)

### Motivation

Speed-up the tracer init time if `runtimeMetrics` is not enabled (in a serverless environment for instance)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
