### PR TITLE
add all dns addresses as a new tag when option is set

### DIFF
--- a/packages/datadog-plugin-dns/src/index.js
+++ b/packages/datadog-plugin-dns/src/index.js
@@ -44,8 +44,18 @@ class DNSPlugin extends Plugin {
       this.enter(span, store)
     }, (result) => {
       const { span } = storage.getStore()
-      const address = Array.isArray(result) ? result[0].address : result
-      span.setTag('dns.address', address)
+
+      if (Array.isArray(result)) {
+        const addresses = Array.isArray(result)
+          ? result.map(address => address.address).sort()
+          : [result]
+
+        span.setTag('dns.address', addresses[0])
+        span.setTag('dns.addresses', addresses.join(','))
+      } else {
+        span.setTag('dns.address', result)
+      }
+
       span.finish()
     })
 

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -42,11 +42,6 @@ describe('Plugin', () => {
     })
 
     it('should instrument lookup with all addresses', done => {
-      const options = {
-        family: 4,
-        all: true
-      }
-
       agent
         .use(traces => {
           expect(traces[0][0]).to.deep.include({
@@ -57,13 +52,14 @@ describe('Plugin', () => {
           expect(traces[0][0].meta).to.deep.include({
             'span.kind': 'client',
             'dns.hostname': 'localhost',
-            'dns.address': '127.0.0.1'
+            'dns.address': '127.0.0.1',
+            'dns.addresses': '127.0.0.1,::1'
           })
         })
         .then(done)
         .catch(done)
 
-      dns.lookup('localhost', options, (err, address, family) => err && done(err))
+      dns.lookup('localhost', { all: true }, (err, address, family) => err && done(err))
     })
 
     it('should instrument errors correctly', done => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add all dns addresses as a new tag when option is set.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is a trade-off so that switching between `all: true` and `all: false` doesn't change the value of the `dns.address` tag by adding a new `dns.addresses` tag instead to store all the addresses while the former will continue to only store the first address.

See https://github.com/DataDog/dd-trace-js/pull/2031#discussion_r865412970