### PR TITLE
fix fs plugin adding error tags

### DIFF
--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -106,10 +106,7 @@ describe('Plugin', () => {
               error: 0,
               meta: {
                 'file.flag': 'r',
-                'file.path': filename,
-                'error.msg': err.message,
-                'error.type': err.name,
-                'error.stack': err.stack
+                'file.path': filename
               }
             })
           })
@@ -162,10 +159,7 @@ describe('Plugin', () => {
                 error: 0,
                 meta: {
                   'file.flag': 'r',
-                  'file.path': filename,
-                  'error.msg': err.message,
-                  'error.type': err.name,
-                  'error.stack': err.stack
+                  'file.path': filename
                 }
               })
             })
@@ -216,10 +210,7 @@ describe('Plugin', () => {
               error: 0,
               meta: {
                 'file.flag': 'r',
-                'file.path': filename,
-                'error.msg': err.message,
-                'error.type': err.name,
-                'error.stack': err.stack
+                'file.path': filename
               }
             })
           }
@@ -1827,12 +1818,7 @@ function testHandleErrors (fs, name, tested, args, agent) {
     tested(fs, args, null, err => {
       expectOneSpan(agent, done, {
         resource: name,
-        error: 0,
-        meta: {
-          'error.type': err.name,
-          'error.msg': err.message,
-          'error.stack': err.stack
-        }
+        error: 0
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `fs` plugin adding error tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

Errors shouldn't be sent for `fs` because it uses errors to check things like if a file exists.