### PR TITLE
remove support for enabling internal errors

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -55,8 +55,7 @@ tracer.init({
         { sampleRate: 0.5, service: 'foo', name: 'foo.request' },
         { sampleRate: 0.1, service: /foo/, name: /foo\.request/ }
       ]
-    },
-    internalErrors: true
+    }
   },
   hostname: 'agent',
   logger: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -358,12 +358,6 @@ export declare interface TracerOptions {
      * @default false
      */
     enableGetRumData?: boolean
-
-    /**
-     * Whether to set the error flag when an error occurs in an internal span.
-     * @default false
-     */
-    internalErrors?: boolean
   };
 
   /**

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -121,11 +121,6 @@ class Config {
       process.env.DD_TRACE_EXPERIMENTAL_GET_RUM_DATA_ENABLED,
       false
     )
-    const DD_TRACE_INTERNAL_ERRORS_ENABLED = coalesce(
-      options.experimental && options.experimental.internalErrors,
-      process.env.DD_TRACE_EXPERIMENTAL_INTERNAL_ERRORS_ENABLED,
-      false
-    )
 
     let appsec = options.appsec || (options.experimental && options.experimental.appsec)
 
@@ -182,8 +177,7 @@ class Config {
       runtimeId: isTrue(DD_TRACE_RUNTIME_ID_ENABLED),
       exporter: DD_TRACE_EXPORTER,
       enableGetRumData: isTrue(DD_TRACE_GET_RUM_DATA_ENABLED),
-      sampler,
-      internalErrors: isTrue(DD_TRACE_INTERNAL_ERRORS_ENABLED)
+      sampler
     }
     this.reportHostname = isTrue(coalesce(options.reportHostname, process.env.DD_TRACE_REPORT_HOSTNAME, false))
     this.scope = process.env.DD_TRACE_SCOPE

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -54,7 +54,6 @@ function extractTags (trace, span) {
   const tags = context._tags
   const hostname = context._hostname
   const priority = context._sampling.priority
-  const internalErrors = span.tracer()._internalErrors
 
   if (tags['span.kind'] && tags['span.kind'] !== 'internal') {
     addTag({}, trace.metrics, MEASURED, 1)
@@ -76,7 +75,7 @@ function extractTags (trace, span) {
         addTag({}, trace.metrics, tag, tags[tag] === undefined || tags[tag] ? 1 : 0)
         break
       case 'error':
-        if (tags[tag] && (context._name !== 'fs.operation' || internalErrors)) {
+        if (tags[tag] && (context._name !== 'fs.operation')) {
           trace.error = 1
         }
         break
@@ -84,7 +83,7 @@ function extractTags (trace, span) {
       case 'error.msg':
       case 'error.stack':
         // HACK: remove when implemented in the backend
-        if (context._name !== 'fs.operation' || internalErrors) {
+        if (context._name !== 'fs.operation') {
           trace.error = 1
         }
       default: // eslint-disable-line no-fallthrough

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -37,7 +37,6 @@ class DatadogTracer extends Tracer {
     this._tags = config.tags
     this._logInjection = config.logInjection
     this._debug = config.debug
-    this._internalErrors = config.experimental.internalErrors
     this._prioritySampler = new PrioritySampler(config.env, config.experimental.sampler)
     this._exporter = new Exporter(config, this._prioritySampler)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -69,7 +69,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.runtimeId', false)
     expect(config).to.have.nested.property('experimental.exporter', undefined)
     expect(config).to.have.nested.property('experimental.enableGetRumData', false)
-    expect(config).to.have.nested.property('experimental.internalErrors', false)
     expect(config).to.have.nested.property('appsec.enabled', false)
     const rulePath = path.join(__dirname, '..', 'src', 'appsec', 'recommended.json')
     expect(config).to.have.nested.property('appsec.rules', rulePath)
@@ -137,7 +136,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.runtimeId', true)
     expect(config).to.have.nested.property('experimental.exporter', 'log')
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
-    expect(config).to.have.nested.property('experimental.internalErrors', true)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rules', './path/rules.json')
   })
@@ -213,8 +211,7 @@ describe('Config', () => {
         sampler: {
           sampleRate: 1,
           rateLimit: 1000
-        },
-        internalErrors: true
+        }
       },
       appsec: true
     })
@@ -249,7 +246,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.runtimeId', true)
     expect(config).to.have.nested.property('experimental.exporter', 'log')
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
-    expect(config).to.have.nested.property('experimental.internalErrors', true)
     expect(config).to.have.deep.nested.property('experimental.sampler', { sampleRate: 1, rateLimit: 1000 })
     expect(config).to.have.nested.property('appsec.enabled', true)
   })
@@ -348,8 +344,7 @@ describe('Config', () => {
         b3: false,
         runtimeId: false,
         exporter: 'agent',
-        enableGetRumData: false,
-        internalErrors: false
+        enableGetRumData: false
       },
       appsec: {
         enabled: true,
@@ -377,7 +372,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.runtimeId', false)
     expect(config).to.have.nested.property('experimental.exporter', 'agent')
     expect(config).to.have.nested.property('experimental.enableGetRumData', false)
-    expect(config).to.have.nested.property('experimental.internalErrors', false)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rules', './path/rules.json')
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove support for enabling internal errors.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was added to restore the old behaviour if needed when we stopped logging errors for `fs`. It was never documented and I don't remember anyone asking for this behaviour back. If errors are not handled, they will bubble up to the parent anyway, so we can safely remove this option.