### PR TITLE
add a benchmark for plugin-dns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,8 @@ jobs:
 
   node-bench-sirun-profiler: *node-bench-sirun-base
 
+  node-bench-sirun-plugin-dns: *node-bench-sirun-base
+
   node-bench-sirun-all:
     docker:
       - image: node
@@ -841,6 +843,7 @@ workflows:
       - node-bench-sirun-scope: *matrix-exact-supported-node-versions
       - node-bench-sirun-exporting-pipeline: *matrix-exact-supported-node-versions
       - node-bench-sirun-profiler: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-dns: *matrix-exact-supported-node-versions
       - node-bench-sirun-all:
           requires:
             - node-bench-sirun-startup
@@ -855,6 +858,7 @@ workflows:
             - node-bench-sirun-scope
             - node-bench-sirun-exporting-pipeline
             - node-bench-sirun-profiler
+            - node-bench-sirun-plugin-dns
   upstream: &upstream-jobs
     jobs:
       # - node-upstream-node

--- a/benchmark/sirun/plugin-dns/README.md
+++ b/benchmark/sirun/plugin-dns/README.md
@@ -1,2 +1,2 @@
-Runs `dns.lookup('localhost', cb)` 1000 times. In the `with-tracer` variant,
-tracing is enabled. Iteration count is set to 100.
+Runs `dns.lookup('localhost', cb)` 10000 times. In the `with-tracer` variant,
+tracing is enabled. Iteration count is set to 10.

--- a/benchmark/sirun/plugin-dns/README.md
+++ b/benchmark/sirun/plugin-dns/README.md
@@ -1,0 +1,2 @@
+Runs `dns.lookup('localhost', cb)` 1000 times. In the `with-tracer` variant,
+tracing is enabled. Iteration count is set to 100.

--- a/benchmark/sirun/plugin-dns/index.js
+++ b/benchmark/sirun/plugin-dns/index.js
@@ -1,0 +1,14 @@
+'use strict'
+
+if (Number(process.env.USE_TRACER)) {
+  require('../../..').init()
+}
+
+const dns = require('dns')
+
+function testRun (count) {
+  if (++count === 1000) return
+  dns.lookup('localhost', () => testRun(count))
+}
+
+testRun(0)

--- a/benchmark/sirun/plugin-dns/index.js
+++ b/benchmark/sirun/plugin-dns/index.js
@@ -7,7 +7,7 @@ if (Number(process.env.USE_TRACER)) {
 const dns = require('dns')
 
 function testRun (count) {
-  if (++count === 1000) return
+  if (++count === 10000) return
   dns.lookup('localhost', () => testRun(count))
 }
 

--- a/benchmark/sirun/plugin-dns/meta.json
+++ b/benchmark/sirun/plugin-dns/meta.json
@@ -1,0 +1,15 @@
+{
+  "name": "plugin-dns",
+  "run": "node index.js",
+  "cachegrind": true,
+  "iterations": 100,
+  "variants": {
+    "control": {
+      "env": { "USE_TRACER": "0" }
+    },
+    "with-tracer": {
+      "baseline": "control",
+      "env": { "USE_TRACER": "1" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-dns/meta.json
+++ b/benchmark/sirun/plugin-dns/meta.json
@@ -2,7 +2,7 @@
   "name": "plugin-dns",
   "run": "node index.js",
   "cachegrind": true,
-  "iterations": 100,
+  "iterations": 10,
   "variants": {
     "control": {
       "env": { "USE_TRACER": "0" }


### PR DESCRIPTION
### What does this PR do?
adds a benchmark for plugin-dns

### Motivation
also serves as a baseline test for new plugin system, once that's in.