### PR TITLE
fix http server error with response objects instantiated directly

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -56,6 +56,9 @@ class HttpServerPlugin extends Plugin {
 
     this.addSub('apm:http:server:request:async-end', ({ req }) => {
       const context = web.getContext(req)
+
+      if (!context) return // Not created by a http.Server instance.
+
       web.wrapRes(context, context.req, context.res, context.res.end)()
     })
   }

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -121,6 +121,15 @@ describe('Plugin', () => {
 
         axios.get(`http://localhost:${port}/user`).catch(done)
       })
+
+      it('should not instrument manually instantiated server responses', () => {
+        const { IncomingMessage, ServerResponse } = http
+
+        const req = new IncomingMessage()
+        const res = new ServerResponse(req)
+
+        expect(() => res.emit('finish')).to.not.throw()
+      })
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix HTTP server error with response objects instantiated directly.

### Motivation
<!-- What inspired you to submit this pull request? -->

The plugin assumed that the `ServerResponse` object was always created by a `Server` object, but the class is exported and this may not be the case.

Fixes #1958 