### PR TITLE
remove client sampling

### DIFF
--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -29,7 +29,6 @@ function createSpan (parent) {
     _parentId: parent ? parent.context()._spanId : id(0),
     _hostname: hostname,
     _sampling: {},
-    _traceFlags: {},
     _tags: {
       'service.name': 'hello',
       a: 'b',

--- a/benchmark/stubs/span.js
+++ b/benchmark/stubs/span.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const constants = require('../../packages/dd-trace/src/constants')
 const id = require('../../packages/dd-trace/src/id')
-
-const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 
 const spanId = id('1234567812345678')
 
@@ -27,11 +24,9 @@ const span = {
       'resource.name': '/resource',
       'service.name': 'benchmark',
       'span.type': 'web',
-      error: true,
-      [SAMPLE_RATE_METRIC_KEY]: 1
+      error: true
     },
     _sampling: {},
-    _traceFlags: {},
     _name: 'operation'
   }),
   _startTime: 1500000000000.123456,

--- a/docs/API.md
+++ b/docs/API.md
@@ -433,7 +433,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | env             | `DD_ENV`                          | -              | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
 | logInjection    | `DD_LOGS_INJECTION`               | `false`        | Enable automatic injection of trace IDs in logs for supported logging libraries. |
 | tags            | `DD_TAGS`                         | `{}`           | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value,key:value` |
-| sampleRate      | -                                 | `1`            | Percentage of spans to sample as a float between 0 and 1. |
+| sampleRate      | `DD_TRACE_SAMPLE_RATE`            | -              | Controls the ingestion sample rate (between 0 and 1) between the agent and the backend. Defaults to deferring the decision to the agent. |
 | flushInterval   | -                                 | `2000`         | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | lookup          | -                                 | `dns.lookup()` | Custom function for DNS lookups when sending requests to the agent. |
 | protocolVersion | `DD_TRACE_AGENT_PROTOCOL_VERSION` | `0.4`          | Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -268,8 +268,7 @@ export declare interface TracerOptions {
   version?: string;
 
   /**
-   * Percentage of spans to sample as a float between 0 and 1.
-   * @default 1
+   * Controls the ingestion sample rate (between 0 and 1) between the agent and the backend.
    */
   sampleRate?: number;
 

--- a/node-upstream-tests/node/run_tests.js
+++ b/node-upstream-tests/node/run_tests.js
@@ -39,8 +39,7 @@ const IGNORED_SUITES = [
 
 const TRACING_HEADERS = [
   'x-datadog-trace-id',
-  'x-datadog-parent-id',
-  'x-datadog-sampled'
+  'x-datadog-parent-id'
 ]
 
 const UNEXPECTED_FAILURES = [

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -2,6 +2,7 @@
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { promisify } = require('util')
+const { storage } = require('../../datadog-core')
 
 describe('Plugin', () => {
   let dns
@@ -187,6 +188,21 @@ describe('Plugin', () => {
         .catch(done)
 
       resolver.resolve('lvh.me', err => err && done(err))
+    })
+
+    it('should skip instrumentation for noop context', done => {
+      const resolver = new dns.Resolver()
+      const timer = setTimeout(done, 200)
+
+      agent
+        .use(() => {
+          done(new Error('Resolve was traced.'))
+          clearTimeout(timer)
+        })
+
+      storage.run({ noop: true }, () => {
+        resolver.resolve('lvh.me', () => {})
+      })
     })
   })
 })

--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { storage } = require('../../datadog-core')
+
 let kDirReadPromisified
 let kDirClosePromisified
 let kHandle
@@ -52,7 +54,7 @@ const orphanable = false
 function createWrapCreateReadStream (config, tracer) {
   return function wrapCreateReadStream (createReadStream) {
     return function createReadStreamWithTrace (path, options) {
-      if (!hasParent(tracer)) {
+      if (!hasParent()) {
         return createReadStream.apply(this, arguments)
       }
       const tags = makeFSFlagTags('ReadStream', path, options, 'r', config, tracer)
@@ -282,8 +284,10 @@ function getSymbolName (sym) {
   return sym.description || sym.toString()
 }
 
-function hasParent (tracer) {
-  return !!tracer.scope().active()
+function hasParent () {
+  const store = storage.getStore()
+
+  return store && store.span && !store.noop
 }
 
 function createWrapCb (tracer, config, name, tagMaker) {

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -13,7 +13,6 @@ const HTTP_HEADERS = formats.HTTP_HEADERS
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
-const MANUAL_DROP = tags.MANUAL_DROP
 const SPAN_KIND = tags.SPAN_KIND
 const CLIENT = kinds.CLIENT
 
@@ -61,10 +60,6 @@ function patch (http, methodName, tracer, config) {
           'http.url': uri
         }
       })
-
-      if (!config.filter(uri)) {
-        span.setTag(MANUAL_DROP, true)
-      }
 
       if (!(hasAmazonSignature(options) || !config.propagationFilter(uri))) {
         tracer.inject(span, HTTP_HEADERS, options.headers)
@@ -299,14 +294,12 @@ function normalizeConfig (tracer, config) {
   config = config.client || config
 
   const validateStatus = getStatusValidator(config)
-  const filter = getFilter(config)
   const propagationFilter = getFilter({ blocklist: config.propagationBlocklist })
   const headers = getHeaders(config)
   const hooks = getHooks(config)
 
   return Object.assign({}, config, {
     validateStatus,
-    filter,
     propagationFilter,
     headers,
     hooks

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const URL = require('url').URL
-const opentracing = require('opentracing')
 const log = require('../../dd-trace/src/log')
-const constants = require('../../dd-trace/src/constants')
 const tags = require('../../../ext/tags')
 const kinds = require('../../../ext/kinds')
 const formats = require('../../../ext/formats')
@@ -11,16 +9,13 @@ const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const shimmer = require('../../datadog-shimmer')
 
-const Reference = opentracing.Reference
-
 const HTTP_HEADERS = formats.HTTP_HEADERS
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
+const MANUAL_DROP = tags.MANUAL_DROP
 const SPAN_KIND = tags.SPAN_KIND
 const CLIENT = kinds.CLIENT
-const REFERENCE_CHILD_OF = opentracing.REFERENCE_CHILD_OF
-const REFERENCE_NOOP = constants.REFERENCE_NOOP
 
 const HTTP2_HEADER_METHOD = ':method'
 const HTTP2_HEADER_PATH = ':path'
@@ -165,12 +160,8 @@ function startSpan (tracer, config, headers, sessionDetails) {
   const method = headers[HTTP2_HEADER_METHOD] || HTTP2_METHOD_GET
   const url = `${sessionDetails.protocol}//${sessionDetails.host}:${sessionDetails.port}${path}`
 
