### PR TITLE
fix fastify error when hooks have only a single parameter

### DIFF
--- a/packages/datadog-plugin-fastify/src/fastify.js
+++ b/packages/datadog-plugin-fastify/src/fastify.js
@@ -38,7 +38,7 @@ function createWrapAddHook (tracer, config) {
 
       if (typeof fn !== 'function') return addHook.apply(this, arguments)
 
-      arguments[arguments.length - 1] = function (request, reply, done) {
+      arguments[arguments.length - 1] = safeWrap(fn, function (request, reply, done) {
         const req = getReq(request)
 
         if (!req) return fn.apply(this, arguments)
@@ -69,7 +69,7 @@ function createWrapAddHook (tracer, config) {
           web.addError(req, e)
           throw e
         }
-      }
+      })
 
       return addHook.apply(this, arguments)
     }
@@ -144,6 +144,32 @@ function wrapHandler (handler) {
     const req = getReq(request)
 
     return web.reactivate(req, () => handler.apply(this, arguments))
+  }
+}
+
+// TODO: move this to a common util
+function safeWrap (fn, wrapper) {
+  switch (fn.length) {
+    case 1:
+      return function (a) { return wrapper.apply(this, arguments) }
+    case 2:
+      return function (a, b) { return wrapper.apply(this, arguments) }
+    case 3:
+      return function (a, b, c) { return wrapper.apply(this, arguments) }
+    case 4:
+      return function (a, b, c, d) { return wrapper.apply(this, arguments) }
+    case 5:
+      return function (a, b, c, d, e) { return wrapper.apply(this, arguments) }
+    case 6:
+      return function (a, b, c, d, e, f) { return wrapper.apply(this, arguments) }
+    case 7:
+      return function (a, b, c, d, e, f, g) { return wrapper.apply(this, arguments) }
+    case 8:
+      return function (a, b, c, d, e, f, g, h) { return wrapper.apply(this, arguments) }
+    case 9:
+      return function (a, b, c, d, e, f, g, h, i) { return wrapper.apply(this, arguments) }
+    default:
+      return function () { return wrapper.apply(this, arguments) }
   }
 }
 

--- a/packages/datadog-plugin-fastify/src/fastify.js
+++ b/packages/datadog-plugin-fastify/src/fastify.js
@@ -149,28 +149,9 @@ function wrapHandler (handler) {
 
 // TODO: move this to a common util
 function safeWrap (fn, wrapper) {
-  switch (fn.length) {
-    case 1:
-      return function (a) { return wrapper.apply(this, arguments) }
-    case 2:
-      return function (a, b) { return wrapper.apply(this, arguments) }
-    case 3:
-      return function (a, b, c) { return wrapper.apply(this, arguments) }
-    case 4:
-      return function (a, b, c, d) { return wrapper.apply(this, arguments) }
-    case 5:
-      return function (a, b, c, d, e) { return wrapper.apply(this, arguments) }
-    case 6:
-      return function (a, b, c, d, e, f) { return wrapper.apply(this, arguments) }
-    case 7:
-      return function (a, b, c, d, e, f, g) { return wrapper.apply(this, arguments) }
-    case 8:
-      return function (a, b, c, d, e, f, g, h) { return wrapper.apply(this, arguments) }
-    case 9:
-      return function (a, b, c, d, e, f, g, h, i) { return wrapper.apply(this, arguments) }
-    default:
-      return function () { return wrapper.apply(this, arguments) }
-  }
+  Object.defineProperty(wrapper, 'length', Object.getOwnPropertyDescriptor(fn, 'length'))
+
+  return wrapper
 }
 
 function getReq (request) {

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -310,6 +310,36 @@ describe('Plugin', () => {
           })
         })
 
+        // fastify doesn't have all application hooks in older versions
+        if (semver.intersects(version, '>=2.15')) {
+          it('should support hooks with a single argument', done => {
+            app.addHook('onReady', done => done())
+
+            app.get('/user', (request, reply) => {
+              reply.send()
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  const spans = traces[0]
+
+                  expect(spans[0]).to.have.property('name', 'fastify.request')
+                  expect(spans[0]).to.have.property('resource', 'GET /user')
+                  expect(spans[0]).to.have.property('error', 0)
+                })
+                .then(done)
+                .catch(done)
+
+              app.listen(port, 'localhost', () => {
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
+              })
+            })
+          })
+        }
+
         // fastify crashes the process on reply exceptions in older versions
         if (semver.intersects(version, '>=3')) {
           it('should handle reply rejections', done => {

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -312,7 +312,7 @@ describe('Plugin', () => {
 
         // fastify doesn't have all application hooks in older versions
         if (semver.intersects(version, '>=2.15')) {
-          it('should support hooks with a single argument', done => {
+          it('should support hooks with a single parameter', done => {
             app.addHook('onReady', done => done())
 
             app.get('/user', (request, reply) => {

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -8,7 +8,7 @@
   "fastify": [
     {
       "name": "fastify",
-      "versions": ["3.0.0", "3.9.2"]
+      "versions": ["2.15.0", "3.0.0", "3.9.2"]
     },
     {
       "name": "middie",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix fastify error when hooks have only a single parameter.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fastify provides different arguments to hooks depending on the function length. Altering the length results in unexpected arguments to the hook which results in an error.

Fixes #1549