### PR TITLE
fix tedious tests using deprecated api for v14

### DIFF
--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -323,7 +323,6 @@ describe('Plugin', () => {
 
           it('should handle bulkload requests', done => {
             const bulkLoad = buildBulkLoad()
-            bulkLoad.addRow({ num: 5 })
 
             agent
               .use(traces => {
@@ -333,10 +332,10 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            connection.execBulkLoad(bulkLoad)
+            connection.execBulkLoad(bulkLoad, [{ num: 5 }])
           })
 
-          if (semver.intersects(version, '>=4.2.0')) {
+          if (semver.intersects(version, '>=4.2.0 <14')) {
             it('should handle streaming BulkLoad requests', done => {
               const bulkLoad = buildBulkLoad()
               const rowStream = bulkLoad.getRowStream()

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -335,7 +335,7 @@ describe('Plugin', () => {
             connection.execBulkLoad(bulkLoad, [{ num: 5 }])
           })
 
-          if (semver.intersects(version, '>=4.2.0 <14')) {
+          if (semver.intersects(version, '>=4.2.0') && !semver.intersects(version, '>=14')) {
             it('should handle streaming BulkLoad requests', done => {
               const bulkLoad = buildBulkLoad()
               const rowStream = bulkLoad.getRowStream()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `tedious` 14.x tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests started failing because some BulkLoad APIs have been removed.