### PR TITLE
fix web requests in blocklist reaching the agent

### DIFF
--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -135,7 +135,7 @@ describe('Plugin', () => {
 
     describe('with a blocklist configuration', () => {
       beforeEach(() => {
-        return agent.load('http', { blocklist: '/health' })
+        return agent.load('http', { client: false, blocklist: '/health' })
           .then(() => {
             http = require('http')
           })

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -69,6 +69,17 @@ const web = {
     context.span = span
     context.res = res
 
+    if (!config.filter(req.url)) {
+      span.setTag(MANUAL_DROP, true)
+      span.context()._trace.isRecording = false
+    }
+
+    if (config.service) {
+      span.setTag(SERVICE_NAME, config.service)
+    }
+
+    analyticsSampler.sample(span, config.measured, true)
+
     return span
   },
   wrap (req) {
@@ -82,16 +93,6 @@ const web = {
   // Start a span and activate a scope for a request.
   instrument (tracer, config, req, res, name, callback) {
     const span = this.startSpan(tracer, config, req, res, name)
-
-    if (!config.filter(req.url)) {
-      span.setTag(MANUAL_DROP, true)
-    }
-
-    if (config.service) {
-      span.setTag(SERVICE_NAME, config.service)
-    }
-
-    analyticsSampler.sample(span, config.measured, true)
 
     this.wrap(req)
 

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -2,14 +2,9 @@
 
 const log = require('./log')
 const format = require('./format')
-const {
-  channel
-} = require('../../datadog-instrumentations/src/helpers/instrument')
 
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
-
-const finishCh = channel('datadog:tracer:trace:finish')
 
 class SpanProcessor {
   constructor (exporter, prioritySampler, config) {
@@ -37,9 +32,7 @@ class SpanProcessor {
         }
       }
 
-      finishCh.publish({ spans: formatted })
-
-      if (formatted.length !== 0) {
+      if (formatted.length !== 0 && trace.isRecording !== false) {
         this._exporter.export(formatted)
       }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix web requests in blocklist reaching the agent.

### Motivation
<!-- What inspired you to submit this pull request? -->

Using an event when the trace is finished means that any new span created afterwards would be traced as normal. Using a property on the trace instead ensures that all chunks will always be dropped.