### PR TITLE
AppSec Rate Limit

### DIFF
--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -25,6 +25,8 @@ function enable (config) {
     return
   }
 
+  Reporter.setRateLimit(config.appsec.rateLimit)
+
   incomingHttpRequestStart.subscribe(incomingHttpStartTranslator)
   incomingHttpRequestEnd.subscribe(incomingHttpEndTranslator)
 

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -82,7 +82,7 @@ function formatHeaderName (name) {
 }
 
 function reportAttack (attackData, store) {
-  if (!limiter.isAllowed()) return
+  if (!limiter.isAllowed()) return false
 
   const req = store && store.get('req')
   const topSpan = req && req._datadog && req._datadog.span

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -82,8 +82,6 @@ function formatHeaderName (name) {
 }
 
 function reportAttack (attackData, store) {
-  if (!limiter.isAllowed()) return false
-
   const req = store && store.get('req')
   const topSpan = req && req._datadog && req._datadog.span
   if (!topSpan) return false
@@ -91,8 +89,11 @@ function reportAttack (attackData, store) {
   const currentTags = topSpan.context()._tags
 
   const newTags = {
-    'appsec.event': 'true',
-    'manual.keep': 'true' // TODO: figure out how to keep appsec traces with sampling revamp
+    'appsec.event': 'true'
+  }
+
+  if (limiter.isAllowed()) {
+    newTags['manual.keep'] = 'true' // TODO: figure out how to keep appsec traces with sampling revamp
   }
 
   // TODO: maybe add this to format.js later (to take decision as late as possible)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -134,6 +134,11 @@ class Config {
       process.env.DD_APPSEC_RULES,
       path.join(__dirname, 'appsec', 'recommended.json')
     )
+    const DD_APPSEC_TRACE_RATE_LIMIT = coalesce(
+      appsec.rateLimit,
+      process.env.DD_APPSEC_TRACE_RATE_LIMIT,
+      100
+    )
 
     const sampler = (options.experimental && options.experimental.sampler) || {}
     const ingestion = options.ingestion || {}
@@ -198,7 +203,8 @@ class Config {
     this.protocolVersion = DD_TRACE_AGENT_PROTOCOL_VERSION
     this.appsec = {
       enabled: isTrue(DD_APPSEC_ENABLED),
-      rules: DD_APPSEC_RULES
+      rules: DD_APPSEC_RULES,
+      rateLimit: DD_APPSEC_TRACE_RATE_LIMIT
     }
 
     tagger.add(this.tags, {

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -16,12 +16,14 @@ describe('AppSec Index', () => {
     config = {
       appsec: {
         enabled: true,
-        rules: './path/rules.json'
+        rules: './path/rules.json',
+        rateLimit: 42
       }
     }
 
     sinon.stub(fs, 'readFileSync').returns('{"rules": [{"a": 1}]}')
     sinon.stub(RuleManager, 'applyRules')
+    sinon.stub(Reporter, 'setRateLimit')
     sinon.stub(incomingHttpRequestStart, 'subscribe')
     sinon.stub(incomingHttpRequestEnd, 'subscribe')
     Gateway.manager.clear()
@@ -38,6 +40,7 @@ describe('AppSec Index', () => {
 
       expect(fs.readFileSync).to.have.been.calledOnceWithExactly('./path/rules.json')
       expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] })
+      expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)
         .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
       expect(incomingHttpRequestEnd.subscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpEndTranslator)

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -22,6 +22,7 @@ describe('reporter', () => {
   afterEach(() => {
     sinon.restore()
     Engine.manager.clear()
+    Reporter.setRateLimit(100)
   })
 
   describe('resolveHTTPRequest', () => {
@@ -129,6 +130,24 @@ describe('reporter', () => {
   })
 
   describe('reportAttack', () => {
+    it('should do nothing when rate limit is reached', (done) => {
+      const store = new Map([[ 'req', stubReq() ]])
+
+      expect(Reporter.reportAttack('', store)).to.not.be.false
+      expect(Reporter.reportAttack('', store)).to.not.be.false
+      expect(Reporter.reportAttack('', store)).to.not.be.false
+
+      Reporter.setRateLimit(1)
+
+      expect(Reporter.reportAttack('', store)).to.not.be.false
+      expect(Reporter.reportAttack('', store)).to.be.false
+
+      setTimeout(() => {
+        expect(Reporter.reportAttack('', store)).to.not.be.false
+        done()
+      }, 1e3)
+    })
+
     it('should do nothing when passed incomplete objects', () => {
       expect(Reporter.reportAttack('', null)).to.be.false
       expect(Reporter.reportAttack('', new Map())).to.be.false

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -187,8 +187,8 @@ describe('reporter', () => {
       Reporter.setRateLimit(1)
 
       expect(Reporter.reportAttack('', store)).to.not.be.false
-      expect(addTags.getCall(3).firstArg).to.have.property('manual.keep').that.equals('true')
       expect(addTags.getCall(3).firstArg).to.have.property('appsec.event').that.equals('true')
+      expect(addTags.getCall(3).firstArg).to.have.property('manual.keep').that.equals('true')
       expect(Reporter.reportAttack('', store)).to.not.be.false
       expect(addTags.getCall(4).firstArg).to.have.property('appsec.event').that.equals('true')
       expect(addTags.getCall(4).firstArg).to.not.have.property('manual.keep')

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -72,6 +72,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.enabled', false)
     const rulePath = path.join(__dirname, '..', 'src', 'appsec', 'recommended.json')
     expect(config).to.have.nested.property('appsec.rules', rulePath)
+    expect(config).to.have.nested.property('appsec.rateLimit', 100)
   })
 
   it('should initialize from the default service', () => {
@@ -115,6 +116,7 @@ describe('Config', () => {
     process.env.DD_TRACE_EXPERIMENTAL_INTERNAL_ERRORS_ENABLED = 'true'
     process.env.DD_APPSEC_ENABLED = 'true'
     process.env.DD_APPSEC_RULES = './path/rules.json'
+    process.env.DD_APPSEC_TRACE_RATE_LIMIT = 42
 
     const config = new Config()
 
@@ -139,6 +141,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rules', './path/rules.json')
+    expect(config).to.have.nested.property('appsec.rateLimit', 42)
   })
 
   it('should read case-insensitive booleans from environment variables', () => {
@@ -313,6 +316,7 @@ describe('Config', () => {
     process.env.DD_TRACE_EXPERIMENTAL_INTERNAL_ERRORS_ENABLED = 'true'
     process.env.DD_APPSEC_ENABLED = 'false'
     process.env.DD_APPSEC_RULES = 'something'
+    process.env.DD_APPSEC_TRACE_RATE_LIMIT = 11
 
     const config = new Config({
       protocolVersion: '0.5',
@@ -339,7 +343,8 @@ describe('Config', () => {
       },
       appsec: {
         enabled: true,
-        rules: './path/rules.json'
+        rules: './path/rules.json',
+        rateLimit: 42
       }
     })
 
@@ -363,6 +368,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.enableGetRumData', false)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rules', './path/rules.json')
+    expect(config).to.have.nested.property('appsec.rateLimit', 42)
   })
 
   it('should give priority to non-experimental options', () => {
@@ -373,7 +379,8 @@ describe('Config', () => {
       },
       appsec: {
         enabled: true,
-        rules: './path/rules.json'
+        rules: './path/rules.json',
+        rateLimit: 42
       },
       experimental: {
         sampler: {
@@ -382,7 +389,8 @@ describe('Config', () => {
         },
         appsec: {
           enabled: false,
-          rules: 'something'
+          rules: 'something',
+          rateLimit: 11
         }
       }
     })
@@ -392,7 +400,8 @@ describe('Config', () => {
     })
     expect(config).to.have.deep.property('appsec', {
       enabled: true,
-      rules: './path/rules.json'
+      rules: './path/rules.json',
+      rateLimit: 42
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
This adds a rate limiter to AppSec, preventing more than 100 (configurable) requests per second to be reported with the tag `manual.keep`.

### Motivation
Since a trace is kept with `manual.keep: true` when an attack is detected, some clients managed to take down our ingestion backend by getting attacked too much.