### PR TITLE
docs: fix reference to mysql2 upstream

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1209,7 +1209,7 @@ declare namespace plugins {
 
   /**
    * This plugin automatically instruments the
-   * [mysql2](https://github.com/brianmario/mysql2) module.
+   * [mysql2](https://github.com/sidorares/node-mysql2) module.
    */
   interface mysql2 extends mysql {}
 


### PR DESCRIPTION
### What does this PR do?

I updated the JSDocs where I found the link for the `mysql2` integration in `index.d.ts` which pointed to the wrong project. It previously pointed to a Ruby package but the instrumented package in `dd-trace-js` is for [this package](https://github.com/sidorares/node-mysql2). The upstream source code link has been updated accordingly.

### Motivation

The good fight for good documentation 🙂

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [x] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

I'm assuming the API docs are generated from the [mysql2 interface docs](https://datadoghq.dev/dd-trace-js/interfaces/plugins.mysql2.html) which is where I encountered the issue.