### PR TITLE
[ci-visibility] Remove old `cypress` folder 

### DIFF
--- a/cypress/plugin.js
+++ b/cypress/plugin.js
@@ -1,5 +1,0 @@
-require('..').init({
-  startupLogs: false
-})
-
-module.exports = require('../packages/datadog-plugin-cypress/src/plugin')

--- a/cypress/support.js
+++ b/cypress/support.js
@@ -1,1 +1,0 @@
-require('../packages/datadog-plugin-cypress/src/support')


### PR DESCRIPTION
### What does this PR do?
It's been a while since we recommend users using `dd-trace/ci`. This folder was used before we had this entry point but it is not longer needed. 

### Motivation
Remove unused code.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
