### PR TITLE
use AsyncResource polyfill instead of custom functions for patching

### DIFF
--- a/packages/datadog-instrumentations/src/dns.js
+++ b/packages/datadog-instrumentations/src/dns.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { channel, addHook, bind } = require('./helpers/instrument')
+const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
 const rrtypes = {
@@ -53,7 +53,7 @@ function wrap (prefix, fn, expectedArgs, rrtype) {
   const errorCh = channel(prefix + ':error')
 
   const wrapped = function () {
-    const cb = bind(arguments[arguments.length - 1])
+    const cb = AsyncResource.bind(arguments[arguments.length - 1])
     if (
       !startCh.hasSubscribers ||
       arguments.length < expectedArgs ||

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -95,7 +95,7 @@ if (semver.satisfies(process.versions.node, '>=16.0.0')) {
   exports.AsyncResource = class extends AsyncResource {
     static bind (fn, type, thisArg) {
       type = type || fn.name
-      return (new AsyncResource(type || 'bound-anonymous-fn')).bind(fn, thisArg)
+      return (new exports.AsyncResource(type || 'bound-anonymous-fn')).bind(fn, thisArg)
     }
 
     bind (fn, thisArg = this) {

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -90,32 +90,31 @@ function getBasedir (id) {
 }
 
 if (semver.satisfies(process.versions.node, '>=16.0.0')) {
-  exports.bind = AsyncResource.bind
-  exports.bindAsyncResource = AsyncResource.prototype.bind
+  exports.AsyncResource = AsyncResource
 } else {
-  exports.bindAsyncResource = function bindAsyncResource (fn, thisArg) {
-    thisArg = thisArg || this
-    const ret = this.runInAsyncScope.bind(this, fn, thisArg)
-    Object.defineProperties(ret, {
-      'length': {
-        configurable: true,
-        enumerable: false,
-        value: fn.length,
-        writable: false
-      },
-      'asyncResource': {
-        configurable: true,
-        enumerable: true,
-        value: this,
-        writable: true
-      }
-    })
-    return ret
-  }
+  exports.AsyncResource = class extends AsyncResource {
+    static bind (fn, type, thisArg) {
+      type = type || fn.name
+      return (new AsyncResource(type || 'bound-anonymous-fn')).bind(fn, thisArg)
+    }
 
-  exports.bind = function bind (fn, type, thisArg) {
-    type = type || fn.name
-    const ar = new AsyncResource(type || 'bound-anonymous-fn')
-    return exports.bindAsyncResource.call(ar, fn, thisArg)
+    bind (fn, thisArg = this) {
+      const ret = this.runInAsyncScope.bind(this, fn, thisArg)
+      Object.defineProperties(ret, {
+        'length': {
+          configurable: true,
+          enumerable: false,
+          value: fn.length,
+          writable: false
+        },
+        'asyncResource': {
+          configurable: true,
+          enumerable: true,
+          value: this,
+          writable: true
+        }
+      })
+      return ret
+    }
   }
 }

--- a/packages/datadog-instrumentations/src/memcached.js
+++ b/packages/datadog-instrumentations/src/memcached.js
@@ -1,11 +1,9 @@
 'use strict'
 
-const { AsyncResource } = require('async_hooks')
 const {
   channel,
   addHook,
-  bind,
-  bindAsyncResource
+  AsyncResource
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
@@ -27,9 +25,9 @@ addHook({ name: 'memcached', versions: ['>=2.2'] }, Memcached => {
 
     const wrappedQueryCompiler = function () {
       const query = queryCompiler.apply(this, arguments)
-      const callback = bindAsyncResource.call(asyncResource, query.callback)
+      const callback = asyncResource.bind(query.callback)
 
-      query.callback = bind(function (err) {
+      query.callback = AsyncResource.bind(function (err) {
         if (err) {
           errorCh.publish(err)
         }

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { executionAsyncId } = require('async_hooks')
+const { expect } = require('chai')
+const { storage } = require('../../../datadog-core')
+const { AsyncResource } = require('../../src/helpers/instrument')
+
+describe.only('helpers/instrument', () => {
+  describe('AsyncResource', () => {
+    it('should bind statically', () => {
+      storage.run('test1', () => {
+        const test = AsyncResource.bind(() => {
+          expect(storage.getStore()).to.equal('test1')
+        })
+
+        storage.run('test2', () => {
+          test()
+        })
+      })
+    })
+
+    it('should bind with the right `this` value statically', () => {
+      const self = 'test'
+
+      const test = AsyncResource.bind(function (a, b, c) {
+        expect(this).to.equal(self)
+        expect(test.asyncResource.asyncId()).to.equal(executionAsyncId())
+        expect(test).to.have.length(3)
+      }, 'test', self)
+
+      test()
+    })
+
+    it('should bind a specific instance', () => {
+      storage.run('test1', () => {
+        const asyncResource = new AsyncResource('test')
+
+        storage.run('test2', () => {
+          const test = asyncResource.bind((a, b, c) => {
+            expect(storage.getStore()).to.equal('test1')
+            expect(test.asyncResource).to.equal(asyncResource)
+            expect(test).to.have.length(3)
+          })
+
+          test()
+        })
+      })
+    })
+
+    it('should bind with the right `this` value with an instance', () => {
+      const self = 'test'
+
+      const asyncResource = new AsyncResource('test')
+      const test = asyncResource.bind(function () {
+        expect(this).to.equal(self)
+      }, self)
+
+      test()
+    })
+  })
+})

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -5,7 +5,7 @@ const { expect } = require('chai')
 const { storage } = require('../../../datadog-core')
 const { AsyncResource } = require('../../src/helpers/instrument')
 
-describe.only('helpers/instrument', () => {
+describe('helpers/instrument', () => {
   describe('AsyncResource', () => {
     it('should bind statically', () => {
       storage.run('test1', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use `AsyncResource` polyfill instead of custom functions for patching.

### Motivation
<!-- What inspired you to submit this pull request? -->

Code is easier to reason about when the API matches the real one from Node.