### PR TITLE
Add runtime-id tag to profiler

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,6 +2,7 @@ Component,Origin,License,Copyright
 require,@datadog/pprof,Apache license 2.0,Copyright 2019 Google Inc.
 require,@datadog/sketches-js,Apache license 2.0,Copyright 2020 Datadog Inc.
 require,@types/node,MIT,Copyright Authors
+require,crypto-randomuuid,MIT,Copyright 2021 Node.js Foundation and contributors
 require,form-data,MIT,Copyright 2012 Felix Geisendörfer and contributors
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,limiter,MIT,Copyright 2011 John Hurliman

--- a/index.d.ts
+++ b/index.d.ts
@@ -321,7 +321,7 @@ export declare interface TracerOptions {
     b3?: boolean
 
     /**
-     * Whether to add an auto-generated `runtime-id` tag to spans and metrics.
+     * Whether to add an auto-generated `runtime-id` tag to metrics.
      * @default false
      */
     runtimeId?: boolean

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@datadog/pprof": "^0.1.3",
     "@datadog/sketches-js": "^1.0.4",
     "@types/node": "^10.12.18",
+    "crypto-randomuuid": "^1.0.0",
     "form-data": "^3.0.0",
     "koalas": "^1.0.2",
     "limiter": "^1.1.4",

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -5,10 +5,8 @@ const pkg = require('./pkg')
 const coalesce = require('koalas')
 const scopes = require('../../../ext/scopes')
 const tagger = require('./tagger')
-const id = require('./id')
 const { isTrue, isFalse } = require('./util')
-
-const runtimeId = `${id().toString()}${id().toString()}`
+const uuid = require('crypto-randomuuid')
 
 const fromEntries = Object.fromEntries || (entries =>
   entries.reduce((obj, [k, v]) => Object.assign(obj, { [k]: v }), {}))
@@ -198,13 +196,12 @@ class Config {
       enabled: isTrue(DD_APPSEC_ENABLED)
     }
 
-    tagger.add(this.tags, { service: this.service, env: this.env, version: this.version })
-
-    if (this.experimental.runtimeId) {
-      tagger.add(this.tags, {
-        'runtime-id': runtimeId
-      })
-    }
+    tagger.add(this.tags, {
+      service: this.service,
+      env: this.env,
+      version: this.version,
+      'runtime-id': uuid()
+    })
   }
 }
 

--- a/packages/dd-trace/src/metrics.js
+++ b/packages/dd-trace/src/metrics.js
@@ -29,6 +29,11 @@ module.exports = {
 
     Object.keys(config.tags)
       .filter(key => typeof config.tags[key] === 'string')
+      .filter(key => {
+        // Skip runtime-id unless enabled as cardinality may be too high
+        if (key !== 'runtime-id') return true
+        return (config.experimental && config.experimental.runtimeId)
+      })
       .forEach(key => {
         // https://docs.datadoghq.com/tagging/#defining-tags
         const value = config.tags[key].replace(/[^a-z0-9_:./-]/ig, '_')

--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -5,7 +5,7 @@ const { profiler } = require('./profiling')
 
 module.exports = {
   start: config => {
-    const { service, version, env, url, hostname, port } = config
+    const { service, version, env, url, hostname, port, tags } = config
     const { enabled, sourceMap, exporters } = config.profiling
     const logger = {
       debug: (message) => log.debug(message),
@@ -24,7 +24,8 @@ module.exports = {
       exporters,
       url,
       hostname,
-      port
+      port,
+      tags
     })
   },
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -219,7 +219,7 @@ describe('Config', () => {
     expect(config).to.have.property('tags')
     expect(config.tags).to.have.property('foo', 'bar')
     expect(config.tags).to.have.property('runtime-id')
-    expect(config.tags['runtime-id']).to.match(/^[0-9a-f]{32}$/)
+    expect(config.tags['runtime-id']).to.match(/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/)
     expect(config).to.have.nested.property('experimental.b3', true)
     expect(config).to.have.nested.property('experimental.runtimeId', true)
     expect(config).to.have.nested.property('experimental.exporter', 'log')

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -78,7 +78,9 @@ describe('exporters/agent', () => {
       const exporter = new AgentExporter({ url, logger })
       const start = new Date()
       const end = new Date()
-      const tags = { foo: 'bar' }
+      const tags = {
+        'runtime-id': 'a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6'
+      }
 
       const [ cpu, heap ] = await Promise.all([
         createProfile(['wall', 'microseconds']),
@@ -100,7 +102,7 @@ describe('exporters/agent', () => {
               'language:javascript',
               'runtime:nodejs',
               'format:pprof',
-              'foo:bar'
+              'runtime-id:a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6'
             ])
             expect(req.body).to.have.deep.property('types', ['cpu', 'heap'])
             expect(req.body).to.have.property('recording-start', start.toISOString())


### PR DESCRIPTION
I've re-enabled the `runtime-id` tag on spans and added them to profiles to allow linking between the two. Metrics support for runtime-id remains behind the existing experimental flag.

I've also added a polyfill for the `crypto.randomUUID` method in Node.js. It is not cryptographically secure as it replaces the `secureBuffer` call with a `randomFillSync` but that shouldn't matter for this particular case. Just worth keeping in mind in case anyone tries to reuse that code for something else in the future. I've included a comment highlighting that concern.