### PR TITLE
add sirun benchmark for graphql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,8 @@ jobs:
 
   node-bench-sirun-plugin-dns: *node-bench-sirun-base
 
+  node-bench-sirun-plugin-graphql: *node-bench-sirun-base
+
   node-bench-sirun-all:
     docker:
       - image: node
@@ -844,6 +846,7 @@ workflows:
       - node-bench-sirun-exporting-pipeline: *matrix-exact-supported-node-versions
       - node-bench-sirun-profiler: *matrix-exact-supported-node-versions
       - node-bench-sirun-plugin-dns: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-graphql: *matrix-exact-supported-node-versions
       - node-bench-sirun-all:
           requires:
             - node-bench-sirun-startup
@@ -859,6 +862,7 @@ workflows:
             - node-bench-sirun-exporting-pipeline
             - node-bench-sirun-profiler
             - node-bench-sirun-plugin-dns
+            - node-bench-sirun-plugin-graphql
   upstream: &upstream-jobs
     jobs:
       # - node-upstream-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,9 @@ jobs:
 
   node-bench-sirun-plugin-dns: *node-bench-sirun-base
 
-  node-bench-sirun-plugin-graphql: *node-bench-sirun-base
+  node-bench-sirun-plugin-graphql:
+    <<: *node-bench-sirun-base
+    resource_class: large
 
   node-bench-sirun-all:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -836,34 +836,34 @@ workflows:
           matrix:
             parameters:
               node-version: ["12", "14", "16"]
-      - node-bench-sirun-spans: *matrix-exact-supported-node-versions
-      - node-bench-sirun-async_hooks: *matrix-exact-supported-node-versions
-      - node-bench-sirun-log: *matrix-exact-supported-node-versions
-      - node-bench-sirun-encoding: *matrix-exact-supported-node-versions
-      - node-bench-sirun-plugin-q: *matrix-exact-supported-node-versions
-      - node-bench-sirun-plugin-bluebird: *matrix-exact-supported-node-versions
-      - node-bench-sirun-plugin-http: *matrix-exact-supported-node-versions
-      - node-bench-sirun-plugin-net: *matrix-exact-supported-node-versions
-      - node-bench-sirun-scope: *matrix-exact-supported-node-versions
-      - node-bench-sirun-exporting-pipeline: *matrix-exact-supported-node-versions
-      - node-bench-sirun-profiler: *matrix-exact-supported-node-versions
-      - node-bench-sirun-plugin-dns: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-spans: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-async_hooks: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-log: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-encoding: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-plugin-q: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-plugin-bluebird: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-plugin-http: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-plugin-net: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-scope: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-exporting-pipeline: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-profiler: *matrix-exact-supported-node-versions
+      # - node-bench-sirun-plugin-dns: *matrix-exact-supported-node-versions
       - node-bench-sirun-plugin-graphql: *matrix-exact-supported-node-versions
       - node-bench-sirun-all:
           requires:
-            - node-bench-sirun-startup
-            - node-bench-sirun-spans
-            - node-bench-sirun-async_hooks
-            - node-bench-sirun-log
-            - node-bench-sirun-encoding
-            - node-bench-sirun-plugin-q
-            - node-bench-sirun-plugin-bluebird
-            - node-bench-sirun-plugin-http
-            - node-bench-sirun-plugin-net
-            - node-bench-sirun-scope
-            - node-bench-sirun-exporting-pipeline
-            - node-bench-sirun-profiler
-            - node-bench-sirun-plugin-dns
+            # - node-bench-sirun-startup
+            # - node-bench-sirun-spans
+            # - node-bench-sirun-async_hooks
+            # - node-bench-sirun-log
+            # - node-bench-sirun-encoding
+            # - node-bench-sirun-plugin-q
+            # - node-bench-sirun-plugin-bluebird
+            # - node-bench-sirun-plugin-http
+            # - node-bench-sirun-plugin-net
+            # - node-bench-sirun-scope
+            # - node-bench-sirun-exporting-pipeline
+            # - node-bench-sirun-profiler
+            # - node-bench-sirun-plugin-dns
             - node-bench-sirun-plugin-graphql
   upstream: &upstream-jobs
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -832,10 +832,10 @@ workflows:
       - node-bench-latest
       - node-bench-profiler-latest
       - node-bench-e2e-latest
