### PR TITLE
[ci-app] Fix `jasmine` Tests

### DIFF
--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -25,7 +25,8 @@ describe('Plugin', () => {
     testRunner: 'jest-jasmine2',
     silent: true,
     testEnvironment: 'node',
-    cache: false
+    cache: false,
+    maxWorkers: '50%'
   }
 
   withVersions(plugin, ['jest-jasmine2'], (version, moduleName) => {


### PR DESCRIPTION
### What does this PR do?
* Set `maxWorkers` to `50%`, like `jest` recommends for [CI environments](https://jestjs.io/docs/configuration#maxworkers-number--string).

>  It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.

### Motivation
* Fix failing tests in `master`

**Note**: run the `jest` tests 10 times in CI and there seems to be no flakiness. 
⚠️ **Important**: consider squashing before merging to `master`: the commits are empty just to trigger CI runs. 