### PR TITLE
feat(plugin-pg): instrument Client.connect and Pool.connect

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -7,24 +7,41 @@ const {
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
-const startCh = channel('apm:pg:query:start')
-const asyncEndCh = channel('apm:pg:query:async-end')
-const endCh = channel('apm:pg:query:end')
-const errorCh = channel('apm:pg:query:error')
+const connectStartCh = channel('apm:pg:connect:start')
+const connectAsyncEndCh = channel('apm:pg:connect:async-end')
+const connectEndCh = channel('apm:pg:connect:end')
+const connectErrorCh = channel('apm:pg:connect:error')
+
+const queryStartCh = channel('apm:pg:query:start')
+const queryAsyncEndCh = channel('apm:pg:query:async-end')
+const queryEndCh = channel('apm:pg:query:end')
+const queryErrorCh = channel('apm:pg:query:error')
+
+const poolStartCh = channel('apm:pg-pool:connect:start')
+const poolAsyncEndCh = channel('apm:pg-pool:connect:async-end')
+const poolEndCh = channel('apm:pg-pool:connect:end')
+const poolErrorCh = channel('apm:pg-pool:connect:error')
 
 addHook({ name: 'pg', versions: ['>=4'] }, pg => {
-  shimmer.wrap(pg.Client.prototype, 'query', query => wrapQuery(query))
+  shimmer.wrap(pg.Client.prototype, 'connect', wrapClientConnect)
+  shimmer.wrap(pg.Client.prototype, 'query', wrapQuery)
   return pg
 })
 
 addHook({ name: 'pg', file: 'lib/native/index.js', versions: ['>=4'] }, Client => {
-  shimmer.wrap(Client.prototype, 'query', query => wrapQuery(query))
+  shimmer.wrap(Client.prototype, 'connect', wrapClientConnect)
+  shimmer.wrap(Client.prototype, 'query', wrapQuery)
   return Client
+})
+
+addHook({ name: 'pg-pool', versions: ['>=2'] }, Pool => {
+  shimmer.wrap(Pool.prototype, 'connect', wrapPoolConnect)
+  return Pool
 })
 
 function wrapQuery (query) {
   return function () {
-    if (!startCh.hasSubscribers) {
+    if (!queryStartCh.hasSubscribers) {
       return query.apply(this, arguments)
     }
 
@@ -41,13 +58,13 @@ function wrapQuery (query) {
     }
     const statement = pgQuery.text
 
-    startCh.publish({ params: this.connectionParameters, statement })
+    queryStartCh.publish({ params: this.connectionParameters, statement })
 
     const finish = AsyncResource.bind(function (error) {
       if (error) {
-        errorCh.publish(error)
+        queryErrorCh.publish(error)
       }
-      asyncEndCh.publish(undefined)
+      queryAsyncEndCh.publish(undefined)
     })
 
     if (pgQuery.callback) {
@@ -67,9 +84,80 @@ function wrapQuery (query) {
     try {
       return retval
     } catch (err) {
-      errorCh.publish(err)
+      queryErrorCh.publish(err)
     } finally {
-      endCh.publish(undefined)
+      queryEndCh.publish(undefined)
     }
+  }
+}
+
+function wrapClientConnect (connect) {
+  return function wrappedConnect (callback) {
+    if (!connectStartCh.hasSubscribers) {
+      return connect.apply(this, arguments)
+    }
+
+    connectStartCh.publish({ params: this.connectionParameters })
+
+    try {
+      return wrapConnect.call(this, connect, arguments, connectAsyncEndCh, connectErrorCh)
+    } finally {
+      connectEndCh.publish(undefined)
+    }
+  }
+}
+
+function wrapPoolConnect (connect) {
+  return function wrappedConnect (callback) {
+    if (!poolStartCh.hasSubscribers) {
+      return connect.apply(this, arguments)
+    }
+
+    poolStartCh.publish({
+      max: this.options.max, // max clients/pool-size
+      idleTimeoutMillis: this.options.idleTimeoutMillis, // client idle timeout
+      idleCount: this.idleCount, // idle clients
+      totalCount: this.totalCount, // current total clients
+      waitingCount: this.waitingCount // pending queries
+    })
+
+    try {
+      return wrapConnect.call(this, connect, arguments, poolAsyncEndCh, poolErrorCh)
+    } finally {
+      poolEndCh.publish(undefined)
+    }
+  }
+}
+
+function wrapConnect (connect, args, asyncEndCh, errorCh) {
+  const callback = args[0]
+  const asyncResource = new AsyncResource('bound-anonymous-fn')
+
+  const finish = AsyncResource.bind(function (error) {
+    if (error) {
+      errorCh.publish(error)
+    }
+    asyncEndCh.publish(undefined)
+  })
+
+  if (callback) {
+    const boundCb = asyncResource.bind(callback)
+
+    args[0] = AsyncResource.bind(function (error) {
+      finish(error)
+      return boundCb.apply(this, arguments)
+    })
+  }
+
+  try {
+    const retval = connect.apply(this, args)
+
+    if (retval && typeof retval.then === 'function') {
+      retval.then(() => finish(), finish)
+    }
+    return retval
+  } catch (error) {
+    errorCh.publish(error)
+    throw error
   }
 }

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -12,7 +12,7 @@ class PGPlugin extends Plugin {
   constructor (...args) {
     super(...args)
 
-    this.addSub(`apm:pg:query:start`, ({ params, statement }) => {
+    this.addSub('apm:pg:query:start', ({ params, statement }) => {
       const service = getServiceName(this.tracer, this.config, params)
       const store = storage.getStore()
       const childOf = store ? store.span : store
@@ -40,19 +40,76 @@ class PGPlugin extends Plugin {
       this.enter(span, store)
     })
 
-    this.addSub(`apm:pg:query:end`, () => {
-      this.exit()
+    this.addSub('apm:pg:connect:start', ({ params }) => {
+      const service = getServiceName(this.tracer, this.config, params)
+      const store = storage.getStore()
+      const childOf = store ? store.span : store
+      const span = this.tracer.startSpan('pg.connect', {
+        childOf,
+        tags: {
+          'service.name': service,
+          'span.type': 'sql',
+          'span.kind': 'client',
+          'db.type': 'postgres'
+        }
+      })
+
+      if (params) {
+        span.addTags({
+          'db.name': params.database,
+          'db.user': params.user,
+          'out.host': params.host,
+          'out.port': params.port
+        })
+      }
+
+      analyticsSampler.sample(span, this.config.measured)
+      this.enter(span, store)
     })
 
-    this.addSub(`apm:pg:query:error`, err => {
+    this.addSub('apm:pg-pool:connect:start', ({ max, idleTimeoutMillis, idleCount, totalCount, waitingCount }) => {
+      const service = getServiceName(this.tracer, this.config)
+      const store = storage.getStore()
+      const childOf = store ? store.span : store
+      const span = this.tracer.startSpan('pg-pool.connect', {
+        childOf,
+        tags: {
+          'service.name': service,
+          'span.type': 'sql',
+          'span.kind': 'client',
+          'db.type': 'postgres',
+          'db.pool.clients.max': max,
+          'db.pool.clients.idle_timeout_millis': idleTimeoutMillis,
+          'db.pool.clients.idle': idleCount,
+          'db.pool.clients.total': totalCount,
+          'db.pool.queries.pending': waitingCount
+        }
+      })
+
+      analyticsSampler.sample(span, this.config.measured)
+      this.enter(span, store)
+    })
+
+    const end = () => { this.exit() }
+    this.addSub('apm:pg:query:end', end)
+    this.addSub('apm:pg:connect:end', end)
+    this.addSub('apm:pg-pool:connect:end', end)
+
+    const error = err => {
       const span = storage.getStore().span
       span.setTag('error', err)
-    })
+    }
+    this.addSub('apm:pg:query:error', error)
+    this.addSub('apm:pg:connect:error', error)
+    this.addSub('apm:pg-pool:connect:error', error)
 
-    this.addSub(`apm:pg:query:async-end`, () => {
+    const asyncEnd = () => {
       const span = storage.getStore().span
       span.finish()
-    })
+    }
+    this.addSub('apm:pg:query:async-end', asyncEnd)
+    this.addSub('apm:pg:connect:async-end', asyncEnd)
+    this.addSub('apm:pg-pool:connect:async-end', asyncEnd)
   }
 }
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -10,6 +10,7 @@ const clients = {
 if (process.env.PG_TEST_NATIVE === 'true') {
   clients['pg.native'] = pg => pg.native.Client
 }
+const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
 describe('Plugin', () => {
   let pg
@@ -91,7 +92,7 @@ describe('Plugin', () => {
             })
           }
 
-          it('should handle errors', done => {
+          it('should handle callback query errors', done => {
             let error
 
             agent.use(traces => {
@@ -111,7 +112,7 @@ describe('Plugin', () => {
             })
           })
 
-          it('should handle errors', done => {
+          it('should handle async query errors', done => {
             let error
 
             agent.use(traces => {
@@ -153,6 +154,64 @@ describe('Plugin', () => {
               })
             })
           })
+        })
+
+        describe(`connection errors when using ${implementation}.Client`, () => {
+          before(() => {
+            return agent.load('pg')
+          })
+
+          after(() => {
+            return agent.close({ ritmReset: false })
+          })
+
+          beforeEach((done) => {
+            pg = require(`../../../versions/pg@${version}`).get()
+
+            const Client = clients[implementation](pg)
+
+            client = new Client({
+              user: 'invalid',
+              password: 'invalid',
+              database: 'invalid',
+              application_name: 'test'
+            })
+
+            done()
+          })
+
+          it('should handle connection errors for callbacks', (done) => {
+            let error
+            agent.use(traces => {
+              expect(traces[0][0].meta).to.have.property('error.type', error.name)
+              expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+              expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+            }).then(done, done)
+
+            client.connect((err) => {
+              error = err
+            })
+          })
+
+          if (semver.intersects(version, '>=5.1')) { // initial promise support
+            it('should handle connection errors for promises', async () => {
+              let error
+
+              const promise = agent.use(traces => {
+                expect(traces[0][0].meta).to.have.property('error.type', error.name)
+                expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+                expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+              })
+
+              try {
+                await client.connect()
+              } catch (err) {
+                error = err
+              }
+
+              await promise
+            })
+          }
         })
       })
 
@@ -235,6 +294,170 @@ describe('Plugin', () => {
           })
         })
       })
+
+      // internal pooling code was replaced with pg-pool in 6.0
+      if (semver.intersects(version, '>=6')) {
+        describe('with a connection pool', () => {
+          let pg
+          let pool
+
+          before(async () => {
+            await agent.load('pg')
+            pg = require(`../../../versions/pg@${version}`).get()
+          })
+
+          beforeEach(async () => {
+            pool = new pg.Pool({
+              user: 'postgres',
+              password: 'postgres',
+              database: 'postgres',
+              application_name: 'test',
+              max: 20,
+              idleTimeoutMillis: 30000,
+              connectionTimeoutMillis: 2000
+            })
+          })
+
+          afterEach(async () => {
+            await pool && pool.end()
+            pool = undefined
+          })
+
+          after(async () => {
+            await agent.close({ ritmReset: false })
+          })
+
+          it('should be configured with the correct values for callbacks', done => {
+            agent.use(traces => {
+              // connect spans from the pool and client come first
+              const spans = sort(traces[0])
+
+              expect(spans[0]).to.have.property('service', 'test-postgres')
+              expect(spans[0]).to.have.property('name', 'pg-pool.connect')
+              expect(spans[0]).to.have.property('resource', 'pg-pool.connect')
+              expect(spans[0]).to.have.property('type', 'sql')
+              expect(spans[0].meta).to.have.property('span.kind', 'client')
+              expect(spans[0].meta).to.have.property('db.type', 'postgres')
+              expect(spans[0].metrics).to.have.property('db.pool.clients.max', 20)
+              expect(spans[0].metrics).to.have.property('db.pool.clients.idle_timeout_millis', 30000)
+              expect(spans[0].metrics).to.have.property('db.pool.clients.idle', 0)
+              expect(spans[0].metrics).to.have.property('db.pool.clients.total', 0)
+              expect(spans[0].metrics).to.have.property('db.pool.queries.pending', 0)
+
+              expect(spans[1]).to.have.property('service', 'test-postgres')
+              expect(spans[1]).to.have.property('name', 'pg.connect')
+              expect(spans[1]).to.have.property('resource', 'pg.connect')
+              expect(spans[1]).to.have.property('type', 'sql')
+              expect(spans[1].meta).to.have.property('span.kind', 'client')
+              expect(spans[1].meta).to.have.property('db.type', 'postgres')
+              expect(spans[1].meta).to.have.property('db.name', 'postgres')
+              expect(spans[1].meta).to.have.property('db.user', 'postgres')
+            }).then(() => {
+              return agent.use(traces => {
+                expect(traces[0][0]).to.have.property('service', 'test-postgres')
+                expect(traces[0][0]).to.have.property('name', 'pg.query')
+                expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
+                expect(traces[0][0]).to.have.property('type', 'sql')
+                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                expect(traces[0][0].meta).to.have.property('db.name', 'postgres')
+                expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
+                expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
+              })
+            }).then(done, done)
+
+            pool.query('SELECT $1::text as message', ['Hello world!'], (err) => {
+              if (err) throw err
+            })
+          })
+
+          it('should be configured with the correct values for promises', async () => {
+            pool.query('SELECT $1::text as message', ['Hello world!']).catch(err => { throw err })
+
+            await agent.use(traces => {
+              // connect spans from the pool and client come first
+              const spans = sort(traces[0])
+
+              expect(spans[0]).to.have.property('name', 'pg-pool.connect')
+              expect(spans[0].metrics).to.have.property('db.pool.clients.max', 20)
+              expect(spans[0].metrics).to.have.property('db.pool.clients.idle', 0)
+              expect(spans[0].metrics).to.have.property('db.pool.clients.total', 0)
+              expect(spans[0].metrics).to.have.property('db.pool.queries.pending', 0)
+
+              expect(spans[1]).to.have.property('name', 'pg.connect')
+            })
+
+            await agent.use(traces => {
+              expect(traces[0][0]).to.have.property('name', 'pg.query')
+            })
+          })
+
+          it('should allow for manual connection calls', async () => {
+            const promise = agent.use(traces => {
+              expect(traces[0][0]).to.have.property('name', 'pg-pool.connect')
+            })
+
+            const client = await pool.connect()
+            await client.query('SELECT NOW()')
+            await promise
+          })
+        })
+
+        describe('connection errors for connection pool', () => {
+          let pg
+          let pool
+
+          before(async () => {
+            await agent.load('pg')
+            pg = require(`../../../versions/pg@${version}`).get()
+          })
+
+          beforeEach((done) => {
+            pool = new pg.Pool({
+              user: 'invalid',
+              password: 'invalid',
+              database: 'invalid',
+              application_name: 'test'
+            })
+
+            done()
+          })
+
+          after(() => {
+            return agent.close({ ritmReset: false })
+          })
+
+          it('should handle connection errors for callbacks', done => {
+            let error
+            agent.use(traces => {
+              expect(traces[0][0].meta).to.have.property('error.type', error.name)
+              expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+              expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+            }).then(done, done)
+
+            pool.connect((err) => {
+              error = err
+            })
+          })
+
+          it('should handle connection errors for promises', async () => {
+            let error
+
+            const promise = agent.use(traces => {
+              expect(traces[0][0].meta).to.have.property('error.type', error.name)
+              expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+              expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+            })
+
+            try {
+              await pool.connect()
+            } catch (err) {
+              error = err
+            }
+
+            await promise
+          })
+        })
+      }
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Extends the `pg` instrumentation to include Client.connect, native.Client.connect, and Pool.connect.

### Motivation
<!-- What inspired you to submit this pull request? -->
Fixes https://github.com/DataDog/dd-trace-js/issues/1923
I had similar pain with diagnosing a db bottleneck with full db connection pools. Having these spans would have made identifying the issue straight forward.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Plugin is [exported][5].

[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Wrapping the `connect` method of both the Client and Pool classes allows for diagnosing two separate delays for a query: the pool being full vs establishing a new network connection.
