### PR TITLE
convert cassandra-driver to new plugin system

### DIFF
--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -3,6 +3,7 @@
 require('./src/amqplib')
 require('./src/bluebird')
 require('./src/bunyan')
+require('./src/cassandra-driver')
 require('./src/couchbase')
 require('./src/cucumber')
 require('./src/dns')

--- a/packages/datadog-instrumentations/src/cassandra-driver.js
+++ b/packages/datadog-instrumentations/src/cassandra-driver.js
@@ -1,0 +1,191 @@
+'use strict'
+
+const {
+  channel,
+  addHook,
+  AsyncResource
+} = require('./helpers/instrument')
+const shimmer = require('../../datadog-shimmer')
+
+const startCh = channel('apm:cassandra:query:start')
+const asyncEndCh = channel('apm:cassandra:query:async-end')
+const endCh = channel('apm:cassandra:query:end')
+const errorCh = channel('apm:cassandra:query:error')
+const addConnectionCh = channel(`apm:cassandra:query:addConnection`)
+
+addHook({ name: 'cassandra-driver', versions: ['>=3.0.0'] }, cassandra => {
+  shimmer.wrap(cassandra.Client.prototype, 'batch', batch => function (queries, options, callback) {
+    if (!startCh.hasSubscribers) {
+      return batch.apply(this, arguments)
+    }
+    const asyncResource = new AsyncResource('bound-anonymous-fn')
+    startCh.publish({ keyspace: this.keyspace, query: queries })
+
+    const lastIndex = arguments.length - 1
+    let cb = arguments[lastIndex]
+
+    if (typeof cb === 'function') {
+      cb = asyncResource.bind(cb)
+      arguments[lastIndex] = wrapCallback(asyncEndCh, errorCh, cb)
+    }
+
+    try {
+      const res = batch.apply(this, arguments)
+      if (typeof res === 'function' || !res) {
+        return wrapCallback(asyncEndCh, errorCh, res)
+      } else {
+        const promiseAsyncResource = new AsyncResource('bound-anonymous-fn')
+        return res.then(
+          promiseAsyncResource.bind(() => finish(asyncEndCh, errorCh)),
+          promiseAsyncResource.bind(err => finish(asyncEndCh, errorCh, err))
+        )
+      }
+    } catch (e) {
+      finish(asyncEndCh, errorCh, e)
+      throw e
+    } finally {
+      endCh.publish(undefined)
+    }
+  })
+  return cassandra
+})
+
+addHook({ name: 'cassandra-driver', versions: ['>=4.4'] }, cassandra => {
+  shimmer.wrap(cassandra.Client.prototype, '_execute', _execute => function (query, params, execOptions, callback) {
+    if (!startCh.hasSubscribers) {
+      return _execute.apply(this, arguments)
+    }
+    startCh.publish({ keyspace: this.keyspace, query })
+    const promise = _execute.apply(this, arguments)
+
+    const promiseAsyncResource = new AsyncResource('bound-anonymous-fn')
+
+    promise.then(
+      promiseAsyncResource.bind(() => finish(asyncEndCh, errorCh)),
+      promiseAsyncResource.bind(err => finish(asyncEndCh, errorCh, err))
+    )
+    endCh.publish(undefined)
+    return promise
+  })
+  return cassandra
+})
+
+addHook({ name: 'cassandra-driver', versions: ['3 - 4.3'] }, cassandra => {
+  shimmer.wrap(cassandra.Client.prototype, '_innerExecute', _innerExecute =>
+    function (query, params, execOptions, callback) {
+      if (!startCh.hasSubscribers) {
+        return _innerExecute.apply(this, arguments)
+      }
+      const asyncResource = new AsyncResource('bound-anonymous-fn')
+      const isValid = (args) => {
+        return args.length === 4 || typeof args[3] === 'function'
+      }
+
+      if (!isValid(arguments)) {
+        return _innerExecute.apply(this, arguments)
+      }
+
+      startCh.publish({ keyspace: this.keyspace, query })
+
+      const lastIndex = arguments.length - 1
+      let cb = arguments[lastIndex]
+
+      if (typeof cb === 'function') {
+        cb = asyncResource.bind(cb)
+        arguments[lastIndex] = wrapCallback(asyncEndCh, errorCh, cb)
+      }
+
+      try {
+        return _innerExecute.apply(this, arguments)
+      } catch (e) {
+        finish(asyncEndCh, errorCh, e)
+        throw e
+      } finally {
+        endCh.publish(undefined)
+      }
+    }
+  )
+  return cassandra
+})
+
+addHook({ name: 'cassandra-driver', versions: ['>=3.3'], file: 'lib/request-execution.js' }, RequestExecution => {
+  shimmer.wrap(RequestExecution.prototype, '_sendOnConnection', _sendOnConnection => function () {
+    if (!startCh.hasSubscribers) {
+      return _sendOnConnection.apply(this, arguments)
+    }
+    addConnectionCh.publish({ address: this._connection.address, port: this._connection.port })
+    return _sendOnConnection.apply(this, arguments)
+  })
+  return RequestExecution
+})
+
+addHook({ name: 'cassandra-driver', versions: ['3.3 - 4.3'], file: 'lib/request-execution.js' }, RequestExecution => {
+  shimmer.wrap(RequestExecution.prototype, 'start', start => function (getHostCallback) {
+    if (!startCh.hasSubscribers) {
+      return getHostCallback.apply(this, arguments)
+    }
+    const asyncResource = new AsyncResource('bound-anonymous-fn')
+    const execution = this
+
+    if (!isRequestValid(this, arguments, 1)) {
+      return start.apply(this, arguments)
+    }
+
+    getHostCallback = asyncResource.bind(getHostCallback)
+
+    arguments[0] = AsyncResource.bind(function () {
+      addConnectionCh.publish({ address: execution._connection.address, port: execution._connection.port })
+      return getHostCallback.apply(this, arguments)
+    })
+
+    return start.apply(this, arguments)
+  })
+  return RequestExecution
+})
+
+addHook({ name: 'cassandra-driver', versions: ['3 - 3.2'], file: 'lib/request-handler.js' }, RequestHandler => {
+  shimmer.wrap(RequestHandler.prototype, 'send', send => function (request, options, callback) {
+    if (!startCh.hasSubscribers) {
+      return send.apply(this, arguments)
+    }
+    const handler = this
+
+    if (!isRequestValid(this, arguments, 3)) {
+      return send.apply(this, arguments)
+    }
+    const asyncResource = new AsyncResource('bound-anonymous-fn')
+
+    callback = asyncResource.bind(callback)
+
+    arguments[2] = AsyncResource.bind(function () {
+      addConnectionCh.publish({ address: handler.connection.address, port: handler.connection.port })
+      return callback.apply(this, arguments)
+    })
+
+    return send.apply(this, arguments)
+  })
+  return RequestHandler
+})
+
+function finish (asyncEndCh, errorCh, error) {
+  if (error) {
+    errorCh.publish(error)
+  }
+  asyncEndCh.publish(undefined)
+}
+
+function wrapCallback (asyncEndCh, errorCh, callback) {
+  return AsyncResource.bind(function (err) {
+    finish(asyncEndCh, errorCh, err)
+    if (callback) {
+      return callback.apply(this, arguments)
+    }
+  })
+}
+
+function isRequestValid (exec, args, length) {
+  if (!exec) return false
+  if (args.length !== length || typeof args[length - 1] !== 'function') return false
+
+  return true
+}

