### PR TITLE
Bump `@datadog/native-appsec` to `0.8.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@datadog/native-appsec": "^0.8.2",
+    "@datadog/native-appsec": "^0.8.3",
     "@datadog/native-metrics": "^1.1.0",
     "@datadog/pprof": "^0.3.0",
     "@datadog/sketches-js": "^1.0.4",


### PR DESCRIPTION
### What does this PR do?
Update native appsec dependency with the `minimist` update. Fixes #1920 
