### PR TITLE
fix `AsyncResource.bind()` binding `this` to itself by default

### DIFF
--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -220,7 +220,8 @@ describe('Plugin', () => {
       const socket = new net.Socket()
 
       tracer.scope().activate(parent, () => {
-        socket.connect({ port }, () => {
+        socket.connect({ port }, function () {
+          expect(this).to.equal(socket)
           expect(tracer.scope().active()).to.equal(parent)
           socket.destroy()
           done()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `AsyncResource.bind()` binding `this` to itself by default.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was actually a bug in Node that was fixed in https://github.com/nodejs/node/pull/42177 and released in 17.8.0. Our polyfill has been updated with the new code as well.