### PR TITLE
fix web plugins breaking user-defined async stores

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -26,15 +26,19 @@ class RouterPlugin extends WebPlugin {
       web.setRoute(req, context.route)
     })
 
-    this.addSub(`apm:${this.constructor.name}:middleware:exit`, ({ req }) => {
+    this.addSub(`apm:${this.constructor.name}:middleware:exit`, () => {
+      this.exit()
+    })
+
+    this.addSub(`apm:${this.constructor.name}:middleware:next`, ({ req }) => {
       const context = this._contexts.get(req)
 
-      if (!context) return
+      if (context) {
+        context.stack.pop()
 
-      context.stack.pop()
-
-      if (context.middleware.length > 0) {
-        context.middleware.pop().finish()
+        if (context.middleware.length > 0) {
+          context.middleware.pop().finish()
+        }
       }
     })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix web plugins breaking user-defined async stores.

### Motivation
<!-- What inspired you to submit this pull request? -->

When these plugins were re-written with the new plugin system, an `AsyncResource` was used to wrap middleware. However, this was not only not needed but also meant that the async context ended up being isolated from previous middleware in the chain which breaks existing user-defined context propagation.

Fixes #2056