### PR TITLE
remove datadog private properties from web plugins

### DIFF
--- a/packages/datadog-plugin-fastify/src/find-my-way.js
+++ b/packages/datadog-plugin-fastify/src/find-my-way.js
@@ -10,7 +10,6 @@ function createWrapOn () {
       const wrapper = function (req) {
         web.patch(req)
         web.enterRoute(req, path)
-        req._datadog.routeEntered = true
 
         return handler.apply(this, arguments)
       }

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -8,6 +8,7 @@ const kinds = require('./kinds')
 const { addMethodTags, addMetadataTags, getFilter } = require('./util')
 
 const patched = new WeakSet()
+const instances = new WeakMap()
 
 function createWrapMakeRequest (tracer, config, methodKind) {
   const filter = getFilter(config, 'metadata')
@@ -188,7 +189,9 @@ function startSpan (tracer, config, path, methodKind) {
 }
 
 function ensureMetadata (client, args, index) {
-  if (!client || !client._datadog) return args
+  const grpc = getGrpc(client)
+
+  if (!client || !grpc) return args
 
   const meta = args[index]
   const normalized = []
@@ -198,7 +201,7 @@ function ensureMetadata (client, args, index) {
   }
 
   if (!meta || !meta.constructor || meta.constructor.name !== 'Metadata') {
-    normalized.push(new client._datadog.grpc.Metadata())
+    normalized.push(new grpc.Metadata())
   }
 
   if (meta) {
@@ -240,6 +243,15 @@ function getMethodKind (definition) {
   return kinds.unary
 }
 
+function getGrpc (client) {
+  let proto = client
+
+  do {
+    const instance = instances.get(proto)
+    if (instance) return instance
+  } while ((proto = Object.getPrototypeOf(proto)))
+}
+
 function patch (grpc, tracer, config) {
   if (config.client === false) return
 
@@ -247,7 +259,7 @@ function patch (grpc, tracer, config) {
 
   const proto = grpc.Client.prototype
 
-  proto._datadog = { grpc }
+  instances.set(proto, grpc)
 
   this.wrap(proto, 'makeBidiStreamRequest', createWrapMakeRequest(tracer, config, kinds.bidi))
   this.wrap(proto, 'makeClientStreamRequest', createWrapMakeRequest(tracer, config, kinds.clientStream))
@@ -258,7 +270,7 @@ function patch (grpc, tracer, config) {
 function unpatch (grpc) {
   const proto = grpc.Client.prototype
 
-  delete proto._datadog
+  instances.delete(proto)
 
   this.unwrap(proto, 'makeBidiStreamRequest')
   this.unwrap(proto, 'makeClientStreamRequest')

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -1,5 +1,7 @@
 'use strict'
 
+// TODO: remove usage of req._datadog when the plugin is re-enabled
+
 const web = require('../../dd-trace/src/plugins/util/web')
 const shimmer = require('../../datadog-shimmer')
 

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -29,6 +29,9 @@ const HTTP2_HEADER_AUTHORITY = ':authority'
 const HTTP2_HEADER_SCHEME = ':scheme'
 const HTTP2_HEADER_PATH = ':path'
 
+const contexts = new WeakMap()
+const ends = new WeakMap()
+
 const web = {
   // Ensure the configuration has the correct structure and defaults.
   normalizeConfig (config) {
@@ -51,8 +54,7 @@ const web = {
 
   // Start a span and activate a scope for a request.
   instrument (tracer, config, req, res, name, callback) {
-    this.patch(req)
-
+    const context = this.patch(req)
     const span = startSpan(tracer, config, req, res, name)
 
     if (!config.filter(req.url)) {
@@ -65,11 +67,11 @@ const web = {
 
     analyticsSampler.sample(span, config.measured, true)
 
-    if (!req._datadog.instrumented) {
-      wrapEnd(req)
-      wrapEvents(req)
+    if (!context.instrumented) {
+      wrapEnd(context)
+      wrapEvents(context)
 
-      req._datadog.instrumented = true
+      context.instrumented = true
     }
 
     return callback && tracer.scope().activate(span, () => callback(span))
@@ -83,22 +85,23 @@ const web = {
   // Add a route segment that will be used for the resource name.
   enterRoute (req, path) {
     if (typeof path === 'string') {
-      req._datadog.paths.push(path)
+      contexts.get(req).paths.push(path)
     }
   },
 
   // Remove the current route segment.
   exitRoute (req) {
-    req._datadog.paths.pop()
+    contexts.get(req).paths.pop()
   },
 
   // Start a new middleware span and activate a new scope with the span.
   wrapMiddleware (req, middleware, name, fn) {
     if (!this.active(req)) return fn()
 
-    const tracer = req._datadog.tracer
+    const context = contexts.get(req)
+    const tracer = context.tracer
     const childOf = this.active(req)
-    const config = req._datadog.config
+    const config = context.config
 
     if (config.middleware === false) return this.bindAndWrapMiddlewareErrors(fn, req, tracer, childOf)
 
@@ -110,7 +113,7 @@ const web = {
       [RESOURCE_NAME]: middleware._name || middleware.name || '<anonymous>'
     })
 
-    req._datadog.middleware.push(span)
+    context.middleware.push(span)
 
     return tracer.scope().activate(span, fn)
   },
@@ -129,7 +132,8 @@ const web = {
   finish (req, error) {
     if (!this.active(req)) return
 
-    const span = req._datadog.middleware.pop()
+    const context = contexts.get(req)
+    const span = context.middleware.pop()
 
     if (span) {
       if (error) {
@@ -146,38 +150,50 @@ const web = {
 
   // Register a callback to run before res.end() is called.
   beforeEnd (req, callback) {
-    req._datadog.beforeEnd.push(callback)
+    contexts.get(req).beforeEnd.push(callback)
   },
 
   // Prepare the request for instrumentation.
   patch (req) {
-    if (req._datadog) return
+    let context = contexts.get(req)
 
-    if (req.stream && req.stream._datadog) {
-      req._datadog = req.stream._datadog
-      return
+    if (context) return context
+
+    context = req.stream && contexts.get(req.stream)
+
+    if (context) {
+      contexts.set(req, context)
+      return context
     }
 
-    req._datadog = {
+    context = {
+      req,
       span: null,
       paths: [],
       middleware: [],
       beforeEnd: [],
       config: {}
     }
+
+    contexts.set(req, context)
+
+    return context
   },
 
   // Return the request root span.
   root (req) {
-    return req && req._datadog ? req._datadog.span : null
+    const context = contexts.get(req)
+    return context ? context.span : null
   },
 
   // Return the active span.
   active (req) {
-    if (!req._datadog) return null
-    if (req._datadog.middleware.length === 0) return req._datadog.span || null
+    const context = contexts.get(req)
 
-    return req._datadog.middleware.slice(-1)[0]
+    if (!context) return null
+    if (context.middleware.length === 0) return context.span || null
+
+    return context.middleware.slice(-1)[0]
   },
 
   // Extract the parent span from the headers and start a new span as its child
@@ -190,10 +206,11 @@ const web = {
 
   // Validate a request's status code and then add error tags if necessary
   addStatusError (req, statusCode) {
-    const span = req._datadog.span
-    const error = req._datadog.error
+    const context = contexts.get(req)
+    const span = context.span
+    const error = context.error
 
-    if (!req._datadog.config.validateStatus(statusCode)) {
+    if (!context.config.validateStatus(statusCode)) {
       span.setTag(ERROR, error || true)
     }
   },
@@ -201,94 +218,95 @@ const web = {
   // Add an error to the request
   addError (req, error) {
     if (error instanceof Error) {
-      req._datadog.error = req._datadog.error || error
+      const context = contexts.get(req)
+      context.error = context.error || error
     }
   }
 }
 
 function startSpan (tracer, config, req, res, name) {
-  req._datadog.config = config
+  const context = contexts.get(req)
+
+  context.config = config
 
   let span
 
-  if (req._datadog.span) {
-    req._datadog.span.context()._name = name
-    span = req._datadog.span
+  if (context.span) {
+    context.span.context()._name = name
+    span = context.span
   } else {
     span = web.startChildSpan(tracer, name, req.headers)
   }
 
-  configureDatadogObject(tracer, span, req, res)
+  context.tracer = tracer
+  context.span = span
+  context.res = res
 
   return span
 }
 
-function configureDatadogObject (tracer, span, req, res) {
-  const ddObj = req._datadog
-  ddObj.tracer = tracer
-  ddObj.span = span
-  ddObj.res = res
+function finish (context) {
+  const { req, res } = context
+
+  if (context.finished && !req.stream) return
+
+  addRequestTags(context)
+  addResponseTags(context)
+
+  context.config.hooks.request(context.span, req, res)
+  addResourceTag(context)
+
+  context.span.finish()
+  context.finished = true
 }
 
-function finish (req, res) {
-  if (req._datadog.finished && !req.stream) return
-
-  addRequestTags(req)
-  addResponseTags(req)
-
-  req._datadog.config.hooks.request(req._datadog.span, req, res)
-  addResourceTag(req)
-
-  req._datadog.span.finish()
-  req._datadog.finished = true
-}
-
-function finishMiddleware (req, res) {
-  if (req._datadog.finished) return
+function finishMiddleware (context) {
+  if (context.finished) return
 
   let span
 
-  while ((span = req._datadog.middleware.pop())) {
+  while ((span = context.middleware.pop())) {
     span.finish()
   }
 }
 
-function wrapEnd (req) {
-  const scope = req._datadog.tracer.scope()
-  const res = req._datadog.res
+function wrapEnd (context) {
+  const scope = context.tracer.scope()
+  const req = context.req
+  const res = context.res
   const end = res.end
 
-  res.writeHead = wrapWriteHead(req)
+  res.writeHead = wrapWriteHead(context)
 
-  res._datadog_end = function () {
-    for (const beforeEnd of req._datadog.beforeEnd) {
+  ends.set(res, function () {
+    for (const beforeEnd of context.beforeEnd) {
       beforeEnd()
     }
 
-    finishMiddleware(req, res)
+    finishMiddleware(context)
 
     if (incomingHttpRequestEnd.hasSubscribers) incomingHttpRequestEnd.publish({ req, res })
 
     const returnValue = end.apply(res, arguments)
 
-    finish(req, res)
+    finish(context)
 
     return returnValue
-  }
+  })
 
   Object.defineProperty(res, 'end', {
     configurable: true,
     get () {
-      return this._datadog_end
+      return ends.get(this)
     },
     set (value) {
-      this._datadog_end = scope.bind(value, req._datadog.span)
+      ends.set(this, scope.bind(value, context.span))
     }
   })
 }
 
-function wrapWriteHead (req) {
-  const res = req._datadog.res
+function wrapWriteHead (context) {
+  const { req, res } = context
   const writeHead = res.writeHead
 
   return function (statusCode, statusMessage, headers) {
@@ -296,15 +314,14 @@ function wrapWriteHead (req) {
     headers = Object.assign(res.getHeaders(), headers)
 
     if (req.method.toLowerCase() === 'options' && isOriginAllowed(req, headers)) {
-      addAllowHeaders(req, headers)
+      addAllowHeaders(req, res, headers)
     }
 
     return writeHead.apply(this, arguments)
   }
 }
 
-function addAllowHeaders (req, headers) {
-  const res = req._datadog.res
+function addAllowHeaders (req, res, headers) {
   const allowHeaders = splitHeader(headers['access-control-allow-headers'])
   const requestHeaders = splitHeader(req.headers['access-control-request-headers'])
   const contextHeaders = [
@@ -337,22 +354,24 @@ function splitHeader (str) {
   return typeof str === 'string' ? str.split(/\s*,\s*/) : []
 }
 
-function wrapEvents (req) {
-  const scope = req._datadog.tracer.scope()
-  const res = req._datadog.res
+function wrapEvents (context) {
+  const scope = context.tracer.scope()
+  const res = context.res
 
-  scope.bind(res, req._datadog.span)
+  scope.bind(res, context.span)
 }
 
 function reactivate (req, fn) {
-  return req._datadog
-    ? req._datadog.tracer.scope().activate(req._datadog.span, fn)
+  const context = contexts.get(req)
+
+  return context
+    ? context.tracer.scope().activate(context.span, fn)
     : fn()
 }
 
-function addRequestTags (req) {
+function addRequestTags (context) {
+  const { req, span } = context
   const url = extractURL(req)
-  const span = req._datadog.span
 
   span.addTags({
     [HTTP_URL]: url.split('?')[0],
@@ -361,15 +380,14 @@ function addRequestTags (req) {
     [SPAN_TYPE]: WEB
   })
 
-  addHeaders(req)
+  addHeaders(context)
 }
 
-function addResponseTags (req) {
-  const span = req._datadog.span
-  const res = req._datadog.res
+function addResponseTags (context) {
+  const { req, res, paths, span } = context
 
-  if (req._datadog.paths.length > 0) {
-    span.setTag(HTTP_ROUTE, req._datadog.paths.join(''))
+  if (paths.length > 0) {
+    span.setTag(HTTP_ROUTE, paths.join(''))
   }
 
   span.addTags({
@@ -379,8 +397,8 @@ function addResponseTags (req) {
   web.addStatusError(req, res.statusCode)
 }
 
-function addResourceTag (req) {
-  const span = req._datadog.span
+function addResourceTag (context) {
+  const { req, span } = context
   const tags = span.context()._tags
 
   if (tags['resource.name']) return
@@ -392,12 +410,12 @@ function addResourceTag (req) {
   span.setTag(RESOURCE_NAME, resource)
 }
 
-function addHeaders (req) {
-  const span = req._datadog.span
+function addHeaders (context) {
+  const { req, res, config, span } = context
 
-  req._datadog.config.headers.forEach(key => {
+  config.headers.forEach(key => {
     const reqHeader = req.headers[key]
-    const resHeader = req._datadog.res.getHeader(key)
+    const resHeader = res.getHeader(key)
 
     if (reqHeader) {
       span.setTag(`${HTTP_REQUEST_HEADERS}.${key}`, reqHeader)

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -290,6 +290,7 @@ describe('reporter', () => {
 
       const result = Reporter.finishAttacks(req, context)
       expect(result).to.not.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
 
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'http.response.headers.content-type': 'application/json',

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -221,6 +221,7 @@ describe('reporter', () => {
 
       const result = Reporter.reportAttack('[]', store)
       expect(result).to.not.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
 
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'appsec.event': 'true',

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -1,23 +1,31 @@
 'use strict'
 
-const Reporter = require('../../src/appsec/reporter')
+const proxyquire = require('proxyquire')
 const Engine = require('../../src/appsec/gateway/engine')
 const { Context } = require('../../src/appsec/gateway/engine/engine')
 const addresses = require('../../src/appsec/addresses')
 
 describe('reporter', () => {
-  function stubReq (oldTags = {}) {
-    return {
-      _datadog: {
-        span: {
-          context: sinon.stub().returns({
-            _tags: oldTags
-          }),
-          addTags: sinon.stub()
-        }
-      }
+  let Reporter
+  let span
+  let web
+
+  beforeEach(() => {
+    span = {
+      context: sinon.stub().returns({
+        _tags: {}
+      }),
+      addTags: sinon.stub()
     }
-  }
+
+    web = {
+      root: sinon.stub().returns(span)
+    }
+
+    Reporter = proxyquire('../../src/appsec/reporter', {
+      '../plugins/util/web': web
+    })
+  })
 
   afterEach(() => {
     sinon.restore()
@@ -131,15 +139,16 @@ describe('reporter', () => {
 
   describe('reportAttack', () => {
     it('should do nothing when passed incomplete objects', () => {
+      web.root.returns(null)
+
       expect(Reporter.reportAttack('', null)).to.be.false
       expect(Reporter.reportAttack('', new Map())).to.be.false
       expect(Reporter.reportAttack('', new Map([['req', null]]))).to.be.false
       expect(Reporter.reportAttack('', new Map([['req', {}]]))).to.be.false
-      expect(Reporter.reportAttack('', new Map([['req', { _datadog: {} }]]))).to.be.false
     })
 
     it('should add tags to request span', () => {
-      const req = stubReq()
+      const req = {}
 
       const context = new Context()
 
@@ -160,7 +169,7 @@ describe('reporter', () => {
       const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]', store)
       expect(result).to.not.be.false
 
-      expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
         'appsec.event': 'true',
         'manual.keep': 'true',
         '_dd.origin': 'appsec',
@@ -173,8 +182,8 @@ describe('reporter', () => {
     })
 
     it('should not add manual.keep when rate limit is reached', (done) => {
-      const req = stubReq()
-      const addTags = req._datadog.span.addTags
+      const req = {}
+      const addTags = span.addTags
       const store = new Map([[ 'req', req ]])
 
       expect(Reporter.reportAttack('', store)).to.not.be.false
@@ -201,15 +210,16 @@ describe('reporter', () => {
     })
 
     it('should not overwrite origin tag', () => {
-      const req = stubReq({ '_dd.origin': 'tracer' })
+      span.context()._tags = { '_dd.origin': 'tracer' }
 
+      const req = {}
       const store = new Map()
       store.set('req', req)
 
       const result = Reporter.reportAttack('[]', store)
       expect(result).to.not.be.false
 
-      expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
         'appsec.event': 'true',
         'manual.keep': 'true',
         '_dd.appsec.json': '{"triggers":[]}'
@@ -217,8 +227,9 @@ describe('reporter', () => {
     })
 
     it('should merge attacks json', () => {
-      const req = stubReq({ '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}' })
+      span.context()._tags = { '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}' }
 
+      const req = {}
       const context = new Context()
 
       context.store = new Map(Object.entries({
@@ -237,7 +248,7 @@ describe('reporter', () => {
       const result = Reporter.reportAttack('[{"rule":{}},{"rule":{},"rule_matches":[{}]}]', store)
       expect(result).to.not.be.false
 
-      expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
         'appsec.event': 'true',
         'manual.keep': 'true',
         '_dd.origin': 'appsec',
@@ -250,14 +261,14 @@ describe('reporter', () => {
 
   describe('finishAttacks', () => {
     it('should do nothing when passed incomplete objects', () => {
+      web.root.returns(null)
+
       expect(Reporter.finishAttacks(null, {})).to.be.false
       expect(Reporter.finishAttacks({}, {})).to.be.false
-      expect(Reporter.finishAttacks({ _datadog: {} }, {})).to.be.false
-      expect(Reporter.finishAttacks({ _datadog: { span: {} } }, null)).to.be.false
     })
 
     it('should add http response data inside request span', () => {
-      const req = stubReq()
+      const req = {}
 
       const context = new Context()
 
@@ -273,7 +284,7 @@ describe('reporter', () => {
       const result = Reporter.finishAttacks(req, context)
       expect(result).to.not.be.false
 
-      expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
         'http.response.headers.content-type': 'application/json',
         'http.response.headers.content-length': '42',
         'http.endpoint': '/path/:param'
@@ -281,7 +292,7 @@ describe('reporter', () => {
     })
 
     it('should add http response data inside request span without endpoint', () => {
-      const req = stubReq()
+      const req = {}
 
       const context = new Context()
 
@@ -296,7 +307,7 @@ describe('reporter', () => {
       const result = Reporter.finishAttacks(req, context)
       expect(result).to.not.be.false
 
-      expect(req._datadog.span.addTags).to.have.been.calledOnceWithExactly({
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
         'http.response.headers.content-type': 'application/json',
         'http.response.headers.content-length': '42'
       })

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -170,6 +170,7 @@ describe('reporter', () => {
 
       const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]', store)
       expect(result).to.not.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
 
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'appsec.event': 'true',

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -313,6 +313,7 @@ describe('reporter', () => {
 
       const result = Reporter.finishAttacks(req, context)
       expect(result).to.not.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
 
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'http.response.headers.content-type': 'application/json',

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -251,6 +251,7 @@ describe('reporter', () => {
 
       const result = Reporter.reportAttack('[{"rule":{}},{"rule":{},"rule_matches":[{}]}]', store)
       expect(result).to.not.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
 
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'appsec.event': 'true',

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -144,7 +144,9 @@ describe('reporter', () => {
       expect(Reporter.reportAttack('', null)).to.be.false
       expect(Reporter.reportAttack('', new Map())).to.be.false
       expect(Reporter.reportAttack('', new Map([['req', null]]))).to.be.false
-      expect(Reporter.reportAttack('', new Map([['req', {}]]))).to.be.false
+      const req = {}
+      expect(Reporter.reportAttack('', new Map([['req', req]]))).to.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
     })
 
     it('should add tags to request span', () => {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -139,14 +139,14 @@ describe('reporter', () => {
 
   describe('reportAttack', () => {
     it('should do nothing when passed incomplete objects', () => {
+      const req = {}
+
       web.root.returns(null)
 
       expect(Reporter.reportAttack('', null)).to.be.false
       expect(Reporter.reportAttack('', new Map())).to.be.false
       expect(Reporter.reportAttack('', new Map([['req', null]]))).to.be.false
-      const req = {}
       expect(Reporter.reportAttack('', new Map([['req', req]]))).to.be.false
-      expect(web.root).to.have.been.calledOnceWith(req)
     })
 
     it('should add tags to request span', () => {
@@ -266,12 +266,12 @@ describe('reporter', () => {
 
   describe('finishAttacks', () => {
     it('should do nothing when passed incomplete objects', () => {
+      const req = {}
+
       web.root.returns(null)
 
       expect(Reporter.finishAttacks(null, {})).to.be.false
-      const req = {}
       expect(Reporter.finishAttacks(req, {})).to.be.false
-      expect(web.root).to.have.been.calledOnceWith(req)
     })
 
     it('should add http response data inside request span', () => {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -269,7 +269,9 @@ describe('reporter', () => {
       web.root.returns(null)
 
       expect(Reporter.finishAttacks(null, {})).to.be.false
-      expect(Reporter.finishAttacks({}, {})).to.be.false
+      const req = {}
+      expect(Reporter.finishAttacks(req, {})).to.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
     })
 
     it('should add http response data inside request span', () => {

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -657,17 +657,6 @@ describe('plugins/util/web', () => {
     })
   })
 
-  describe('patch', () => {
-    it('should patch the request with Datadog metadata', () => {
-      web.patch(req)
-
-      expect(req._datadog).to.deep.include({
-        paths: [],
-        beforeEnd: []
-      })
-    })
-  })
-
   describe('root', () => {
     it('should return the request root span', () => {
       web.instrument(tracer, config, req, res, 'test.request', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove Datadog private properties from Web plugins.

### Motivation
<!-- What inspired you to submit this pull request? -->

When logging objects that contain references to tracer objects, it can add significant noise, and in some cases even performance issues or crashes. These properties should be completely unavailable from the user code.