### PR TITLE
update mongo test version to support mongodb 4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,7 +524,7 @@ jobs:
         environment:
           - SERVICES=mongo
           - PLUGINS=mongoose
-      - image: circleci/mongo:3.4
+      - image: circleci/mongo:3.6
 
   node-net: *node-plugin-base
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
   mongo:
-    image: circleci/mongo:3.4
+    image: circleci/mongo:3.6
     ports:
       - "127.0.0.1:27017:27017"
   oracledb:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update mongo test version to support `mongodb` 4.2.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests were failing because Mongo 3.4 is no longer supported by the latest version of `mongodb`.