### PR TITLE
replace mysql with mariadb for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,7 +503,7 @@ jobs:
         environment:
           - SERVICES=mysql
           - PLUGINS=mysql|mysql2
-      - image: mysql:5.7
+      - image: mariadb:10.4
         environment:
           - MYSQL_ALLOW_EMPTY_PASSWORD=yes
           - MYSQL_DATABASE=db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "127.0.0.1:1433:1433"
   mysql:
-    image: mysql:5.7
+    image: mariadb:10.4
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=db


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Replace MySQL with MariaDB for tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `mysql` image doesn't start on ARM macs unless the `--platform` config is set. Instead of adding the configuration, Docker [recommends](https://docs.docker.com/desktop/mac/apple-silicon/#known-issues) using MariaDB which has native support.