### PR TITLE
fix prepublish script using the wrong checksum algorithm

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -145,7 +145,7 @@ function validatePrebuilds () {
   const content = fs.readFileSync(file)
   const sum = fs.readFileSync(path.join(`${file}.sha1`), 'ascii')
 
-  if (sum !== checksum(content)) {
+  if (sum !== checksum(content, { algorithm: 'sha256' })) {
     throw new Error('Invalid checksum for "prebuilds.tgz".')
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix prepublish script using the wrong checksum algorithm.

### Motivation
<!-- What inspired you to submit this pull request? -->

Prepublish script was removed from master since the prebuilds were moved to a separate repository, so this change must go directly to the v0.x branch.