### PR TITLE
fix unreturned promise in fastify hooks

### DIFF
--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -45,7 +45,7 @@ function wrapAddHook (addHook) {
 
       if (!requestResource) return fn.apply(this, arguments)
 
-      requestResource.runInAsyncScope(() => {
+      return requestResource.runInAsyncScope(() => {
         const hookResource = new AsyncResource('bound-anonymous-fn')
 
         try {

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -279,6 +279,22 @@ describe('Plugin', () => {
             })
           })
 
+          // This is a regression test for https://github.com/DataDog/dd-trace-js/issues/2047
+          it('should not time out on async hooks', (done) => {
+            app.addHook('onRequest', async (request, reply) => {})
+
+            app.get('/user', (request, reply) => {
+              reply.send()
+            })
+
+            getPort().then(port => {
+              app.listen(port, 'localhost', async () => {
+                await axios.get(`http://localhost:${port}/user`)
+                done()
+              })
+            })
+          })
+
           it('should handle hook errors', done => {
             let error
 


### PR DESCRIPTION
### What does this PR do?

Returns the promise created by async functions used as hooks in fastify.

### Motivation
Not returning the promise created by async functions used as hooks resulted in fastify getting confused and expecting done to be called. This meant that requests would just hang.

Fixes #2047