### PR TITLE
source-map and source-map-resolve are no longer used

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -22,8 +22,6 @@ require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
 require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
-require,source-map,BSD-3-Clause,Copyright 2009-2011 Mozilla Foundation and contributors
-require,source-map-resolve,MIT,Copyright 2014-2020 Simon Lydell 2019 Jinxiang
 dev,autocannon,MIT,Copyright 2016 Matteo Collina
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie
 dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David Dalton

--- a/package.json
+++ b/package.json
@@ -83,9 +83,7 @@
     "path-to-regexp": "^0.1.2",
     "performance-now": "^2.1.0",
     "retry": "^0.10.1",
-    "semver": "^5.5.0",
-    "source-map": "^0.7.3",
-    "source-map-resolve": "^0.6.0"
+    "semver": "^5.5.0"
   },
   "devDependencies": {
     "autocannon": "^4.5.2",


### PR DESCRIPTION
Missed removing some dependencies when changing to use the pprof source mapper.

Fixes #1808