### PR TITLE
normalize http plugin config only when needed

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -24,7 +24,6 @@ class HttpClientPlugin extends Plugin {
 
     this.addSub('apm:http:client:request:start', ({ args, http }) => {
       const store = storage.getStore()
-      this.config = normalizeClientConfig(this.config)
       const options = args.options
       const agent = options.agent || options._defaultAgent || http.globalAgent
       const protocol = options.protocol || agent.protocol || 'http:'
@@ -78,6 +77,10 @@ class HttpClientPlugin extends Plugin {
     })
 
     this.addSub('apm:http:client:request:error', errorHandler)
+  }
+
+  configure (config) {
+    return super.configure(normalizeClientConfig(config))
   }
 }
 

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -18,8 +18,6 @@ class HttpServerPlugin extends Plugin {
 
     this.addSub('apm:http:server:request:start', ({ req, res }) => {
       const store = storage.getStore()
-      this.config = web.normalizeConfig(this.config)
-
       const span = web.startSpan(this.tracer, this.config, req, res, 'http.request')
 
       if (this.config.service) {
@@ -58,6 +56,10 @@ class HttpServerPlugin extends Plugin {
       const context = web.getContext(req)
       web.wrapRes(context, context.req, context.res, context.res.end)()
     })
+  }
+
+  configure (config) {
+    return super.configure(web.normalizeConfig(config))
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Normalize `http` plugin config only when needed.

### Motivation
<!-- What inspired you to submit this pull request? -->

Avoid unnecessary reassignment.