### PR TITLE
fix invalid context reference in state tracking

### DIFF
--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -64,15 +64,18 @@ class SpanProcessor {
       }
 
       for (const span of trace.started) {
+        const context = span.context()
+        const id = context.toSpanId()
+
         if (started.has(span)) {
           log.error(`Span was already started in the same trace: ${span}`)
         } else {
           started.add(span)
 
-          if (startedIds.has(span)) {
+          if (startedIds.has(id)) {
             log.error(`Another span with the same ID was already started in the same trace: ${span}`)
           } else {
-            startedIds.add(span)
+            startedIds.add(id)
           }
 
           if (context._trace !== trace) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix invalid context reference in state tracking.

### Motivation
<!-- What inspired you to submit this pull request? -->

The checks for started IDs was using spans instead of IDs and was referencing a variable from a previous loop.