### PR TITLE
[ci-visibility] Fix Cucumber Tests

### DIFF
--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -23,6 +23,7 @@ const {
 
 const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
   const stdout = new PassThrough()
+  const stderr = new PassThrough()
   const cwd = path.resolve(path.join(__dirname, `../../../versions/@cucumber/cucumber@${version}`))
   const cucumberJs = `${cwd}/node-modules/.bin/cucumber-js`
   const argv = [
@@ -37,7 +38,9 @@ const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
   const cli = new Cucumber.Cli({
     argv,
     cwd,
-    stdout
+    stdout,
+    stderr,
+    env: process.env
   })
 
   return cli.run()


### PR DESCRIPTION
### What does this PR do?
New 8.0.0 cucumber release has a couple of breaking changes, specifically when running the cli programmatically, as we do in our test suite: https://github.com/cucumber/cucumber-js/blob/main/UPGRADING.md#using-cli-programmatically. 
It now requires `stderr` and `env` as parameters.

### Motivation
Fix cucumber tests. 

