### PR TITLE
dont send traces to agent for routes on blocklist

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -59,6 +59,16 @@ class HttpServerPlugin extends Plugin {
 
       web.wrapRes(context, context.req, context.res, context.res.end)()
     })
+
+    this.addSub('datadog:tracer:trace:finish', ({ spans }) => {
+      if (spans.length === 0 || spans[0].name !== 'http.request') {
+        return
+      }
+
+      if (!this.config.filter(new URL(spans[0].meta['http.url']).pathname)) {
+        spans.length = 0
+      }
+    })
   }
 
   configure (config) {

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -31,6 +31,7 @@ describe('Plugin', () => {
 
     afterEach(() => {
       appListener && appListener.close()
+      app = null
       return agent.close({ ritmReset: false })
     })
 
@@ -129,6 +130,38 @@ describe('Plugin', () => {
         const res = new ServerResponse(req)
 
         expect(() => res.emit('finish')).to.not.throw()
+      })
+    })
+
+    describe('with a blocklist configuration', () => {
+      beforeEach(() => {
+        return agent.load('http', { blocklist: '/health' })
+          .then(() => {
+            http = require('http')
+          })
+      })
+
+      beforeEach(done => {
+        const server = new http.Server(listener)
+        appListener = server
+          .listen(port, 'localhost', () => done())
+      })
+
+      it('should drop traces for blocklist route', done => {
+        const spy = sinon.spy(() => {})
+
+        agent
+          .use((traces) => {
+            spy()
+          })
+          .catch(done)
+
+        setTimeout(() => {
+          expect(spy).to.not.have.been.called
+          done()
+        }, 100)
+
+        axios.get(`http://localhost:${port}/health`).catch(done)
       })
     })
   })

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -2,9 +2,14 @@
 
 const log = require('./log')
 const format = require('./format')
+const {
+  channel
+} = require('../../datadog-instrumentations/src/helpers/instrument')
 
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
+
+const finishCh = channel('datadog:tracer:trace:finish')
 
 class SpanProcessor {
   constructor (exporter, prioritySampler, config) {
@@ -32,7 +37,12 @@ class SpanProcessor {
         }
       }
 
-      this._exporter.export(formatted)
+      finishCh.publish({ spans: formatted })
+
+      if (formatted.length !== 0) {
+        this._exporter.export(formatted)
+      }
+
       this._erase(trace, active)
     }
   }


### PR DESCRIPTION
### What does this PR do?
don't send traces to agent for routes on blocklist

### Motivation
to fix a regression in pkg version 2.x.x where tracer would still export traces to agent for routers that were on blocklist

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
