### PR TITLE
Appsec waf optimization

### DIFF
--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -49,19 +49,6 @@ function incomingHttpStartTranslator (data) {
 
   store.set('req', data.req)
   store.set('res', data.res)
-
-  const headers = Object.assign({}, data.req.headers)
-  delete headers.cookie
-
-  const context = store.get('context')
-
-  Gateway.propagate({
-    [addresses.HTTP_INCOMING_URL]: data.req.url,
-    [addresses.HTTP_INCOMING_HEADERS]: headers,
-    [addresses.HTTP_INCOMING_METHOD]: data.req.method,
-    [addresses.HTTP_INCOMING_REMOTE_IP]: data.req.socket.remoteAddress,
-    [addresses.HTTP_INCOMING_REMOTE_PORT]: data.req.socket.remotePort
-  }, context)
 }
 
 function incomingHttpEndTranslator (data) {
@@ -69,13 +56,21 @@ function incomingHttpEndTranslator (data) {
 
   if (!context) return
 
+  const requestHeaders = Object.assign({}, data.req.headers)
+  delete requestHeaders.cookie
+
   // TODO: this doesn't support headers sent with res.writeHead()
-  const headers = Object.assign({}, data.res.getHeaders())
-  delete headers['set-cookie']
+  const responseHeaders = Object.assign({}, data.res.getHeaders())
+  delete responseHeaders['set-cookie']
 
   const payload = {
+    [addresses.HTTP_INCOMING_URL]: data.req.url,
+    [addresses.HTTP_INCOMING_HEADERS]: requestHeaders,
+    [addresses.HTTP_INCOMING_METHOD]: data.req.method,
+    [addresses.HTTP_INCOMING_REMOTE_IP]: data.req.socket.remoteAddress,
+    [addresses.HTTP_INCOMING_REMOTE_PORT]: data.req.socket.remotePort,
     [addresses.HTTP_INCOMING_RESPONSE_CODE]: data.res.statusCode,
-    [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: headers
+    [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: responseHeaders
   }
 
   // TODO: temporary express instrumentation, will use express plugin later

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -85,8 +85,8 @@ function reportAttack (attackData, store) {
   const currentTags = topSpan.context()._tags
 
   const newTags = {
-    'appsec.event': true,
-    'manual.keep': true // TODO: figure out how to keep appsec traces with sampling revamp
+    'appsec.event': 'true',
+    'manual.keep': 'true' // TODO: figure out how to keep appsec traces with sampling revamp
   }
 
   // TODO: maybe add this to format.js later (to take decision as late as possible)

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -103,9 +103,6 @@ describe('AppSec Index', () => {
       const store = new Map()
       sinon.stub(Gateway, 'startContext').returns(store)
 
-      const context = {}
-      store.set('context', context)
-
       const topSpan = {
         addTags: sinon.stub()
       }
@@ -139,16 +136,7 @@ describe('AppSec Index', () => {
       expect(Gateway.startContext).to.have.been.calledOnce
       expect(store.get('req')).to.equal(req)
       expect(store.get('res')).to.equal(res)
-      expect(Gateway.propagate).to.have.been.calledOnceWithExactly({
-        'server.request.uri.raw': '/path',
-        'server.request.headers.no_cookies': {
-          'user-agent': 'Arachni',
-          'host': 'localhost'
-        },
-        'server.request.method': 'POST',
-        'server.request.client_ip': '127.0.0.1',
-        'server.request.client_port': 8080
-      }, context)
+      expect(Gateway.propagate).to.not.have.been.called
     })
   })
 
@@ -180,7 +168,19 @@ describe('AppSec Index', () => {
 
       sinon.stub(Gateway, 'getContext').returns(context)
 
-      const req = {}
+      const req = {
+        url: '/path',
+        headers: {
+          'user-agent': 'Arachni',
+          'host': 'localhost',
+          cookie: 'a=1;b=2'
+        },
+        method: 'POST',
+        socket: {
+          remoteAddress: '127.0.0.1',
+          remotePort: 8080
+        }
+      }
       const res = {
         getHeaders: () => ({
           'content-type': 'application/json',
@@ -196,6 +196,14 @@ describe('AppSec Index', () => {
 
       expect(Gateway.getContext).to.have.been.calledOnce
       expect(Gateway.propagate).to.have.been.calledOnceWithExactly({
+        'server.request.uri.raw': '/path',
+        'server.request.headers.no_cookies': {
+          'user-agent': 'Arachni',
+          'host': 'localhost'
+        },
+        'server.request.method': 'POST',
+        'server.request.client_ip': '127.0.0.1',
+        'server.request.client_port': 8080,
         'server.response.status': 201,
         'server.response.headers.no_cookies': {
           'content-type': 'application/json',
@@ -211,6 +219,17 @@ describe('AppSec Index', () => {
       sinon.stub(Gateway, 'getContext').returns(context)
 
       const req = {
+        url: '/path',
+        headers: {
+          'user-agent': 'Arachni',
+          'host': 'localhost',
+          cookie: 'a=1;b=2'
+        },
+        method: 'POST',
+        socket: {
+          remoteAddress: '127.0.0.1',
+          remotePort: 8080
+        },
         body: null,
         query: 'string',
         route: {},
@@ -232,6 +251,14 @@ describe('AppSec Index', () => {
 
       expect(Gateway.getContext).to.have.been.calledOnce
       expect(Gateway.propagate).to.have.been.calledOnceWithExactly({
+        'server.request.uri.raw': '/path',
+        'server.request.headers.no_cookies': {
+          'user-agent': 'Arachni',
+          'host': 'localhost'
+        },
+        'server.request.method': 'POST',
+        'server.request.client_ip': '127.0.0.1',
+        'server.request.client_port': 8080,
         'server.response.status': 201,
         'server.response.headers.no_cookies': {
           'content-type': 'application/json',
@@ -247,6 +274,17 @@ describe('AppSec Index', () => {
       sinon.stub(Gateway, 'getContext').returns(context)
 
       const req = {
+        url: '/path',
+        headers: {
+          'user-agent': 'Arachni',
+          'host': 'localhost',
+          cookie: 'a=1;b=2'
+        },
+        method: 'POST',
+        socket: {
+          remoteAddress: '127.0.0.1',
+          remotePort: 8080
+        },
         body: {
           a: '1'
         },
@@ -278,6 +316,14 @@ describe('AppSec Index', () => {
 
       expect(Gateway.getContext).to.have.been.calledOnce
       expect(Gateway.propagate).to.have.been.calledOnceWithExactly({
+        'server.request.uri.raw': '/path',
+        'server.request.headers.no_cookies': {
+          'user-agent': 'Arachni',
+          'host': 'localhost'
+        },
+        'server.request.method': 'POST',
+        'server.request.client_ip': '127.0.0.1',
+        'server.request.client_port': 8080,
         'server.response.status': 201,
         'server.response.headers.no_cookies': {
           'content-type': 'application/json',

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -160,8 +160,8 @@ describe('reporter', () => {
       expect(result).to.not.be.false
 
       expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
-        'appsec.event': true,
-        'manual.keep': true,
+        'appsec.event': 'true',
+        'manual.keep': 'true',
         '_dd.origin': 'appsec',
         '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}',
         'http.request.headers.host': 'localhost',
@@ -181,8 +181,8 @@ describe('reporter', () => {
       expect(result).to.not.be.false
 
       expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
-        'appsec.event': true,
-        'manual.keep': true,
+        'appsec.event': 'true',
+        'manual.keep': 'true',
         '_dd.appsec.json': '{"triggers":[]}'
       })
     })
@@ -209,8 +209,8 @@ describe('reporter', () => {
       expect(result).to.not.be.false
 
       expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
-        'appsec.event': true,
-        'manual.keep': true,
+        'appsec.event': 'true',
+        'manual.keep': 'true',
         '_dd.origin': 'appsec',
         '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]},{"rule":{}},{"rule":{},"rule_matches":[{}]}]}',
         'http.request.headers.host': 'localhost',


### PR DESCRIPTION
### What does this PR do?
This moves the http request WAF call, to the http response, thus combining request and response analysis.

I also included a fix to change boolean tags to strings.

### Motivation
After profiling AppSec, we observed that the WAF takes a non-trivial amount of time to execute. And since blocking behavior is not expected to be needed soon, we decided to regroup the WAF calls to reduce the overhead.