### PR TITLE
fix pino tests failing with version 8

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -723,9 +723,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
-      - run: yarn test:plugins:ci
-      # - run: yarn test:plugins:upstream
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       # - run: yarn test:plugins:upstream

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -21,7 +21,7 @@ describe('Plugin', () => {
       })
 
       withExports('pino', version, ['default', 'pino'], '>=6.8.0', getExport => {
-        function setup (options) {
+        function setup (options = {}) {
           const pino = getExport()
 
           span = tracer.startSpan('test')
@@ -30,6 +30,14 @@ describe('Plugin', () => {
           stream._write = () => {}
 
           sinon.spy(stream, 'write')
+
+          if (semver.intersects(version, '>=8') && options.prettyPrint) {
+            delete options.prettyPrint // deprecated
+
+            const pretty = require(`../../../versions/pino-pretty@8.0.0`).get()
+
+            stream = pretty().pipe(stream)
+          }
 
           logger = pino && pino(options, stream)
         }

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -128,7 +128,8 @@
   "pino": [
     {
       "name": "pino-pretty",
-      "dep": true
+      "dep": true,
+      "versions": ["8.0.0"]
     }
   ],
   "q": [

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -78,15 +78,13 @@ async function assertVersions () {
   const externalNames = Object.keys(externals).filter(name => ~names.indexOf(name))
   for (const name of externalNames) {
     for (const inst of [].concat(externals[name])) {
-      if (!inst.dep) {
-        await assertInstrumentation(inst, true)
-      }
+      await assertInstrumentation(inst, true)
     }
   }
 }
 
 async function assertInstrumentation (instrumentation, external) {
-  const versions = [].concat(instrumentation.versions)
+  const versions = [].concat(instrumentation.versions || [])
   for (const version of versions) {
     if (version) {
       await assertModules(instrumentation.name, semver.coerce(version).version, external)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix pino tests failing with version 8.

### Motivation
<!-- What inspired you to submit this pull request? -->

The latest Pino release drops support for older versions of Node and replaces the `prettyPrint` option with using the `pino-print` module directly, resulting in our tests failing.