### PR TITLE
move calling of hook to finish

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/helpers.js
+++ b/packages/datadog-plugin-aws-sdk/src/helpers.js
@@ -19,7 +19,7 @@ function getService (Service) {
 }
 
 const helpers = {
-  finish (span, err) {
+  finish (config, span, response, err) {
     if (err) {
       span.setTag('error', err)
 
@@ -27,6 +27,8 @@ const helpers = {
         span.addTags({ 'aws.response.request_id': err.requestId })
       }
     }
+
+    config.hooks.request(span, response)
 
     span.finish()
   },
@@ -43,14 +45,12 @@ const helpers = {
       : true
   },
 
-  addResponseTags (span, response, serviceName, config) {
+  addResponseTags (span, response, serviceName) {
     if (!span) return
 
     if (response.request) {
       this.addServicesTags(span, response, serviceName)
     }
-
-    config.hooks.request(span, response)
   },
 
   addServicesTags (span, response, serviceName) {

--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -36,7 +36,7 @@ function createWrapRequest (tracer, config) {
         if (!span) return
 
         awsHelpers.addResponseTags(span, response, serviceIdentifier, config, tracer)
-        awsHelpers.finish(span, response.error)
+        awsHelpers.finish(config, span, response, response.error)
       })
 
       analyticsSampler.sample(span, config.measured)


### PR DESCRIPTION
### What does this PR do?
fix the ordering of the call to hook in aws-sdk helpers

### Motivation
<!-- What inspired you to submit this pull request? -->
this bug blocked a customer from being able to override error tags in their aws-sdk hook

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
