### PR TITLE
Make `dd-trace` available within `jest` tests 

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -50,6 +50,7 @@ function getWrappedEnvironment (BaseEnvironment) {
       super(config, context)
       this.testSuite = getTestSuitePath(context.testPath, config.rootDir)
       this.nameToParams = {}
+      this.global._ddtrace = global._ddtrace
     }
     async teardown () {
       super.teardown().finally(() => {
@@ -141,6 +142,7 @@ addHook({
   file: 'build/jasmineAsyncInstall.js'
 }, (jasmineAsyncInstallExport) => {
   return function (globalConfig, globalInput) {
+    globalInput._ddtrace = global._ddtrace
     shimmer.wrap(globalInput.jasmine.Spec.prototype, 'execute', execute => function (onComplete) {
       const asyncResource = new AsyncResource('bound-anonymous-fn')
       asyncResource.runInAsyncScope(() => {

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -61,6 +61,11 @@ describe('Plugin', function () {
     describe('jest with jest-circus', () => {
       it('should create test spans for sync, async, integration, parameterized and retried tests', (done) => {
         const tests = [
+          {
+            name: 'jest-test-suite tracer and active span are available',
+            status: 'pass',
+            extraTags: { 'test.add.stuff': 'stuff' }
+          },
           { name: 'jest-test-suite done', status: 'pass' },
           { name: 'jest-test-suite done fail', status: 'fail' },
           { name: 'jest-test-suite done fail uncaught', status: 'fail' },
@@ -88,7 +93,7 @@ describe('Plugin', function () {
           { name: 'jest-circus-test-retry can retry', status: 'pass' }
         ]
 
-        const assertionPromises = tests.map(({ name, status, error, parameters }) => {
+        const assertionPromises = tests.map(({ name, status, error, parameters, extraTags }) => {
           return agent.use(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.parent_id.toString()).to.equal('0')
@@ -103,6 +108,9 @@ describe('Plugin', function () {
               [TEST_TYPE]: 'test',
               [JEST_TEST_RUNNER]: 'jest-circus'
             })
+            if (extraTags) {
+              expect(testSpan.meta).to.contain(extraTags)
+            }
             if (error) {
               expect(testSpan.meta[ERROR_MESSAGE]).to.include(error)
             }

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -54,6 +54,11 @@ describe('Plugin', () => {
       this.timeout(60000)
       it('instruments async, sync and integration tests', function (done) {
         const tests = [
+          {
+            name: 'jest-test-suite tracer and active span are available',
+            status: 'pass',
+            extraTags: { 'test.add.stuff': 'stuff' }
+          },
           { name: 'jest-test-suite done', status: 'pass' },
           { name: 'jest-test-suite done fail', status: 'fail' },
           { name: 'jest-test-suite done fail uncaught', status: 'fail' },
@@ -67,7 +72,7 @@ describe('Plugin', () => {
           { name: 'jest-test-suite skips', status: 'skip' },
           { name: 'jest-test-suite skips todo', status: 'skip' }
         ]
-        const assertionPromises = tests.map(({ name, status, error }) => {
+        const assertionPromises = tests.map(({ name, status, error, extraTags }) => {
           return agent.use(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.parent_id.toString()).to.equal('0')
@@ -82,6 +87,9 @@ describe('Plugin', () => {
               [TEST_TYPE]: 'test',
               [JEST_TEST_RUNNER]: 'jest-jasmine2'
             })
+            if (extraTags) {
+              expect(testSpan.meta).to.contain(extraTags)
+            }
             if (error) {
               expect(testSpan.meta[ERROR_MESSAGE]).to.include(error)
             }

--- a/packages/datadog-plugin-jest/test/jest-test.js
+++ b/packages/datadog-plugin-jest/test/jest-test.js
@@ -1,6 +1,13 @@
 const http = require('http')
+const tracer = require('dd-trace')
 
 describe('jest-test-suite', () => {
+  it('tracer and active span are available', () => {
+    expect(global._ddtrace).not.toEqual(undefined)
+    const testSpan = tracer.scope().active()
+    expect(testSpan).not.toEqual(null)
+    testSpan.setTag('test.add.stuff', 'stuff')
+  })
   // eslint-disable-next-line
   jest.setTimeout(200)
   it('done', (done) => {


### PR DESCRIPTION
### What does this PR do?
Make `'dd-trace'` available within `jest` tests. It was not available because tests run in a different global context. 

### Motivation
Inspired by #2000 - Thanks @mdbenjam !
Fixes #1999 

### Plugin Checklist
- [x] Unit tests.
