### PR TITLE
Use `datadog-ci` standalone binary instead of `npm` installed version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,10 @@ commands:
           when: always
       - run:
           name: Upload JUnit XML Report
-          command: yarn junit:upload
+          command: |
+            curl -L "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-linux-x64" --output "/usr/bin/datadog-ci"
+            chmod +x "/usr/bin/datadog-ci"
+            yarn junit:upload
           when: always
       - run:
           name: Merge coverage report
@@ -229,7 +232,7 @@ jobs:
   node-bench-sirun-plugin-dns: *node-bench-sirun-base
 
   node-bench-sirun-plugin-graphql: *node-bench-sirun-base
-  
+
   node-bench-sirun-appsec: *node-bench-sirun-base
 
   node-bench-sirun-all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Upload JUnit XML Report
           command: |
-            curl -L "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-linux-x64" --output "/usr/bin/datadog-ci"
+            curl -L "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/bin/datadog-ci"
             chmod +x "/usr/bin/datadog-ci"
             yarn junit:upload
           when: always

--- a/scripts/junit_report.js
+++ b/scripts/junit_report.js
@@ -7,8 +7,6 @@ function uploadJUnitXMLReport () {
     console.log('Running in a fork. Skipping step.')
     return
   }
-  // we install @datadog/datadog-ci
-  execSync('yarn global add @datadog/datadog-ci@0.13.2', { stdio: 'inherit' })
   const service = process.env.PLUGINS ? 'plugins' : 'core'
   // we execute the upload command
   execSync(


### PR DESCRIPTION
### What does this PR do?
Use the standalone binary for `datadog-ci` for upload JUnit XML reports instead of using `npm`. In this case it isn't necessary because `npm` is available, but it is a way to test that the standalone binary works as it should. 

### Motivation
Dogfood the standalone binary for `datadog-ci`, which is useful for users that can't install node in their environment. 

