### PR TITLE
fix(pino): support module exports for pino version >= 6.8.0

### DIFF
--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -100,7 +100,7 @@ module.exports = [
   },
   {
     name: 'pino',
-    versions: ['>=5.14.0'],
+    versions: ['>=5.14.0 <6.8.0'],
     patch (pino, tracer, config) {
       if (!tracer._logInjection) return
 
@@ -110,6 +110,30 @@ module.exports = [
     },
     unpatch (pino) {
       return this.unwrapExport(pino)
+    }
+  },
+  {
+    name: 'pino',
+    versions: ['>=6.8.0'],
+    patch (pino, tracer, config) {
+      if (!tracer._logInjection) return
+
+      const mixinSym = pino.symbols.mixinSym
+
+      const wrapped = this.wrapExport(pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino))
+
+      wrapped.pino = this.wrapExport(pino.pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.pino))
+      wrapped.default = this.wrapExport(pino.default,
+        createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.default))
+
+      return wrapped
+    },
+    unpatch (pino) {
+      const unwrapped = this.unwrapExport(pino)
+      unwrapped.pino = this.unwrapExport(pino.pino)
+      unwrapped.default = this.unwrapExport(pino.default)
+
+      return unwrapped
     }
   },
   {

--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -122,16 +122,16 @@ module.exports = [
 
       const wrapped = this.wrapExport(pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino))
 
-      wrapped.pino = this.wrapExport(pino.pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.pino))
-      wrapped.default = this.wrapExport(pino.default,
-        createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.default))
+      wrapped.pino = wrapped
+      wrapped.default = wrapped
 
       return wrapped
     },
     unpatch (pino) {
       const unwrapped = this.unwrapExport(pino)
-      unwrapped.pino = this.unwrapExport(pino.pino)
-      unwrapped.default = this.unwrapExport(pino.default)
+
+      unwrapped.pino = unwrapped
+      unwrapped.default = unwrapped
 
       return unwrapped
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Wraps the `module.exports.default` and `module.exports.pino` for Pino.

### Motivation
<!-- What inspired you to submit this pull request? -->
Fixes https://github.com/DataDog/dd-trace-js/issues/1732

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
