### PR TITLE
fix http client spans marked as errors for requests without a response

### DIFF
--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -84,9 +84,9 @@ function patch (http, methodName) {
                 finish(req, arg)
                 break
               case 'error':
+              case 'timeout':
                 errorClientCh.publish(arg)
               case 'abort': // deprecated and replaced by `close` in node 17
-              case 'timeout':
               case 'close':
                 finish(req)
             }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -64,8 +64,6 @@ class HttpClientPlugin extends Plugin {
         }
 
         addResponseHeaders(res, span, this.config)
-      } else {
-        span.setTag('error', 1)
       }
 
       addRequestHeaders(req, span, this.config)
@@ -84,11 +82,16 @@ class HttpClientPlugin extends Plugin {
 
 function errorHandler (err) {
   const span = storage.getStore().span
-  span.addTags({
-    'error.type': err.name,
-    'error.msg': err.message,
-    'error.stack': err.stack
-  })
+
+  if (err) {
+    span.addTags({
+      'error.type': err.name,
+      'error.msg': err.message,
+      'error.stack': err.stack
+    })
+  } else {
+    span.setTag('error', 1)
+  }
 }
 
 function addResponseHeaders (res, span, config) {

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -708,7 +708,7 @@ describe('Plugin', () => {
           })
         })
 
-        it('should record aborted requests as errors', done => {
+        it('should not record aborted requests as errors', done => {
           const app = express()
 
           app.get('/user', (req, res) => {})
@@ -716,7 +716,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.not.have.property('http.status_code')
               })
               .then(done)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix http client spans marked as errors for requests without a response.

### Motivation
<!-- What inspired you to submit this pull request? -->

Requests that are aborted or finished without a response are not necessarily errors and shouldn't be marked as such.

Fixes #2089 