### PR TITLE
Updating global._ddtrace in tests

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -72,6 +72,7 @@ function getWrappedEnvironment (BaseEnvironment) {
       const setNameToParams = (name, params) => { this.nameToParams[name] = params }
 
       if (event.name === 'setup') {
+        this.global._ddtrace = global._ddtrace
         shimmer.wrap(this.global.test, 'each', each => function () {
           const testParameters = getFormattedJestTestParameters(arguments)
           const eachBind = each.apply(this, arguments)
@@ -102,6 +103,7 @@ function getWrappedEnvironment (BaseEnvironment) {
       }
       if (event.name === 'test_done') {
         const asyncResource = asyncResources.get(event.test)
+        this.global._ddtrace = undefined;
         asyncResource.runInAsyncScope(() => {
           let status = 'pass'
           if (event.test.errors && event.test.errors.length) {


### PR DESCRIPTION
### What does this PR do?
Addresses #1999 

It appears the Jest Environment we create doesn't pass all global variables into the test's context. Without the global `_ddtrace` object the test thinks the tracer has not been initialized, even when it has been. This provides the global `_ddtrace` object to tests so that they can continue traces started by the jest plugin.

### Motivation
Addresses #1999 

