### PR TITLE
Make Node.js typings consistent with engines and allow newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@datadog/native-metrics": "^1.0.1",
     "@datadog/pprof": "^0.3.0",
     "@datadog/sketches-js": "^1.0.4",
-    "@types/node": "^10.12.18",
+    "@types/node": ">=12",
     "crypto-randomuuid": "^1.0.0",
     "form-data": "^3.0.0",
     "import-in-the-middle": "^1.1.2",


### PR DESCRIPTION
### What does this PR do?
* Make Node.js typings consistent with `engines` specification (`>=12`)
* Allow newer versions of node typings for use in projects that use e.g. Node.js 14 or 16

### Motivation
`yarn` kept installing version 10 of `@types/node` in the root `node_modules` directory of our project, resulting in compile errors.