### PR TITLE
[ci-visibility] Always Return a Test Suite Value

### DIFF
--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -128,7 +128,10 @@ function getTestParentSpan (tracer) {
  */
 function getTestSuitePath (testSuiteAbsolutePath, sourceRoot) {
   if (!testSuiteAbsolutePath) {
-    return testSuiteAbsolutePath
+    return sourceRoot
   }
-  return path.relative(sourceRoot, testSuiteAbsolutePath).replace(path.sep, '/')
+  const testSuitePath = testSuiteAbsolutePath === sourceRoot
+    ? testSuiteAbsolutePath : path.relative(sourceRoot, testSuiteAbsolutePath)
+
+  return testSuitePath.replace(path.sep, '/')
 }

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -1,4 +1,4 @@
-const { getTestParametersString } = require('../../../src/plugins/util/test')
+const { getTestParametersString, getTestSuitePath } = require('../../../src/plugins/util/test')
 
 describe('getTestParametersString', () => {
   it('returns formatted test parameters and removes params from input', () => {
@@ -27,5 +27,19 @@ describe('getTestParametersString', () => {
     expect(getTestParametersString(input, 'test_stuff')).to.equal(
       JSON.stringify({ arguments: ['params2'], metadata: {} })
     )
+  })
+})
+
+describe('getTestSuitePath', () => {
+  it('returns sourceRoot if the test path is falsy', () => {
+    const sourceRoot = '/users/opt'
+    const testSuitePath = getTestSuitePath(undefined, sourceRoot)
+    expect(testSuitePath).to.equal(sourceRoot)
+  })
+  it('returns sourceRoot if the test path has the same value', () => {
+    const sourceRoot = '/users/opt'
+    const testSuiteAbsolutePath = sourceRoot
+    const testSuitePath = getTestSuitePath(testSuiteAbsolutePath, sourceRoot)
+    expect(testSuitePath).to.equal(sourceRoot)
   })
 })


### PR DESCRIPTION
### What does this PR do?
* Return `sourceRoot` when `sourceRoot === testSuiteAbsolutePath`. Since we are using `path.relative`, if those two coincided, we were returning `''`.
* If `testSuiteAbsolutePath` is falsy for whatever reason, fall back to `sourceRoot`.

### Motivation
Customer is seeing empty test suite values.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
