### PR TITLE
[ci-app] Fix `jest` Test Suite

### DIFF
--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -38,7 +38,10 @@ describe('Plugin', () => {
       tracer = require('../../dd-trace')
       return agent.load(['jest', 'fs', 'http']).then(() => {
         DatadogJestEnvironment = require(`../../../versions/${moduleName}@${version}`).get()
-        datadogJestEnv = new DatadogJestEnvironment({ rootDir: BUILD_SOURCE_ROOT }, { testPath: TEST_SUITE })
+        datadogJestEnv = new DatadogJestEnvironment({
+          rootDir: BUILD_SOURCE_ROOT,
+          testEnvironmentOptions: { userAgent: null }
+        }, { testPath: TEST_SUITE })
         // TODO: avoid mocking expect once we instrument the runner instead of the environment
         datadogJestEnv.getVmContext = () => ({
           expect: {


### PR DESCRIPTION
### What does this PR do?
After a new release of `jest`, our tests are broken. I think this might be a bug in `jest`, where they now force you to pass `testEnvironmentOptions` when creating an environment (https://github.com/facebook/jest/pull/11773).

### Motivation
Fix `jest` test suite.

