### PR TITLE
fix missing tag when publishing for 0.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,12 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
-      - run: npm publish --tag latest-node8 --tag latest-node10
+      - run: npm publish --tag latest-node10
       - id: pkg
         run: |
           content=`cat ./package.json | tr '\n' ' '`
           echo "::set-output name=json::$content"
+      - run: npm dist-tag add dd-trace@${{ fromJson(steps.pkg.outputs.json).version }} latest-node8
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing tag when publishing for 0.x.

### Motivation
<!-- What inspired you to submit this pull request? -->

The npm CLI only supports a single tag, so the second tag must be set later.