### PR TITLE
[ci-visibility] Improve Initialization of CI Visibility Library

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -1,10 +1,9 @@
-// TODO: provide a way to do this with the init function
-process.env.DD_TRACE_DISABLED_PLUGINS = 'fs'
-
 const tracer = require('../packages/dd-trace')
 
 tracer.init({
   startupLogs: false
 })
+
+tracer.use('fs', false)
 
 module.exports = tracer

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -1,10 +1,10 @@
-process.env.DD_TRACE_DISABLED_PLUGINS = 'fs'
-
 const tracer = require('../../packages/dd-trace')
 
 tracer.init({
   startupLogs: false,
   flushInterval: 400000
 })
+
+tracer.use('fs', false)
 
 module.exports = tracer


### PR DESCRIPTION
### What does this PR do?
Use `tracer.use('fs', false)` rather than modifying `process.env.DD_TRACE_DISABLED_PLUGINS` for disabling `fs` for testing instrumentations. 

### Motivation
Use a better initialization method. 
