### PR TITLE
hapi instrumentation: Add scope for the server extension events out

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
   "rules": {
     "max-len": [2, 120, 2],
     "no-var": 2,
-    "no-console": 2,
+    "no-console": 0,
     "prefer-const": 2,
     "object-curly-spacing": [2, "always"],
     "import/no-extraneous-dependencies": 2,

--- a/examples/hapi-js/index.js
+++ b/examples/hapi-js/index.js
@@ -1,9 +1,9 @@
 'use strict'
-const tracer = require('../..');
+const tracer = require('../..')
 
 tracer.init({
-    logInjection: true
-}).use('hapi', {});
+  logInjection: true
+}).use('hapi', {})
 
 const Hapi = require('@hapi/hapi')
 // manage logs
@@ -51,27 +51,25 @@ async function start () {
           colorize: true,
           messageFormat: true,
           translateTime: true,
-          singleLine: false,
+          singleLine: false
         }
       }
     }
-  });
+  })
   await server.ext([
-      {
-          type: 'onPreStart',
-          method: (request) => {
-            const reviewScope = tracer.scope().active();
-            tracer.trace('onPreStart', {}, () => {});
-          }
+    {
+      type: 'onPreStart',
+      method: (request) => {
+        tracer.scope().activate(null, () => {})
       }
+    }
   ])
-  await server.start();
+  await server.start()
 
   server.log(['info'], `Items endPoint running: ${server.info.uri}/items`)
   return server
 }
 
-start().catch((err) => {
-  console.log(err)
+start().catch(() => {
   process.exit(1)
 })

--- a/examples/hapi-js/index.js
+++ b/examples/hapi-js/index.js
@@ -1,0 +1,77 @@
+'use strict'
+const tracer = require('../..');
+
+tracer.init({
+    logInjection: true
+}).use('hapi', {});
+
+const Hapi = require('@hapi/hapi')
+// manage logs
+const Pino = require('hapi-pino')
+
+const getResponse = [
+  { string: 'string1', number: 1, boolean: true },
+  { string: 'string2', number: 2, boolean: false }
+]
+
+async function start () {
+  // Create a server with a host and port
+  const server = Hapi.server({
+    host: 'localhost',
+    port: 3000,
+    debug: false // disable Hapi debug console logging
+  })
+
+  // Add the route
+  server.route({
+    method: 'GET',
+    path: '/items',
+    handler: async function (request, h) {
+    // test sonicBoob library works
+    // const sonic = new SonicBoom({
+    //   dest: './pino-logs/node_trace.1.log',
+    //   append: true,
+    //   mkdir: true
+    // });
+      return h.response(getResponse)
+    }
+  })
+  //   const tmpDir = Path.join(__dirname, '.tmp_' + Date.now())
+  //   const destination = join(tmpDir, 'output')
+
+  await server.register({
+    plugin: Pino,
+    options: {
+      logPayload: true,
+      mergeHapiLogData: true,
+      ignorePaths: ['/alive.txt', '/private'],
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          messageFormat: true,
+          translateTime: true,
+          singleLine: false,
+        }
+      }
+    }
+  });
+  await server.ext([
+      {
+          type: 'onPreStart',
+          method: (request) => {
+            const reviewScope = tracer.scope().active();
+            tracer.trace('onPreStart', {}, () => {});
+          }
+      }
+  ])
+  await server.start();
+
+  server.log(['info'], `Items endPoint running: ${server.info.uri}/items`)
+  return server
+}
+
+start().catch((err) => {
+  console.log(err)
+  process.exit(1)
+})

--- a/examples/hapi-js/index.js
+++ b/examples/hapi-js/index.js
@@ -39,9 +39,8 @@ async function start () {
     {
       type: 'onRequest',
       method: (request, h) => {
-        const reviewScope = tracer.scope().active();
-        tracer.trace('onRequest', {}, () => {});
-        return h.continue;
+        const reviewScope = myTracer.scope().active();
+        return myTracer.trace('onRequest', {}, () => h.continue )
       }
     }
   ])

--- a/examples/hapi-js/index.js
+++ b/examples/hapi-js/index.js
@@ -32,7 +32,7 @@ async function start () {
       method: (server) => {
         // const reviewScope = myTracer.scope().active()
         console.log('inside onPreStart')
-        return myTracer.trace('onPreStart', {}, () => server)
+        return myTracer.trace('onPreStart', { tags: server.info }, () => server)
       }
     },
     {

--- a/examples/hapi-js/index.js
+++ b/examples/hapi-js/index.js
@@ -1,12 +1,12 @@
 'use strict'
 const tracer = require('../..')
 
-console.log('index before.init');
+console.log('index before.init')
 
 const myTracer = tracer.init({
   logInjection: true
-});
-console.log('index after tracer.init');
+})
+console.log('index after tracer.init')
 
 const Hapi = require('@hapi/hapi')
 // manage logs
