### PR TITLE
test that amqplib commands run normally

### DIFF
--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -18,29 +18,35 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => {
-          return agent.load('amqplib')
+        beforeEach(done => {
+          require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
+            .connect((err, conn) => {
+              connection = conn
+
+              if (err != null) {
+                return done(err)
+              }
+
+              conn.createChannel((err, ch) => {
+                channel = ch
+                done(err)
+              })
+            })
         })
 
-        after(() => {
-          return agent.close({ ritmReset: false })
+        describe('without plugin', () => {
+          it('should run commands normally', done => {
+            channel.assertQueue('test', {}, () => { done() })
+          })
         })
 
         describe('when using a callback', () => {
-          beforeEach(done => {
-            require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
-              .connect((err, conn) => {
-                connection = conn
+          before(() => {
+            return agent.load('amqplib')
+          })
 
-                if (err != null) {
-                  return done(err)
-                }
-
-                conn.createChannel((err, ch) => {
-                  channel = ch
-                  done(err)
-                })
-              })
+          after(() => {
+            return agent.close({ ritmReset: false })
           })
 
           describe('when sending commands', () => {


### PR DESCRIPTION
### What does this PR do?
it adds a test to make sure commands run normally when plugin is not active

### Motivation
it's a test to check for this bug https://github.com/DataDog/dd-trace-js/issues/1961

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
