### PR TITLE
[ci-visibility] Code Owners for `jest`

### DIFF
--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -16,7 +16,8 @@ const {
   CI_APP_ORIGIN,
   JEST_TEST_RUNNER,
   ERROR_MESSAGE,
-  TEST_PARAMETERS
+  TEST_PARAMETERS,
+  TEST_CODE_OWNERS
 } = require('../../dd-trace/src/plugins/util/test')
 
 describe('Plugin', function () {
@@ -101,7 +102,8 @@ describe('Plugin', function () {
               [TEST_STATUS]: status,
               [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-test.js',
               [TEST_TYPE]: 'test',
-              [JEST_TEST_RUNNER]: 'jest-circus'
+              [JEST_TEST_RUNNER]: 'jest-circus',
+              [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/apm-js']) // reads from dd-trace-js
             })
             if (error) {
               expect(testSpan.meta[ERROR_MESSAGE]).to.include(error)

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -15,7 +15,8 @@ const {
   CI_APP_ORIGIN,
   TEST_FRAMEWORK_VERSION,
   JEST_TEST_RUNNER,
-  ERROR_MESSAGE
+  ERROR_MESSAGE,
+  TEST_CODE_OWNERS
 } = require('../../dd-trace/src/plugins/util/test')
 
 describe('Plugin', () => {
@@ -80,7 +81,8 @@ describe('Plugin', () => {
               [TEST_STATUS]: status,
               [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-test.js',
               [TEST_TYPE]: 'test',
-              [JEST_TEST_RUNNER]: 'jest-jasmine2'
+              [JEST_TEST_RUNNER]: 'jest-jasmine2',
+              [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/apm-js']) // reads from dd-trace-js
             })
             if (error) {
               expect(testSpan.meta[ERROR_MESSAGE]).to.include(error)


### PR DESCRIPTION
### What does this PR do?
Attempt to read `CODEOWNERS` from `jest` plugin. If it's present, read the test file path and add the owner as a test span tag.

### Motivation
Allow owners of failed tests to be notified. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

