### PR TITLE
remove support for nested object tags

### DIFF
--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -77,7 +77,7 @@ module.exports = (on, config) => {
           activeSpan.setTag('error', error)
         }
         if (isRUMActive) {
-          activeSpan.setTag(TEST_IS_RUM_ACTIVE, true)
+          activeSpan.setTag(TEST_IS_RUM_ACTIVE, 'true')
         }
         activeSpan.finish()
       }

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -2,7 +2,6 @@
 
 const constants = require('./constants')
 const tags = require('../../../ext/tags')
-const log = require('./log')
 const id = require('./id')
 const { isError } = require('./util')
 
@@ -38,8 +37,8 @@ function formatSpan (span) {
     trace_id: spanContext._traceId,
     span_id: spanContext._spanId,
     parent_id: spanContext._parentId || id('0'),
-    name: serialize(spanContext._name),
-    resource: serialize(spanContext._name),
+    name: String(spanContext._name),
+    resource: String(spanContext._name),
     error: 0,
     meta: {},
     metrics: {},
@@ -133,7 +132,7 @@ function extractError (trace, span) {
   }
 }
 
-function addTag (meta, metrics, key, value, seen) {
+function addTag (meta, metrics, key, value, nested) {
   switch (typeof value) {
     case 'string':
       if (!value) break
@@ -143,6 +142,9 @@ function addTag (meta, metrics, key, value, seen) {
       if (isNaN(value)) break
       metrics[key] = value
       break
+    case 'boolean':
+      metrics[key] = value ? 1 : 0
+      break
     case 'undefined':
       break
     case 'object':
@@ -151,41 +153,15 @@ function addTag (meta, metrics, key, value, seen) {
       // Special case for Node.js Buffer and URL
       if (isNodeBuffer(value) || isUrl(value)) {
         metrics[key] = value.toString()
-        break
+      } else if (!Array.isArray(value) && !nested) {
+        for (const prop in value) {
+          if (!value.hasOwnProperty(prop)) continue
+
+          addTag(meta, metrics, `${key}.${prop}`, value[prop], true)
+        }
       }
 
-      if (!Array.isArray(value)) {
-        addObjectTag(meta, metrics, key, value, seen)
-        break
-      }
-
-    default: // eslint-disable-line no-fallthrough
-      addTag(meta, metrics, key, serialize(value))
-  }
-}
-
-function addObjectTag (meta, metrics, key, value, seen) {
-  seen = seen || []
-
-  if (~seen.indexOf(value)) {
-    meta[key] = '[Circular]'
-    return
-  }
-
-  seen.push(value)
-
-  for (const prop in value) {
-    addTag(meta, metrics, `${key}.${prop}`, value[prop], seen)
-  }
-
-  seen.pop()
-}
-
-function serialize (obj) {
-  try {
-    return obj && typeof obj.toString !== 'function' ? JSON.stringify(obj) : String(obj)
-  } catch (e) {
-    log.error(e)
+      break
   }
 }
 

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -172,6 +172,15 @@ describe('format', () => {
       expect(trace.metrics).to.have.property('metric', 50)
     })
 
+    it('should extract boolean tags as metrics', () => {
+      spanContext._tags = { yes: true, no: false }
+
+      trace = format(span)
+
+      expect(trace.metrics).to.have.property('yes', 1)
+      expect(trace.metrics).to.have.property('no', 0)
+    })
+
     it('should ignore metrics with invalid type', () => {
       spanContext._metrics = { metric: 'test' }
 

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -220,45 +220,6 @@ describe('format', () => {
       expect(trace.meta[ORIGIN_KEY]).to.equal('synthetics')
     })
 
-    it('should extract unempty objects', () => {
-      spanContext._tags['root'] = {
-        level1: {
-          level2: {
-            level3: {}
-          },
-          array: ['hello']
-        }
-      }
-
-      trace = format(span)
-
-      expect(trace.meta['root.level1.array']).to.equal('hello')
-      expect(trace.meta['root.level1.level2']).to.be.undefined
-      expect(trace.meta['root.level1.level2.level3']).to.be.undefined
-    })
-
-    it('should support nested arrays', () => {
-      spanContext._tags['root'] = {
-        array: ['a', ['b', ['c']]]
-      }
-
-      trace = format(span)
-
-      expect(trace.meta['root.array']).to.equal('a,b,c')
-    })
-
-    it('should support objects in arrays', () => {
-      class Foo {}
-
-      spanContext._tags['root'] = {
-        array: ['a', { 'bar': 'baz' }, new Foo()]
-      }
-
-      trace = format(span)
-
-      expect(trace.meta['root.array']).to.equal('a,[object Object],[object Object]')
-    })
-
     it('should add runtime tags', () => {
       spanContext._tags['service.name'] = 'test'
 
@@ -356,153 +317,22 @@ describe('format', () => {
       expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
     })
 
-    it('should support objects without a toString implementation', () => {
-      spanContext._tags['foo'] = []
-      spanContext._tags['foo'].toString = null
-      trace = format(span)
-      expect(trace.meta['foo']).to.equal('[]')
-    })
-
-    it('should support objects with a non-function toString property', () => {
-      spanContext._tags['foo'] = []
-      spanContext._tags['foo'].toString = 'baz'
-      trace = format(span)
-      expect(trace.meta['foo']).to.equal('[]')
-    })
-
-    it('should support direct circular references', () => {
-      const tag = { 'foo': 'bar' }
-
-      tag.self = tag
-      spanContext._tags['circularTag'] = tag
-
-      trace = format(span)
-
-      expect(trace.meta['circularTag.foo']).to.equal('bar')
-      expect(trace.meta['circularTag.self']).to.equal('[Circular]')
-    })
-
-    it('should support indirect circular references', () => {
-      const obj = { 'foo': 'bar' }
-      const tag = { obj, 'baz': 'qux' }
-
-      obj.self = tag
-
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag.baz']).to.equal('qux')
-      expect(trace.meta['circularTag.obj.foo']).to.equal('bar')
-      expect(trace.meta['circularTag.obj.self']).to.equal('[Circular]')
-    })
-
-    it('should support deep circular references', () => {
+    it('should support only the first level of depth for objects', () => {
       const tag = {
         A: {
-          B: {
-            C: {
-              D: {
-                E: {
-                  num: '6'
-                },
-                num: '5'
-              },
-              num: '4'
-            },
-            num: '3'
-          },
+          B: {},
           num: '2'
         },
         num: '1'
       }
 
-      tag.A.B.C.D.E.self = tag.A.B
-
-      spanContext._tags['circularTag'] = tag
+      spanContext._tags['nested'] = tag
       trace = format(span)
 
-      expect(trace.meta['circularTag.num']).to.equal('1')
-      expect(trace.meta['circularTag.A.num']).to.equal('2')
-      expect(trace.meta['circularTag.A.B.num']).to.equal('3')
-      expect(trace.meta['circularTag.A.B.C.num']).to.equal('4')
-      expect(trace.meta['circularTag.A.B.C.D.num']).to.equal('5')
-      expect(trace.meta['circularTag.A.B.C.D.E.num']).to.equal('6')
-      expect(trace.meta['circularTag.A.B.C.D.E.self']).to.equal('[Circular]')
-    })
-
-    it('should support circular references in a class', () => {
-      class CircularTag {
-        constructor () {
-          this.foo = 'bar'
-          this.self = this
-        }
-      }
-
-      const tag = new CircularTag()
-
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag.foo']).to.equal('bar')
-      expect(trace.meta['circularTag.self']).to.equal('[Circular]')
-    })
-
-    it('should support re-used objects', () => {
-      const obj = { foo: 'bar' }
-      const tag = {
-        baz: obj,
-        qux: obj
-      }
-
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag.baz.foo']).to.equal('bar')
-      expect(trace.meta['circularTag.qux.foo']).to.equal('bar')
-    })
-
-    it('should support doubly-linked objects', () => {
-      const tag = {
-        selfA: { ghost: 'eater' },
-        selfB: { space: 'invader' }
-      }
-
-      tag.selfA.self = tag.selfB
-      tag.selfB.self = tag.selfA
-
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag.selfA.ghost']).to.equal('eater')
-      expect(trace.meta['circularTag.selfA.self.self']).to.equal('[Circular]')
-      expect(trace.meta['circularTag.selfA.self.space']).to.equal('invader')
-      expect(trace.meta['circularTag.selfB.self.ghost']).to.equal('eater')
-      expect(trace.meta['circularTag.selfB.self.self']).to.equal('[Circular]')
-      expect(trace.meta['circularTag.selfB.space']).to.equal('invader')
-    })
-
-    it('should support re-used arrays', () => {
-      const obj = ['bar']
-      const tag = {
-        baz: obj,
-        qux: obj
-      }
-
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag.baz']).to.equal('bar')
-      expect(trace.meta['circularTag.qux']).to.equal('bar')
-    })
-
-    it('should support re-used arrays within arrays', () => {
-      const obj = {}
-      const tag = [obj, [obj]]
-
-      spanContext._tags['circularTag'] = tag
-      trace = format(span)
-
-      expect(trace.meta['circularTag']).to.equal('[object Object],[object Object]')
+      expect(trace.meta['nested.num']).to.equal('1')
+      expect(trace.meta['nested.A']).to.be.undefined
+      expect(trace.meta['nested.A.B']).to.be.undefined
+      expect(trace.meta['nested.A.num']).to.be.undefined
     })
 
     it('should accept a boolean for measured', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove support for nested object tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

Support for object tags was originally added for use cases where key-value pairs should be added all with the same prefix. A common example of this would be headers for HTTP requests, or query params.

However, we ended up also allowing deeply nested objects, which requires detecting circular references and can end up causing very large spans for complex objects that were passed inadvertently which in turn can cause performance and stability issues. It's safer to only handle a single level of depth out of the box, and leave it to the user if a more complex use case is needed so that they have full control on what gets included.

Moving forward we may want to even only handle POJSOs, but for now this is enough to at least prevent issues.