### PR TITLE
fix support for loading the tracer with `mocha --require`

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -1,5 +1,8 @@
+const path = require('path')
 const tracer = require('../packages/dd-trace')
 const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
+const { mochaHook } = require('../packages/datadog-instrumentations/src/mocha')
+const { wrapRun } = require('../packages/datadog-instrumentations/src/cucumber')
 
 const options = {
   startupLogs: false,
@@ -14,15 +17,22 @@ if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED && (process.env.DATADOG_API_KE
   }
 }
 
+// TODO: remove this in a later major version since we now recommend using
+// `NODE_OPTIONS='-r dd-trace/ci/init'`.
+for (const filename in require.cache) {
+  const id = filename.split(path.sep).join('/')
+
+  if (id.includes('/node_modules/mocha/lib/runner.js')) {
+    mochaHook(require.cache[filename].exports)
+  } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/pickle_runner.js')) {
+    wrapRun(require.cache[filename].exports, false)
+  } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js')) {
+    wrapRun(require.cache[filename].exports, true)
+  }
+}
+
 tracer.init(options)
 
 tracer.use('fs', false)
-
-// TODO: remove this in a later major version since we now recommend
-// `NODE_OPTIONS='-r dd-trace/ci/init'` instead of `mocha -r dd-trace/ci/init`.
-tracer.mochaGlobalSetup = function () {
-  const { mochaHook } = require('../packages/datadog-instrumentations/src/mocha')
-  mochaHook(this.constructor)
-}
 
 module.exports = tracer

--- a/ci/init.js
+++ b/ci/init.js
@@ -19,16 +19,20 @@ if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED && (process.env.DATADOG_API_KE
 
 // TODO: remove this in a later major version since we now recommend using
 // `NODE_OPTIONS='-r dd-trace/ci/init'`.
-for (const filename in require.cache) {
-  const id = filename.split(path.sep).join('/')
+try {
+  for (const filename in require.cache) {
+    const id = filename.split(path.sep).join('/')
 
-  if (id.includes('/node_modules/mocha/lib/runner.js')) {
-    mochaHook(require.cache[filename].exports)
-  } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/pickle_runner.js')) {
-    wrapRun(require.cache[filename].exports, false)
-  } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js')) {
-    wrapRun(require.cache[filename].exports, true)
+    if (id.includes('/node_modules/mocha/lib/runner.js')) {
+      mochaHook(require.cache[filename].exports)
+    } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/pickle_runner.js')) {
+      wrapRun(require.cache[filename].exports, false)
+    } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js')) {
+      wrapRun(require.cache[filename].exports, true)
+    }
   }
+} catch (e) {
+  // ignore error and let the tracer initialize anyway
 }
 
 tracer.init(options)

--- a/ci/init.js
+++ b/ci/init.js
@@ -2,7 +2,7 @@ const path = require('path')
 const tracer = require('../packages/dd-trace')
 const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
 const { mochaHook } = require('../packages/datadog-instrumentations/src/mocha')
-const { wrapRun } = require('../packages/datadog-instrumentations/src/cucumber')
+const { pickleHook, testCaseHook } = require('../packages/datadog-instrumentations/src/cucumber')
 
 const options = {
   startupLogs: false,
@@ -21,14 +21,15 @@ if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED && (process.env.DATADOG_API_KE
 // `NODE_OPTIONS='-r dd-trace/ci/init'`.
 try {
   for (const filename in require.cache) {
+    const cache = require.cache[filename]
     const id = filename.split(path.sep).join('/')
 
     if (id.includes('/node_modules/mocha/lib/runner.js')) {
-      mochaHook(require.cache[filename].exports)
+      cache.exports = mochaHook(cache.exports)
     } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/pickle_runner.js')) {
-      wrapRun(require.cache[filename].exports, false)
+      cache.exports = pickleHook(cache.exports)
     } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js')) {
-      wrapRun(require.cache[filename].exports, true)
+      cache.exports = testCaseHook(cache.exports)
     }
   }
 } catch (e) {

--- a/ci/init.js
+++ b/ci/init.js
@@ -18,4 +18,11 @@ tracer.init(options)
 
 tracer.use('fs', false)
 
+// TODO: remove this in a later major version since we now recommend
+// `NODE_OPTIONS='-r dd-trace/ci/init'` instead of `mocha -r dd-trace/ci/init`.
+tracer.mochaGlobalSetup = function () {
+  const { mochaHook } = require('../packages/datadog-instrumentations/src/mocha')
+  mochaHook(this.constructor)
+}
+
 module.exports = tracer

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -100,28 +100,32 @@ function wrapRun (pl, isLatestVersion) {
   })
 }
 
-addHook({
-  name: '@cucumber/cucumber',
-  versions: ['7.0.0 - 7.2.1'],
-  file: 'lib/runtime/pickle_runner.js'
-}, (PickleRunner) => {
+function pickleHook (PickleRunner) {
   const pl = PickleRunner.default
 
   wrapRun(pl, false)
 
   return PickleRunner
-})
+}
 
