### PR TITLE
[ci-app] [Prototype] Cypress Browser HTTP Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node": ">=12"
   },
   "dependencies": {
+    "@datadog/browser-core": "^3.1.1",
     "@datadog/pprof": "^0.1.3",
     "@datadog/sketches-js": "^1.0.4",
     "@types/node": "^10.12.18",

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -1,0 +1,84 @@
+const {
+  TEST_TYPE,
+  TEST_NAME,
+  TEST_SUITE,
+  TEST_STATUS,
+  getTestEnvironmentMetadata
+} = require('../../dd-trace/src/plugins/util/test')
+
+const id = require('../../dd-trace/src/id')
+const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
+const { SAMPLING_PRIORITY, SPAN_TYPE, RESOURCE_NAME } = require('../../../ext/tags')
+const { AUTO_KEEP } = require('../../../ext/priority')
+
+const CYPRESS_STATUS_TO_TEST_STATUS = {
+  passed: 'pass',
+  failed: 'fail',
+  pending: 'skip',
+  skipped: 'skip'
+}
+
+function getTestSpanMetadata (tracer, testName, testSuite) {
+  const childOf = tracer.extract('text_map', {
+    'x-datadog-trace-id': id().toString(10),
+    'x-datadog-parent-id': '0000000000000000',
+    'x-datadog-sampled': 1
+  })
+
+  return {
+    childOf,
+    resource: `${testSuite}.${testName}`,
+    [TEST_TYPE]: 'test',
+    [TEST_NAME]: testName,
+    [TEST_SUITE]: testSuite,
+    [SAMPLING_RULE_DECISION]: 1,
+    [SAMPLING_PRIORITY]: AUTO_KEEP
+  }
+}
+
+module.exports = (on, config) => {
+  const tracer = require('../../dd-trace').init({
+    startupLogs: false,
+    plugins: false
+  })
+  const testEnvironmentMetadata = getTestEnvironmentMetadata('cypress')
+  let activeSpan = null
+  on('task', {
+    beforeEach: (test) => {
+      const { testName, testSuite } = test
+
+      const {
+        childOf,
+        resource,
+        ...testSpanMetadata
+      } = getTestSpanMetadata(tracer, testName, testSuite)
+
+      if (!activeSpan) {
+        activeSpan = tracer.startSpan('cypress.test', {
+          childOf,
+          tags: {
+            [SPAN_TYPE]: 'test',
+            [RESOURCE_NAME]: resource,
+            ...testSpanMetadata,
+            ...testEnvironmentMetadata
+          }
+        })
+      }
+      return null
+    },
+    afterEach: (test) => {
+      const { state, error } = test
+      if (activeSpan) {
+        activeSpan.setTag(TEST_STATUS, CYPRESS_STATUS_TO_TEST_STATUS[state])
+        if (error) {
+          activeSpan.setTag('error.msg', error.message)
+          activeSpan.setTag('error.type', error.name)
+          activeSpan.setTag('error.stack', error.stack)
+        }
+        activeSpan.finish()
+      }
+      activeSpan = null
+      return null
+    }
+  })
+}

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+beforeEach(() => {
+  cy.task('beforeEach', {
+    testName: Cypress.mocha.getRunner().suite.ctx.currentTest.fullTitle(),
+    testSuite: Cypress.mocha.getRootSuite().file
+  })
+})
+
+afterEach(() => {
+  const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
+  cy.task('afterEach', {
+    testName: currentTest.fullTitle(),
+    testSuite: Cypress.mocha.getRootSuite().file,
+    state: currentTest.state,
+    error: currentTest.err
+  })
+})

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -1,4 +1,18 @@
 /* eslint-disable */
+const {startFetchProxy, resetFetchProxy} = require('@datadog/browser-core')
+
+Cypress.on('window:before:load', win => {
+    const httpRequests = {}
+    const fetchProxy = startFetchProxy(win)
+    fetchProxy.onRequestComplete((request) => {
+        httpRequests[request.startClocks.timeStamp] = request
+        Cypress.mocha.getRunner().test.httpRequests = Object.values(httpRequests)
+    })
+})
+Cypress.on('window:before:unload', () => {
+    resetFetchProxy()
+})
+
 beforeEach(() => {
   cy.task('beforeEach', {
     testName: Cypress.mocha.getRunner().suite.ctx.currentTest.fullTitle(),
@@ -12,6 +26,7 @@ afterEach(() => {
     testName: currentTest.fullTitle(),
     testSuite: Cypress.mocha.getRootSuite().file,
     state: currentTest.state,
-    error: currentTest.err
+    error: currentTest.err,
+    httpRequests: currentTest.httpRequests
   })
 })


### PR DESCRIPTION
### What does this PR do?
* Add support to HTTP requests in the browser run by `cypress` using `browser-sdk`

### Motivation
* Have visibility over HTTP requests 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
