### PR TITLE
feat: mariadb plugin and instrumentation

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -501,29 +501,6 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 
-  mariadb:
-    runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mariadb:10.4
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: 'db'
-        ports:
-          - 3306:3306
-    env:
-      PLUGINS: mariadb
-      SERVICES: mysql
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/node/setup
-      - run: yarn install
-      - uses: ./.github/actions/node/oldest
-      - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
-      - run: yarn test:plugins:ci
-      - uses: codecov/codecov-action@v2
-
   memcached:
     runs-on: ubuntu-latest
     services:
@@ -637,7 +614,7 @@ jobs:
         ports:
           - 3306:3306
     env:
-      PLUGINS: mysql|mysql2 # TODO: move mysql2 to its own job
+      PLUGINS: mysql|mysql2|mariadb # TODO: move mysql2 to its own job
       SERVICES: mysql
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -501,6 +501,29 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 
+  mariadb:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mariadb:10.4
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_DATABASE: 'db'
+        ports:
+          - 3306:3306
+    env:
+      PLUGINS: mariadb
+      SERVICES: mysql
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/node/setup
+      - run: yarn install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:plugins:ci
+      - uses: codecov/codecov-action@v2
+
   memcached:
     runs-on: ubuntu-latest
     services:

--- a/docs/API.md
+++ b/docs/API.md
@@ -58,6 +58,7 @@ tracer.use('pg', {
 <h5 id="koa"></h5>
 <h5 id="koa-tags"></h5>
 <h5 id="koa-config"></h5>
+<h5 id="mariadb"></h5>
 <h5 id="memcached"></h5>
 <h5 id="memcached-tags"></h5>
 <h5 id="memcached-config"></h5>
@@ -120,6 +121,7 @@ tracer.use('pg', {
 * [knex](./interfaces/plugins.knex.html)
 * [koa](./interfaces/plugins.koa.html)
 * [ioredis](./interfaces/plugins.ioredis.html)
+* [mariadb](./interfaces/plugins.mariadb.html)
 * [microgateway--core](./interfaces/plugins.microgateway_core.html)
 * [mocha](./interfaces/plugins.mocha.html)
 * [mongodb-core](./interfaces/plugins.mongodb_core.html)
@@ -443,14 +445,14 @@ const tracer = require('dd-trace').init()
 function handle () {
   tracer.setUser({
     id: '123456789', // *REQUIRED* Unique identifier of the user.
-    
+
     // All other fields are optional.
     email: 'jane.doe@example.com', // Email of the user.
     name: 'Jane Doe', // User-friendly name of the user.
     session_id: '987654321', // Session ID of the user.
     role: 'admin', // Role the user is making the request under.
     scope: 'read:message, write:files', // Scopes or granted authorizations the user currently possesses.
-    
+
     // Arbitrary fields are also accepted to attach custom data to the user (RBAC, Oauth, etc…)
     custom_tag: 'custom data'
   })

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -235,6 +235,7 @@ tracer.use('kafkajs');
 tracer.use('knex');
 tracer.use('koa');
 tracer.use('koa', httpServerOptions);
+tracer.use('mariadb', { service: () => `my-custom-mariadb` })
 tracer.use('memcached');
 tracer.use('microgateway-core', httpServerOptions);
 tracer.use('mocha');

--- a/index.d.ts
+++ b/index.d.ts
@@ -564,6 +564,7 @@ interface Plugins {
   "kafkajs": plugins.kafkajs
   "knex": plugins.knex;
   "koa": plugins.koa;
+  "mariadb": plugins.mariadb;
   "memcached": plugins.memcached;
   "microgateway-core": plugins.microgateway_core;
   "mocha": plugins.mocha;
@@ -1140,6 +1141,14 @@ declare namespace plugins {
    * [kafkajs](https://kafka.js.org/) module.
    */
   interface kafkajs extends Instrumentation {}
+
+  /**
+   * This plugin automatically instruments the
+   * [mariadb](https://github.com/mariadb-corporation/mariadb-connector-nodejs) module.
+   */
+   interface mariadb extends Instrumentation {
+    service?: string | ((params: any) => string);
+  }
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -1,82 +1,85 @@
-'use strict'
+"use strict";
 
-const {
-  channel,
-  addHook,
-  AsyncResource
-} = require('./helpers/instrument')
+const { channel, addHook, AsyncResource } = require("./helpers/instrument");
 
-const shimmer = require('../../datadog-shimmer')
+const shimmer = require("../../datadog-shimmer");
 
-const startCh = channel('apm:mariadb:query:start');
-const finishCh = channel('apm:mariadb:query:finish');
-const errorCh = channel('apm:mariadb:query:error');
+const startCh = channel("apm:mariadb:query:start");
+const finishCh = channel("apm:mariadb:query:finish");
+const errorCh = channel("apm:mariadb:query:error");
+
+function wrapQueryCmd(queryCmd) {
+  return function (_conn, sql, _values) {
+    if (!startCh.hasSubscribers) {
+      return queryCmd.apply(this, arguments);
+    }
+
+    const asyncResource = new AsyncResource("bound-anonymous-fn");
+
+    return asyncResource.runInAsyncScope(() => {
+      startCh.publish({ sql });
+
+      try {
+        const promise = queryCmd.apply(this, arguments);
+
+        promise.then(
+          asyncResource.bind(() => finishCh.publish()),
+          asyncResource.bind((e) => {
+            errorCh.publish(e);
+            finishCh.publish();
+          })
+        );
+
+        return promise;
+      } catch (e) {
+        errorCh.publish(e);
+        finishCh.publish();
+        throw e;
+      }
+    });
+  };
+}
+
+function wrapQueryStream(queryStream) {
+  return function (sql, _values) {
+    if (!startCh.hasSubscribers) {
+      return queryStream.apply(this, arguments);
+    }
+
+    const asyncResource = new AsyncResource("bound-anonymous-fn");
+
+    return asyncResource.runInAsyncScope(() => {
+      startCh.publish({ sql });
+
+      try {
+        const stream = queryStream.apply(this, arguments);
+
+        stream
+          .once("end", () => finishCh.publish())
+          .once("error", (e) => {
+            errorCh.publish(e);
+            finishCh.publish();
+          });
+
+        return stream;
+      } catch (e) {
+        errorCh.publish(e);
+        finishCh.publish();
+        throw e;
+      }
+    });
+  };
+}
 
 addHook(
   {
-    name: 'mariadb',
-    file: 'lib/connection-promise.js',
-    versions: ['>=3'],
+    name: "mariadb",
+    file: "lib/connection-promise.js",
+    versions: [">=3"],
   },
   (ConnectionPromise) => {
-    shimmer.wrap(ConnectionPromise, '_QUERY_CMD', (queryCmd) => {
-      return function (_conn, sql, _values) {
-        if (!startCh.hasSubscribers) {
-          return queryCmd.apply(this, arguments);
-        }
-
-        const asyncResource = new AsyncResource('bound-anonymous-fn');
-
-        return asyncResource.runInAsyncScope(() => {
-          startCh.publish({ sql });
-
-          try {
-            const promise = queryCmd.apply(this, arguments);
-
-            promise.then(
-              asyncResource.bind(() => finishCh.publish()),
-              asyncResource.bind((e) => {
-                errorCh.publish(e);
-                finishCh.publish();
-              })
-            );
-
-            return promise;
-          } catch (e) {
-            errorCh.publish(e);
-            finishCh.publish();
-            throw e;
-          }
-        });
-      };
-    });
-
-    shimmer.wrap(ConnectionPromise.prototype, 'queryStream', (queryStream) => {
-      return function (sql, _values) {
-        if (!startCh.hasSubscribers) {
-          return queryStream.apply(this, arguments);
-        }
-
-        startCh.publish({ sql });
-
-        try {
-          const stream = queryStream.apply(this, arguments);
-
-          stream
-            .once('end', () => finishCh.publish())
-            .once('error', (e) => {
-              errorCh.publish(e);
-              finishCh.publish();
-            });
-
-          return stream;
-        } catch (e) {
-          errorCh.publish(e);
-          finishCh.publish();
-          throw e;
-        }
-      };
-    });
+    shimmer.wrap(ConnectionPromise, "_QUERY_CMD", wrapQueryCmd);
+    shimmer.wrap(ConnectionPromise.prototype, "queryStream", wrapQueryStream);
 
     return ConnectionPromise;
   }

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const {
+  channel,
+  addHook,
+  AsyncResource
+} = require('./helpers/instrument')
+
+const shimmer = require('../../datadog-shimmer')
+
+const startCh = channel('apm:mariadb:query:start');
+const finishCh = channel('apm:mariadb:query:finish');
+const errorCh = channel('apm:mariadb:query:error');
+
+addHook(
+  {
+    name: 'mariadb',
+    file: 'lib/connection-promise.js',
+    versions: ['>=3'],
+  },
+  (ConnectionPromise) => {
+    shimmer.wrap(ConnectionPromise, '_QUERY_CMD', (queryCmd) => {
+      return function (_conn, sql, _values) {
+        if (!startCh.hasSubscribers) {
+          return queryCmd.apply(this, arguments);
+        }
+
+        const asyncResource = new AsyncResource('bound-anonymous-fn');
+
+        return asyncResource.runInAsyncScope(() => {
+          startCh.publish({ sql });
+
+          try {
+            const promise = queryCmd.apply(this, arguments);
+
+            promise.then(
+              asyncResource.bind(() => finishCh.publish()),
+              asyncResource.bind((e) => {
+                errorCh.publish(e);
+                finishCh.publish();
+              })
+            );
+
+            return promise;
+          } catch (e) {
+            errorCh.publish(e);
+            finishCh.publish();
+            throw e;
+          }
+        });
+      };
+    });
+
+    shimmer.wrap(ConnectionPromise.prototype, 'queryStream', (queryStream) => {
+      return function (sql, _values) {
+        if (!startCh.hasSubscribers) {
+          return queryStream.apply(this, arguments);
+        }
+
+        const asyncResource = new AsyncResource('bound-anonymous-fn');
+
+        return asyncResource.runInAsyncScope(() => {
+          startCh.publish({ sql });
+
+          try {
+            const stream = queryStream.apply(this, arguments);
+
+            stream
+              .once('end', () => finishCh.publish())
+              .once('error', (e) => {
+                errorCh.publish(e);
+                finishCh.publish();
+              });
+
+            return stream;
+          } catch (e) {
+            errorCh.publish(e);
+            finishCh.publish();
+            throw e;
+          }
+        });
+      };
+    });
+
+    return ConnectionPromise;
+  }
+);

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -23,11 +23,14 @@ function wrapConnectionQuery(query) {
         const cmd = query.apply(this, arguments);
 
         cmd
-          .once("end", () => finishCh.publish())
-          .once("error", (e) => {
-            errorCh.publish(e);
-            finishCh.publish();
-          });
+          .once(
+            "end",
+            asyncResource.bind(() => finishCh.publish())
+          )
+          .once(
+            "error",
+            asyncResource.bind((e) => errorCh.publish(e))
+          );
 
         return cmd;
       } catch (e) {

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const Plugin = require('../../dd-trace/src/plugins/plugin');
+const { storage } = require('../../datadog-core');
+const analyticsSampler = require('../../dd-trace/src/analytics_sampler');
+
+class MariadbPlugin extends Plugin {
+  static get name() {
+    return 'mariadb';
+  }
+
+  constructor(...args) {
+    super(...args);
+
+    this.addSub('apm:mariadb:query:start', ({ sql }) => {
+      const service = getServiceName(this.tracer, this.config);
+      const store = storage.getStore();
+      const childOf = store ? store.span : store;
+      const tags = {
+        'service.name': service,
+        'span.type': 'sql',
+        'span.kind': 'client',
+        'db.type': 'mysql',
+        'resource.name': sql,
+      };
+
+      const span = this.tracer.startSpan('mariadb.query', {
+        childOf,
+        tags,
+      });
+
+      analyticsSampler.sample(span, this.config.measured);
+      this.enter(span, store);
+    });
+
+    this.addSub('apm:mariadb:query:error', (err) => {
+      const span = storage.getStore().span;
+      span.setTag('error', err);
+    });
+
+    this.addSub('apm:mariadb:query:finish', () => {
+      const span = storage.getStore().span;
+      span.finish();
+    });
+  }
+}
+
+function getServiceName(tracer, config) {
+  if (config.service) {
+    return config.service;
+  } else {
+    return `${tracer._service}-mariadb`;
+  }
+}
+
+module.exports = MariadbPlugin;

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -45,11 +45,13 @@ class MariadbPlugin extends Plugin {
   }
 }
 
-function getServiceName(tracer, config) {
-  if (config.service) {
-    return config.service;
+function getServiceName (tracer, config) {
+  if (typeof config.service === 'function') {
+    return config.service()
+  } else if (config.service) {
+    return config.service
   } else {
-    return `${tracer._service}-mariadb`;
+    return `${tracer._service}-mariadb`
   }
 }
 

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -1,47 +1,47 @@
-'use strict';
+'use strict'
 
-const Plugin = require('../../dd-trace/src/plugins/plugin');
-const { storage } = require('../../datadog-core');
-const analyticsSampler = require('../../dd-trace/src/analytics_sampler');
+const Plugin = require('../../dd-trace/src/plugins/plugin')
+const { storage } = require('../../datadog-core')
+const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 
 class MariadbPlugin extends Plugin {
-  static get name() {
-    return 'mariadb';
+  static get name () {
+    return 'mariadb'
   }
 
-  constructor(...args) {
-    super(...args);
+  constructor (...args) {
+    super(...args)
 
     this.addSub('apm:mariadb:query:start', ({ sql }) => {
-      const service = getServiceName(this.tracer, this.config);
-      const store = storage.getStore();
-      const childOf = store ? store.span : store;
+      const service = getServiceName(this.tracer, this.config)
+      const store = storage.getStore()
+      const childOf = store ? store.span : store
       const tags = {
         'service.name': service,
         'span.type': 'sql',
         'span.kind': 'client',
         'db.type': 'mysql',
-        'resource.name': sql,
-      };
+        'resource.name': sql
+      }
 
       const span = this.tracer.startSpan('mariadb.query', {
         childOf,
-        tags,
-      });
+        tags
+      })
 
-      analyticsSampler.sample(span, this.config.measured);
-      this.enter(span, store);
-    });
+      analyticsSampler.sample(span, this.config.measured)
+      this.enter(span, store)
+    })
 
     this.addSub('apm:mariadb:query:error', (err) => {
-      const span = storage.getStore().span;
-      span.setTag('error', err);
-    });
+      const span = storage.getStore().span
+      span.setTag('error', err)
+    })
 
     this.addSub('apm:mariadb:query:finish', () => {
-      const span = storage.getStore().span;
-      span.finish();
-    });
+      const span = storage.getStore().span
+      span.finish()
+    })
   }
 }
 
@@ -55,4 +55,4 @@ function getServiceName (tracer, config) {
   }
 }
 
-module.exports = MariadbPlugin;
+module.exports = MariadbPlugin

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { resolve } = require('path');
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 
@@ -21,7 +22,7 @@ describe('Plugin', () => {
           })
         })
 
-        beforeEach(async (done) => {
+        beforeEach(async () => {
           await agent.load('mariadb')
           mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
 
@@ -31,12 +32,14 @@ describe('Plugin', () => {
             database: 'db'
           })
 
-          connection.connect(err => {
-            if (err) {
-              done(err)
-            } else {
-              done()
-            }
+          return new Promise((resolve, reject) => {
+            connection.connect(err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(connection)
+              }
+            })
           })
         })
 
@@ -120,7 +123,7 @@ describe('Plugin', () => {
           })
         })
 
-        beforeEach(async (done) => {
+        beforeEach(async () => {
           await agent.load('mariadb', { service: 'custom' })
           mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
 
@@ -130,12 +133,14 @@ describe('Plugin', () => {
             database: 'db'
           })
 
-          connection.connect(err => {
-            if (err) {
-              done(err)
-            } else {
-              done()
-            }
+          return new Promise((resolve, reject) => {
+            connection.connect(err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(connection)
+              }
+            })
           })
         })
 
@@ -159,7 +164,7 @@ describe('Plugin', () => {
           })
         })
 
-        beforeEach(async (done) => {
+        beforeEach(async () => {
           await agent.load('mariadb', { service: serviceSpy })
           mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
 
@@ -169,12 +174,14 @@ describe('Plugin', () => {
             database: 'db'
           })
 
-          connection.connect(err => {
-            if (err) {
-              done(err)
-            } else {
-              done()
-            }
+          return new Promise((resolve, reject) => {
+            connection.connect(err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(connection)
+              }
+            })
           })
         })
 

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -133,6 +133,8 @@ describe('Plugin', () => {
           connection.connect(err => {
             if (err) {
               done(err)
+            } else {
+              done()
             }
           })
         })
@@ -170,6 +172,8 @@ describe('Plugin', () => {
           connection.connect(err => {
             if (err) {
               done(err)
+            } else {
+              done()
             }
           })
         })

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -23,7 +23,7 @@ describe('Plugin', () => {
 
         beforeEach(async (done) => {
           await agent.load('mariadb')
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -120,7 +120,7 @@ describe('Plugin', () => {
 
         beforeEach(async (done) => {
           await agent.load('mariadb', { service: 'custom' })
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -157,7 +157,7 @@ describe('Plugin', () => {
 
         beforeEach(async (done) => {
           await agent.load('mariadb', { service: serviceSpy })
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -198,7 +198,7 @@ describe('Plugin', () => {
 
         beforeEach(async () => {
           await agent.load('mariadb')
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
 
           pool = mariadb.createPool({
             connectionLimit: 1,

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -34,6 +34,8 @@ describe('Plugin', () => {
           connection.connect(err => {
             if (err) {
               done(err)
+            } else {
+              done()
             }
           })
         })

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -21,9 +21,9 @@ describe('Plugin', () => {
           })
         })
 
-        beforeEach(async () => {
+        beforeEach(async (done) => {
           await agent.load('mariadb')
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -31,7 +31,11 @@ describe('Plugin', () => {
             database: 'db'
           })
 
-          connection.connect()
+          connection.connect(err => {
+            if (err) {
+              done(err)
+            }
+          })
         })
 
         it('should propagate context to callbacks, with correct callback args', done => {
@@ -114,9 +118,9 @@ describe('Plugin', () => {
           })
         })
 
-        beforeEach(async () => {
+        beforeEach(async (done) => {
           await agent.load('mariadb', { service: 'custom' })
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -124,7 +128,11 @@ describe('Plugin', () => {
             database: 'db'
           })
 
-          connection.connect()
+          connection.connect(err => {
+            if (err) {
+              done(err)
+            }
+          })
         })
 
         it('should be configured with the correct values', done => {
@@ -147,9 +155,9 @@ describe('Plugin', () => {
           })
         })
 
-        beforeEach(async () => {
+        beforeEach(async (done) => {
           await agent.load('mariadb', { service: serviceSpy })
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -157,7 +165,11 @@ describe('Plugin', () => {
             database: 'db'
           })
 
-          connection.connect()
+          connection.connect(err => {
+            if (err) {
+              done(err)
+            }
+          })
         })
 
         it('should be configured with the correct values', done => {
@@ -186,7 +198,7 @@ describe('Plugin', () => {
 
         beforeEach(async () => {
           await agent.load('mariadb')
-          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
 
           pool = mariadb.createPool({
             connectionLimit: 1,

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -23,7 +23,7 @@ describe('Plugin', () => {
 
         beforeEach(async (done) => {
           await agent.load('mariadb')
-          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -120,7 +120,7 @@ describe('Plugin', () => {
 
         beforeEach(async (done) => {
           await agent.load('mariadb', { service: 'custom' })
-          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -157,7 +157,7 @@ describe('Plugin', () => {
 
         beforeEach(async (done) => {
           await agent.load('mariadb', { service: serviceSpy })
-          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
 
           connection = mariadb.createConnection({
             host: 'localhost',
@@ -198,7 +198,7 @@ describe('Plugin', () => {
 
         beforeEach(async () => {
           await agent.load('mariadb')
-          mariadb = proxyquire(`../../../versions/mariadb@${version}/callback`, {}).get()
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`).get('mariadb/callback')
 
           pool = mariadb.createPool({
             connectionLimit: 1,

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -1,0 +1,241 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const proxyquire = require('proxyquire').noPreserveCache()
+
+describe('Plugin', () => {
+  let mariadb
+  let tracer
+
+  describe('mariadb', () => {
+    withVersions('mariadb', 'mariadb', version => {
+      beforeEach(() => {
+        tracer = require('../../dd-trace')
+      })
+      describe('without configuration', () => {
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+
+          connection = mariadb.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          connection.connect()
+        })
+
+        it('should propagate context to callbacks, with correct callback args', done => {
+          const span = tracer.startSpan('test')
+
+          tracer.scope().activate(span, () => {
+            const span = tracer.scope().active()
+            connection.query('SELECT 1 + 1 AS solution', (err, results, fields) => {
+              expect(results).to.not.be.null
+              expect(fields).to.not.be.null
+              expect(tracer.scope().active()).to.equal(span)
+              done()
+            })
+          })
+        })
+
+        it('should run the callback in the parent context', done => {
+          connection.query('SELECT 1 + 1 AS solution', () => {
+            expect(tracer.scope().active()).to.be.null
+            done()
+          })
+        })
+
+        it('should run event listeners in the parent context', done => {
+          const query = connection.query('SELECT 1 + 1 AS solution')
+
+          query.on('result', () => {
+            expect(tracer.scope().active()).to.be.null
+            done()
+          })
+        })
+
+        it('should do automatic instrumentation', done => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
+            expect(traces[0][0]).to.have.property('type', 'sql')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
+
+            done()
+          })
+
+          connection.query('SELECT 1 + 1 AS solution', (error, results, fields) => {
+            if (error) throw error
+          })
+        })
+
+        it('should handle errors', done => {
+          let error
+
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('error.type', error.name)
+            expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+            expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+
+            done()
+          })
+
+          connection.query('INVALID', (err, results, fields) => {
+            error = err
+          })
+        })
+
+        it('should work without a callback', done => {
+          agent.use(traces => {
+            done()
+          })
+
+          connection.query('SELECT 1 + 1 AS solution')
+        })
+      })
+
+      describe('with configuration', () => {
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb', { service: 'custom' })
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+
+          connection = mariadb.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          connection.connect()
+        })
+
+        it('should be configured with the correct values', done => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'custom')
+            done()
+          })
+
+          connection.query('SELECT 1 + 1 AS solution', () => {})
+        })
+      })
+
+      describe('with service configured as function', () => {
+        const serviceSpy = sinon.stub().returns('custom')
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb', { service: serviceSpy })
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+
+          connection = mariadb.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          connection.connect()
+        })
+
+        it('should be configured with the correct values', done => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'custom')
+            sinon.assert.calledWith(serviceSpy, sinon.match({
+              host: 'localhost',
+              user: 'root',
+              database: 'db'
+            }))
+            done()
+          })
+
+          connection.query('SELECT 1 + 1 AS solution', () => {})
+        })
+      })
+
+      describe('with a connection pool', () => {
+        let pool
+
+        afterEach((done) => {
+          pool.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get()
+
+          pool = mariadb.createPool({
+            connectionLimit: 1,
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+        })
+
+        it('should do automatic instrumentation', done => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
+            expect(traces[0][0]).to.have.property('type', 'sql')
+            expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
+
+            done()
+          })
+
+          pool.query('SELECT 1 + 1 AS solution', () => {})
+        })
+
+        it('should run the callback in the parent context', done => {
+          pool.query('SELECT 1 + 1 AS solution', () => {
+            expect(tracer.scope().active()).to.be.null
+            done()
+          })
+        })
+
+        it('should propagate context to callbacks', done => {
+          const span1 = tracer.startSpan('test1')
+          const span2 = tracer.startSpan('test2')
+
+          tracer.trace('test', () => {
+            tracer.scope().activate(span1, () => {
+              pool.query('SELECT 1 + 1 AS solution', () => {
+                expect(tracer.scope().active() === span1).to.eql(true)
+                tracer.scope().activate(span2, () => {
+                  pool.query('SELECT 1 + 1 AS solution', () => {
+                    expect(tracer.scope().active() === span2).to.eql(true)
+                    done()
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -35,6 +35,7 @@ module.exports = {
   get 'koa' () { return require('../../../datadog-plugin-koa/src') },
   get 'koa-router' () { return require('../../../datadog-plugin-koa/src') },
   get 'kafkajs' () { return require('../../../datadog-plugin-kafkajs/src') },
+  get 'mariadb' () { return require('../../../datadog-plugin-mariadb/src') },
   get 'memcached' () { return require('../../../datadog-plugin-memcached/src') },
   get 'microgateway-core' () { return require('../../../datadog-plugin-microgateway-core/src') },
   get 'mocha' () { return require('../../../datadog-plugin-mocha/src') },


### PR DESCRIPTION
### What does this PR do?

Add [mariadb](https://github.com/mariadb-corporation/mariadb-connector-nodejs) instrumentation and plugin. 

### Motivation

The package is a good alternative to the mysql and mysql2 packages.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
