### PR TITLE
Update AppSec rules to v1.2.7

### DIFF
--- a/packages/dd-trace/src/appsec/recommended.json
+++ b/packages/dd-trace/src/appsec/recommended.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.2.6"
+    "rules_version": "1.2.7"
   },
   "rules": [
     {
@@ -281,9 +281,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -297,53 +294,54 @@
               }
             ],
             "list": [
-              ".htaccess",
-              ".htdigest",
-              ".htpasswd",
-              ".addressbook",
-              ".aptitude/config",
-              ".bash_config",
-              ".bash_history",
-              ".bash_logout",
-              ".bash_profile",
-              ".bashrc",
+              "/.htaccess",
+              "/.htdigest",
+              "/.htpasswd",
+              "/.addressbook",
+              "/.aptitude/config",
+              "/.bash_config",
+              "/.bash_history",
+              "/.bash_logout",
+              "/.bash_profile",
+              "/.bashrc",
               ".cache/notify-osd.log",
               ".config/odesk/odesk team.conf",
-              ".cshrc",
-              ".dockerignore",
+              "/.cshrc",
+              "/.dockerignore",
               ".drush/",
-              ".eslintignore",
-              ".fbcindex",
-              ".forward",
-              ".git",
-              ".gitattributes",
-              ".gitconfig",
+              "/.eslintignore",
+              "/.fbcindex",
+              "/.forward",
+              "/.git",
+              ".git/",
+              "/.gitattributes",
+              "/.gitconfig",
               ".gnupg/",
               ".hplip/hplip.conf",
-              ".ksh_history",
-              ".lesshst",
+              "/.ksh_history",
+              "/.lesshst",
               ".lftp/",
-              ".lhistory",
-              ".lldb-history",
+              "/.lhistory",
+              "/.lldb-history",
               ".local/share/mc/",
-              ".lynx_cookies",
-              ".my.cnf",
-              ".mysql_history",
-              ".nano_history",
-              ".node_repl_history",
-              ".pearrc",
-              ".php_history",
-              ".pinerc",
+              "/.lynx_cookies",
+              "/.my.cnf",
+              "/.mysql_history",
+              "/.nano_history",
+              "/.node_repl_history",
+              "/.pearrc",
+              "/.php_history",
+              "/.pinerc",
               ".pki/",
-              ".proclog",
-              ".procmailrc",
-              ".psql_history",
-              ".python_history",
-              ".rediscli_history",
-              ".rhistory",
-              ".rhosts",
-              ".sh_history",
-              ".sqlite_history",
+              "/.proclog",
+              "/.procmailrc",
+              "/.psql_history",
+              "/.python_history",
+              "/.rediscli_history",
+              "/.rhistory",
+              "/.rhosts",
+              "/.sh_history",
+              "/.sqlite_history",
               ".ssh/authorized_keys",
               ".ssh/config",
               ".ssh/id_dsa",
@@ -357,17 +355,17 @@
               ".subversion/config",
               ".subversion/servers",
               ".tconn/tconn.conf",
-              ".tcshrc",
+              "/.tcshrc",
               ".vidalia/vidalia.conf",
-              ".viminfo",
-              ".vimrc",
-              ".www_acl",
-              ".wwwacl",
-              ".xauthority",
-              ".zhistory",
-              ".zshrc",
-              ".zsh_history",
-              ".nsconfig",
+              "/.viminfo",
+              "/.vimrc",
+              "/.www_acl",
+              "/.wwwacl",
+              "/.xauthority",
+              "/.zhistory",
+              "/.zshrc",
+              "/.zsh_history",
+              "/.nsconfig",
               "etc/redis.conf",
               "etc/redis-sentinel.conf",
               "etc/php.ini",
@@ -1349,26 +1347,26 @@
               "etc/vmware-tools/vmware-tools-libraries.conf",
               "var/log/vmware/hostd.log",
               "var/log/vmware/hostd-1.log",
-              "wp-config.php",
-              "wp-config.bak",
-              "wp-config.old",
-              "wp-config.temp",
-              "wp-config.tmp",
-              "wp-config.txt",
-              "config.yml",
-              "config_dev.yml",
-              "config_prod.yml",
-              "config_test.yml",
-              "parameters.yml",
-              "routing.yml",
-              "security.yml",
-              "services.yml",
+              "/wp-config.php",
+              "/wp-config.bak",
+              "/wp-config.old",
+              "/wp-config.temp",
+              "/wp-config.tmp",
+              "/wp-config.txt",
+              "/config.yml",
+              "/config_dev.yml",
+              "/config_prod.yml",
+              "/config_test.yml",
+              "/parameters.yml",
+              "/routing.yml",
+              "/security.yml",
+              "/services.yml",
               "sites/default/default.settings.php",
               "sites/default/settings.php",
               "sites/default/settings.local.php",
               "app/etc/local.xml",
-              "sftp-config.json",
-              "web.config",
+              "/sftp-config.json",
+              "/web.config",
               "includes/config.php",
               "includes/configure.php",
               "config.inc.php",
@@ -1392,14 +1390,14 @@
               "system32/config/system",
               "system32/config/software",
               "winnt/repair/sam._",
-              "package.json",
-              "package-lock.json",
-              "gruntfile.js",
-              "npm-debug.log",
-              "ormconfig.json",
-              "tsconfig.json",
-              "webpack.config.js",
-              "yarn.lock"
+              "/package.json",
+              "/package-lock.json",
+              "/gruntfile.js",
+              "/npm-debug.log",
+              "/ormconfig.json",
+              "/tsconfig.json",
+              "/webpack.config.js",
+              "/yarn.lock"
             ]
           },
           "operator": "phrase_match"
