### PR TITLE
fix loopback tests unable to install the module

### DIFF
--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -8,7 +8,7 @@
   "express": [
     {
       "name": "loopback",
-      "versions": [">=2.13.0"]
+      "versions": [">=2.38.1"]
     }
   ],
   "fastify": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update `loopback` test version to fix loopback tests unable to install the module.

### Motivation
<!-- What inspired you to submit this pull request? -->

It looks like the install script requires a specific Strongloop endpoint to exist which no longer exist since the version has been EOL for years.