### PR TITLE
move @types/node to devDependencies

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,7 +2,6 @@ Component,Origin,License,Copyright
 require,@datadog/native-metrics,Apache license 2.0,Copyright 2018 Datadog Inc.
 require,@datadog/pprof,Apache license 2.0,Copyright 2019 Google Inc.
 require,@datadog/sketches-js,Apache license 2.0,Copyright 2020 Datadog Inc.
-require,@types/node,MIT,Copyright Authors
 require,crypto-randomuuid,MIT,Copyright 2021 Node.js Foundation and contributors
 require,diagnostics_channel,MIT,Copyright 2021 Simon D.
 require,form-data,MIT,Copyright 2012 Felix Geisendörfer and contributors
@@ -23,6 +22,7 @@ require,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 require,source-map,BSD-3-Clause,Copyright 2009-2011 Mozilla Foundation and contributors
 require,source-map-resolve,MIT,Copyright 2014-2020 Simon Lydell 2019 Jinxiang
+dev,@types/node,MIT,Copyright Authors
 dev,autocannon,MIT,Copyright 2016 Matteo Collina
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie
 dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David Dalton

--- a/benchmark/sirun/startup/README.md
+++ b/benchmark/sirun/startup/README.md
@@ -1,3 +1,3 @@
-This is a simple startup test. It tests with an without the tracer, and with
+This is a simple startup test. It tests with and without the tracer, and with
 and without requiring every dependency and devDependency in the package.json,
 for a total of four variants.

--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -7,7 +7,7 @@ if (Number(process.env.USE_TRACER)) {
 if (Number(process.env.EVERYTHING)) {
   const json = require('../../../package.json')
   for (const pkg in json.dependencies) {
-    if (pkg !== '@types/node' && pkg !== 'nan') {
+    if (pkg !== 'nan') {
       require(pkg)
     }
   }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@datadog/native-metrics": "^1.1.0",
     "@datadog/pprof": "^0.3.0",
     "@datadog/sketches-js": "^1.0.4",
-    "@types/node": ">=12",
     "crypto-randomuuid": "^1.0.0",
     "diagnostics_channel": "^1.1.0",
     "form-data": "^3.0.0",
@@ -85,6 +84,7 @@
     "source-map-resolve": "^0.6.0"
   },
   "devDependencies": {
+    "@types/node": ">=12",
     "autocannon": "^4.5.2",
     "axios": "^0.21.2",
     "benchmark": "^2.1.4",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Move the `@types/node` package from dependencies to devDependencies.

### Motivation
<!-- What inspired you to submit this pull request? -->

Reduce `dd-trace-js` package size by removing unnecessary prod dependency.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
