### PR TITLE
fix aws-sdk complete event running in wrong async context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,9 +109,6 @@ services:
       - FORCE_NONINTERACTIVE=true
       - START_WEB=0
       - LAMBDA_EXECUTOR=local
-      - DEBUG=true
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
   kafka:
     image: debezium/kafka:1.7
     ports:

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -20,12 +20,12 @@ describe('Plugin', () => {
         before(() => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
-          const endpoint = new AWS.Endpoint('http://localhost:4572')
+          const endpoint = new AWS.Endpoint('http://127.0.0.1:4572')
 
           s3 = new AWS.S3({ endpoint, s3ForcePathStyle: true })
           tracer = require('../../dd-trace')
 
-          return agent.load('aws-sdk')
+          return agent.load(['aws-sdk', 'http'], [{}, { server: false }])
         })
 
         after(() => {
@@ -129,25 +129,23 @@ describe('Plugin', () => {
         before(() => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
-          const endpoint = new AWS.Endpoint('http://localhost:5000')
+          const endpoint = new AWS.Endpoint('http://127.0.0.1:5000')
 
           s3 = new AWS.S3({ endpoint, s3ForcePathStyle: true })
           tracer = require('../../dd-trace')
 
-          return agent.load('aws-sdk', {
+          return agent.load(['aws-sdk', 'http'], [{
             service: 'test',
             splitByAwsService: false,
             hooks: {
               request (span, response) {
                 span.setTag('hook.operation', response.request.operation)
-                if (response.error.code === 'NetworkingError' || response.error.code === 'UnknownEndpoint') {
-                  span.addTags({
-                    'error': 0
-                  })
-                }
+                span.addTags({
+                  'error': 0
+                })
               }
             }
-          })
+          }, { server: false }])
         })
 
         after(() => {
@@ -176,14 +174,14 @@ describe('Plugin', () => {
         before(() => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
-          s3 = new AWS.S3({ endpoint: new AWS.Endpoint('http://localhost:4572'), s3ForcePathStyle: true })
-          sqs = new AWS.SQS({ endpoint: new AWS.Endpoint('http://localhost:4576') })
+          s3 = new AWS.S3({ endpoint: new AWS.Endpoint('http://127.0.0.1:4572'), s3ForcePathStyle: true })
+          sqs = new AWS.SQS({ endpoint: new AWS.Endpoint('http://127.0.0.1:4576') })
           tracer = require('../../dd-trace')
 
-          return agent.load('aws-sdk', {
+          return agent.load(['aws-sdk', 'http'], [{
             service: 'test',
             s3: false
-          })
+          }, { server: false }])
         })
 
         after(() => {

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -18,14 +18,16 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
+          return agent.load(['aws-sdk', 'http'], [{}, { server: false }])
+        })
+
+        before(() => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
           const endpoint = new AWS.Endpoint('http://127.0.0.1:4572')
 
           s3 = new AWS.S3({ endpoint, s3ForcePathStyle: true })
           tracer = require('../../dd-trace')
-
-          return agent.load(['aws-sdk', 'http'], [{}, { server: false }])
         })
 
         after(() => {
@@ -127,13 +129,6 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          AWS = require(`../../../versions/aws-sdk@${version}`).get()
-
-          const endpoint = new AWS.Endpoint('http://127.0.0.1:5000')
-
-          s3 = new AWS.S3({ endpoint, s3ForcePathStyle: true })
-          tracer = require('../../dd-trace')
-
           return agent.load(['aws-sdk', 'http'], [{
             service: 'test',
             splitByAwsService: false,
@@ -146,6 +141,15 @@ describe('Plugin', () => {
               }
             }
           }, { server: false }])
+        })
+
+        before(() => {
+          AWS = require(`../../../versions/aws-sdk@${version}`).get()
+
+          const endpoint = new AWS.Endpoint('http://127.0.0.1:5000')
+
+          s3 = new AWS.S3({ endpoint, s3ForcePathStyle: true })
+          tracer = require('../../dd-trace')
         })
 
         after(() => {
@@ -172,16 +176,18 @@ describe('Plugin', () => {
 
       describe('with service configuration', () => {
         before(() => {
+          return agent.load(['aws-sdk', 'http'], [{
+            service: 'test',
+            s3: false
+          }, { server: false }])
+        })
+
+        before(() => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
           s3 = new AWS.S3({ endpoint: new AWS.Endpoint('http://127.0.0.1:4572'), s3ForcePathStyle: true })
           sqs = new AWS.SQS({ endpoint: new AWS.Endpoint('http://127.0.0.1:4576') })
           tracer = require('../../dd-trace')
-
-          return agent.load(['aws-sdk', 'http'], [{
-            service: 'test',
-            s3: false
-          }, { server: false }])
         })
 
         after(() => {

--- a/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
@@ -30,7 +30,7 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
-          const lambdaEndpoint = new AWS.Endpoint('http://localhost:4566')
+          const lambdaEndpoint = new AWS.Endpoint('http://127.0.0.1:4566')
           lambda = new AWS.Lambda({ endpoint: lambdaEndpoint, region: 'us-east-1' })
 
           lambda.createFunction({

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -30,7 +30,7 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
-          const endpoint = new AWS.Endpoint('http://localhost:4576')
+          const endpoint = new AWS.Endpoint('http://127.0.0.1:4576')
 
           sqs = new AWS.SQS({ endpoint, region: 'us-east-1' })
           sqs.createQueue(queueOptions, (err, res) => {
@@ -152,7 +152,7 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/aws-sdk@${version}`).get()
 
-          const endpoint = new AWS.Endpoint('http://localhost:4576')
+          const endpoint = new AWS.Endpoint('http://127.0.0.1:4576')
 
           sqs = new AWS.SQS({ endpoint, region: 'us-east-1' })
           sqs.createQueue(queueOptions, (err, res) => {
@@ -180,7 +180,7 @@ describe('Plugin', () => {
 
             expect(span).to.include({
               name: 'aws.request',
-              resource: 'sendMessage http://localhost:4576/queue/SQS_QUEUE_NAME'
+              resource: 'sendMessage http://127.0.0.1:4576/queue/SQS_QUEUE_NAME'
             })
 
             total++
@@ -191,7 +191,7 @@ describe('Plugin', () => {
 
             expect(span).to.include({
               name: 'aws.request',
-              resource: 'receiveMessage http://localhost:4576/queue/SQS_QUEUE_NAME'
+              resource: 'receiveMessage http://127.0.0.1:4576/queue/SQS_QUEUE_NAME'
             })
 
             total++

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -180,7 +180,7 @@ describe('Plugin', () => {
 
             expect(span).to.include({
               name: 'aws.request',
-              resource: 'sendMessage http://127.0.0.1:4576/queue/SQS_QUEUE_NAME'
+              resource: 'sendMessage http://localhost:4576/queue/SQS_QUEUE_NAME'
             })
 
             total++
@@ -191,7 +191,7 @@ describe('Plugin', () => {
 
             expect(span).to.include({
               name: 'aws.request',
-              resource: 'receiveMessage http://127.0.0.1:4576/queue/SQS_QUEUE_NAME'
+              resource: 'receiveMessage http://localhost:4576/queue/SQS_QUEUE_NAME'
             })
 
             total++

--- a/packages/dd-trace/test/setup/services/localstack.js
+++ b/packages/dd-trace/test/setup/services/localstack.js
@@ -14,14 +14,14 @@ function waitForAWS () {
     // Set the region
     AWS.config.update({ region: 'us-east-1' })
 
-    const ddbEndpoint = new AWS.Endpoint('http://localhost:4569')
-    const kinesisEndpoint = new AWS.Endpoint('http://localhost:4568')
-    const s3Endpoint = new AWS.Endpoint('http://localhost:4572')
-    const sqsEndpoint = new AWS.Endpoint('http://localhost:4576')
-    const snsEndpoint = new AWS.Endpoint('http://localhost:4575')
-    const route53Endpoint = new AWS.Endpoint('http://localhost:4580')
-    const redshiftEndpoint = new AWS.Endpoint('http://localhost:4577')
-    const lambdaEndpoint = new AWS.Endpoint('http://localhost:4566')
+    const ddbEndpoint = new AWS.Endpoint('http://127.0.0.1:4569')
+    const kinesisEndpoint = new AWS.Endpoint('http://127.0.0.1:4568')
+    const s3Endpoint = new AWS.Endpoint('http://127.0.0.1:4572')
+    const sqsEndpoint = new AWS.Endpoint('http://127.0.0.1:4576')
+    const snsEndpoint = new AWS.Endpoint('http://127.0.0.1:4575')
+    const route53Endpoint = new AWS.Endpoint('http://127.0.0.1:4580')
+    const redshiftEndpoint = new AWS.Endpoint('http://127.0.0.1:4577')
+    const lambdaEndpoint = new AWS.Endpoint('http://127.0.0.1:4566')
 
     const ddb = new AWS.DynamoDB({ endpoint: ddbEndpoint })
     const kinesis = new AWS.Kinesis({ endpoint: kinesisEndpoint })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix aws-sdk complete event running in wrong async context.

### Motivation
<!-- What inspired you to submit this pull request? -->

Running the event in the wrong context means that sometimes it receives the HTTP span and never finishes the AWS span, thus never finishing the trace.