### PR TITLE
generate a little less garbage when adding tags

### DIFF
--- a/packages/dd-trace/src/encode/chunk.js
+++ b/packages/dd-trace/src/encode/chunk.js
@@ -17,9 +17,8 @@ class Chunk {
   push (...bytes) {
     this._reserve(bytes.length)
 
-    for (const byte of bytes) {
-      this.buffer[this.length++] = byte
-    }
+    this.buffer.set(bytes, this.length);
+    this.length += bytes.length;
   }
 
   write (value) {
@@ -27,12 +26,15 @@ class Chunk {
     const offset = this.length
 
     if (length < 0x20) { // fixstr
-      this.push(length | 0xa0)
+      this._reserve(length + 1)
+      this.buffer[this.length] = length | 0xa0
+      this.length += 1
     } else if (length < 0x100000000) { // str 32
-      this.push(0xdb, length >> 24, length >> 16, length >> 8, length)
+      this._reserve(length + 5)
+      this.buffer[this.length] = 0xdb
+      this.buffer.writeUInt32BE(length, this.length + 1)
+      this.length += 5
     }
-
-    this._reserve(length)
 
     this.length += this.buffer.utf8Write(value, this.length, length)
 

--- a/packages/dd-trace/src/tagger.js
+++ b/packages/dd-trace/src/tagger.js
@@ -5,32 +5,25 @@ const log = require('./log')
 function add (carrier, keyValuePairs) {
   if (!carrier || !keyValuePairs) return
 
-  if (typeof keyValuePairs === 'string') {
-    return add(
-      carrier,
-      keyValuePairs
-        .split(',')
-        .filter(tag => tag.indexOf(':') !== -1)
-        .reduce((prev, next) => {
-          const tag = next.split(':')
-          const key = tag[0].trim()
-          const value = tag.slice(1).join(':').trim()
-
-          prev[key] = value
-
-          return prev
-        }, {})
-    )
-  }
-
   if (Array.isArray(keyValuePairs)) {
     return keyValuePairs.forEach(tags => add(carrier, tags))
   }
 
   try {
-    Object.keys(keyValuePairs).forEach(key => {
-      carrier[key] = keyValuePairs[key]
-    })
+    if (typeof keyValuePairs === 'string') {
+      const segments = keyValuePairs.split(',')
+      for (const segment of segments) {
+        const separatorIndex = segment.indexOf(':')
+        if (separatorIndex === -1) continue
+
+        const key = segment.slice(0, separatorIndex)
+        const value = segment.slice(separatorIndex + 1)
+
+        carrier[key.trim()] = value.trim()
+      }
+    } else {
+      Object.assign(carrier, keyValuePairs)
+    }
   } catch (e) {
     log.error(e)
   }

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -22,7 +22,7 @@ class DatadogTracer extends Tracer {
   }
 
   trace (name, options, fn) {
-    options = Object.assign({}, {
+    options = Object.assign({
       childOf: this.scope().active()
     }, options)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Moves some stuff around to avoid allocating closures and excess arrays when adding tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

Extremely minor perf opt to reduce GC noise

### Additional Notes
<!-- Anything else we should know when reviewing? -->

this can be checked with `node --inspect-brk benchmark/dd-trace.js` and using the memory tooling.

I've attached 2 allocation tracking profiles I took:

[Archive.zip](https://github.com/DataDog/dd-trace-js/files/7469378/Archive.zip)

Numbers look pretty good but likely won't account for a huge amount overall.

Before:
<img width="1160" alt="Screen Shot 2021-11-03 at 12 00 16 PM" src="https://user-images.githubusercontent.com/234659/140119763-14dbb55a-09e2-4bd8-b9d1-7106b5059031.png">

After:
<img width="1164" alt="Screen Shot 2021-11-03 at 11 59 44 AM" src="https://user-images.githubusercontent.com/234659/140120036-6644d6fc-b5f4-4f88-8508-cedabc5a8f15.png">

