### PR TITLE
remove grpc client service suffix and rename spans

### DIFF
--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -19,13 +19,13 @@ class GrpcClientPlugin extends Plugin {
       const metadataFilter = this.config.metadataFilter
       const store = storage.getStore()
       const childOf = store && store.span
-      const span = this.tracer.startSpan('grpc.request', {
+      const span = this.tracer.startSpan('grpc.client', {
         childOf,
         tags: {
           [Tags.SPAN_KIND]: 'client',
           'span.type': 'http',
           'resource.name': path,
-          'service.name': this.config.service || `${this.tracer._service}-grpc-client`,
+          'service.name': this.config.service || this.tracer._service,
           'component': 'grpc'
         }
       })

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -19,13 +19,13 @@ class GrpcServerPlugin extends Plugin {
       const metadataFilter = this.config.metadataFilter
       const store = storage.getStore()
       const childOf = extract(this.tracer, metadata)
-      const span = this.tracer.startSpan('grpc.request', {
+      const span = this.tracer.startSpan('grpc.server', {
         childOf,
         tags: {
           [Tags.SPAN_KIND]: 'server',
           'span.type': 'web',
           'resource.name': name,
-          'service.name': this.config.service || `${this.tracer._service}`,
+          'service.name': this.config.service || this.tracer._service,
           'component': 'grpc'
         }
       })

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -102,8 +102,8 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.request',
-                    service: 'test-grpc-client',
+                    name: 'grpc.client',
+                    service: 'test',
                     resource: '/test.TestService/getUnary',
                     type: 'http'
                   })
@@ -138,8 +138,8 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.request',
-                    service: 'test-grpc-client',
+                    name: 'grpc.client',
+                    service: 'test',
                     resource: '/test.TestService/getServerStream',
                     type: 'http'
                   })
@@ -172,8 +172,8 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.request',
-                    service: 'test-grpc-client',
+                    name: 'grpc.client',
+                    service: 'test',
                     resource: '/test.TestService/getClientStream',
                     type: 'http'
                   })
@@ -206,8 +206,8 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.request',
-                    service: 'test-grpc-client',
+                    name: 'grpc.client',
+                    service: 'test',
                     resource: '/test.TestService/getBidi',
                     type: 'http'
                   })
@@ -338,8 +338,8 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.request',
-                    service: 'test-grpc-client',
+                    name: 'grpc.client',
+                    service: 'test',
                     resource: '/test.TestService/getUnary'
                   })
 
@@ -369,8 +369,8 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.request',
-                    service: 'test-grpc-client',
+                    name: 'grpc.client',
+                    service: 'test',
                     resource: '/test.TestService/getUnary'
                   })
 

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -82,7 +82,7 @@ describe('Plugin', () => {
           return agent
             .use(traces => {
               expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
+                name: 'grpc.server',
                 service: 'test',
                 resource: '/test.TestService/getUnary',
                 type: 'web'
@@ -108,7 +108,7 @@ describe('Plugin', () => {
           return agent
             .use(traces => {
               expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
+                name: 'grpc.server',
                 service: 'test',
                 resource: '/test.TestService/getServerStream',
                 type: 'web'
@@ -133,7 +133,7 @@ describe('Plugin', () => {
           return agent
             .use(traces => {
               expect(traces[0][0]).to.deep.include({
-                name: 'grpc.request',
+                name: 'grpc.server',
                 service: 'test',
                 resource: '/test.TestService/getBidi',
                 type: 'web'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove `grpc` client service suffix and rename spans.

### Motivation
<!-- What inspired you to submit this pull request? -->

Clients to remote services should not be suffixed and should instead be differentiated based on the operation name.