### PR TITLE
[ci-visibility] Add `ci_library` Tags

### DIFF
--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -16,7 +16,9 @@ const {
   CI_APP_ORIGIN,
   ERROR_MESSAGE,
   TEST_SKIP_REASON,
-  TEST_FRAMEWORK_VERSION
+  TEST_FRAMEWORK_VERSION,
+  CI_LIBRARY_LANGUAGE,
+  CI_LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 
 const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
@@ -80,13 +82,15 @@ describe('Plugin', () => {
               [TEST_NAME]: 'pass scenario',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_STATUS]: 'pass'
+              [TEST_STATUS]: 'pass',
+              [CI_LIBRARY_LANGUAGE]: 'javascript'
             })
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('cucumber.test')
             expect(testSpan.resource).to.equal('pass scenario')
+            expect(testSpan.meta[CI_LIBRARY_VERSION]).not.to.be.undefined
           })
           const result = await runCucumber(version, Cucumber, 'simple.js', 'simple.feature', 'pass scenario')
           expect(result.success).to.equal(true)

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -16,7 +16,9 @@ const {
   CI_APP_ORIGIN,
   ERROR_TYPE,
   ERROR_MESSAGE,
-  TEST_FRAMEWORK_VERSION
+  TEST_FRAMEWORK_VERSION,
+  CI_LIBRARY_LANGUAGE,
+  CI_LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 
 describe('Plugin', () => {
@@ -67,9 +69,11 @@ describe('Plugin', () => {
               [TEST_SUITE]: 'cypress/integration/integration-test.js',
               [TEST_TYPE]: 'test',
               [ORIGIN_KEY]: CI_APP_ORIGIN,
-              [TEST_IS_RUM_ACTIVE]: 'true'
+              [TEST_IS_RUM_ACTIVE]: 'true',
+              [CI_LIBRARY_LANGUAGE]: 'javascript'
             })
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+            expect(testSpan.meta[CI_LIBRARY_VERSION]).not.to.be.undefined
           })
         const failingTestPromise = agent
           .use(traces => {

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -16,7 +16,9 @@ const {
   ERROR_STACK,
   TEST_PARAMETERS,
   CI_APP_ORIGIN,
-  JEST_TEST_RUNNER
+  JEST_TEST_RUNNER,
+  CI_LIBRARY_LANGUAGE,
+  CI_LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 
 describe('Plugin', function () {
@@ -71,13 +73,15 @@ describe('Plugin', function () {
               [TEST_STATUS]: 'pass',
               [TEST_SUITE_TAG]: TEST_SUITE,
               [TEST_TYPE]: 'test',
-              [JEST_TEST_RUNNER]: 'jest-circus'
+              [JEST_TEST_RUNNER]: 'jest-circus',
+              [CI_LIBRARY_LANGUAGE]: 'javascript'
             })
             expect(traces[0][0].type).to.equal('test')
             expect(traces[0][0].name).to.equal('jest.test')
             expect(traces[0][0].resource).to.equal(`${TEST_SUITE}.${TEST_NAME}`)
             expect(traces[0][0].service).to.equal('test')
             expect(traces[0][0].meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+            expect(traces[0][0].meta[CI_LIBRARY_VERSION]).not.to.be.undefined
           }).then(done).catch(done)
 
         const passingTestEvent = {

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -13,7 +13,9 @@ const {
   TEST_STATUS,
   CI_APP_ORIGIN,
   TEST_FRAMEWORK_VERSION,
-  JEST_TEST_RUNNER
+  JEST_TEST_RUNNER,
+  CI_LIBRARY_LANGUAGE,
+  CI_LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 
 describe('Plugin', () => {
@@ -72,13 +74,15 @@ describe('Plugin', () => {
               [TEST_STATUS]: status,
               [TEST_SUITE_TAG]: 'packages/datadog-plugin-jest/test/jest-test.js',
               [TEST_TYPE]: 'test',
-              [JEST_TEST_RUNNER]: 'jest-jasmine2'
+              [JEST_TEST_RUNNER]: 'jest-jasmine2',
+              [CI_LIBRARY_LANGUAGE]: 'javascript'
             })
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('jest.test')
             expect(testSpan.service).to.equal('test')
             expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+            expect(testSpan.meta[CI_LIBRARY_VERSION]).not.to.be.undefined
           })
         })
 

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -19,7 +19,9 @@ const {
   ERROR_MESSAGE,
   ERROR_STACK,
   CI_APP_ORIGIN,
-  TEST_FRAMEWORK_VERSION
+  TEST_FRAMEWORK_VERSION,
+  CI_LIBRARY_LANGUAGE,
+  CI_LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 
 const ASYNC_TESTS = [
@@ -139,7 +141,8 @@ describe('Plugin', () => {
               [TEST_STATUS]: 'fail',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'mocha',
-              [TEST_SUITE]: testSuite
+              [TEST_SUITE]: testSuite,
+              [CI_LIBRARY_LANGUAGE]: 'javascript'
             })
             expect(testSpan.meta).to.contain({
               [ERROR_TYPE]: 'AssertionError',
@@ -151,6 +154,7 @@ describe('Plugin', () => {
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('mocha.test')
             expect(testSpan.resource).to.equal(`${testSuite}.mocha-test-fail can fail`)
+            expect(testSpan.meta[CI_LIBRARY_VERSION]).not.to.be.undefined
           }).then(done, done)
 
         const mocha = new Mocha({
@@ -201,7 +205,8 @@ describe('Plugin', () => {
                 [TEST_STATUS]: test.status,
                 [TEST_TYPE]: 'test',
                 [TEST_FRAMEWORK]: 'mocha',
-                [TEST_SUITE]: testSuite
+                [TEST_SUITE]: testSuite,
+                [CI_LIBRARY_LANGUAGE]: 'javascript'
               })
               if (test.fileName === 'mocha-test-fail.js') {
                 expect(testSpan.meta).to.contain({
@@ -215,6 +220,7 @@ describe('Plugin', () => {
               expect(testSpan.type).to.equal('test')
               expect(testSpan.name).to.equal('mocha.test')
               expect(testSpan.resource).to.equal(`${testSuite}.${test.root} ${test.testName}`)
+              expect(testSpan.meta[CI_LIBRARY_VERSION]).not.to.be.undefined
             }).then(done, done)
 
           const mocha = new Mocha({

--- a/packages/dd-trace/src/plugins/util/dd_pkg.js
+++ b/packages/dd-trace/src/plugins/util/dd_pkg.js
@@ -1,0 +1,30 @@
+// similar to packages/dd-trace/src/pkg.js, only this always returns the
+// dd-trace's package (and not the version of the require.main file, for example)
+const fs = require('fs')
+const path = require('path')
+
+function findUp (name, cwd) {
+  let directory = path.resolve(cwd)
+  const { root } = path.parse(directory)
+
+  while (true) {
+    const current = path.resolve(directory, name)
+
+    if (fs.existsSync(current)) return current
+    if (directory === root) return
+
+    directory = path.dirname(directory)
+  }
+}
+
+function getDDTracePkg () {
+  const filePath = findUp('package.json', '.')
+
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (e) {
+    return {}
+  }
+}
+
+module.exports = getDDTracePkg()

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -4,6 +4,7 @@ const { getGitMetadata } = require('./git')
 const { getUserProviderGitMetadata } = require('./user-provided-git')
 const { getCIMetadata } = require('./ci')
 const { getRuntimeAndOSMetadata } = require('./env')
+const ddPkg = require('./dd_pkg')
 const {
   GIT_BRANCH,
   GIT_COMMIT_SHA,
@@ -26,6 +27,9 @@ const TEST_PARAMETERS = 'test.parameters'
 const TEST_SKIP_REASON = 'test.skip_reason'
 const TEST_IS_RUM_ACTIVE = 'test.is_rum_active'
 
+const CI_LIBRARY_LANGUAGE = 'ci_library.language'
+const CI_LIBRARY_VERSION = 'ci_library.version'
+
 const ERROR_TYPE = 'error.type'
 const ERROR_MESSAGE = 'error.msg'
 const ERROR_STACK = 'error.stack'
@@ -35,6 +39,8 @@ const CI_APP_ORIGIN = 'ciapp-test'
 const JEST_TEST_RUNNER = 'test.jest.test_runner'
 
 module.exports = {
+  CI_LIBRARY_LANGUAGE,
+  CI_LIBRARY_VERSION,
   TEST_FRAMEWORK,
   TEST_FRAMEWORK_VERSION,
   JEST_TEST_RUNNER,
@@ -90,7 +96,9 @@ function getTestEnvironmentMetadata (testFramework, config) {
     ...gitMetadata,
     ...ciMetadata,
     ...userProvidedGitMetadata,
-    ...runtimeAndOSMetadata
+    ...runtimeAndOSMetadata,
+    [CI_LIBRARY_LANGUAGE]: 'javascript',
+    [CI_LIBRARY_VERSION]: ddPkg.version
   }
   if (config && config.service) {
     metadata['service.name'] = config.service


### PR DESCRIPTION
### What does this PR do?
* Add `ci_library.version` and `ci_library.language` tags to the test spans. 

### Motivation
Be able to debug issues with specific versions/languages of CI Visibility libraries. 

* `ci_library.version` is the version of `dd-trace`. 
* `ci_library.language` is `'javascript'`.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
