### PR TITLE
fix mongoose context propagation for aggregations

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/unified.js
+++ b/packages/datadog-plugin-mongodb-core/src/unified.js
@@ -98,7 +98,7 @@ module.exports = [
   },
   {
     name: 'mongodb',
-    versions: ['>=3.5'],
+    versions: ['>=3.5.4'],
     file: 'lib/utils.js',
     patch (util, tracer, config) {
       this.wrap(util, 'maybePromise', createWrapMaybePromise(tracer, config))

--- a/packages/datadog-plugin-mongodb-core/src/unified.js
+++ b/packages/datadog-plugin-mongodb-core/src/unified.js
@@ -26,6 +26,22 @@ function createWrapCommand (tracer, config, name) {
   }
 }
 
+function createWrapMaybePromise (tracer, config) {
+  return function wrapMaybePromise (maybePromise) {
+    return function maybePromiseWithTrace (parent, callback, fn) {
+      const callbackIndex = arguments.length - 2
+
+      callback = arguments[callbackIndex]
+
+      if (typeof callback === 'function') {
+        arguments[callbackIndex] = tracer.scope().bind(callback)
+      }
+
+      return maybePromise.apply(this, arguments)
+    }
+  }
+}
+
 function patch (wp, tracer, config) {
   this.wrap(wp, 'command', createWrapCommand(tracer, config))
   this.wrap(wp, 'insert', createWrapCommand(tracer, config, 'insert'))
@@ -79,6 +95,17 @@ module.exports = [
     file: 'lib/cmap/connection.js',
     patch: patchConnection,
     unpatch: unpatchConnection
+  },
+  {
+    name: 'mongodb',
+    versions: ['>=3.5'],
+    file: 'lib/utils.js',
+    patch (util, tracer, config) {
+      this.wrap(util, 'maybePromise', createWrapMaybePromise(tracer, config))
+    },
+    unpatch (util) {
+      this.unwrap(util, 'maybePromise')
+    }
   },
   {
     name: 'mongodb',

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -20,7 +20,7 @@ const withTopologies = fn => {
     })
 
     // unified topology is now the only topology and thus the default since 4.x
-    if (semver.intersects(version, '<4')) {
+    if (!semver.intersects(version, '>=4')) {
       describe('using the unified topology', () => {
         fn(async () => {
           const { MongoClient, Server } = require(`../../../versions/${moduleName}@${version}`).get()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix mongoose context propagation for aggregations.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests started failing because the latest version started using `maybePromise` in aggregations which was losing the context.