### PR TITLE
[ci-visibility] Fix mocha when run in parallel mode: new plugin.

### DIFF
--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -9,6 +9,7 @@ const testAsyncEndCh = channel('ci:mocha:test:async-end')
 const suiteEndCh = channel('ci:mocha:suite:end')
 const hookErrorCh = channel('ci:mocha:hook:error')
 const parameterizedTestCh = channel('ci:mocha:test:parameterize')
+const testRunEndCh = channel('ci:mocha:run:end')
 
 function isRetry (test) {
   return test._currentRetry !== undefined && test._currentRetry !== 0
@@ -78,6 +79,9 @@ addHook({
     if (!suiteEndCh.hasSubscribers) {
       return runTests.apply(this, arguments)
     }
+    this.once('end', AsyncResource.bind(() => {
+      testRunEndCh.publish(undefined)
+    }))
     runTests.apply(this, arguments)
     const suite = arguments[0]
     // We call `getAllTestsInSuite` with the root suite so every skipped test

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -126,6 +126,10 @@ class MochaPlugin extends Plugin {
     this.addSub('ci:mocha:test:parameterize', ({ name, params }) => {
       this._testNameToParams[name] = params
     })
+
+    this.addSub('ci:mocha:run:end', () => {
+      this.tracer._exporter._writer.flush()
+    })
   }
 
   startTestSpan (test) {


### PR DESCRIPTION
### What does this PR do?
I just realised that the fix for parallel mocha added in https://github.com/DataDog/dd-trace-js/pull/1757 was not being done in the new rewrite. This fixes that. 

### Motivation
Keep working in parallel mode when using the new plugin system.

