### PR TITLE
Appsec config cleanup

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -446,6 +446,8 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | -               | `DD_TRACE_DISABLED_PLUGINS`       | -              | A comma-separated string of integration names automatically disabled when tracer is initialized. Environment variable only e.g. `DD_TRACE_DISABLED_PLUGINS=express,dns`. |
 | logLevel        | `DD_TRACE_LOG_LEVEL`              | `debug`        | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `'error'`, `'debug'`. |
 | startupLogs     | `DD_TRACE_STARTUP_LOGS`           | `true`         | Enable tracer startup configuration and diagnostic log. |
+| appsec.enabled  | `DD_APPSEC_ENABLED`               | `false`        | Enable AppSec protection. |
+| appsec.rules    | `DD_APPSEC_RULES`                 | -              | A path to a custom AppSec rules file. |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -126,17 +126,19 @@ class Config {
       process.env.DD_TRACE_EXPERIMENTAL_INTERNAL_ERRORS_ENABLED,
       false
     )
-    // TODO(simon-id): add documentation for appsec config when we release it in public beta
+
+    let appsec = options.appsec || (options.experimental && options.experimental.appsec)
+
     const DD_APPSEC_ENABLED = coalesce(
-      options.experimental &&
-        options.experimental.appsec &&
-        (options.experimental.appsec === true || options.experimental.appsec.enabled === true),
-      process.env.DD_EXPERIMENTAL_APPSEC_ENABLED,
+      appsec && (appsec === true || appsec.enabled === true),
       process.env.DD_APPSEC_ENABLED,
       false
     )
+
+    appsec = appsec || {}
+
     const DD_APPSEC_RULES = coalesce(
-      options.experimental && options.experimental.appsec && options.experimental.appsec.rules,
+      appsec.rules,
       process.env.DD_APPSEC_RULES,
       path.join(__dirname, 'appsec', 'recommended.json')
     )

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -214,9 +214,9 @@ describe('Config', () => {
           sampleRate: 1,
           rateLimit: 1000
         },
-        internalErrors: true,
-        appsec: true
-      }
+        internalErrors: true
+      },
+      appsec: true
     })
 
     expect(config).to.have.property('enabled', false)
@@ -349,11 +349,11 @@ describe('Config', () => {
         runtimeId: false,
         exporter: 'agent',
         enableGetRumData: false,
-        internalErrors: false,
-        appsec: {
-          enabled: true,
-          rules: './path/rules.json'
-        }
+        internalErrors: false
+      },
+      appsec: {
+        enabled: true,
+        rules: './path/rules.json'
       }
     })
 
@@ -388,16 +388,28 @@ describe('Config', () => {
         sampleRate: 0.5,
         rateLimit: 500
       },
+      appsec: {
+        enabled: true,
+        rules: './path/rules.json'
+      },
       experimental: {
         sampler: {
           sampleRate: 0.1,
           rateLimit: 100
+        },
+        appsec: {
+          enabled: false,
+          rules: 'something'
         }
       }
     })
 
     expect(config).to.have.deep.nested.property('experimental.sampler', {
       sampleRate: 0.5, rateLimit: 500
+    })
+    expect(config).to.have.deep.property('appsec', {
+      enabled: true,
+      rules: './path/rules.json'
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
Cleans up the config for AppSec public beta, add docs and drop the experimental wording (with backward compat)