### PR TITLE
Fix typo in variable name.

### DIFF
--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -7,10 +7,10 @@ const Loader = require('./loader')
 const { isTrue } = require('./util')
 const plugins = require('./plugins')
 
-const disabldPlugins = process.env.DD_TRACE_DISABLED_PLUGINS
+const disabledPlugins = process.env.DD_TRACE_DISABLED_PLUGINS
 
 const collectDisabledPlugins = () => {
-  return new Set(disabldPlugins && disabldPlugins.split(',').map(plugin => plugin.trim()))
+  return new Set(disabledPlugins && disabledPlugins.split(',').map(plugin => plugin.trim()))
 }
 
 function cleanEnv (name) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix a typo in a variable name.
`disabldPlugins` -> `disabledPlugins`

### Motivation
<!-- What inspired you to submit this pull request? -->
Reading through code to take the magic out of the autoconfig, and stumbled upon what appears to be a typo in the rye 🍞. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
It's possible this is intentional. Just thought it looked sus 👀 , and figured worst case I'd get an understanding of motivation 😅 .