### PR TITLE
[ci-app] Fix Skipped Cucumber Steps Being Marked as Errors

### DIFF
--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -7,6 +7,7 @@ const {
   TEST_NAME,
   TEST_SUITE,
   TEST_STATUS,
+  TEST_SKIP_REASON,
   CI_APP_ORIGIN,
   ERROR_MESSAGE,
   getTestEnvironmentMetadata,
@@ -18,10 +19,9 @@ function setStatusFromResult (span, result, tag) {
     span.setTag(tag, 'pass')
   } else if (result.status === 2) {
     span.setTag(tag, 'skip')
-    span.setTag(ERROR_MESSAGE, 'skipped')
   } else if (result.status === 4) {
     span.setTag(tag, 'skip')
-    span.setTag(ERROR_MESSAGE, 'not implemented')
+    span.setTag(TEST_SKIP_REASON, 'not implemented')
   } else {
     span.setTag(tag, 'fail')
     span.setTag(ERROR_MESSAGE, result.message)
@@ -31,9 +31,11 @@ function setStatusFromResult (span, result, tag) {
 function setStatusFromResultLatest (span, result, tag) {
   if (result.status === 'PASSED') {
     span.setTag(tag, 'pass')
-  } else if (result.status === 'SKIPPED' || result.status === 'PENDING' || result.status === 'UNDEFINED') {
+  } else if (result.status === 'SKIPPED' || result.status === 'PENDING') {
     span.setTag(tag, 'skip')
-    span.setTag(ERROR_MESSAGE, result.message || 'skipped')
+  } else if (result.status === 'UNDEFINED') {
+    span.setTag(tag, 'skip')
+    span.setTag(TEST_SKIP_REASON, 'not implemented')
   } else {
     span.setTag(tag, 'fail')
     span.setTag(ERROR_MESSAGE, result.message)

--- a/packages/datadog-plugin-cucumber/test/features/simple.feature
+++ b/packages/datadog-plugin-cucumber/test/features/simple.feature
@@ -19,6 +19,11 @@ Feature: Datadog integration
   Scenario: skip scenario based on tag
     Given datadog
 
+  Scenario: not implemented scenario
+    Given datadog
+    When not-implemented
+    Then pass
+
   Scenario: integration scenario
     Given datadog
     When integration

--- a/packages/dd-trace/src/plugins/util/ci-app-spec.json
+++ b/packages/dd-trace/src/plugins/util/ci-app-spec.json
@@ -4,6 +4,7 @@
   "test.framework",
   "test.suite",
   "test.name",
+  "test.skip_reason",
   "ci.pipeline.id",
   "ci.pipeline.name",
   "ci.pipeline.number",

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -18,6 +18,7 @@ const TEST_NAME = 'test.name'
 const TEST_SUITE = 'test.suite'
 const TEST_STATUS = 'test.status'
 const TEST_PARAMETERS = 'test.parameters'
+const TEST_SKIP_REASON = 'test.skip_reason'
 
 const ERROR_TYPE = 'error.type'
 const ERROR_MESSAGE = 'error.msg'
@@ -32,6 +33,7 @@ module.exports = {
   TEST_SUITE,
   TEST_STATUS,
   TEST_PARAMETERS,
+  TEST_SKIP_REASON,
   ERROR_TYPE,
   ERROR_MESSAGE,
   ERROR_STACK,


### PR DESCRIPTION
### What does this PR do?
* An `error.message` tag was being added to skipped steps and tests, which meant that skipped tests were marked as errors, which messes up other features like outlier calculation. 
* Additionally, an extra test for not implemented steps was added. 

### Motivation
* Fix cucumber instrumentation. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
