### PR TITLE
fix elasticsearch plugin re-normalizing its configuration on every query

### DIFF
--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -13,8 +13,6 @@ class ElasticsearchPlugin extends Plugin {
     super(...args)
 
     this.addSub('apm:elasticsearch:query:start', ({ params }) => {
-      this.config = normalizeConfig(this.config)
-
       const store = storage.getStore()
       const childOf = store ? store.span : store
       const body = getBody(params.body || params.bulkBody)
@@ -50,6 +48,10 @@ class ElasticsearchPlugin extends Plugin {
       this.config.hooks.query(span, params)
       span.finish()
     })
+  }
+
+  configure (config) {
+    super.configure(normalizeConfig(config))
   }
 }
 

--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -51,7 +51,7 @@ class ElasticsearchPlugin extends Plugin {
   }
 
   configure (config) {
-    super.configure(normalizeConfig(config))
+    return super.configure(normalizeConfig(config))
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `elasticsearch` plugin re-normalizing its configuration on every query.

### Motivation
<!-- What inspired you to submit this pull request? -->

This should only happen when the plugin is explicitly reconfigured.