### PR TITLE
[ci-app] Fix `this.skip` in Mocha

### DIFF
--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -79,8 +79,13 @@ function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
               activeSpan.setTag(TEST_STATUS, 'fail')
             }
           } catch (error) {
-            activeSpan.setTag(TEST_STATUS, 'fail')
-            activeSpan.setTag('error', error)
+            // this.skip has been called
+            if (error.constructor.name === 'Pending' && !this.forbidPending) {
+              activeSpan.setTag(TEST_STATUS, 'skip')
+            } else {
+              activeSpan.setTag(TEST_STATUS, 'fail')
+              activeSpan.setTag('error', error)
+            }
             throw error
           } finally {
             finishAllTraceSpans(activeSpan)

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -165,7 +165,8 @@ describe('Plugin', () => {
         const testNames = [
           'mocha-test-skip can skip',
           'mocha-test-skip-different can skip too',
-          'mocha-test-skip-different can skip twice'
+          'mocha-test-skip-different can skip twice',
+          'mocha-test-programmatic-skip can skip too'
         ]
         const assertionPromises = testNames.map(testName => {
           return agent.use(trace => {

--- a/packages/datadog-plugin-mocha/test/mocha-test-skip.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-skip.js
@@ -14,3 +14,9 @@ describe('mocha-test-skip-different', () => {
     expect(true).to.equal(false)
   })
 })
+
+describe('mocha-test-programmatic-skip', () => {
+  it('can skip too', function () {
+    this.skip()
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Tests in which `this.skip` was called were being considered as failed. 

### Motivation
Stick with the testing framework's way of classifying tests. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
