### PR TITLE
Allow additional spans to be passed to tracer

### DIFF
--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -9,8 +9,6 @@ beforeEach(() => {
 afterEach(() => {
   const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
   cy.task('dd:afterEach', {
-    testName: currentTest.fullTitle(),
-    testSuite: Cypress.mocha.getRootSuite().file,
     state: currentTest.state,
     error: currentTest.err
   })


### PR DESCRIPTION
### What does this PR do?
Adds functionality that allows to add additional spans to trace in Cypress plugin.

### Motivation
I need to add additional spans to Datadog for each of tests. With this change I can just add my own beforeEach and afterEach with proper task names.

### Additional Notes
My PR could be improved:
 - exporting `dd:afterEach` and `dd:beforeEach` as constants from `dd-trace-js` package
 - refactor `getTestSpanMetadata` a bit - arguments are beginning to look like a mess
