### PR TITLE
make measuredByDefault actually do something

### DIFF
--- a/packages/dd-trace/src/analytics_sampler.js
+++ b/packages/dd-trace/src/analytics_sampler.js
@@ -6,8 +6,10 @@ module.exports = {
   sample (span, measured, measuredByDefault) {
     if (typeof measured === 'object') {
       this.sample(span, measured[span.context()._name], measuredByDefault)
-    } else if (measured || measured !== undefined) {
+    } else if (measured !== undefined) {
       span.setTag(MEASURED, !!measured)
+    } else if (measuredByDefault) {
+      span.setTag(MEASURED, true)
     }
   }
 }

--- a/packages/dd-trace/test/analytics_sampler.spec.js
+++ b/packages/dd-trace/test/analytics_sampler.spec.js
@@ -36,5 +36,11 @@ describe('analyticsSampler', () => {
 
       expect(span.setTag).to.not.have.been.called
     })
+
+    it('should sample if `measuredByDefault` is true', () => {
+      sampler.sample(span, undefined, true)
+
+      expect(span.setTag).to.have.been.calledWith(MEASURED, true)
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Makes the `measuredByDefault` param to `analytics_sampler.sample()` actually act as a default.

### Motivation
<!-- What inspired you to submit this pull request? -->
Previously this parameter did nothing.
