### PR TITLE
fix context propagation for promises in new plugins

### DIFF
--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const agent = require('../../dd-trace/test/plugins/agent')
+const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')
 
 describe('Plugin', () => {
   let redis
@@ -25,6 +26,7 @@ describe('Plugin', () => {
         })
 
         afterEach(async () => {
+          unbreakThen(Promise.prototype)
           await client.quit()
         })
 
@@ -60,6 +62,25 @@ describe('Plugin', () => {
             error = e
           }
 
+          await promise
+        })
+
+        it('should work with userland promises', async () => {
+          const promise = agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('name', 'redis.command')
+              expect(traces[0][0]).to.have.property('service', 'test-redis')
+              expect(traces[0][0]).to.have.property('resource', 'GET')
+              expect(traces[0][0]).to.have.property('type', 'redis')
+              expect(traces[0][0].meta).to.have.property('db.name', '0')
+              expect(traces[0][0].meta).to.have.property('db.type', 'redis')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].meta).to.have.property('redis.raw_command', 'GET foo')
+            })
+
+          breakThen(Promise.prototype)
+
+          await client.get('foo')
           await promise
         })
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix context propagation for promises in new plugins.

### Motivation
<!-- What inspired you to submit this pull request? -->

With the new plugin system, we rely on `async_hooks` to keep track of the span across events. This means that the current async context must always be correct, otherwise it could cause errors or the span to never finish. For promises, some libraries allow using a promise library explicitly, and some even override the global one. By explicitly binding the promise handlers we are guaranteed to have the correct context.

Fixes #1879 