### PR TITLE
Update Typescript types to allow disabling of client or server in http plugins

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -972,12 +972,12 @@ declare namespace plugins {
     /**
      * Configuration for HTTP clients.
      */
-    client?: HttpClient | false,
+    client?: HttpClient | boolean,
 
     /**
      * Configuration for HTTP servers.
      */
-    server?: HttpServer | false
+    server?: HttpServer | boolean
 
     /**
      * Hooks to run before spans are finished.
@@ -1006,12 +1006,12 @@ declare namespace plugins {
     /**
      * Configuration for HTTP clients.
      */
-    client?: Http2Client | false,
+    client?: Http2Client | boolean,
 
     /**
      * Configuration for HTTP servers.
      */
-    server?: Http2Server | false
+    server?: Http2Server | boolean
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -972,12 +972,12 @@ declare namespace plugins {
     /**
      * Configuration for HTTP clients.
      */
-    client?: HttpClient,
+    client?: HttpClient | false,
 
     /**
      * Configuration for HTTP servers.
      */
-    server?: HttpServer
+    server?: HttpServer | false
 
     /**
      * Hooks to run before spans are finished.
@@ -1006,12 +1006,12 @@ declare namespace plugins {
     /**
      * Configuration for HTTP clients.
      */
-    client?: Http2Client,
+    client?: Http2Client | false,
 
     /**
      * Configuration for HTTP servers.
      */
-    server?: Http2Server
+    server?: Http2Server | false
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
Update the Typescript types for the `http` and `http2` plugin configuration to allow passing `false` to either `client` or `server` to disable them.

### Motivation
The plugins support individually disabling the `client` or `server` by passing in `false` for their configuration. However, this is not reflected in the Typescript types or generated documentation.

### Additional Notes
The types for the configuration of the `client` and `server` properties allow setting the `enabled`  property but I don't believe the code honors this when setting it to `false`?