### PR TITLE
[ci-app] Calculate `ci.workspace_path` from `git` too

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -7,19 +7,18 @@ const {
   GIT_COMMIT_AUTHOR_EMAIL,
   GIT_COMMIT_AUTHOR_NAME,
   GIT_COMMIT_MESSAGE,
-  GIT_COMMIT_AUTHOR_DATE
-} = require('./git')
-
-const CI_PIPELINE_ID = 'ci.pipeline.id'
-const CI_PIPELINE_NAME = 'ci.pipeline.name'
-const CI_PIPELINE_NUMBER = 'ci.pipeline.number'
-const CI_PIPELINE_URL = 'ci.pipeline.url'
-const CI_PROVIDER_NAME = 'ci.provider.name'
-const CI_WORKSPACE_PATH = 'ci.workspace_path'
-const GIT_REPOSITORY_URL = 'git.repository_url'
-const CI_JOB_URL = 'ci.job.url'
-const CI_JOB_NAME = 'ci.job.name'
-const CI_STAGE_NAME = 'ci.stage.name'
+  GIT_COMMIT_AUTHOR_DATE,
+  GIT_REPOSITORY_URL,
+  CI_PIPELINE_ID,
+  CI_PIPELINE_NAME,
+  CI_PIPELINE_NUMBER,
+  CI_PIPELINE_URL,
+  CI_PROVIDER_NAME,
+  CI_WORKSPACE_PATH,
+  CI_JOB_URL,
+  CI_JOB_NAME,
+  CI_STAGE_NAME
+} = require('./tags')
 
 // Receives a string with the form 'John Doe <john.doe@gmail.com>'
 // and returns { name: 'John Doe', email: 'john.doe@gmail.com' }
