### PR TITLE
add caching to random id generation

### DIFF
--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -10,7 +10,6 @@ describe('id', () => {
     seeds[0] = seeds[1] = 0xFF000000
 
     crypto = {
-      randomBytes: sinon.stub().returns(Buffer.from(seeds.buffer)),
       randomFillSync: data => {
         for (let i = 0; i < data.length / 8; i += 8) {
           data[i] = 0xFF

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -5,10 +5,6 @@ describe('id', () => {
   let crypto
 
   beforeEach(() => {
-    const seeds = new Uint32Array(2)
-
-    seeds[0] = seeds[1] = 0xFF000000
-
     crypto = {
       randomFillSync: data => {
         for (let i = 0; i < data.length / 8; i += 8) {

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -10,7 +10,20 @@ describe('id', () => {
     seeds[0] = seeds[1] = 0xFF000000
 
     crypto = {
-      randomBytes: sinon.stub().returns(Buffer.from(seeds.buffer))
+      randomBytes: sinon.stub().returns(Buffer.from(seeds.buffer)),
+      randomFillSync: data => {
+        for (let i = 0; i < data.length / 8; i += 8) {
+          data[i] = 0xFF
+          data[i + 1] = 0x00
+          data[i + 2] = 0xFF
+          data[i + 3] = 0x00
+          data[i + 4] = 0xFF
+          data[i + 5] = 0x00
+          data[i + 6] = 0xFF
+          data[i + 7] = 0x00
+        }
+        data
+      }
     }
 
     sinon.stub(Math, 'random')

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -7,7 +7,7 @@ describe('id', () => {
   beforeEach(() => {
     crypto = {
       randomFillSync: data => {
-        for (let i = 0; i < data.length / 8; i += 8) {
+        for (let i = 0; i < data.length; i += 8) {
           data[i] = 0xFF
           data[i + 1] = 0x00
           data[i + 2] = 0xFF
@@ -17,7 +17,6 @@ describe('id', () => {
           data[i + 6] = 0xFF
           data[i + 7] = 0x00
         }
-        data
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Optimize ID generation by adding a large buffer cache that is randomized with `randomFillSync` and reused for many IDs, which is faster than creating a new buffer and using `Math.random()` for every single ID.

### Motivation
<!-- What inspired you to submit this pull request? -->

I realized that this approach is faster while working on unrelated benchmarks. It's also the approach that Node uses internally for `crypto.randomUUID()`.