### PR TITLE
run core tests in parallel

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -56,5 +56,6 @@ dev,rimraf,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen
 dev,sinon-chai,WTFPL and BSD-2-Clause,Copyright 2004 Sam Hocevar 2012–2017 Domenic Denicola
 dev,tape,MIT,Copyright James Halliday
+dev,tap,ISC,Copyright 2011-2022 Isaac Z. Schlueter and Contributors,
 dev,wait-on,MIT,Copyright 2015 Jeff Barczewski
 file,profile.proto,Apache license 2.0,Copyright 2016 Google Inc.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "services": "node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services",
     "tdd": "node scripts/tdd.js",
     "test": "SERVICES=* yarn services && mocha --exit --expose-gc 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
-    "test:trace:core": "mocha --exit --expose-gc --file packages/dd-trace/test/setup/core.js \"packages/dd-trace/test/**/*.spec.js\"",
-    "test:trace:core:ci": "nyc --include \"packages/dd-trace/src/**/*.js\" -- npm run test:trace:core --  --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json",
+    "test:trace:core": "tap --no-coverage --expose-gc --node-arg=\"--require=./packages/dd-trace/test/setup/core.js\" \"packages/dd-trace/test/**/*.spec.js\"",
+    "test:trace:core:ci": "nyc --include \"packages/dd-trace/src/**/*.js\" -- npm run test:trace:core",
     "test:instrumentations": "mocha --file 'packages/dd-trace/test/setup/core.js' 'packages/datadog-instrumentations/test/**/*.spec.js'",
     "test:instrumentations:ci": "nyc --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations -- --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json",
     "test:core": "mocha --file packages/datadog-core/test/setup.js 'packages/datadog-core/test/**/*.spec.js'",
@@ -119,6 +119,7 @@
     "rimraf": "^3.0.0",
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
+    "tap": "^16.0.0",
     "tape": "^4.9.1",
     "wait-on": "^5.0.0"
   }

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -23,7 +23,7 @@ describe('Plugin', function () {
         })
 
         after(() => {
-          listener.close()
+          listener && listener.close()
           return agent.close()
         })
 

--- a/packages/dd-trace/test/pkg.spec.js
+++ b/packages/dd-trace/test/pkg.spec.js
@@ -22,7 +22,7 @@ describe('pkg', () => {
   })
 
   it('should load the service name from the main module', () => {
-    expect(pkg.name).to.equal('mocha')
+    expect(pkg.name).to.equal('dd-trace')
   })
 
   it('should load the version number from the main module', () => {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -48,7 +48,7 @@ async function createProfile (periodType) {
   return profiler.encode(profile)
 }
 
-const describeOnUnix = os.platform() === 'win32' ? describe.skip : describe
+const describeOnUnix = os.platform() === 'win32' ? () => {} : describe
 
 describe('exporters/agent', () => {
   let AgentExporter
@@ -236,7 +236,7 @@ describe('exporters/agent', () => {
     })
 
     it('should log exports and handle http errors gracefully', async function () {
-      this.timeout(10000)
+      this.setTimeout(10000)
       const expectedLogs = [
         /^Building agent export report: (\n {2}[a-z-_]+(\[\])?: [a-z0-9-TZ:.]+)+$/m,
         /^Adding cpu profile to agent export:( [0-9a-f]{2})+$/,

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -126,6 +126,7 @@ describe('profiler', () => {
 
   it('should stop when capturing failed', async () => {
     const rejected = Promise.reject(new Error('boom'))
+    rejected.catch(e => {}) // avoid unhandled rejection error
     cpuProfiler.encode.returns(rejected)
 
     await profiler._start({ profilers, exporters, logger })

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -1,5 +1,9 @@
 'use strict'
 
+if ('TAP_CHILD_ID' in process.env) {
+  require('tap').mochaGlobals()
+}
+
 const sinon = require('sinon')
 const chai = require('chai')
 const sinonChai = require('sinon-chai')


### PR DESCRIPTION
### What does this PR do?

This uses `tap` to run tests instead of `mocha`. This comes with the
following advantages:

1. Tests run in parallel.
2. Tests run in isolation.

Under this approach, tests are less prone to failure due to the
environment being modified by other tests.

In future commits, other tests can be converted to use `tap` if desired.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Sequential non-isolated tests meant that anything could break in unrelated tests at any time. Some tests aren't cleaning up properly, and it's very difficult to figure out which ones. It's much safer to run each test file in its own process, and using `tap` is far easier than trying to get `mocha` to do what we want here. Luckily it supports mocha's API without issue.
