### PR TITLE
fix password added to the redis span for AUTH commands

### DIFF
--- a/packages/dd-trace/src/plugins/util/redis.js
+++ b/packages/dd-trace/src/plugins/util/redis.js
@@ -42,7 +42,7 @@ const redis = {
 function formatCommand (command, args) {
   command = command.toUpperCase()
 
-  if (!args) return command
+  if (!args || command === 'AUTH') return command
 
   for (let i = 0, l = args.length; i < l; i++) {
     if (typeof args[i] === 'function') continue

--- a/packages/dd-trace/test/plugins/util/redis.spec.js
+++ b/packages/dd-trace/test/plugins/util/redis.spec.js
@@ -80,5 +80,13 @@ describe('plugins/util/redis', () => {
       expect(rawCommand.substr(0, 10)).to.equal('GET aaaaaa')
       expect(rawCommand.substr(990)).to.equal('aaaaaaa...')
     })
+
+    it('should ignore arguments for authentication', () => {
+      span = redis.instrument(tracer, config, '1', 'auth', ['username', 'password'])
+
+      const rawCommand = span.context()._tags['redis.raw_command']
+
+      expect(rawCommand).to.equal('AUTH')
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix password added to the redis span for AUTH commands.

### Motivation
<!-- What inspired you to submit this pull request? -->

Sensitive information should not be added to traces, and the AUTH command is always sending sensitive information.

Fixes #1634 