-      # - node-bench-sirun-startup: &matrix-exact-supported-node-versions
-      #     matrix:
-      #       parameters:
-      #         node-version: ["12", "14", "16"]
+      - node-bench-sirun-startup: &matrix-exact-supported-node-versions
+          matrix:
+            parameters:
+              node-version: ["12", "14", "16"]
       # - node-bench-sirun-spans: *matrix-exact-supported-node-versions
       # - node-bench-sirun-async_hooks: *matrix-exact-supported-node-versions
       # - node-bench-sirun-log: *matrix-exact-supported-node-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -832,10 +832,10 @@ workflows:
       - node-bench-latest
       - node-bench-profiler-latest
       - node-bench-e2e-latest
-      - node-bench-sirun-startup: &matrix-exact-supported-node-versions
-          matrix:
-            parameters:
-              node-version: ["12", "14", "16"]
+      # - node-bench-sirun-startup: &matrix-exact-supported-node-versions
+      #     matrix:
+      #       parameters:
+      #         node-version: ["12", "14", "16"]
       # - node-bench-sirun-spans: *matrix-exact-supported-node-versions
       # - node-bench-sirun-async_hooks: *matrix-exact-supported-node-versions
       # - node-bench-sirun-log: *matrix-exact-supported-node-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,9 +228,7 @@ jobs:
 
   node-bench-sirun-plugin-dns: *node-bench-sirun-base
 
-  node-bench-sirun-plugin-graphql:
-    <<: *node-bench-sirun-base
-    resource_class: large
+  node-bench-sirun-plugin-graphql: *node-bench-sirun-base
 
   node-bench-sirun-all:
     docker:
@@ -836,34 +834,34 @@ workflows:
           matrix:
             parameters:
               node-version: ["12", "14", "16"]
-      # - node-bench-sirun-spans: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-async_hooks: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-log: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-encoding: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-plugin-q: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-plugin-bluebird: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-plugin-http: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-plugin-net: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-scope: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-exporting-pipeline: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-profiler: *matrix-exact-supported-node-versions
-      # - node-bench-sirun-plugin-dns: *matrix-exact-supported-node-versions
+      - node-bench-sirun-spans: *matrix-exact-supported-node-versions
+      - node-bench-sirun-async_hooks: *matrix-exact-supported-node-versions
+      - node-bench-sirun-log: *matrix-exact-supported-node-versions
+      - node-bench-sirun-encoding: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-q: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-bluebird: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-http: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-net: *matrix-exact-supported-node-versions
+      - node-bench-sirun-scope: *matrix-exact-supported-node-versions
+      - node-bench-sirun-exporting-pipeline: *matrix-exact-supported-node-versions
+      - node-bench-sirun-profiler: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-dns: *matrix-exact-supported-node-versions
       - node-bench-sirun-plugin-graphql: *matrix-exact-supported-node-versions
       - node-bench-sirun-all:
           requires:
-            # - node-bench-sirun-startup
-            # - node-bench-sirun-spans
-            # - node-bench-sirun-async_hooks
-            # - node-bench-sirun-log
-            # - node-bench-sirun-encoding
-            # - node-bench-sirun-plugin-q
-            # - node-bench-sirun-plugin-bluebird
-            # - node-bench-sirun-plugin-http
-            # - node-bench-sirun-plugin-net
-            # - node-bench-sirun-scope
-            # - node-bench-sirun-exporting-pipeline
-            # - node-bench-sirun-profiler
-            # - node-bench-sirun-plugin-dns
+            - node-bench-sirun-startup
+            - node-bench-sirun-spans
+            - node-bench-sirun-async_hooks
+            - node-bench-sirun-log
+            - node-bench-sirun-encoding
+            - node-bench-sirun-plugin-q
+            - node-bench-sirun-plugin-bluebird
+            - node-bench-sirun-plugin-http
+            - node-bench-sirun-plugin-net
+            - node-bench-sirun-scope
+            - node-bench-sirun-exporting-pipeline
+            - node-bench-sirun-profiler
+            - node-bench-sirun-plugin-dns
             - node-bench-sirun-plugin-graphql
   upstream: &upstream-jobs
     jobs:

