### PR TITLE
update version script to not conflict branch with tag

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -33,12 +33,12 @@ exec(`git checkout ${currentBranch}`)
 function bump (newVersion) {
   pkg.version = newVersion
 
-  exec(`git checkout -b v${newVersion}`)
+  exec(`git checkout -b v${newVersion}-bump`)
   write('package.json', JSON.stringify(pkg, null, 2) + '\n')
   write('packages/dd-trace/lib/version.js', `module.exports = '${newVersion}'\n`)
   add('package.json')
   add('packages/dd-trace/lib/version.js')
-  exec(`git commit -m v"${newVersion}"`)
+  exec(`git commit -m "v${newVersion}"`)
   exec(`git push -u origin HEAD`)
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update version script to not conflict branch with tag.

### Motivation
<!-- What inspired you to submit this pull request? -->

If the branch for the version bump has the same name as the release tag, it becomes more difficult to push changes as they need to differentiated, or otherwise the branch needs to always be deleted afterwards.