### PR TITLE
handle path.parse when undefined

### DIFF
--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -11,7 +11,14 @@ function findRoot () {
 
 function findPkg () {
   const cwd = findRoot()
-  const filePath = findUp('package.json', cwd)
+  const directory = path.resolve(cwd)
+  const res = path.parse(directory)
+
+  if (!res) return {}
+
+  const { root } = res
+
+  const filePath = findUp('package.json', root, directory)
 
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'))
@@ -20,14 +27,12 @@ function findPkg () {
   }
 }
 
-function findUp (name, cwd) {
-  let directory = path.resolve(cwd)
-  const { root } = path.parse(directory)
-
+function findUp (name, root, directory) {
   while (true) {
     const current = path.resolve(directory, name)
 
     if (fs.existsSync(current)) return current
+
     if (directory === root) return
 
     directory = path.dirname(directory)

--- a/packages/dd-trace/test/pkg.spec.js
+++ b/packages/dd-trace/test/pkg.spec.js
@@ -2,6 +2,7 @@
 
 const os = require('os')
 const { execSync } = require('child_process')
+const proxyquire = require('proxyquire').noPreserveCache()
 
 describe('pkg', () => {
   let pkg
@@ -27,5 +28,15 @@ describe('pkg', () => {
 
   it('should load the version number from the main module', () => {
     expect(pkg.version).to.match(/^\d+.\d+.\d+/)
+  })
+})
+
+describe('load', () => {
+  it('should not break if path.parse returns undefined', () => {
+    const pathStub = { }
+    pathStub.parse = function () {
+      return undefined
+    }
+    proxyquire('../src/pkg', { 'path': pathStub })
   })
 })


### PR DESCRIPTION
### What does this PR do?
handle path.parse when undefined

### Motivation
https://github.com/DataDog/dd-trace-js/issues/1843

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
