### PR TITLE
fix integration tests not erroring when the child process exits

### DIFF
--- a/integration-tests/esm.spec.js
+++ b/integration-tests/esm.spec.js
@@ -31,7 +31,7 @@ describe('esm', () => {
   })
 
   afterEach(async () => {
-    proc.kill()
+    proc && proc.kill()
     await agent.stop()
   })
 
@@ -40,7 +40,7 @@ describe('esm', () => {
       proc = await spawnProc(path.join(cwd, 'esm/http.mjs'), {
         cwd,
         env: {
-          NODE_OPTIONS: `--no-warnings --loader=${hookFile}`,
+          NODE_OPTIONS: `--loader=${hookFile}`,
           AGENT_PORT: agent.port
         }
       })
@@ -60,7 +60,7 @@ describe('esm', () => {
       proc = await spawnProc(path.join(cwd, 'esm/express.mjs'), {
         cwd,
         env: {
-          NODE_OPTIONS: `--no-warnings --loader=${hookFile}`,
+          NODE_OPTIONS: `--loader=${hookFile}`,
           AGENT_PORT: agent.port
         }
       })

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -95,10 +95,13 @@ class FakeAgent extends EventEmitter {
 function spawnProc (filename, options = {}) {
   const proc = fork(filename, options)
   return new Promise((resolve, reject) => {
-    proc.on('message', ({ port }) => {
-      proc.url = `http://localhost:${port}`
-      resolve(proc)
-    }).on('error', reject)
+    proc
+      .on('message', ({ port }) => {
+        proc.url = `http://localhost:${port}`
+        resolve(proc)
+      })
+      .on('error', reject)
+      .on('exit', code => reject(new Error(`Process exited with status code ${code}.`)))
   })
 }
 

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -101,7 +101,11 @@ function spawnProc (filename, options = {}) {
         resolve(proc)
       })
       .on('error', reject)
-      .on('exit', code => reject(new Error(`Process exited with status code ${code}.`)))
+      .on('exit', code => {
+        if (code !== 0) {
+          reject(new Error(`Process exited with status code ${code}.`))
+        }
+      })
   })
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix integration tests not erroring when the child process exits.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise the test would just hang forever.