### PR TITLE
add integration tests against bundlers and browsers

### DIFF
--- a/empty.js
+++ b/empty.js
@@ -1,0 +1,12 @@
+// this file intentionally empty for bundlers that end up including dd-trace-js
+// when building for browsers, this file should only be gotten to by the
+// "exports" field of package.json, if you are in the browser and see this
+// file, it likely means something imported dd-trace-js accidentally.
+// dd-trace-js does not currently support running inside of browsers.
+
+// a minimal shim is here to avoid errors if people do manage to
+// import dd-trace-js improperly but it should avoid errors.
+exports.default = exports;
+exports.init = ({
+    init() {}
+}).init;

--- a/integration-tests/browsers/README.md
+++ b/integration-tests/browsers/README.md
@@ -1,0 +1,5 @@
+This test is a bit specialized. It is testing how builds are performed against
+bundlers. Many JS CDNs use bundlers and might allow importing dd-trace into a
+browser where it isn't supposed to be used. These tests ensure no errors occur
+when doing so and check that the bundlers still work when targeting node if they
+support node.

--- a/integration-tests/browsers/bundle-entrypoint.js
+++ b/integration-tests/browsers/bundle-entrypoint.js
@@ -1,0 +1,1 @@
+require('dd-trace').init();

--- a/integration-tests/browsers/index.spec.js
+++ b/integration-tests/browsers/index.spec.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const { expect } = require('chai')
+const { execSync, spawnSync } = require('child_process')
+const { readFileSync, symlinkSync, mkdirSync, unlinkSync } = require('fs')
+const { platform } = require('os')
+const { resolve } = require('path')
+const puppeteer = require('puppeteer')
+
+// we can't use self import unfortunately for a few reasons so we setup our own local link
+mkdirSync(resolve(__dirname, 'node_modules'), {
+  recursive: true
+})
+// we have to recreate this everytime due to windows junctions being unsafe for
+// move operations
+try {
+  unlinkSync(resolve(__dirname, 'node_modules', 'dd-trace'))
+} catch {}
+symlinkSync(
+  resolve(__dirname, '..', '..'),
+  resolve(__dirname, 'node_modules', 'dd-trace'),
+  platform() === 'win32' ? 'junction' : 'file'
+)
+
+for (const buildCommand of [
+  "npx rollup -c rollup.config.mjs --validate",
+  "npx webpack --target web --output-filename webpack.js",
+  "npx webpack --target node --output-filename webpack-node.js",
+  "npx esbuild --bundle --outfile=./out/esbuild.js ./bundle-entrypoint.js",
+  "npx esbuild --bundle --outfile=./out/esbuild-node.js --platform=node ./bundle-entrypoint.js"
+]) {
+  execSync(buildCommand, {
+    cwd: __dirname
+  })
+}
+
+
+function createTestForBundler(outFileLocation) {
+  return async function () {
+    this.timeout(20e3)
+
+    const browser = await puppeteer.launch()
+    const page = await browser.newPage()
+    await page.goto('about:blank')
+
+    const pageError = new Promise((f, r) => {
+      page.on('pageerror', r)
+    })
+    const error = new Promise((f, r) => {
+      page.on('error', r)
+    })
+
+    const fn = eval(`() => {
+      ${readFileSync(resolve(__dirname, outFileLocation), 'utf8')}
+    }`)
+  
+    // execute standard javascript in the context of the page.
+    const result = page.evaluate(fn);
+
+    try {
+      await Promise.race([
+        result,
+        pageError,
+        error
+      ])
+      const typeofDDTrace = await page.evaluate(() => {
+        return typeof this._ddtrace
+      })
+
+      expect(typeofDDTrace).to.equal('undefined')
+    } finally {
+      await browser.close()
+    }
+  }
+}
+
+function createTestForNode(outFileLocation) {
+  return function () {
+    this.timeout(20e3)
+
+    const result = spawnSync('node', ['node-entrypoint.js', resolve(__dirname, outFileLocation)], {
+      cwd: __dirname
+    })
+
+    if (result.status !== 0) {
+      throw new Error(result.stderr.toString());
+    }
+  }
+}
+
+describe('bundlers for browsers and JS CDNs', () => {
+  // these are the common bundlers JS CDNs use under the hood in various ways
+  it('should perform a no-op instead of loading the tracer with webpack', createTestForBundler('./out/webpack.js'))
+  it('should perform a no-op instead of loading the tracer with esbuild', createTestForBundler('./out/esbuild.js'))
+  it('should perform a no-op instead of loading the tracer with rollup', createTestForBundler('./out/rollup.js'))
+
+  // these will still be bloating the bundle, but shouldn't cause errors
+  it('should perform a no-op instead of loading the tracer with webpack targeting node', createTestForBundler('./out/webpack-node.js'))
+  it('should perform a no-op instead of loading the tracer with esbuild targeting node', createTestForBundler('./out/esbuild.js'))
+})
+
+describe('bundlers for servers', () => {
+  it('should load the tracer with webpack', createTestForNode('./out/webpack-node.js'))
+  it('should load the tracer with esbuild', createTestForNode('./out/esbuild-node.js'))
+})

