### PR TITLE
Appsec express support

### DIFF
--- a/packages/dd-trace/src/appsec/addresses.js
+++ b/packages/dd-trace/src/appsec/addresses.js
@@ -1,11 +1,18 @@
 'use strict'
 
 module.exports = {
-  HTTP_INCOMING_URL: 'server.request.uri.raw',
+  HTTP_INCOMING_BODY: 'server.request.body',
+  HTTP_INCOMING_QUERY: 'server.request.query',
   HTTP_INCOMING_HEADERS: 'server.request.headers.no_cookies',
+  // TODO: 'server.request.trailers',
+  HTTP_INCOMING_URL: 'server.request.uri.raw',
   HTTP_INCOMING_METHOD: 'server.request.method',
-  HTTP_INCOMING_REMOTE_IP: 'server.request.client_ip',
-  HTTP_INCOMING_REMOTE_PORT: 'server.request.client_port',
+  HTTP_INCOMING_ROUTE: 'server.request.framework_endpoint',
+  HTTP_INCOMING_PARAMS: 'server.request.path_params',
+  HTTP_INCOMING_COOKIES: 'server.request.cookies',
   HTTP_INCOMING_RESPONSE_CODE: 'server.response.status',
-  HTTP_INCOMING_RESPONSE_HEADERS: 'server.response.headers.no_cookies'
+  HTTP_INCOMING_RESPONSE_HEADERS: 'server.response.headers.no_cookies',
+  // TODO: 'server.response.trailers',
+  HTTP_INCOMING_REMOTE_IP: 'server.request.client_ip',
+  HTTP_INCOMING_REMOTE_PORT: 'server.request.client_port'
 }

