### PR TITLE
[ci-visibility] Fix potentially missing `err.stack`

### DIFF
--- a/packages/datadog-plugin-jest/src/jest-jasmine2.js
+++ b/packages/datadog-plugin-jest/src/jest-jasmine2.js
@@ -97,9 +97,11 @@ function createWrapOnException (tracer, globalInput) {
       if (isActiveSpanFailing && !testStatus) {
         activeTestSpan.setTag(TEST_STATUS, 'fail')
         // If we don't do this, jest will show this file on its error message
-        const stackFrames = err.stack.split('\n')
-        const filteredStackFrames = stackFrames.filter(frame => !frame.includes(__dirname)).join('\n')
-        err.stack = filteredStackFrames
+        if (err.stack) {
+          const stackFrames = err.stack.split('\n')
+          const filteredStackFrames = stackFrames.filter(frame => !frame.includes(__dirname)).join('\n')
+          err.stack = filteredStackFrames
+        }
         activeTestSpan.setTag('error', err)
         // need to manually finish, as it will not be caught in `itWithTrace`
         activeTestSpan.finish()

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -57,7 +57,8 @@ describe('Plugin', () => {
           { name: 'jest-test-suite passes', status: 'pass' },
           { name: 'jest-test-suite fails', status: 'fail' },
           { name: 'jest-test-suite skips', status: 'skip' },
-          { name: 'jest-test-suite skips with test too', status: 'skip' }
+          { name: 'jest-test-suite skips with test too', status: 'skip' },
+          { name: 'jest-test-suite does not crash with missing stack', status: 'fail' }
         ]
         const assertionPromises = tests.map(({ name, status }) => {
           return agent.use(trace => {

--- a/packages/datadog-plugin-jest/test/jest-test.js
+++ b/packages/datadog-plugin-jest/test/jest-test.js
@@ -59,4 +59,11 @@ describe('jest-test-suite', () => {
   test.skip('skips with test too', () => {
     expect(100).toEqual(100)
   })
+  it('does not crash with missing stack', (done) => {
+    setTimeout(() => {
+      const error = new Error('fail')
+      delete error.stack
+      throw error
+    }, 100)
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/DataDog/dd-trace-js/issues/1899

### Motivation
Do not crash when `err.stack` is missing

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
