### PR TITLE
Appsec response reporting

### DIFF
--- a/packages/dd-trace/src/appsec/addresses.js
+++ b/packages/dd-trace/src/appsec/addresses.js
@@ -5,5 +5,7 @@ module.exports = {
   HTTP_INCOMING_HEADERS: 'server.request.headers.no_cookies',
   HTTP_INCOMING_METHOD: 'server.request.method',
   HTTP_INCOMING_REMOTE_IP: 'server.request.client_ip',
-  HTTP_INCOMING_REMOTE_PORT: 'server.request.client_port'
+  HTTP_INCOMING_REMOTE_PORT: 'server.request.client_port',
+  HTTP_INCOMING_RESPONSE_CODE: 'server.response.status',
+  HTTP_INCOMING_RESPONSE_HEADERS: 'server.response.headers.no_cookies'
 }

--- a/packages/dd-trace/src/appsec/callbacks/ddwaf.js
+++ b/packages/dd-trace/src/appsec/callbacks/ddwaf.js
@@ -36,7 +36,7 @@ class WAFCallback {
     // closures are faster than binds
     const self = this
     const method = (params, store) => {
-      self.action(params, store)
+      return self.action(params, store)
     }
 
     // might be its own class with more info later
@@ -103,7 +103,7 @@ class WAFCallback {
           delete param.highlight
         }
 
-        Reporter.reportAttack(point.rule, ruleMatch, false)
+        Reporter.reportAttack(point.rule, ruleMatch)
       }
     }
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -73,8 +73,8 @@ function incomingHttpEndTranslator (data) {
   delete headers['set-cookie']
 
   Gateway.propagate({
-    [Addresses.HTTP_INCOMING_RESPONSE_CODE]: data.res.statusCode,
-    [Addresses.HTTP_INCOMING_RESPONSE_HEADERS]: headers
+    [addresses.HTTP_INCOMING_RESPONSE_CODE]: data.res.statusCode,
+    [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: headers
   }, context)
 
   Reporter.finishAttacks(context)
@@ -82,7 +82,9 @@ function incomingHttpEndTranslator (data) {
 
 function disable () {
   RuleManager.clearAllRules()
-  if (INCOMING_HTTP_REQUEST_START.hasSubscribers) INCOMING_HTTP_REQUEST_START.unsubscribe(incomingHttpTranslator)
+
+  if (INCOMING_HTTP_REQUEST_START.hasSubscribers) INCOMING_HTTP_REQUEST_START.unsubscribe(incomingHttpStartTranslator)
+  if (INCOMING_HTTP_REQUEST_END.hasSubscribers) INCOMING_HTTP_REQUEST_END.unsubscribe(incomingHttpEndTranslator)
 
   const tags = global._ddtrace._tracer._tags
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -64,6 +64,7 @@ function incomingHttpEndTranslator (data) {
 
   if (!context) return
 
+  // TODO: this doesn't support headers sent with res.writeHead()
   const headers = Object.assign({}, data.res.getHeaders())
   delete headers['set-cookie']
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const log = require('../log')
 const RuleManager = require('./rule_manager')
-const { INCOMING_HTTP_REQUEST_START } = require('../gateway/channels')
+const { INCOMING_HTTP_REQUEST_START, INCOMING_HTTP_REQUEST_END } = require('../gateway/channels')
 const Gateway = require('../gateway/engine/index')
 const Addresses = require('./addresses')
 const Reporter = require('./reporter')
@@ -18,7 +18,8 @@ function enable (config) {
 
     RuleManager.applyRules(rules)
 
-    INCOMING_HTTP_REQUEST_START.subscribe(incomingHttpTranslator)
+    INCOMING_HTTP_REQUEST_START.subscribe(incomingHttpStartTranslator)
+    INCOMING_HTTP_REQUEST_END.subscribe(incomingHttpEndTranslator)
 
     config.tags['_dd.appsec.enabled'] = 1
     config.tags['_dd.runtime_family'] = 'nodejs'
@@ -29,6 +30,8 @@ function enable (config) {
     Gateway.manager.addresses.add(Addresses.HTTP_INCOMING_METHOD)
     Gateway.manager.addresses.add(Addresses.HTTP_INCOMING_REMOTE_IP)
     Gateway.manager.addresses.add(Addresses.HTTP_INCOMING_REMOTE_PORT)
+    Gateway.manager.addresses.add(Addresses.HTTP_INCOMING_RESPONSE_CODE)
+    Gateway.manager.addresses.add(Addresses.HTTP_INCOMING_RESPONSE_HEADERS)
 
     Reporter.scheduler.start()
   } catch (err) {
@@ -36,7 +39,7 @@ function enable (config) {
   }
 }
 
-function incomingHttpTranslator (data) {
+function incomingHttpStartTranslator (data) {
   const store = Gateway.startContext()
 
   store.set('req', data.req)
@@ -56,6 +59,22 @@ function incomingHttpTranslator (data) {
   }, context)
 }
 
+function incomingHttpEndTranslator (data) {
+  const context = Gateway.getContext()
+
+  if (!context) return
+
+  const headers = Object.assign({}, data.res.getHeaders())
+  delete headers['set-cookie']
+
+  Gateway.propagate({
+    [Addresses.HTTP_INCOMING_RESPONSE_CODE]: data.res.statusCode,
+    [Addresses.HTTP_INCOMING_RESPONSE_HEADERS]: headers
+  }, context)
+
+  Reporter.finishAttacks(context)
+}
+
 function disable () {
   RuleManager.clearAllRules()
   if (INCOMING_HTTP_REQUEST_START.hasSubscribers) INCOMING_HTTP_REQUEST_START.unsubscribe(incomingHttpTranslator)
@@ -72,5 +91,6 @@ function disable () {
 module.exports = {
   enable,
   disable,
-  incomingHttpTranslator
+  incomingHttpStartTranslator,
+  incomingHttpEndTranslator
 }

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -12,7 +12,7 @@ const libVersion = require('../../lib/version')
 const FLUSH_INTERVAL = 2e3
 const MAX_EVENT_BACKLOG = 1e6
 
-const REQUEST_HEADERS_WHITELIST = [
+const REQUEST_HEADERS_PASSLIST = [
   'accept',
   'accept-encoding',
   'accept-language',
@@ -33,7 +33,7 @@ const REQUEST_HEADERS_WHITELIST = [
   'x-real-ip'
 ]
 
-const RESPONSE_HEADERS_WHITELIST = [
+const RESPONSE_HEADERS_PASSLIST = [
   'content-encoding',
   'content-language',
   'content-length',
@@ -71,7 +71,7 @@ function resolveHTTPRequest (context) {
     // resource: context.resolve(addresses.HTTP_INCOMING_ROUTE),
     remote_ip: context.resolve(addresses.HTTP_INCOMING_REMOTE_IP),
     remote_port: context.resolve(addresses.HTTP_INCOMING_REMOTE_PORT),
-    headers: filterHeaders(headers, REQUEST_HEADERS_WHITELIST)
+    headers: filterHeaders(headers, REQUEST_HEADERS_PASSLIST)
   }
 }
 
@@ -82,18 +82,18 @@ function resolveHTTPResponse (context) {
 
   return {
     status: context.resolve(addresses.HTTP_INCOMING_RESPONSE_CODE),
-    headers: filterHeaders(headers, RESPONSE_HEADERS_WHITELIST),
+    headers: filterHeaders(headers, RESPONSE_HEADERS_PASSLIST),
     blocked: false
   }
 }
 
-function filterHeaders (headers, whitelist) {
+function filterHeaders (headers, passlist) {
   const result = {}
 
   if (!headers) return result
 
-  for (let i = 0; i < whitelist.length; ++i) {
-    const headerName = whitelist[i]
+  for (let i = 0; i < passlist.length; ++i) {
+    const headerName = passlist[i]
 
     if (headers[headerName]) {
       result[headerName] = [ headers[headerName].toString() ]

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -78,10 +78,10 @@ function resolveHTTPRequest (context) {
 function resolveHTTPResponse (context) {
   if (!context) return {}
 
-  const headers = context.resolve(Addresses.HTTP_INCOMING_RESPONSE_HEADERS)
+  const headers = context.resolve(addresses.HTTP_INCOMING_RESPONSE_HEADERS)
 
   return {
-    status: context.resolve(Addresses.HTTP_INCOMING_RESPONSE_CODE),
+    status: context.resolve(addresses.HTTP_INCOMING_RESPONSE_CODE),
     headers: filterHeaders(headers, RESPONSE_HEADERS_WHITELIST),
     blocked: false
   }

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -97,7 +97,7 @@ function filterHeaders (headers, whitelist) {
     const headerName = whitelist[i]
 
     if (headers[headerName]) {
-      result[headerName] = [ headers[headerName] ]
+      result[headerName] = [ headers[headerName].toString() ]
     }
   }
 

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -197,7 +197,9 @@ function finishAttacks (context) {
 
   const resolvedResponse = resolveHTTPResponse(context)
 
-  for (const event of list) {
+  for (let i = 0; i < list.length; ++i) {
+    const event = list[i]
+
     event.context.http.response = resolvedResponse
 
     events.add(event)

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -183,6 +183,7 @@ function reportAttack (rule, ruleMatch) {
       toFinish.set(context, [ event ])
     }
   } else {
+    // we know this will not get finished so we commit it directly
     events.add(event)
   }
 

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -64,12 +64,11 @@ function resolveHTTPRequest (context) {
     // resource: context.resolve(Addresses.HTTP_INCOMING_ROUTE),
     remote_ip: context.resolve(Addresses.HTTP_INCOMING_REMOTE_IP),
     remote_port: context.resolve(Addresses.HTTP_INCOMING_REMOTE_PORT),
-    headers: getHeadersToSend(headers, REQUEST_HEADERS_WHITELIST)
+    headers: filterHeaders(headers, REQUEST_HEADERS_WHITELIST)
   }
 }
 
-
-function getHeadersToSend (headers, whitelist) {
+function filterHeaders (headers, whitelist) {
   const result = {}
 
   if (!headers) return result
@@ -216,7 +215,7 @@ const scheduler = new Scheduler(flush, FLUSH_INTERVAL)
 module.exports = {
   events,
   resolveHTTPRequest,
-  getHeadersToSend,
+  filterHeaders,
   getTracerData,
   reportAttack,
   flush,

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -176,7 +176,13 @@ function reportAttack (rule, ruleMatch) {
   }
 
   if (context) {
-    toFinish.set(context, event)
+    const list = toFinish.get(context)
+
+    if (list) {
+      list.push(event)
+    } else {
+      toFinish.set(context, [ event ])
+    }
   } else {
     events.add(event)
   }
@@ -185,13 +191,18 @@ function reportAttack (rule, ruleMatch) {
 }
 
 function finishAttacks (context) {
-  const event = toFinish.get(context)
+  const list = toFinish.get(context)
 
-  if (!event) return false
+  if (!list) return false
 
-  event.context.http.response = resolveHTTPResponse(context)
+  const resolvedResponse = resolveHTTPResponse(context)
 
-  events.add(event)
+  for (const event of list) {
+    event.context.http.response = resolvedResponse
+
+    events.add(event)
+  }
+
   toFinish.delete(context)
 }
 

--- a/packages/dd-trace/test/appsec/callbacks/ddwaf.spec.js
+++ b/packages/dd-trace/test/appsec/callbacks/ddwaf.spec.js
@@ -80,7 +80,7 @@ describe('WAFCallback', () => {
 
       sinon.stub(WAFCallback, 'loadDDWAF').returns(ddwaf)
 
-      sinon.stub(WAFCallback.prototype, 'action')
+      sinon.stub(WAFCallback.prototype, 'action').returns('result')
 
       sinon.stub(Gateway.manager, 'addSubscription')
 
@@ -111,9 +111,10 @@ describe('WAFCallback', () => {
       ])
       expect(thirdCall).to.have.property('callback').that.equals(callback)
 
-      callback.method('params', 'store')
+      const result = callback.method('params', 'store')
       expect(WAFCallback.prototype.action).to.have.been.calledOnceWithExactly('params', 'store')
       expect(WAFCallback.prototype.action).to.have.been.calledOn(waf)
+      expect(result).to.equal('result')
     })
   })
 
@@ -277,7 +278,7 @@ describe('WAFCallback', () => {
             value: '/wordpress?<script>'
           }],
           highlight: ['arachni/v', 'wordpress', '<script']
-        }, false)
+        })
 
         expect(Reporter.reportAttack.secondCall).to.have.been.calledWithExactly({
           id: 'ua-1337-rx',
@@ -295,7 +296,7 @@ describe('WAFCallback', () => {
             value: '/PG_SLEEP 1'
           }],
           highlight: []
-        }, false)
+        })
       })
 
       it('should do nothing when passed no action', () => {

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -148,4 +148,58 @@ describe('AppSec Index', () => {
       }, context)
     })
   })
+
+  describe('incomingHttpEndTranslator', () => {
+    it('should do nothing when context is not found', () => {
+      sinon.stub(Gateway, 'getContext').returns(null)
+
+      const req = {}
+      const res = {
+        getHeaders: () => ({
+          'content-type': 'application/json',
+          'content-lenght': 42
+        }),
+        statusCode: 201
+      }
+
+      sinon.stub(Gateway, 'propagate')
+      sinon.stub(Reporter, 'finishAttacks')
+
+      AppSec.incomingHttpEndTranslator({ req, res })
+
+      expect(Gateway.getContext).to.have.been.calledOnce
+      expect(Gateway.propagate).to.not.have.been.called
+      expect(Reporter.finishAttacks).to.not.have.been.called
+    })
+
+    it('should propagate incoming http end data', () => {
+      const context = {}
+
+      sinon.stub(Gateway, 'getContext').returns(context)
+
+      const req = {}
+      const res = {
+        getHeaders: () => ({
+          'content-type': 'application/json',
+          'content-lenght': 42
+        }),
+        statusCode: 201
+      }
+
+      sinon.stub(Gateway, 'propagate')
+      sinon.stub(Reporter, 'finishAttacks')
+
+      AppSec.incomingHttpEndTranslator({ req, res })
+
+      expect(Gateway.getContext).to.have.been.calledOnce
+      expect(Gateway.propagate).to.have.been.calledOnceWithExactly({
+        'server.response.status': 201,
+        'server.response.headers.no_cookies': {
+          'content-type': 'application/json',
+          'content-lenght': 42
+        }
+      }, context)
+      expect(Reporter.finishAttacks).to.have.been.calledOnceWithExactly(context)
+    })
+  })
 })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -5,7 +5,7 @@ const path = require('path')
 const log = require('../../src/log')
 const AppSec = require('../../src/appsec')
 const RuleManager = require('../../src/appsec/rule_manager')
-const { INCOMING_HTTP_REQUEST_START } = require('../../src/gateway/channels')
+const { INCOMING_HTTP_REQUEST_START, INCOMING_HTTP_REQUEST_END } = require('../../src/gateway/channels')
 const Gateway = require('../../src/gateway/engine/index')
 const addresses = require('../../src/appsec/addresses')
 const Reporter = require('../../src/appsec/reporter')
@@ -20,6 +20,7 @@ describe('AppSec Index', () => {
     sinon.stub(fs, 'readFileSync').returns('{"rules": [{"a": 1}]}')
     sinon.stub(RuleManager, 'applyRules')
     sinon.stub(INCOMING_HTTP_REQUEST_START, 'subscribe')
+    sinon.stub(INCOMING_HTTP_REQUEST_END, 'subscribe')
     sinon.stub(Reporter.scheduler, 'start')
     Gateway.manager.clear()
   })
@@ -37,7 +38,9 @@ describe('AppSec Index', () => {
       const rulesPath = path.resolve(path.join(__dirname, '..', '..', 'src', 'appsec', 'recommended.json'))
       expect(fs.readFileSync).to.have.been.calledOnceWithExactly(rulesPath)
       expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] })
-      expect(INCOMING_HTTP_REQUEST_START.subscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpTranslator)
+      expect(INCOMING_HTTP_REQUEST_START.subscribe)
+        .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
+      expect(INCOMING_HTTP_REQUEST_END.subscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpEndTranslator)
       expect(config.tags).to.deep.equal({
         '_dd.appsec.enabled': 1,
         '_dd.runtime_family': 'nodejs'
@@ -47,7 +50,9 @@ describe('AppSec Index', () => {
         addresses.HTTP_INCOMING_HEADERS,
         addresses.HTTP_INCOMING_METHOD,
         addresses.HTTP_INCOMING_REMOTE_IP,
-        addresses.HTTP_INCOMING_REMOTE_PORT
+        addresses.HTTP_INCOMING_REMOTE_PORT,
+        addresses.HTTP_INCOMING_RESPONSE_CODE,
+        addresses.HTTP_INCOMING_RESPONSE_HEADERS
       )
       expect(Reporter.scheduler.start).to.have.been.calledOnce
     })
@@ -61,6 +66,7 @@ describe('AppSec Index', () => {
 
       expect(log.error).to.have.been.calledOnceWithExactly('Unable to apply AppSec rules: Error: Invalid Rules')
       expect(INCOMING_HTTP_REQUEST_START.subscribe).to.not.have.been.called
+      expect(INCOMING_HTTP_REQUEST_END.subscribe).to.not.have.been.called
       expect(config.tags).to.be.empty
       expect(Gateway.manager.addresses).to.be.empty
       expect(Reporter.scheduler.start).to.not.have.been.called
@@ -71,16 +77,20 @@ describe('AppSec Index', () => {
     it('should disable AppSec', () => {
       // we need real DC for this test
       INCOMING_HTTP_REQUEST_START.subscribe.restore()
+      INCOMING_HTTP_REQUEST_END.subscribe.restore()
 
       AppSec.enable(config)
 
       sinon.stub(RuleManager, 'clearAllRules')
       sinon.spy(INCOMING_HTTP_REQUEST_START, 'unsubscribe')
+      sinon.spy(INCOMING_HTTP_REQUEST_END, 'unsubscribe')
 
       AppSec.disable()
 
       expect(RuleManager.clearAllRules).to.have.been.calledOnce
-      expect(INCOMING_HTTP_REQUEST_START.unsubscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpTranslator)
+      expect(INCOMING_HTTP_REQUEST_START.unsubscribe)
+        .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
+      expect(INCOMING_HTTP_REQUEST_END.unsubscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpEndTranslator)
       expect(config.tags).to.not.have.any.keys('_dd.appsec.enabled', '_dd.runtime_family')
     })
 
@@ -96,8 +106,8 @@ describe('AppSec Index', () => {
     })
   })
 
-  describe('incomingHttpTranslator', () => {
-    it('should propagate incoming http data', () => {
+  describe('incomingHttpStartTranslator', () => {
+    it('should propagate incoming http start data', () => {
       const store = new Map()
       sinon.stub(Gateway, 'startContext').returns(store)
 
@@ -121,7 +131,7 @@ describe('AppSec Index', () => {
 
       sinon.stub(Gateway, 'propagate')
 
-      AppSec.incomingHttpTranslator({ req, res })
+      AppSec.incomingHttpStartTranslator({ req, res })
 
       expect(Gateway.startContext).to.have.been.calledOnce
       expect(store.get('req')).to.equal(req)

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -25,6 +25,7 @@ describe('AppSec Index', () => {
   afterEach(() => {
     sinon.restore()
     AppSec.disable()
+    delete global._ddtrace
   })
 
   describe('enable', () => {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -353,6 +353,7 @@ describe('reporter', () => {
       const result = Reporter.finishAttacks({})
 
       expect(result).to.be.false
+      expect(Reporter.events).to.be.empty
     })
 
     it('should add http response data inside events', () => {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -90,6 +90,38 @@ describe('reporter', () => {
     })
   })
 
+  describe('resolveHTTPResponse', () => {
+    it('should return empty object when passed no context', () => {
+      const result = Reporter.resolveHTTPResponse()
+
+      expect(result).to.be.an('object').that.is.empty
+    })
+
+    it('should return resolved addresses', () => {
+      const context = new Context()
+
+      context.store = new Map(Object.entries({
+        [addresses.HTTP_INCOMING_RESPONSE_CODE]: 201,
+        [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: {
+          'content-type': 'application/json',
+          'content-length': 42,
+          secret: 'password'
+        }
+      }))
+
+      const result = Reporter.resolveHTTPResponse(context)
+
+      expect(result).to.deep.equal({
+        status: 201,
+        headers: {
+          'content-type': [ 'application/json' ],
+          'content-length': [ '42' ]
+        },
+        blocked: false
+      })
+    })
+  })
+
   describe('filterHeaders', () => {
     it('should return empty object when providing no headers', () => {
       const result = Reporter.filterHeaders(null)

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -6,11 +6,26 @@ const als = require('../../src/gateway/als')
 const Addresses = require('../../src/appsec/addresses')
 const log = require('../../src/log')
 const URL = require('url').URL
+const os = require('os')
 
 const MAX_EVENT_BACKLOG = 1e6
 
 describe('reporter', () => {
   let scope
+
+  function stubActiveSpan () {
+    const span = {
+      setTag: sinon.stub(),
+      context: sinon.stub().returns({
+        toSpanId: sinon.stub().returns('spanId'),
+        toTraceId: sinon.stub().returns('traceId')
+      })
+    }
+
+    sinon.stub(scope, 'active').returns(span)
+
+    return span
+  }
 
   beforeEach(() => {
     scope = {
@@ -33,6 +48,7 @@ describe('reporter', () => {
     Engine.manager.clear()
     als.exit(cb)
     Reporter.events.clear()
+    delete global._ddtrace
   })
 
   describe('resolveHTTPAddresses', () => {
@@ -118,20 +134,20 @@ describe('reporter', () => {
 
   describe('getTracerData', () => {
     it('should get tracer data with active span', () => {
-      const tracer = require('../../').init({ plugins: false })
-      const span = tracer.startSpan('test')
+      const span = stubActiveSpan()
 
-      sinon.spy(span, 'setTag')
-      sinon.stub(scope, 'active').callsFake(() => tracer.scope().active())
+      const result = Reporter.getTracerData()
 
-      tracer.scope().activate(span, () => {
-        const result = Reporter.getTracerData()
-
-        expect(span.setTag).to.have.been.calledTwice
-        expect(span.setTag.firstCall).to.have.been.calledWithExactly('manual.keep')
-        expect(span.setTag.secondCall).to.have.been.calledWithExactly('appsec.event', true)
-        expect(result.spanId).to.not.be.empty
-        expect(result.traceId).to.not.be.empty
+      expect(span.setTag).to.have.been.calledTwice
+      expect(span.setTag.firstCall).to.have.been.calledWithExactly('manual.keep')
+      expect(span.setTag.secondCall).to.have.been.calledWithExactly('appsec.event', true)
+      expect(result).to.deep.equal({
+        serviceName: 'service',
+        serviceEnv: 'env',
+        serviceVersion: 'version',
+        tags: ['a:1', 'b:2'],
+        spanId: 'spanId',
+        traceId: 'traceId'
       })
     })
 
@@ -205,81 +221,78 @@ describe('reporter', () => {
         [Addresses.HTTP_INCOMING_REMOTE_PORT]: 1337
       }))
 
-      const tracer = require('../../').init({ plugins: false })
-      const span = tracer.startSpan('test')
+      stubActiveSpan()
 
-      sinon.stub(scope, 'active').callsFake(() => tracer.scope().active())
+      const event = Reporter.reportAttack(rule, ruleMatch, false)
 
-      tracer.scope().activate(span, () => {
-        const event = Reporter.reportAttack(rule, ruleMatch, false)
+      expect(Reporter.events).to.have.all.keys(event)
 
-        expect(Reporter.events).to.have.all.keys(event)
-
-        expect(event).to.have.property('event_id').that.is.a('string')
-        expect(event).to.have.property('detected_at').that.is.a('string')
-        expect(event.rule).to.equal(rule)
-        expect(event.rule_match).to.equal(ruleMatch)
-        expect(event).to.deep.include({
-          event_type: 'appsec',
-          event_version: '1.0.0',
-          rule: {
-            id: 'ruleId',
-            name: 'ruleName',
-            tags: {
-              type: 'ruleType',
-              category: 'ruleCategory'
-            }
-          },
-          rule_match: {
-            operator: 'matchOperator',
-            operator_value: 'matchOperatorValue',
-            parameters: [{
-              address: 'server.request.uri.raw',
-              key_path: [],
-              value: '../..'
-            }, {
-              address: 'server.request.headers.no_cookies',
-              key_path: ['user-agent'],
-              value: 'Arachni/v1'
-            }],
-            highlight: [
-              'numero_uno',
-              'numero_dos'
-            ]
+      expect(event).to.have.property('event_id').that.is.a('string')
+      expect(event).to.have.property('detected_at').that.is.a('string')
+      expect(event.rule).to.equal(rule)
+      expect(event.rule_match).to.equal(ruleMatch)
+      expect(event).to.deep.include({
+        event_type: 'appsec',
+        event_version: '1.0.0',
+        rule: {
+          id: 'ruleId',
+          name: 'ruleName',
+          tags: {
+            type: 'ruleType',
+            category: 'ruleCategory'
           }
-        })
-
-        expect(event).to.have.nested.property('context.host.context_version').that.equals('0.1.0')
-        expect(event).to.have.nested.property('context.host.os_type').that.is.a('string')
-        expect(event).to.have.nested.property('context.host.hostname').that.is.a('string')
-
-        expect(event).to.have.nested.property('context.http.context_version').that.equals('1.0.0')
-        expect(event).to.have.nested.property('context.http.request.method').that.is.a('string')
-        expect(event).to.have.nested.property('context.http.request.url').that.is.a('string')
-        // expect(event).to.have.nested.property('context.http.request.ressource').that.is.a('string')
-        expect(event).to.have.nested.property('context.http.request.remote_ip').that.is.a('string')
-        expect(event).to.have.nested.property('context.http.request.remote_port').that.is.a('number')
-        expect(event).to.have.nested.property('context.http.request.headers').that.is.an('object')
-
-        expect(event).to.have.nested.property('context.library.context_version').that.equals('0.1.0')
-        expect(event).to.have.nested.property('context.library.runtime_type').that.equals('nodejs')
-        expect(event).to.have.nested.property('context.library.runtime_version').that.is.a('string')
-        expect(event).to.have.nested.property('context.library.lib_version').that.is.a('string')
-
-        expect(event).to.have.nested.property('context.service.context_version').that.equals('0.1.0')
-        expect(event).to.have.nested.property('context.service.name').that.is.a('string')
-        expect(event).to.have.nested.property('context.service.environment').that.is.a('string')
-        expect(event).to.have.nested.property('context.service.version').that.is.a('string')
-
-        expect(event).to.have.nested.property('context.span.context_version').that.equals('0.1.0')
-        expect(event).to.have.nested.property('context.span.id').that.is.a('string')
-
-        expect(event).to.have.nested.property('context.tags.context_version').that.equals('0.1.0')
-        expect(event).to.have.nested.property('context.tags.values').that.is.an('array')
-
-        expect(event).to.have.nested.property('context.trace.context_version').that.equals('0.1.0')
-        expect(event).to.have.nested.property('context.trace.id').that.is.a('string')
+        },
+        rule_match: {
+          operator: 'matchOperator',
+          operator_value: 'matchOperatorValue',
+          parameters: [{
+            address: 'server.request.uri.raw',
+            key_path: [],
+            value: '../..'
+          }, {
+            address: 'server.request.headers.no_cookies',
+            key_path: ['user-agent'],
+            value: 'Arachni/v1'
+          }],
+          highlight: [
+            'numero_uno',
+            'numero_dos'
+          ]
+        }
       })
+
+      expect(event).to.have.nested.property('context.host.context_version').that.equals('0.1.0')
+      expect(event).to.have.nested.property('context.host.os_type').that.equals(os.type())
+      expect(event).to.have.nested.property('context.host.hostname').that.equals(os.hostname())
+
+      expect(event).to.have.nested.property('context.http.context_version').that.equals('1.0.0')
+      expect(event).to.have.nested.property('context.http.request.method').that.equals('GET')
+      expect(event).to.have.nested.property('context.http.request.url').that.equals('http://localhost/path')
+      // expect(event).to.have.nested.property('context.http.request.ressource').that.equals('')
+      expect(event).to.have.nested.property('context.http.request.remote_ip').that.equals('8.8.8.8')
+      expect(event).to.have.nested.property('context.http.request.remote_port').that.equals(1337)
+      expect(event).to.have.nested.property('context.http.request.headers').that.deep.equals({
+        'user-agent': ['arachni']
+      })
+
+      expect(event).to.have.nested.property('context.library.context_version').that.equals('0.1.0')
+      expect(event).to.have.nested.property('context.library.runtime_type').that.equals('nodejs')
+      expect(event).to.have.nested.property('context.library.runtime_version').that.equals(process.version)
+      expect(event).to.have.nested.property('context.library.lib_version').that.is.a('string')
+
+      expect(event).to.have.nested.property('context.service.context_version').that.equals('0.1.0')
+      expect(event).to.have.nested.property('context.service.name').that.equals('service')
+      expect(event).to.have.nested.property('context.service.environment').that.equals('env')
+      expect(event).to.have.nested.property('context.service.version').that.equals('version')
+
+      expect(event).to.have.nested.property('context.span.context_version').that.equals('0.1.0')
+      expect(event).to.have.nested.property('context.span.id').that.equals('spanId')
+
+      expect(event).to.have.nested.property('context.tags.context_version').that.equals('0.1.0')
+      expect(event).to.have.nested.property('context.tags.values').that.deep.equals(['a:1', 'b:2'])
+
+      expect(event).to.have.nested.property('context.trace.context_version').that.equals('0.1.0')
+      expect(event).to.have.nested.property('context.trace.id').that.equals('traceId')
     })
   })
 

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -129,7 +129,7 @@ describe('reporter', () => {
       expect(result).to.be.an('object').that.is.empty
     })
 
-    it('should filter and format headers from whitelist', () => {
+    it('should filter and format headers from passlist', () => {
       const result = Reporter.filterHeaders({
         host: 'localhost',
         'user-agent': 42,

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -166,7 +166,7 @@ describe('reporter', () => {
 
   describe('reportAttack', () => {
     it('should do nothing when backlog is full', () => {
-      Reporter.reportAttack({}, {}, false)
+      Reporter.reportAttack({}, {})
 
       expect(Reporter.events.size).to.equal(1)
 
@@ -174,7 +174,7 @@ describe('reporter', () => {
 
       expect(Reporter.events.size).to.equal(MAX_EVENT_BACKLOG + 1)
 
-      Reporter.reportAttack({}, {}, false)
+      Reporter.reportAttack({}, {})
 
       expect(Reporter.events.size).to.equal(MAX_EVENT_BACKLOG + 1)
     })
@@ -224,7 +224,7 @@ describe('reporter', () => {
 
       stubActiveSpan()
 
-      const event = Reporter.reportAttack(rule, ruleMatch, false)
+      const event = Reporter.reportAttack(rule, ruleMatch)
 
       expect(Reporter.events).to.have.all.keys(event)
 


### PR DESCRIPTION
### What does this PR do?
Enables AppSec to report http response data by storing events until the response is over, then sending them
