### PR TITLE
add `validateStatus` config option to the `next` integration

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -179,6 +179,7 @@ describe('Plugin', function () {
         const config = {}
 
         before(() => {
+          config.validateStatus = code => false
           config.hooks = {
             request: sinon.spy()
           }
@@ -186,7 +187,7 @@ describe('Plugin', function () {
 
         setup(config)
 
-        it('should execute the hook', done => {
+        it('should execute the hook and validate the status', done => {
           agent
             .use(traces => {
               const spans = traces[0]
@@ -195,6 +196,7 @@ describe('Plugin', function () {
               expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('type', 'web')
               expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
+              expect(spans[0]).to.have.property('error', 1)
               expect(spans[0].meta).to.have.property('span.kind', 'server')
               expect(spans[0].meta).to.have.property('http.method', 'GET')
               expect(spans[0].meta).to.have.property('http.status_code', '200')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `validateStatus` config option to the `next` integration.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `next` span is not merged with the `http` span like other Web frameworks because it's not always top-level. For example, it could be nested in an Express middleware. Because of this, it doesn't automatically get the same behaviour as `http` and any common behaviour has to be added manually.

In this case, `validateStatus` is needed since otherwise when the promise is resolved it wouldn't be considered an error even if the status code was set to a 500. This is problematic as it's not possible to query based on the `error` status of the `http` span and the `next.page` tag of the `next` span simultaneously, making it difficult to group errors by endpoints.