### PR TITLE
Report AppSec events over top span

### DIFF
--- a/packages/dd-trace/src/appsec/callbacks/ddwaf.js
+++ b/packages/dd-trace/src/appsec/callbacks/ddwaf.js
@@ -38,7 +38,7 @@ class WAFCallback {
     // closures are faster than binds
     const self = this
     const method = (params, store) => {
-      self.action(params, store)
+      return self.action(params, store)
     }
 
     // might be its own class with more info later

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -39,9 +39,6 @@ function notifyIncomingHttpEnd ({ req }) {
   if (context.triggers.length === 0) return
   const topSpan = req._datadog.span
   topSpan.setTag('_dd.appsec.json', JSON.stringify({ triggers: context.triggers }))
-  topSpan.setTag('manual.keep')
-  topSpan.setTag('appsec.event', true)
-  topSpan.setTag('_dd.origin', 'appsec')
   // we now write extra info about the HTTP request in the spans
   // TODO(@vdeturckheim) add HTTP request info on the top span
 }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -39,6 +39,8 @@ function notifyIncomingHttpEnd ({ req }) {
   if (context.triggers.length === 0) return
   const topSpan = req._datadog.span
   topSpan.setTag('_dd.appsec.json', JSON.stringify({ triggers: context.triggers }))
+  topSpan.setTag('manual.keep')
+  topSpan.setTag('appsec.event', true)
   // we now write extra info about the HTTP request in the spans
   // TODO(@vdeturckheim) add HTTP request info on the top span
 }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -41,6 +41,7 @@ function notifyIncomingHttpEnd ({ req }) {
   topSpan.setTag('_dd.appsec.json', JSON.stringify({ triggers: context.triggers }))
   topSpan.setTag('manual.keep')
   topSpan.setTag('appsec.event', true)
+  topSpan.setTag('_dd.origin', 'appsec')
   // we now write extra info about the HTTP request in the spans
   // TODO(@vdeturckheim) add HTTP request info on the top span
 }

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -1,32 +1,6 @@
 'use strict'
-
-const os = require('os')
-const path = require('path')
-const uuid = require('crypto-randomuuid')
-const requirePackageJson = require('../require-package-json')
 const { getContext } = require('../gateway/engine')
 const Addresses = require('./addresses')
-const Scheduler = require('../exporters/agent/scheduler')
-const request = require('../exporters/agent/request')
-const log = require('../log')
-
-const FLUSH_INTERVAL = 2e3
-const MAX_EVENT_BACKLOG = 1e6
-
-const host = {
-  context_version: '0.1.0',
-  os_type: os.type(),
-  hostname: os.hostname()
-}
-
-const tracer = {
-  context_version: '0.1.0',
-  runtime_type: 'nodejs',
-  runtime_version: process.version,
-  lib_version: requirePackageJson(path.join(__dirname, '..', '..', '..', '..')).version
-}
-
-const events = new Set()
 
 function resolveHTTPAddresses () {
   const context = getContext()
@@ -78,31 +52,6 @@ function getHeadersToSend (headers) {
   return result
 }
 
-function getTracerData () {
-  const scope = global._ddtrace._tracer.scope()
-
-  const result = {
-    serviceName: scope._config.service,
-    serviceEnv: scope._config.env,
-    serviceVersion: scope._config.version,
-    tags: Object.entries(scope._config.tags).map(([k, v]) => `${k}:${v}`) // TODO: this can be optimized
-  }
-
-  const activeSpan = scope.active()
-
-  if (activeSpan) {
-    activeSpan.setTag('manual.keep')
-    activeSpan.setTag('appsec.event', true)
-
-    const context = activeSpan.context()
-
-    result.spanId = context.toSpanId()
-    result.traceId = context.toTraceId()
-  }
-
-  return result
-}
-
 function formatAttack ({
   ruleId,
   ruleName,
@@ -127,55 +76,6 @@ function formatAttack ({
   }
 }
 
-// TODO: lock
-function flush () {
-  if (!events.size) return
-  else if (events.size >= MAX_EVENT_BACKLOG) {
-    log.warn('Dropping AppSec events because the backlog is full')
-  }
-
-  const eventsArray = Array.from(events.values())
-
-  // if they fail to send, we drop the events
-  for (let i = 0; i < eventsArray.length; ++i) {
-    events.delete(eventsArray[i])
-  }
-
-  const options = {
-    path: '/appsec/proxy/api/v2/appsecevts',
-    method: 'POST',
-    headers: {
-      'X-Api-Version': 'v0.1.0',
-      'Content-Type': 'application/json'
-    },
-    data: JSON.stringify({
-      protocol_version: 1,
-      idempotency_key: uuid(),
-      events: eventsArray
-    })
-  }
-
-  const url = global._ddtrace._tracer._exporter._writer._url
-
-  if (url.protocol === 'unix:') {
-    options.socketPath = url.pathname
-  } else {
-    options.protocol = url.protocol
-    options.hostname = url.hostname
-    options.port = url.port
-  }
-
-  request(options, (err, res, status) => {
-    if (err) {
-      log.error(err)
-    }
-  })
-}
-
-const scheduler = new Scheduler(flush, FLUSH_INTERVAL)
-scheduler.start()
-
 module.exports = {
-  scheduler,
   formatAttack
 }

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -103,90 +103,28 @@ function getTracerData () {
   return result
 }
 
-function reportAttack ({
-  eventType,
-  blocked,
+function formatAttack ({
   ruleId,
   ruleName,
-  ruleSet,
+  ruleTags,
   matchOperator,
   matchOperatorValue,
   matchParameters,
   matchHighlight
 }) {
-  if (events.size > MAX_EVENT_BACKLOG) return
-
-  const resolvedHttp = resolveHTTPAddresses()
-
-  const { spanId, traceId, serviceName, serviceEnv, serviceVersion, tags } = getTracerData()
-
-  const event = {
-    event_id: uuid(),
-    event_type: eventType,
-    event_version: '0.1.0',
-    detected_at: (new Date()).toJSON(),
-    type: ruleSet,
-    blocked,
+  return {
     rule: {
       id: ruleId,
       name: ruleName,
-      set: ruleSet
+      tags: ruleTags
     },
     rule_match: {
       operator: matchOperator,
       operator_value: matchOperatorValue,
       parameters: matchParameters,
       highlight: matchHighlight
-    },
-    context: {
-      actor: {
-        context_version: '0.1.0',
-        identifiers: null,
-        _id: null
-      },
-      host,
-      http: {
-        context_version: '0.1.0',
-        request: {
-          scheme: resolvedHttp.scheme,
-          method: resolvedHttp.method,
-          url: resolvedHttp.url,
-          host: resolvedHttp.host,
-          port: resolvedHttp.port,
-          path: resolvedHttp.path,
-          resource: resolvedHttp.route,
-          remote_ip: resolvedHttp.remote_ip,
-          remote_port: resolvedHttp.remote_port,
-          headers: getHeadersToSend(resolvedHttp.headers)
-        },
-        response: {
-          status: resolvedHttp.responseCode,
-          blocked
-        }
-      },
-      service: {
-        context_version: '0.1.0',
-        name: serviceName,
-        environment: serviceEnv,
-        version: serviceVersion
-      },
-      span: {
-        context_version: '0.1.0',
-        id: spanId
-      },
-      tags: {
-        context_version: '0.1.0',
-        values: tags
-      },
-      trace: {
-        context_version: '0.1.0',
-        id: traceId
-      },
-      tracer
     }
   }
-
-  events.add(event)
 }
 
 // TODO: lock
@@ -239,5 +177,5 @@ scheduler.start()
 
 module.exports = {
   scheduler,
-  reportAttack
+  formatAttack
 }

--- a/packages/dd-trace/src/gateway/engine/engine.js
+++ b/packages/dd-trace/src/gateway/engine/engine.js
@@ -135,15 +135,17 @@ class Context {
 
     const result = Context.manager.dispatch(this.newAddresses, this.allAddresses, this)
 
+    let appsecKeep = false
     for (const { triggers } of result) {
       if (triggers) {
         this.triggers.push(...triggers)
+        appsecKeep = true
       }
     }
 
     this.newAddresses = []
 
-    return result
+    return { appsecKeep, result }
   }
 
   resolve (address) {

--- a/packages/dd-trace/src/gateway/engine/engine.js
+++ b/packages/dd-trace/src/gateway/engine/engine.js
@@ -94,6 +94,7 @@ class Context {
     this.store = new Map()
     this.allAddresses = new Set()
     this.newAddresses = []
+    this.triggers = []
   }
 
   clear () {
@@ -133,6 +134,12 @@ class Context {
     if (this.newAddresses.length === 0) return []
 
     const result = Context.manager.dispatch(this.newAddresses, this.allAddresses, this)
+
+    for (const { triggers } of result) {
+      if (triggers) {
+        this.triggers.push(...triggers)
+      }
+    }
 
     this.newAddresses = []
 

--- a/packages/dd-trace/src/gateway/engine/index.js
+++ b/packages/dd-trace/src/gateway/engine/index.js
@@ -35,7 +35,17 @@ function propagate (data, context = getContext()) {
     }
   }
 
-  context.dispatch()
+  const { appsecKeep } = context.dispatch()
+  if (appsecKeep) {
+    const store = als.getStore()
+    const req = store && store.get('req')
+    const topSpan = req && req._datadog && req._datadog.span
+    if (!topSpan) return
+    // TODO(vdeturckheim) check/ask if we need to place this on the current span too
+    topSpan.setTag('manual.keep')
+    topSpan.setTag('appsec.event', true)
+    topSpan.setTag('_dd.origin', 'appsec')
+  }
 }
 
 module.exports = {

--- a/packages/dd-trace/test/gateway/engine/engine.spec.js
+++ b/packages/dd-trace/test/gateway/engine/engine.spec.js
@@ -284,7 +284,7 @@ describe('Gateway Engine', () => {
 
         const result = context.dispatch()
 
-        expect(result).to.equal('result')
+        expect(result.result).to.equal('result')
 
         expect(Context.manager.dispatch).to.have.been.calledOnceWithExactly(
           ['a'],


### PR DESCRIPTION
### What does this PR do?
This PR moves the reporting of AppSec events over the top span.

It misses:
- [ ] the APPSEC_KEEP update (still under discussion)
- [ ] HTTP request traits collection (still under spec)
- [x] cleanup of the reporter to remove scheduler
- [ ] add tests when #1462 has more of them

### Motivation
Have AppSec event correlated with traces properly.
