### PR TITLE
[ci-visibility] Fix `jest` instrumentation after latest major release 

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -124,7 +124,9 @@ function getWrappedEnvironment (BaseEnvironment) {
 function getTestEnvironment (pkg) {
   if (pkg.default) {
     const wrappedTestEnvironment = getWrappedEnvironment(pkg.default)
-    return { ...pkg, TestEnvironment: wrappedTestEnvironment, default: wrappedTestEnvironment }
+    pkg.default = wrappedTestEnvironment
+    pkg.TestEnvironment = wrappedTestEnvironment
+    return pkg
   }
   return getWrappedEnvironment(pkg)
 }

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -64,13 +64,7 @@ function getWrappedEnvironment (BaseEnvironment) {
         await super.handleTestEvent(event, state)
       }
 
-      let context
-      if (this.getVmContext) {
-        context = this.getVmContext()
-      } else {
-        context = this.context
-      }
-
+      const globalExpect = this.global.expect
       const setNameToParams = (name, params) => { this.nameToParams[name] = params }
 
       if (event.name === 'setup') {
@@ -93,7 +87,7 @@ function getWrappedEnvironment (BaseEnvironment) {
         asyncResources.set(event.test, asyncResource)
         asyncResource.runInAsyncScope(() => {
           testStartCh.publish({
-            name: context.expect.getState().currentTestName,
+            name: globalExpect.getState().currentTestName,
             suite: this.testSuite,
             runner: 'jest-circus',
             testParameters
@@ -118,7 +112,7 @@ function getWrappedEnvironment (BaseEnvironment) {
       }
       if (event.name === 'test_skip' || event.name === 'test_todo') {
         testSkippedCh.publish({
-          name: context.expect.getState().currentTestName,
+          name: globalExpect.getState().currentTestName,
           suite: this.testSuite,
           runner: 'jest-circus'
         })

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -121,25 +121,23 @@ function getWrappedEnvironment (BaseEnvironment) {
   }
 }
 
+function getTestEnvironment (pkg) {
+  if (pkg.default) {
+    const wrappedTestEnvironment = getWrappedEnvironment(pkg.default)
+    return { ...pkg, TestEnvironment: wrappedTestEnvironment, default: wrappedTestEnvironment }
+  }
+  return getWrappedEnvironment(pkg)
+}
+
 addHook({
   name: 'jest-environment-node',
   versions: ['>=24.8.0']
-}, (pkg) => {
-  if (pkg.default) {
-    return getWrappedEnvironment(pkg.default)
-  }
-  return getWrappedEnvironment(pkg)
-})
+}, getTestEnvironment)
 
 addHook({
   name: 'jest-environment-jsdom',
   versions: ['>=24.8.0']
-}, (pkg) => {
-  if (pkg.default) {
-    return getWrappedEnvironment(pkg.default)
-  }
-  return getWrappedEnvironment(pkg)
-})
+}, getTestEnvironment)
 
 addHook({
   name: 'jest-jasmine2',

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -48,7 +48,8 @@ function getWrappedEnvironment (BaseEnvironment) {
   return class DatadogEnvironment extends BaseEnvironment {
     constructor (config, context) {
       super(config, context)
-      this.testSuite = getTestSuitePath(context.testPath, config.rootDir)
+      const rootDir = config.globalConfig ? config.globalConfig.rootDir : config.rootDir
+      this.testSuite = getTestSuitePath(context.testPath, rootDir)
       this.nameToParams = {}
       this.global._ddtrace = global._ddtrace
     }
@@ -129,12 +130,22 @@ function getWrappedEnvironment (BaseEnvironment) {
 addHook({
   name: 'jest-environment-node',
   versions: ['>=24.8.0']
-}, getWrappedEnvironment)
+}, (pkg) => {
+  if (pkg.default) {
+    return getWrappedEnvironment(pkg.default)
+  }
+  return getWrappedEnvironment(pkg)
+})
 
 addHook({
   name: 'jest-environment-jsdom',
   versions: ['>=24.8.0']
-}, getWrappedEnvironment)
+}, (pkg) => {
+  if (pkg.default) {
+    return getWrappedEnvironment(pkg.default)
+  }
+  return getWrappedEnvironment(pkg)
+})
 
 addHook({
   name: 'jest-jasmine2',

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -26,7 +26,7 @@ describe('Plugin', function () {
 
   this.timeout(20000)
 
-  withVersions('jest', ['jest-environment-node'], (version) => {
+  withVersions('jest', ['jest-environment-node', 'jest-environment-jsdom'], (version, moduleName) => {
     afterEach(() => {
       const jestTestFile = fs.readdirSync(__dirname).filter(name => name.startsWith('jest-'))
       jestTestFile.forEach((testFile) => {
@@ -43,6 +43,7 @@ describe('Plugin', function () {
         .reply(200, 'OK')
 
       return agent.load(['jest', 'http'], { service: 'test' }).then(() => {
+        global.__libraryName__ = moduleName
         global.__libraryVersion__ = version
         jestExecutable = require(`../../../versions/jest@${version}`).get()
 

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -26,7 +26,7 @@ describe('Plugin', function () {
 
   this.timeout(20000)
 
-  withVersions('jest', ['jest-environment-node', 'jest-environment-jsdom'], (version) => {
+  withVersions('jest', ['jest-environment-node'], (version) => {
     afterEach(() => {
       const jestTestFile = fs.readdirSync(__dirname).filter(name => name.startsWith('jest-'))
       jestTestFile.forEach((testFile) => {

--- a/packages/datadog-plugin-jest/test/env.js
+++ b/packages/datadog-plugin-jest/test/env.js
@@ -2,4 +2,4 @@ require('../../../ci/jest/env')
 
 const node = require(`../../../versions/jest-environment-node@${global.__libraryVersion__}`).get()
 
-module.exports = node
+module.exports = node.default ? node.default : node

--- a/packages/datadog-plugin-jest/test/env.js
+++ b/packages/datadog-plugin-jest/test/env.js
@@ -1,5 +1,5 @@
 require('../../../ci/jest/env')
 
-const node = require(`../../../versions/jest-environment-node@${global.__libraryVersion__}`).get()
+const env = require(`../../../versions/${global.__libraryName__}@${global.__libraryVersion__}`).get()
 
-module.exports = node.default ? node.default : node
+module.exports = env.default ? env.default : env


### PR DESCRIPTION
### What does this PR do?
Fix `jest` instrumentation. 

Context: https://jestjs.io/docs/configuration#testenvironment-string (note that `jest-environment-node` import now requires a `.default` suffix). 

### Motivation
Fix `jest@28` 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