--- a/benchmark/sirun/aggregate.js
+++ b/benchmark/sirun/aggregate.js
@@ -16,12 +16,17 @@ fs.writeFileSync('all-sirun-output.ndjson', ndjsons)
 
 const versionResults = {}
 ndjsons.trim().split('\n').forEach(x => {
-  const results = JSON.parse(x)
-  const nodeVersion = results.nodeVersion.split('.')[0]
-  if (!versionResults[nodeVersion]) {
-    versionResults[nodeVersion] = []
+  try {
+    const results = JSON.parse(x)
+    const nodeVersion = results.nodeVersion.split('.')[0]
+    if (!versionResults[nodeVersion]) {
+      versionResults[nodeVersion] = []
+    }
+    versionResults[nodeVersion].push(results)
+  } catch (e) {
+    console.log(x) // eslint-disable-line no-console
+    throw e
   }
-  versionResults[nodeVersion].push(results)
 })
 
 const buildData = {

--- a/benchmark/sirun/aggregate.js
+++ b/benchmark/sirun/aggregate.js
@@ -16,17 +16,12 @@ fs.writeFileSync('all-sirun-output.ndjson', ndjsons)
 
 const versionResults = {}
 ndjsons.trim().split('\n').forEach(x => {
-  try {
-    const results = JSON.parse(x)
-    const nodeVersion = results.nodeVersion.split('.')[0]
-    if (!versionResults[nodeVersion]) {
-      versionResults[nodeVersion] = []
-    }
-    versionResults[nodeVersion].push(results)
-  } catch (e) {
-    console.log(x) // eslint-disable-line no-console
-    throw e
+  const results = JSON.parse(x)
+  const nodeVersion = results.nodeVersion.split('.')[0]
+  if (!versionResults[nodeVersion]) {
+    versionResults[nodeVersion] = []
   }
+  versionResults[nodeVersion].push(results)
 })
 
 const buildData = {

--- a/benchmark/sirun/plugin-graphql/README.md
+++ b/benchmark/sirun/plugin-graphql/README.md
@@ -1,0 +1,3 @@
+This makes 5 queries to a GraphQL server with highly nested (100x1000) results.
+
+The variants are with `async_hooks` and without.

--- a/benchmark/sirun/plugin-graphql/README.md
+++ b/benchmark/sirun/plugin-graphql/README.md
@@ -1,3 +1,3 @@
-This makes 5 queries to a GraphQL server with highly nested (100x1000) results.
+This makes 5 queries to a GraphQL server with highly nested (100x100) results.
 
 The variants are with `async_hooks` and without.

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -1,12 +1,13 @@
 'use strict'
 
+const semver = require('semver')
+
 // TODO: benchmark the tracer as well but for now it's just too slow
 // if (Number(process.env.WITH_TRACER)) {
 //   require('../../..').init().use('graphql', { depth: 0 })
 // }
 
 if (Number(process.env.WITH_ASYNC_HOOKS)) {
-  const semver = require('semver')
   const hook = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
     ? { init () {} }
     : { init () {}, before () {}, after () {}, destroy () {} }
@@ -38,6 +39,6 @@ const source = `
 
 const variableValues = { who: 'world' }
 
-for (let i = 0; i < 1; i++) {
+for (let i = 0; i < 25; i++) {
   graphql.graphql({ schema, source, variableValues })
 }

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -39,6 +39,6 @@ const source = `
 
 const variableValues = { who: 'world' }
 
-for (let i = 0; i < 25; i++) {
+for (let i = 0; i < 5; i++) {
   graphql.graphql({ schema, source, variableValues })
 }

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -1,0 +1,43 @@
+'use strict'
+
+// TODO: benchmark the tracer as well but for now it's just too slow
+// if (Number(process.env.WITH_TRACER)) {
+//   require('../../..').init().use('graphql', { depth: 0 })
+// }
+
+if (Number(process.env.WITH_ASYNC_HOOKS)) {
+  const semver = require('semver')
+  const hook = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
+    ? { init () {} }
+    : { init () {}, before () {}, after () {}, destroy () {} }
+
+  require('async_hooks').createHook(hook).enable()
+}
+
+const graphql = require('../../../versions/graphql/node_modules/graphql')
+const schema = require('./schema')
+
+const source = `
+{
+  friends {
+    name
+    address {
+      civicNumber
+      street
+    }
+    pets {
+      type
+      name
+      owner {
+        name
+      }
+    }
+  }
+}
+`
+
+const variableValues = { who: 'world' }
+
+for (let i = 0; i < 5; i++) {
+  graphql.graphql({ schema, source, variableValues })
+}

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -38,6 +38,6 @@ const source = `
 
 const variableValues = { who: 'world' }
 
-for (let i = 0; i < 5; i++) {
+for (let i = 0; i < 1; i++) {
   graphql.graphql({ schema, source, variableValues })
 }

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-graphql",
   "run": "node index.js",
-  "cachegrind": true,
+  "cachegrind": false,
   "iterations": 10,
   "variants": {
     "control": {},

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "plugin-graphql",
+  "run": "node index.js",
+  "cachegrind": true,
+  "iterations": 10,
+  "variants": {
+    "control": {},
+    "with-async-hooks": {
+      "baseline": "control",
+      "env": { "WITH_ASYNC_HOOKS": "1" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-graphql",
   "run": "node index.js",
-  "cachegrind": false,
+  "cachegrind": true,
   "iterations": 3,
   "variants": {
     "control": {},

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -2,7 +2,7 @@
   "name": "plugin-graphql",
   "run": "node index.js",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 3,
   "variants": {
     "control": {},
     "with-async-hooks": {

--- a/benchmark/sirun/plugin-graphql/schema.js
+++ b/benchmark/sirun/plugin-graphql/schema.js
@@ -115,7 +115,7 @@ const schema = new graphql.GraphQLSchema({
         async resolve (obj, args) {
           const promises = []
 
-          for (let i = 0; i < 1000; i++) {
+          for (let i = 0; i < 100; i++) {
             promises.push(await Promise.resolve({}))
           }
 

--- a/benchmark/sirun/plugin-graphql/schema.js
+++ b/benchmark/sirun/plugin-graphql/schema.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const graphql = require('../../../versions/graphql/node_modules/graphql')
+
+const Human = new graphql.GraphQLObjectType({
+  name: 'Human',
+  fields: {
+    name: {
+      type: graphql.GraphQLString,
+      async resolve (obj, args) {
+        const name = await Promise.resolve('test')
+
+        return name
+      }
+    },
+    address: {
+      type: new graphql.GraphQLObjectType({
+        name: 'Address',
+        fields: {
+          civicNumber: {
+            type: graphql.GraphQLString,
+            async resolve () {
+              const civicNumber = await Promise.resolve('123')
+
+              return civicNumber
+            }
+          },
+          street: {
+            type: graphql.GraphQLString,
+            async resolve () {
+              const street = await Promise.resolve('foo street')
+
+              return street
+            }
+          }
+        }
+      }),
+      async resolve (obj, args) {
+        const address = await Promise.resolve({})
+
+        return address
+      }
+    },
+    pets: {
+      type: new graphql.GraphQLList(new graphql.GraphQLNonNull(new graphql.GraphQLObjectType({
+        name: 'Pet',
+        fields: () => ({
+          type: {
+            type: graphql.GraphQLString,
+            async resolve (obj, args) {
+              const type = await Promise.resolve('dog')
+
+              return type
+            }
+          },
+          name: {
+            type: graphql.GraphQLString,
+            async resolve (obj, args) {
+              const name = await Promise.resolve('foo bar')
+
+              return name
+            }
+          },
+          owner: {
+            type: Human,
+            async resolve (obj, args) {
+              const owner = await Promise.resolve({})
+
+              return owner
+            }
+          },
+          colours: {
+            type: new graphql.GraphQLList(new graphql.GraphQLObjectType({
+              name: 'Colour',
+              fields: {
+                code: {
+                  type: graphql.GraphQLString,
+                  async resolve (obj, args) {
+                    const code = await Promise.resolve('#ffffff')
+
+                    return code
+                  }
+                }
+              }
+            })),
+            async resolve (obj, args) {
+              const colours = await Promise.resolve([{}, {}])
+
+              return colours
+            }
+          }
+        })
+      }))),
+      async resolve (obj, args) {
+        const promises = []
+
+        for (let i = 0; i < 100; i++) {
+          promises.push(await Promise.resolve({}))
+        }
+
+        const pets = await Promise.all(promises)
+
+        return pets
+      }
+    }
+  }
+})
+
+const schema = new graphql.GraphQLSchema({
+  query: new graphql.GraphQLObjectType({
+    name: 'RootQueryType',
+    fields: {
+      friends: {
+        type: new graphql.GraphQLList(Human),
+        async resolve (obj, args) {
+          const promises = []
+
+          for (let i = 0; i < 1000; i++) {
+            promises.push(await Promise.resolve({}))
+          }
+
+          const friends = await Promise.all(promises)
+
+          return friends
+        }
+      }
+    }
+  })
+})
+
+module.exports = schema


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a sirun benchmark for `graphql` with and without `async_hooks` for now.

### Motivation
<!-- What inspired you to submit this pull request? -->

GraphQL is problematic performance-wise for promise-heavy queries, so we should have a benchmark in place for that use case.