### PR TITLE
fix error on log injection when there is no tracing context

### DIFF
--- a/packages/datadog-plugin-bunyan/test/index.spec.js
+++ b/packages/datadog-plugin-bunyan/test/index.spec.js
@@ -82,6 +82,16 @@ describe('Plugin', () => {
             expect(record).to.not.have.property('dd')
           })
         })
+
+        it('should skip injection without an active span', () => {
+          logger.info('message')
+
+          expect(stream.write).to.have.been.called
+
+          const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+          expect(record).to.not.have.property('dd')
+        })
       })
     })
   })

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -136,6 +136,17 @@ describe('Plugin', () => {
             })
           })
 
+          it('should skip injection when there is no active span', () => {
+            logger.info('message')
+
+            expect(stream.write).to.have.been.called
+
+            const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+            expect(record).to.not.have.property('dd')
+            expect(record).to.have.deep.property('msg', 'message')
+          })
+
           if (semver.intersects(version, '>=5.14.0')) {
             it('should not alter pino mixin behavior', () => {
               const opts = { mixin: () => ({ addedMixin: true }) }

--- a/packages/datadog-plugin-winston/test/index.spec.js
+++ b/packages/datadog-plugin-winston/test/index.spec.js
@@ -3,6 +3,7 @@
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const http = require('http')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire').noPreserveCache()
 
 function createLogServer () {
@@ -240,17 +241,8 @@ describe('Plugin', () => {
             expect(await logServer.logPromise).to.include(meta.dd)
           })
 
-          it('should skip injection without an active span', async () => {
-            const meta = {
-              dd: {
-                trace_id: span.context().toTraceId(),
-                span_id: span.context().toSpanId()
-              }
-            }
-
-            winston.info('message')
-
-            expect(await logServer.logPromise).to.not.include(meta.dd)
+          it('should skip injection without a store', async () => {
+            expect(() => winston.info('message')).to.not.throw()
           })
         })
 

--- a/packages/datadog-plugin-winston/test/index.spec.js
+++ b/packages/datadog-plugin-winston/test/index.spec.js
@@ -239,6 +239,19 @@ describe('Plugin', () => {
             })
             expect(await logServer.logPromise).to.include(meta.dd)
           })
+
+          it('should skip injection without an active span', async () => {
+            const meta = {
+              dd: {
+                trace_id: span.context().toTraceId(),
+                span_id: span.context().toSpanId()
+              }
+            }
+
+            winston.info('message')
+
+            expect(await logServer.logPromise).to.not.include(meta.dd)
+          })
         })
 
         describe('with splat formatting', () => {

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -34,11 +34,16 @@ module.exports = class LogPlugin extends Plugin {
     this.addSub(`apm:${this.constructor.name}:log`, (arg) => {
       // TODO rather than checking this every time, setting it ought to enable/disable any plugin
       // extending from this one
-      if (this.tracer._logInjection) {
-        const holder = {}
-        this.tracer.inject(storage.getStore().span, LOG, holder)
-        arg.message = messageProxy(arg.message, holder)
-      }
+      if (!this.tracer._logInjection) return
+
+      const store = storage.getStore()
+      const span = store && store.span
+
+      if (!span) return
+
+      const holder = {}
+      this.tracer.inject(span, LOG, holder)
+      arg.message = messageProxy(arg.message, holder)
     })
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix error on log injection when there is no tracing context.

### Motivation
<!-- What inspired you to submit this pull request? -->

The new logging plugins were not checking if there is a tracing context available before trying to inject the active span which resulted in an error.

Fixes part of #1879