### PR TITLE
[ci-visibility] Add `library_version` to agentless and agent based intake

### DIFF
--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -18,8 +18,11 @@ const {
   CI_APP_ORIGIN,
   ERROR_MESSAGE,
   TEST_SKIP_REASON,
-  TEST_FRAMEWORK_VERSION
+  TEST_FRAMEWORK_VERSION,
+  LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
+
+const { version: ddTraceVersion } = require('../../../package.json')
 
 const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
   const stdout = new PassThrough()
@@ -85,7 +88,8 @@ describe('Plugin', function () {
               [TEST_NAME]: 'pass scenario',
               [TEST_TYPE]: 'test',
               [TEST_FRAMEWORK]: 'cucumber',
-              [TEST_STATUS]: 'pass'
+              [TEST_STATUS]: 'pass',
+              [LIBRARY_VERSION]: ddTraceVersion
             })
             expect(testSpan.metrics).to.contain({
               [SAMPLING_PRIORITY]: AUTO_KEEP

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -16,8 +16,11 @@ const {
   ERROR_TYPE,
   ERROR_MESSAGE,
   TEST_FRAMEWORK_VERSION,
-  TEST_CODE_OWNERS
+  TEST_CODE_OWNERS,
+  LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
+
+const { version: ddTraceVersion } = require('../../../package.json')
 
 describe('Plugin', () => {
   let cypressExecutable
@@ -69,7 +72,8 @@ describe('Plugin', () => {
               [TEST_TYPE]: 'test',
               [ORIGIN_KEY]: CI_APP_ORIGIN,
               [TEST_IS_RUM_ACTIVE]: 'true',
-              [TEST_CODE_OWNERS]: JSON.stringify(['@datadog'])
+              [TEST_CODE_OWNERS]: JSON.stringify(['@datadog']),
+              [LIBRARY_VERSION]: ddTraceVersion
             })
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
           })

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -17,8 +17,11 @@ const {
   JEST_TEST_RUNNER,
   ERROR_MESSAGE,
   TEST_PARAMETERS,
-  TEST_CODE_OWNERS
+  TEST_CODE_OWNERS,
+  LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
+
+const { version: ddTraceVersion } = require('../../../package.json')
 
 describe('Plugin', function () {
   let jestExecutable
@@ -109,7 +112,8 @@ describe('Plugin', function () {
               [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-test.js',
               [TEST_TYPE]: 'test',
               [JEST_TEST_RUNNER]: 'jest-circus',
-              [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/apm-js']) // reads from dd-trace-js
+              [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/apm-js']), // reads from dd-trace-js
+              [LIBRARY_VERSION]: ddTraceVersion
             })
             if (extraTags) {
               expect(testSpan.meta).to.contain(extraTags)

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -16,8 +16,11 @@ const {
   TEST_FRAMEWORK_VERSION,
   JEST_TEST_RUNNER,
   ERROR_MESSAGE,
-  TEST_CODE_OWNERS
+  TEST_CODE_OWNERS,
+  LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
+
+const { version: ddTraceVersion } = require('../../../package.json')
 
 describe('Plugin', () => {
   let jestExecutable
@@ -87,7 +90,8 @@ describe('Plugin', () => {
               [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-test.js',
               [TEST_TYPE]: 'test',
               [JEST_TEST_RUNNER]: 'jest-jasmine2',
-              [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/apm-js']) // reads from dd-trace-js
+              [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/apm-js']), // reads from dd-trace-js
+              [LIBRARY_VERSION]: ddTraceVersion
             })
             if (extraTags) {
               expect(testSpan.meta).to.contain(extraTags)

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -19,8 +19,11 @@ const {
   ERROR_STACK,
   CI_APP_ORIGIN,
   TEST_FRAMEWORK_VERSION,
-  TEST_CODE_OWNERS
+  TEST_CODE_OWNERS,
+  LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
+
+const { version: ddTraceVersion } = require('../../../package.json')
 
 const ASYNC_TESTS = [
   {
@@ -117,6 +120,7 @@ describe('Plugin', () => {
             expect(testSpan.meta[TEST_CODE_OWNERS]).to.equal(
               JSON.stringify(['@DataDog/apm-js']) // reads from dd-trace-js
             )
+            expect(testSpan.meta[LIBRARY_VERSION]).to.equal(ddTraceVersion)
           })
         })
         Promise.all(assertionPromises)

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -2,6 +2,7 @@
 const { truncateSpan, normalizeSpan } = require('./tags-processors')
 const Chunk = require('./chunk')
 const { AgentEncoder } = require('./0.4')
+const { version: ddTraceVersion } = require('../../../../package.json')
 
 const ENCODING_VERSION = 1
 
@@ -156,7 +157,8 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       version: ENCODING_VERSION,
       metadata: {
         '*': {
-          'language': 'javascript'
+          'language': 'javascript',
+          'library_version': ddTraceVersion
         }
       },
       events: []

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -22,6 +22,7 @@ const id = require('../../id')
 const { SPAN_TYPE, RESOURCE_NAME, SAMPLING_PRIORITY } = require('../../../../../ext/tags')
 const { SAMPLING_RULE_DECISION } = require('../../constants')
 const { AUTO_KEEP } = require('../../../../../ext/priority')
+const { version: ddTraceVersion } = require('../../../../../package.json')
 
 const TEST_FRAMEWORK = 'test.framework'
 const TEST_FRAMEWORK_VERSION = 'test.framework_version'
@@ -33,6 +34,7 @@ const TEST_PARAMETERS = 'test.parameters'
 const TEST_SKIP_REASON = 'test.skip_reason'
 const TEST_IS_RUM_ACTIVE = 'test.is_rum_active'
 const TEST_CODE_OWNERS = 'test.codeowners'
+const LIBRARY_VERSION = 'library_version'
 
 const ERROR_TYPE = 'error.type'
 const ERROR_MESSAGE = 'error.msg'
@@ -58,6 +60,7 @@ module.exports = {
   ERROR_MESSAGE,
   ERROR_STACK,
   CI_APP_ORIGIN,
+  LIBRARY_VERSION,
   getTestEnvironmentMetadata,
   getTestParametersString,
   finishAllTraceSpans,
@@ -149,7 +152,8 @@ function getTestCommonTags (name, suite, version) {
     [TEST_NAME]: name,
     [TEST_SUITE]: suite,
     [RESOURCE_NAME]: `${suite}.${name}`,
-    [TEST_FRAMEWORK_VERSION]: version
+    [TEST_FRAMEWORK_VERSION]: version,
+    [LIBRARY_VERSION]: ddTraceVersion
   }
 }
 

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -17,6 +17,8 @@ const {
   DEFAULT_SERVICE_NAME
 } = require('../../src/encode/tags-processors')
 
+const { version: ddTraceVersion } = require('../../../../package.json')
+
 describe('agentless-ci-visibility-encode', () => {
   let encoder
   let writer
@@ -66,7 +68,8 @@ describe('agentless-ci-visibility-encode', () => {
 
     expect(decodedTrace.version.toNumber()).to.equal(1)
     expect(decodedTrace.metadata['*']).to.contain({
-      language: 'javascript'
+      language: 'javascript',
+      library_version: ddTraceVersion
     })
     const spanEvent = decodedTrace.events[0]
     expect(spanEvent.type).to.equal('span')


### PR DESCRIPTION
### What does this PR do?
Add `library_version` root tag. 

### Motivation
The agent adds a version tag by reading the HTTP header sent by the tracer. There is no such header in the agentless intake, so we're lacking this information. This PR adds it. 

Additionally we're adding this tag to the agent-based intake, by adding it to the test spans in testing framework instrumentations. This is a temporary workaround, until all CI Visibility traffic is using the new intake. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
