### PR TITLE
fix fs spans never finishing when a stream is not consumed

### DIFF
--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -60,6 +60,7 @@ function createWrapCreateReadStream (config, tracer) {
       const tags = makeFSFlagTags('ReadStream', path, options, 'r', config, tracer)
       return tracer.trace('fs.operation', { tags, orphanable }, (span, done) => {
         const stream = createReadStream.apply(this, arguments)
+        stream.once('close', done)
         stream.once('end', done)
         stream.once('error', done)
         return stream
@@ -74,6 +75,7 @@ function createWrapCreateWriteStream (config, tracer) {
       const tags = makeFSFlagTags('WriteStream', path, options, 'w', config, tracer)
       return tracer.trace('fs.operation', { tags, orphanable }, (span, done) => {
         const stream = createWriteStream.apply(this, arguments)
+        stream.once('close', done)
         stream.once('finish', done)
         stream.once('error', done)
         return stream

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -598,6 +598,17 @@ describe('Plugin', () => {
           fs.createReadStream(__filename).on('error', done).resume()
         })
 
+        it('should be instrumented when closed', (done) => {
+          expectOneSpan(agent, done, {
+            resource: 'ReadStream',
+            meta: {
+              'file.path': __filename,
+              'file.flag': 'r+'
+            }
+          })
+          fs.createReadStream(__filename, { flags: 'r+' }).on('error', done).destroy()
+        })
+
         it('should be instrumented with flags', (done) => {
           expectOneSpan(agent, done, {
             resource: 'ReadStream',
@@ -636,6 +647,18 @@ describe('Plugin', () => {
           })
 
           fs.createWriteStream(filename).on('error', done).end()
+        })
+
+        it('should be instrumented when closed', (done) => {
+          expectOneSpan(agent, done, {
+            resource: 'WriteStream',
+            meta: {
+              'file.path': filename,
+              'file.flag': 'w'
+            }
+          })
+
+          fs.createWriteStream(filename).on('error', done).destroy()
         })
 
         it('should be instrumented with flags', (done) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `fs` spans never finishing when a stream is not consumed.

### Motivation
<!-- What inspired you to submit this pull request? -->

This would prevent traces to ever be sent.