### PR TITLE
bump `@datadog/native-appsec` to `^0.8.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@datadog/native-appsec": "^0.8.1",
+    "@datadog/native-appsec": "^0.8.2",
     "@datadog/native-metrics": "^1.1.0",
     "@datadog/pprof": "^0.3.0",
     "@datadog/sketches-js": "^1.0.4",


### PR DESCRIPTION
This version fixes a bug where the rules object would get truncated