### PR TITLE
[ci-visibility] Do not instrument tests if agentless is setup but no API key is provided

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -13,6 +13,8 @@ const options = {
   }
 }
 
+let shouldInit = true
+
 if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED) {
   if (process.env.DATADOG_API_KEY || process.env.DD_API_KEY) {
     options.experimental = {
@@ -20,9 +22,11 @@ if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED) {
     }
   } else {
     console.error(`
-DD_CIVISIBILITY_AGENTLESS_ENABLED is set,
-but neither DD_API_KEY nor DATADOG_API_KEY are set in your environment.`)
-    process.exit(1)
+      DD_CIVISIBILITY_AGENTLESS_ENABLED is set, \
+      but neither DD_API_KEY nor DATADOG_API_KEY are set in your environment, \
+      so dd-trace will not be initialized.`
+    )
+    shouldInit = false
   }
 }
 
@@ -45,8 +49,9 @@ try {
   // ignore error and let the tracer initialize anyway
 }
 
-tracer.init(options)
-
-tracer.use('fs', false)
+if (shouldInit) {
+  tracer.init(options)
+  tracer.use('fs', false)
+}
 
 module.exports = tracer

--- a/ci/init.js
+++ b/ci/init.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const path = require('path')
 const tracer = require('../packages/dd-trace')
 const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
@@ -11,9 +13,16 @@ const options = {
   }
 }
 
-if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED && (process.env.DATADOG_API_KEY || process.env.DD_API_KEY)) {
-  options.experimental = {
-    exporter: 'datadog'
+if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED) {
+  if (process.env.DATADOG_API_KEY || process.env.DD_API_KEY) {
+    options.experimental = {
+      exporter: 'datadog'
+    }
+  } else {
+    console.error(`
+DD_CIVISIBILITY_AGENTLESS_ENABLED is set,
+but neither DD_API_KEY nor DATADOG_API_KEY are set in your environment.`)
+    process.exit(1)
   }
 }
 

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -20,9 +20,10 @@ if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED) {
     })
   } else {
     console.error(`
-DD_CIVISIBILITY_AGENTLESS_ENABLED is set your environment,
-but neither DD_API_KEY nor DATADOG_API_KEY are set in your environment.`)
-    process.exit(1)
+      DD_CIVISIBILITY_AGENTLESS_ENABLED is set, \
+      but neither DD_API_KEY nor DATADOG_API_KEY are set in your environment, \
+      so dd-trace will not be initialized.`
+    )
   }
 } else {
   tracer.init({

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const tracer = require('../../packages/dd-trace')
 const { ORIGIN_KEY } = require('../../packages/dd-trace/src/constants')
 
@@ -8,13 +10,20 @@ const options = {
   }
 }
 
-if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED && (process.env.DATADOG_API_KEY || process.env.DD_API_KEY)) {
-  tracer.init({
-    ...options,
-    experimental: {
-      exporter: 'datadog'
-    }
-  })
+if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED) {
+  if (process.env.DATADOG_API_KEY || process.env.DD_API_KEY) {
+    tracer.init({
+      ...options,
+      experimental: {
+        exporter: 'datadog'
+      }
+    })
+  } else {
+    console.error(`
+DD_CIVISIBILITY_AGENTLESS_ENABLED is set your environment,
+but neither DD_API_KEY nor DATADOG_API_KEY are set in your environment.`)
+    process.exit(1)
+  }
 } else {
   tracer.init({
     ...options,


### PR DESCRIPTION
### What does this PR do?
Do not call `tracer.init` if `DD_CIVISIBILITY_AGENTLESS_ENABLED` and no `DATADOG_API_KEY` is set, instead of falling back to the agent-based intake.

### Motivation
* It aligns with the rest of the libraries. 
* The user has decided to explicitly opt in through `DD_CIVISIBILITY_AGENTLESS_ENABLED` but they have misconfigured the library, so it shouldn't fallback to the agent-based intake. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