-  const type = config.filter(url) ? REFERENCE_CHILD_OF : REFERENCE_NOOP
-
   const span = tracer.startSpan('http.request', {
-    references: [
-      new Reference(type, childOf)
-    ],
+    childOf,
     tags: {
       [SPAN_KIND]: CLIENT,
       'service.name': getServiceName(tracer, config, sessionDetails),
@@ -180,6 +171,10 @@ function startSpan (tracer, config, headers, sessionDetails) {
       'http.url': url.split('?')[0]
     }
   })
+
+  if (!config.filter(url)) {
+    span.setTag(MANUAL_DROP, true)
+  }
 
   if (!hasAmazonSignature(headers, path)) {
     tracer.inject(span, HTTP_HEADERS, headers)

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -20,6 +20,7 @@ const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_ROUTE = tags.HTTP_ROUTE
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
+const MANUAL_DROP = tags.MANUAL_DROP
 
 const HTTP_STATUS_OK = 200
 const HTTP2_HEADER_AUTHORITY = ':authority'
@@ -73,9 +74,8 @@ function instrumentStream (tracer, config, stream, headers, name, callback) {
 
   const span = startStreamSpan(tracer, config, stream, headers, name)
 
-  // TODO: replace this with a REFERENCE_NOOP after we split http/express/etc
   if (!config.filter(headers[HTTP2_HEADER_PATH])) {
-    span.context()._traceFlags.sampled = false
+    span.setTag(MANUAL_DROP, true)
   }
 
   if (config.service) {

--- a/packages/datadog-plugin-net/src/index.js
+++ b/packages/datadog-plugin-net/src/index.js
@@ -2,10 +2,15 @@
 
 const tx = require('../../dd-trace/src/plugins/util/tx')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
+const { storage } = require('../../datadog-core')
 
 function createWrapConnect (tracer, config) {
   return function wrapConnect (connect) {
     return function connectWithTrace () {
+      const store = storage.getStore()
+
+      if (store && store.noop) return connect.apply(this, arguments)
+
       const scope = tracer.scope()
       const options = getOptions(arguments)
       const lastIndex = arguments.length - 1

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -143,7 +143,12 @@ class Config {
     const dogstatsd = coalesce(options.dogstatsd, {})
 
     Object.assign(sampler, {
-      sampleRate: coalesce(ingestion.sampleRate, sampler.sampleRate, process.env.DD_TRACE_SAMPLE_RATE),
+      sampleRate: coalesce(
+        options.sampleRate,
+        ingestion.sampleRate,
+        sampler.sampleRate,
+        process.env.DD_TRACE_SAMPLE_RATE
+      ),
       rateLimit: coalesce(ingestion.rateLimit, sampler.rateLimit, process.env.DD_TRACE_RATE_LIMIT)
     })
 
@@ -159,7 +164,7 @@ class Config {
     this.hostname = DD_AGENT_HOST || (this.url && this.url.hostname)
     this.port = String(DD_TRACE_AGENT_PORT || (this.url && this.url.port))
     this.flushInterval = coalesce(parseInt(options.flushInterval, 10), defaultFlushInterval)
-    this.sampleRate = coalesce(Math.min(Math.max(options.sampleRate, 0), 1), 1)
+    this.sampleRate = coalesce(Math.min(Math.max(sampler.sampleRate, 0), 1), 1)
     this.logger = options.logger
     this.plugins = !!coalesce(options.plugins, true)
     this.service = DD_SERVICE

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -1,12 +1,10 @@
 'use strict'
 
 module.exports = {
-  SAMPLE_RATE_METRIC_KEY: '_sample_rate',
   SAMPLING_PRIORITY_KEY: '_sampling_priority_v1',
   ANALYTICS_KEY: '_dd1.sr.eausr',
   ORIGIN_KEY: '_dd.origin',
   HOSTNAME_KEY: '_dd.hostname',
-  REFERENCE_NOOP: 'noop',
   SAMPLING_RULE_DECISION: '_dd.rule_psr',
   SAMPLING_LIMIT_DECISION: '_dd.limit_psr',
   SAMPLING_AGENT_DECISION: '_dd.agent_psr',

--- a/packages/dd-trace/src/exporters/agent/request.js
+++ b/packages/dd-trace/src/exporters/agent/request.js
@@ -4,12 +4,17 @@ const http = require('http')
 const https = require('https')
 const docker = require('./docker')
 const log = require('../../log')
+const { storage } = require('../../../../datadog-core')
 
 const httpAgent = new http.Agent({ keepAlive: true })
 const httpsAgent = new https.Agent({ keepAlive: true })
 const containerId = docker.id()
 
 function retriableRequest (options, callback, client, data) {
+  const store = storage.getStore()
+
+  storage.enterWith({ noop: true })
+
   const req = client.request(options, res => {
     let data = ''
 
@@ -29,6 +34,9 @@ function retriableRequest (options, callback, client, data) {
   })
   req.setTimeout(options.timeout, req.abort)
   data.forEach(buffer => req.write(buffer))
+
+  storage.enterWith(store)
+
   return req
 }
 

--- a/packages/dd-trace/src/log.js
+++ b/packages/dd-trace/src/log.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const NoopSpan = require('./noop/span')
+const { storage } = require('../../datadog-core')
 
 const _default = {
   debug: msg => console.debug(msg), /* eslint-disable-line no-console */
@@ -45,11 +45,11 @@ function processMsg (msg) {
 }
 
 function withNoop (fn) {
-  if (!log._tracer) {
-    fn()
-  } else {
-    log._tracer.scope().activate(log._noopSpan(), fn)
-  }
+  const store = storage.getStore()
+
+  storage.enterWith({ noop: true })
+  fn()
+  storage.enterWith(store)
 }
 
 const log = {
@@ -73,18 +73,9 @@ const log = {
     return this
   },
 
-  _noopSpan () {
-    if (!this.__noopSpan) {
-      this.__noopSpan = new NoopSpan(this._tracer)
-    }
-    return this.__noopSpan
-  },
-
   reset () {
     this._logger = _default
     this._enabled = false
-    delete this._tracer
-    delete this.__noopSpan
     this._deprecate = memoize((code, message) => {
       withNoop(() => this._logger.error(message))
       return this

--- a/packages/dd-trace/src/noop/span_context.js
+++ b/packages/dd-trace/src/noop/span_context.js
@@ -9,7 +9,6 @@ class NoopSpanContext extends DatadogSpanContext {
   constructor (props) {
     super(props)
 
-    this._traceFlags.sampled = false
     this._sampling.priority = USER_REJECT
   }
 }

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -105,7 +105,7 @@ class TextMapPropagator {
     carrier[b3SampledKey] = spanContext._sampling.priority >= AUTO_KEEP ? '1' : '0'
 
     if (spanContext._sampling.priority > AUTO_KEEP) {
-      carrier[b3FlagsKey] = '1' // debug flag means force trace
+      carrier[b3FlagsKey] = '1'
     }
 
     if (spanContext._parentId) {

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -4,29 +4,24 @@ const opentracing = require('opentracing')
 const now = require('performance-now')
 const Span = opentracing.Span
 const SpanContext = require('./span_context')
-const constants = require('../constants')
 const id = require('../id')
 const tagger = require('../tagger')
 const log = require('../log')
 const { storage } = require('../../../datadog-core')
 
-const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 const { DD_TRACE_EXPERIMENTAL_STATE_TRACKING } = process.env
 
 class DatadogSpan extends Span {
-  constructor (tracer, processor, sampler, prioritySampler, fields, debug) {
+  constructor (tracer, processor, prioritySampler, fields, debug) {
     super()
 
     const operationName = fields.operationName
     const parent = fields.parent || null
-    const tags = Object.assign({
-      [SAMPLE_RATE_METRIC_KEY]: sampler.rate()
-    }, fields.tags)
+    const tags = Object.assign({}, fields.tags)
     const hostname = fields.hostname
 
     this._parentTracer = tracer
     this._debug = debug
-    this._sampler = sampler
     this._processor = processor
     this._prioritySampler = prioritySampler
     this._store = storage.getStore()

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -16,9 +16,6 @@ class DatadogSpanContext extends SpanContext {
     this._tags = props.tags || {}
     this._sampling = props.sampling || {}
     this._baggageItems = props.baggageItems || {}
-    this._traceFlags = props.traceFlags || {}
-    this._traceFlags.sampled = this._traceFlags.sampled !== false
-    this._traceFlags.debug = this._traceFlags.debug === true
     this._noop = props.noop || null
     this._trace = props.trace || {
       started: [],

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -7,21 +7,17 @@ const Reference = opentracing.Reference
 const Span = require('./span')
 const SpanContext = require('./span_context')
 const SpanProcessor = require('../span_processor')
-const Sampler = require('../sampler')
 const PrioritySampler = require('../priority_sampler')
 const TextMapPropagator = require('./propagation/text_map')
 const HttpPropagator = require('./propagation/http')
 const BinaryPropagator = require('./propagation/binary')
 const LogPropagator = require('./propagation/log')
-const NoopSpan = require('../noop/span')
 const formats = require('../../../../ext/formats')
 
 const log = require('../log')
-const constants = require('../constants')
 const metrics = require('../metrics')
 const getExporter = require('../exporter')
 
-const REFERENCE_NOOP = constants.REFERENCE_NOOP
 const REFERENCE_CHILD_OF = opentracing.REFERENCE_CHILD_OF
 const REFERENCE_FOLLOWS_FROM = opentracing.REFERENCE_FOLLOWS_FROM
 
@@ -41,7 +37,6 @@ class DatadogTracer extends Tracer {
     this._exporter = new Exporter(config, this._prioritySampler)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)
     this._url = this._exporter._url
-    this._sampler = new Sampler(config.sampleRate)
     this._enableGetRumData = config.experimental.enableGetRumData
     this._propagators = {
       [formats.TEXT_MAP]: new TextMapPropagator(config),
@@ -56,20 +51,16 @@ class DatadogTracer extends Tracer {
 
   _startSpan (name, fields) {
     const reference = getParent(fields.references)
-    const type = reference && reference.type()
     const parent = reference && reference.referencedContext()
-    return this._startSpanInternal(name, fields, parent, type)
+    return this._startSpanInternal(name, fields, parent)
   }
 
-  _startSpanInternal (name, fields = {}, parent, type) {
-    if (parent && parent._noop) return parent._noop
-    if (!isSampled(this._sampler, parent, type)) return new NoopSpan(this, parent)
-
+  _startSpanInternal (name, fields = {}, parent) {
     const tags = {
       'service.name': this._service
     }
 
-    const span = new Span(this, this._processor, this._sampler, this._prioritySampler, {
+    const span = new Span(this, this._processor, this._prioritySampler, {
       operationName: fields.operationName || name,
       parent,
       tags,
@@ -120,12 +111,12 @@ function getParent (references = []) {
     const spanContext = ref.referencedContext()
     const type = ref.type()
 
-    if (type !== REFERENCE_NOOP && spanContext && !(spanContext instanceof SpanContext)) {
+    if (spanContext && !(spanContext instanceof SpanContext)) {
       log.error(() => `Expected ${spanContext} to be an instance of SpanContext`)
       continue
     }
 
-    if (type === REFERENCE_CHILD_OF || type === REFERENCE_NOOP) {
+    if (type === REFERENCE_CHILD_OF) {
       parent = ref
       break
     } else if (type === REFERENCE_FOLLOWS_FROM) {
@@ -136,14 +127,6 @@ function getParent (references = []) {
   }
 
   return parent
-}
-
-function isSampled (sampler, parent, type) {
-  if (type === REFERENCE_NOOP) return false
-  if (parent && !parent._traceFlags.sampled) return false
-  if (!parent && !sampler.isSampled()) return false
-
-  return true
 }
 
 module.exports = DatadogTracer

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -6,7 +6,13 @@ const { storage } = require('../../../datadog-core')
 class Subscription {
   constructor (event, handler) {
     this._channel = dc.channel(event)
-    this._handler = handler
+    this._handler = (message, name) => {
+      const store = storage.getStore()
+
+      if (!store || !store.noop) {
+        handler(message, name)
+      }
+    }
   }
 
   enable () {

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -124,8 +124,7 @@ function finishAllTraceSpans (span) {
 function getTestParentSpan (tracer) {
   return tracer.extract('text_map', {
     'x-datadog-trace-id': id().toString(10),
-    'x-datadog-parent-id': '0000000000000000',
-    'x-datadog-sampled': 1
+    'x-datadog-parent-id': '0000000000000000'
   })
 }
 /**

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -23,6 +23,7 @@ const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_ROUTE = tags.HTTP_ROUTE
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
+const MANUAL_DROP = tags.MANUAL_DROP
 
 const HTTP2_HEADER_AUTHORITY = ':authority'
 const HTTP2_HEADER_SCHEME = ':scheme'
@@ -54,9 +55,8 @@ const web = {
 
     const span = startSpan(tracer, config, req, res, name)
 
-    // TODO: replace this with a REFERENCE_NOOP after we split http/express/etc
     if (!config.filter(req.url)) {
-      span.context()._traceFlags.sampled = false
+      span.setTag(MANUAL_DROP, true)
     }
 
     if (config.service) {
@@ -310,7 +310,7 @@ function addAllowHeaders (req, headers) {
   const contextHeaders = [
     'x-datadog-origin',
     'x-datadog-parent-id',
-    'x-datadog-sampled',
+    'x-datadog-sampled', // Deprecated, but still accept it in case it's sent.
     'x-datadog-sampling-priority',
     'x-datadog-trace-id'
   ]

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -16,13 +16,6 @@ class SpanProcessor {
 
     if (trace.started.length === trace.finished.length) {
       this._prioritySampler.sample(spanContext)
-
-      if (spanContext._traceFlags.sampled === false) {
-        log.debug(() => `Dropping trace due to user configured filtering: ${trace.started}`)
-        this._erase(trace)
-        return
-      }
-
       const formattedSpans = trace.finished.map(format)
       this._exporter.export(formattedSpans)
       this._erase(trace)

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -4,6 +4,7 @@ const Tracer = require('./opentracing/tracer')
 const tags = require('../../../ext/tags')
 const ScopeManager = require('./scope/noop/scope_manager')
 const Scope = require('./scope')
+const { storage } = require('../../datadog-core')
 const { isError } = require('./util')
 const { setStartupLogConfig } = require('./startup-log')
 
@@ -68,6 +69,10 @@ class DatadogTracer extends Tracer {
     const tracer = this
 
     return function () {
+      const store = storage.getStore()
+
+      if (store && store.noop) return fn.apply(this, arguments)
+
       let optionsObj = options
       if (typeof optionsObj === 'function' && typeof fn === 'function') {
         optionsObj = optionsObj.apply(this, arguments)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -129,6 +129,7 @@ describe('Config', () => {
     expect(config).to.have.property('runtimeMetrics', true)
     expect(config).to.have.property('reportHostname', true)
     expect(config).to.have.property('env', 'test')
+    expect(config).to.have.property('sampleRate', 0.5)
     expect(config.tags).to.include({ foo: 'bar', baz: 'qux' })
     expect(config.tags).to.include({ service: 'service', 'version': '1.0.0', 'env': 'test' })
     expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: '0.5', rateLimit: '-1' })
@@ -246,8 +247,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.runtimeId', true)
     expect(config).to.have.nested.property('experimental.exporter', 'log')
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
-    expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: 1, rateLimit: 1000 })
     expect(config).to.have.nested.property('appsec.enabled', true)
+    expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: 0.5, rateLimit: 1000 })
   })
 
   it('should initialize from the options with url taking precedence', () => {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const { expect } = require('chai')
+const { storage } = require('../../datadog-core')
+
 /* eslint-disable no-console */
 
 describe('log', () => {
@@ -41,6 +44,14 @@ describe('log', () => {
         .debug('debug')
         .reset()
     }).to.not.throw()
+  })
+
+  it('should call the logger in a noop context', () => {
+    logger.debug = () => {
+      expect(storage.getStore()).to.have.property('noop', true)
+    }
+
+    log.use(logger).debug('debug')
   })
 
   describe('debug', () => {
@@ -262,33 +273,6 @@ describe('log', () => {
       log.deprecate('test', 'message')
 
       expect(console.error).to.have.been.calledOnce
-    })
-  })
-
-  describe('tracing', () => {
-    it('should be disabled inside logging', (done) => {
-      let onceDone = () => {
-        onceDone = () => {}
-        done()
-      }
-      const tracer = require('../../dd-trace').init({
-        debug: true,
-        plugins: false,
-        service: 'test',
-        logger: {
-          debug: () => {
-            expect(!!tracer.scope().active().context()._noop).to.equal(true)
-            onceDone()
-          },
-          info: () => {},
-          warn: () => {},
-          error: () => {}
-        }
-      })
-      tracer.trace('testing.testing', () => {
-        expect(!!tracer.scope().active().context()._noop).to.equal(false)
-        log.debug()
-      })
     })
   })
 })

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -1,10 +1,7 @@
 'use strict'
 
-const constants = require('../../src/constants')
 const Config = require('../../src/config')
 const TextMapPropagator = require('../../src/opentracing/propagation/text_map')
-
-const SAMPLE_RATE_METRIC_KEY = constants.SAMPLE_RATE_METRIC_KEY
 
 describe('Span', () => {
   let Span
@@ -12,7 +9,6 @@ describe('Span', () => {
   let tracer
   let processor
   let prioritySampler
-  let sampler
   let now
   let metrics
   let handle
@@ -34,10 +30,6 @@ describe('Span', () => {
     id.onSecondCall().returns('456')
 
     tracer = {}
-
-    sampler = {
-      rate: sinon.stub().returns(1)
-    }
 
     processor = {
       process: sinon.stub()
@@ -64,14 +56,14 @@ describe('Span', () => {
   })
 
   it('should have a default context', () => {
-    span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+    span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 
     expect(span.context()._traceId).to.deep.equal('123')
     expect(span.context()._spanId).to.deep.equal('123')
   })
 
   it('should add itself to the context trace started spans', () => {
-    span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+    span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 
     expect(span.context()._trace.started).to.deep.equal([span])
   })
@@ -81,7 +73,7 @@ describe('Span', () => {
     now.onSecondCall().returns(300)
     now.onThirdCall().returns(700)
 
-    span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+    span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
     span.finish()
 
     expect(Math.round(span._startTime)).to.equal(1500000000200)
@@ -92,7 +84,7 @@ describe('Span', () => {
     now.onFirstCall().returns(100)
     now.onSecondCall().returns(100)
 
-    const parent = new Span(tracer, processor, sampler, prioritySampler, {
+    const parent = new Span(tracer, processor, prioritySampler, {
       operationName: 'parent'
     })
 
@@ -100,7 +92,7 @@ describe('Span', () => {
     now.onFirstCall().returns(300)
     now.onSecondCall().returns(700)
 
-    span = new Span(tracer, processor, sampler, prioritySampler, {
+    span = new Span(tracer, processor, prioritySampler, {
       operationName: 'operation',
       parent: parent.context()
     })
@@ -121,7 +113,7 @@ describe('Span', () => {
     now.onSecondCall().returns(300)
     now.onThirdCall().returns(700)
 
-    span = new Span(tracer, processor, sampler, prioritySampler, {
+    span = new Span(tracer, processor, prioritySampler, {
       operationName: 'operation',
       parent
     })
@@ -143,7 +135,7 @@ describe('Span', () => {
       }
     }
 
-    span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation', parent })
+    span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
 
     expect(span.context()._traceId).to.deep.equal('123')
     expect(span.context()._parentId).to.deep.equal('456')
@@ -151,13 +143,9 @@ describe('Span', () => {
     expect(span.context()._trace).to.equal(parent._trace)
   })
 
-  it('should set the sample rate metric from the sampler', () => {
-    expect(span.context()._tags).to.have.property(SAMPLE_RATE_METRIC_KEY, 1)
-  })
-
   describe('tracer', () => {
     it('should return its parent tracer', () => {
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 
       expect(span.tracer()).to.equal(tracer)
     })
@@ -165,7 +153,7 @@ describe('Span', () => {
 
   describe('setOperationName', () => {
     it('should set the operation name', () => {
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'foo' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'foo' })
       span.setOperationName('bar')
 
       expect(span.context()._name).to.equal('bar')
@@ -184,7 +172,7 @@ describe('Span', () => {
         }
       }
 
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation', parent })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
       span.setBaggageItem('foo', 'bar')
 
       expect(span.context()._baggageItems).to.have.property('foo', 'bar')
@@ -204,7 +192,7 @@ describe('Span', () => {
         }
       }
 
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation', parent })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
 
       expect(span.context()._baggageItems).to.have.property('foo', 'bar')
     })
@@ -212,7 +200,7 @@ describe('Span', () => {
 
   describe('getBaggageItem', () => {
     it('should get a baggage item', () => {
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
       span._spanContext._baggageItems.foo = 'bar'
 
       expect(span.getBaggageItem('foo')).to.equal('bar')
@@ -221,7 +209,7 @@ describe('Span', () => {
 
   describe('setTag', () => {
     it('should set a tag', () => {
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
       span.setTag('foo', 'bar')
 
       expect(tagger.add).to.have.been.calledWith(span.context()._tags, { foo: 'bar' })
@@ -230,7 +218,7 @@ describe('Span', () => {
 
   describe('addTags', () => {
     beforeEach(() => {
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
     })
 
     it('should add tags', () => {
@@ -254,7 +242,7 @@ describe('Span', () => {
     it('should add itself to the context trace finished spans', () => {
       processor.process.returns(Promise.resolve())
 
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
       span.finish()
 
       expect(span.context()._trace.finished).to.deep.equal([span])
@@ -263,7 +251,7 @@ describe('Span', () => {
     it('should record the span', () => {
       processor.process.returns(Promise.resolve())
 
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
       span.finish()
 
       expect(processor.process).to.have.been.calledWith(span)
@@ -272,7 +260,7 @@ describe('Span', () => {
     it('should not record the span if already finished', () => {
       processor.process.returns(Promise.resolve())
 
-      span = new Span(tracer, processor, sampler, prioritySampler, { operationName: 'operation' })
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
       span.finish()
       span.finish()
 

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -21,10 +21,6 @@ describe('SpanContext', () => {
       metrics: {},
       sampling: { priority: 2 },
       baggageItems: { foo: 'bar' },
-      traceFlags: {
-        sampled: false,
-        debug: true
-      },
       noop,
       trace: {
         started: ['span1', 'span2'],
@@ -43,10 +39,6 @@ describe('SpanContext', () => {
       _tags: {},
       _sampling: { priority: 2 },
       _baggageItems: { foo: 'bar' },
-      _traceFlags: {
-        sampled: false,
-        debug: true
-      },
       _noop: noop,
       _trace: {
         started: ['span1', 'span2'],
@@ -71,10 +63,6 @@ describe('SpanContext', () => {
       _tags: {},
       _sampling: {},
       _baggageItems: {},
-      _traceFlags: {
-        sampled: true,
-        debug: false
-      },
       _noop: null,
       _trace: {
         started: [],

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -3,7 +3,6 @@
 const opentracing = require('opentracing')
 const os = require('os')
 const SpanContext = require('../../src/opentracing/span_context')
-const NoopSpan = require('../../src/noop/span')
 const Reference = opentracing.Reference
 
 describe('Tracer', () => {
@@ -18,8 +17,6 @@ describe('Tracer', () => {
   let processor
   let exporter
   let agentExporter
-  let Sampler
-  let sampler
   let spanContext
   let fields
   let carrier
@@ -52,11 +49,6 @@ describe('Tracer', () => {
       process: sinon.spy()
     }
     SpanProcessor = sinon.stub().returns(processor)
-
-    sampler = {
-      isSampled: sinon.stub().returns(true)
-    }
-    Sampler = sinon.stub().returns(sampler)
 
     spanContext = {}
     carrier = {}
@@ -93,7 +85,6 @@ describe('Tracer', () => {
       './span_context': SpanContext,
       '../priority_sampler': PrioritySampler,
       '../span_processor': SpanProcessor,
-      '../sampler': Sampler,
       './propagation/text_map': TextMapPropagator,
       './propagation/http': HttpPropagator,
       './propagation/binary': BinaryPropagator,
@@ -110,12 +101,6 @@ describe('Tracer', () => {
     expect(SpanProcessor).to.have.been.calledWith(agentExporter, prioritySampler)
   })
 
-  it('should support sampling', () => {
-    tracer = new Tracer(config)
-
-    expect(Sampler).to.have.been.calledWith(config.sampleRate)
-  })
-
   describe('startSpan', () => {
     it('should start a span', () => {
       fields.tags = { foo: 'bar' }
@@ -124,7 +109,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       const testSpan = tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWith(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWith(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null,
         tags: {
@@ -151,7 +136,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent
       })
@@ -167,7 +152,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent
       })
@@ -180,7 +165,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       const testSpan = tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWith(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWith(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null,
         tags: {
@@ -204,7 +189,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent
       })
@@ -220,7 +205,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null
       })
@@ -232,7 +217,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null
       })
@@ -246,7 +231,7 @@ describe('Tracer', () => {
       tracer = new Tracer(config)
       tracer.startSpan('name', fields)
 
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, sampler, prioritySampler, {
+      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null
       })
@@ -268,58 +253,6 @@ describe('Tracer', () => {
 
       expect(span.addTags).to.have.been.calledWith(config.tags)
       expect(span.addTags).to.have.been.calledWith(fields.tags)
-    })
-
-    it('should return a noop span when not sampled', () => {
-      sampler.isSampled.returns(false)
-
-      tracer = new Tracer(config)
-      span = tracer.startSpan('name', fields)
-
-      expect(span.context()).to.have.property('_noop', span)
-      expect(span.context()._traceFlags).to.include({ sampled: false })
-    })
-
-    it('should return a noop when the parent is not sampled', () => {
-      tracer = new Tracer(config)
-
-      const parent = new SpanContext({ traceFlags: { sampled: false } })
-
-      fields.references = [
-        new Reference(opentracing.REFERENCE_CHILD_OF, parent)
-      ]
-
-      span = tracer.startSpan('name', fields)
-
-      expect(span.context()).to.have.property('_noop', span)
-      expect(span.context()._traceFlags).to.include({ sampled: false })
-    })
-
-    it('should return the same instance when the parent is a noop', () => {
-      tracer = new Tracer(config)
-
-      const parent = new NoopSpan(tracer)
-
-      fields.childOf = parent
-
-      span = tracer.startSpan('name', fields)
-
-      expect(span).to.equal(parent)
-    })
-
-    it('should always start a new span when the parent is sampled', () => {
-      const parent = new SpanContext()
-
-      fields.references = [
-        new Reference(opentracing.REFERENCE_CHILD_OF, parent)
-      ]
-
-      sampler.isSampled.returns(false)
-
-      tracer = new Tracer(config)
-      tracer.startSpan('name', fields)
-
-      expect(Span).to.have.been.called
     })
   })
 

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -6,6 +6,7 @@ const types = require('../../../../../ext/types')
 const kinds = require('../../../../../ext/kinds')
 const tags = require('../../../../../ext/tags')
 const { incomingHttpRequestEnd } = require('../../../src/appsec/gateway/channels')
+const { USER_REJECT } = require('../../../../../ext/priority')
 
 const WEB = types.WEB
 const SERVER = kinds.SERVER
@@ -375,6 +376,18 @@ describe('plugins/util/web', () => {
             [HTTP_METHOD]: 'GET',
             [SPAN_KIND]: SERVER
           })
+        })
+      })
+
+      it('should drop filtered out requests', () => {
+        config.filter = () => false
+
+        web.instrument(tracer, config, req, res, 'test.request', span => {
+          const sampling = span.context()._sampling
+
+          res.end()
+
+          expect(sampling).to.have.property('priority', USER_REJECT)
         })
       })
     })

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -20,8 +20,7 @@ describe('SpanProcessor', () => {
       context: sinon.stub().returns({
         _trace: trace,
         _sampling: {},
-        _tags: {},
-        _traceFlags: {}
+        _tags: {}
       })
     }
 
@@ -59,12 +58,6 @@ describe('SpanProcessor', () => {
   it('should skip traces with unfinished spans', () => {
     trace.started = [span]
     trace.finished = []
-    processor.process(span)
-
-    expect(exporter.export).not.to.have.been.called
-  })
-  it('should not append if the span was dropped', () => {
-    span.context()._traceFlags.sampled = false
     processor.process(span)
 
     expect(exporter.export).not.to.have.been.called

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Span = require('opentracing').Span
+const { storage } = require('../../datadog-core')
 const Config = require('../src/config')
 const tags = require('../../../ext/tags')
 
@@ -410,6 +411,18 @@ describe('Tracer', () => {
       expect(tracer.trace).to.have.been.calledWith('name', {
         tags: { sometag: 'somevalue', invocations: 2 }
       })
+    })
+
+    it('should not trace in a noop context', () => {
+      const fn = tracer.wrap('name', {}, () => {})
+
+      sinon.spy(tracer, 'trace')
+
+      storage.enterWith({ noop: true })
+      fn()
+      storage.enterWith(null)
+
+      expect(tracer.trace).to.have.not.been.called
     })
 
     describe('when there is no parent span', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Deprecate client sampling and update the existing configuration options to configure sampling priority instead.

### Motivation
<!-- What inspired you to submit this pull request? -->

Client sampling in its current form has many problems:

- Causes stats to become inaccurate.
- Propagates the decision using a header that is not standardized across languages.
- Isn't deterministic when the header is not present.
- Conflicts with sampling priority in many places.

At the end of the day, it also doesn't reduce significantly the performance overhead which was one of the main two goals. The other one was to reduce the load on the agent, but over the years there were several improvements to the agent and it's now able to protect itself if it receives too many traces/sec.

Moving forward, the sampling priority will also be handled in the tracer instead of the agent, so we'll get client sampling back for free at that point.