### PR TITLE
[ci-visibility] Rewrite `cucumber` plugin to new plugin system

### DIFF
--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -3,6 +3,7 @@
 require('./src/bluebird')
 require('./src/bunyan')
 require('./src/couchbase')
+require('./src/cucumber')
 require('./src/dns')
 require('./src/elasticsearch')
 require('./src/generic-pool')

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -5,9 +5,9 @@ const shimmer = require('../../datadog-shimmer')
 
 const runStartCh = channel('ci:cucumber:run:start')
 const runEndCh = channel('ci:cucumber:run:end')
-const runAsyncEndCh = channel('ci:cucumber:runAsync:end')
-const runStepStartCh = channel('ci:cucumber:runStep:start')
-const runStepEndCh = channel('ci:cucumber:runStep:end')
+const runAsyncEndCh = channel('ci:cucumber:run:async-end')
+const runStepStartCh = channel('ci:cucumber:run-step:start')
+const runStepEndCh = channel('ci:cucumber:run-step:end')
 const errorCh = channel('ci:cucumber:error')
 
 function wrapRun (pl, isLatestVersion) {

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const { addHook, channel } = require('./helpers/instrument')
+const shimmer = require('../../datadog-shimmer')
+
+const runStartCh = channel('ci:cucumber:run:start')
+const runEndCh = channel('ci:cucumber:run:end')
+const runAsyncEndCh = channel('ci:cucumber:runAsync:end')
+const runStepStartCh = channel('ci:cucumber:runStep:start')
+const runStepEndCh = channel('ci:cucumber:runStep:end')
+const errorCh = channel('ci:cucumber:error')
+
+function wrapRun (pl, isLatestVersion) {
+  shimmer.wrap(pl.prototype, 'run', run => function () {
+    if (!runStartCh.hasSubscribers) {
+      return run.apply(this, arguments)
+    }
+
+    runStartCh.publish({ pickleName: this.pickle.name, pickleUri: this.pickle.uri })
+    try {
+      const promise = run.apply(this, arguments)
+      promise.finally(() => {
+        runAsyncEndCh.publish({ result: this.getWorstStepResult(), isLatestVersion })
+      })
+      return promise
+    } catch (err) {
+      errorCh.publish(err)
+    } finally {
+      runEndCh.publish(undefined)
+    }
+  })
+  shimmer.wrap(pl.prototype, 'runStep', runStep => function () {
+    if (!runStepStartCh.hasSubscribers) {
+      return runStep.apply(this, arguments)
+    }
+    const testStep = arguments[0]
+    let resource
+
+    if (isLatestVersion) {
+      resource = testStep.text
+    } else {
+      resource = testStep.isHook ? 'hook' : testStep.pickleStep.text
+    }
+
+    runStepStartCh.publish({ resource })
+    try {
+      const promise = runStep.apply(this, arguments)
+      promise.then((result) => {
+        runAsyncEndCh.publish({ result, isStep: true, isLatestVersion })
+      })
+      return promise
+    } catch (err) {
+      errorCh.publish(err)
+    } finally {
+      runStepEndCh.publish(undefined)
+    }
+  })
+}
+
+addHook({
+  name: '@cucumber/cucumber',
+  versions: ['7.0.0 - 7.2.1'],
+  file: 'lib/runtime/pickle_runner.js'
+}, (PickleRunner) => {
+  const pl = PickleRunner.default
+
+  wrapRun(pl, false)
+
+  return PickleRunner
+})
+
+addHook({
+  name: '@cucumber/cucumber',
+  versions: ['>=7.3.0'],
+  file: 'lib/runtime/test_case_runner.js'
+}, (TestCaseRunner) => {
+  const pl = TestCaseRunner.default
+
+  wrapRun(pl, true)
+
+  return TestCaseRunner
+})

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -1,18 +1,22 @@
-const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
+'use strict'
+
+const Plugin = require('../../dd-trace/src/plugins/plugin')
+const { storage } = require('../../datadog-core')
 
 const {
+  CI_APP_ORIGIN,
   TEST_TYPE,
   TEST_NAME,
   TEST_SUITE,
-  TEST_STATUS,
-  TEST_FRAMEWORK_VERSION,
   TEST_SKIP_REASON,
-  CI_APP_ORIGIN,
+  TEST_FRAMEWORK_VERSION,
   ERROR_MESSAGE,
-  getTestEnvironmentMetadata,
+  TEST_STATUS,
   finishAllTraceSpans,
-  getTestSuitePath
+  getTestEnvironmentMetadata
 } = require('../../dd-trace/src/plugins/util/test')
+const { SPAN_TYPE, RESOURCE_NAME } = require('../../../ext/tags')
+const { SAMPLING_RULE_DECISION } = require('../../dd-trace/src/constants')
 
 function setStatusFromResult (span, result, tag) {
   if (result.status === 1) {
@@ -42,109 +46,78 @@ function setStatusFromResultLatest (span, result, tag) {
   }
 }
 
-function createWrapRun (tracer, testEnvironmentMetadata, sourceRoot, setStatus) {
-  return function wrapRun (run) {
-    return function handleRun () {
-      const testName = this.pickle.name
-      const testSuite = getTestSuitePath(this.pickle.uri, sourceRoot)
+class CucumberPlugin extends Plugin {
+  static get name () {
+    return 'cucumber'
+  }
 
-      const commonSpanTags = {
-        [TEST_TYPE]: 'test',
-        [TEST_NAME]: testName,
-        [TEST_SUITE]: testSuite,
-        [SAMPLING_RULE_DECISION]: 1,
-        [TEST_FRAMEWORK_VERSION]: tracer._version,
-        ...testEnvironmentMetadata
-      }
+  constructor (...args) {
+    super(...args)
 
-      return tracer.trace(
-        'cucumber.test',
-        {
-          type: 'test',
-          resource: testName,
-          tags: commonSpanTags
-        },
-        (testSpan) => {
-          testSpan.context()._trace.origin = CI_APP_ORIGIN
-          const promise = run.apply(this, arguments)
-          promise.then(() => {
-            setStatus(testSpan, this.getWorstStepResult(), TEST_STATUS)
-          }).finally(() => {
-            finishAllTraceSpans(testSpan)
-          })
-          return promise
+    const testEnvironmentMetadata = getTestEnvironmentMetadata('cucumber', this.config)
+
+    this.addSub('ci:cucumber:run:start', ({ pickleName, pickleUri }) => {
+      const store = storage.getStore()
+      const childOf = store ? store.span : store
+      const span = this.tracer.startSpan('cucumber.test', {
+        childOf,
+        tags: {
+          [SPAN_TYPE]: 'test',
+          [RESOURCE_NAME]: pickleName,
+          [TEST_TYPE]: 'test',
+          [TEST_NAME]: pickleName,
+          [TEST_SUITE]: pickleUri,
+          [SAMPLING_RULE_DECISION]: 1,
+          [TEST_FRAMEWORK_VERSION]: this.tracer._version,
+          ...testEnvironmentMetadata
         }
-      )
-    }
+      })
+      span.context()._trace.origin = CI_APP_ORIGIN
+      this.enter(span, store)
+    })
+
+    this.addSub('ci:cucumber:run:end', () => {
+      this.exit()
+    })
+
+    this.addSub('ci:cucumber:runStep:start', ({ resource }) => {
+      const store = storage.getStore()
+      const childOf = store ? store.span : store
+      const span = this.tracer.startSpan('cucumber.step', {
+        childOf,
+        tags: {
+          'cucumber.step': resource,
+          [RESOURCE_NAME]: resource
+        }
+      })
+      this.enter(span, store)
+    })
+
+    this.addSub('ci:cucumber:runStep:end', () => {
+      this.exit()
+    })
+
+    this.addSub('ci:cucumber:runAsync:end', ({ result, isStep, isLatestVersion }) => {
+      const span = storage.getStore().span
+      const tag = isStep ? 'step.status' : TEST_STATUS
+      if (isLatestVersion) {
+        setStatusFromResultLatest(span, result, tag)
+      } else {
+        setStatusFromResult(span, result, tag)
+      }
+      span.finish()
+      if (!isStep) {
+        finishAllTraceSpans(span)
+      }
+    })
+
+    this.addSub('ci:cucumber:error', (err) => {
+      if (err) {
+        const span = storage.getStore().span
+        span.setTag('error', err)
+      }
+    })
   }
 }
 
-function createWrapRunStep (tracer, getResourceName, setStatus) {
-  return function wrapRunStep (runStep) {
-    return function handleRunStep () {
-      const resource = getResourceName(arguments[0])
-      return tracer.trace(
-        'cucumber.step',
-        { resource, tags: { 'cucumber.step': resource } },
-        (span) => {
-          const promise = runStep.apply(this, arguments)
-          promise.then((result) => {
-            setStatus(span, result, 'step.status')
-          })
-          return promise
-        }
-      )
-    }
-  }
-}
-
-module.exports = [
-  {
-    name: '@cucumber/cucumber',
-    versions: ['7.0.0 - 7.2.1'],
-    file: 'lib/runtime/pickle_runner.js',
-    patch (PickleRunner, tracer, config) {
-      const testEnvironmentMetadata = getTestEnvironmentMetadata('cucumber', config)
-      const sourceRoot = process.cwd()
-      const pl = PickleRunner.default
-      this.wrap(
-        pl.prototype,
-        'run',
-        createWrapRun(tracer, testEnvironmentMetadata, sourceRoot, setStatusFromResult)
-      )
-      const getResourceName = (testStep) => {
-        return testStep.isHook ? 'hook' : testStep.pickleStep.text
-      }
-      this.wrap(pl.prototype, 'runStep', createWrapRunStep(tracer, getResourceName, setStatusFromResult))
-    },
-    unpatch (PickleRunner) {
-      const pl = PickleRunner.default
-      this.unwrap(pl.prototype, 'run')
-      this.unwrap(pl.prototype, 'runStep')
-    }
-  },
-  {
-    name: '@cucumber/cucumber',
-    versions: ['>=7.3.0'],
-    file: 'lib/runtime/test_case_runner.js',
-    patch (TestCaseRunner, tracer, config) {
-      const testEnvironmentMetadata = getTestEnvironmentMetadata('cucumber', config)
-      const sourceRoot = process.cwd()
-      const pl = TestCaseRunner.default
-      this.wrap(
-        pl.prototype,
-        'run',
-        createWrapRun(tracer, testEnvironmentMetadata, sourceRoot, setStatusFromResultLatest)
-      )
-      const getResourceName = (testStep) => {
-        return testStep.text
-      }
-      this.wrap(pl.prototype, 'runStep', createWrapRunStep(tracer, getResourceName, setStatusFromResultLatest))
-    },
-    unpatch (TestCaseRunner) {
-      const pl = TestCaseRunner.default
-      this.unwrap(pl.prototype, 'run')
-      this.unwrap(pl.prototype, 'runStep')
-    }
-  }
-]
+module.exports = CucumberPlugin

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -41,9 +41,9 @@ const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
   return cli.run()
 }
 
-describe('Plugin', () => {
+describe('Plugin', function () {
   let Cucumber
-
+  this.timeout(4000)
   withVersions('cucumber', '@cucumber/cucumber', version => {
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -43,7 +43,7 @@ const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
 
 describe('Plugin', function () {
   let Cucumber
-  this.timeout(4000)
+  this.timeout(10000)
   withVersions('cucumber', '@cucumber/cucumber', version => {
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -2,11 +2,11 @@
 const path = require('path')
 const { PassThrough } = require('stream')
 
+const proxyquire = require('proxyquire').noPreserveCache()
 const nock = require('nock')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ORIGIN_KEY } = require('../../dd-trace/src/constants')
-const plugin = require('../src')
 const {
   TEST_FRAMEWORK,
   TEST_TYPE,
@@ -44,12 +44,12 @@ const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
 describe('Plugin', () => {
   let Cucumber
 
-  withVersions(plugin, '@cucumber/cucumber', version => {
+  withVersions('cucumber', '@cucumber/cucumber', version => {
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache
       // before subsequent calls in whichever manner best suits your needs.
       delete require.cache[require.resolve(path.join(__dirname, 'features', 'simple.js'))]
-      return agent.close()
+      return agent.close({ ritmReset: false })
     })
     beforeEach(() => {
       // for http integration tests
@@ -58,7 +58,7 @@ describe('Plugin', () => {
         .reply(200, 'OK')
 
       return agent.load(['cucumber', 'http']).then(() => {
-        Cucumber = require(`../../../versions/@cucumber/cucumber@${version}`).get()
+        Cucumber = proxyquire(`../../../versions/@cucumber/cucumber@${version}`, {}).get()
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
Rewrite `cucumber` to the new plugin system.

### Motivation
Adjust to the new plugin system.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
