### PR TITLE
add cypress 'dd:addTags' command

### DIFF
--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -83,6 +83,12 @@ module.exports = (on, config) => {
       }
       activeSpan = null
       return null
+    },
+    'dd:addTags': (tags) => {
+      if (activeSpan) {
+        activeSpan.addTags(tags)
+      }
+      return null
     }
   })
 }

--- a/packages/datadog-plugin-cypress/test/app/cypress/integration/integration-test.js
+++ b/packages/datadog-plugin-cypress/test/app/cypress/integration/integration-test.js
@@ -2,13 +2,20 @@
 context('can visit a page', () => {
   beforeEach(() => {
     cy.visit('/')
+    cy.task('dd:addTags', { addTagsBeforeEach: 'custom' })
+  })
+  afterEach(() => {
+    cy.task('dd:addTags', { addTagsAfterEach: 'custom' })
   })
   it('renders a hello world', () => {
+    cy.task('dd:addTags', { addTags: 'custom' })
     cy.get('.hello-world')
       .should('have.text', 'Hello World')
   })
   it('will fail', () => {
+    cy.task('dd:addTags', { addTags: 'custom' })
     cy.get('.hello-world')
       .should('have.text', 'Bye World')
+    cy.task('dd:addTags', { addTagsAfterFailure: 'custom' })
   })
 })

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -58,6 +58,9 @@ describe('Plugin', () => {
             expect(testSpan.type).to.equal('test')
             expect(testSpan.meta).to.contain({
               language: 'javascript',
+              addTags: 'custom',
+              addTagsBeforeEach: 'custom',
+              addTagsAfterEach: 'custom',
               [TEST_FRAMEWORK]: 'cypress',
               [TEST_NAME]: 'can visit a page renders a hello world',
               [TEST_STATUS]: 'pass',
@@ -78,6 +81,9 @@ describe('Plugin', () => {
             expect(testSpan.type).to.equal('test')
             expect(testSpan.meta).to.contain({
               language: 'javascript',
+              addTags: 'custom',
+              addTagsBeforeEach: 'custom',
+              addTagsAfterEach: 'custom',
               [TEST_FRAMEWORK]: 'cypress',
               [TEST_NAME]: 'can visit a page will fail',
               [TEST_STATUS]: 'fail',
@@ -86,6 +92,9 @@ describe('Plugin', () => {
               [ORIGIN_KEY]: CI_APP_ORIGIN,
               [ERROR_TYPE]: 'AssertionError',
               [TEST_IS_RUM_ACTIVE]: 'true'
+            })
+            expect(testSpan.meta).to.not.contain({
+              addTagsAfterFailure: 'custom'
             })
             expect(testSpan.meta[ERROR_MESSAGE]).to.contain(
               "expected '<div.hello-world>' to have text 'Bye World', but the text was 'Hello World'"


### PR DESCRIPTION
### What does this PR do?
add a `cy.task('dd:addTags', { custom: 'value' })` command to cypress

### Motivation
We like to annotate cypress tests with additional information like the responsible team and a link to the video recording.

### Additional Notes
Based on the discussion in [1662](https://github.com/DataDog/dd-trace-js/pull/1662)
