### PR TITLE
Fix: Don't attach x-datadog-tags when it is empty

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -91,7 +91,9 @@ class TextMapPropagator {
     const header = tags.join(',')
 
     if (header.length <= 512) {
-      carrier[tagsKey] = header
+      if (header.length >= 1) {
+        carrier[tagsKey] = header
+      }
     } else {
       trace.tags['_dd.propagation_error:max_size'] = 1
     }


### PR DESCRIPTION
### What does this PR do?
The new `x-datadog-tags` attribute added in 1.7.0 won't get attached anymore when it has no contents.

I believe that this could happen when messages are sent outside of a tracing scope, but so far I have limited debugging on the situation.

### Motivation
Some services (AWS SQS/SNS) require attributes to be non-empty strings.

I've observed these error messages since upgrading to 1.7.0:

    ParameterValueInvalid: The message attribute 'x-datadog-tags' must contain non-empty message attribute value for message attribute type 'String'.

and

    InvalidParameterValue: Message (user) attribute 'x-datadog-tags' must contain a non-empty value of type 'String'.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
