### PR TITLE
migrate amqplib to new plugin system

### DIFF
--- a/packages/datadog-instrumentations/index.js
+++ b/packages/datadog-instrumentations/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+require('./src/amqplib')
 require('./src/bluebird')
 require('./src/bunyan')
 require('./src/couchbase')

--- a/packages/datadog-instrumentations/src/amqplib.js
+++ b/packages/datadog-instrumentations/src/amqplib.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const {
+  channel,
+  addHook
+} = require('./helpers/instrument')
+const kebabCase = require('lodash.kebabcase')
+const shimmer = require('../../datadog-shimmer')
+
+const startCh = channel('apm:amqplib:command:start')
+const endCh = channel('apm:amqplib:command:end')
+const errorCh = channel('apm:amqplib:command:error')
+
+let methods = {}
+
+addHook({ name: 'amqplib', file: 'lib/defs.js', versions: ['>=0.5'] }, defs => {
+  methods = Object.keys(defs)
+    .filter(key => Number.isInteger(defs[key]))
+    .filter(key => isCamelCase(key))
+    .reduce((acc, key) => Object.assign(acc, { [defs[key]]: kebabCase(key).replace('-', '.') }), {})
+  return defs
+})
+
+addHook({ name: 'amqplib', file: 'lib/channel.js', versions: ['>=0.5'] }, channel => {
+  shimmer.wrap(channel.Channel.prototype, 'sendImmediately', sendImmediately => function (method, fields) {
+    return sendWithTrace(sendImmediately, this, arguments, methods[method], fields)
+  })
+
+  shimmer.wrap(channel.Channel.prototype, 'sendMessage', sendMessage => function (fields) {
+    return sendWithTrace(sendMessage, this, arguments, 'basic.publish', fields)
+  })
+
+  shimmer.wrap(channel.BaseChannel.prototype, 'dispatchMessage', dispatchMessage => function (fields, message) {
+    return sendWithTrace(dispatchMessage, this, arguments, 'basic.deliver', fields, message)
+  })
+  return channel
+})
+
+function sendWithTrace (send, channel, args, method, fields, message) {
+  if (!startCh.hasSubscribers) {
+    return send.apply(this, arguments)
+  }
+  startCh.publish({ channel, method, fields, message })
+
+  try {
+    return send.apply(channel, args)
+  } catch (err) {
+    errorCh.publish(err)
+
+    throw err
+  } finally {
+    endCh.publish(undefined)
+  }
+}
+
+function isCamelCase (str) {
+  return /([A-Z][a-z0-9]+)+/.test(str)
+}