@@ -1481,9 +1479,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -1782,9 +1777,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -1839,9 +1831,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -1878,9 +1867,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -1915,9 +1901,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -1998,9 +1981,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2035,9 +2015,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.headers.no_cookies"
               },
@@ -2078,9 +2055,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2119,9 +2093,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2157,9 +2128,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.headers.no_cookies",
                 "key_path": [
@@ -2205,9 +2173,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.headers.no_cookies",
                 "key_path": [
@@ -2258,9 +2223,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.headers.no_cookies",
                 "key_path": [
                   "user-agent"
@@ -2309,9 +2271,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.headers.no_cookies",
                 "key_path": [
@@ -2362,9 +2321,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2408,9 +2364,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2448,9 +2401,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -2490,9 +2440,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2531,9 +2478,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2570,9 +2514,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -2613,9 +2554,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2652,9 +2590,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -2693,9 +2628,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2732,9 +2664,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -2773,9 +2702,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2811,9 +2737,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -2851,9 +2774,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2886,9 +2806,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -2926,9 +2843,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -2964,9 +2878,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -3001,9 +2912,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -3041,9 +2949,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -3079,9 +2984,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -3116,9 +3018,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -3156,9 +3055,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -3193,9 +3089,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -3232,9 +3125,6 @@
         {
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },
@@ -3278,9 +3168,6 @@
                 "address": "server.request.path_params"
               },
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.headers.no_cookies"
               },
               {
@@ -3322,9 +3209,6 @@
                 "address": "server.request.path_params"
               },
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.headers.no_cookies"
               },
               {
@@ -3350,9 +3234,6 @@
               },
               {
                 "address": "server.request.path_params"
-              },
-              {
-                "address": "server.request.cookies"
               },
               {
                 "address": "server.request.headers.no_cookies"
@@ -3394,9 +3275,6 @@
               },
               {
                 "address": "server.request.path_params"
-              },
-              {
-                "address": "server.request.cookies"
               },
               {
                 "address": "server.request.headers.no_cookies"
@@ -3504,9 +3382,6 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.request.cookies"
-              },
-              {
                 "address": "server.request.query"
               },
               {
@@ -3540,9 +3415,6 @@
           "operator": "match_regex",
           "parameters": {
             "inputs": [
-              {
-                "address": "server.request.cookies"
-              },
               {
                 "address": "server.request.query"
               },


### PR DESCRIPTION
### What does this PR do?
Updates the default AppSec rules file to their v1.2.7 release. It removes cookie support and fixes some false positives.
Full release here: https://github.com/DataDog/appsec-event-rules/releases/tag/1.2.7