--- a/packages/dd-trace/src/appsec/addresses.js
+++ b/packages/dd-trace/src/appsec/addresses.js
@@ -7,7 +7,7 @@ module.exports = {
   // TODO: 'server.request.trailers',
   HTTP_INCOMING_URL: 'server.request.uri.raw',
   HTTP_INCOMING_METHOD: 'server.request.method',
-  HTTP_INCOMING_ROUTE: 'server.request.framework_endpoint',
+  HTTP_INCOMING_ENDPOINT: 'server.request.framework_endpoint',
   HTTP_INCOMING_PARAMS: 'server.request.path_params',
   HTTP_INCOMING_COOKIES: 'server.request.cookies',
   HTTP_INCOMING_RESPONSE_CODE: 'server.response.status',

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -79,10 +79,6 @@ function incomingHttpEndTranslator (data) {
   }
 
   // TODO: temporary express instrumentation, will use express plugin later
-  // if (data.req.body !== undefined && data.req.body !== null) {
-  //   payload[addresses.HTTP_INCOMING_BODY] = data.req.body
-  // }
-
   if (data.req.query && typeof data.req.query === 'object') {
     payload[addresses.HTTP_INCOMING_QUERY] = data.req.query
   }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -30,8 +30,9 @@ function enable (config) {
 
   // add fields needed for HTTP context reporting
   Gateway.manager.addresses.add(addresses.HTTP_INCOMING_HEADERS)
-  Gateway.manager.addresses.add(addresses.HTTP_INCOMING_REMOTE_IP)
+  Gateway.manager.addresses.add(addresses.HTTP_INCOMING_ENDPOINT)
   Gateway.manager.addresses.add(addresses.HTTP_INCOMING_RESPONSE_HEADERS)
+  Gateway.manager.addresses.add(addresses.HTTP_INCOMING_REMOTE_IP)
 }
 
 function incomingHttpStartTranslator (data) {
@@ -87,7 +88,7 @@ function incomingHttpEndTranslator (data) {
   }
 
   if (data.req.route && typeof data.req.route.path === 'string') {
-    payload[addresses.HTTP_INCOMING_ROUTE] = data.req.route.path
+    payload[addresses.HTTP_INCOMING_ENDPOINT] = data.req.route.path
   }
 
   if (data.req.params && typeof data.req.params === 'object') {

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -79,9 +79,9 @@ function incomingHttpEndTranslator (data) {
   }
 
   // TODO: temporary express instrumentation, will use express plugin later
-  if (data.req.body !== undefined && data.req.body !== null) {
-    payload[addresses.HTTP_INCOMING_BODY] = data.req.body
-  }
+  // if (data.req.body !== undefined && data.req.body !== null) {
+  //   payload[addresses.HTTP_INCOMING_BODY] = data.req.body
+  // }
 
   if (data.req.query && typeof data.req.query === 'object') {
     payload[addresses.HTTP_INCOMING_QUERY] = data.req.query

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -72,10 +72,33 @@ function incomingHttpEndTranslator (data) {
   const headers = Object.assign({}, data.res.getHeaders())
   delete headers['set-cookie']
 
-  Gateway.propagate({
+  const payload = {
     [addresses.HTTP_INCOMING_RESPONSE_CODE]: data.res.statusCode,
     [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: headers
-  }, context)
+  }
+
+  // TODO: temporary express instrumentation, will use express plugin later
+  if (data.req.body !== undefined && data.req.body !== null) {
+    payload[addresses.HTTP_INCOMING_BODY] = data.req.body
+  }
+
+  if (data.req.query && typeof data.req.query === 'object') {
+    payload[addresses.HTTP_INCOMING_QUERY] = data.req.query
+  }
+
+  if (data.req.route && typeof data.req.route.path === 'string') {
+    payload[addresses.HTTP_INCOMING_ROUTE] = data.req.route.path
+  }
+
+  if (data.req.params && typeof data.req.params === 'object') {
+    payload[addresses.HTTP_INCOMING_PARAMS] = data.req.params
+  }
+
+  if (data.req.cookies && typeof data.req.cookies === 'object') {
+    payload[addresses.HTTP_INCOMING_COOKIES] = data.req.cookies
+  }
+
+  Gateway.propagate(payload, context)
 
   Reporter.finishAttacks(data.req, context)
 }

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -125,11 +125,15 @@ function finishAttacks (req, context) {
   const topSpan = req && req._datadog && req._datadog.span
   if (!topSpan || !context) return false
 
-  const resolvedReponse = resolveHTTPResponse(context)
+  const resolvedResponse = resolveHTTPResponse(context)
 
-  topSpan.addTags(Object.assign({
-    'http.endpoint': resolvedReponse.endpoint
-  }, resolvedReponse.headers))
+  const newTags = resolvedResponse.headers
+
+  if (resolvedResponse.endpoint) {
+    newTags['http.endpoint'] = resolvedResponse.endpoint
+  }
+
+  topSpan.addTags(newTags)
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -36,7 +36,6 @@ function resolveHTTPRequest (context) {
   const headers = context.resolve(addresses.HTTP_INCOMING_HEADERS)
 
   return {
-    // route: context.resolve(addresses.HTTP_INCOMING_ROUTE),
     remote_ip: context.resolve(addresses.HTTP_INCOMING_REMOTE_IP),
     headers: filterHeaders(headers, REQUEST_HEADERS_PASSLIST, 'http.request.headers.')
   }
@@ -48,6 +47,7 @@ function resolveHTTPResponse (context) {
   const headers = context.resolve(addresses.HTTP_INCOMING_RESPONSE_HEADERS)
 
   return {
+    endpoint: context.resolve(addresses.HTTP_INCOMING_ENDPOINT),
     headers: filterHeaders(headers, RESPONSE_HEADERS_PASSLIST, 'http.response.headers.')
   }
 }
@@ -116,8 +116,6 @@ function reportAttack (attackData, store) {
     }
 
     newTags['network.client.ip'] = resolvedRequest.remote_ip
-
-    // newTags['http.endpoint'] = resolvedRequest.route
   }
 
   topSpan.addTags(newTags)
@@ -129,7 +127,9 @@ function finishAttacks (req, context) {
 
   const resolvedReponse = resolveHTTPResponse(context)
 
-  topSpan.addTags(resolvedReponse.headers)
+  topSpan.addTags(Object.assign({
+    'http.endpoint': resolvedReponse.endpoint
+  }, resolvedReponse.headers))
 }
 
 module.exports = {

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -283,7 +283,6 @@ describe('AppSec Index', () => {
           'content-type': 'application/json',
           'content-lenght': 42
         },
-        // 'server.request.body': { a: '1' },
         'server.request.query': { b: '2' },
         'server.request.framework_endpoint': '/path/:c',
         'server.request.path_params': { c: '3' },

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -205,7 +205,7 @@ describe('AppSec Index', () => {
       expect(Reporter.finishAttacks).to.have.been.calledOnceWithExactly(req, context)
     })
 
-    it('should propagate incoming http end data with weird framework', () => {
+    it('should propagate incoming http end data with invalid framework properties', () => {
       const context = {}
 
       sinon.stub(Gateway, 'getContext').returns(context)

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -283,7 +283,7 @@ describe('AppSec Index', () => {
           'content-type': 'application/json',
           'content-lenght': 42
         },
-        'server.request.body': { a: '1' },
+        // 'server.request.body': { a: '1' },
         'server.request.query': { b: '2' },
         'server.request.framework_endpoint': '/path/:c',
         'server.request.path_params': { c: '3' },

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -43,8 +43,9 @@ describe('AppSec Index', () => {
       expect(incomingHttpRequestEnd.subscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpEndTranslator)
       expect(Gateway.manager.addresses).to.have.all.keys(
         addresses.HTTP_INCOMING_HEADERS,
-        addresses.HTTP_INCOMING_REMOTE_IP,
-        addresses.HTTP_INCOMING_RESPONSE_HEADERS
+        addresses.HTTP_INCOMING_ENDPOINT,
+        addresses.HTTP_INCOMING_RESPONSE_HEADERS,
+        addresses.HTTP_INCOMING_REMOTE_IP
       )
     })
 
@@ -200,6 +201,93 @@ describe('AppSec Index', () => {
           'content-type': 'application/json',
           'content-lenght': 42
         }
+      }, context)
+      expect(Reporter.finishAttacks).to.have.been.calledOnceWithExactly(req, context)
+    })
+
+    it('should propagate incoming http end data with weird framework', () => {
+      const context = {}
+
+      sinon.stub(Gateway, 'getContext').returns(context)
+
+      const req = {
+        body: null,
+        query: 'string',
+        route: {},
+        params: 'string',
+        cookies: 'string'
+      }
+      const res = {
+        getHeaders: () => ({
+          'content-type': 'application/json',
+          'content-lenght': 42
+        }),
+        statusCode: 201
+      }
+
+      sinon.stub(Gateway, 'propagate')
+      sinon.stub(Reporter, 'finishAttacks')
+
+      AppSec.incomingHttpEndTranslator({ req, res })
+
+      expect(Gateway.getContext).to.have.been.calledOnce
+      expect(Gateway.propagate).to.have.been.calledOnceWithExactly({
+        'server.response.status': 201,
+        'server.response.headers.no_cookies': {
+          'content-type': 'application/json',
+          'content-lenght': 42
+        }
+      }, context)
+      expect(Reporter.finishAttacks).to.have.been.calledOnceWithExactly(req, context)
+    })
+
+    it('should propagate incoming http end data with express', () => {
+      const context = {}
+
+      sinon.stub(Gateway, 'getContext').returns(context)
+
+      const req = {
+        body: {
+          a: '1'
+        },
+        query: {
+          b: '2'
+        },
+        route: {
+          path: '/path/:c'
+        },
+        params: {
+          c: '3'
+        },
+        cookies: {
+          d: '4'
+        }
+      }
+      const res = {
+        getHeaders: () => ({
+          'content-type': 'application/json',
+          'content-lenght': 42
+        }),
+        statusCode: 201
+      }
+
+      sinon.stub(Gateway, 'propagate')
+      sinon.stub(Reporter, 'finishAttacks')
+
+      AppSec.incomingHttpEndTranslator({ req, res })
+
+      expect(Gateway.getContext).to.have.been.calledOnce
+      expect(Gateway.propagate).to.have.been.calledOnceWithExactly({
+        'server.response.status': 201,
+        'server.response.headers.no_cookies': {
+          'content-type': 'application/json',
+          'content-lenght': 42
+        },
+        'server.request.body': { a: '1' },
+        'server.request.query': { b: '2' },
+        'server.request.framework_endpoint': '/path/:c',
+        'server.request.path_params': { c: '3' },
+        'server.request.cookies': { d: '4' }
       }, context)
       expect(Reporter.finishAttacks).to.have.been.calledOnceWithExactly(req, context)
     })

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -69,6 +69,7 @@ describe('reporter', () => {
       const context = new Context()
 
       context.store = new Map(Object.entries({
+        [addresses.HTTP_INCOMING_ENDPOINT]: '/path/:param',
         [addresses.HTTP_INCOMING_RESPONSE_CODE]: 201,
         [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: {
           'content-type': 'application/json',
@@ -80,6 +81,7 @@ describe('reporter', () => {
       const result = Reporter.resolveHTTPResponse(context)
 
       expect(result).to.deep.equal({
+        endpoint: '/path/:param',
         headers: {
           'http.response.headers.content-type': 'application/json',
           'http.response.headers.content-length': '42'
@@ -226,6 +228,30 @@ describe('reporter', () => {
     })
 
     it('should add http response data inside request span', () => {
+      const req = stubReq()
+
+      const context = new Context()
+
+      context.store = new Map(Object.entries({
+        [addresses.HTTP_INCOMING_ENDPOINT]: '/path/:param',
+        [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: {
+          'content-type': 'application/json',
+          'content-length': 42,
+          secret: 'password'
+        }
+      }))
+
+      const result = Reporter.finishAttacks(req, context)
+      expect(result).to.not.be.false
+
+      expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
+        'http.response.headers.content-type': 'application/json',
+        'http.response.headers.content-length': '42',
+        'http.endpoint': '/path/:param'
+      })
+    })
+
+    it('should add http response data inside request span without endpoint', () => {
       const req = stubReq()
 
       const context = new Context()


### PR DESCRIPTION
### What does this PR do?
This makes AppSec support express datapoints without changing dd-trace instrumentation. This is a temporary solution.
