### PR TITLE
Update pprof

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@datadog/native-metrics": "^1.0.0",
-    "@datadog/pprof": "^0.1.3",
+    "@datadog/pprof": "^0.2.0",
     "@datadog/sketches-js": "^1.0.4",
     "@types/node": "^10.12.18",
     "crypto-randomuuid": "^1.0.0",


### PR DESCRIPTION
### What does this PR do?
Updates pprof.

### Motivation
When attempting to install locally, `0.2.0` is not installed. Semver below `0.x.x` doesn't work "normally".
DataDog rep said this library update was necessary for "correct" behavior of the profiler.
