### PR TITLE
[ci-visibility] Add Performance Overhead Check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
-  node-bench-ci-performance:
+  node-ci-visibility-performance-benchmark:
     docker:
       - image: node
     resource_class: medium
@@ -258,7 +258,7 @@ jobs:
     steps:
       - checkout-and-yarn-install
       - run:
-          name: E2E Benchmark
+          name: CI Visibility Performance Overhead Test
           command: yarn bench:e2e:ci-visibility
 
   # Shimmer tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,16 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+  node-bench-ci-performance:
+    resource_class: medium
+    working_directory: ~/dd-trace-js
+
+    steps:
+      - checkout-and-yarn-install
+      - run:
+          name: E2E Benchmark
+          command: yarn bench:e2e:ci-visibility
+
   # Shimmer tests
 
   shimmer:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -882,6 +882,7 @@ workflows:
             - node-bench-sirun-profiler
             - node-bench-sirun-plugin-dns
             - node-bench-sirun-plugin-graphql
+      - node-ci-visibility-performance-benchmark
   upstream: &upstream-jobs
     jobs:
       # - node-upstream-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,8 @@ jobs:
           path: /tmp/artifacts
 
   node-bench-ci-performance:
+    docker:
+      - image: node
     resource_class: medium
     working_directory: ~/dd-trace-js
 

