### PR TITLE
require semver labels

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "semver-patch, semver-minor, semver-major"


### PR DESCRIPTION
### What does this PR do?
Adds an Action that requires the presence of a semver label.
### Motivation
<!-- What inspired you to submit this pull request? -->
By blocking merges on this, this forces the decision to be made at PR time, instead of retroactively at release time.

