### PR TITLE
Appsec fix express

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -2,6 +2,7 @@
 
 const web = require('../../dd-trace/src/plugins/util/web')
 const Scope = require('../../dd-trace/src/scope')
+const { incomingHttpRequestStart } = require('../../dd-trace/src/appsec/gateway/channels')
 
 function createWrapEmit (tracer, config) {
   config = web.normalizeConfig(config)
@@ -10,6 +11,10 @@ function createWrapEmit (tracer, config) {
     return function emitWithTrace (eventName, req, res) {
       if (eventName === 'request') {
         return web.instrument(tracer, config, req, res, 'http.request', () => {
+          if (incomingHttpRequestStart.hasSubscribers) {
+            incomingHttpRequestStart.publish({ req, res })
+          }
+
           return emit.apply(this, arguments)
         })
       }

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -8,7 +8,7 @@ const tags = require('../../../../../ext/tags')
 const types = require('../../../../../ext/types')
 const kinds = require('../../../../../ext/kinds')
 const urlFilter = require('./urlfilter')
-const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../appsec/gateway/channels')
+const { incomingHttpRequestEnd } = require('../../appsec/gateway/channels')
 
 const WEB = types.WEB
 const SERVER = kinds.SERVER
@@ -72,17 +72,7 @@ const web = {
       req._datadog.instrumented = true
     }
 
-    if (callback) {
-      return tracer.scope().activate(span, () => {
-        if (incomingHttpRequestStart.hasSubscribers) {
-          incomingHttpRequestStart.publish({ req, res })
-        }
-
-        callback(span)
-      })
-    } else if (incomingHttpRequestStart.hasSubscribers) {
-      incomingHttpRequestStart.publish({ req, res })
-    }
+    return callback && tracer.scope().activate(span, () => callback(span))
   },
 
   // Reactivate the request scope in case it was changed by a middleware.

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -5,7 +5,7 @@ const agent = require('../agent')
 const types = require('../../../../../ext/types')
 const kinds = require('../../../../../ext/kinds')
 const tags = require('../../../../../ext/tags')
-const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../../src/appsec/gateway/channels')
+const { incomingHttpRequestEnd } = require('../../../src/appsec/gateway/channels')
 
 const WEB = types.WEB
 const SERVER = kinds.SERVER
@@ -376,40 +376,6 @@ describe('plugins/util/web', () => {
             [SPAN_KIND]: SERVER
           })
         })
-      })
-
-      it('should call diagnostics_channel', () => {
-        const spy = sinon.spy((data) => {
-          expect(data.req).to.equal(req)
-          expect(data.res).to.equal(res)
-          expect(tracer.scope().active()).to.exist
-        })
-
-        incomingHttpRequestStart.subscribe(spy)
-
-        web.instrument(tracer, config, req, res, 'test.request', span => {
-          expect(spy).to.have.been.calledOnce
-
-          expect(tracer.scope().active()).to.equal(span)
-        })
-
-        incomingHttpRequestStart.unsubscribe(spy)
-      })
-
-      it('should call diagnostics_channel even without callback', () => {
-        const spy = sinon.spy((data) => {
-          expect(data.req).to.equal(req)
-          expect(data.res).to.equal(res)
-          expect(tracer.scope().active()).to.not.exist
-        })
-
-        incomingHttpRequestStart.subscribe(spy)
-
-        web.instrument(tracer, config, req, res, 'test.request')
-
-        incomingHttpRequestStart.unsubscribe(spy)
-
-        expect(spy).to.have.been.calledOnce
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
Fix a bug where using Express would trigger the WAF twice on request start