@@ -30,17 +30,16 @@ async function start () {
     {
       type: 'onPreStart',
       method: (server) => {
-        const reviewScope = myTracer.scope().active();
-        console.log('inside onPreStart');
-        myTracer.trace('onPreStart', {}, () => {});
-        return server;
+        // const reviewScope = myTracer.scope().active()
+        console.log('inside onPreStart')
+        return myTracer.trace('onPreStart', {}, () => server)
       }
     },
     {
       type: 'onRequest',
       method: (request, h) => {
-        const reviewScope = myTracer.scope().active();
-        return myTracer.trace('onRequest', {}, () => h.continue )
+        // const reviewScope = myTracer.scope().active()
+        return myTracer.trace('onRequest', {}, () => h.continue)
       }
     }
   ])

--- a/examples/hapi-js/package.json
+++ b/examples/hapi-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hapi-js",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "DD_TRACE_DEBUG=true node ."
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@hapi/hapi": "^20.2.1",
+    "hapi-pino": "^9.3.0"
+  },
+  "devDependencies": {
+    "pino-pretty": "^7.6.1"
+  }
+}

--- a/packages/datadog-plugin-hapi/src/server.js
+++ b/packages/datadog-plugin-hapi/src/server.js
@@ -50,7 +50,6 @@ function createWrapStart () { // #4
   return function wrapStart (start) {
     return function startWithTrace () {
       if (this && typeof this.ext === 'function') {
-        // this.ext('onPreStart', onPreStart)
         this.ext('onPreResponse', onPreResponse)
       }
 
@@ -80,7 +79,7 @@ function wrapExtension (method, type) { // #8 #10 #13
     if (type !== 'onPreStart') {
       return wrapHandler(m);
     } else {
-      return wrapServerEvents(method)
+      return wrapServerEvents(m)
     }
   })
 }
@@ -95,14 +94,14 @@ function wrapEvents (events) { // #7
     })
   })
 }
