### PR TITLE
fix elasticsearch tests and make instrumentation safer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,10 +458,10 @@ jobs:
         environment:
           - SERVICES=elasticsearch
           - PLUGINS=elasticsearch
-      - image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0
         environment:
           - discovery.type=single-node
-          - "ES_JAVA_OPTS=-Xms64m -Xmx64m"
+          - "ES_JAVA_OPTS=-Xms128m -Xmx128m"
 
   node-express: *node-plugin-base
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,10 +40,10 @@ services:
       - '127.0.0.1:1521:1521'
       - '127.0.0.1:5500:5500'
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0
     environment:
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms64m -Xmx64m"
+      - "ES_JAVA_OPTS=-Xms128m -Xmx128m"
     ports:
       - "127.0.0.1:9200:9200"
   rabbitmq:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix elasticsearch tests and make instrumentation safer.

While looking at the code, I realized that the callback handling was not safe as it replaced the arguments, so a change in the API could break. The callback was also not bound to the scope of the parent, which could theoretically cause it to run in the incorrect scope. I have addressed both of these as well at the same time.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests started failing because version 7.14 of the client requires minimum version 7.14 of the server because of a new check for the authenticity of the server. This also means that there is an additional request made before the first request, meaning that traces in the tests now have 2 spans instead of 1, so the tests were updated accordingly.