### PR TITLE
remove recursion when sanitizing BSON

### DIFF
--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -108,11 +108,16 @@ describe('Plugin', () => {
             }, () => {})
           })
 
-          it('should sanitize the query', done => {
+          it('should sanitize the query', function (done) {
+            const queryObjectDepth = 200
+            const maxSupportedObjectDepth = 20
+
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const query = '{"foo":"?","bar":{"baz":"?"}}'
+                const query = (`{"foo":"?","bar":{"baz":"?"},"deep":${
+                  '{"x":'.repeat(maxSupportedObjectDepth) + '"?"' + '}'.repeat(maxSupportedObjectDepth)
+                }}`)
                 const resource = `find test.${collectionName} ${query}`
 
                 expect(span).to.have.property('resource', resource)
@@ -125,7 +130,10 @@ describe('Plugin', () => {
               foo: 1,
               bar: {
                 baz: [1, 2, 3]
-              }
+              },
+              deep: Array(queryObjectDepth).fill('x').reduce((acc) => {
+                return { x: acc }
+              }, 'sanitize me')
             }).toArray()
           })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

stops using recursion to sanitize BSON so that very deep objects don't break things

### Motivation
<!-- What inspired you to submit this pull request? -->

should fix https://github.com/DataDog/dd-trace-js/issues/1851

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I put the test object depth pretty high as even up to 5000 it passed locally.