### PR TITLE
Fix http server async-end when context doesn't have response

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -47,7 +47,7 @@ class HttpServerPlugin extends Plugin {
     this.addSub('apm:http:server:request:async-end', ({ req }) => {
       const context = web.getContext(req)
 
-      if (!context) return // Not created by a http.Server instance.
+      if (!context || !context.res) return // Not created by a http.Server instance.
 
       web.wrapRes(context, context.req, context.res, context.res.end)()
     })


### PR DESCRIPTION
### What does this PR do?
Fix http server async-end when context doesn't have response

### Motivation
This bug is causing process crashes