### PR TITLE
fix(pino): support module exports for pino version >= 6.8.0

### DIFF
--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -100,7 +100,7 @@ module.exports = [
   },
   {
     name: 'pino',
-    versions: ['>=5.14.0'],
+    versions: ['>=5.14.0 <6.8.0'],
     patch (pino, tracer, config) {
       if (!tracer._logInjection) return
 
@@ -110,6 +110,30 @@ module.exports = [
     },
     unpatch (pino) {
       return this.unwrapExport(pino)
+    }
+  },
+  {
+    name: 'pino',
+    versions: ['>=6.8.0'],
+    patch (pino, tracer, config) {
+      if (!tracer._logInjection) return
+
+      const mixinSym = pino.symbols.mixinSym
+
+      const wrapped = this.wrapExport(pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino))
+
+      wrapped.pino = this.wrapExport(pino.pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.pino))
+      wrapped.default = this.wrapExport(pino.default,
+        createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.default))
+
+      return wrapped
+    },
+    unpatch (pino) {
+      const unwrapped = this.unwrapExport(pino)
+      unwrapped.pino = this.unwrapExport(pino.pino)
+      unwrapped.default = this.unwrapExport(pino.default)
+
+      return unwrapped
     }
   },
   {

--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -120,11 +120,11 @@ module.exports = [
 
       const mixinSym = pino.symbols.mixinSym
 
-      const wrapped = this.wrapExport(pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino))
+      const wrapper = createWrapPino(tracer, config, mixinSym, createWrapMixin)
 
-      wrapped.pino = this.wrapExport(pino.pino, createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.pino))
-      wrapped.default = this.wrapExport(pino.default,
-        createWrapPino(tracer, config, mixinSym, createWrapMixin)(pino.default))
+      const wrapped = this.wrapExport(pino, wrapper(pino))
+      wrapped.pino = this.wrapExport(pino.pino, wrapper(pino.pino))
+      wrapped.default = this.wrapExport(pino.default, wrapper(pino.default))
 
       return wrapped
     },

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -11,137 +11,100 @@ describe('Plugin', () => {
   let stream
   let span
 
-  function setup (version, options) {
-    const pino = require(`../../../versions/pino@${version}`).get()
+  function withExports (version, testRunner) {
+    describe(`with export`, () => {
+      testRunner()
+    })
 
-    span = tracer.startSpan('test')
+    let exports = []
+    if (semver.intersects(version, '>=6.8')) {
+      exports = ['default', 'pino']
+    }
 
-    stream = new Writable()
-    stream._write = () => {}
-
-    sinon.spy(stream, 'write')
-
-    logger = pino(options, stream)
+    exports.forEach((exportName) => {
+      describe(`with export.${exportName}`, () => {
+        testRunner(exportName)
+      })
+    })
   }
 
   describe('pino', () => {
     withVersions(plugin, 'pino', version => {
-      beforeEach(() => {
-        tracer = require('../../dd-trace')
-        return agent.load('pino')
-      })
+      withExports(version, exportName => {
+        function setup (version, options) {
+          let pino = require(`../../../versions/pino@${version}`).get()
 
-      afterEach(() => {
-        return agent.close()
-      })
+          if (exportName) {
+            pino = pino[exportName]
+          }
 
-      describe('without configuration', () => {
-        beforeEach(() => {
-          setup(version)
-        })
+          span = tracer.startSpan('test')
 
-        it('should not alter the default behavior', () => {
-          tracer.scope().activate(span, () => {
-            logger.info('message')
+          stream = new Writable()
+          stream._write = () => {}
 
-            expect(stream.write).to.have.been.called
+          sinon.spy(stream, 'write')
 
-            const record = JSON.parse(stream.write.firstCall.args[0].toString())
-
-            expect(record).to.not.have.property('dd')
-            expect(record).to.have.deep.property('msg', 'message')
-          })
-        })
-
-        if (semver.intersects(version, '>=5')) {
-          it('should not alter the default behavior with pretty print', () => {
-            setup(version, { prettyPrint: true })
-
-            tracer.scope().activate(span, () => {
-              logger.info('message')
-
-              expect(stream.write).to.have.been.called
-
-              const record = stream.write.firstCall.args[0].toString()
-
-              expect(record).to.not.include('trace_id')
-              expect(record).to.not.include('span_id')
-              expect(record).to.include('message')
-            })
-          })
+          logger = pino(options, stream)
         }
-      })
 
-      describe('with configuration', () => {
         beforeEach(() => {
-          tracer._tracer._logInjection = true
-          setup(version)
+          tracer = require('../../dd-trace')
+          return agent.load('pino')
         })
 
-        it('should add the trace identifiers to logger instances', () => {
-          tracer.scope().activate(span, () => {
-            logger.info('message')
+        afterEach(() => {
+          return agent.close()
+        })
 
-            expect(stream.write).to.have.been.called
-
-            const record = JSON.parse(stream.write.firstCall.args[0].toString())
-
-            expect(record.dd).to.deep.include({
-              trace_id: span.context().toTraceId(),
-              span_id: span.context().toSpanId()
-            })
-
-            expect(record).to.have.deep.property('msg', 'message')
+        describe('without configuration', () => {
+          beforeEach(() => {
+            setup(version)
           })
-        })
 
-        it('should support errors', () => {
-          tracer.scope().activate(span, () => {
-            const error = new Error('boom')
-
-            logger.info(error)
-
-            const record = JSON.parse(stream.write.firstCall.args[0].toString())
-
-            if (record.err) { // pino >=7
-              expect(record.err).to.have.property('message', error.message)
-              expect(record.err).to.have.property('type', 'Error')
-              expect(record.err).to.have.property('stack', error.stack)
-            } else { // pino <7
-              expect(record).to.have.property('msg', error.message)
-              expect(record).to.have.property('type', 'Error')
-              expect(record).to.have.property('stack', error.stack)
-            }
-          })
-        })
-
-        it('should not alter the original record', () => {
-          tracer.scope().activate(span, () => {
-            const record = {
-              foo: 'bar'
-            }
-
-            logger.info(record)
-
-            expect(record).to.not.have.property('dd')
-          })
-        })
-
-        if (semver.intersects(version, '>=5.14.0')) {
-          it('should not alter pino mixin behavior', () => {
-            const opts = { mixin: () => ({ addedMixin: true }) }
-
-            sinon.spy(opts, 'mixin')
-
-            setup(version, opts)
-
+          it('should not alter the default behavior', () => {
             tracer.scope().activate(span, () => {
               logger.info('message')
 
-              expect(opts.mixin).to.have.been.called
-
               expect(stream.write).to.have.been.called
 
+              const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+              expect(record).to.not.have.property('dd')
+              expect(record).to.have.deep.property('msg', 'message')
+            })
+          })
+
+          if (semver.intersects(version, '>=5')) {
+            it('should not alter the default behavior with pretty print', () => {
+              setup(version, { prettyPrint: true })
+
+              tracer.scope().activate(span, () => {
+                logger.info('message')
+
+                expect(stream.write).to.have.been.called
+
+                const record = stream.write.firstCall.args[0].toString()
+
+                expect(record).to.not.include('trace_id')
+                expect(record).to.not.include('span_id')
+                expect(record).to.include('message')
+              })
+            })
+          }
+        })
+
+        describe('with configuration', () => {
+          beforeEach(() => {
+            tracer._tracer._logInjection = true
+            setup(version)
+          })
+
+          it('should add the trace identifiers to logger instances', () => {
+            tracer.scope().activate(span, () => {
+              logger.info('message')
+
+              expect(stream.write).to.have.been.called
               const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
               expect(record.dd).to.deep.include({
@@ -150,31 +113,90 @@ describe('Plugin', () => {
               })
 
               expect(record).to.have.deep.property('msg', 'message')
-              expect(record).to.have.deep.property('addedMixin', true)
             })
           })
-        }
 
-        // TODO: test with a version matrix against pino. externals.json doesn't allow that
-        //       and we cannot control the version of pino-pretty internally required by pino
-        if (semver.intersects(version, '>=5')) {
-          it('should add the trace identifiers to logger instances with pretty print', () => {
-            setup(version, { prettyPrint: true })
-
+          it('should support errors', () => {
             tracer.scope().activate(span, () => {
-              logger.info('message')
+              const error = new Error('boom')
 
-              expect(stream.write).to.have.been.called
+              logger.info(error)
 
-              const record = stream.write.firstCall.args[0].toString()
+              const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
-              expect(record).to.match(new RegExp(`trace_id\\W+?${span.context().toTraceId()}`))
-              expect(record).to.match(new RegExp(`span_id\\W+?${span.context().toSpanId()}`))
-
-              expect(record).to.include('message')
+              if (record.err) { // pino >=7
+                expect(record.err).to.have.property('message', error.message)
+                expect(record.err).to.have.property('type', 'Error')
+                expect(record.err).to.have.property('stack', error.stack)
+              } else { // pino <7
+                expect(record).to.have.property('msg', error.message)
+                expect(record).to.have.property('type', 'Error')
+                expect(record).to.have.property('stack', error.stack)
+              }
             })
           })
-        }
+
+          it('should not alter the original record', () => {
+            tracer.scope().activate(span, () => {
+              const record = {
+                foo: 'bar'
+              }
+
+              logger.info(record)
+
+              expect(record).to.not.have.property('dd')
+            })
+          })
+
+          if (semver.intersects(version, '>=5.14.0')) {
+            it('should not alter pino mixin behavior', () => {
+              const opts = { mixin: () => ({ addedMixin: true }) }
+
+              sinon.spy(opts, 'mixin')
+
+              setup(version, opts)
+
+              tracer.scope().activate(span, () => {
+                logger.info('message')
+
+                expect(opts.mixin).to.have.been.called
+
+                expect(stream.write).to.have.been.called
+
+                const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+                expect(record.dd).to.deep.include({
+                  trace_id: span.context().toTraceId(),
+                  span_id: span.context().toSpanId()
+                })
+
+                expect(record).to.have.deep.property('msg', 'message')
+                expect(record).to.have.deep.property('addedMixin', true)
+              })
+            })
+          }
+
+          // TODO: test with a version matrix against pino. externals.json doesn't allow that
+          //       and we cannot control the version of pino-pretty internally required by pino
+          if (semver.intersects(version, '>=5')) {
+            it('should add the trace identifiers to logger instances with pretty print', () => {
+              setup(version, { prettyPrint: true })
+
+              tracer.scope().activate(span, () => {
+                logger.info('message')
+
+                expect(stream.write).to.have.been.called
+
+                const record = stream.write.firstCall.args[0].toString()
+
+                expect(record).to.match(new RegExp(`trace_id\\W+?${span.context().toTraceId()}`))
+                expect(record).to.match(new RegExp(`span_id\\W+?${span.context().toSpanId()}`))
+
+                expect(record).to.include('message')
+              })
+            })
+          }
+        })
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?
Based on 
- https://github.com/DataDog/dd-trace-js/pull/1733

Wraps the `module.exports.default` and `module.exports.pino` for Pino.

Recommend to review without the whitespace diff 😄 
https://github.com/DataDog/dd-trace-js/pull/1788/files?diff=split&w=1 

### Motivation
Fixes #1732

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
