### PR TITLE
Fix timeout overflow warning

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -159,4 +159,4 @@ class AgentExporter {
   }
 }
 
-module.exports = { AgentExporter }
+module.exports = { AgentExporter, computeRetries }

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -131,7 +131,7 @@ class AgentExporter {
       })
 
       operation.attempt((attempt) => {
-        const timeout = Math.pow(this._backoffTime, attempt)
+        const timeout = this._backoffTime * Math.pow(2, attempt)
         sendRequest({ ...options, timeout }, form, (err, response) => {
           if (operation.retry(err)) {
             this._logger.error(`Error from the agent: ${err.message}`)

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -40,7 +40,7 @@ function computeRetries (uploadTimeout) {
     tries++
     uploadTimeout /= 2
   }
-  return [tries, uploadTimeout]
+  return [tries, Math.floor(uploadTimeout)]
 }
 
 class AgentExporter {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -207,6 +207,14 @@ describe('exporters/agent', () => {
       expect(failed).to.be.true
       expect(attempt).to.be.greaterThan(0)
 
+      // Verify computeRetries produces correct starting values
+      for (let i = 1; i <= 100; i++) {
+        const [retries, timeout] = computeRetries(i * 1000)
+        expect(retries).to.be.gte(2)
+        expect(timeout).to.be.lte(1000)
+        expect(Number.isInteger(timeout)).to.be.true
+      }
+
       const initialTimeout = computeRetries(uploadTimeout)[1]
       const spyCalls = http.request.getCalls()
       for (let i = 0; i < spyCalls.length; i++) {


### PR DESCRIPTION
Simple logical error. It didn't quite match the algorithm the retry modules uses for computing its timeouts so it was getting out of sync.

Fixes #1685
Fixes #1715