### PR TITLE
[ci-visibility] Update agentless payload format

### DIFF
--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -1,5 +1,4 @@
 'use strict'
-const tracerVersion = require('../../lib/version')
 const { truncateSpan, normalizeSpan } = require('./tags-processors')
 const Chunk = require('./chunk')
 const { AgentEncoder } = require('./0.4')
@@ -156,29 +155,27 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     const payload = {
       version: ENCODING_VERSION,
       metadata: {
-        'language': 'javascript',
-        'library_version': tracerVersion,
-        'runtime.name': 'node',
-        'runtime.version': process.version
+        '*': {
+          'language': 'javascript'
+        }
       },
       events: []
     }
 
-    if (this.service) {
-      payload.metadata.service = this.service
-    }
     if (this.env) {
-      payload.metadata.env = this.env
+      payload.metadata['*'].env = this.env
     }
     if (this.runtimeId) {
-      payload.metadata['runtime-id'] = this.runtimeId
+      payload.metadata['*']['runtime-id'] = this.runtimeId
     }
 
     this._encodeMapPrefix(bytes, payload)
     this._encodeString(bytes, 'version')
     this._encodeNumber(bytes, payload.version)
     this._encodeString(bytes, 'metadata')
-    this._encodeMap(bytes, payload.metadata)
+    this._encodeMapPrefix(bytes, payload.metadata)
+    this._encodeString(bytes, '*')
+    this._encodeMap(bytes, payload.metadata['*'])
     this._encodeString(bytes, 'events')
     // Get offset of the events list to update the length of the array when calling `makePayload`
     this._eventsOffset = bytes.length

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -65,11 +65,8 @@ describe('agentless-ci-visibility-encode', () => {
     const decodedTrace = msgpack.decode(buffer, { codec })
 
     expect(decodedTrace.version.toNumber()).to.equal(1)
-    expect(decodedTrace.metadata).to.contain({
-      language: 'javascript',
-      'runtime.name': 'node',
-      'runtime.version':
-      process.version
+    expect(decodedTrace.metadata['*']).to.contain({
+      language: 'javascript'
     })
     const spanEvent = decodedTrace.events[0]
     expect(spanEvent.type).to.equal('span')


### PR DESCRIPTION
### What does this PR do?
Update the agentless payload format.

### Motivation
Since the fields in `metadata` are applied to every span in a trace, we have decided to reduce the number of them. Also, we have created a nested `*` key with the idea of adding new keys in the future, for example `test`, for metadata that is applied only to tests. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
