### PR TITLE
Fix Test Suite Calculation for Windows

### DIFF
--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -1,5 +1,3 @@
-const { relative } = require('path')
-
 const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
 
 const {
@@ -11,7 +9,8 @@ const {
   CI_APP_ORIGIN,
   ERROR_MESSAGE,
   getTestEnvironmentMetadata,
-  finishAllTraceSpans
+  finishAllTraceSpans,
+  getTestSuitePath
 } = require('../../dd-trace/src/plugins/util/test')
 
 function setStatusFromResult (span, result, tag) {
@@ -42,11 +41,11 @@ function setStatusFromResultLatest (span, result, tag) {
   }
 }
 
-function createWrapRun (tracer, testEnvironmentMetadata, getTestSuiteName, setStatus) {
+function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot, setStatus) {
   return function wrapRun (run) {
     return function handleRun () {
       const testName = this.pickle.name
-      const testSuite = getTestSuiteName(this.pickle.uri)
+      const testSuite = getTestSuitePath(this.pickle.uri, sourceRoot)
 
       const commonSpanTags = {
         [TEST_TYPE]: 'test',
@@ -105,14 +104,11 @@ module.exports = [
     patch (PickleRunner, tracer) {
       const testEnvironmentMetadata = getTestEnvironmentMetadata('cucumber')
       const sourceRoot = process.cwd()
-      const getTestSuiteName = (pickleUri) => {
-        return relative(sourceRoot, pickleUri)
-      }
       const pl = PickleRunner.default
       this.wrap(
         pl.prototype,
         'run',
-        createWrapRun(tracer, testEnvironmentMetadata, getTestSuiteName, setStatusFromResult)
+        createWrapRun(tracer, testEnvironmentMetadata, sourceRoot, setStatusFromResult)
       )
       const getResourceName = (testStep) => {
         return testStep.isHook ? 'hook' : testStep.pickleStep.text
@@ -132,14 +128,11 @@ module.exports = [
     patch (TestCaseRunner, tracer) {
       const testEnvironmentMetadata = getTestEnvironmentMetadata('cucumber')
       const sourceRoot = process.cwd()
-      const getTestSuiteName = (pickleUri) => {
-        return relative(sourceRoot, pickleUri)
-      }
       const pl = TestCaseRunner.default
       this.wrap(
         pl.prototype,
         'run',
-        createWrapRun(tracer, testEnvironmentMetadata, getTestSuiteName, setStatusFromResultLatest)
+        createWrapRun(tracer, testEnvironmentMetadata, sourceRoot, setStatusFromResultLatest)
       )
       const getResourceName = (testStep) => {
         return testStep.text

--- a/packages/datadog-plugin-jest/src/jest-environment.js
+++ b/packages/datadog-plugin-jest/src/jest-environment.js
@@ -11,7 +11,8 @@ const {
   CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
   getTestParametersString,
-  finishAllTraceSpans
+  finishAllTraceSpans,
+  getTestSuitePath
 } = require('../../dd-trace/src/plugins/util/test')
 const {
   getFormattedJestTestParameters,
@@ -30,7 +31,7 @@ function wrapEnvironment (BaseEnvironment) {
   return class DatadogJestEnvironment extends BaseEnvironment {
     constructor (config, context) {
       super(config, context)
-      this.testSuite = context.testPath.replace(`${config.rootDir}/`, '')
+      this.testSuite = getTestSuitePath(context.testPath, config.rootDir)
       this.testSpansByTestName = {}
       this.originalTestFnByTestName = {}
     }

--- a/packages/datadog-plugin-jest/src/jest-jasmine2.js
+++ b/packages/datadog-plugin-jest/src/jest-jasmine2.js
@@ -7,7 +7,8 @@ const {
   TEST_STATUS,
   CI_APP_ORIGIN,
   getTestEnvironmentMetadata,
-  finishAllTraceSpans
+  finishAllTraceSpans,
+  getTestSuitePath
 } = require('../../dd-trace/src/plugins/util/test')
 const { getTestSpanTags, setSuppressedErrors } = require('./util')
 
@@ -21,7 +22,7 @@ function createWrapIt (tracer, globalConfig, globalInput, testEnvironmentMetadat
 
       const { childOf, commonSpanTags } = getTestSpanTags(tracer, testEnvironmentMetadata)
 
-      const testSuite = globalInput.jasmine.testPath.replace(`${globalConfig.rootDir}/`, '')
+      const testSuite = getTestSuitePath(globalInput.jasmine.testPath, globalConfig.rootDir)
 
       const newSpecFunction = tracer.wrap(
         'jest.test',
@@ -107,7 +108,7 @@ function createWrapItSkip (tracer, globalConfig, globalInput, testEnvironmentMet
     return function itSkipWithTrace () {
       const { childOf, commonSpanTags } = getTestSpanTags(tracer, testEnvironmentMetadata)
 
-      const testSuite = globalInput.jasmine.testPath.replace(`${globalConfig.rootDir}/`, '')
+      const testSuite = getTestSuitePath(globalInput.jasmine.testPath, globalConfig.rootDir)
 
       const spec = it.apply(this, arguments)
 

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -41,7 +41,7 @@ describe('Plugin', () => {
         datadogJestEnv = new DatadogJestEnvironment({
           rootDir: BUILD_SOURCE_ROOT,
           testEnvironmentOptions: { userAgent: null }
-        }, { testPath: TEST_SUITE })
+        }, { testPath: `${BUILD_SOURCE_ROOT}/${TEST_SUITE}` })
         // TODO: avoid mocking expect once we instrument the runner instead of the environment
         datadogJestEnv.getVmContext = () => ({
           expect: {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1,5 +1,3 @@
-const path = require('path')
-
 const { promisify } = require('util')
 
 const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
@@ -15,22 +13,23 @@ const {
   getTestEnvironmentMetadata,
   getTestParametersString,
   finishAllTraceSpans,
-  getTestParentSpan
+  getTestParentSpan,
+  getTestSuitePath
 } = require('../../dd-trace/src/plugins/util/test')
 
 function getTestSpanMetadata (tracer, test, sourceRoot) {
   const childOf = getTestParentSpan(tracer)
 
-  const { file: testSuite } = test
+  const { file: testSuiteAbsolutePath } = test
   const fullTestName = test.fullTitle()
-  const strippedTestSuite = testSuite ? path.relative(sourceRoot, testSuite) : ''
+  const testSuite = getTestSuitePath(testSuiteAbsolutePath, sourceRoot)
 
   return {
     childOf,
-    resource: `${strippedTestSuite}.${fullTestName}`,
+    resource: `${testSuite}.${fullTestName}`,
     [TEST_TYPE]: 'test',
     [TEST_NAME]: fullTestName,
-    [TEST_SUITE]: strippedTestSuite,
+    [TEST_SUITE]: testSuite,
     [SAMPLING_RULE_DECISION]: 1,
     [SAMPLING_PRIORITY]: AUTO_KEEP
   }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const { promisify } = require('util')
 
 const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
@@ -21,7 +23,7 @@ function getTestSpanMetadata (tracer, test, sourceRoot) {
 
   const { file: testSuite } = test
   const fullTestName = test.fullTitle()
-  const strippedTestSuite = testSuite ? testSuite.replace(`${sourceRoot}/`, '') : ''
+  const strippedTestSuite = testSuite ? path.relative(sourceRoot, testSuite) : ''
 
   return {
     childOf,

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const { getGitMetadata } = require('./git')
 const { getCIMetadata } = require('./ci')
 const { getRuntimeAndOSMetadata } = require('./env')
@@ -42,7 +44,8 @@ module.exports = {
   getTestEnvironmentMetadata,
   getTestParametersString,
   finishAllTraceSpans,
-  getTestParentSpan
+  getTestParentSpan,
+  getTestSuitePath
 }
 
 function getTestEnvironmentMetadata (testFramework) {
@@ -109,4 +112,14 @@ function getTestParentSpan (tracer) {
     'x-datadog-parent-id': '0000000000000000',
     'x-datadog-sampled': 1
   })
+}
+/**
+ * We want to make sure that test suites are reported the same way for
+ * every OS, so we replace `path.sep` by `/`
+ */
+function getTestSuitePath (testSuiteAbsolutePath, sourceRoot) {
+  if (!testSuiteAbsolutePath) {
+    return testSuiteAbsolutePath
+  }
+  return path.relative(sourceRoot, testSuiteAbsolutePath).replace(path.sep, '/')
 }


### PR DESCRIPTION
### What does this PR do?
* Fix test suite calculation by using `path.relative` rather than directly substituting the `sourceRoot`. 
* Fix test suite path separator to `/`, even for windows file paths. This makes it so that we always report the same test (test name + test suite), whether windows or otherwise. This is important for CI Visibility product. 

### Motivation
Fix test suite calculation integration for windows users.

