### PR TITLE
fix graphql query source exposed by default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -880,6 +880,16 @@ declare namespace plugins {
     depth?: number;
 
     /**
+     * Whether to include the source of the operation within the query as a tag
+     * on every span. This may contain sensitive information and sould only be
+     * enabled if sensitive data is always sent as variables and not in the
+     * query text.
+     *
+     * @default false
+     */
+    source?: boolean;
+
+    /**
      * An array of variable names to record. Can also be a callback that returns
      * the key/value pairs to record. For example, using
      * `variables => variables` would record all variables.

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -61,7 +61,7 @@ function createWrapParse (tracer, config) {
           document._datadog_source = source.body || source
         }
 
-        addDocumentTags(span, document)
+        addDocumentTags(span, document, config)
 
         return document
       } catch (e) {
@@ -84,7 +84,7 @@ function createWrapValidate (tracer, config) {
 
       // skip for schema stitching nested validation
       if (document && document.loc) {
-        addDocumentTags(span, document)
+        addDocumentTags(span, document, config)
       }
 
       let errors
@@ -232,7 +232,7 @@ function startExecutionSpan (tracer, config, operation, args) {
   const span = startSpan(tracer, config, 'execute')
 
   addExecutionTags(span, config, operation, args.document, args.operationName)
-  addDocumentTags(span, args.document)
+  addDocumentTags(span, args.document, config)
   addVariableTags(tracer, config, span, args.variableValues)
 
   analyticsSampler.sample(span, config.measured, true)
@@ -258,10 +258,10 @@ function addExecutionTags (span, config, operation, document, operationName) {
   span.addTags(tags)
 }
 
-function addDocumentTags (span, document) {
+function addDocumentTags (span, document, config) {
   const tags = {}
 
-  if (document && document._datadog_source) {
+  if (config.source && document && document._datadog_source) {
     tags['graphql.source'] = document._datadog_source
   }
 
@@ -309,7 +309,7 @@ function startResolveSpan (tracer, config, childOf, path, info, contextValue) {
   })
 
   if (fieldNode) {
-    if (document && fieldNode.loc) {
+    if (config.source && document && fieldNode.loc) {
       span.setTag('graphql.source', document.substring(fieldNode.loc.start, fieldNode.loc.end))
     }
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -186,7 +186,7 @@ describe('Plugin', () => {
               expect(span).to.have.property('name', 'graphql.parse')
               expect(span).to.have.property('resource', 'graphql.parse')
               expect(span).to.have.property('type', 'graphql')
-              expect(span.meta).to.have.property('graphql.source', source)
+              expect(span.meta).to.not.have.property('graphql.source')
             })
             .then(done)
             .catch(done)
@@ -205,7 +205,7 @@ describe('Plugin', () => {
               expect(span).to.have.property('name', 'graphql.validate')
               expect(span).to.have.property('resource', 'graphql.validate')
               expect(span).to.have.property('type', 'graphql')
-              expect(span.meta).to.have.property('graphql.source', source)
+              expect(span.meta).to.not.have.property('graphql.source')
             })
             .then(done)
             .catch(done)
@@ -224,7 +224,7 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
               expect(spans[0]).to.have.property('type', 'graphql')
-              expect(spans[0].meta).to.have.property('graphql.source', source)
+              expect(spans[0].meta).to.not.have.property('graphql.source')
               expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
               expect(spans[0].meta).to.have.property('graphql.operation.name', 'MyQuery')
             })
@@ -264,7 +264,7 @@ describe('Plugin', () => {
               expect(spans[1].meta).to.have.property('graphql.field.name', 'hello')
               expect(spans[1].meta).to.have.property('graphql.field.path', 'hello')
               expect(spans[1].meta).to.have.property('graphql.field.type', 'String')
-              expect(spans[1].meta).to.have.property('graphql.source', 'hello(name: "world")')
+              expect(spans[1].meta).to.not.have.property('graphql.source')
             })
             .then(done)
             .catch(done)
@@ -634,7 +634,7 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
-              expect(spans[0].meta).to.have.property('graphql.source', source)
+              expect(spans[0].meta).to.not.have.property('graphql.source')
             })
             .then(done)
             .catch(done)
@@ -904,7 +904,7 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query SecondQuery{hello(name:"")}')
-              expect(spans[0].meta).to.have.property('graphql.source', source)
+              expect(spans[0].meta).to.not.have.property('graphql.source')
               expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
               expect(spans[0].meta).to.have.property('graphql.operation.name', 'SecondQuery')
             })
@@ -935,7 +935,7 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', resource)
-              expect(spans[0].meta).to.have.property('graphql.source', source)
+              expect(spans[0].meta).to.not.have.property('graphql.source')
               expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
               expect(spans[0].meta).to.have.property('graphql.operation.name', 'WithFragments')
             })
@@ -980,7 +980,7 @@ describe('Plugin', () => {
         //       expect(spans[0]).to.have.property('service', 'test')
         //       expect(spans[0]).to.have.property('name', 'graphql.execute')
         //       expect(spans[0]).to.have.property('resource', resource)
-        //       expect(spans[0].meta).to.have.property('graphql.source', source)
+        //       expect(spans[0].meta).to.not.have.property('graphql.source')
         //       expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
         //       expect(spans[0].meta).to.have.property('graphql.operation.name', 'WithFragments')
         //     })
@@ -1013,7 +1013,8 @@ describe('Plugin', () => {
 
           return agent.load('graphql', {
             service: 'test',
-            variables: variables => Object.assign({}, variables, { who: 'REDACTED' })
+            variables: variables => Object.assign({}, variables, { who: 'REDACTED' }),
+            source: true
           })
         })
 
@@ -1026,7 +1027,7 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should be configured with the correct values', done => {
+        it.only('should be configured with the correct values', done => {
           const source = `{ hello(name: "world") }`
 
           agent
@@ -1036,6 +1037,8 @@ describe('Plugin', () => {
               expect(spans).to.have.length(2)
               expect(spans[0]).to.have.property('service', 'test')
               expect(spans[1]).to.have.property('service', 'test')
+              expect(spans[0].meta).to.have.property('graphql.source', '{ hello(name: "world") }')
+              expect(spans[1].meta).to.have.property('graphql.source', 'hello(name: "world")')
             })
             .then(done)
             .catch(done)
@@ -1491,7 +1494,7 @@ describe('Plugin', () => {
 
               expect(spans[0]).to.have.property('name', 'graphql.execute')
               expect(spans[0]).to.have.property('resource', 'query MyQuery{hello}')
-              expect(spans[0].meta).to.have.property('graphql.source')
+              expect(spans[0].meta).to.not.have.property('graphql.source')
 
               expect(spans[1]).to.have.property('name', 'graphql.resolve')
               expect(spans[1]).to.have.property('resource', 'hello:String')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1027,7 +1027,7 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it.only('should be configured with the correct values', done => {
+        it('should be configured with the correct values', done => {
           const source = `{ hello(name: "world") }`
 
           agent


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix GraphQL query source exposed by default.

### Motivation
<!-- What inspired you to submit this pull request? -->

GraphQL queries may contain sensitive information and should never have been exposed by default, so this is considered a bug fix.