### PR TITLE
Revert "Change `cypress` `test.type` to `'browser'`"

### DIFF
--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -27,7 +27,7 @@ function getTestSpanMetadata (tracer, testName, testSuite, cypressConfig) {
   return {
     childOf,
     resource: `${testSuite}.${testName}`,
-    [TEST_TYPE]: 'browser',
+    [TEST_TYPE]: 'test',
     [TEST_NAME]: testName,
     [TEST_SUITE]: testSuite,
     [SAMPLING_RULE_DECISION]: 1,

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -65,7 +65,7 @@ describe('Plugin', () => {
               [TEST_NAME]: 'can visit a page renders a hello world',
               [TEST_STATUS]: 'pass',
               [TEST_SUITE]: 'cypress/integration/integration-test.js',
-              [TEST_TYPE]: 'browser',
+              [TEST_TYPE]: 'test',
               [ORIGIN_KEY]: CI_APP_ORIGIN,
               [TEST_IS_RUM_ACTIVE]: 'true'
             })
@@ -88,7 +88,7 @@ describe('Plugin', () => {
               [TEST_NAME]: 'can visit a page will fail',
               [TEST_STATUS]: 'fail',
               [TEST_SUITE]: 'cypress/integration/integration-test.js',
-              [TEST_TYPE]: 'browser',
+              [TEST_TYPE]: 'test',
               [ORIGIN_KEY]: CI_APP_ORIGIN,
               [ERROR_TYPE]: 'AssertionError',
               [TEST_IS_RUM_ACTIVE]: 'true'


### PR DESCRIPTION
Reverts DataDog/dd-trace-js#1762