### PR TITLE
fix mixing esm and commonjs modules and add error handling

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -22,7 +22,10 @@ function Hook (modules, onrequire) {
 
   this._ritmHook = ritm(modules, {}, safeHook)
   this._iitmHook = iitm(modules, {}, (moduleExports, moduleName, moduleBaseDir) => {
-    // Default export is always moved to `default` for CommonJS modules.
+    // TODO: Move this logic to import-in-the-middle and only do it for CommonJS
+    // modules and not ESM. In the meantime, all the modules we instrument are
+    // CommonJS modules for which the default export is always moved to
+    // `default` anyway.
     if (moduleExports && moduleExports.default) {
       moduleExports.default = safeHook(moduleExports.default, moduleName, moduleBaseDir)
       return moduleExports

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const path = require('path')
+const iitm = require('../../../dd-trace/src/iitm')
+const ritm = require('../../../dd-trace/src/ritm')
+
+function Hook (modules, onrequire) {
+  if (!(this instanceof Hook)) return new Hook(modules, onrequire)
+
+  this._patched = {}
+
+  const safeHook = (moduleExports, moduleName, moduleBaseDir) => {
+    const parts = [moduleBaseDir, moduleName].filter(v => v)
+    const filename = path.join(...parts)
+
+    if (this._patched[filename]) return moduleExports
+
+    this._patched[filename] = true
+
+    return onrequire(moduleExports, moduleName, moduleBaseDir)
+  }
+
+  this._ritmHook = ritm(modules, {}, safeHook)
+  this._iitmHook = iitm(modules, {}, (moduleExports, moduleName, moduleBaseDir) => {
+    if (moduleExports && moduleExports.default) {
+      moduleExports.default = safeHook(moduleExports.default, moduleName, moduleBaseDir)
+      return moduleExports
+    } else {
+      return safeHook(moduleExports, moduleName, moduleBaseDir)
+    }
+  })
+}
+
+Hook.prototype.unhook = function () {
+  this._ritmHook.unhook()
+  this._iitmHook.unhook()
+  this._patched = {}
+}
+
+module.exports = Hook

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -22,6 +22,7 @@ function Hook (modules, onrequire) {
 
   this._ritmHook = ritm(modules, {}, safeHook)
   this._iitmHook = iitm(modules, {}, (moduleExports, moduleName, moduleBaseDir) => {
+    // Default export is always moved to `default` for CommonJS modules.
     if (moduleExports && moduleExports.default) {
       moduleExports.default = safeHook(moduleExports.default, moduleName, moduleBaseDir)
       return moduleExports

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -7,7 +7,7 @@ const ritm = require('../../../dd-trace/src/ritm')
 function Hook (modules, onrequire) {
   if (!(this instanceof Hook)) return new Hook(modules, onrequire)
 
-  this._patched = {}
+  this._patched = Object.create(null)
 
   const safeHook = (moduleExports, moduleName, moduleBaseDir) => {
     const parts = [moduleBaseDir, moduleName].filter(v => v)
@@ -35,7 +35,7 @@ function Hook (modules, onrequire) {
 Hook.prototype.unhook = function () {
   this._ritmHook.unhook()
   this._iitmHook.unhook()
-  this._patched = {}
+  this._patched = Object.create(null)
 }
 
 module.exports = Hook

--- a/packages/dd-trace/src/iitm.js
+++ b/packages/dd-trace/src/iitm.js
@@ -8,5 +8,9 @@ if (semver.satisfies(process.versions.node, '^12.20.0 || >=14.13.1')) {
 } else {
   logger.warn('ESM is not fully supported by this version of Node.js, ' +
     'so dd-trace will not intercept ESM loading.')
-  module.exports = () => {}
+  module.exports = () => ({
+    unhook: () => {}
+  })
+  module.exports.addHook = () => {}
+  module.exports.removeHook = () => {}
 }

--- a/packages/dd-trace/src/loader.js
+++ b/packages/dd-trace/src/loader.js
@@ -30,10 +30,6 @@ class Loader {
 
     this._hook && this._hook.unhook()
     this._hook = Hook(instrumentedModules, (moduleExports, moduleName, moduleBaseDir) => {
-      if (this._patched[moduleName]) return moduleExports
-
-      this._patched[moduleName] = true
-
       return this._hookModule(moduleExports, moduleName, moduleBaseDir)
     })
   }

--- a/packages/dd-trace/src/loader.js
+++ b/packages/dd-trace/src/loader.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const semver = require('semver')
-const hook = require('./ritm')
-const esmHook = require('./iitm')
+const Hook = require('../../datadog-instrumentations/src/helpers/hook')
 const parse = require('module-details-from-path')
 const path = require('path')
 const uniq = require('lodash.uniq')
@@ -18,6 +17,7 @@ class Loader {
 
   reload (plugins) {
     this._plugins = plugins
+    this._patched = []
 
     const instrumentations = Array.from(this._plugins.keys())
       .reduce((prev, current) => prev.concat(current), [])
@@ -29,10 +29,13 @@ class Loader {
       .map(instrumentation => filename(instrumentation)))
 
     this._hook && this._hook.unhook()
-    this._hook = hook(instrumentedModules, this._hookModule.bind(this))
+    this._hook = Hook(instrumentedModules, (moduleExports, moduleName, moduleBaseDir) => {
+      if (this._patched[moduleName]) return moduleExports
 
-    this._esmHook && this._esmHook.unhook()
-    this._esmHook = esmHook(instrumentedModules, this._hookModule.bind(this))
+      this._patched[moduleName] = true
+
+      return this._hookModule(moduleExports, moduleName, moduleBaseDir)
+    })
   }
 
   load (instrumentation, config) {

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -53,7 +53,7 @@ function Hook (modules, options, onrequire) {
     let name, basedir, hooks
 
     // return known patched modules immediately
-    if (cache.hasOwnProperty(filename)) {
+    if (cache[filename]) {
       // require.cache was potentially altered externally
       if (require.cache[filename] && require.cache[filename].exports !== cache[filename].original) {
         return require.cache[filename].exports

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -11,8 +11,8 @@ const origRequire = Module.prototype.require
 module.exports = Hook
 
 let moduleHooks = Object.create(null)
-let cache = {}
-let patching = {}
+let cache = Object.create(null)
+let patching = Object.create(null)
 let patchedRequire = null
 
 function Hook (modules, options, onrequire) {
@@ -121,8 +121,8 @@ function Hook (modules, options, onrequire) {
 Hook.reset = function () {
   Module.prototype.require = origRequire
   patchedRequire = null
-  patching = {}
-  cache = {}
+  patching = Object.create(null)
+  cache = Object.create(null)
   moduleHooks = Object.create(null)
 }
 

--- a/packages/dd-trace/test/iitm.spec.js
+++ b/packages/dd-trace/test/iitm.spec.js
@@ -35,9 +35,14 @@ describe('iitm.js', () => {
       Object.defineProperty(process.versions, 'node', desc)
     })
 
-    it('should export an empty function', () => {
+    it('should export a noop hook', () => {
       expect(iitmjs).to.not.equal(iitm)
-      expect(iitmjs()).to.be.undefined
+
+      const hook = iitmjs()
+
+      expect(() => hook.unhook()).to.not.throw()
+      expect(() => iitmjs.addHook()).to.not.throw()
+      expect(() => iitmjs.removeHook()).to.not.throw()
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix ESM support when mixed with CommonJS. I also added error handling in the new plugin system hooks so that errors don't result in unhandled exceptions and instead log the error, similar to the legacy instrumenter.

### Motivation
<!-- What inspired you to submit this pull request? -->

When mixing import-in-the-middle and require-in-the-middle together, the module structure received by the hook would be different where a CommonJS would get its default export moved to a `default` property when going through import-in-the-middle. Since we only instrument a known small subset of modules, it's safe to assume that instrumenting only the `default` property is enough for import-in-the-middle.

Using both systems together was also resulting in double-patching which is now fixed as well. Unfortunately the fix didn't really play well with the post-load hook for CommonJS, so I removed it completely. It wasn't useful anyway since we load instrumentations when dd-trace is imported and not when it's initialized.

Fixes #1932