### PR TITLE
Fix issue in `cjsPostLoad`

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -20,11 +20,11 @@ exports.channel = function channel (name) {
 }
 
 exports.addHook = function addHook ({ name, versions, file }, hook) {
-  file = filename(name, file)
+  const fullFilename = filename(name, file)
   const loaderHook = (moduleExports, moduleName, moduleBaseDir) => {
     moduleName = moduleName.replace(pathSepExpr, '/')
     const moduleVersion = getVersion(moduleBaseDir)
-    if (moduleName !== file || !matchVersion(moduleVersion, versions)) {
+    if (moduleName !== fullFilename || !matchVersion(moduleVersion, versions)) {
       return moduleExports
     }
     return hook(moduleExports)
@@ -65,7 +65,7 @@ function cjsPostLoad (instrumentation, hook) {
     if (!id.includes(`/node_modules/${instrumentation.name}/`)) continue
 
     if (instrumentation.file) {
-      if (!id.endsWith(`/node_modules/${filename(instrumentation)}`)) continue
+      if (!id.endsWith(`/node_modules/${filename(instrumentation.name, instrumentation.file)}`)) continue
 
       const basedir = getBasedir(ids[i])
 


### PR DESCRIPTION
### What does this PR do?
I noticed this when doing e2e testing with the rewrite of `mocha` plugin in https://github.com/DataDog/dd-trace-js/pull/1893. The hook passed to `addHook` was not being called. I debugged a bit and I noticed two issues:

* `filename` in https://github.com/DataDog/dd-trace-js/pull/1905/files#diff-13c218aa9de685d13c84b78f90f82d5f962d4b2ad15707e623dcbe7a0dab1e97R68 was being called with `instrumentation` but it expects two different arguments. 
* `file` was being modified in https://github.com/DataDog/dd-trace-js/pull/1905/files#diff-13c218aa9de685d13c84b78f90f82d5f962d4b2ad15707e623dcbe7a0dab1e97L23, so that it includes the library name, for example `file = 'mocha/lib/runner'`. The problem is that when passing it to `cjsPostLoad`, we were passing an object of the shape 
```javascript
{ name: 'mocha', file: 'mocha/lib/runner' } 
```
This meant that when running this `if`: https://github.com/DataDog/dd-trace-js/pull/1905/files#diff-13c218aa9de685d13c84b78f90f82d5f962d4b2ad15707e623dcbe7a0dab1e97R68 we were looking for `mocha/mocha/lib/runner`, that is, twice `mocha`, which is *wrong*. This made it so that we never actually patched the `require.cache`. 

### Motivation
Fix issue in `mocha` and potentially other plugins. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