--- a/integration-tests/browsers/node-entrypoint.js
+++ b/integration-tests/browsers/node-entrypoint.js
@@ -1,0 +1,9 @@
+'use strict'
+
+// used to load the bundle output from ./bundle-entrypoint.js
+// this already tests .init()
+require(process.argv[2]);
+
+if (!global._ddtrace) {
+    throw new Error('expected global._ddtrace to exist from ' + process.argv[2])
+}

--- a/integration-tests/browsers/rollup.config.mjs
+++ b/integration-tests/browsers/rollup.config.mjs
@@ -1,0 +1,15 @@
+import commonjs from '@rollup/plugin-commonjs'
+import nodeResolve from '@rollup/plugin-node-resolve'
+
+export default {
+    input: './bundle-entrypoint.js',
+    plugins: [
+        commonjs(),
+        nodeResolve()
+    ],
+    output: {
+        name: 'dd-trace',
+        file: 'out/rollup.js',
+        format: 'umd'
+    }
+}

--- a/integration-tests/browsers/webpack.config.js
+++ b/integration-tests/browsers/webpack.config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+module.exports = {
+    mode: 'production',
+    entry: "./bundle-entrypoint.js",
+    output: {
+        path: path.resolve(__dirname, './out/')
+    }
+}
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,18 @@
   "version": "2.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "node": "./index.js",
+      "default": "./empty.js"
+    },
+    "./index.js": {
+      "node": "./index.js",
+      "default": "./empty.js"
+    },
+    "./*": "./*",
+    "./package.json": "./package.json"
+  },
   "typings": "index.d.ts",
   "scripts": {
     "preinstall": "node scripts/preinstall.js",
@@ -117,6 +129,13 @@
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "tape": "^4.9.1",
-    "wait-on": "^5.0.0"
+    "wait-on": "^5.0.0",
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-node-resolve": "^13.0.6",
+    "esbuild": "^0.13.12",
+    "rollup": "^2.59.0",
+    "webpack": "^5.61.0",
+    "webpack-cli": "^4.9.1",
+    "puppeteer": "^10.4.0"
   }
 }

--- a/packages/dd-trace/index.js
+++ b/packages/dd-trace/index.js
@@ -1,5 +1,13 @@
 'use strict'
 
+if (typeof process === 'undefined') {
+  // using exports.* simple assignments to deal w/ transpilers using
+  // cjs-module-lexer
+  exports.default = exports;
+  exports.init = require('../../empty.js').init;
+  return;
+}
+
 if (!global._ddtrace) {
   const TracerProxy = require('./src/proxy')
 


### PR DESCRIPTION
See https://github.com/DataDog/dd-trace-js/pull/1674 , trying to make CI happy with new PR