### PR TITLE
Fix CPU profiler latency

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/cpu.js
+++ b/packages/dd-trace/src/profiling/profilers/cpu.js
@@ -25,9 +25,11 @@ class NativeCpuProfiler {
 
   profile () {
     if (!this._stop) return
-    const profile = this._stop()
+    // Next profile MUST be started before previous ends otherwise V8 will tear
+    // down the symbolizer thread and start a new one when the next one starts.
+    const stop = this._stop
     this._record()
-    return profile
+    return stop()
   }
 
   encode (profile) {


### PR DESCRIPTION
The current profile must be stopped AFTER the next begins. This is because V8 will tear down the symbolizer thread when the active profile count reaches zero. This means the next profile started will spin up a new symbolizer thread. When this thread starts it streams in all the JIT location information which could block the JavaScript thread for a significant length of time.