--- a/benchmark/e2e-ci/benchmark-run.js
+++ b/benchmark/e2e-ci/benchmark-run.js
@@ -51,7 +51,7 @@ const getWorkflowRunsInProgress = () => {
   return new Promise((resolve, reject) => {
     let response = ''
     const request = https.request(
-      `${GET_WORKFLOWS_URL}?event=workflow_dispatch&status=in_progress OR waiting OR requested`,
+      `${GET_WORKFLOWS_URL}?event=workflow_dispatch&status=in_progress OR waiting OR requested OR queued`,
       {
         headers: getCommonHeaders()
       },

--- a/benchmark/e2e-ci/benchmark-run.js
+++ b/benchmark/e2e-ci/benchmark-run.js
@@ -109,7 +109,7 @@ async function main () {
   const httpResponseCode = await triggerWorkflow()
   console.log('GitHub API Response code:', httpResponseCode)
   // Give some time for GH to process the request
-  await wait(5000)
+  await wait(15000)
   // Get the run ID from the workflow we just triggered
   const workflowsInProgress = await getWorkflowRunsInProgress()
   console.log('workflows in progress:', workflowsInProgress)

--- a/benchmark/e2e-ci/benchmark-run.js
+++ b/benchmark/e2e-ci/benchmark-run.js
@@ -11,7 +11,7 @@ const GET_WORKFLOWS_URL = `${API_REPOSITORY_URL}/actions/runs`
 const getCommonHeaders = () => {
   return {
     'Content-Type': 'application/json',
-    'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+    'authorization': `Bearer ${process.env.ROBOT_CI_GITHUB_PERSONAL_ACCESS_TOKEN}`,
     'Accept': 'application/vnd.github.v3+json',
     'user-agent': 'dd-trace benchmark tests'
   }

--- a/benchmark/e2e-ci/benchmark-run.js
+++ b/benchmark/e2e-ci/benchmark-run.js
@@ -19,6 +19,7 @@ const getCommonHeaders = () => {
 
 const triggerWorkflow = () => {
   return new Promise((resolve, reject) => {
+    // eslint-disable-next-line
     let response = ''
     const body = JSON.stringify({
       ref: 'main'

--- a/benchmark/e2e-ci/benchmark-run.js
+++ b/benchmark/e2e-ci/benchmark-run.js
@@ -1,28 +1,37 @@
+'use strict'
+
+/* eslint-disable no-console */
+
 const https = require('https')
+
+const API_REPOSITORY_URL = 'https://api.github.com/repos/DataDog/test-environment'
+const DISPATCH_WORKFLOW_URL = `${API_REPOSITORY_URL}/actions/workflows/dd-trace-js-tests.yml/dispatches`
+const GET_WORKFLOWS_URL = `${API_REPOSITORY_URL}/actions/runs`
+
+const getCommonHeaders = () => {
+  return {
+    'Content-Type': 'application/json',
+    'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+    'Accept': 'application/vnd.github.v3+json',
+    'user-agent': 'dd-trace benchmark tests'
+  }
+}
 
 const triggerWorkflow = () => {
   return new Promise((resolve, reject) => {
-    let response = ''
     const body = JSON.stringify({
       ref: 'main'
     })
-    const request = https.request('https://api.github.com/repos/DataDog/test-environment/actions/workflows/dd-trace-js-tests.yml/dispatches', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': body.length,
-        'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
-        'Accept': 'application/vnd.github.v3+json',
-        'user-agent': 'dd-trace benchmark tests'
-      }
-    }, (res) => {
-      res.on('data', (chunk) => {
-        response += chunk
+    const request = https.request(
+      DISPATCH_WORKFLOW_URL,
+      {
+        method: 'POST',
+        headers: getCommonHeaders()
+      }, (res) => {
+        res.on('end', () => {
+          resolve()
+        })
       })
-      res.on('end', () => {
-        resolve(JSON.parse(response))
-      })
-    })
     request.on('error', (error) => {
       reject(error)
     })
@@ -33,23 +42,18 @@ const triggerWorkflow = () => {
 
 const getWorkflowRunsInProgress = () => {
   return new Promise((resolve, reject) => {
-    let body = ''
+    let response = ''
     const request = https.request(
-      'https://api.github.com/repos/DataDog/test-environment/actions/runs?event=workflow_dispatch&status=in_progress OR waiting OR requested',
+      `${GET_WORKFLOWS_URL}?event=workflow_dispatch&status=in_progress OR waiting OR requested`,
       {
-        headers: {
-          'Content-Type': 'application/json',
-          'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
-          'Accept': 'application/vnd.github.v3+json',
-          'user-agent': 'dd-trace benchmark tests'
-        }
+        headers: getCommonHeaders()
       },
       (res) => {
         res.on('data', (chunk) => {
-          body += chunk
+          response += chunk
         })
         res.on('end', () => {
-          resolve(JSON.parse(body))
+          resolve(JSON.parse(response))
         })
       })
     request.on('error', err => {
@@ -63,18 +67,13 @@ const getCurrentWorkflowJobs = (runId) => {
   let body = ''
   return new Promise((resolve, reject) => {
     if (!runId) {
-      reject(new Error('no job id'))
+      reject(new Error('No job run id specified'))
       return
     }
     const request = https.request(
-      `https://api.github.com/repos/DataDog/test-environment/actions/runs/${runId}/jobs`,
+      `${GET_WORKFLOWS_URL}/${runId}/jobs`,
       {
-        headers: {
-          'Content-Type': 'application/json',
-          'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
-          'Accept': 'application/vnd.github.v3+json',
-          'user-agent': 'dd-trace benchmark tests'
-        }
+        headers: getCommonHeaders()
       },
       (res) => {
         res.on('data', (chunk) => {
@@ -100,14 +99,15 @@ const wait = (timeToWaitMs) => {
 }
 
 async function main () {
-  // trigger JS GHA
-  triggerWorkflow()
+  // Trigger JS GHA
+  await triggerWorkflow()
 
-  // give some time for GH to process the request
+  // Give some time for GH to process the request
   await wait(1000)
 
-  const res = await getWorkflowRunsInProgress()
-  const { workflow_runs: workflows } = res
+  // Get the run ID from the workflow we just triggered
+  const workflowsInProgress = await getWorkflowRunsInProgress()
+  const { workflow_runs: workflows } = workflowsInProgress
   const [{ id: runId } = {}] = workflows
 
   // Poll every 10 seconds until we have a finished status
@@ -119,7 +119,7 @@ async function main () {
         resolve()
         clearInterval(intervalId)
       } else if (status === 'completed' && conclusion !== 'success') {
-        reject(new Error('failed performance overhead test'))
+        reject(new Error('Performance overhead test failed'))
       }
     }, 10000)
   })

--- a/benchmark/e2e-ci/benchmark-run.js
+++ b/benchmark/e2e-ci/benchmark-run.js
@@ -1,0 +1,131 @@
+const https = require('https')
+
+const triggerWorkflow = () => {
+  return new Promise((resolve, reject) => {
+    let response = ''
+    const body = JSON.stringify({
+      ref: 'main'
+    })
+    const request = https.request('https://api.github.com/repos/DataDog/test-environment/actions/workflows/dd-trace-js-tests.yml/dispatches', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': body.length,
+        'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+        'Accept': 'application/vnd.github.v3+json',
+        'user-agent': 'dd-trace benchmark tests'
+      }
+    }, (res) => {
+      res.on('data', (chunk) => {
+        response += chunk
+      })
+      res.on('end', () => {
+        resolve(JSON.parse(response))
+      })
+    })
+    request.on('error', (error) => {
+      reject(error)
+    })
+    request.write(body)
+    request.end()
+  })
+}
+
+const getWorkflowRunsInProgress = () => {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    const request = https.request(
+      'https://api.github.com/repos/DataDog/test-environment/actions/runs?event=workflow_dispatch&status=in_progress OR waiting OR requested',
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+          'Accept': 'application/vnd.github.v3+json',
+          'user-agent': 'dd-trace benchmark tests'
+        }
+      },
+      (res) => {
+        res.on('data', (chunk) => {
+          body += chunk
+        })
+        res.on('end', () => {
+          resolve(JSON.parse(body))
+        })
+      })
+    request.on('error', err => {
+      reject(err)
+    })
+    request.end()
+  })
+}
+
+const getCurrentWorkflowJobs = (runId) => {
+  let body = ''
+  return new Promise((resolve, reject) => {
+    if (!runId) {
+      reject(new Error('no job id'))
+      return
+    }
+    const request = https.request(
+      `https://api.github.com/repos/DataDog/test-environment/actions/runs/${runId}/jobs`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'authorization': `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+          'Accept': 'application/vnd.github.v3+json',
+          'user-agent': 'dd-trace benchmark tests'
+        }
+      },
+      (res) => {
+        res.on('data', (chunk) => {
+          body += chunk
+        })
+        res.on('end', () => {
+          resolve(JSON.parse(body))
+        })
+      })
+    request.on('error', err => {
+      reject(err)
+    })
+    request.end()
+  })
+}
+
+const wait = (timeToWaitMs) => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve()
+    }, timeToWaitMs)
+  })
+}
+
+async function main () {
+  // trigger JS GHA
+  triggerWorkflow()
+
+  // give some time for GH to process the request
+  await wait(1000)
+
+  const res = await getWorkflowRunsInProgress()
+  const { workflow_runs: workflows } = res
+  const [{ id: runId } = {}] = workflows
+
+  // Poll every 10 seconds until we have a finished status
+  await new Promise((resolve, reject) => {
+    const intervalId = setInterval(async () => {
+      const currentWorkflow = await getCurrentWorkflowJobs(runId)
+      const { jobs: [{ status, conclusion }] } = currentWorkflow
+      if (status === 'completed' && conclusion === 'success') {
+        resolve()
+        clearInterval(intervalId)
+      } else if (status === 'completed' && conclusion !== 'success') {
+        reject(new Error('failed performance overhead test'))
+      }
+    }, 10000)
+  })
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exitCode = 1
+})

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bench": "node benchmark",
     "bench:profiler": "node benchmark/profiler",
     "bench:e2e": "SERVICES=mongo yarn services && cd benchmark/e2e && node benchmark-run.js --duration=30",
+    "bench:e2e:ci-visibility": "node benchmark/e2e-ci/benchmark-run.js",
     "type:doc": "cd docs && yarn && yarn build",
     "type:test": "cd docs && yarn && yarn test",
     "lint": "node scripts/check_licenses.js && eslint . && yarn audit --groups dependencies",


### PR DESCRIPTION
### What does this PR do?
* Add a new job that checks the performance overhead of `dd-trace-js` in different OSS projects.

Example of a successful check: https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/5534/workflows/9ce2aaae-ee20-4879-9a0c-333920ac225f/jobs/553581 

### Motivation
* Prevent releases that add a significant performance overhead.

