### PR TITLE
Paullgdc/telemetry config fix

### DIFF
--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -208,6 +208,7 @@ class Instrumenter {
 
     if (!instrumented) {
       this._instrumented.set(instrumentation, instrumented = new Set())
+      telemetry.updateIntegrations()
     }
 
     if (!instrumented.has(moduleExports)) {

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -45,10 +45,15 @@ function getDependencies () {
   return deps
 }
 
-function flatten (input, result = {}, prefix = []) {
+function flatten (input, result = {}, prefix = [], traversedObjects = null) {
+  traversedObjects = traversedObjects ? traversedObjects : new WeakSet()
+  if (traversedObjects.has(input)) {
+    return
+  }
+  traversedObjects.add(input)
   for (const [key, value] of Object.entries(input)) {
     if (typeof value === 'object' && value !== null) {
-      flatten(value, result, [...prefix, key])
+      flatten(value, result, [...prefix, key], traversedObjects)
     } else {
       result[[...prefix, key].join('.')] = value
     }

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -92,15 +92,12 @@ function sendData (reqType, payload = {}) {
     hostname,
     port
   } = config
-  const backendHost = 'tracer-telemetry-edge.datadoghq.com'
-  const backendUrl = `https://${backendHost}/api/v2/apmtelemetry`
   const req = http.request({
     hostname,
     port,
     method: 'POST',
-    path: backendUrl,
+    path: '/telemetry/proxy/api/v2/apmtelemetry',
     headers: {
-      host: backendHost,
       'content-type': 'application/json',
       'dd-telemetry-api-version': 'v1',
       'dd-telemetry-request-type': reqType

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -11,7 +11,7 @@ const os = require('os')
 let config
 let instrumenter
 
-let seqId = -1
+let seqId = 0
 let application
 let host
 let interval
@@ -112,7 +112,7 @@ function sendData (reqType, payload = {}) {
     request_type: reqType,
     tracer_time: Math.floor(Date.now() / 1000),
     runtime_id: config.tags['runtime-id'],
-    seqId: ++seqId,
+    seq_id: ++seqId,
     payload,
     application,
     host

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -45,8 +45,8 @@ function getDependencies () {
   return deps
 }
 
-function flatten (input, result = {}, prefix = [], traversedObjects = null) {
-  traversedObjects = traversedObjects ? traversedObjects : new WeakSet()
+function flatten (input, result = [], prefix = [], traversedObjects = null) {
+  traversedObjects = traversedObjects || new WeakSet()
   if (traversedObjects.has(input)) {
     return
   }
@@ -55,7 +55,7 @@ function flatten (input, result = {}, prefix = [], traversedObjects = null) {
     if (typeof value === 'object' && value !== null) {
       flatten(value, result, [...prefix, key], traversedObjects)
     } else {
-      result[[...prefix, key].join('.')] = value
+      result.push({ name: [...prefix, key].join('.'), value })
     }
   }
   return result
@@ -66,7 +66,7 @@ function appStarted () {
     integrations: getIntegrations(),
     dependencies: getDependencies(),
     configuration: flatten(config),
-    additional_payload: {}
+    additional_payload: []
   }
 }
 

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -15,10 +15,10 @@ let seqId = 0
 let application
 let host
 let interval
-let sentIntegrations = new Set()
+const sentIntegrations = new Set()
 
 function getIntegrations () {
-  const newIntegrations = [];
+  const newIntegrations = []
   for (const plugin of instrumenter._instrumented.keys()) {
     if (sentIntegrations.has(plugin.name)) {
       continue
@@ -152,7 +152,7 @@ function stop () {
 
 function updateIntegrations () {
   const integrations = getIntegrations()
-  if (integrations.length == 0) {
+  if (integrations.length === 0) {
     return
   }
   sendData('app-integrations-change', { integrations })

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -151,7 +151,11 @@ function stop () {
 }
 
 function updateIntegrations () {
-  sendData('app-integrations-change', { integrations: getIntegrations() })
+  const integrations = getIntegrations()
+  if (integrations.length == 0) {
+    return
+  }
+  sendData('app-integrations-change', { integrations })
 }
 
 module.exports = {

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -15,13 +15,22 @@ let seqId = 0
 let application
 let host
 let interval
+let sentIntegrations = new Set()
 
 function getIntegrations () {
-  return [...new Set(instrumenter._instrumented.keys())].map(plugin => ({
-    name: plugin.name,
-    enabled: true,
-    auto_enabled: true
-  }))
+  const newIntegrations = [];
+  for (const plugin of instrumenter._instrumented.keys()) {
+    if (sentIntegrations.has(plugin.name)) {
+      continue
+    }
+    newIntegrations.push({
+      name: plugin.name,
+      enabled: true,
+      auto_enabled: true
+    })
+    sentIntegrations.add(plugin.name)
+  }
+  return newIntegrations
 }
 
 function getDependencies () {

--- a/packages/dd-trace/test/telemetry.spec.js
+++ b/packages/dd-trace/test/telemetry.spec.js
@@ -125,9 +125,20 @@ describe('telemetry', () => {
     return testSeq(3, 'app-integrations-change', payload => {
       expect(payload).to.deep.equal({
         integrations: [
-          { name: 'foo', enabled: true, auto_enabled: true },
-          { name: 'bar', enabled: true, auto_enabled: true },
           { name: 'baz', enabled: true, auto_enabled: true }
+        ]
+      })
+    })
+  })
+
+  it('should send app-integrations-change', () => {
+    instrumentedMap.set({ name: 'boo' }, {})
+    telemetry.updateIntegrations()
+
+    return testSeq(4, 'app-integrations-change', payload => {
+      expect(payload).to.deep.equal({
+        integrations: [
+          { name: 'boo', enabled: true, auto_enabled: true }
         ]
       })
     })
@@ -136,7 +147,7 @@ describe('telemetry', () => {
   it('should send app-closing', () => {
     process.emit('beforeExit')
 
-    return testSeq(4, 'app-closing', payload => {
+    return testSeq(5, 'app-closing', payload => {
       expect(payload).to.deep.equal({})
     })
   })

--- a/packages/dd-trace/test/telemetry.spec.js
+++ b/packages/dd-trace/test/telemetry.spec.js
@@ -97,19 +97,18 @@ describe('telemetry', () => {
           { name: 'foo', enabled: true, auto_enabled: true },
           { name: 'bar', enabled: true, auto_enabled: true }
         ],
-        dependencies: getMochaDeps(),
-        configuration: {
-          telemetryEnabled: true,
-          hostname: 'localhost',
-          port: traceAgent.address().port,
-          service: 'test service',
-          version: '1.2.3-beta4',
-          env: 'preprod',
-          'tags.runtime-id': '1a2b3c',
-          'circularObject.field': 'parent_value',
-          'circularObject.child.field': 'child_value'
-        }
-      })
+        dependencies: getMochaDeps()
+      }).and.to.have.property('configuration').that.include.members([
+        { name: 'telemetryEnabled', value: true },
+        { name: 'hostname', value: 'localhost' },
+        { name: 'port', value: traceAgent.address().port },
+        { name: 'service', value: 'test service' },
+        { name: 'version', value: '1.2.3-beta4' },
+        { name: 'env', value: 'preprod' },
+        { name: 'tags.runtime-id', value: '1a2b3c' },
+        { name: 'circularObject.field', value: 'parent_value' },
+        { name: 'circularObject.child.field', value: 'child_value' }
+      ])
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Fix a few bugs with telemetry:

* Rename seqId to seq_id in telemetry payloads
* Start seq_id at `1`
* Stop at cycles when serialising the config object, to prevent blowing up stack if objects contain circular reference (for instance if the tracer is passed a winston `logger` at initialisation)
* Fix integrations-change not being sent on patches
* Send only the new integrations

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
