### PR TITLE
fix address tag for dns lookups with `all` option

### DIFF
--- a/packages/datadog-plugin-dns/src/index.js
+++ b/packages/datadog-plugin-dns/src/index.js
@@ -44,7 +44,8 @@ class DNSPlugin extends Plugin {
       this.enter(span, store)
     }, (result) => {
       const { span } = storage.getStore()
-      span.setTag('dns.address', result)
+      const address = Array.isArray(result) ? result[0].address : result
+      span.setTag('dns.address', address)
       span.finish()
     })
 

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -41,6 +41,31 @@ describe('Plugin', () => {
       dns.lookup('localhost', 4, (err, address, family) => err && done(err))
     })
 
+    it('should instrument lookup with all addresses', done => {
+      const options = {
+        family: 4,
+        all: true
+      }
+
+      agent
+        .use(traces => {
+          expect(traces[0][0]).to.deep.include({
+            name: 'dns.lookup',
+            service: 'test',
+            resource: 'localhost'
+          })
+          expect(traces[0][0].meta).to.deep.include({
+            'span.kind': 'client',
+            'dns.hostname': 'localhost',
+            'dns.address': '127.0.0.1'
+          })
+        })
+        .then(done)
+        .catch(done)
+
+      dns.lookup('localhost', options, (err, address, family) => err && done(err))
+    })
+
     it('should instrument errors correctly', done => {
       agent
         .use(traces => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix address tag for dns lookups with `all` option.

### Motivation
<!-- What inspired you to submit this pull request? -->

The tag is otherwise set to an array of `[Object object]`.

Fixes #2026