### PR TITLE
feat: Don't enable DD_TRACE_TELEMETRY API in Lambda, unless env is set

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -93,6 +93,7 @@ class Config {
     )
     const DD_TRACE_TELEMETRY_ENABLED = coalesce(
       process.env.DD_TRACE_TELEMETRY_ENABLED,
+      !process.env.AWS_LAMBDA_FUNCTION_NAME,
       true
     )
     const DD_TRACE_DEBUG = coalesce(

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -93,8 +93,7 @@ class Config {
     )
     const DD_TRACE_TELEMETRY_ENABLED = coalesce(
       process.env.DD_TRACE_TELEMETRY_ENABLED,
-      !process.env.AWS_LAMBDA_FUNCTION_NAME,
-      true
+      !process.env.AWS_LAMBDA_FUNCTION_NAME
     )
     const DD_TRACE_DEBUG = coalesce(
       process.env.DD_TRACE_DEBUG,


### PR DESCRIPTION
### What does this PR do?
We received a few reports of proxy errors and increased cold starts due to this feature being enabled but not supported by Lambda.
https://github.com/DataDog/datadog-agent/issues/12448
https://github.com/DataDog/datadog-lambda-extension/issues/64

This change will disable DD_TRACE_TELEMETRY_ENABLED if a function name env var is present.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
