### PR TITLE
[GraphQL] Path Checking Performance Fix

### DIFF
--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -8,10 +8,10 @@ if (Number(process.env.WITH_TRACER)) {
 
   // Note: depth must be an integer >= 0, and collapse either 0 or 1 (true or false)
   if (Number(process.env.WITH_DEPTH)) {
-    tracer.use('graphql', { depth: +process.env.WITH_DEPTH })
+    tracer.use('graphql', { depth: Number(process.env.WITH_DEPTH) })
   } else if (process.env.WITH_DEPTH_AND_COLLAPSE) {
     const [depth, collapse] = process.env.WITH_DEPTH_AND_COLLAPSE.split(',')
-    tracer.use('graphql', { depth: +depth, collapse: !!+collapse })
+    tracer.use('graphql', { depth: Number(depth), collapse: Number(collapse) > 0 })
   }
 }
 

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -4,7 +4,7 @@ const semver = require('semver')
 
 // TODO: benchmark the tracer as well but for now it's just too slow
 // if (Number(process.env.WITH_TRACER)) {
-//   require('../../..').init().use('graphql', { depth: 0 })
+require('../../..').init().use('graphql', { depth: 3, collapse: true })
 // }
 
 if (Number(process.env.WITH_ASYNC_HOOKS)) {
@@ -40,5 +40,6 @@ const source = `
 const variableValues = { who: 'world' }
 
 for (let i = 0; i < 5; i++) {
-  graphql.graphql({ schema, source, variableValues })
+  console.time(`Execution Time ${i}`)
+  graphql.graphql({ schema, source, variableValues }).then(() => console.timeEnd(`Execution Time ${i}`))
 }

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -4,7 +4,15 @@ const semver = require('semver')
 
 // TODO: benchmark the tracer as well but for now it's just too slow
 if (Number(process.env.WITH_TRACER)) {
-  require('../../..').init().use('graphql', { depth: 3, collapse: false })
+  const tracer = require('../../..').init()
+
+  // Note: depth must be an integer >= 0, and collapse either 0 or 1 (true or false)
+  if (Number(process.env.WITH_DEPTH)) {
+    tracer.use('graphql', { depth: +process.env.WITH_DEPTH })
+  } else if (process.env.WITH_DEPTH_AND_COLLAPSE) {
+    const [depth, collapse] = process.env.WITH_DEPTH_AND_COLLAPSE.split(',')
+    tracer.use('graphql', { depth: +depth, collapse: !!+collapse })
+  }
 }
 
 if (Number(process.env.WITH_ASYNC_HOOKS)) {

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -3,9 +3,9 @@
 const semver = require('semver')
 
 // TODO: benchmark the tracer as well but for now it's just too slow
-// if (Number(process.env.WITH_TRACER)) {
-require('../../..').init().use('graphql', { depth: 3, collapse: true })
-// }
+if (Number(process.env.WITH_TRACER)) {
+  require('../../..').init().use('graphql', { depth: 3, collapse: false })
+}
 
 if (Number(process.env.WITH_ASYNC_HOOKS)) {
   const hook = semver.satisfies(process.versions.node, '>=14.5 || ^12.19.0')
@@ -40,6 +40,5 @@ const source = `
 const variableValues = { who: 'world' }
 
 for (let i = 0; i < 5; i++) {
-  console.time(`Execution Time ${i}`)
-  graphql.graphql({ schema, source, variableValues }).then(() => console.timeEnd(`Execution Time ${i}`))
+  graphql.graphql({ schema, source, variableValues })
 }

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-graphql",
   "run": "node index.js",
-  "cachegrind": true,
+  "cachegrind": false,
   "iterations": 3,
   "variants": {
     "control": {},
@@ -11,22 +11,18 @@
     },
     "with-depth-off": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0"},
-      "cachegrind": false
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0"}
     },"with-depth-on-max": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4"},
-      "cachegrind": false
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4"}
     },
     "with-depth-and-collapse-off": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0"},
-      "cachegrind": false
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0"}
     },
     "with-depth-and-collapse-on": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,1"},
-      "cachegrind": false
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,1"}
     }
   }
 }

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -8,6 +8,21 @@
     "with-async-hooks": {
       "baseline": "control",
       "env": { "WITH_ASYNC_HOOKS": "1" }
+    },
+    "with-depth-off": {
+      "baseline": "control",
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0"}
+    },"with-depth-on-max": {
+      "baseline": "control",
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4"}
+    },
+    "with-depth-and-collapse-off": {
+      "baseline": "control",
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0"}
+    },
+    "with-depth-and-collapse-on": {
+      "baseline": "control",
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,1"}
     }
   }
 }

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -11,18 +11,22 @@
     },
     "with-depth-off": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0"}
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0"},
+      "cachegrind": false
     },"with-depth-on-max": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4"}
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4"},
+      "cachegrind": false
     },
     "with-depth-and-collapse-off": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0"}
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0"},
+      "cachegrind": false
     },
     "with-depth-and-collapse-on": {
       "baseline": "control",
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,1"}
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,1"},
+      "cachegrind": false
     }
   }
 }

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -230,13 +230,11 @@ function callInAsyncScope (fn, aR, thisArg, args, cb) {
   })
 }
 
