### PR TITLE
fix grpc client instrumentation when service prop exists

### DIFF
--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -48,7 +48,7 @@ function createWrapMakeClientConstructor (tracer, config) {
 function wrapPackageDefinition (tracer, config, def) {
   for (const name in def) {
     if (def[name].format) continue
-    if (def[name].service) {
+    if (def[name].service && def[name].prototype) {
       wrapClientConstructor(tracer, config, def[name], def[name].service)
     } else {
       wrapPackageDefinition(tracer, config, def[name])

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -322,6 +322,14 @@ describe('Plugin', () => {
                 })
             })
 
+            it('should handle property named "service"', async () => {
+              const definition = loader.loadSync(`${__dirname}/hasservice.proto`)
+              const thing = grpc.loadPackageDefinition(definition).thing
+              await buildClient({
+                getUnary: (_, callback) => callback(null)
+              }, thing.service.ThingService)
+            })
+
             it('should handle a missing callback', async () => {
               const client = await buildClient({
                 getUnary: (_, callback) => callback()

--- a/packages/datadog-plugin-grpc/test/hasservice.proto
+++ b/packages/datadog-plugin-grpc/test/hasservice.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package thing.service;
+
+service ThingService {
+  rpc FindOne (ThingById) returns (Thing);
+  rpc FindMany (stream ThingById) returns (stream Thing);
+}
+
+message ThingById {
+  int32 id = 1;
+}
+
+message Thing {
+  int32 id = 1;
+  string name = 2;
+}


### PR DESCRIPTION
Fixes #1659 

Previously, this bit of code was incorrectly assuming every `.service` property was a constructor. That assumption was causing an exception to be thrown at startup.
