### PR TITLE
[ci-visibility] New Entrypoint

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,3 +15,4 @@
 !loader-hook.mjs
 !package.json
 !cypress/**/*
+!ci/**/*

--- a/ci/cypress/plugin.js
+++ b/ci/cypress/plugin.js
@@ -1,0 +1,3 @@
+require('../init')
+
+module.exports = require('../../packages/datadog-plugin-cypress/src/plugin')

--- a/ci/cypress/support.js
+++ b/ci/cypress/support.js
@@ -1,0 +1,1 @@
+require('../../packages/datadog-plugin-cypress/src/support')

--- a/ci/init.js
+++ b/ci/init.js
@@ -1,0 +1,10 @@
+// TODO: provide a way to do this with the init function
+process.env.DD_TRACE_DISABLED_PLUGINS = 'fs'
+
+const tracer = require('../packages/dd-trace')
+
+tracer.init({
+  startupLogs: false
+})
+
+module.exports = tracer

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -1,0 +1,10 @@
+process.env.DD_TRACE_DISABLED_PLUGINS = 'fs'
+
+const tracer = require('../../packages/dd-trace')
+
+tracer.init({
+  startupLogs: false,
+  flushInterval: 400000
+})
+
+module.exports = tracer


### PR DESCRIPTION
### What does this PR do?
A new way to require and initialize ci visibility with `dd-trace-js`. 

* `jest` `testEnvironment` file:

From 
```javascript
require('dd-trace').init({
  flushInterval: 400000, // leaks an implementation detail 
});
module.exports = require('jest-environment-node');
```
to
```javascript
require('dd-trace/ci/jest/env') // does not leak
module.exports = require('jest-environment-node')
```

* `mocha`: From passing `--require=dd-trace/init` to passing `--require=dd-trace/ci/init`

* `cucumber`:  From passing `--require-module dd-trace/init` to passing `--require-module dd-trace/ci/init`

* `cypress`: From using `dd-trace/cypress/plugin` and `dd-trace/cypress/support` to using `dd-trace/ci/cypress/plugin` and `dd-trace/ci/cypress/support`
  * ⚠️ `cypress` plugin does not belong in `packages/datadog-plugin-cypress` as it is not an APM instrumentation. It will be moved to `ci/cypress` in a follow up PR. 


#### What does this allow? 

By providing a custom `ci/init.js` file we can do custom configuration, such as: 
* Disable `fs` plugin: already done in this PR.
* Configure a different exporter (like agentless) without having to tell the user to change the way they call `init`: not done in this PR yet. 

By providing a separate folder per CI integration we can add custom logic that does not belong in tracing, such as: 
* On start / on end handlers for `jest`, for sending git metadata once and signaling finish, respectively. 
* CI instrumentation (not APM instrumentation) like `cypress`, whose plugin is *not* a typical APM instrumentation.
  * Browser instrumentation for `cypress`, in an integration with RUM. 


### Motivation
* Allow adding non-tracing features to ci visibility without interfering with APM. 
* Set the basis for a new "CI Visibility library".

