### PR TITLE
Make profiler use form-data as stream

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -10,7 +10,7 @@ const version = require('../../../lib/version')
 
 const containerId = docker.id()
 
-function sendRequest (options, body, callback) {
+function sendRequest (options, form, callback) {
   const req = request(options, res => {
     if (res.statusCode >= 400) {
       const error = new Error(`HTTP Error ${res.statusCode}`)
@@ -21,7 +21,7 @@ function sendRequest (options, body, callback) {
     }
   })
   req.on('error', callback)
-  if (body) req.write(body)
+  if (form) form.pipe(req)
   req.end()
 }
 
@@ -101,7 +101,6 @@ class AgentExporter {
       })
     }
 
-    const body = form.getBuffer()
     const options = {
       method: 'POST',
       path: '/profiling/v1/input',
@@ -133,7 +132,7 @@ class AgentExporter {
 
       operation.attempt((attempt) => {
         const timeout = Math.pow(this._backoffTime, attempt)
-        sendRequest({ ...options, timeout }, body, (err, response) => {
+        sendRequest({ ...options, timeout }, form, (err, response) => {
           if (operation.retry(err)) {
             this._logger.error(`Error from the agent: ${err.message}`)
             return


### PR DESCRIPTION
This should improve export performance. Turns out concatenating larger buffers is more expensive than streamed writes.