### PR TITLE
fix: flush tracer after jest environment is torn down

### DIFF
--- a/packages/datadog-plugin-jest/src/jest-environment.js
+++ b/packages/datadog-plugin-jest/src/jest-environment.js
@@ -56,10 +56,9 @@ function createWrapTeardown (tracer, instrumenter) {
       }
 
       instrumenter.unwrap(this.global.test, 'each')
-      await new Promise((resolve) => {
-        tracer._exporter._writer.flush(resolve)
-      })
-      return teardown.apply(this, arguments)
+      return teardown
+        .apply(this, arguments)
+        .then(() => new Promise((resolve) => tracer._exporter._writer.flush(resolve)))
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
It flushes the tracer after jest environment is torn down instead of delaying the teardown.

### Motivation
Fixes issues with error boundaries in React like #1945

