### PR TITLE
fix express integration losing the route when handled in a middlware

### DIFF
--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -520,6 +520,36 @@ describe('Plugin', () => {
           })
         })
 
+        it('should not lose the current path when route handler is a middlware', done => {
+          const app = express()
+
+          app.get('/app', (req, res, next) => {
+            res.body = 'test'
+            next()
+          })
+
+          app.use((req, res) => {
+            res.status(200).send(req.body)
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /app')
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = app.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/app`)
+                .catch(done)
+            })
+          })
+        })
+
         it('should not leak the current scope to other requests when using a task queue', done => {
           const app = express()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix express integration losing the route when handled in a middlware by using the longest route that matched during the request instead of the current path when the request is ended.

### Motivation
<!-- What inspired you to submit this pull request? -->

Whenever the route handler would not directly handle the route and would instead store the response and status code somewhere for later retrieval in a generic global handler, the route would be lost and the resource name of the span would be empty.

For example:

```js
app.get('/app', (req, res, next) => {
  res.body = 'test'
  next()
})

app.use((req, res) => {
  res.status(200).send(req.body)
})
```

This is because we relied on the current path which is no longer active by the time the request is ended in the global handler middleware. By using the longest route instead, we are more likely to preserve the correct route regardless of when the request is ended.