### PR TITLE
fix express recording urls in blocklist

### DIFF
--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -6,6 +6,7 @@ const { expectSomeSpan, withDefaults } = require('../../dd-trace/test/plugins/he
 
 describe('Plugin', () => {
   describe('kafkajs', function () {
+    this.timeout(10000) // TODO: remove when new internal trace has landed
     afterEach(() => {
       return agent.close({ ritmReset: false })
     })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix express recording URLs in blocklist.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was fixed for `http` to avoid generating metrics for URLs in the blocklist but was not ported to the web util. 

Fixes #1928