### PR TITLE
Correct profiler naming

### DIFF
--- a/benchmark/sirun/goal.json
+++ b/benchmark/sirun/goal.json
@@ -1030,7 +1030,7 @@
         }
       }
     },
-    "with-heap-profiler": {
+    "with-space-profiler": {
       "instructions": 336410425,
       "nodeVersion": "16.12.0",
       "summary": {

--- a/benchmark/sirun/profiler/index.js
+++ b/benchmark/sirun/profiler/index.js
@@ -2,19 +2,19 @@
 
 const {
   profiler,
-  CpuProfiler,
-  HeapProfiler
+  WallProfiler,
+  SpaceProfiler
 } = require('../../../packages/dd-trace/src/profiling')
 
 const { PROFILER } = process.env
 
 const profilers = []
 
-if (PROFILER === 'cpu' || PROFILER === 'all') {
-  profilers.push(new CpuProfiler())
+if (PROFILER === 'wall' || PROFILER === 'all') {
+  profilers.push(new WallProfiler())
 }
-if (PROFILER === 'heap' || PROFILER === 'all') {
-  profilers.push(new HeapProfiler())
+if (PROFILER === 'space' || PROFILER === 'all') {
+  profilers.push(new SpaceProfiler())
 }
 
 const exporters = [{

--- a/benchmark/sirun/profiler/meta.json
+++ b/benchmark/sirun/profiler/meta.json
@@ -11,12 +11,12 @@
     },
     "with-cpu-profiler": {
       "env": {
-        "PROFILER": "cpu"
+        "PROFILER": "wall"
       }
     },
-    "with-heap-profiler": {
+    "with-space-profiler": {
       "env": {
-        "PROFILER": "heap"
+        "PROFILER": "space"
       }
     },
     "with-all-profilers": {

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -6,8 +6,8 @@ const { URL } = require('url')
 const { AgentExporter } = require('./exporters/agent')
 const { FileExporter } = require('./exporters/file')
 const { ConsoleLogger } = require('./loggers/console')
-const CpuProfiler = require('./profilers/cpu')
-const HeapProfiler = require('./profilers/heap')
+const WallProfiler = require('./profilers/wall')
+const SpaceProfiler = require('./profilers/space')
 const { tagger } = require('./tagger')
 
 const {
@@ -64,8 +64,8 @@ class Config {
     ], this)
 
     const profilers = coalesce(options.profilers, DD_PROFILING_PROFILERS, [
-      new CpuProfiler(),
-      new HeapProfiler()
+      new WallProfiler(),
+      new SpaceProfiler()
     ])
 
     this.profilers = ensureProfilers(profilers, this)
@@ -100,10 +100,10 @@ function ensureExporters (exporters, options) {
 
 function getProfiler (name, options) {
   switch (name) {
-    case 'cpu':
-      return new CpuProfiler(options)
-    case 'heap':
-      return new HeapProfiler(options)
+    case 'wall':
+      return new WallProfiler(options)
+    case 'space':
+      return new SpaceProfiler(options)
     default:
       options.logger.error(`Unknown profiler "${name}"`)
   }

--- a/packages/dd-trace/src/profiling/index.js
+++ b/packages/dd-trace/src/profiling/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const { Profiler } = require('./profiler')
-const CpuProfiler = require('./profilers/cpu')
-const HeapProfiler = require('./profilers/heap')
+const WallProfiler = require('./profilers/wall')
+const SpaceProfiler = require('./profilers/space')
 const { AgentExporter } = require('./exporters/agent')
 const { FileExporter } = require('./exporters/file')
 const { ConsoleLogger } = require('./loggers/console')
@@ -13,7 +13,7 @@ module.exports = {
   profiler,
   AgentExporter,
   FileExporter,
-  CpuProfiler,
-  HeapProfiler,
+  WallProfiler,
+  SpaceProfiler,
   ConsoleLogger
 }

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -1,6 +1,6 @@
 'use strict'
 
-class NativeHeapProfiler {
+class NativeSpaceProfiler {
   constructor (options = {}) {
     this.type = 'space'
     this._samplingInterval = options.samplingInterval || 512 * 1024
@@ -27,4 +27,4 @@ class NativeHeapProfiler {
   }
 }
 
-module.exports = NativeHeapProfiler
+module.exports = NativeSpaceProfiler

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -1,6 +1,6 @@
 'use strict'
 
-class NativeCpuProfiler {
+class NativeWallProfiler {
   constructor (options = {}) {
     this.type = 'wall'
     this._samplingInterval = options.samplingInterval || 1e6 / 99 // 99hz
@@ -43,4 +43,4 @@ class NativeCpuProfiler {
   }
 }
 
-module.exports = NativeCpuProfiler
+module.exports = NativeWallProfiler

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -4,8 +4,8 @@ const { expect } = require('chai')
 const os = require('os')
 const { AgentExporter } = require('../../src/profiling/exporters/agent')
 const { FileExporter } = require('../../src/profiling/exporters/file')
-const CpuProfiler = require('../../src/profiling/profilers/cpu')
-const HeapProfiler = require('../../src/profiling/profilers/heap')
+const WallProfiler = require('../../src/profiling/profilers/wall')
+const SpaceProfiler = require('../../src/profiling/profilers/space')
 const { ConsoleLogger } = require('../../src/profiling/loggers/console')
 
 describe('config', () => {
@@ -31,8 +31,8 @@ describe('config', () => {
 
     expect(config.logger).to.be.an.instanceof(ConsoleLogger)
     expect(config.exporters[0]).to.be.an.instanceof(AgentExporter)
-    expect(config.profilers[0]).to.be.an.instanceof(CpuProfiler)
-    expect(config.profilers[1]).to.be.an.instanceof(HeapProfiler)
+    expect(config.profilers[0]).to.be.an.instanceof(WallProfiler)
+    expect(config.profilers[1]).to.be.an.instanceof(SpaceProfiler)
   })
 
   it('should support configuration options', () => {
@@ -47,7 +47,7 @@ describe('config', () => {
         error () { }
       },
       exporters: 'agent,file',
-      profilers: 'cpu',
+      profilers: 'wall',
       url: 'http://localhost:1234/'
     }
 
@@ -69,7 +69,7 @@ describe('config', () => {
     expect(config.exporters[1]).to.be.an.instanceof(FileExporter)
     expect(config.profilers).to.be.an('array')
     expect(config.profilers.length).to.equal(1)
-    expect(config.profilers[0]).to.be.an.instanceOf(CpuProfiler)
+    expect(config.profilers[0]).to.be.an.instanceOf(WallProfiler)
   })
 
   it('should filter out invalid profilers', () => {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -10,8 +10,8 @@ const { request } = require('http')
 const getPort = require('get-port')
 const proxyquire = require('proxyquire')
 const { gunzipSync } = require('zlib')
-const CpuProfiler = require('../../../src/profiling/profilers/cpu')
-const HeapProfiler = require('../../../src/profiling/profilers/heap')
+const WallProfiler = require('../../../src/profiling/profilers/wall')
+const SpaceProfiler = require('../../../src/profiling/profilers/space')
 const logger = require('../../../src/log')
 const { perftools } = require('@datadog/pprof/proto/profile')
 const semver = require('semver')
@@ -31,7 +31,7 @@ function wait (ms) {
 
 async function createProfile (periodType) {
   const [ type ] = periodType
-  const profiler = type === 'wall' ? new CpuProfiler() : new HeapProfiler()
+  const profiler = type === 'wall' ? new WallProfiler() : new SpaceProfiler()
   profiler.start({
     // Throw errors in test rather than logging them
     logger: {
@@ -75,28 +75,28 @@ describe('exporters/agent', () => {
       'format:pprof',
       'runtime-id:a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6'
     ])
-    expect(req.body).to.have.deep.property('types', ['cpu', 'heap'])
+    expect(req.body).to.have.deep.property('types', ['wall', 'space'])
     expect(req.body).to.have.property('recording-start', start.toISOString())
     expect(req.body).to.have.property('recording-end', end.toISOString())
 
     expect(req.files[0]).to.have.property('fieldname', 'data[0]')
-    expect(req.files[0]).to.have.property('originalname', 'cpu.pb.gz')
+    expect(req.files[0]).to.have.property('originalname', 'wall.pb.gz')
     expect(req.files[0]).to.have.property('mimetype', 'application/octet-stream')
     expect(req.files[0]).to.have.property('size', req.files[0].buffer.length)
 
     expect(req.files[1]).to.have.property('fieldname', 'data[1]')
-    expect(req.files[1]).to.have.property('originalname', 'heap.pb.gz')
+    expect(req.files[1]).to.have.property('originalname', 'space.pb.gz')
     expect(req.files[1]).to.have.property('mimetype', 'application/octet-stream')
     expect(req.files[1]).to.have.property('size', req.files[1].buffer.length)
 
-    const cpuProfile = decode(gunzipSync(req.files[0].buffer))
-    const heapProfile = decode(gunzipSync(req.files[1].buffer))
+    const wallProfile = decode(gunzipSync(req.files[0].buffer))
+    const spaceProfile = decode(gunzipSync(req.files[1].buffer))
 
-    expect(cpuProfile).to.be.a.profile
-    expect(heapProfile).to.be.a.profile
+    expect(wallProfile).to.be.a.profile
+    expect(spaceProfile).to.be.a.profile
 
-    expect(cpuProfile).to.deep.equal(decode(gunzipSync(profiles.cpu)))
-    expect(heapProfile).to.deep.equal(decode(gunzipSync(profiles.heap)))
+    expect(wallProfile).to.deep.equal(decode(gunzipSync(profiles.wall)))
+    expect(spaceProfile).to.deep.equal(decode(gunzipSync(profiles.space)))
   }
 
   beforeEach(() => {
@@ -141,14 +141,14 @@ describe('exporters/agent', () => {
         'runtime-id': 'a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6'
       }
 
-      const [ cpu, heap ] = await Promise.all([
+      const [ wall, space ] = await Promise.all([
         createProfile(['wall', 'microseconds']),
         createProfile(['space', 'bytes'])
       ])
 
       const profiles = {
-        cpu,
-        heap
+        wall,
+        space
       }
 
       await new Promise((resolve, reject) => {
@@ -181,14 +181,14 @@ describe('exporters/agent', () => {
         'runtime-id': 'a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6'
       }
 
-      const [ cpu, heap ] = await Promise.all([
+      const [ wall, space ] = await Promise.all([
         createProfile(['wall', 'microseconds']),
         createProfile(['space', 'bytes'])
       ])
 
       const profiles = {
-        cpu,
-        heap
+        wall,
+        space
       }
 
       let attempt = 0
@@ -239,8 +239,8 @@ describe('exporters/agent', () => {
       this.timeout(10000)
       const expectedLogs = [
         /^Building agent export report: (\n {2}[a-z-_]+(\[\])?: [a-z0-9-TZ:.]+)+$/m,
-        /^Adding cpu profile to agent export:( [0-9a-f]{2})+$/,
-        /^Adding heap profile to agent export:( [0-9a-f]{2})+$/,
+        /^Adding wall profile to agent export:( [0-9a-f]{2})+$/,
+        /^Adding space profile to agent export:( [0-9a-f]{2})+$/,
         /^Submitting profiler agent report attempt #1 to:/i,
         /^Error from the agent: HTTP Error 400$/,
         /^Submitting profiler agent report attempt #2 to:/i,
@@ -272,14 +272,14 @@ describe('exporters/agent', () => {
       const end = new Date()
       const tags = { foo: 'bar' }
 
-      const [ cpu, heap ] = await Promise.all([
+      const [ wall, space ] = await Promise.all([
         createProfile(['wall', 'microseconds']),
         createProfile(['space', 'bytes'])
       ])
 
       const profiles = {
-        cpu,
-        heap
+        wall,
+        space
       }
 
       let tries = 0
@@ -325,14 +325,14 @@ describe('exporters/agent', () => {
       const end = new Date()
       const tags = { foo: 'bar' }
 
-      const [ cpu, heap ] = await Promise.all([
+      const [ wall, space ] = await Promise.all([
         createProfile(['wall', 'microseconds']),
         createProfile(['space', 'bytes'])
       ])
 
       const profiles = {
-        cpu,
-        heap
+        wall,
+        space
       }
 
       await new Promise((resolve, reject) => {
@@ -351,28 +351,28 @@ describe('exporters/agent', () => {
               'format:pprof',
               'foo:bar'
             ])
-            expect(req.body).to.have.deep.property('types', ['cpu', 'heap'])
+            expect(req.body).to.have.deep.property('types', ['wall', 'space'])
             expect(req.body).to.have.property('recording-start', start.toISOString())
             expect(req.body).to.have.property('recording-end', end.toISOString())
 
             expect(req.files[0]).to.have.property('fieldname', 'data[0]')
-            expect(req.files[0]).to.have.property('originalname', 'cpu.pb.gz')
+            expect(req.files[0]).to.have.property('originalname', 'wall.pb.gz')
             expect(req.files[0]).to.have.property('mimetype', 'application/octet-stream')
             expect(req.files[0]).to.have.property('size', req.files[0].buffer.length)
 
             expect(req.files[1]).to.have.property('fieldname', 'data[1]')
-            expect(req.files[1]).to.have.property('originalname', 'heap.pb.gz')
+            expect(req.files[1]).to.have.property('originalname', 'space.pb.gz')
             expect(req.files[1]).to.have.property('mimetype', 'application/octet-stream')
             expect(req.files[1]).to.have.property('size', req.files[1].buffer.length)
 
-            const cpuProfile = decode(gunzipSync(req.files[0].buffer))
-            const heapProfile = decode(gunzipSync(req.files[1].buffer))
+            const wallProfile = decode(gunzipSync(req.files[0].buffer))
+            const spaceProfile = decode(gunzipSync(req.files[1].buffer))
 
-            expect(cpuProfile).to.be.a.profile
-            expect(heapProfile).to.be.a.profile
+            expect(wallProfile).to.be.a.profile
+            expect(spaceProfile).to.be.a.profile
 
-            expect(cpuProfile).to.deep.equal(decode(gunzipSync(profiles.cpu)))
-            expect(heapProfile).to.deep.equal(decode(gunzipSync(profiles.heap)))
+            expect(wallProfile).to.deep.equal(decode(gunzipSync(profiles.wall)))
+            expect(spaceProfile).to.deep.equal(decode(gunzipSync(profiles.space)))
 
             resolve()
           } catch (e) {

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -5,17 +5,20 @@ const sinon = require('sinon')
 
 const pprof = require('@datadog/pprof')
 
+const SpaceProfiler = require('../../src/profiling/profilers/space')
+const WallProfiler = require('../../src/profiling/profilers/wall')
+
 const INTERVAL = 65 * 1000
 
 describe('profiler', () => {
   let Profiler
   let profiler
-  let cpuProfiler
-  let cpuProfile
-  let cpuProfilePromise
-  let heapProfiler
-  let heapProfile
-  let heapProfilePromise
+  let wallProfiler
+  let wallProfile
+  let wallProfilePromise
+  let spaceProfiler
+  let spaceProfile
+  let spaceProfilePromise
   let clock
   let exporter
   let exporterPromise
@@ -26,8 +29,8 @@ describe('profiler', () => {
 
   function waitForExport () {
     return Promise.all([
-      cpuProfilePromise,
-      heapProfilePromise,
+      wallProfilePromise,
+      spaceProfilePromise,
       exporterPromise
     // After all profiles resolve, need to wait another microtask
     // tick until _collect method calls _submit to begin the export.
@@ -47,29 +50,29 @@ describe('profiler', () => {
       error: sinon.spy()
     }
 
-    cpuProfile = {}
-    cpuProfilePromise = Promise.resolve(cpuProfile)
-    cpuProfiler = {
-      type: 'cpu',
+    wallProfile = {}
+    wallProfilePromise = Promise.resolve(wallProfile)
+    wallProfiler = {
+      type: 'wall',
       start: sinon.stub(),
       stop: sinon.stub(),
       profile: sinon.stub().returns('profile'),
-      encode: sinon.stub().returns(cpuProfilePromise)
+      encode: sinon.stub().returns(wallProfilePromise)
     }
 
-    heapProfile = {}
-    heapProfilePromise = Promise.resolve(heapProfile)
-    heapProfiler = {
-      type: 'heap',
+    spaceProfile = {}
+    spaceProfilePromise = Promise.resolve(spaceProfile)
+    spaceProfiler = {
+      type: 'space',
       start: sinon.stub(),
       stop: sinon.stub(),
       profile: sinon.stub().returns('profile'),
-      encode: sinon.stub().returns(heapProfilePromise)
+      encode: sinon.stub().returns(spaceProfilePromise)
     }
 
     logger = consoleLogger
     exporters = [exporter]
-    profilers = [cpuProfiler, heapProfiler]
+    profilers = [wallProfiler, spaceProfiler]
 
     Profiler = require('../../src/profiling/profiler').Profiler
 
@@ -84,49 +87,82 @@ describe('profiler', () => {
   it('should start the internal time profilers', async () => {
     await profiler._start({ profilers, exporters })
 
-    sinon.assert.calledOnce(cpuProfiler.start)
-    sinon.assert.calledOnce(heapProfiler.start)
+    sinon.assert.calledOnce(wallProfiler.start)
+    sinon.assert.calledOnce(spaceProfiler.start)
   })
 
   it('should start only once', async () => {
     await profiler._start({ profilers, exporters })
     await profiler._start({ profilers, exporters })
 
-    sinon.assert.calledOnce(cpuProfiler.start)
-    sinon.assert.calledOnce(heapProfiler.start)
+    sinon.assert.calledOnce(wallProfiler.start)
+    sinon.assert.calledOnce(spaceProfiler.start)
   })
 
-  it('should allow configuring exporters by string name', async () => {
-    await profiler._start({ exporters: 'agent' })
-    expect(profiler._config.exporters[0].export).to.be.a('function')
+  it('should allow configuring exporters by string or string array', async () => {
+    const checks = [
+      'agent',
+      ['agent']
+    ]
+
+    for (const exporters of checks) {
+      await profiler._start({
+        sourceMap: false,
+        exporters
+      })
+
+      expect(profiler._config.exporters[0].export).to.be.a('function')
+
+      profiler.stop()
+    }
   })
 
-  it('should allow configuring exporters by string array', async () => {
-    await profiler._start({ exporters: ['agent'] })
-    expect(profiler._config.exporters[0].export).to.be.a('function')
+  it('should allow configuring profilers by string or string arrays', async () => {
+    const checks = [
+      ['space', SpaceProfiler],
+      ['wall', WallProfiler],
+      ['space,wall', SpaceProfiler, WallProfiler],
+      ['wall,space', WallProfiler, SpaceProfiler],
+      [['space', 'wall'], SpaceProfiler, WallProfiler],
+      [['wall', 'space'], WallProfiler, SpaceProfiler]
+    ]
+
+    for (const [profilers, ...expected] of checks) {
+      await profiler._start({
+        sourceMap: false,
+        profilers
+      })
+
+      expect(profiler._config.profilers.length).to.equal(expected.length)
+      for (let i = 0; i < expected.length; i++) {
+        expect(profiler._config.profilers[i]).to.be.instanceOf(expected[i])
+      }
+
+      profiler.stop()
+    }
   })
 
   it('should stop the internal profilers', async () => {
     await profiler._start({ profilers, exporters })
     profiler.stop()
 
-    sinon.assert.calledOnce(cpuProfiler.stop)
-    sinon.assert.calledOnce(heapProfiler.stop)
+    sinon.assert.calledOnce(wallProfiler.stop)
+    sinon.assert.calledOnce(spaceProfiler.stop)
   })
 
   it('should stop when starting failed', async () => {
-    cpuProfiler.start.throws()
+    wallProfiler.start.throws()
 
     await profiler._start({ profilers, exporters, logger })
 
-    sinon.assert.calledOnce(cpuProfiler.stop)
-    sinon.assert.calledOnce(heapProfiler.stop)
+    sinon.assert.calledOnce(wallProfiler.stop)
+    sinon.assert.calledOnce(spaceProfiler.stop)
     sinon.assert.calledOnce(consoleLogger.error)
   })
 
   it('should stop when capturing failed', async () => {
     const rejected = Promise.reject(new Error('boom'))
-    cpuProfiler.encode.returns(rejected)
+    wallProfiler.encode.returns(rejected)
 
     await profiler._start({ profilers, exporters, logger })
 
@@ -134,8 +170,8 @@ describe('profiler', () => {
 
     await rejected.catch(() => {})
 
-    sinon.assert.calledOnce(cpuProfiler.stop)
-    sinon.assert.calledOnce(heapProfiler.stop)
+    sinon.assert.calledOnce(wallProfiler.stop)
+    sinon.assert.calledOnce(spaceProfiler.stop)
     sinon.assert.calledOnce(consoleLogger.error)
   })
 
@@ -158,8 +194,8 @@ describe('profiler', () => {
 
     const { profiles, start, end, tags } = exporter.export.args[0][0]
 
-    expect(profiles).to.have.property('cpu', cpuProfile)
-    expect(profiles).to.have.property('heap', heapProfile)
+    expect(profiles).to.have.property('wall', wallProfile)
+    expect(profiles).to.have.property('space', spaceProfile)
     expect(start).to.be.a('date')
     expect(end).to.be.a('date')
     expect(end - start).to.equal(65000)
@@ -169,8 +205,8 @@ describe('profiler', () => {
   it('should not start when disabled', async () => {
     await profiler._start({ profilers, exporters, enabled: false })
 
-    sinon.assert.notCalled(cpuProfiler.start)
-    sinon.assert.notCalled(heapProfiler.start)
+    sinon.assert.notCalled(wallProfiler.start)
+    sinon.assert.notCalled(spaceProfiler.start)
   })
 
   it('should log exporter errors', async () => {

--- a/packages/dd-trace/test/profiling/profilers/space.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/space.spec.js
@@ -4,8 +4,8 @@ const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
-describe('profilers/native/heap', () => {
-  let NativeHeapProfiler
+describe('profilers/native/space', () => {
+  let NativeSpaceProfiler
   let pprof
 
   beforeEach(() => {
@@ -18,13 +18,13 @@ describe('profilers/native/heap', () => {
       }
     }
 
-    NativeHeapProfiler = proxyquire('../../../src/profiling/profilers/heap', {
+    NativeSpaceProfiler = proxyquire('../../../src/profiling/profilers/space', {
       '@datadog/pprof': pprof
     })
   })
 
-  it('should start the internal heap profiler', () => {
-    const profiler = new NativeHeapProfiler()
+  it('should start the internal space profiler', () => {
+    const profiler = new NativeSpaceProfiler()
 
     profiler.start()
 
@@ -34,7 +34,7 @@ describe('profilers/native/heap', () => {
   it('should use the provided configuration options', () => {
     const samplingInterval = 1024
     const stackDepth = 10
-    const profiler = new NativeHeapProfiler({ samplingInterval, stackDepth })
+    const profiler = new NativeSpaceProfiler({ samplingInterval, stackDepth })
 
     profiler.start()
 
@@ -42,8 +42,8 @@ describe('profilers/native/heap', () => {
     sinon.assert.calledWith(pprof.heap.start, samplingInterval, stackDepth)
   })
 
-  it('should stop the internal heap profiler', () => {
-    const profiler = new NativeHeapProfiler()
+  it('should stop the internal space profiler', () => {
+    const profiler = new NativeSpaceProfiler()
 
     profiler.start()
     profiler.stop()
@@ -51,8 +51,8 @@ describe('profilers/native/heap', () => {
     sinon.assert.calledOnce(pprof.heap.stop)
   })
 
-  it('should collect profiles from the pprof heap profiler', () => {
-    const profiler = new NativeHeapProfiler()
+  it('should collect profiles from the pprof space profiler', () => {
+    const profiler = new NativeSpaceProfiler()
 
     profiler.start()
 
@@ -63,8 +63,8 @@ describe('profilers/native/heap', () => {
     expect(profile).to.equal('profile')
   })
 
-  it('should encode profiles from the pprof heap profiler', () => {
-    const profiler = new NativeHeapProfiler()
+  it('should encode profiles from the pprof space profiler', () => {
+    const profiler = new NativeSpaceProfiler()
 
     profiler.start()
     const profile = profiler.profile()
@@ -74,7 +74,7 @@ describe('profilers/native/heap', () => {
   })
 
   it('should use mapper if given', () => {
-    const profiler = new NativeHeapProfiler()
+    const profiler = new NativeSpaceProfiler()
 
     const mapper = {}
 

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -4,8 +4,8 @@ const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
-describe('profilers/native/cpu', () => {
-  let NativeCpuProfiler
+describe('profilers/native/wall', () => {
+  let NativeWallProfiler
   let pprof
   let stop
 
@@ -18,13 +18,13 @@ describe('profilers/native/cpu', () => {
       }
     }
 
-    NativeCpuProfiler = proxyquire('../../../src/profiling/profilers/cpu', {
+    NativeWallProfiler = proxyquire('../../../src/profiling/profilers/wall', {
       '@datadog/pprof': pprof
     })
   })
 
   it('should start the internal time profiler', () => {
-    const profiler = new NativeCpuProfiler()
+    const profiler = new NativeWallProfiler()
 
     // Verify start/stop profiler idle notifiers are created if not present.
     // These functions may not exist in worker threads.
@@ -48,7 +48,7 @@ describe('profilers/native/cpu', () => {
 
   it('should use the provided configuration options', () => {
     const samplingInterval = 500
-    const profiler = new NativeCpuProfiler({ samplingInterval })
+    const profiler = new NativeWallProfiler({ samplingInterval })
 
     profiler.start()
 
@@ -56,7 +56,7 @@ describe('profilers/native/cpu', () => {
   })
 
   it('should stop the internal time profiler', () => {
-    const profiler = new NativeCpuProfiler()
+    const profiler = new NativeWallProfiler()
 
     profiler.start()
     profiler.stop()
@@ -65,7 +65,7 @@ describe('profilers/native/cpu', () => {
   })
 
   it('should collect profiles from the internal time profiler', () => {
-    const profiler = new NativeCpuProfiler()
+    const profiler = new NativeWallProfiler()
 
     profiler.start()
 
@@ -78,7 +78,7 @@ describe('profilers/native/cpu', () => {
   })
 
   it('should encode profiles from the pprof time profiler', () => {
-    const profiler = new NativeCpuProfiler()
+    const profiler = new NativeWallProfiler()
 
     profiler.start()
 
@@ -90,7 +90,7 @@ describe('profilers/native/cpu', () => {
   })
 
   it('should use mapper if given', () => {
-    const profiler = new NativeCpuProfiler()
+    const profiler = new NativeWallProfiler()
 
     const mapper = {}
 


### PR DESCRIPTION
The naming of the individual profilers now match how we refer to them in the backend. This also fixes the incorrect naming of the "cpu" profiler which is actually a _wall_ profiler.

This is a prerequisite to publicly documenting the `DD_PROFILING_PROFILERS` environment variable.