### PR TITLE
Fix typo introduced in #1734

### DIFF
--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -1,5 +1,5 @@
 const tracer = require('../../packages/dd-trace')
-const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
+const { ORIGIN_KEY } = require('../../packages/dd-trace/src/constants')
 
 tracer.init({
   startupLogs: false,


### PR DESCRIPTION
### What does this PR do?
I introduced a bug in #1734. The require path is wrong. I caught it with a failing circle ci in `master`: https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/5593/workflows/da6663fd-d5b5-4a3d-a150-326ade558bfc/jobs/565279. 

This pipeline for #1734 should have included the ci visibility benchmark test: https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/5587/workflows/5b271b67-ce6e-4455-a540-475b65c91e90 but it didn't. The branch was not up to date with `master`. It shouldn't happen again. 

The [pipeline](https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/5595/workflows/b9d831bf-4209-4ee4-b675-a383facee74f/jobs/565756) for this PR works.

### Motivation
Fix `master`
