### PR TITLE
disable flaky pino upstream test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -886,7 +886,8 @@ workflows:
       - node-upstream-connect: *matrix-supported-node-versions
       - node-upstream-graphql: *matrix-supported-node-versions
       - node-upstream-koa: *matrix-supported-node-versions
-      - node-upstream-pino: *matrix-supported-node-versions
+      # TODO: re-enable if it ever stops being flaky
+      # - node-upstream-pino: *matrix-supported-node-versions
       - node-upstream-promise: *matrix-supported-node-versions
       - node-upstream-q: *matrix-supported-node-versions
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable flaky pino upstream test.

### Motivation
<!-- What inspired you to submit this pull request? -->

The upstream test itself is flaky. Sometimes it fails, sometimes it doesn't, regardless of the tracer being there or not.