### PR TITLE
fix publish docs script pointing to old main branch

### DIFF
--- a/scripts/publish_docs.js
+++ b/scripts/publish_docs.js
@@ -18,4 +18,4 @@ exec('git init', { cwd: './docs/out' }) // cloning would overwrite generated doc
 exec('git remote add origin git@github.com:DataDog/dd-trace-js.git', { cwd: './docs/out' })
 exec('git add -A', { cwd: './docs/out' })
 exec(`git commit -m "${msg}"`, { cwd: './docs/out' })
-exec('git push -f origin master:gh-pages', { cwd: './docs/out' })
+exec('git push -f origin main:gh-pages', { cwd: './docs/out' })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix publish docs script pointing to old main branch.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `git init` command now uses `main` as the default branch name.