### PR TITLE
Flush after jest environment has been tore down

### DIFF
--- a/packages/datadog-plugin-jest/src/jest-environment.js
+++ b/packages/datadog-plugin-jest/src/jest-environment.js
@@ -56,8 +56,10 @@ function createWrapTeardown (tracer, instrumenter) {
       }
 
       instrumenter.unwrap(this.global.test, 'each')
-      await teardown.apply(this, arguments)
-      return new Promise(resolve => tracer._exporter._writer.flush(resolve))
+
+      return teardown.apply(this, arguments).finally(() => {
+        return new Promise(resolve => tracer._exporter._writer.flush(resolve))
+      })
     }
   }
 }

--- a/packages/datadog-plugin-jest/src/jest-environment.js
+++ b/packages/datadog-plugin-jest/src/jest-environment.js
@@ -56,10 +56,8 @@ function createWrapTeardown (tracer, instrumenter) {
       }
 
       instrumenter.unwrap(this.global.test, 'each')
-      await new Promise((resolve) => {
-        tracer._exporter._writer.flush(resolve)
-      })
-      return teardown.apply(this, arguments)
+      await teardown.apply(this, arguments)
+      return new Promise(resolve => tracer._exporter._writer.flush(resolve))
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Call `flush` after tearing down jest's environment, as calling it afterwards seem to have undesired side effects.

### Motivation
Fixes #1945

### Additional Notes
I don't think we have a way to add unit tests for this. In any case, from my tests this seems to be a safe change. Automatic E2E are passing too.
