### PR TITLE
fix experimental warning in next test

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -10,6 +10,7 @@ const plugin = require('../src')
 const { writeFileSync } = require('fs')
 
 describe('Plugin', function () {
+  let server
   let port
 
   describe('next', () => {
@@ -23,7 +24,8 @@ describe('Plugin', function () {
 
         before(function (done) {
           const cwd = __dirname
-          const server = spawn('node', ['server'], {
+
+          server = spawn('node', ['server'], {
             cwd,
             env: {
               ...process.env,
@@ -35,11 +37,12 @@ describe('Plugin', function () {
           })
 
           server.on('error', done)
-          server.stderr.on('data', done)
+          server.stderr.on('data', () => {})
           server.stdout.on('data', () => done())
         })
 
         after(async () => {
+          server.kill()
           await axios.get(`http://localhost:${port}/api/hello/world`).catch(() => {})
           await agent.close()
         })
@@ -118,7 +121,6 @@ describe('Plugin', function () {
                 expect(spans[0]).to.have.property('name', 'next.request')
                 expect(spans[0]).to.have.property('service', 'test')
                 expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET /404')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
                 expect(spans[0].meta).to.have.property('http.method', 'GET')
                 expect(spans[0].meta).to.have.property('http.status_code', '404')
@@ -183,7 +185,6 @@ describe('Plugin', function () {
                 expect(spans[0]).to.have.property('name', 'next.request')
                 expect(spans[0]).to.have.property('service', 'test')
                 expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET /404')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
                 expect(spans[0].meta).to.have.property('http.method', 'GET')
                 expect(spans[0].meta).to.have.property('http.status_code', '404')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix experimental warning in next test.

### Motivation
<!-- What inspired you to submit this pull request? -->

Next now outputs a warning to `stderr` when experimental features are used, which ended up calling `done()`. The output is now ignored instead.

The latest version also changed the internal route for 404 errors. Since there are no guarantees about that route I removed the test for it.