### PR TITLE
[ci-app] Allow User Defined Git Tags

### DIFF
--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -39,18 +39,34 @@ function getGitMetadata (ciMetadata) {
     committerDate
   ] = sanitizedExec('git show -s --format=%an,%ae,%ad,%cn,%ce,%cd', { stdio: 'pipe' }).split(',')
 
+  const {
+    DD_GIT_REPOSITORY_URL,
+    DD_GIT_COMMIT_SHA,
+    DD_GIT_BRANCH,
+    DD_GIT_TAG,
+    DD_GIT_COMMIT_MESSAGE,
+    DD_GIT_COMMIT_AUTHOR_NAME,
+    DD_GIT_COMMIT_AUTHOR_EMAIL,
+    DD_GIT_COMMIT_AUTHOR_DATE,
+    DD_GIT_COMMIT_COMMITTER_NAME,
+    DD_GIT_COMMIT_COMMITTER_EMAIL,
+    DD_GIT_COMMIT_COMMITTER_DATE
+  } = process.env
+
   return {
-    [GIT_REPOSITORY_URL]: repositoryUrl || sanitizedExec('git ls-remote --get-url', { stdio: 'pipe' }),
-    [GIT_COMMIT_MESSAGE]: commitMessage || sanitizedExec('git show -s --format=%s', { stdio: 'pipe' }),
-    [GIT_COMMIT_AUTHOR_DATE]: authorDate,
-    [GIT_COMMIT_AUTHOR_NAME]: ciAuthorName || authorName,
-    [GIT_COMMIT_AUTHOR_EMAIL]: ciAuthorEmail || authorEmail,
-    [GIT_COMMIT_COMMITTER_DATE]: committerDate,
-    [GIT_COMMIT_COMMITTER_NAME]: committerName,
-    [GIT_COMMIT_COMMITTER_EMAIL]: committerEmail,
-    [GIT_BRANCH]: branch || sanitizedExec('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' }),
-    [GIT_COMMIT_SHA]: commitSHA || sanitizedExec('git rev-parse HEAD', { stdio: 'pipe' }),
-    [GIT_TAG]: tag,
+    [GIT_REPOSITORY_URL]:
+      DD_GIT_REPOSITORY_URL || repositoryUrl || sanitizedExec('git ls-remote --get-url', { stdio: 'pipe' }),
+    [GIT_COMMIT_MESSAGE]:
+      DD_GIT_COMMIT_MESSAGE || commitMessage || sanitizedExec('git show -s --format=%s', { stdio: 'pipe' }),
+    [GIT_COMMIT_AUTHOR_DATE]: DD_GIT_COMMIT_AUTHOR_DATE || authorDate,
+    [GIT_COMMIT_AUTHOR_NAME]: DD_GIT_COMMIT_AUTHOR_NAME || ciAuthorName || authorName,
+    [GIT_COMMIT_AUTHOR_EMAIL]: DD_GIT_COMMIT_AUTHOR_EMAIL || ciAuthorEmail || authorEmail,
+    [GIT_COMMIT_COMMITTER_DATE]: DD_GIT_COMMIT_COMMITTER_DATE || committerDate,
+    [GIT_COMMIT_COMMITTER_NAME]: DD_GIT_COMMIT_COMMITTER_NAME || committerName,
+    [GIT_COMMIT_COMMITTER_EMAIL]: DD_GIT_COMMIT_COMMITTER_EMAIL || committerEmail,
+    [GIT_BRANCH]: DD_GIT_BRANCH || branch || sanitizedExec('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' }),
+    [GIT_COMMIT_SHA]: DD_GIT_COMMIT_SHA || commitSHA || sanitizedExec('git rev-parse HEAD', { stdio: 'pipe' }),
+    [GIT_TAG]: DD_GIT_TAG || tag,
     [CI_WORKSPACE_PATH]: ciWorkspacePath || sanitizedExec('git rev-parse --show-toplevel', { stdio: 'pipe' })
   }
 }

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -136,6 +136,7 @@ describe('git', () => {
       .onCall(2).returns('this is a commit message')
       .onCall(3).returns('gitBranch')
       .onCall(4).returns('gitCommitSHA')
+      .onCall(5).returns('ciWorkspacePath')
 
     const ciMetadata = {
       commitSHA: 'ciSHA',
@@ -170,6 +171,7 @@ describe('git', () => {
       .onCall(2).returns('this is a commit message')
       .onCall(3).returns('gitBranch')
       .onCall(4).returns('gitCommitSHA')
+      .onCall(5).returns('ciWorkspacePath')
 
     const metadata = getGitMetadata({ tag: 'ciTag' })
     expect(metadata).to.eql({
@@ -183,7 +185,8 @@ describe('git', () => {
       [GIT_COMMIT_AUTHOR_NAME]: 'git author',
       [GIT_COMMIT_COMMITTER_EMAIL]: 'DD_GIT_COMMIT_COMMITTER_EMAIL',
       [GIT_COMMIT_COMMITTER_DATE]: '1973',
-      [GIT_COMMIT_COMMITTER_NAME]: 'DD_GIT_COMMIT_COMMITTER_NAME'
+      [GIT_COMMIT_COMMITTER_NAME]: 'DD_GIT_COMMIT_COMMITTER_NAME',
+      [CI_WORKSPACE_PATH]: 'ciWorkspacePath'
     })
   })
 })

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -28,6 +28,17 @@ const { getGitMetadata } = proxyquire('../../../src/plugins/util/git',
 describe('git', () => {
   afterEach(() => {
     sanitizedExecStub.reset()
+    delete process.env.DD_GIT_COMMIT_SHA
+    delete process.env.DD_GIT_REPOSITORY_URL
+    delete process.env.DD_GIT_BRANCH
+    delete process.env.DD_GIT_TAG
+    delete process.env.DD_GIT_COMMIT_MESSAGE
+    delete process.env.DD_GIT_COMMIT_AUTHOR_NAME
+    delete process.env.DD_GIT_COMMIT_AUTHOR_EMAIL
+    delete process.env.DD_GIT_COMMIT_AUTHOR_DATE
+    delete process.env.DD_GIT_COMMIT_COMMITTER_NAME
+    delete process.env.DD_GIT_COMMIT_COMMITTER_EMAIL
+    delete process.env.DD_GIT_COMMIT_COMMITTER_DATE
   })
   it('returns ci metadata if it is present and does not call git for those parameters', () => {
     const ciMetadata = {
@@ -105,5 +116,74 @@ describe('git', () => {
     expect(sanitizedExecStub).to.have.been.calledWith('git rev-parse HEAD', { stdio: 'pipe' })
     expect(sanitizedExecStub).to.have.been.calledWith('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' })
     expect(sanitizedExecStub).to.have.been.calledWith('git rev-parse --show-toplevel', { stdio: 'pipe' })
+  })
+  it('returns user defined git metadata if present', () => {
+    process.env.DD_GIT_COMMIT_SHA = 'DD_GIT_COMMIT_SHA'
+    process.env.DD_GIT_REPOSITORY_URL = 'DD_GIT_REPOSITORY_URL'
+    process.env.DD_GIT_BRANCH = 'DD_GIT_BRANCH'
+    process.env.DD_GIT_TAG = 'DD_GIT_TAG'
+    process.env.DD_GIT_COMMIT_MESSAGE = 'DD_GIT_COMMIT_MESSAGE'
+    process.env.DD_GIT_COMMIT_AUTHOR_NAME = 'DD_GIT_COMMIT_AUTHOR_NAME'
+    process.env.DD_GIT_COMMIT_AUTHOR_EMAIL = 'DD_GIT_COMMIT_AUTHOR_EMAIL'
+    process.env.DD_GIT_COMMIT_AUTHOR_DATE = 'DD_GIT_COMMIT_AUTHOR_DATE'
+    process.env.DD_GIT_COMMIT_COMMITTER_NAME = 'DD_GIT_COMMIT_COMMITTER_NAME'
+    process.env.DD_GIT_COMMIT_COMMITTER_EMAIL = 'DD_GIT_COMMIT_COMMITTER_EMAIL'
+    process.env.DD_GIT_COMMIT_COMMITTER_DATE = 'DD_GIT_COMMIT_COMMITTER_DATE'
+
+    sanitizedExecStub
+      .onCall(0).returns('git author,git.author@email.com,1972,git committer,git.committer@email.com,1973')
+      .onCall(1).returns('gitRepositoryUrl')
+      .onCall(2).returns('this is a commit message')
+      .onCall(3).returns('gitBranch')
+      .onCall(4).returns('gitCommitSHA')
+
+    const ciMetadata = {
+      commitSHA: 'ciSHA',
+      branch: 'myBranch',
+      commitMessage: 'myCommitMessage',
+      authorName: 'ciAuthorName'
+    }
+    const metadata = getGitMetadata(ciMetadata)
+    expect(metadata).to.contain(
+      {
+        [GIT_BRANCH]: 'DD_GIT_BRANCH',
+        [GIT_TAG]: 'DD_GIT_TAG',
+        [GIT_COMMIT_MESSAGE]: 'DD_GIT_COMMIT_MESSAGE',
+        [GIT_COMMIT_SHA]: 'DD_GIT_COMMIT_SHA',
+        [GIT_REPOSITORY_URL]: 'DD_GIT_REPOSITORY_URL',
+        [GIT_COMMIT_AUTHOR_EMAIL]: 'DD_GIT_COMMIT_AUTHOR_EMAIL',
+        [GIT_COMMIT_AUTHOR_DATE]: 'DD_GIT_COMMIT_AUTHOR_DATE',
+        [GIT_COMMIT_AUTHOR_NAME]: 'DD_GIT_COMMIT_AUTHOR_NAME',
+        [GIT_COMMIT_COMMITTER_EMAIL]: 'DD_GIT_COMMIT_COMMITTER_EMAIL',
+        [GIT_COMMIT_COMMITTER_DATE]: 'DD_GIT_COMMIT_COMMITTER_DATE',
+        [GIT_COMMIT_COMMITTER_NAME]: 'DD_GIT_COMMIT_COMMITTER_NAME'
+      }
+    )
+  })
+  it('returns user defined git metadata if only certain parameters are included', () => {
+    process.env.DD_GIT_COMMIT_COMMITTER_NAME = 'DD_GIT_COMMIT_COMMITTER_NAME'
+    process.env.DD_GIT_COMMIT_COMMITTER_EMAIL = 'DD_GIT_COMMIT_COMMITTER_EMAIL'
+
+    sanitizedExecStub
+      .onCall(0).returns('git author,git.author@email.com,1972,git committer,git.committer@email.com,1973')
+      .onCall(1).returns('gitRepositoryUrl')
+      .onCall(2).returns('this is a commit message')
+      .onCall(3).returns('gitBranch')
+      .onCall(4).returns('gitCommitSHA')
+
+    const metadata = getGitMetadata({ tag: 'ciTag' })
+    expect(metadata).to.eql({
+      [GIT_BRANCH]: 'gitBranch',
+      [GIT_TAG]: 'ciTag',
+      [GIT_COMMIT_MESSAGE]: 'this is a commit message',
+      [GIT_COMMIT_SHA]: 'gitCommitSHA',
+      [GIT_REPOSITORY_URL]: 'gitRepositoryUrl',
+      [GIT_COMMIT_AUTHOR_EMAIL]: 'git.author@email.com',
+      [GIT_COMMIT_AUTHOR_DATE]: '1972',
+      [GIT_COMMIT_AUTHOR_NAME]: 'git author',
+      [GIT_COMMIT_COMMITTER_EMAIL]: 'DD_GIT_COMMIT_COMMITTER_EMAIL',
+      [GIT_COMMIT_COMMITTER_DATE]: '1973',
+      [GIT_COMMIT_COMMITTER_NAME]: 'DD_GIT_COMMIT_COMMITTER_NAME'
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
* Read certain env vars to check if the user has provided git metadata.

### Motivation
Let user pass git metadata if other methods fail.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