--- a/packages/datadog-plugin-cassandra-driver/src/index.js
+++ b/packages/datadog-plugin-cassandra-driver/src/index.js
@@ -1,181 +1,75 @@
 'use strict'
 
+const Plugin = require('../../dd-trace/src/plugins/plugin')
+const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
-const tx = require('../../dd-trace/src/plugins/util/tx')
 
-function createWrapInnerExecute (tracer, config) {
-  const isValid = (args) => {
-    return args.length === 4 || typeof args[3] === 'function'
+class CassandraDriverPlugin extends Plugin {
+  static get name () {
+    return 'cassandra-driver'
   }
+  constructor (...args) {
+    super(...args)
 
-  return function wrapInnerExecute (_innerExecute) {
-    return function _innerExecuteWithTrace (query, params, execOptions, callback) {
-      if (!isValid(arguments)) {
-        return _innerExecute.apply(this, arguments)
+    this.addSub(`apm:cassandra:query:start`, ({ keyspace, query, connectionOptions }) => {
+      const store = storage.getStore()
+      const childOf = store ? store.span : store
+
+      if (Array.isArray(query)) {
+        query = combine(query)
       }
 
-      const scope = tracer.scope()
-      const span = start(tracer, config, this, query)
+      const span = this.tracer.startSpan('cassandra.query', {
+        childOf,
+        tags: {
+          'service.name': this.config.service || `${this.tracer._service}-cassandra`,
+          'resource.name': trim(query, 5000),
+          'span.type': 'cassandra',
+          'span.kind': 'client',
+          'db.type': 'cassandra',
+          'cassandra.query': query,
+          'cassandra.keyspace': keyspace
+        }
+      })
 
-      return scope.bind(_innerExecute, span).apply(this, tx.wrap(span, arguments))
-    }
-  }
-}
-
-function createWrapExecute (tracer, config) {
-  return function wrapExecute (_execute) {
-    return function _executeWithTrace (query, params, execOptions, callback) {
-      const span = start(tracer, config, this, query)
-      const promise = tracer.scope().bind(_execute, span).apply(this, arguments)
-
-      return tx.wrap(span, promise)
-    }
-  }
-}
-
-function createWrapExecutionStart (tracer, config) {
-  return function wrapExecutionStart (start) {
-    return function startWithTrace (getHostCallback) {
-      const span = tracer.scope().active()
-      const execution = this
-
-      if (!isRequestValid(this, arguments, 1, span)) {
-        return start.apply(this, arguments)
+      if (connectionOptions) {
+        span.addTags({
+          'out.host': connectionOptions.host,
+          'out.port': connectionOptions.port
+        })
       }
 
-      arguments[0] = function () {
-        addHost(span, execution._connection)
-        return getHostCallback.apply(this, arguments)
+      analyticsSampler.sample(span, this.config.measured)
+      this.enter(span, store)
+    })
+
+    this.addSub(`apm:cassandra:query:end`, () => {
+      this.exit()
+    })
+
+    this.addSub(`apm:cassandra:query:error`, err => {
+      storage.getStore().span.setTag('error', err)
+    })
+
+    this.addSub(`apm:cassandra:query:async-end`, () => {
+      storage.getStore().span.finish()
+    })
+
+    this.addSub(`apm:cassandra:query:addConnection`, connectionOptions => {
+      const store = storage.getStore()
+      if (!store) {
+        return
       }
-
-      return start.apply(this, arguments)
-    }
-  }
-}
-
-function createWrapSendOnConnection (tracer, config) {
-  return function wrapSendOnConnection (_sendOnConnection) {
-    return function _sendOnConnectionWithTrace () {
-      const span = tracer.scope().active()
-
-      addHost(span, this._connection)
-
-      return _sendOnConnection.apply(this, arguments)
-    }
-  }
-}
-
-function createWrapSend (tracer, config) {
-  return function wrapSend (send) {
-    return function sendWithTrace (request, options, callback) {
-      const span = tracer.scope().active()
-      const handler = this
-
-      if (!isRequestValid(this, arguments, 3, span)) {
-        return send.apply(this, arguments)
-      }
-
-      arguments[2] = function () {
-        addHost(span, handler.connection)
-        return callback.apply(this, arguments)
-      }
-
-      return send.apply(this, arguments)
-    }
-  }
-}
-
-function createWrapBatch (tracer, config) {
-  return function wrapBatch (batch) {
-    return function batchWithTrace (queries, options, callback) {
-      const query = combine(queries)
-      const span = start(tracer, config, this, query)
-      const scope = tracer.scope()
-      const fn = scope.bind(batch, span)
-
-      try {
-        return tx.wrap(span, fn.apply(this, tx.wrap(span, arguments)))
-      } catch (e) {
-        finish(span, e)
-        throw e
-      }
-    }
-  }
-}
-
-function createWrapStream (tracer, config) {
-  return function wrapStream (stream) {
-    return function streamWithTrace (query, params, options, callback) {
-      return tracer.scope().bind(stream.apply(this, arguments))
-    }
-  }
-}
-
-function start (tracer, config, client = {}, query) {
-  const scope = tracer.scope()
-  const childOf = scope.active()
-  const span = tracer.startSpan('cassandra.query', {
-    childOf,
-    tags: {
-      'service.name': config.service || `${tracer._service}-cassandra`,
-      'resource.name': trim(query, 5000),
-      'span.type': 'cassandra',
-      'span.kind': 'client',
-      'db.type': 'cassandra',
-      'cassandra.query': query,
-      'cassandra.keyspace': client.keyspace
-    }
-  })
-
-  analyticsSampler.sample(span, config.measured)
-
-  return span
-}
-
-function finish (span, error) {
-  addError(span, error)
-
-  span.finish()
-
-  return error
-}
-
-function addTag (span, key, value) {
-  if (value) {
-    span.setTag(key, value)
-  }
-}
-
-function addHost (span, connection) {
-  if (span && connection) {
-    addTag(span, 'out.host', connection.address)
-    addTag(span, 'out.port', connection.port)
-  }
-}
-
-function addError (span, error) {
-  if (error && error instanceof Error) {
-    span.addTags({
-      'error.type': error.name,
-      'error.msg': error.message,
-      'error.stack': error.stack
+      const span = store.span
+      span.addTags({
+        'out.host': connectionOptions.address,
+        'out.port': connectionOptions.port
+      })
     })
   }
-
-  return error
-}
-
-function isRequestValid (exec, args, length, span) {
-  if (!exec) return false
-  if (args.length !== length || typeof args[length - 1] !== 'function') return false
-  if (!span || span.context()._name !== 'cassandra.query') return false
-
-  return true
 }
 
 function combine (queries) {
-  if (!Array.isArray(queries)) return []
-
   return queries
     .map(query => (query.query || query).replace(/;?$/, ';'))
     .join(' ')
@@ -187,70 +81,4 @@ function trim (str, size) {
   return `${str.substr(0, size - 3)}...`
 }
 
-module.exports = [
-  {
-    name: 'cassandra-driver',
-    versions: ['>=3.0.0'],
-    patch (cassandra, tracer, config) {
-      this.wrap(cassandra.Client.prototype, 'batch', createWrapBatch(tracer, config))
-      this.wrap(cassandra.Client.prototype, 'stream', createWrapStream(tracer, config))
-    },
-    unpatch (cassandra) {
-      this.unwrap(cassandra.Client.prototype, 'batch')
-      this.unwrap(cassandra.Client.prototype, 'stream')
-    }
-  },
-  {
-    name: 'cassandra-driver',
-    versions: ['>=4.4'],
-    patch (cassandra, tracer, config) {
-      this.wrap(cassandra.Client.prototype, '_execute', createWrapExecute(tracer, config))
-    },
-    unpatch (cassandra) {
-      this.unwrap(cassandra.Client.prototype, '_execute')
-    }
-  },
-  {
-    name: 'cassandra-driver',
-    versions: ['3 - 4.3'],
-    patch (cassandra, tracer, config) {
-      this.wrap(cassandra.Client.prototype, '_innerExecute', createWrapInnerExecute(tracer, config))
-    },
-    unpatch (cassandra) {
-      this.unwrap(cassandra.Client.prototype, '_innerExecute')
-    }
-  },
-  {
-    name: 'cassandra-driver',
-    versions: ['>=3.3'],
-    file: 'lib/request-execution.js',
-    patch (RequestExecution, tracer, config) {
-      this.wrap(RequestExecution.prototype, '_sendOnConnection', createWrapSendOnConnection(tracer, config))
-    },
-    unpatch (RequestExecution) {
-      this.unwrap(RequestExecution.prototype, '_sendOnConnection')
-    }
-  },
-  {
-    name: 'cassandra-driver',
-    versions: ['3.3 - 4.3'],
-    file: 'lib/request-execution.js',
-    patch (RequestExecution, tracer, config) {
-      this.wrap(RequestExecution.prototype, 'start', createWrapExecutionStart(tracer, config))
-    },
-    unpatch (RequestExecution) {
-      this.unwrap(RequestExecution.prototype, 'start')
-    }
-  },
-  {
-    name: 'cassandra-driver',
-    versions: ['3 - 3.2'],
-    file: 'lib/request-handler.js',
-    patch (RequestHandler, tracer, config) {
-      this.wrap(RequestHandler.prototype, 'send', createWrapSend(tracer, config))
-    },
-    unpatch (RequestHandler) {
-      this.unwrap(RequestHandler.prototype, 'send')
-    }
-  }
-]
+module.exports = CassandraDriverPlugin

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -2,14 +2,13 @@
 
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
-const plugin = require('../src')
 
 describe('Plugin', () => {
   let cassandra
   let tracer
 
   describe('cassandra-driver', () => {
-    withVersions(plugin, 'cassandra-driver', version => {
+    withVersions('cassandra-driver', 'cassandra-driver', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
         global.tracer = tracer
@@ -23,7 +22,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          return agent.close()
+          return agent.close({ ritmReset: false })
         })
 
         beforeEach(done => {
@@ -44,7 +43,6 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           const query = 'SELECT now() FROM local;'
-
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'test-cassandra')
@@ -141,19 +139,6 @@ describe('Plugin', () => {
             })
           })
         })
-
-        it('should run event listeners in the correct scope', done => {
-          const emitter = client.stream('SELECT now() FROM local;')
-          const span = tracer.startSpan('test')
-          const scope = tracer.scope()
-
-          scope.activate(span, () => {
-            emitter.once('readable', () => {
-              expect(scope.active()).to.equal(span)
-              done()
-            })
-          })
-        })
       })
 
       describe('with configuration', () => {
@@ -164,7 +149,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          return agent.close()
+          return agent.close({ ritmReset: false })
         })
 
         beforeEach(done => {
@@ -205,7 +190,7 @@ describe('Plugin', () => {
           })
 
           after(() => {
-            return agent.close()
+            return agent.close({ ritmReset: false })
           })
 
           beforeEach(done => {


### PR DESCRIPTION
### What does this PR do?
convert cassandra-driver to new plugin system

### Motivation
convert plugins to new plugin system

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
