### PR TITLE
add option to enable or disable only tracing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -422,8 +422,9 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 
 | Config          | Environment Variable              | Default     | Description |
 | --------------- | --------------------------------- | ----------- | ----------- |
-| -               | `DD_TRACE_ENABLED`                | `true`         | Whether to enable the tracer. |
-| -               | `DD_TRACE_DEBUG`                  | `false`        | Enable debug logging in the tracer. |
+| -               | `DD_TRACE_ENABLED`                | `true`         | Whether to enable dd-trace. Setting this to `false` will disable all features of the library. |
+| -               | `DD_TRACE_DEBUG`                  | `false`        | Enable debug logging. |
+| -               | `DD_TRACING_ENABLED`              | `true`         | Whether to enable tracing. |
 | service         | `DD_SERVICE`                      | -              | The service name to be used for this program. Defaults to value of the `name` field in `package.json`. |
 | version         | `DD_VERSION`                      | -              | The version number of the application. Defaults to value of the `version` field in `package.json`. |
 | url             | `DD_TRACE_AGENT_URL`              | -              | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -24,7 +24,10 @@ class Config {
     tagger.add(this.tags, process.env.DD_TRACE_GLOBAL_TAGS)
     tagger.add(this.tags, options.tags)
 
-    // Temporary disabled
+    const DD_TRACING_ENABLED = coalesce(
+      process.env.DD_TRACING_ENABLED,
+      true
+    )
     const DD_PROFILING_ENABLED = coalesce(
       options.profiling, // TODO: remove when enabled by default
       process.env.DD_EXPERIMENTAL_PROFILING_ENABLED,
@@ -86,10 +89,6 @@ class Config {
       options.startupLogs,
       process.env.DD_TRACE_STARTUP_LOGS,
       false
-    )
-    const DD_TRACE_ENABLED = coalesce(
-      process.env.DD_TRACE_ENABLED,
-      true
     )
     const DD_TRACE_DEBUG = coalesce(
       process.env.DD_TRACE_DEBUG,
@@ -153,7 +152,7 @@ class Config {
     const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
     const defaultFlushInterval = inAWSLambda ? 0 : 2000
 
-    this.enabled = isTrue(DD_TRACE_ENABLED)
+    this.tracing = !isFalse(DD_TRACING_ENABLED)
     this.debug = isTrue(DD_TRACE_DEBUG)
     this.logInjection = isTrue(DD_LOGS_INJECTION)
     this.env = DD_ENV

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -51,7 +51,7 @@ describe('Config', () => {
     const config = new Config()
 
     expect(config).to.have.property('service', 'node')
-    expect(config).to.have.property('enabled', true)
+    expect(config).to.have.property('tracing', true)
     expect(config).to.have.property('debug', false)
     expect(config).to.have.property('protocolVersion', '0.4')
     expect(config).to.have.nested.property('dogstatsd.hostname', '127.0.0.1')
@@ -97,7 +97,7 @@ describe('Config', () => {
     process.env.DD_TRACE_AGENT_PORT = '6218'
     process.env.DD_DOGSTATSD_HOSTNAME = 'dsd-agent'
     process.env.DD_DOGSTATSD_PORT = '5218'
-    process.env.DD_TRACE_ENABLED = 'false'
+    process.env.DD_TRACING_ENABLED = 'false'
     process.env.DD_TRACE_DEBUG = 'true'
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.5'
     process.env.DD_SERVICE = 'service'
@@ -118,7 +118,7 @@ describe('Config', () => {
 
     const config = new Config()
 
-    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('tracing', false)
     expect(config).to.have.property('debug', true)
     expect(config).to.have.property('protocolVersion', '0.5')
     expect(config).to.have.property('hostname', 'agent')
@@ -142,13 +142,13 @@ describe('Config', () => {
   })
 
   it('should read case-insensitive booleans from environment variables', () => {
-    process.env.DD_TRACE_ENABLED = 'False'
+    process.env.DD_TRACING_ENABLED = 'False'
     process.env.DD_TRACE_DEBUG = 'TRUE'
     process.env.DD_RUNTIME_METRICS_ENABLED = '0'
 
     const config = new Config()
 
-    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('tracing', false)
     expect(config).to.have.property('debug', true)
     expect(config).to.have.property('runtimeMetrics', false)
   })
@@ -158,14 +158,14 @@ describe('Config', () => {
     process.env.DD_SITE = 'datadoghq.eu'
     process.env.DD_TRACE_AGENT_HOSTNAME = 'agent'
     process.env.DD_TRACE_AGENT_PORT = '6218'
-    process.env.DD_TRACE_ENABLED = 'false'
+    process.env.DD_TRACING_ENABLED = 'false'
     process.env.DD_TRACE_DEBUG = 'true'
     process.env.DD_SERVICE = 'service'
     process.env.DD_ENV = 'test'
 
     const config = new Config()
 
-    expect(config).to.have.property('enabled', false)
+    expect(config).to.have.property('tracing', false)
     expect(config).to.have.property('debug', true)
     expect(config).to.have.nested.property('dogstatsd.hostname', 'agent')
     expect(config).to.have.nested.property('url.protocol', 'https:')

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -56,10 +56,11 @@ describe('TracerProxy', () => {
     Instrumenter = sinon.stub().returns(instrumenter)
 
     config = {
-      enabled: true,
+      tracing: true,
       experimental: {},
       logger: 'logger',
       debug: true,
+      profiling: {},
       appsec: {}
     }
     Config = sinon.stub().returns(config)
@@ -122,7 +123,7 @@ describe('TracerProxy', () => {
       })
 
       it('should not initialize when disabled', () => {
-        config.enabled = false
+        config.tracing = false
 
         proxy.init()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add option to enable or disable only tracing.

### Motivation
<!-- What inspired you to submit this pull request? -->

It is not currently possible to enable other features like profiling and runtime metrics without also enabling tracing.