### PR TITLE
Integrate browser-bunyan

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -157,6 +157,25 @@ jobs:
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v2
 
+  browser-bunyan:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: browser-bunyan
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
+      - run: yarn install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - run: yarn test:plugins:upstream
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:plugins:ci
+      - run: yarn test:plugins:upstream
+      - if: always()
+        uses: ./.github/actions/testagent/logs
+      - uses: codecov/codecov-action@v2
+
   cassandra:
     runs-on: ubuntu-latest
     services:

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,7 @@ tracer.use('pg', {
 <h5 id="aws-sdk-tags"></h5>
 <h5 id="aws-sdk-config"></h5>
 <h5 id="bunyan"></h5>
+<h5 id="browser-bunyan"></h5>
 <h5 id="couchbase"></h5>
 <h5 id="cucumber"></h5>
 <h5 id="dns"></h5>
@@ -105,6 +106,7 @@ tracer.use('pg', {
 * [couchbase](./interfaces/plugins.couchbase.html)
 * [cucumber](./interfaces/plugins.cucumber.html)
 * [bunyan](./interfaces/plugins.bunyan.html)
+* [browser-bunyan](./interfaces/plugins.browser_bunyan.html)
 * [cassandra-driver](./interfaces/plugins.cassandra_driver.html)
 * [connect](./interfaces/plugins.connect.html)
 * [dns](./interfaces/plugins.dns.html)

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -237,6 +237,7 @@ tracer.use('amqplib');
 tracer.use('aws-sdk');
 tracer.use('aws-sdk', awsSdkOptions);
 tracer.use('bunyan');
+tracer.use('browser-bunyan');
 tracer.use('couchbase');
 tracer.use('cassandra-driver');
 tracer.use('connect');

--- a/index.d.ts
+++ b/index.d.ts
@@ -753,6 +753,7 @@ interface Plugins {
   "amqplib": plugins.amqplib;
   "aws-sdk": plugins.aws_sdk;
   "bunyan": plugins.bunyan;
+  "browser-bunyan": plugins.browser_bunyan;
   "cassandra-driver": plugins.cassandra_driver;
   "connect": plugins.connect;
   "couchbase": plugins.couchbase;
@@ -1041,6 +1042,14 @@ declare namespace plugins {
    * on the tracer.
    */
   interface bunyan extends Integration {}
+
+  /**
+   * This plugin patches the [browser-bunyan](https://github.com/philmander/browser-bunyan)
+   * to automatically inject trace identifiers in log records when the
+   * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+   * on the tracer.
+   */
+  interface browser_bunyan extends Integration {}
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-instrumentations/src/browser-bunyan.js
+++ b/packages/datadog-instrumentations/src/browser-bunyan.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const {
+  channel,
+  addHook
+} = require('./helpers/instrument')
+const shimmer = require('../../datadog-shimmer')
+
+addHook({ name: 'browser-bunyan', versions: ['>=1'] }, def => {
+  const logCh = channel('apm:browser-bunyan:log')
+  shimmer.wrap(def.Logger.prototype, '_emit', emit => {
+    return function wrappedEmit (rec) {
+      if (logCh.hasSubscribers) {
+        const payload = { message: rec }
+        logCh.publish(payload)
+        arguments[0] = payload.message
+      }
+      return emit.apply(this, arguments)
+    }
+  })
+  return def
+})

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -23,6 +23,7 @@ module.exports = {
   'bluebird': () => require('../bluebird'),
   'body-parser': () => require('../body-parser'),
   'bunyan': () => require('../bunyan'),
+  'browser-bunyan': () => require('../browser-bunyan'),
   'cassandra-driver': () => require('../cassandra-driver'),
   'child_process': () => require('../child-process'),
   'node:child_process': () => require('../child-process'),

--- a/packages/datadog-plugin-browser-bunyan/src/index.js
+++ b/packages/datadog-plugin-browser-bunyan/src/index.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
+
+class BrowserBunyanPlugin extends LogPlugin {
+  static get id () {
+    return 'browser-bunyan'
+  }
+}
+module.exports = BrowserBunyanPlugin

--- a/packages/datadog-plugin-browser-bunyan/test/index.spec.js
+++ b/packages/datadog-plugin-browser-bunyan/test/index.spec.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const Writable = require('stream').Writable
+const agent = require('../../dd-trace/test/plugins/agent')
+
+describe('Plugin', () => {
+  let logger
+  let tracer
+  let stream
+  let span
+
+  class ConsoleJsonStream {
+    constructor (stream) {
+      this._stream = stream
+    }
+    write (rec) {
+      this._stream.write(JSON.stringify(rec))
+    }
+  }
+
+  function setupTest (version) {
+    const bunyan = require(`../../../versions/browser-bunyan@${version}`).get()
+
+    span = tracer.startSpan('test')
+
+    stream = new Writable()
+    stream._write = () => {}
+
+    sinon.spy(stream, 'write')
+
+    logger = bunyan.createLogger({ name: 'test', stream: new ConsoleJsonStream(stream) })
+  }
+
+  describe('browser-bunyan', () => {
+    withVersions('browser-bunyan', 'browser-bunyan', version => {
+      beforeEach(() => {
+        tracer = require('../../dd-trace')
+      })
+
+      afterEach(() => {
+        return agent.close({ ritmReset: false })
+      })
+
+      describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load('browser-bunyan')
+        })
+
+        beforeEach(() => {
+          setupTest(version)
+        })
+
+        it('should not alter the default behavior', () => {
+          tracer.scope().activate(span, () => {
+            logger.info('message')
+
+            expect(stream.write).to.have.been.called
+
+            const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+            expect(record).to.not.have.property('dd')
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        beforeEach(() => {
+          return agent.load('browser-bunyan', { logInjection: true })
+        })
+
+        beforeEach(() => {
+          setupTest(version)
+        })
+
+        it('should add the trace identifiers to logger instances', () => {
+          tracer.scope().activate(span, () => {
+            logger.info('message')
+
+            expect(stream.write).to.have.been.called
+
+            const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+            expect(record.dd).to.deep.include({
+              trace_id: span.context().toTraceId(),
+              span_id: span.context().toSpanId()
+            })
+          })
+        })
+
+        it('should not mutate the original record', () => {
+          tracer.scope().activate(span, () => {
+            const record = { foo: 'bar' }
+
+            logger.info(record)
+
+            expect(stream.write).to.have.been.called
+            expect(record).to.not.have.property('dd')
+          })
+        })
+
+        it('should not inject trace_id or span_id without an active span', () => {
+          logger.info('message')
+
+          expect(stream.write).to.have.been.called
+
+          const record = JSON.parse(stream.write.firstCall.args[0].toString())
+
+          expect(record).to.have.property('dd')
+          expect(record.dd).to.not.have.property('trace_id')
+          expect(record.dd).to.not.have.property('span_id')
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-browser-bunyan/test/suite.js
+++ b/packages/datadog-plugin-browser-bunyan/test/suite.js
@@ -1,0 +1,4 @@
+'use strict'
+const suiteTest = require('../../dd-trace/test/plugins/suite')
+
+suiteTest('browser-bunyan', 'philmander/browser-bunyan', 'latest')

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -19,6 +19,7 @@ module.exports = {
   get 'amqplib' () { return require('../../../datadog-plugin-amqplib/src') },
   get 'aws-sdk' () { return require('../../../datadog-plugin-aws-sdk/src') },
   get 'bunyan' () { return require('../../../datadog-plugin-bunyan/src') },
+  get 'browser-bunyan' () { return require('../../../datadog-plugin-browser-bunyan/src') },
   get 'cassandra-driver' () { return require('../../../datadog-plugin-cassandra-driver/src') },
   get 'connect' () { return require('../../../datadog-plugin-connect/src') },
   get 'couchbase' () { return require('../../../datadog-plugin-couchbase/src') },

--- a/packages/dd-trace/test/plugins/suite.js
+++ b/packages/dd-trace/test/plugins/suite.js
@@ -131,6 +131,7 @@ async function setup (modName, repoName, commitish) {
   const repoUrl = `https://github.com/${repoName}.git`
   const cwd = await getTmpDir()
   await execOrError(`git clone ${repoUrl} --branch ${commitish} --single-branch ${cwd}`)
+  await execOrError(`rm -f ${cwd}/package-lock.json`)
   await execOrError(`npm install --legacy-peer-deps`, { cwd })
 }
 


### PR DESCRIPTION
### What does this PR do?
 This pull requests integrates `dd-trace` with the logging library `browser-bunyan`, when it is running on the server-side in Node.js.

### Motivation
As frameworks such as Next.js and Remix focus on isomorphic React, the logging library should be isomorphic. I've found `browser-bunyan` to fit the bill of something lightweight and very usable.

For example, if a web app is attempting to follow the twelve-factor methodology, then it only needs to write its event stream, unbuffered, to stdout, so a simpler the logging library is better.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This updates all the upstream tests to remove `package-lock.json` from the upstream repos to better simulate installing as a library and to clear any non-public `resolved` URLs that were saved in the repo.