-function pathToArray (path, includeNumbers = true) {
+function pathToArray (path) {
   const flattened = []
   let curr = path
   while (curr) {
-    const key = curr.key
-    flattened.push(key)
-    if (typeof key === 'number' && !includeNumbers) flattened.splice(-1)
+    flattened.push(curr.key)
     curr = curr.prev
   }
   return flattened.reverse()

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -170,7 +170,7 @@ function wrapExecute (execute) {
           docSource: documentSources.get(document)
         })
 
-        const context = { source, asyncResource, fields: {}, collapsedPaths: {} }
+        const context = { source, asyncResource, fields: {} }
 
         contexts.set(contextValue, context)
 

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -246,10 +246,8 @@ function assertField (context, info) {
   const pathInfo = info && info.path
 
   const path = pathToArray(pathInfo)
-  const collapsedPath = pathToArray(pathInfo, false)
 
   const pathString = path.join('.')
-  const collapsedPathString = collapsedPath.join('.')
   const fields = context.fields
 
   let field = fields[pathString]
@@ -266,8 +264,7 @@ function assertField (context, info) {
       childResource.runInAsyncScope(() => {
         startResolveCh.publish({
           info,
-          context,
-          collapsedPathString
+          context
         })
       })
 
@@ -276,8 +273,6 @@ function assertField (context, info) {
         asyncResource: childResource,
         error: null
       }
-
-      context.collapsedPaths[collapsedPathString] = true
     })
   }
 

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -12,12 +12,15 @@ class GraphQLResolvePlugin extends Plugin {
   constructor (...args) {
     super(...args)
 
-    this.addSub('apm:graphql:resolve:start', ({ info, context, collapsedPathString }) => {
+    this.addSub('apm:graphql:resolve:start', ({ info, context }) => {
       const store = storage.getStore()
       depthPredicate(info, this.config, (computedPath) => {
         const computedPathString = computedPath.join('.')
         if ((!this.config.collapse && !context.fields[computedPathString]) ||
-             !context.collapsedPaths[collapsedPathString]) {
+             !context.collapsedPaths[computedPathString]) {
+          // cache the collapsed string here
+          if (this.config.collapse) context.collapsedPaths[computedPathString] = true
+
           const service = this.config.service || this.tracer._service
           const childOf = store ? store.span : store
           const span = this.tracer.startSpan(`graphql.resolve`, {

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -19,7 +19,7 @@ class GraphQLResolvePlugin extends Plugin {
       depthPredicate(info, this.config, (computedPath) => {
         const computedPathString = computedPath.join('.')
         if ((!this.config.collapse && !context.fields[computedPathString]) ||
-             (context[collapsedPathSym] && !context[collapsedPathSym][computedPathString])) {
+             (!context[collapsedPathSym] || !context[collapsedPathSym][computedPathString])) {
           // cache the collapsed string here
           if (this.config.collapse) {
             if (!context[collapsedPathSym]) context[collapsedPathSym] = {}

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -19,7 +19,7 @@ class GraphQLResolvePlugin extends Plugin {
       depthPredicate(info, this.config, (computedPath) => {
         const computedPathString = computedPath.join('.')
         if ((!this.config.collapse && !context.fields[computedPathString]) ||
-             !context[collapsedPathSym]?.[computedPathString]) {
+             (context[collapsedPathSym] && !context[collapsedPathSym][computedPathString])) {
           // cache the collapsed string here
           if (this.config.collapse) {
             if (!context[collapsedPathSym]) context[collapsedPathSym] = {}

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -83,12 +83,27 @@ class GraphQLResolvePlugin extends Plugin {
  * that has already been processed for a span that either looks like or is the computed path.
  * In the case where the user intentionally sets config.collapse = false, there should be no change.
  */
-function hasLikePath (context, computedPathArray) {
-  const computedPath = computedPathArray.join('.')
+function hasLikePath (context, actualPath) {
   const paths = Object.keys(context.fields)
-  const number = '([0-9]+)'
-  const regexPath = new RegExp(computedPath.replace(/\*/g, number))
-  return paths.filter(path => regexPath.test(path)).length > 0
+  for (let i = 0; i < paths.length; i++) {
+    const arrayPath = paths[i].split('.')
+    if (arrayPath.length !== actualPath.length) continue
+    let matches = true
+    for (let j = 0; j < arrayPath.length; j++) {
+      const seg1 = arrayPath[j]
+      const seg2 = actualPath[j]
+      if (seg1 !== seg2) {
+        if (seg1 === '*' || seg2 === '*') {
+          matches = true
+        } else {
+          matches = false
+          break
+        }
+      }
+    }
+    if (matches) return true
+  }
+  return false
 }
 
 function depthPredicate (info, config, func) {


### PR DESCRIPTION
### What does this PR do?
Improves path-checking performance

### Motivation
Fixes #2159 
The `hasLikePath` function was slow, likely due to the use of iterative application of a regex test. This PR attempts to resolve it through means other than regex, starting with a similar iterative approach, but doing more basic logic checks.

### Performance Measurement

All these metrics come from the benchmark structure and schema in `./benchmark/sirun/plugin-graphql`, which runs a stress test of 5 rounds against a runtime-heavy schema.

5 runs w/o tracer:

388.651ms, 386.741ms, 386.139ms, 385.662ms, 382.978ms

5 runs w/ tracer, before final changes (using intermediate commit, which has iterative approach)

**collapse set to true**: 1.702s, 1.682s, 1.680s, 1.678s, 1.677s
**collapse set to false**: 17:19.589, 17:19.555, 17:19.553, 17:19.551, 17:19.550 (all in m:ss.mmm)

5 runs w/ tracer, after final changes (cached approach)

**collapse set to true**: 1.889s, 1.869s, 1.866s, 1.864s, 1.864s
**collapse set to false**: 2.931s, 2.910s, 2.907s, 2.905s, 2.904s

Note that these results *are on* a stress test, so an individual run would be faster as well, but the stress test shows increased performance on a consistent basis.