### PR TITLE
fix error when the execution async resource is undefined

### DIFF
--- a/packages/datadog-core/src/storage/async_resource.js
+++ b/packages/datadog-core/src/storage/async_resource.js
@@ -69,7 +69,7 @@ class AsyncResourceStorage {
   }
 
   _executionAsyncResource () {
-    return executionAsyncResource()
+    return executionAsyncResource() || {}
   }
 }
 


### PR DESCRIPTION
This is a re-do of a previous commit, which was erased in a refactor.

Ref: https://github.com/DataDog/dd-trace-js/pull/1390