### PR TITLE
Fix CPU profiler latency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@datadog/native-metrics": "^1.0.1",
-    "@datadog/pprof": "^0.2.1",
+    "@datadog/pprof": "^0.3.0",
     "@datadog/sketches-js": "^1.0.4",
     "@types/node": "^10.12.18",
     "crypto-randomuuid": "^1.0.0",

--- a/packages/dd-trace/src/profiling/profilers/cpu.js
+++ b/packages/dd-trace/src/profiling/profilers/cpu.js
@@ -25,11 +25,7 @@ class NativeCpuProfiler {
 
   profile () {
     if (!this._stop) return
-    // Next profile MUST be started before previous ends otherwise V8 will tear
-    // down the symbolizer thread and start a new one when the next one starts.
-    const stop = this._stop
-    this._record()
-    return stop()
+    return this._stop(true)
   }
 
   encode (profile) {

--- a/packages/dd-trace/test/profiling/profilers/cpu.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/cpu.spec.js
@@ -74,7 +74,7 @@ describe('profilers/native/cpu', () => {
     expect(profile).to.equal('profile')
 
     sinon.assert.calledOnce(stop)
-    sinon.assert.calledTwice(pprof.time.start)
+    sinon.assert.calledOnce(pprof.time.start)
   })
 
   it('should encode profiles from the pprof time profiler', () => {


### PR DESCRIPTION
Depends on https://github.com/DataDog/pprof-nodejs/pull/13

The current profile must be stopped AFTER the next begins. This is because V8 will tear down the symbolizer thread when the active profile count reaches zero. This means the next profile started will spin up a new symbolizer thread. When this thread starts it streams in all the JIT location information which could block the JavaScript thread for a significant length of time.

However, pre-v16 versions of Node.js have a memory leak in V8 that requires disposing the profiler between each profile. This has been fixed in the pprof module by changing to reusing the stop function with an argument to specify if it should start a new profile when called. This allows the ordering to be rearranged depending on the Node.js version.