### PR TITLE
Feat: conditionally inject headers (#1601)

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -103,6 +103,7 @@ const httpServerOptions = {
 const httpClientOptions = {
   ...httpOptions,
   splitByDomain: true,
+  propagationBlocklist: ['url', /url/, url => true],
   hooks: {
     request: (span, req, res) => {}
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -635,11 +635,6 @@ declare namespace plugins {
      * @default true
      */
     middleware?: boolean;
-
-    /**
-     * List of urls to which propagation headers should not be injected
-     */
-    propagationBlockList?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
   }
 
   /** @hidden */
@@ -669,6 +664,11 @@ declare namespace plugins {
        */
       request?: (span?: opentracing.Span, req?: ClientRequest, res?: IncomingMessage) => any;
     };
+
+    /**
+     * List of urls to which propagation headers should not be injected
+     */
+    propagationBlocklist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
   }
 
   /** @hidden */

--- a/index.d.ts
+++ b/index.d.ts
@@ -635,6 +635,11 @@ declare namespace plugins {
      * @default true
      */
     middleware?: boolean;
+
+    /**
+     * List of urls to which propagation headers should not be injected
+     */
+    propagationBlockList?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
   }
 
   /** @hidden */

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -65,7 +65,7 @@ function patch (http, methodName, tracer, config) {
         }
       })
 
-      if (!hasAmazonSignature(options)) {
+      if (!(hasAmazonSignature(options) || !config.propagationFilter(uri))) {
         tracer.inject(span, HTTP_HEADERS, options.headers)
       }
 
@@ -308,12 +308,14 @@ function normalizeConfig (tracer, config) {
 
   const validateStatus = getStatusValidator(config)
   const filter = getFilter(tracer, config)
+  const propagationFilter = getFilter(tracer, { blocklist: config.propagationBlocklist })
   const headers = getHeaders(config)
   const hooks = getHooks(config)
 
   return Object.assign({}, config, {
     validateStatus,
     filter,
+    propagationFilter,
     headers,
     hooks
   })


### PR DESCRIPTION
### What does this PR do?
Adds a mechanism for conditionally injecting headers configured via an option in the http plugin config.

### Motivation
The necessity to not inject propagation headers for some hosts as described in (#1601)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
