### PR TITLE
[ci-visibility] Fix `insertGlobals: false` in `jest`

### DIFF
--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -33,4 +33,16 @@ function getFormattedJestTestParameters (testParameters) {
   return formattedParameters
 }
 
-module.exports = { getFormattedJestTestParameters }
+// https://github.com/facebook/jest/blob/3e38157ad5f23fb7d24669d24fae8ded06a7ab75/packages/jest-circus/src/utils.ts#L396
+function getJestTestName (test) {
+  const titles = []
+  let parent = test
+  do {
+    titles.unshift(parent.name)
+  } while ((parent = parent.parent))
+
+  titles.shift() // remove TOP_DESCRIBE_BLOCK_NAME
+  return titles.join(' ')
+}
+
+module.exports = { getFormattedJestTestParameters, getJestTestName }


### PR DESCRIPTION
### What does this PR do?
We can't assume `this.global.test` will be defined, because it isn't when `insertGlobals` is false. 

### Motivation
Fix #2125

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
