### PR TITLE
Update typescript definition to prevent experimental:true property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -313,10 +313,10 @@ export declare interface TracerOptions {
   };
 
   /**
-   * Experimental features can be enabled all at once by using true or individually using key / value pairs.
+   * Experimental features can be enabled individually using key / value pairs.
    * @default {}
    */
-  experimental?: boolean | {
+  experimental?: {
     b3?: boolean
     traceparent?: boolean
 


### PR DESCRIPTION
### What does this PR do?
Updates index.d.ts file to be compatible with the code that ignores `{experimental: true}`property.

### Motivation
I've seen that it is wrong
