### PR TITLE
bump sketches-js to avoid security warning and add audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1522,6 +1522,7 @@ workflows:
               only:
                 - master
     jobs:
+      - lint
       - node-core-12
       - node-core-14
       - node-core-16

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bench:e2e": "SERVICES=mongo yarn services && cd benchmark/e2e && node benchmark-run.js --duration=30",
     "type:doc": "cd docs && yarn && yarn build",
     "type:test": "cd docs && yarn && yarn test",
-    "lint": "node scripts/check_licenses.js && eslint .",
+    "lint": "node scripts/check_licenses.js && eslint . && yarn audit --groups dependencies",
     "services": "node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services",
     "tdd": "node scripts/tdd.js",
     "test": "SERVICES=* yarn services && mocha --exit --expose-gc 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
@@ -56,7 +56,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@datadog/sketches-js": "^1.0.2",
+    "@datadog/sketches-js": "^1.0.3",
     "@types/node": "^10.12.18",
     "form-data": "^3.0.0",
     "koalas": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@datadog/sketches-js": "^1.0.3",
+    "@datadog/sketches-js": "^1.0.4",
     "@types/node": "^10.12.18",
     "form-data": "^3.0.0",
     "koalas": "^1.0.2",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump `sketches-js` to avoid security warning and add audit.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fixes #1548