### PR TITLE
fix amqplib upstream tests failing due to missing tag for release

### DIFF
--- a/packages/datadog-plugin-amqplib/test/suite.js
+++ b/packages/datadog-plugin-amqplib/test/suite.js
@@ -1,4 +1,5 @@
 'use strict'
 const suiteTest = require('../../dd-trace/test/plugins/suite')
 
-suiteTest('amqplib', 'amqp-node/amqplib', 'latest')
+// TODO: restore use of latest branch when it gets a matching tag
+suiteTest('amqplib', 'amqp-node/amqplib', 'v0.9.0')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix amqplib upstream tests failing due to missing tag for release.

### Motivation
<!-- What inspired you to submit this pull request? -->

The latest release doesn't have a corresponding tag which results in an error. For now we can just pin to the previous release.