### PR TITLE
[ci-visibility] Mocha: fix `this.retries`

### DIFF
--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -40,6 +40,12 @@ function getTestSpanMetadata (tracer, test, sourceRoot) {
 function createWrapRunTest (tracer, testEnvironmentMetadata, sourceRoot) {
   return function wrapRunTest (runTest) {
     return async function runTestWithTrace () {
+      // `runTest` is rerun when retries are configured through `this.retries` and the test fails.
+      // This clause prevents rewrapping `this.test.fn` when it has already been wrapped.
+      if (this.test._currentRetry !== undefined && this.test._currentRetry !== 0) {
+        return runTest.apply(this, arguments)
+      }
+
       let specFunction = this.test.fn
       if (specFunction.length) {
         specFunction = promisify(specFunction)

--- a/packages/datadog-plugin-mocha/test/mocha-test-retries.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-retries.js
@@ -1,0 +1,9 @@
+const { expect } = require('chai')
+
+let attempt = 0
+describe('mocha-test-retries', function () {
+  this.retries(4)
+  it('will be retried', () => {
+    expect(attempt++).to.equal(2)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Stop spec functions from being re-wrapped when it has already been wrapped.

### Motivation
* Fix usage of `this.retries`

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.