### PR TITLE
remove zookeeper dependency when testing kafka support

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -445,15 +445,17 @@ jobs:
     runs-on: ubuntu-latest
     services:
       kafka:
-        image: wurstmeister/kafka
+        image: debezium/kafka:1.7
         env:
-          KAFKA_ADVERTISED_HOST_NAME: '127.0.0.1'
-          KAFKA_CREATE_TOPICS: 'test-topic:1:1'
-          KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+          CLUSTER_ID: 5Yr1SIgYQz-b-dgRabWx4g
+          NODE_ID: "1"
+          CREATE_TOPICS: "test-topic:1:1"
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
         ports:
           - 9092:9092
-      zookeeper:
-        image: wurstmeister/zookeeper
+          - 9093:9093
     env:
       PLUGINS: kafkajs
       SERVICES: kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,13 +112,16 @@ services:
       - DEBUG=true
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-  zookeeper:
-    image: wurstmeister/zookeeper
   kafka:
-    image: wurstmeister/kafka
+    image: debezium/kafka:1.7
     ports:
       - "127.0.0.1:9092:9092"
+      - "127.0.0.1:9093:9093"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
-      KAFKA_CREATE_TOPICS: "test-topic:1:1"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      - CLUSTER_ID=5Yr1SIgYQz-b-dgRabWx4g
+      - NODE_ID=1
+      - CREATE_TOPICS="test-topic:1:1"
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove ZooKeeper dependency when testing Kafka support.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests have been flaky, with the consumer sometimes just hanging forever, waiting for Kafka to become ready. The only theory we have right now is that there is a race condition between Kafka and ZooKeeper. Removing ZooKeeper removes the very possibility of a race condition by reducing the Kafka stack to a single service.