### PR TITLE
fix require hooks iterating over object prototype when instrumenting

### DIFF
--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -10,7 +10,7 @@ const origRequire = Module.prototype.require
 
 module.exports = Hook
 
-let moduleHooks = {}
+let moduleHooks = Object.create(null)
 let cache = {}
 let patching = {}
 let patchedRequire = null
@@ -26,9 +26,10 @@ function Hook (modules, options, onrequire) {
     options = {}
   }
 
+  modules = modules || []
   options = options || {}
 
-  this.modules = modules || ['']
+  this.modules = modules
   this.options = options
   this.onrequire = onrequire
 
@@ -122,7 +123,7 @@ Hook.reset = function () {
   patchedRequire = null
   patching = {}
   cache = {}
-  moduleHooks = {}
+  moduleHooks = Object.create(null)
 }
 
 Hook.prototype.unhook = function () {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix require hooks iterating over object prototype when instrumenting.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some libraries like Mocha add enumerable properties to the `Object` prototype which end up being iterated over in the require hooks. By removing the prototype entirely this is no longer an issue.