### PR TITLE
AppSec Rate Limiter

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -142,6 +142,11 @@ class Config {
       process.env.DD_APPSEC_RULES,
       path.join(__dirname, 'appsec', 'recommended.json')
     )
+    const DD_APPSEC_TRACE_RATE_LIMIT = coalesce(
+      appsec.rateLimit,
+      process.env.DD_APPSEC_TRACE_RATE_LIMIT,
+      100
+    )
 
     const sampler = (options.experimental && options.experimental.sampler) || {}
     const ingestion = options.ingestion || {}
@@ -202,7 +207,8 @@ class Config {
     this.protocolVersion = DD_TRACE_AGENT_PROTOCOL_VERSION
     this.appsec = {
       enabled: isTrue(DD_APPSEC_ENABLED),
-      rules: DD_APPSEC_RULES
+      rules: DD_APPSEC_RULES,
+      rateLimit: DD_APPSEC_TRACE_RATE_LIMIT
     }
 
     tagger.add(this.tags, {


### PR DESCRIPTION
### What does this PR do?
This adds a rate limiter to AppSec, preventing more than 100 (configurable) requests per second to be analysed and reported.

### Motivation
Since a trace is kept with `manual.keep: true` when an attack is detected, some clients managed to take down our ingestion backend by getting attacked too much.