### PR TITLE
feat: Use base64 encoded JSON and Binary type to avoid message being …

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -40,7 +40,7 @@ class Sns {
       const b64EncodedTraceContext = Buffer.from(JSON.stringify(ddInfo), 'ascii').toString('base64')
       injectPath.MessageAttributes._datadog = {
         DataType: 'Binary',
-        StringValue: b64EncodedTraceContext
+        BinaryValue: b64EncodedTraceContext
       }
     }
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -37,10 +37,9 @@ class Sns {
       }
       const ddInfo = {}
       tracer.inject(span, 'text_map', ddInfo)
-      const b64EncodedTraceContext = Buffer.from(JSON.stringify(ddInfo), 'ascii').toString('base64')
       injectPath.MessageAttributes._datadog = {
         DataType: 'Binary',
-        BinaryValue: b64EncodedTraceContext
+        BinaryValue: JSON.stringify(ddInfo) // BINARY types are automatically base64 encoded
       }
     }
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -37,9 +37,10 @@ class Sns {
       }
       const ddInfo = {}
       tracer.inject(span, 'text_map', ddInfo)
+      const b64EncodedTraceContext = Buffer.from(JSON.stringify(ddInfo), 'ascii').toString('base64')
       injectPath.MessageAttributes._datadog = {
-        DataType: 'String',
-        StringValue: JSON.stringify(ddInfo)
+        DataType: 'Binary',
+        StringValue: b64EncodedTraceContext
       }
     }
   }

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -66,7 +66,7 @@ describe('Sns', () => {
         MessageAttributes: {
           '_datadog': {
             'DataType': 'Binary',
-            'BinaryValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
+            'BinaryValue': '{"x-datadog-trace-id":"456853219676779160","x-datadog-parent-id":"456853219676779160","x-datadog-sampling-priority":"1"}'
           }
         },
         'TopicArn': 'some ARN'
@@ -98,7 +98,7 @@ describe('Sns', () => {
             MessageAttributes: {
               '_datadog': {
                 'DataType': 'Binary',
-                'BinaryValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
+                'BinaryValue': '{"x-datadog-trace-id":"456853219676779160","x-datadog-parent-id":"456853219676779160","x-datadog-sampling-priority":"1"}'
               }
             }
           },

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -66,7 +66,7 @@ describe('Sns', () => {
         MessageAttributes: {
           '_datadog': {
             'DataType': 'Binary',
-            'StringValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
+            'BinaryValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
           }
         },
         'TopicArn': 'some ARN'
@@ -98,7 +98,7 @@ describe('Sns', () => {
             MessageAttributes: {
               '_datadog': {
                 'DataType': 'Binary',
-                'StringValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
+                'BinaryValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
               }
             }
           },

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -65,8 +65,8 @@ describe('Sns', () => {
         Message: 'Here is my sns message',
         MessageAttributes: {
           '_datadog': {
-            'DataType': 'String',
-            'StringValue': '{"x-datadog-trace-id":"456853219676779160","x-datadog-parent-id":"456853219676779160","x-datadog-sampling-priority":"1"}'
+            'DataType': 'Binary',
+            'StringValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
           }
         },
         'TopicArn': 'some ARN'
@@ -97,8 +97,8 @@ describe('Sns', () => {
             Message: 'Here is my SNS message',
             MessageAttributes: {
               '_datadog': {
-                'DataType': 'String',
-                'StringValue': '{"x-datadog-trace-id":"456853219676779160","x-datadog-parent-id":"456853219676779160","x-datadog-sampling-priority":"1"}'
+                'DataType': 'Binary',
+                'StringValue': 'eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0NTY4NTMyMTk2NzY3NzkxNjAiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiNDU2ODUzMjE5Njc2Nzc5MTYwIiwieC1kYXRhZG9nLXNhbXBsaW5nLXByaW9yaXR5IjoiMSJ9'
               }
             }
           },


### PR DESCRIPTION
…dropped by filter policies

### What does this PR do?
A report (https://github.com/DataDog/serverless-plugin-datadog/issues/232) led us to uncover that there's an issue with passing string which contains JSON via SNS Message Attributes. Although AWS is aware of the issue, we'd rather move quickly on this and address it.

This PR moves to using a binary datatype and passing a base64 encoded string instead.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
