### PR TITLE
[ci-visibility] Remove require.cache hack in `ci/init`

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -1,10 +1,7 @@
 /* eslint-disable no-console */
-
-const path = require('path')
 const tracer = require('../packages/dd-trace')
 const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
-const { mochaHook } = require('../packages/datadog-instrumentations/src/mocha')
-const { pickleHook, testCaseHook } = require('../packages/datadog-instrumentations/src/cucumber')
+const { isTrue } = require('../packages/dd-trace/src/util')
 
 const options = {
   startupLogs: false,
@@ -15,9 +12,7 @@ const options = {
 
 let shouldInit = true
 
-const isAgentlessEnabled = process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED &&
-  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== 'false' &&
-  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== '0'
+const isAgentlessEnabled = isTrue(process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED)
 
 if (isAgentlessEnabled) {
   if (process.env.DATADOG_API_KEY || process.env.DD_API_KEY) {
@@ -30,25 +25,6 @@ but neither DD_API_KEY nor DATADOG_API_KEY are set in your environment, \
 so dd-trace will not be initialized.`)
     shouldInit = false
   }
-}
-
-// TODO: remove this in a later major version since we now recommend using
-// `NODE_OPTIONS='-r dd-trace/ci/init'`.
-try {
-  for (const filename in require.cache) {
-    const cache = require.cache[filename]
-    const id = filename.split(path.sep).join('/')
-
-    if (id.includes('/node_modules/mocha/lib/runner.js')) {
-      cache.exports = mochaHook(cache.exports)
-    } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/pickle_runner.js')) {
-      cache.exports = pickleHook(cache.exports)
-    } else if (id.includes('/node_modules/@cucumber/cucumber/lib/runtime/test_case_runner.js')) {
-      cache.exports = testCaseHook(cache.exports)
-    }
-  }
-} catch (e) {
-  // ignore error and let the tracer initialize anyway
 }
 
 if (shouldInit) {

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -2,7 +2,7 @@
 
 const tracer = require('../../packages/dd-trace')
 const { ORIGIN_KEY } = require('../../packages/dd-trace/src/constants')
-const { isTrue } = require('../packages/dd-trace/src/util')
+const { isTrue } = require('../../packages/dd-trace/src/util')
 
 const options = {
   startupLogs: false,

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -2,6 +2,7 @@
 
 const tracer = require('../../packages/dd-trace')
 const { ORIGIN_KEY } = require('../../packages/dd-trace/src/constants')
+const { isTrue } = require('../packages/dd-trace/src/util')
 
 const options = {
   startupLogs: false,
@@ -10,9 +11,7 @@ const options = {
   }
 }
 
-const isAgentlessEnabled = process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED &&
-  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== 'false' &&
-  process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED !== '0'
+const isAgentlessEnabled = isTrue(process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED)
 
 if (isAgentlessEnabled) {
   if (process.env.DATADOG_API_KEY || process.env.DD_API_KEY) {


### PR DESCRIPTION
### What does this PR do?
Remove the manual patching of the `require.cache` now that the way to use CI Visibility is through `NODE_OPTIONS`

### Motivation
Remove unused code. 

