### PR TITLE
branched out sending telemetry payload depending on api key availability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ acmeair-nodejs
 !packages/*/test/**/dist
 !packages/*/test/**/node_modules
 test-results.xml
+/.idea/

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -174,7 +174,6 @@ class Config {
     this.experimental = {
       b3: isTrue(DD_TRACE_B3_ENABLED),
       runtimeId: isTrue(DD_TRACE_RUNTIME_ID_ENABLED),
-      runtimeIdValue: runtimeId,
       exporter: DD_TRACE_EXPORTER,
       enableGetRumData: isTrue(DD_TRACE_GET_RUM_DATA_ENABLED),
       sampler,

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -170,6 +170,7 @@ class Config {
     this.experimental = {
       b3: isTrue(DD_TRACE_B3_ENABLED),
       runtimeId: isTrue(DD_TRACE_RUNTIME_ID_ENABLED),
+      runtimeIdValue: runtimeId,
       exporter: DD_TRACE_EXPORTER,
       enableGetRumData: isTrue(DD_TRACE_GET_RUM_DATA_ENABLED),
       sampler,

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -85,6 +85,10 @@ class Config {
       process.env.DD_TRACE_STARTUP_LOGS,
       true
     )
+    const DD_TRACE_TELEMETRY_ENABLED = coalesce(
+      process.env.DD_TRACE_TELEMETRY_ENABLED,
+      true
+    )
     const DD_TRACE_ENABLED = coalesce(
       options.enabled,
       process.env.DD_TRACE_ENABLED,
@@ -192,6 +196,7 @@ class Config {
     }
     this.lookup = options.lookup
     this.startupLogs = isTrue(DD_TRACE_STARTUP_LOGS)
+    this.telemetryEnabled = isTrue(DD_TRACE_TELEMETRY_ENABLED)
     this.protocolVersion = DD_TRACE_AGENT_PROTOCOL_VERSION
     this.appsec = {
       enabled: isTrue(DD_APPSEC_ENABLED)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -128,6 +128,10 @@ class Config {
       process.env.DD_TRACE_EXPERIMENTAL_INTERNAL_ERRORS_ENABLED,
       false
     )
+    const DD_API_KEY = coalesce(
+      process.env.DD_API_KEY,
+      null
+    )
     // TODO(simon-id): add documentation for appsec config when we release it in public beta
     const DD_APPSEC_ENABLED = coalesce(
       options.experimental && options.experimental.appsec,
@@ -161,6 +165,7 @@ class Config {
     this.logger = options.logger
     this.plugins = !!coalesce(options.plugins, true)
     this.service = DD_SERVICE
+    this.apiKey = DD_API_KEY
     this.serviceMapping = DD_SERVICE_MAPPING.length ? fromEntries(
       DD_SERVICE_MAPPING.split(',').map(x => x.trim().split(':'))
     ) : {}

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -6,6 +6,7 @@ const metrics = require('./metrics')
 const Loader = require('./loader')
 const { isTrue } = require('./util')
 const plugins = require('./plugins')
+const telemetry = require('./telemetry')
 
 shimmer({ logger: () => {} })
 
@@ -52,6 +53,7 @@ class Instrumenter {
 
     try {
       this._set(plugins[name.toLowerCase()], { name, config })
+      telemetry.updateIntegrations()
     } catch (e) {
       log.debug(`Could not find a plugin named "${name}".`)
     }

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -34,4 +34,4 @@ function findUp (name, cwd) {
   }
 }
 
-module.exports = findPkg()
+module.exports = Object.assign(findPkg(), { findRoot, findUp })

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -8,6 +8,7 @@ const Instrumenter = require('./instrumenter')
 const metrics = require('./metrics')
 const log = require('./log')
 const { setStartupLogInstrumenter } = require('./startup-log')
+const startTelemetry = require('./telemetry')
 
 const noop = new NoopTracer()
 
@@ -54,6 +55,7 @@ class Tracer extends BaseTracer {
           this._tracer = new DatadogTracer(config)
           this._instrumenter.enable(config)
           setStartupLogInstrumenter(this._instrumenter)
+          startTelemetry(config, this._instrumenter)
         }
       } catch (e) {
         log.error(e)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -8,7 +8,7 @@ const Instrumenter = require('./instrumenter')
 const metrics = require('./metrics')
 const log = require('./log')
 const { setStartupLogInstrumenter } = require('./startup-log')
-const startTelemetry = require('./telemetry')
+const telemetry = require('./telemetry')
 
 const noop = new NoopTracer()
 
@@ -55,7 +55,7 @@ class Tracer extends BaseTracer {
           this._tracer = new DatadogTracer(config)
           this._instrumenter.enable(config)
           setStartupLogInstrumenter(this._instrumenter)
-          startTelemetry(config, this._instrumenter)
+          telemetry.start(config, this._instrumenter)
         }
       } catch (e) {
         log.error(e)

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -150,6 +150,9 @@ function sendData (data) {
 }
 
 function startTelemetry (aConfig, theInstrumenter) {
+  if (!aConfig.telemetryEnabled) {
+    return
+  }
   config = aConfig
   instrumenter = theInstrumenter
   return setInterval(sendTelemetry, 60 * 1000)

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -94,7 +94,6 @@ function sendData (reqType, payload = {}) {
     apiKey
   } = config
 
-
   let backendHost = 'tracer-telemetry-edge.datadoghq.com'
   let backendUrlPath = 'api/v2/apmtelemetry'
   let backendProtocol = 'https'
@@ -105,7 +104,7 @@ function sendData (reqType, payload = {}) {
     'dd-telemetry-request-type': reqType
   }
 
-  if (!!apiKey) {
+  if (apiKey) {
     backendUrlPath = 'telemetry/proxy/' + backendUrlPath
     backendHost = 'localhost:8126'
     backendProtocol = 'http'
@@ -113,7 +112,7 @@ function sendData (reqType, payload = {}) {
   } else {
     headers['dd-api-key'] = apiKey
   }
-  let backendUrl = `${backendProtocol}://${backendHost}/${backendUrlPath}`
+  const backendUrl = `${backendProtocol}://${backendHost}/${backendUrlPath}`
 
   const req = http.request({
     hostname,

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -91,23 +91,27 @@ function sendData (reqType, payload = {}) {
   const {
     hostname,
     port,
-    DD_API_KEY
+    apiKey
   } = config
 
+
+  let backendHost = 'tracer-telemetry-edge.datadoghq.com'
+  let backendUrlPath = 'api/v2/apmtelemetry'
+  let backendProtocol = 'https'
   const headers = {
+    host: backendHost,
     'content-type': 'application/json',
     'dd-telemetry-api-version': 'v1',
     'dd-telemetry-request-type': reqType
   }
-  const backendHost = 'tracer-telemetry-edge.datadoghq.com'
-  let backendProtocol = 'https'
-  let backendUrlPath = 'api/v2/apmtelemetry'
 
-  if (!!DD_API_KEY) {
-    backendProtocol = 'http'
+  if (!!apiKey) {
     backendUrlPath = 'telemetry/proxy/' + backendUrlPath
+    backendHost = 'localhost:8126'
+    backendProtocol = 'http'
+    headers['host'] = backendHost
   } else {
-    headers['dd-api-key'] = DD_API_KEY
+    headers['dd-api-key'] = apiKey
   }
   let backendUrl = `${backendProtocol}://${backendHost}/${backendUrlPath}`
 
@@ -116,10 +120,7 @@ function sendData (reqType, payload = {}) {
     port,
     method: 'POST',
     path: backendUrl,
-    headers: {
-      host: backendHost,
-      ...headers
-    }
+    headers
   })
   req.on('error', () => {}) // Ignore errors
   req.write(JSON.stringify({

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -99,15 +99,18 @@ function sendData (reqType, payload = {}) {
     'dd-telemetry-api-version': 'v1',
     'dd-telemetry-request-type': reqType
   }
-
+  const backendHost = 'tracer-telemetry-edge.datadoghq.com'
+  let backendProtocol = 'https'
   let backendUrlPath = 'api/v2/apmtelemetry'
+
   if (!!DD_API_KEY) {
-    backendUrlPath = 'telemetry/proxy/api/v2/apmtelemetry'
+    backendProtocol = 'http'
+    backendUrlPath = 'telemetry/proxy/' + backendUrlPath
   } else {
     headers['dd-api-key'] = DD_API_KEY
   }
-  const backendHost = 'tracer-telemetry-edge.datadoghq.com'
-  const backendUrl = `https://${backendHost}/${backendUrlPath}`
+  let backendUrl = `${backendProtocol}://${backendHost}/${backendUrlPath}`
+
   const req = http.request({
     hostname,
     port,

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -1,0 +1,159 @@
+'use strict'
+
+const tracerVersion = require('../lib/version')
+const pkg = require('./pkg')
+const util = require('util')
+const fs = require('fs')
+const path = require('path')
+const http = require('http')
+
+let config
+let instrumenter
+
+const data = {
+  seq_id: -1
+}
+
+function getIntegrations () {
+  return [...new Set(instrumenter._instrumented.keys())].map(plugin => ({
+    name: plugin.name,
+    enabled: true,
+    auto_enabled: true
+  }))
+}
+
+function recursiveGetDeps (nmDir, results = []) {
+  let deps
+  try {
+    deps = fs.readdirSync(nmDir, 'utf8')
+  } catch (e) {
+    return results
+  }
+  for (const dir of deps) {
+    const moduleDir = path.join(nmDir, dir)
+    if (dir.startsWith('@')) {
+      recursiveGetDeps(moduleDir, results)
+    } else {
+      const pkgPath = path.join(moduleDir, 'package.json')
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+        results.push({
+          name: pkg.name,
+          verison: pkg.version
+        })
+      } catch (e) { /* skip */ }
+      const newNmDir = path.join(moduleDir, 'node_modules')
+      recursiveGetDeps(newNmDir, results)
+    }
+  }
+  return results
+}
+
+function getDependencies () {
+  const cwd = pkg.findRoot()
+  const dirPath = pkg.findUp('node_modules', cwd)
+  return recursiveGetDeps(dirPath)
+}
+
+function flatten (input, result = {}, prefix = []) {
+  for (const [key, value] in Object.entries(input)) {
+    if (typeof value === 'object' && value !== null) {
+      flatten(value, result, [...prefix, key])
+    } else {
+      result[[...prefix, key].join('.')] = value
+    }
+  }
+}
+
+function sendTelemetry () {
+  if (!config || !instrumenter) {
+    return
+  }
+
+  const integrations = getIntegrations()
+  if (util.isDeepStrictEqual(integrations, data.integrations)) {
+    return
+  }
+
+  if (!data.runtime_id) {
+    data.runtime_id = config.experimental.runtimeIdValue // TODO
+  }
+
+  data.seq_id++
+
+  if (!data.service_name) {
+    data.service_name = config.service
+  }
+
+  if (!data.env) {
+    data.env = config.env
+  }
+
+  if (!data.started_at) {
+    data.started_at = Math.floor(Date.now() / 1000) - Math.floor(process.uptime()) // seconds since epoch?
+  }
+
+  if (!data.tracer_version) {
+    data.tracer_version = tracerVersion
+  }
+
+  if (!data.language_name) {
+    data.language_name = 'node_js'
+  }
+
+  data.integrations = integrations
+
+  if (!data.depenencies && pkg.dependencies) {
+    const deps = []
+    for (const [name, version] of Object.entries(pkg.dependencies)) {
+      deps.push({ name, version })
+    }
+    data.dependencies = getDependencies()
+  }
+
+  if (!data.service_version) {
+    data.service_version = pkg.version
+  }
+
+  if (!data.language_version) {
+    data.language_version = process.versions.node
+  }
+
+  if (!data.configuration) {
+    data.configuration = flatten(config)
+  }
+
+  sendData(data)
+}
+
+function sendData (data) {
+  const {
+    hostname,
+    port
+  } = config
+  const backendHost = 'tracer-telemetry-edge.datadoghq.com'
+  const backendUrl = `https://${backendHost}/api/v1/intake/apm-app-env`
+  const req = http.request({
+    hostname,
+    port,
+    method: 'POST',
+    path: backendUrl,
+    headers: {
+      host: backendHost,
+      'content-type': 'application/json',
+      'dd-tracer-timestamp': Math.floor(Date.now() / 1000)
+    }
+  })
+  req.on('error', () => {
+    // Ignore errors
+  })
+  req.end(JSON.stringify(data))
+}
+
+function startTelemetry (aConfig, theInstrumenter) {
+  config = aConfig
+  instrumenter = theInstrumenter
+  return setInterval(sendTelemetry, 6 * 1000)
+}
+
+module.exports = startTelemetry

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -90,10 +90,24 @@ function createHostObject () {
 function sendData (reqType, payload = {}) {
   const {
     hostname,
-    port
+    port,
+    DD_API_KEY
   } = config
+
+  const headers = {
+    'content-type': 'application/json',
+    'dd-telemetry-api-version': 'v1',
+    'dd-telemetry-request-type': reqType
+  }
+
+  let backendUrlPath = 'api/v2/apmtelemetry'
+  if (!!DD_API_KEY) {
+    backendUrlPath = 'telemetry/proxy/api/v2/apmtelemetry'
+  } else {
+    headers['dd-api-key'] = DD_API_KEY
+  }
   const backendHost = 'tracer-telemetry-edge.datadoghq.com'
-  const backendUrl = `https://${backendHost}/api/v2/apmtelemetry`
+  const backendUrl = `https://${backendHost}/${backendUrlPath}`
   const req = http.request({
     hostname,
     port,
@@ -101,9 +115,7 @@ function sendData (reqType, payload = {}) {
     path: backendUrl,
     headers: {
       host: backendHost,
-      'content-type': 'application/json',
-      'dd-telemetry-api-version': 'v1',
-      'dd-telemetry-request-type': reqType
+      ...headers
     }
   })
   req.on('error', () => {}) // Ignore errors

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -12,6 +12,7 @@ describe('Instrumenter', () => {
   let instrumenter
   let integrations
   let tracer
+  let telemetry
 
   before(() => {
     process.env.DD_TRACE_DISABLED_PLUGINS = 'mocha'
@@ -61,6 +62,10 @@ describe('Instrumenter', () => {
       }
     }
 
+    telemetry = {
+      updateIntegrations: sinon.spy()
+    }
+
     Instrumenter = proxyquire('../src/instrumenter', {
       './plugins': {
         'http': integrations.http,
@@ -71,7 +76,8 @@ describe('Instrumenter', () => {
       '../../datadog-plugin-http/src': integrations.http,
       '../../datadog-plugin-express-mock/src': integrations.express,
       '../../datadog-plugin-mysql-mock/src': integrations.mysql,
-      '../../datadog-plugin-other/src': integrations.other
+      '../../datadog-plugin-other/src': integrations.other,
+      './telemetry': telemetry
     })
 
     instrumenter = new Instrumenter(tracer)
@@ -206,6 +212,12 @@ describe('Instrumenter', () => {
 
       it('should not interfere with userland modules masking core modules', () => {
         expect(require('http2/foo.js')).to.equal('Hello, World!')
+      })
+
+      it('should call updateIntegrations on telemetry', () => {
+        instrumenter.use('express-mock')
+
+        expect(telemetry.updateIntegrations).to.have.been.called
       })
     })
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -15,6 +15,7 @@ describe('TracerProxy', () => {
   let log
   let profiler
   let appsec
+  let telemetry
 
   beforeEach(() => {
     tracer = {
@@ -78,6 +79,10 @@ describe('TracerProxy', () => {
       enable: sinon.spy()
     }
 
+    telemetry = {
+      start: sinon.spy()
+    }
+
     Proxy = proxyquire('../src/proxy', {
       './tracer': DatadogTracer,
       './noop/tracer': NoopTracer,
@@ -86,7 +91,8 @@ describe('TracerProxy', () => {
       './instrumenter': Instrumenter,
       './log': log,
       './profiler': profiler,
-      './appsec': appsec
+      './appsec': appsec,
+      './telemetry': telemetry
     })
 
     proxy = new Proxy()
@@ -215,6 +221,12 @@ describe('TracerProxy', () => {
 
         const expectedErr = sinon.match.instanceOf(Error).and(sinon.match.has('code', 'MODULE_NOT_FOUND'))
         sinon.assert.calledWith(log.error, sinon.match(expectedErr))
+      })
+
+      it('should start telemetry', () => {
+        proxy.init()
+
+        expect(telemetry.start).to.have.been.called
       })
     })
 

--- a/packages/dd-trace/test/telemetry.spec.js
+++ b/packages/dd-trace/test/telemetry.spec.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const tracerVersion = require('../../../package.json').version
+const telemetry = require('../src/telemetry')
+const http = require('http')
+
+describe('telemetry', () => {
+  let traceAgent
+  let origSetInterval
+
+  beforeEach(done => {
+    origSetInterval = setInterval
+    let expectedRequests
+    let resolveDoneIntervals
+    const doneIntervals = new Promise((resolve, reject) => {
+      resolveDoneIntervals = resolve
+    })
+    global.setInterval = (fn, interval) => {
+      expect(interval).to.equal(60000)
+      let intervals = 0
+      return origSetInterval(() => {
+        fn()
+        // we want a few more intervals than requests
+        if (++intervals === expectedRequests + 3) {
+          resolveDoneIntervals()
+        }
+      }, 0)
+    }
+    let requestCount = 0
+    traceAgent = http.createServer(async (req, res) => {
+      try {
+        if (++requestCount > expectedRequests) {
+          throw new Error(`expected only ${expectedRequests} requests`)
+        }
+        const chunks = []
+        for await (const chunk of req) {
+          chunks.push(chunk)
+        }
+        req.body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+        await traceAgent.handlers.shift()(req)
+        res.end(() => {
+          if (traceAgent.handlers.length === 0) {
+            traceAgent.resolveHandled()
+          }
+        })
+      } catch (e) {
+        traceAgent.rejectHandled(e)
+      }
+    }).listen(0, done)
+
+    // Only call this once per test
+    traceAgent.handle = function (...handlers) {
+      expectedRequests = handlers.length
+      this.handlers = handlers
+      return Promise.all([
+        doneIntervals,
+        new Promise((resolve, reject) => {
+          this.resolveHandled = resolve
+          this.rejectHandled = reject
+        })
+      ])
+    }
+  })
+
+  afterEach(() => {
+    traceAgent.close()
+    global.setInterval = origSetInterval
+  })
+
+  it('should work', async () => {
+    const instrumentedMap = new Map([
+      [{ name: 'foo' }, {}],
+      [{ name: 'bar' }, {}]
+    ])
+    const interval = telemetry({
+      hostname: 'localhost',
+      port: traceAgent.address().port,
+      service: 'test service',
+      version: '1.2.3-beta4',
+      env: 'preprod',
+      experimental: {
+        runtimeIdValue: '1a2b3c'
+      }
+    }, {
+      _instrumented: instrumentedMap
+    })
+
+    const backendHost = 'tracer-telemetry-edge.datadoghq.com'
+    const backendUrl = `https://${backendHost}/api/v1/intake/apm-app-env`
+    const testSeq = (seqId, ...instrumented) => req => {
+      expect(req.method).to.equal('POST')
+      expect(req.url).to.equal(backendUrl)
+      expect(req.headers.host).to.equal(backendHost)
+      expect(Math.floor(Date.now() / 1000 - req.headers['dd-tracer-timestamp'])).to.equal(0)
+      expect(req.headers['content-type']).to.equal('application/json')
+
+      expect(req.body.runtime_id).to.equal('1a2b3c')
+      expect(req.body.seq_id).to.equal(seqId)
+      expect(req.body.service_name).to.equal('test service')
+      expect(req.body.env).to.equal('preprod')
+      expect(req.body.started_at).to.equal(Math.floor(Date.now() / 1000) - Math.floor(process.uptime()))
+      expect(req.body.tracer_version).to.equal(tracerVersion)
+      expect(req.body.language_name).to.equal('node_js')
+      expect(req.body.integrations).to.deep.equal(instrumented.map(name => ({
+        name, enabled: true, auto_enabled: true
+      })))
+      // TODO dependencies
+      expect(req.body.service_version).to.equal('1.2.3-beta4')
+      expect(req.body.language_version).to.equal(process.versions.node)
+      expect(req.body.configuration).to.deep.equal({
+        hostname: 'localhost',
+        port: traceAgent.address().port,
+        service: 'test service',
+        env: 'preprod',
+        version: '1.2.3-beta4',
+        'experimental.runtimeIdValue': '1a2b3c'
+      })
+
+      // Next iteration, baz will be set
+      instrumentedMap.set({ name: 'baz' }, {})
+    }
+    await traceAgent.handle(
+      testSeq(0, 'foo', 'bar'),
+      testSeq(1, 'foo', 'bar', 'baz')
+    )
+    clearInterval(interval)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Branching out the telemetry payload sending based on the availability of the DD-Api-Key

### Motivation
<!-- What inspired you to submit this pull request? -->
[This task](https://datadoghq.atlassian.net/browse/IT-54)
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