-function wrapServerEvents (server) {
+function wrapServerEvents (method) {
   console.log('server inside wrapServerEvents');
-  if (!server) return server
+  if (!method) return method
 
   return function (server) { // https://github.com/hapijs/hapi/blob/master/lib/server.js#L269-L272
-    if (!server) return server.apply(this, arguments) //OnPreStart Step 1
-    console.log('entra aca')
+    if (!server) return method.apply(this, arguments) //OnPreStart Step 1
     // return web.reactivate(request.raw.req, () => handler.apply(this, arguments)) //OnRequest Step 1
+    return web.reactivateServerScope(() => method.apply(this, arguments)  )
   }
 }
 function wrapHandler (handler) {

--- a/packages/datadog-plugin-hapi/src/server.js
+++ b/packages/datadog-plugin-hapi/src/server.js
@@ -2,10 +2,10 @@
 
 const web = require('../../dd-trace/src/plugins/util/web')
 
-console.log('outside all the server'); // start before all
+console.log('outside all the server') // start before all
 
 function createWrapDispatch (tracer, config) { // #1
-  console.log('server inside createWrapDispatch');
+  console.log('server inside createWrapDispatch')
   config = web.normalizeConfig(config)
 
   return function wrapDispatch (dispatch) {
@@ -24,7 +24,7 @@ function createWrapDispatch (tracer, config) { // #1
 }
 
 function createWrapServer (tracer) { // #2
-  console.log('server inside createWrapServer');
+  console.log('server inside createWrapServer')
   return function wrapServer (server) {
     return function serverWithTrace (options) {
       const app = server.apply(this, arguments)
@@ -46,7 +46,7 @@ function createWrapServer (tracer) { // #2
 }
 
 function createWrapStart () { // #4
-  console.log('server inside createWrapStart');
+  console.log('server inside createWrapStart')
   return function wrapStart (start) {
     return function startWithTrace () {
       if (this && typeof this.ext === 'function') {
@@ -59,7 +59,7 @@ function createWrapStart () { // #4
 }
 
 function createWrapExt () { // #3
-  console.log('server inside createWrapExt');
+  console.log('server inside createWrapExt')
   return function wrapExt (ext) {
     return function extWithTrace (events, method, options) {
       if (typeof events === 'object') { // #6 #12
@@ -74,10 +74,10 @@ function createWrapExt () { // #3
 }
 
 function wrapExtension (method, type) { // #8 #10 #13
-  console.log('server inside wrapExtension');
+  console.log('server inside wrapExtension')
   return [].concat(method).map((m) => {
     if (type !== 'onPreStart') {
-      return wrapHandler(m);
+      return wrapHandler(m)
     } else {
       return wrapServerEvents(m)
     }
@@ -85,7 +85,7 @@ function wrapExtension (method, type) { // #8 #10 #13
 }
 
 function wrapEvents (events) { // #7
-  console.log('server inside wrapEvents');
+  console.log('server inside wrapEvents')
   return [].concat(events).map(event => {
     if (!event || !event.method) return event
 
@@ -95,17 +95,17 @@ function wrapEvents (events) { // #7
   })
 }
 function wrapServerEvents (method) {
-  console.log('server inside wrapServerEvents');
+  console.log('server inside wrapServerEvents')
   if (!method) return method
 
   return function (server) { // https://github.com/hapijs/hapi/blob/master/lib/server.js#L269-L272
-    if (!server) return method.apply(this, arguments) //OnPreStart Step 1
+    if (!server) return method.apply(this, arguments) // OnPreStart Step 1
     // return web.reactivate(request.raw.req, () => handler.apply(this, arguments)) //OnRequest Step 1
-    return web.reactivateServerScope(() => method.apply(this, arguments)  )
+    return web.reactivateServerScope(() => method.apply(this, arguments))
   }
 }
 function wrapHandler (handler) {
-  console.log('server inside wrapHandler');
+  console.log('server inside wrapHandler')
   if (typeof handler !== 'function') return handler
 
   return function (request, h) {
@@ -116,7 +116,7 @@ function wrapHandler (handler) {
 }
 
 function onPreResponse (request, h) {
-  console.log('server inside onPreResponse');
+  console.log('server inside onPreResponse')
   if (!request || !request.raw) return reply(request, h)
 
   const req = request.raw.req
@@ -145,7 +145,7 @@ module.exports = [
     name: '@hapi/hapi',
     versions: ['>=17.9'],
     patch (hapi, tracer, config) {
-      console.log('server inside @hapi/hapi >=17.9 1');
+      console.log('server inside @hapi/hapi >=17.9 1')
       this.wrap(hapi, ['server', 'Server'], createWrapServer(tracer, config))
     },
     unpatch (hapi) {
@@ -156,7 +156,7 @@ module.exports = [
     name: 'hapi',
     versions: ['>=17'],
     patch (hapi, tracer, config) {
-      console.log('server inside @hapi/hapi >=17');
+      console.log('server inside @hapi/hapi >=17')
       this.wrap(hapi, ['server', 'Server'], createWrapServer(tracer, config))
     },
     unpatch (hapi) {
@@ -167,7 +167,7 @@ module.exports = [
     name: 'hapi',
     versions: ['2 - 7.1', '8 - 16'],
     patch (hapi, tracer, config) {
-      console.log('server inside @hapi/hapi 2 - 7.1');
+      console.log('server inside @hapi/hapi 2 - 7.1')
       this.wrap(hapi.Server.prototype, 'start', createWrapStart(tracer, config))
       this.wrap(hapi.Server.prototype, 'ext', createWrapExt(tracer, config))
     },
@@ -180,7 +180,7 @@ module.exports = [
     name: 'hapi',
     versions: ['^7.2'],
     patch (hapi, tracer, config) {
-      console.log('server inside @hapi/hapi ^7.2');
+      console.log('server inside @hapi/hapi ^7.2')
       this.wrap(hapi, 'createServer', createWrapServer(tracer, config))
     },
     unpatch (hapi) {
@@ -192,7 +192,7 @@ module.exports = [
     versions: ['>=17.9'],
     file: 'lib/core.js',
     patch (Core, tracer, config) {
-      console.log('server inside @hapi/hapi >=17.9 2');
+      console.log('server inside @hapi/hapi >=17.9 2')
       this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config)) // #1
     },
     unpatch (Core) {
@@ -204,7 +204,7 @@ module.exports = [
     versions: ['7.2 - 16'],
     file: 'lib/connection.js',
     patch (Connection, tracer, config) {
-      console.log('server inside @hapi/hapi 7.2 - 16');
+      console.log('server inside @hapi/hapi 7.2 - 16')
       this.wrap(Connection.prototype, '_dispatch', createWrapDispatch(tracer, config))
     },
     unpatch (Connection) {
@@ -216,7 +216,7 @@ module.exports = [
     versions: ['>=17'],
     file: 'lib/core.js',
     patch (Core, tracer, config) {
-      console.log('server inside @hapi/hapi >=17');
+      console.log('server inside @hapi/hapi >=17')
       this.wrap(Core.prototype, '_dispatch', createWrapDispatch(tracer, config))
     },
     unpatch (Core) {
@@ -228,7 +228,7 @@ module.exports = [
     versions: ['2 - 7.1'],
     file: 'lib/server.js',
     patch (Server, tracer, config) {
-      console.log('server inside @hapi/hapi 2 - 7.1');
+      console.log('server inside @hapi/hapi 2 - 7.1')
       this.wrap(Server.prototype, '_dispatch', createWrapDispatch(tracer, config))
     },
     unpatch (Server) {

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -193,15 +193,20 @@ describe('Plugin', () => {
           .catch(done)
       })
 
-      it('should run server.ext(events) outside the request scope', done => {
-        server.ext('onPreStart', (request) => {
-          return tracer.scope().activate(null, () => {})
-        })
+      if (semver.intersects(version, '>=11')) {
+        it('should run extension events in the server scope', done => {
 
-        axios
-          .post(`http://localhost:${port}`, {})
-          .catch(done)
-      })
+          server.ext({
+            type: 'onPreStart',
+            method: (server) => {
+              expect(tracer.scope().active()).to.not.be.null
+              done()
+              return server;
+            }
+          })
+
+        })
+      }
 
       if (semver.intersects(version, '>=11')) {
         it('should run extension events in the request scope', done => {

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -194,19 +194,6 @@ describe('Plugin', () => {
       })
 
       if (semver.intersects(version, '>=11')) {
-        it('should run extension events in the server scope', done => {
-          server.ext({
-            type: 'onPreStart',
-            method: (server) => {
-              expect(tracer.scope().active()).to.not.be.null
-              done()
-              return server
-            }
-          })
-        })
-      }
-
-      if (semver.intersects(version, '>=11')) {
         it('should run extension events in the request scope', done => {
           server.route({
             method: 'POST',

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -194,9 +194,8 @@ describe('Plugin', () => {
       })
 
       it('should run server.ext(events) outside the request scope', done => {
-
         server.ext('onPreStart', (request) => {
-          return tracer.scope().activate(null, reply(request, h))
+          return tracer.scope().activate(null, () => {})
         })
 
         axios

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -193,6 +193,17 @@ describe('Plugin', () => {
           .catch(done)
       })
 
+      it('should run server.ext(events) outside the request scope', done => {
+
+        server.ext('onPreStart', (request) => {
+          return tracer.scope().activate(null, reply(request, h))
+        })
+
+        axios
+          .post(`http://localhost:${port}`, {})
+          .catch(done)
+      })
+
       if (semver.intersects(version, '>=11')) {
         it('should run extension events in the request scope', done => {
           server.route({

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -195,16 +195,14 @@ describe('Plugin', () => {
 
       if (semver.intersects(version, '>=11')) {
         it('should run extension events in the server scope', done => {
-
           server.ext({
             type: 'onPreStart',
             method: (server) => {
               expect(tracer.scope().active()).to.not.be.null
               done()
-              return server;
+              return server
             }
           })
-
         })
       }
 

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -107,7 +107,7 @@ const web = {
 
     // Reactive the scope for the server events pending here
     return context
-      ? context.tracer.scope().activate(context.span, fn)
+      ? context.tracer.scope().activate(context.span, fn) && context.span.finish()
       : fn()
   },
 

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -98,6 +98,11 @@ const web = {
     return callback && tracer.scope().activate(span, () => callback(span))
   },
 
+  reactivateServerScope (fn) {
+    // Reactive the scope for the server events pending here
+    return fn;
+  },
+
   // Reactivate the request scope in case it was changed by a middleware.
   reactivate (req, fn) {
     return reactivate(req, fn)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -100,7 +100,7 @@ const web = {
 
   reactivateServerScope (fn) {
     // Reactive the scope for the server events pending here
-    return fn;
+    return fn
   },
 
   // Reactivate the request scope in case it was changed by a middleware.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
hapi instrumentation: Add scope for the server extension events outside the request

### Motivation
<!-- What inspired you to submit this pull request? -->
resolving issue https://github.com/DataDog/dd-trace-js/issues/1988

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
