### PR TITLE
[ci-visibility] Increase expectation callback's timeout for `jest` tests

### DIFF
--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -135,7 +135,7 @@ describe('Plugin', function () {
             expect(testSpan.service).to.equal('test')
             expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-          }, { timeoutMs: 20000 })
+          }, { timeoutMs: 10000 })
         })
 
         Promise.all(assertionPromises).then(() => done()).catch(done)

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -135,7 +135,7 @@ describe('Plugin', function () {
             expect(testSpan.service).to.equal('test')
             expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-          })
+          }, { timeoutMs: 20000 })
         })
 
         Promise.all(assertionPromises).then(() => done()).catch(done)


### PR DESCRIPTION
### What does this PR do?
Increase timeout for expectation callbacks in `jest` tests.

The default timeout for expectation callbacks (when you pass to `agent.use` in tests) is 1000: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/test/plugins/agent.js#L86. This is too short for `jest` tests.

### Motivation
Hopefully fix flakiness in `jest` tests. 

