### PR TITLE
[ci-visibility] Fix mocha when run in `parallel` mode 

### DIFF
--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -122,10 +122,7 @@ function getAllTestsInSuite (root) {
 function createWrapRunTests (tracer, testEnvironmentMetadata, sourceRoot) {
   return function wrapRunTests (runTests) {
     return function runTestsWithTrace () {
-      if (!this.__datadog_end_handled) {
-        this.once('end', () => tracer._exporter._writer.flush())
-        this.__datadog_end_handled = true
-      }
+      this.once('end', () => tracer._exporter._writer.flush())
       runTests.apply(this, arguments)
       const suite = arguments[0]
       const tests = getAllTestsInSuite(suite)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -122,6 +122,10 @@ function getAllTestsInSuite (root) {
 function createWrapRunTests (tracer, testEnvironmentMetadata, sourceRoot) {
   return function wrapRunTests (runTests) {
     return function runTestsWithTrace () {
+      if (!this.__datadog_end_handled) {
+        this.once('end', () => tracer._exporter._writer.flush())
+        this.__datadog_end_handled = true
+      }
       runTests.apply(this, arguments)
       const suite = arguments[0]
       const tests = getAllTestsInSuite(suite)


### PR DESCRIPTION
### What does this PR do?
When run in `parallel` mode, `mocha` leverages [`workerpool`](https://github.com/josdejong/workerpool) for its "child processes pool". Under certain situations, these child processes are being terminated _before the `'beforeExit'` handler_ is being called. This means that we were not flushing our traces in https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/exporters/agent/scheduler.js#L14. 

With this change, we make sure we flush our test traces before `mocha` finishes, by listening to its `'end'` event, defined [here](https://github.com/mochajs/mocha/blob/master/lib/runner.js#L82).

### Motivation
Work with `mocha` when run in `parallel` mode. 

