### PR TITLE
increase cypress test timeout

### DIFF
--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -38,7 +38,7 @@ describe('Plugin', () => {
     afterEach(done => appServer.close(done))
 
     describe('cypress', function () {
-      this.timeout(60000)
+      this.timeout(120000)
       it('instruments tests', function (done) {
         process.env.DD_TRACE_AGENT_PORT = agentListenPort
         cypressExecutable.run({


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase `cypress` test timeout.

### Motivation
<!-- What inspired you to submit this pull request? -->

It randomly takes a bit over 60 seconds to complete resulting in a timeout error.