@@ -89,12 +88,6 @@ function resolveTilde (filePath) {
 }
 
 module.exports = {
-  CI_PIPELINE_ID,
-  CI_PIPELINE_NAME,
-  CI_PIPELINE_NUMBER,
-  CI_PIPELINE_URL,
-  CI_PROVIDER_NAME,
-  CI_WORKSPACE_PATH,
   getCIMetadata () {
     const { env } = process
 

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -1,16 +1,19 @@
 const { sanitizedExec } = require('./exec')
 
-const GIT_COMMIT_SHA = 'git.commit.sha'
-const GIT_BRANCH = 'git.branch'
-const GIT_REPOSITORY_URL = 'git.repository_url'
-const GIT_TAG = 'git.tag'
-const GIT_COMMIT_MESSAGE = 'git.commit.message'
-const GIT_COMMIT_COMMITTER_DATE = 'git.commit.committer.date'
-const GIT_COMMIT_COMMITTER_EMAIL = 'git.commit.committer.email'
-const GIT_COMMIT_COMMITTER_NAME = 'git.commit.committer.name'
-const GIT_COMMIT_AUTHOR_DATE = 'git.commit.author.date'
-const GIT_COMMIT_AUTHOR_EMAIL = 'git.commit.author.email'
-const GIT_COMMIT_AUTHOR_NAME = 'git.commit.author.name'
+const {
+  GIT_COMMIT_SHA,
+  GIT_BRANCH,
+  GIT_REPOSITORY_URL,
+  GIT_TAG,
+  GIT_COMMIT_MESSAGE,
+  GIT_COMMIT_COMMITTER_DATE,
+  GIT_COMMIT_COMMITTER_EMAIL,
+  GIT_COMMIT_COMMITTER_NAME,
+  GIT_COMMIT_AUTHOR_DATE,
+  GIT_COMMIT_AUTHOR_EMAIL,
+  GIT_COMMIT_AUTHOR_NAME,
+  CI_WORKSPACE_PATH
+} = require('./tags')
 
 // If there is ciMetadata, it takes precedence.
 function getGitMetadata (ciMetadata) {
@@ -21,7 +24,8 @@ function getGitMetadata (ciMetadata) {
     tag,
     commitMessage,
     authorName: ciAuthorName,
-    authorEmail: ciAuthorEmail
+    authorEmail: ciAuthorEmail,
+    ciWorkspacePath
   } = ciMetadata
 
   // With stdio: 'pipe', errors in this command will not be output to the parent process,
@@ -46,21 +50,9 @@ function getGitMetadata (ciMetadata) {
     [GIT_COMMIT_COMMITTER_EMAIL]: committerEmail,
     [GIT_BRANCH]: branch || sanitizedExec('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' }),
     [GIT_COMMIT_SHA]: commitSHA || sanitizedExec('git rev-parse HEAD', { stdio: 'pipe' }),
-    [GIT_TAG]: tag
+    [GIT_TAG]: tag,
+    [CI_WORKSPACE_PATH]: ciWorkspacePath || sanitizedExec('git rev-parse --show-toplevel', { stdio: 'pipe' })
   }
 }
 
-module.exports = {
-  getGitMetadata,
-  GIT_COMMIT_SHA,
-  GIT_BRANCH,
-  GIT_REPOSITORY_URL,
-  GIT_TAG,
-  GIT_COMMIT_MESSAGE,
-  GIT_COMMIT_COMMITTER_DATE,
-  GIT_COMMIT_COMMITTER_EMAIL,
-  GIT_COMMIT_COMMITTER_NAME,
-  GIT_COMMIT_AUTHOR_DATE,
-  GIT_COMMIT_AUTHOR_EMAIL,
-  GIT_COMMIT_AUTHOR_NAME
-}
+module.exports = { getGitMetadata }

--- a/packages/dd-trace/src/plugins/util/tags.js
+++ b/packages/dd-trace/src/plugins/util/tags.js
@@ -1,0 +1,44 @@
+const GIT_COMMIT_SHA = 'git.commit.sha'
+const GIT_BRANCH = 'git.branch'
+const GIT_REPOSITORY_URL = 'git.repository_url'
+const GIT_TAG = 'git.tag'
+const GIT_COMMIT_MESSAGE = 'git.commit.message'
+const GIT_COMMIT_COMMITTER_DATE = 'git.commit.committer.date'
+const GIT_COMMIT_COMMITTER_EMAIL = 'git.commit.committer.email'
+const GIT_COMMIT_COMMITTER_NAME = 'git.commit.committer.name'
+const GIT_COMMIT_AUTHOR_DATE = 'git.commit.author.date'
+const GIT_COMMIT_AUTHOR_EMAIL = 'git.commit.author.email'
+const GIT_COMMIT_AUTHOR_NAME = 'git.commit.author.name'
+
+const CI_PIPELINE_ID = 'ci.pipeline.id'
+const CI_PIPELINE_NAME = 'ci.pipeline.name'
+const CI_PIPELINE_NUMBER = 'ci.pipeline.number'
+const CI_PIPELINE_URL = 'ci.pipeline.url'
+const CI_PROVIDER_NAME = 'ci.provider.name'
+const CI_WORKSPACE_PATH = 'ci.workspace_path'
+const CI_JOB_URL = 'ci.job.url'
+const CI_JOB_NAME = 'ci.job.name'
+const CI_STAGE_NAME = 'ci.stage.name'
+
+module.exports = {
+  GIT_COMMIT_SHA,
+  GIT_BRANCH,
+  GIT_REPOSITORY_URL,
+  GIT_TAG,
+  GIT_COMMIT_MESSAGE,
+  GIT_COMMIT_COMMITTER_DATE,
+  GIT_COMMIT_COMMITTER_EMAIL,
+  GIT_COMMIT_COMMITTER_NAME,
+  GIT_COMMIT_AUTHOR_DATE,
+  GIT_COMMIT_AUTHOR_EMAIL,
+  GIT_COMMIT_AUTHOR_NAME,
+  CI_PIPELINE_ID,
+  CI_PIPELINE_NAME,
+  CI_PIPELINE_NUMBER,
+  CI_PIPELINE_URL,
+  CI_PROVIDER_NAME,
+  CI_WORKSPACE_PATH,
+  CI_JOB_URL,
+  CI_JOB_NAME,
+  CI_STAGE_NAME
+}

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1,15 +1,16 @@
+const { getGitMetadata } = require('./git')
+const { getCIMetadata } = require('./ci')
+const { getRuntimeAndOSMetadata } = require('./env')
 const {
-  getGitMetadata,
   GIT_BRANCH,
   GIT_COMMIT_SHA,
   GIT_REPOSITORY_URL,
   GIT_TAG,
   GIT_COMMIT_AUTHOR_EMAIL,
   GIT_COMMIT_AUTHOR_NAME,
-  GIT_COMMIT_MESSAGE
-} = require('./git')
-const { getCIMetadata } = require('./ci')
-const { getRuntimeAndOSMetadata } = require('./env')
+  GIT_COMMIT_MESSAGE,
+  CI_WORKSPACE_PATH
+} = require('./tags')
 
 const TEST_FRAMEWORK = 'test.framework'
 const TEST_TYPE = 'test.type'
@@ -50,7 +51,8 @@ function getTestEnvironmentMetadata (testFramework) {
     [GIT_TAG]: tag,
     [GIT_COMMIT_AUTHOR_NAME]: authorName,
     [GIT_COMMIT_AUTHOR_EMAIL]: authorEmail,
-    [GIT_COMMIT_MESSAGE]: commitMessage
+    [GIT_COMMIT_MESSAGE]: commitMessage,
+    [CI_WORKSPACE_PATH]: ciWorkspacePath
   } = ciMetadata
 
   const gitMetadata = getGitMetadata({
@@ -60,7 +62,8 @@ function getTestEnvironmentMetadata (testFramework) {
     tag,
     authorName,
     authorEmail,
-    commitMessage
+    commitMessage,
+    ciWorkspacePath
   })
 
   const runtimeAndOSMetadata = getRuntimeAndOSMetadata()


### PR DESCRIPTION
### What does this PR do?
* Calculate `ci.workspace_path` from local `git` too. 

### Motivation
* Maximise chances of getting this value. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