-addHook({
-  name: '@cucumber/cucumber',
-  versions: ['>=7.3.0'],
-  file: 'lib/runtime/test_case_runner.js'
-}, (TestCaseRunner) => {
+function testCaseHook (TestCaseRunner) {
   const pl = TestCaseRunner.default
 
   wrapRun(pl, true)
 
   return TestCaseRunner
-})
+}
 
-module.exports = { wrapRun }
+addHook({
+  name: '@cucumber/cucumber',
+  versions: ['7.0.0 - 7.2.1'],
+  file: 'lib/runtime/pickle_runner.js'
+}, pickleHook)
+
+addHook({
+  name: '@cucumber/cucumber',
+  versions: ['>=7.3.0'],
+  file: 'lib/runtime/test_case_runner.js'
+}, testCaseHook)
+
+module.exports = { pickleHook, testCaseHook }

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -116,3 +116,5 @@ addHook({
 
   return TestCaseRunner
 })
+
+module.exports = { wrapRun }

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -10,6 +10,9 @@ const runStepStartCh = channel('ci:cucumber:run-step:start')
 const runStepEndCh = channel('ci:cucumber:run-step:end')
 const errorCh = channel('ci:cucumber:error')
 
+// TODO: remove in a later major version
+const patched = new WeakSet()
+
 function getStatusFromResult (result) {
   if (result.status === 1) {
     return { status: 'pass' }
@@ -37,6 +40,10 @@ function getStatusFromResultLatest (result) {
 }
 
 function wrapRun (pl, isLatestVersion) {
+  if (patched.has(pl)) return
+
+  patched.add(pl)
+
   shimmer.wrap(pl.prototype, 'run', run => function () {
     if (!runStartCh.hasSubscribers) {
       return run.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -32,17 +32,6 @@ function getAllTestsInSuite (root) {
   return tests
 }
 
-addHook({
-  name: 'mocha',
-  versions: ['>=5.2.0'],
-  file: 'lib/runner.js'
-}, mochaHook)
-
-addHook({
-  name: 'mocha-each',
-  versions: ['>=2.0.1']
-}, mochaEachHook)
-
 function mochaHook (Runner) {
   if (patched.has(Runner)) return Runner
 
@@ -135,5 +124,16 @@ function mochaEachHook (mochaEach) {
     }
   })
 }
+
+addHook({
+  name: 'mocha',
+  versions: ['>=5.2.0'],
+  file: 'lib/runner.js'
+}, mochaHook)
+
+addHook({
+  name: 'mocha-each',
+  versions: ['>=2.0.1']
+}, mochaEachHook)
 
 module.exports = { mochaHook, mochaEachHook }

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -11,6 +11,9 @@ const hookErrorCh = channel('ci:mocha:hook:error')
 const parameterizedTestCh = channel('ci:mocha:test:parameterize')
 const testRunEndCh = channel('ci:mocha:run:end')
 
+// TODO: remove when root hooks and fixtures are implemented
+const patched = new WeakSet()
+
 function isRetry (test) {
   return test._currentRetry !== undefined && test._currentRetry !== 0
 }
@@ -33,7 +36,18 @@ addHook({
   name: 'mocha',
   versions: ['>=5.2.0'],
   file: 'lib/runner.js'
-}, (Runner) => {
+}, mochaHook)
+
+addHook({
+  name: 'mocha-each',
+  versions: ['>=2.0.1']
+}, mochaEachHook)
+
+function mochaHook (Runner) {
+  if (patched.has(Runner)) return Runner
+
+  patched.add(Runner)
+
   shimmer.wrap(Runner.prototype, 'runTest', runTest => function () {
     if (!testStartCh.hasSubscribers) {
       return runTest.apply(this, arguments)
@@ -102,12 +116,13 @@ addHook({
   })
 
   return Runner
-})
+}
 
-addHook({
-  name: 'mocha-each',
-  versions: ['>=2.0.1']
-}, (mochaEach) => {
+function mochaEachHook (mochaEach) {
+  if (patched.has(mochaEach)) return mochaEach
+
+  patched.add(mochaEach)
+
   return shimmer.wrap(mochaEach, function () {
     const [params] = arguments
     const { it, ...rest } = mochaEach.apply(this, arguments)
@@ -119,4 +134,6 @@ addHook({
       ...rest
     }
   })
-})
+}
+
+module.exports = { mochaHook, mochaEachHook }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix support for loading the tracer with `mocha --require`.

### Motivation
<!-- What inspired you to submit this pull request? -->

In the documentation right now we recommend loading dd-trace in Mocha with `mocha --require dd-trace/ci/init <pattern>` which ends up loading Mocha before dd-trace which is not supported. It used to work simply because we had a few hacks in place to attempt patching the require cache in place, but it was removed as it was causing other issues. The documentation will be updated to recommend using `NODE_OPTIONS='-r dd-trace/ci/init'` instead, but for now we need the current behaviour to work as documented hence this PR. We can remove this later on once users had enough time to make the switch.