### PR TITLE
Attempt to fix Flakiness in node-core-* jobs

### DIFF
--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -19,11 +19,11 @@ describe('dd-trace', () => {
 
     return getPort().then(port => {
       agent = express()
-      listener = agent.listen()
+      listener = agent.listen(port)
 
       tracer.init({
         service: 'test',
-        port: listener.address().port,
+        port,
         flushInterval: 0,
         plugins: false
       })

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -15,6 +15,9 @@ describe('dd-trace', () => {
   let listener
 
   beforeEach(() => {
+    delete require.cache[require.resolve('../')]
+    delete global._ddtrace
+
     tracer = require('../')
 
     return getPort().then(port => {


### PR DESCRIPTION
### What does this PR do?
`node-core-*` jobs have been failing lately. My guess is that it's because we're reusing the tracer instance initialized in other tests, so we might be receiving spans from other tests. 

Examples of failures in `master`:
https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/6359/workflows/fd0fdaab-b58a-4af2-b36e-b7fcbd3e7db0/jobs/747516 
https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/6361/workflows/278afe30-4b90-465f-aa6f-0985051a6f85/jobs/748198

I've rerun the tests 10 times in circleCI and they seem to be passing consistently.

### Motivation
Reduce flakiness in CI. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
