### PR TITLE
[ci-visibility] Provide fallback for `env` in agentless intake

### DIFF
--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -156,7 +156,8 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       version: ENCODING_VERSION,
       metadata: {
         '*': {
-          'language': 'javascript'
+          'language': 'javascript',
+          'env': 'none'
         }
       },
       events: []


### PR DESCRIPTION
### What does this PR do?
Provide fallback for `env` in agentless intake.

### Motivation
Follow what the agent currently does.

