### PR TITLE
[ci-visibility] Code Owners for `mocha`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -7,6 +7,7 @@ require,@types/node,MIT,Copyright Authors
 require,crypto-randomuuid,MIT,Copyright 2021 Node.js Foundation and contributors
 require,diagnostics_channel,MIT,Copyright 2021 Simon D.
 require,form-data,MIT,Copyright 2012 Felix Geisendörfer and contributors
+require,ignore,MIT,Copyright 2013 Kael Zhang and contributors
 require,import-in-the-middle,Apache license 2.0,Copyright 2021 Datadog Inc.
 require,koalas,MIT,Copyright 2013-2017 Brian Woodward
 require,limiter,MIT,Copyright 2011 John Hurliman

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "crypto-randomuuid": "^1.0.0",
     "diagnostics_channel": "^1.1.0",
     "form-data": "^3.0.0",
+    "ignore": "^5.2.0",
     "import-in-the-middle": "^1.2.1",
     "koalas": "^1.0.2",
     "limiter": "^1.1.4",

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -143,7 +143,7 @@ class MochaPlugin extends Plugin {
     if (testParametersString) {
       testSpanMetadata[TEST_PARAMETERS] = testParametersString
     }
-    const codeOwners = getCodeOwnersForFilename(testSpanMetadata[TEST_SUITE])
+    const codeOwners = getCodeOwnersForFilename(testSpanMetadata[TEST_SUITE], this.codeOwnersEntries)
 
     if (codeOwners) {
       testSpanMetadata[TEST_CODE_OWNERS] = codeOwners

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -148,7 +148,12 @@ function getTestSuitePath (testSuiteAbsolutePath, sourceRoot) {
   return testSuitePath.replace(path.sep, '/')
 }
 
-const POSSIBLE_CODEOWNERS_LOCATIONS = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS']
+const POSSIBLE_CODEOWNERS_LOCATIONS = [
+  'CODEOWNERS',
+  '.github/CODEOWNERS',
+  'docs/CODEOWNERS',
+  '.gitlab/CODEOWNERS'
+]
 
 function getCodeOwnersFileEntries (rootDir = process.cwd()) {
   let codeOwnersContent

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -165,6 +165,9 @@ function getCodeOwnersFileEntries (rootDir = process.cwd()) {
       // retry with next path
     }
   })
+  if (!codeOwnersContent) {
+    return
+  }
 
   const entries = []
   const lines = codeOwnersContent.split('\n')
@@ -181,6 +184,9 @@ function getCodeOwnersFileEntries (rootDir = process.cwd()) {
 }
 
 function getCodeOwnersForFilename (filename, entries) {
+  if (!entries) {
+    return null
+  }
   for (const entry of entries) {
     const isResponsible = ignore().add(entry.pattern).ignores(filename)
     if (isResponsible) {

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -166,7 +166,7 @@ function getCodeOwnersFileEntries (rootDir = process.cwd()) {
     }
   })
   if (!codeOwnersContent) {
-    return
+    return null
   }
 
   const entries = []

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1,4 +1,7 @@
 const path = require('path')
+const fs = require('fs')
+
+const ignore = require('ignore')
 
 const { getGitMetadata } = require('./git')
 const { getUserProviderGitMetadata } = require('./user-provided-git')
@@ -25,6 +28,7 @@ const TEST_STATUS = 'test.status'
 const TEST_PARAMETERS = 'test.parameters'
 const TEST_SKIP_REASON = 'test.skip_reason'
 const TEST_IS_RUM_ACTIVE = 'test.is_rum_active'
+const TEST_CODE_OWNERS = 'test.codeowners'
 
 const ERROR_TYPE = 'error.type'
 const ERROR_MESSAGE = 'error.msg'
@@ -35,6 +39,7 @@ const CI_APP_ORIGIN = 'ciapp-test'
 const JEST_TEST_RUNNER = 'test.jest.test_runner'
 
 module.exports = {
+  TEST_CODE_OWNERS,
   TEST_FRAMEWORK,
   TEST_FRAMEWORK_VERSION,
   JEST_TEST_RUNNER,
@@ -53,7 +58,9 @@ module.exports = {
   getTestParametersString,
   finishAllTraceSpans,
   getTestParentSpan,
-  getTestSuitePath
+  getTestSuitePath,
+  getCodeOwnersFileEntries,
+  getCodeOwnersForFilename
 }
 
 function getTestEnvironmentMetadata (testFramework, config) {
@@ -139,4 +146,41 @@ function getTestSuitePath (testSuiteAbsolutePath, sourceRoot) {
     ? testSuiteAbsolutePath : path.relative(sourceRoot, testSuiteAbsolutePath)
 
   return testSuitePath.replace(path.sep, '/')
+}
+
+const POSSIBLE_CODEOWNERS_LOCATIONS = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS']
+
+function getCodeOwnersFileEntries (rootDir = process.cwd()) {
+  let codeOwnersContent
+
+  POSSIBLE_CODEOWNERS_LOCATIONS.forEach(location => {
+    try {
+      codeOwnersContent = fs.readFileSync(`${rootDir}/${location}`).toString()
+    } catch (e) {
+      // retry with next path
+    }
+  })
+
+  const entries = []
+  const lines = codeOwnersContent.split('\n')
+
+  for (const line of lines) {
+    const [content] = line.split('#')
+    const trimmed = content.trim()
+    if (trimmed === '') continue
+    const [pattern, ...owners] = trimmed.split(/\s+/)
+    entries.push({ pattern, owners })
+  }
+  // Reverse because rules defined last take precedence
+  return entries.reverse()
+}
+
+function getCodeOwnersForFilename (filename, entries) {
+  for (const entry of entries) {
+    const isResponsible = ignore().add(entry.pattern).ignores(filename)
+    if (isResponsible) {
+      return JSON.stringify(entry.owners)
+    }
+  }
+  return null
 }

--- a/packages/dd-trace/test/plugins/util/__test__/CODEOWNERS
+++ b/packages/dd-trace/test/plugins/util/__test__/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS for testing purposes
+packages/dd-trace/test/plugins/util/* @datadog-apm-js
+packages/dd-trace/test/plugins/util/test.spec.js @datadog-ci-app


### PR DESCRIPTION
### What does this PR do?
Attempt to read `CODEOWNERS` from `mocha` plugin. If it's present, read the test file path and add the owner as a test span tag.

### Motivation
Allow owners of failed tests to be notified. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