--- a/packages/datadog-instrumentations/src/amqplib.js
+++ b/packages/datadog-instrumentations/src/amqplib.js
@@ -23,20 +23,20 @@ addHook({ name: 'amqplib', file: 'lib/defs.js', versions: ['>=0.5'] }, defs => {
 
 addHook({ name: 'amqplib', file: 'lib/channel.js', versions: ['>=0.5'] }, channel => {
   shimmer.wrap(channel.Channel.prototype, 'sendImmediately', sendImmediately => function (method, fields) {
-    return sendWithTrace(sendImmediately, this, arguments, methods[method], fields)
+    return instrument(sendImmediately, this, arguments, methods[method], fields)
   })
 
   shimmer.wrap(channel.Channel.prototype, 'sendMessage', sendMessage => function (fields) {
-    return sendWithTrace(sendMessage, this, arguments, 'basic.publish', fields)
+    return instrument(sendMessage, this, arguments, 'basic.publish', fields)
   })
 
   shimmer.wrap(channel.BaseChannel.prototype, 'dispatchMessage', dispatchMessage => function (fields, message) {
-    return sendWithTrace(dispatchMessage, this, arguments, 'basic.deliver', fields, message)
+    return instrument(dispatchMessage, this, arguments, 'basic.deliver', fields, message)
   })
   return channel
 })
 
-function sendWithTrace (send, channel, args, method, fields, message) {
+function instrument (send, channel, args, method, fields, message) {
   if (!startCh.hasSubscribers) {
     return send.apply(this, arguments)
   }

--- a/packages/datadog-plugin-amqplib/src/index.js
+++ b/packages/datadog-plugin-amqplib/src/index.js
@@ -1,74 +1,92 @@
 'use strict'
 
-const kebabCase = require('lodash.kebabcase')
+const Plugin = require('../../dd-trace/src/plugins/plugin')
+const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { TEXT_MAP } = require('../../../ext/formats')
 
-let methods = {}
-
-function createWrapSendImmediately (tracer, config) {
-  return function wrapSendImmediately (sendImmediately) {
-    return function sendImmediatelyWithTrace (method, fields) {
-      return sendWithTrace(sendImmediately, this, arguments, tracer, config, methods[method], fields)
-    }
+class AmqplibPlugin extends Plugin {
+  static get name () {
+    return 'amqplib'
   }
-}
 
-function createWrapSendMessage (tracer, config) {
-  return function wrapSendMessage (sendMessage) {
-    return function sendMessageWithTrace (fields) {
-      return sendWithTrace(sendMessage, this, arguments, tracer, config, 'basic.publish', fields)
-    }
-  }
-}
+  constructor (...args) {
+    super(...args)
 
-function createWrapDispatchMessage (tracer, config) {
-  return function wrapDispatchMessage (dispatchMessage) {
-    return function dispatchMessageWithTrace (fields, message) {
-      const childOf = extract(tracer, message)
-      const span = tracer.startSpan('amqp.command', { childOf })
+    this.addSub(`apm:amqplib:command:start`, ({ channel, method, fields, message }) => {
+      const store = storage.getStore()
+      let childOf
 
-      addTags(this, tracer, config, span, 'basic.deliver', fields)
+      if (method === 'basic.deliver') {
+        childOf = extract(this.tracer, message)
+      } else {
+        fields.headers = fields.headers || {}
+        childOf = store ? store.span : store
+      }
 
-      analyticsSampler.sample(span, config.measured, true)
-
-      tracer.scope().activate(span, () => {
-        try {
-          dispatchMessage.apply(this, arguments)
-        } catch (e) {
-          throw addError(span, e)
-        } finally {
-          span.finish()
+      const span = this.tracer.startSpan('amqp.command', {
+        childOf,
+        tags: {
+          'service.name': this.config.service || `${this.tracer._service}-amqp`,
+          'resource.name': getResourceName(method, fields)
         }
       })
-    }
-  }
-}
 
-function sendWithTrace (send, channel, args, tracer, config, method, fields) {
-  const childOf = tracer.scope().active()
-  const span = tracer.startSpan('amqp.command', { childOf })
+      if (channel && channel.connection && channel.connection.stream) {
+        span.addTags({
+          'out.host': channel.connection.stream._host,
+          'out.port': channel.connection.stream.remotePort
+        })
+      }
+      const fieldNames = [
+        'queue',
+        'exchange',
+        'routingKey',
+        'consumerTag',
+        'source',
+        'destination'
+      ]
 
-  fields.headers = fields.headers || {}
+      switch (method) {
+        case 'basic.publish':
+          span.setTag('span.kind', 'producer')
+          break
+        case 'basic.consume':
+        case 'basic.get':
+        case 'basic.deliver':
+          span.addTags({
+            'span.kind': 'consumer',
+            'span.type': 'worker'
+          })
+          break
+        default:
+          span.setTag('span.kind', 'client')
+      }
 
-  addTags(channel, tracer, config, span, method, fields)
-  tracer.inject(span, TEXT_MAP, fields.headers)
+      fieldNames.forEach(field => {
+        fields[field] !== undefined && span.setTag(`amqp.${field}`, fields[field])
+      })
+      if (method === 'basic.deliver') {
+        analyticsSampler.sample(span, this.config.measured, true)
+      } else {
+        this.tracer.inject(span, TEXT_MAP, fields.headers)
+        analyticsSampler.sample(span, this.config.measured)
+      }
 
-  analyticsSampler.sample(span, config.measured)
+      this.enter(span, store)
+    })
 
-  return tracer.scope().activate(span, () => {
-    try {
-      return send.apply(channel, args)
-    } catch (e) {
-      throw addError(span, e)
-    } finally {
+    this.addSub(`apm:amqplib:command:end`, () => {
+      const span = storage.getStore().span
       span.finish()
-    }
-  })
-}
+      this.exit()
+    })
 
-function isCamelCase (str) {
-  return /([A-Z][a-z0-9]+)+/.test(str)
+    this.addSub(`apm:amqplib:command:error`, err => {
+      const span = storage.getStore().span
+      span.setTag('error', err)
+    })
+  }
 }
 
 function getResourceName (method, fields = {}) {
@@ -82,93 +100,10 @@ function getResourceName (method, fields = {}) {
   ].filter(val => val).join(' ')
 }
 
-function addError (span, error) {
-  span.addTags({
-    'error.type': error.name,
-    'error.msg': error.message,
-    'error.stack': error.stack
-  })
-
-  return error
-}
-
-function addTags (channel, tracer, config, span, method, fields) {
-  const fieldNames = [
-    'queue',
-    'exchange',
-    'routingKey',
-    'consumerTag',
-    'source',
-    'destination'
-  ]
-
-  span.addTags({
-    'service.name': config.service || `${tracer._service}-amqp`,
-    'resource.name': getResourceName(method, fields)
-  })
-
-  if (channel && channel.connection && channel.connection.stream) {
-    span.addTags({
-      'out.host': channel.connection.stream._host,
-      'out.port': channel.connection.stream.remotePort
-    })
-  }
-
-  switch (method) {
-    case 'basic.publish':
-      span.setTag('span.kind', 'producer')
-      break
-    case 'basic.consume':
-    case 'basic.get':
-    case 'basic.deliver':
-      span.addTags({
-        'span.kind': 'consumer',
-        'span.type': 'worker'
-      })
-      break
-    default:
-      span.setTag('span.kind', 'client')
-  }
-
-  fieldNames.forEach(field => {
-    fields[field] !== undefined && span.setTag(`amqp.${field}`, fields[field])
-  })
-}
-
 function extract (tracer, message) {
   return message
     ? tracer.extract(TEXT_MAP, message.properties.headers)
     : null
 }
 
-module.exports = [
-  {
-    name: 'amqplib',
-    file: 'lib/defs.js',
-    versions: ['>=0.5'],
-    patch (defs, tracer, config) {
-      methods = Object.keys(defs)
-        .filter(key => Number.isInteger(defs[key]))
-        .filter(key => isCamelCase(key))
-        .reduce((acc, key) => Object.assign(acc, { [defs[key]]: kebabCase(key).replace('-', '.') }), {})
-    },
-    unpatch (defs) {
-      methods = {}
-    }
-  },
-  {
-    name: 'amqplib',
-    file: 'lib/channel.js',
-    versions: ['>=0.5'],
-    patch (channel, tracer, config) {
-      this.wrap(channel.Channel.prototype, 'sendImmediately', createWrapSendImmediately(tracer, config))
-      this.wrap(channel.Channel.prototype, 'sendMessage', createWrapSendMessage(tracer, config))
-      this.wrap(channel.BaseChannel.prototype, 'dispatchMessage', createWrapDispatchMessage(tracer, config))
-    },
-    unpatch (channel) {
-      this.unwrap(channel.Channel.prototype, 'sendImmediately')
-      this.unwrap(channel.Channel.prototype, 'sendMessage')
-      this.unwrap(channel.BaseChannel.prototype, 'dispatchMessage')
-    }
-  }
-]
+module.exports = AmqplibPlugin

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const plugin = require('../src')
 
 describe('Plugin', () => {
   let tracer
@@ -9,7 +8,7 @@ describe('Plugin', () => {
   let channel
 
   describe('amqplib', () => {
-    withVersions(plugin, 'amqplib', version => {
+    withVersions('amqplib', 'amqplib', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
       })
@@ -24,7 +23,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          return agent.close()
+          return agent.close({ ritmReset: false })
         })
 
         describe('when using a callback', () => {
@@ -49,7 +48,6 @@ describe('Plugin', () => {
               agent
                 .use(traces => {
                   const span = traces[0][0]
-
                   expect(span).to.have.property('name', 'amqp.command')
                   expect(span).to.have.property('service', 'test-amqp')
                   expect(span).to.have.property('resource', 'queue.declare test')
@@ -160,7 +158,6 @@ describe('Plugin', () => {
               agent
                 .use(traces => {
                   const span = traces[0][0]
-
                   expect(span).to.have.property('name', 'amqp.command')
                   expect(span).to.have.property('service', 'test-amqp')
                   expect(span).to.have.property('resource', `basic.deliver ${queue}`)
@@ -256,7 +253,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          return agent.close()
+          return agent.close({ ritmReset: false })
         })
 
         beforeEach(done => {


### PR DESCRIPTION
### What does this PR do?
migrates amqplib to new plugin system

### Motivation
migrate plugins to new plugin system

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
