### PR TITLE
[ci-visibility] Fix initialization of agentless via `DD_CIVISIBILITY_AGENTLESS_ENABLED`

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -15,7 +15,11 @@ const options = {
 
 let shouldInit = true
 
-if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED) {
+const isAgentlessEnabled = process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED &&
+  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== 'false' &&
+  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== '0'
+
+if (isAgentlessEnabled) {
   if (process.env.DATADOG_API_KEY || process.env.DD_API_KEY) {
     options.experimental = {
       exporter: 'datadog'

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -10,7 +10,11 @@ const options = {
   }
 }
 
-if (process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED) {
+const isAgentlessEnabled = process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED &&
+  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== 'false' &&
+  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== '0'
+
+if (isAgentlessEnabled) {
   if (process.env.DATADOG_API_KEY || process.env.DD_API_KEY) {
     tracer.init({
       ...options,


### PR DESCRIPTION
### What does this PR do?
Check if `DD_CIVISIBILITY_AGENTLESS_ENABLED` is not `'false'` or `'0'`. 

### Motivation
We initialized agentless regardless of the value of `DD_CIVISIBILITY_AGENTLESS_ENABLED`

