### PR TITLE
Change `cypress` `test.type` to `'browser'`

### DIFF
--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -27,7 +27,7 @@ function getTestSpanMetadata (tracer, testName, testSuite, cypressConfig) {
   return {
     childOf,
     resource: `${testSuite}.${testName}`,
-    [TEST_TYPE]: 'test',
+    [TEST_TYPE]: 'browser',
     [TEST_NAME]: testName,
     [TEST_SUITE]: testSuite,
     [SAMPLING_RULE_DECISION]: 1,

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -62,7 +62,7 @@ describe('Plugin', () => {
               [TEST_NAME]: 'can visit a page renders a hello world',
               [TEST_STATUS]: 'pass',
               [TEST_SUITE]: 'cypress/integration/integration-test.js',
-              [TEST_TYPE]: 'test',
+              [TEST_TYPE]: 'browser',
               [ORIGIN_KEY]: CI_APP_ORIGIN,
               [TEST_IS_RUM_ACTIVE]: 'true'
             })
@@ -82,7 +82,7 @@ describe('Plugin', () => {
               [TEST_NAME]: 'can visit a page will fail',
               [TEST_STATUS]: 'fail',
               [TEST_SUITE]: 'cypress/integration/integration-test.js',
-              [TEST_TYPE]: 'test',
+              [TEST_TYPE]: 'browser',
               [ORIGIN_KEY]: CI_APP_ORIGIN,
               [ERROR_TYPE]: 'AssertionError',
               [TEST_IS_RUM_ACTIVE]: 'true'


### PR DESCRIPTION
### What does this PR do?
Set `test.type` to `browser` for `cypress` tests. 

### Motivation
Be able to distinguish tests that spin up a browser.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
