### PR TITLE
[codeowners] Add CI Visibility

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,17 @@
 * @DataDog/apm-js
-/packages/dd-trace/src/ci-visibility/ @DataDog/ci-app-tracers
+
+/ci/**/*                                                 @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/jest.js           @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/mocha.js          @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cucumber.js       @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cypress.js        @DataDog/ci-app-libraries
+/packages/datadog-plugin-jest/**/*                       @DataDog/ci-app-libraries
+/packages/datadog-plugin-mocha/**/*                      @DataDog/ci-app-libraries
+/packages/datadog-plugin-cucumber/**/*                   @DataDog/ci-app-libraries
+/packages/datadog-plugin-cypress/**/*                    @DataDog/ci-app-libraries
+/packages/dd-trace/src/ci-visibility/**/*                @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/agentless-ci-visibility.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/test.js              @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/git.js               @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/ci.js                @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/user-provided-git.js @DataDog/ci-app-libraries


### PR DESCRIPTION
### What does this PR do?
Makes CI Visibility the codeowner of all CI Visibility-specific files

### Motivation
Allow the CI team to review PRs that only affect CI Visibility-specific code.
