### PR TITLE
fix fastify non-default exports not being instrumented

### DIFF
--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -9,7 +9,8 @@
     "expect": true,
     "sinon": true,
     "proxyquire": true,
-    "withVersions": true
+    "withVersions": true,
+    "withExports": true
   },
   "rules": {
     "no-unused-expressions": 0,

--- a/packages/datadog-plugin-fastify/src/fastify.js
+++ b/packages/datadog-plugin-fastify/src/fastify.js
@@ -165,7 +165,28 @@ function getRes (reply) {
 module.exports = [
   {
     name: 'fastify',
-    versions: ['>=1'],
+    versions: ['>=3'],
+    patch (fastify, tracer, config) {
+      // `fastify` is a function so we return a wrapper that will replace its export.
+      const wrapped = this.wrapExport(fastify, createWrapFastify(tracer, config)(fastify))
+
+      wrapped.fastify = wrapped
+      wrapped.default = wrapped
+
+      return wrapped
+    },
+    unpatch (fastify) {
+      const unwrapped = this.unwrapExport(fastify)
+
+      unwrapped.fastify = unwrapped
+      unwrapped.default = unwrapped
+
+      return unwrapped
+    }
+  },
+  {
+    name: 'fastify',
+    versions: ['1 - 2'],
     patch (fastify, tracer, config) {
       // `fastify` is a function so we return a wrapper that will replace its export.
       return this.wrapExport(fastify, createWrapFastify(tracer, config)(fastify))

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -21,91 +21,59 @@ describe('Plugin', () => {
         app.close()
       })
 
-      describe('without configuration', () => {
-        before(() => {
-          return agent.load('fastify')
-        })
-
-        after(() => {
-          return agent.close()
-        })
-
-        beforeEach(() => {
-          fastify = require(`../../../versions/fastify@${version}`).get()
-          app = fastify()
-
-          if (semver.intersects(version, '>=3')) {
-            return app.register(require('../../../versions/middie').get())
-          }
-        })
-
-        it('should do automatic instrumentation on the app routes', done => {
-          app.get('/user', (request, reply) => {
-            reply.send()
+      withExports('fastify', version, ['default', 'fastify'], '>=3', getExport => {
+        describe('without configuration', () => {
+          before(() => {
+            return agent.load('fastify')
           })
 
-          getPort().then(port => {
-            agent
-              .use(traces => {
-                const spans = traces[0]
-
-                expect(spans[0]).to.have.property('name', 'fastify.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET /user')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '200')
-              })
-              .then(done)
-              .catch(done)
-
-            app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          after(() => {
+            return agent.close()
           })
-        })
 
-        it('should do automatic instrumentation on route full syntax', done => {
-          app.route({
-            method: 'GET',
-            url: '/user/:id',
-            handler: (request, reply) => {
-              reply.send()
+          beforeEach(() => {
+            fastify = getExport()
+            app = fastify()
+
+            if (semver.intersects(version, '>=3')) {
+              return app.register(require('../../../versions/middie').get())
             }
           })
 
-          getPort().then(port => {
-            agent
-              .use(traces => {
-                const spans = traces[0]
+          it('should do automatic instrumentation on the app routes', done => {
+            app.get('/user', (request, reply) => {
+              reply.send()
+            })
 
-                expect(spans[0]).to.have.property('name', 'fastify.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET /user/:id')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '200')
-              })
-              .then(done)
-              .catch(done)
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  const spans = traces[0]
 
-            app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/123`)
+                  expect(spans[0]).to.have.property('name', 'fastify.request')
+                  expect(spans[0]).to.have.property('service', 'test')
+                  expect(spans[0]).to.have.property('type', 'web')
+                  expect(spans[0]).to.have.property('resource', 'GET /user')
+                  expect(spans[0].meta).to.have.property('span.kind', 'server')
+                  expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+                  expect(spans[0].meta).to.have.property('http.method', 'GET')
+                  expect(spans[0].meta).to.have.property('http.status_code', '200')
+                })
+                .then(done)
                 .catch(done)
+
+              app.listen(port, 'localhost', () => {
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(done)
+              })
             })
           })
-        })
 
-        if (semver.intersects(version, '>=1.2')) {
-          it('should do automatic instrumentation on route with handler in options', done => {
-            app.get('/user/:id', {
+          it('should do automatic instrumentation on route full syntax', done => {
+            app.route({
+              method: 'GET',
+              url: '/user/:id',
               handler: (request, reply) => {
                 reply.send()
               }
@@ -135,206 +103,144 @@ describe('Plugin', () => {
               })
             })
           })
-        }
 
-        it('should run handlers in the request scope', done => {
-          app.use((req, res, next) => {
-            expect(tracer.scope().active()).to.not.be.null
-            next()
-          })
+          if (semver.intersects(version, '>=1.2')) {
+            it('should do automatic instrumentation on route with handler in options', done => {
+              app.get('/user/:id', {
+                handler: (request, reply) => {
+                  reply.send()
+                }
+              })
 
-          app.get('/user', (request, reply) => {
-            expect(tracer.scope().active()).to.not.be.null
-            reply.send()
-          })
+              getPort().then(port => {
+                agent
+                  .use(traces => {
+                    const spans = traces[0]
 
-          getPort().then(port => {
-            app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .then(() => done())
-                .catch(done)
+                    expect(spans[0]).to.have.property('name', 'fastify.request')
+                    expect(spans[0]).to.have.property('service', 'test')
+                    expect(spans[0]).to.have.property('type', 'web')
+                    expect(spans[0]).to.have.property('resource', 'GET /user/:id')
+                    expect(spans[0].meta).to.have.property('span.kind', 'server')
+                    expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
+                    expect(spans[0].meta).to.have.property('http.method', 'GET')
+                    expect(spans[0].meta).to.have.property('http.status_code', '200')
+                  })
+                  .then(done)
+                  .catch(done)
+
+                app.listen(port, 'localhost', () => {
+                  axios
+                    .get(`http://localhost:${port}/user/123`)
+                    .catch(done)
+                })
+              })
             })
-          })
-        })
+          }
 
-        it('should run middleware in the request scope', done => {
-          app.use((req, res, next) => {
-            expect(tracer.scope().active()).to.not.be.null
-            next()
-          })
-
-          app.get('/user', (request, reply) => reply.send())
-
-          getPort().then(port => {
-            app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .then(() => done())
-                .catch(done)
+          it('should run handlers in the request scope', done => {
+            app.use((req, res, next) => {
+              expect(tracer.scope().active()).to.not.be.null
+              next()
             })
-          })
-        })
 
-        it('should run POST handlers in the request scope', done => {
-          app.post('/user', (request, reply) => {
-            expect(tracer.scope().active()).to.not.be.null
-            reply.send()
-          })
-
-          getPort().then(port => {
-            app.listen(port, 'localhost', () => {
-              axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
-                .then(() => done())
-                .catch(done)
-            })
-          })
-        })
-
-        it('should run routes in the request scope', done => {
-          app.use((req, res, next) => {
-            expect(tracer.scope().active()).to.not.be.null
-            next()
-          })
-
-          app.route({
-            method: 'POST',
-            url: '/user',
-            handler: (request, reply) => {
+            app.get('/user', (request, reply) => {
               expect(tracer.scope().active()).to.not.be.null
               reply.send()
-            }
-          })
-
-          getPort().then(port => {
-            app.listen(port, 'localhost', () => {
-              axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
-                .then(() => done())
-                .catch(done)
             })
-          })
-        })
 
-        it('should run hooks in the request scope', done => {
-          app.addHook('onRequest', (request, reply, next) => {
-            expect(tracer.scope().active()).to.not.be.null
-            next()
-          })
-
-          app.addHook('onResponse', (request, reply, next) => {
-            expect(tracer.scope().active()).to.not.be.null
-            next ? next() : reply()
-          })
-
-          app.get('/user', (request, reply) => reply.send())
-
-          getPort().then(port => {
-            app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .then(() => done())
-                .catch(done)
-            })
-          })
-        })
-
-        it('should handle reply errors', done => {
-          let error
-
-          app.get('/user', (request, reply) => {
-            reply.send(error = new Error('boom'))
-          })
-
-          getPort().then(port => {
-            agent
-              .use(traces => {
-                const spans = traces[0]
-
-                expect(spans[0]).to.have.property('name', 'fastify.request')
-                expect(spans[0]).to.have.property('resource', 'GET /user')
-                expect(spans[0].meta).to.have.property('error.type', error.name)
-                expect(spans[0].meta).to.have.property('error.msg', error.message)
-                expect(spans[0].meta).to.have.property('error.stack', error.stack)
+            getPort().then(port => {
+              app.listen(port, 'localhost', () => {
+                axios.get(`http://localhost:${port}/user`)
+                  .then(() => done())
+                  .catch(done)
               })
-              .then(done)
-              .catch(done)
-
-            app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(() => {})
             })
           })
-        })
 
-        it('should handle hook errors', done => {
-          let error
+          it('should run middleware in the request scope', done => {
+            app.use((req, res, next) => {
+              expect(tracer.scope().active()).to.not.be.null
+              next()
+            })
 
-          app.addHook('onRequest', (request, reply, next) => {
-            next(error = new Error('boom'))
-          })
+            app.get('/user', (request, reply) => reply.send())
 
-          app.get('/user', (request, reply) => {
-            reply.send()
-          })
-
-          getPort().then(port => {
-            agent
-              .use(traces => {
-                const spans = traces[0]
-
-                expect(spans[0]).to.have.property('name', 'fastify.request')
-                expect(spans[0]).to.have.property('resource', 'GET /user')
-                expect(spans[0]).to.have.property('error', 1)
-                expect(spans[0].meta).to.have.property('error.type', error.name)
-                expect(spans[0].meta).to.have.property('error.msg', error.message)
-                expect(spans[0].meta).to.have.property('error.stack', error.stack)
+            getPort().then(port => {
+              app.listen(port, 'localhost', () => {
+                axios.get(`http://localhost:${port}/user`)
+                  .then(() => done())
+                  .catch(done)
               })
-              .then(done)
-              .catch(done)
-
-            app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(() => {})
             })
           })
-        })
 
-        // fastify doesn't have all application hooks in older versions
-        if (semver.intersects(version, '>=2.15')) {
-          it('should support hooks with a single parameter', done => {
-            app.addHook('onReady', done => done())
-
-            app.get('/user', (request, reply) => {
+          it('should run POST handlers in the request scope', done => {
+            app.post('/user', (request, reply) => {
+              expect(tracer.scope().active()).to.not.be.null
               reply.send()
             })
 
             getPort().then(port => {
-              agent
-                .use(traces => {
-                  const spans = traces[0]
-
-                  expect(spans[0]).to.have.property('name', 'fastify.request')
-                  expect(spans[0]).to.have.property('resource', 'GET /user')
-                  expect(spans[0]).to.have.property('error', 0)
-                })
-                .then(done)
-                .catch(done)
-
               app.listen(port, 'localhost', () => {
-                axios
-                  .get(`http://localhost:${port}/user`)
-                  .catch(() => {})
+                axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
+                  .then(() => done())
+                  .catch(done)
               })
             })
           })
-        }
 
-        // fastify crashes the process on reply exceptions in older versions
-        if (semver.intersects(version, '>=3')) {
-          it('should handle reply rejections', done => {
+          it('should run routes in the request scope', done => {
+            app.use((req, res, next) => {
+              expect(tracer.scope().active()).to.not.be.null
+              next()
+            })
+
+            app.route({
+              method: 'POST',
+              url: '/user',
+              handler: (request, reply) => {
+                expect(tracer.scope().active()).to.not.be.null
+                reply.send()
+              }
+            })
+
+            getPort().then(port => {
+              app.listen(port, 'localhost', () => {
+                axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
+                  .then(() => done())
+                  .catch(done)
+              })
+            })
+          })
+
+          it('should run hooks in the request scope', done => {
+            app.addHook('onRequest', (request, reply, next) => {
+              expect(tracer.scope().active()).to.not.be.null
+              next()
+            })
+
+            app.addHook('onResponse', (request, reply, next) => {
+              expect(tracer.scope().active()).to.not.be.null
+              next ? next() : reply()
+            })
+
+            app.get('/user', (request, reply) => reply.send())
+
+            getPort().then(port => {
+              app.listen(port, 'localhost', () => {
+                axios.get(`http://localhost:${port}/user`)
+                  .then(() => done())
+                  .catch(done)
+              })
+            })
+          })
+
+          it('should handle reply errors', done => {
             let error
 
             app.get('/user', (request, reply) => {
-              return Promise.reject(error = new Error('boom'))
+              reply.send(error = new Error('boom'))
             })
 
             getPort().then(port => {
@@ -359,47 +265,11 @@ describe('Plugin', () => {
             })
           })
 
-          it('should handle reply exceptions', done => {
-            let error
-
-            app.setErrorHandler((error, request, reply) => {
-              reply.send()
-            })
-            app.get('/user', (request, reply) => {
-              throw (error = new Error('boom'))
-            })
-
-            getPort().then(port => {
-              agent
-                .use(traces => {
-                  const spans = traces[0]
-
-                  expect(spans[0]).to.have.property('name', 'fastify.request')
-                  expect(spans[0]).to.have.property('resource', 'GET /user')
-                  expect(spans[0].meta).to.have.property('error.type', error.name)
-                  expect(spans[0].meta).to.have.property('error.msg', error.message)
-                  expect(spans[0].meta).to.have.property('error.stack', error.stack)
-                })
-                .then(done)
-                .catch(done)
-
-              app.listen(port, 'localhost', () => {
-                axios
-                  .get(`http://localhost:${port}/user`)
-                  .catch(() => {})
-              })
-            })
-          })
-        }
-
-        // fastify crashes the process on hook exceptions in older versions
-        // which was fixed in https://github.com/fastify/fastify/pull/2695
-        if (semver.intersects(version, '>=3.9.2')) {
-          it('should handle hook exceptions', done => {
+          it('should handle hook errors', done => {
             let error
 
             app.addHook('onRequest', (request, reply, next) => {
-              throw (error = new Error('boom'))
+              next(error = new Error('boom'))
             })
 
             app.get('/user', (request, reply) => {
@@ -428,7 +298,139 @@ describe('Plugin', () => {
               })
             })
           })
-        }
+
+          // fastify doesn't have all application hooks in older versions
+          if (semver.intersects(version, '>=2.15')) {
+            it('should support hooks with a single parameter', done => {
+              app.addHook('onReady', done => done())
+
+              app.get('/user', (request, reply) => {
+                reply.send()
+              })
+
+              getPort().then(port => {
+                agent
+                  .use(traces => {
+                    const spans = traces[0]
+
+                    expect(spans[0]).to.have.property('name', 'fastify.request')
+                    expect(spans[0]).to.have.property('resource', 'GET /user')
+                    expect(spans[0]).to.have.property('error', 0)
+                  })
+                  .then(done)
+                  .catch(done)
+
+                app.listen(port, 'localhost', () => {
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(() => {})
+                })
+              })
+            })
+          }
+
+          // fastify crashes the process on reply exceptions in older versions
+          if (semver.intersects(version, '>=3')) {
+            it('should handle reply rejections', done => {
+              let error
+
+              app.get('/user', (request, reply) => {
+                return Promise.reject(error = new Error('boom'))
+              })
+
+              getPort().then(port => {
+                agent
+                  .use(traces => {
+                    const spans = traces[0]
+
+                    expect(spans[0]).to.have.property('name', 'fastify.request')
+                    expect(spans[0]).to.have.property('resource', 'GET /user')
+                    expect(spans[0].meta).to.have.property('error.type', error.name)
+                    expect(spans[0].meta).to.have.property('error.msg', error.message)
+                    expect(spans[0].meta).to.have.property('error.stack', error.stack)
+                  })
+                  .then(done)
+                  .catch(done)
+
+                app.listen(port, 'localhost', () => {
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(() => {})
+                })
+              })
+            })
+
+            it('should handle reply exceptions', done => {
+              let error
+
+              app.setErrorHandler((error, request, reply) => {
+                reply.send()
+              })
+              app.get('/user', (request, reply) => {
+                throw (error = new Error('boom'))
+              })
+
+              getPort().then(port => {
+                agent
+                  .use(traces => {
+                    const spans = traces[0]
+
+                    expect(spans[0]).to.have.property('name', 'fastify.request')
+                    expect(spans[0]).to.have.property('resource', 'GET /user')
+                    expect(spans[0].meta).to.have.property('error.type', error.name)
+                    expect(spans[0].meta).to.have.property('error.msg', error.message)
+                    expect(spans[0].meta).to.have.property('error.stack', error.stack)
+                  })
+                  .then(done)
+                  .catch(done)
+
+                app.listen(port, 'localhost', () => {
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(() => {})
+                })
+              })
+            })
+          }
+
+          // fastify crashes the process on hook exceptions in older versions
+          // which was fixed in https://github.com/fastify/fastify/pull/2695
+          if (semver.intersects(version, '>=3.9.2')) {
+            it('should handle hook exceptions', done => {
+              let error
+
+              app.addHook('onRequest', (request, reply, next) => {
+                throw (error = new Error('boom'))
+              })
+
+              app.get('/user', (request, reply) => {
+                reply.send()
+              })
+
+              getPort().then(port => {
+                agent
+                  .use(traces => {
+                    const spans = traces[0]
+
+                    expect(spans[0]).to.have.property('name', 'fastify.request')
+                    expect(spans[0]).to.have.property('resource', 'GET /user')
+                    expect(spans[0]).to.have.property('error', 1)
+                    expect(spans[0].meta).to.have.property('error.type', error.name)
+                    expect(spans[0].meta).to.have.property('error.msg', error.message)
+                    expect(spans[0].meta).to.have.property('error.stack', error.stack)
+                  })
+                  .then(done)
+                  .catch(done)
+
+                app.listen(port, 'localhost', () => {
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(() => {})
+                })
+              })
+            })
+          }
+        })
       })
     })
   })

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -19,6 +19,7 @@ global.sinon = sinon
 global.expect = chai.expect
 global.proxyquire = proxyquire
 global.withVersions = withVersions
+global.withExports = withExports
 
 afterEach(() => {
   agent.reset()
@@ -106,4 +107,21 @@ function withVersions (plugin, modules, range, cb) {
         })
       })
   })
+}
+
+function withExports (moduleName, version, exportNames, versionRange, fn) {
+  const getExport = () => require(`../../../../versions/${moduleName}@${version}`).get()
+  describe('with the default export', () => fn(getExport))
+
+  if (typeof versionRange === 'function') {
+    fn = versionRange
+    versionRange = '*'
+  }
+
+  if (!semver.intersects(version, versionRange)) return
+
+  for (const exportName of exportNames) {
+    const getExport = () => require(`../../../../versions/${moduleName}@${version}`).get()[exportName]
+    describe(`with exports.${exportName}`, () => fn(getExport))
+  }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `fastify` non-default exports not being instrumented.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fastify is exported as not only the default export but also `exports.default` and `exports.fastify` since version 3.0.