### PR TITLE
update log plugins to receive log injection config directly

### DIFF
--- a/packages/datadog-plugin-bunyan/test/index.spec.js
+++ b/packages/datadog-plugin-bunyan/test/index.spec.js
@@ -26,7 +26,6 @@ describe('Plugin', () => {
     withVersions('bunyan', 'bunyan', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
-        return agent.load('bunyan')
       })
 
       afterEach(() => {
@@ -34,6 +33,10 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load('bunyan')
+        })
+
         beforeEach(() => {
           setup(version)
         })
@@ -53,7 +56,10 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         beforeEach(() => {
-          tracer._tracer._logInjection = true
+          return agent.load('bunyan', { logInjection: true })
+        })
+
+        beforeEach(() => {
           setup(version)
         })
 

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -14,7 +14,6 @@ describe('Plugin', () => {
     withVersions('pino', 'pino', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
-        return agent.load('pino')
       })
 
       afterEach(() => {
@@ -36,6 +35,10 @@ describe('Plugin', () => {
         }
 
         describe('without configuration', () => {
+          beforeEach(() => {
+            return agent.load('pino')
+          })
+
           beforeEach(function () {
             setup()
 
@@ -77,9 +80,11 @@ describe('Plugin', () => {
         })
 
         describe('with configuration', () => {
-          beforeEach(function () {
-            tracer._tracer._logInjection = true
+          beforeEach(() => {
+            return agent.load('pino', { logInjection: true })
+          })
 
+          beforeEach(function () {
             setup()
 
             if (!logger) {

--- a/packages/datadog-plugin-winston/test/index.spec.js
+++ b/packages/datadog-plugin-winston/test/index.spec.js
@@ -93,7 +93,6 @@ describe('Plugin', () => {
     withVersions('winston', 'winston', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
-        return agent.load('winston')
       })
 
       afterEach(() => {
@@ -101,6 +100,10 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
+        beforeEach(() => {
+          return agent.load('winston')
+        })
+
         beforeEach(() => {
           return setup(version)
         })
@@ -125,7 +128,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         beforeEach(() => {
-          tracer._tracer._logInjection = true
+          return agent.load('winston', { logInjection: true })
         })
 
         describe('without formatting', () => {

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -31,11 +31,8 @@ function messageProxy (message, holder) {
 module.exports = class LogPlugin extends Plugin {
   constructor (...args) {
     super(...args)
-    this.addSub(`apm:${this.constructor.name}:log`, (arg) => {
-      // TODO rather than checking this every time, setting it ought to enable/disable any plugin
-      // extending from this one
-      if (!this.tracer._logInjection) return
 
+    this.addSub(`apm:${this.constructor.name}:log`, (arg) => {
       const store = storage.getStore()
       const span = store && store.span
 
@@ -44,6 +41,13 @@ module.exports = class LogPlugin extends Plugin {
       const holder = {}
       this.tracer.inject(span, LOG, holder)
       arg.message = messageProxy(arg.message, holder)
+    })
+  }
+
+  configure (config) {
+    return super.configure({
+      ...config,
+      enabled: config.enabled && config.logInjection
     })
   }
 }

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -150,20 +150,18 @@ describe('Plugin Manager', () => {
   })
 
   describe('configure', () => {
-    afterEach(() => {
+    it('skips configuring plugins entirely when plugins is false', () => {
+      pm.configurePlugin = sinon.spy()
       pm.configure({ plugins: false })
+      expect(pm.configurePlugin).not.to.have.been.called
     })
-    it('configures plugins when plugins is false', () => {
-      pm.configure({ plugins: false })
-      expect(Two.prototype.configure).to.have.been.calledWith({ enabled: false })
-      expect(Four.prototype.configure).to.have.been.calledWith({ enabled: false })
-    })
-    it('observes serviceMapping', () => {
+    it('observes configuration options', () => {
       pm.configure({
-        serviceMapping: { two: 'deux' }
+        serviceMapping: { two: 'deux' },
+        logInjection: true
       })
-      expect(Two.prototype.configure).to.have.been.calledWith({ enabled: true, service: 'deux' })
-      expect(Four.prototype.configure).to.have.been.calledWith({ enabled: true })
+      expect(Two.prototype.configure).to.have.been.calledWith({ enabled: true, service: 'deux', logInjection: true })
+      expect(Four.prototype.configure).to.have.been.calledWith({ enabled: true, logInjection: true })
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update log plugins to receive log injection config directly.

### Motivation
<!-- What inspired you to submit this pull request? -->

Plugins shouldn't read private properties of the tracer. Copying the option from the tracer to the plugin config also has the benefit that the subscription can be disabled completely when the feature is disabled.