### PR TITLE
Bump `@datadog/native-appsec` to `1.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@datadog/native-appsec": "^1.0.0",
+    "@datadog/native-appsec": "^1.0.1",
     "@datadog/native-metrics": "^1.1.0",
     "@datadog/pprof": "^0.3.0",
     "@datadog/sketches-js": "^1.0.4",


### PR DESCRIPTION
Fixes some memory issues in the appsec bindings, as some memory freeing was missing.