### PR TITLE
add experimental state tracking

### DIFF
--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -1,6 +1,9 @@
 const log = require('./log')
 const format = require('./format')
 
+const startedSpans = new WeakSet()
+const finishedSpans = new WeakSet()
+
 class SpanProcessor {
   constructor (exporter, prioritySampler) {
     this._exporter = exporter
@@ -27,9 +30,77 @@ class SpanProcessor {
   }
 
   _erase (trace) {
-    trace.finished.forEach(span => {
+    if (process.env.DD_TRACE_EXPERIMENTAL_STATE_TRACKING === 'true') {
+      const started = new Set()
+      const startedIds = new Set()
+      const finished = new Set()
+      const finishedIds = new Set()
+
+      for (const span of trace.finished) {
+        const context = span.context()
+        const id = context.toSpanId()
+
+        if (finished.has(span)) {
+          log.error(`Span was already finished in the same trace: ${span}`)
+        } else {
+          finished.add(span)
+
+          if (finishedIds.has(id)) {
+            log.error(`Another span with the same ID was already finished in the same trace: ${span}`)
+          } else {
+            finishedIds.add(id)
+          }
+
+          if (context._trace !== trace) {
+            log.error(`A span was finished in the wrong trace: ${span}.`)
+          }
+
+          if (finishedSpans.has(span)) {
+            log.error(`Span was already finished in a different trace: ${span}`)
+          } else {
+            finishedSpans.add(span)
+          }
+        }
+      }
+
+      for (const span of trace.started) {
+        if (started.has(span)) {
+          log.error(`Span was already started in the same trace: ${span}`)
+        } else {
+          started.add(span)
+
+          if (startedIds.has(span)) {
+            log.error(`Another span with the same ID was already started in the same trace: ${span}`)
+          } else {
+            startedIds.add(span)
+          }
+
+          if (context._trace !== trace) {
+            log.error(`A span was started in the wrong trace: ${span}.`)
+          }
+
+          if (startedSpans.has(span)) {
+            log.error(`Span was already started in a different trace: ${span}`)
+          } else {
+            startedSpans.add(span)
+          }
+        }
+
+        if (!finished.has(span)) {
+          log.error(`Span started in one trace but was finished in another trace: ${span}`)
+        }
+      }
+
+      for (const span of trace.finished) {
+        if (!started.has(span)) {
+          log.error(`Span finished in one trace but was started in another trace: ${span}`)
+        }
+      }
+    }
+
+    for (const span of trace.finished) {
       span.context()._tags = {}
-    })
+    }
 
     trace.started = []
     trace.finished = []


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add experimental tracing state tracking.

### Motivation
<!-- What inspired you to submit this pull request? -->

There are cases where spans are sent multiple times which should never happen. Enabling this tracking will log when an inconsistent tracing state is detected.