### PR TITLE
remove version file and use package.json directly instead

### DIFF
--- a/packages/dd-trace/lib/version.js
+++ b/packages/dd-trace/lib/version.js
@@ -1,1 +1,0 @@
-module.exports = '3.0.0-pre'

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -4,7 +4,7 @@ const request = require('../common/request')
 const { startupLog } = require('../../startup-log')
 const metrics = require('../../metrics')
 const log = require('../../log')
-const tracerVersion = require('../../../lib/version')
+const tracerVersion = require('../../../../../package.json').version
 const BaseWriter = require('../common/writer')
 
 const METRIC_PREFIX = 'datadog.tracer.node.exporter.agent'

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -6,7 +6,7 @@ const FormData = require('form-data')
 
 // TODO: avoid using dd-trace internals. Make this a separate module?
 const docker = require('../../exporters/common/docker')
-const version = require('../../../lib/version')
+const version = require('../../../../../package.json').version
 
 const containerId = docker.id()
 

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -4,7 +4,7 @@ const mainLogger = require('./log')
 
 const os = require('os')
 const { inspect } = require('util')
-const tracerVersion = require('../lib/version')
+const tracerVersion = require('../../../package.json').version
 const requirePackageJson = require('./require-package-json')
 
 const logger = Object.create(mainLogger)

--- a/packages/dd-trace/src/telemetry.js
+++ b/packages/dd-trace/src/telemetry.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tracerVersion = require('../lib/version')
+const tracerVersion = require('../../../package.json').version
 const pkg = require('./pkg')
 const containerId = require('./exporters/common/docker').id()
 const requirePackageJson = require('./require-package-json')

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -54,7 +54,7 @@ function describeWriter (protocolVersion) {
       '../common/request': request,
       '../../encode/0.4': { AgentEncoder },
       '../../encode/0.5': { AgentEncoder },
-      '../../../lib/version': 'tracerVersion',
+      '../../../../../package.json': 'tracerVersion',
       '../../log': log
     })
     writer = new Writer({ url, prioritySampler, protocolVersion })

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -54,7 +54,7 @@ function describeWriter (protocolVersion) {
       '../common/request': request,
       '../../encode/0.4': { AgentEncoder },
       '../../encode/0.5': { AgentEncoder },
-      '../../../../../package.json': 'tracerVersion',
+      '../../../../../package.json': { version: 'tracerVersion' },
       '../../log': log
     })
     writer = new Writer({ url, prioritySampler, protocolVersion })

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -15,7 +15,7 @@ const SpaceProfiler = require('../../../src/profiling/profilers/space')
 const logger = require('../../../src/log')
 const { perftools } = require('@datadog/pprof/proto/profile')
 const semver = require('semver')
-const version = require('../../../lib/version')
+const version = require('../../../../../package.json').version
 
 if (!semver.satisfies(process.version, '>=10.12')) {
   describe = describe.skip // eslint-disable-line no-global-assign

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const os = require('os')
-const tracerVersion = require('../lib/version')
+const tracerVersion = require('../../../package.json').version
 
 describe('startup logging', () => {
   let semverVersion


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove version file and use `package.json` directly instead.

### Motivation
<!-- What inspired you to submit this pull request? -->

This file was originally added because dd-trace worked in the browser and the package.json shouldn't be included in the bundled code in that environment. However, now that browser support was moved to RUM instead, this file is no longer needed and we can require `package.json` to get the version instead.