### PR TITLE
remove datadog private properties from additional plugins

### DIFF
--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -7,6 +7,8 @@ const { ERROR } = require('../../../ext/tags')
 const kinds = require('./kinds')
 const { addMethodTags, addMetadataTags, getFilter } = require('./util')
 
+const patched = new WeakSet()
+
 function createWrapMakeRequest (tracer, config, methodKind) {
   const filter = getFilter(config, 'metadata')
 
@@ -80,7 +82,7 @@ function wrapClientConstructor (tracer, config, ServiceClient, methods) {
 }
 
 function wrapMethod (tracer, config, method, path, methodKind) {
-  if (typeof method !== 'function' || method._datadog_patched) {
+  if (typeof method !== 'function' || patched.has(method)) {
     return method
   }
 
@@ -94,7 +96,7 @@ function wrapMethod (tracer, config, method, path, methodKind) {
 
   Object.assign(methodWithTrace, method)
 
-  methodWithTrace._datadog_patched = true
+  patched.add(methodWithTrace)
 
   return methodWithTrace
 }

--- a/packages/datadog-plugin-microgateway-core/src/index.js
+++ b/packages/datadog-plugin-microgateway-core/src/index.js
@@ -84,9 +84,7 @@ function wrapPluginInit (init) {
   return function initWithTrace (config, logging, stats) {
     const handler = init.apply(this, arguments)
 
-    if (!handler._dd_patched) {
-      wrapListeners(handler)
-    }
+    wrapListeners(handler)
 
     return handler
   }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -7,6 +7,7 @@ const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('./gateway/
 const Gateway = require('./gateway/engine')
 const addresses = require('./addresses')
 const Reporter = require('./reporter')
+const web = require('../plugins/util/web')
 
 function enable (config) {
   try {
@@ -39,7 +40,7 @@ function enable (config) {
 
 function incomingHttpStartTranslator (data) {
   // TODO: get span from datadog-core storage instead
-  const topSpan = data.req._datadog && data.req._datadog.span
+  const topSpan = web.root(data.req)
   if (topSpan) {
     topSpan.addTags({
       '_dd.appsec.enabled': 1,

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -2,6 +2,7 @@
 
 const addresses = require('./addresses')
 const Limiter = require('../rate_limiter')
+const web = require('../plugins/util/web')
 
 // default limiter, configurable with setRateLimit()
 let limiter = new Limiter(100)
@@ -83,7 +84,7 @@ function formatHeaderName (name) {
 
 function reportAttack (attackData, store) {
   const req = store && store.get('req')
-  const topSpan = req && req._datadog && req._datadog.span
+  const topSpan = web.root(req)
   if (!topSpan) return false
 
   const currentTags = topSpan.context()._tags
@@ -129,7 +130,7 @@ function reportAttack (attackData, store) {
 }
 
 function finishAttacks (req, context) {
-  const topSpan = req && req._datadog && req._datadog.span
+  const topSpan = web.root(req)
   if (!topSpan || !context) return false
 
   const resolvedResponse = resolveHTTPResponse(context)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -169,7 +169,7 @@ const web = {
 
   // Return the request root span.
   root (req) {
-    return req._datadog ? req._datadog.span : null
+    return req && req._datadog ? req._datadog.span : null
   },
 
   // Return the active span.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove Datadog private properties from most remaining integrations and core, except web frameworks that will be done in a third and final PR.

### Motivation
<!-- What inspired you to submit this pull request? -->

When logging objects that contain references to tracer objects, it can add significant noise, and in some cases even performance issues or crashes. These properties should be completely unavailable from the user code.