### PR TITLE
[ci-visibility] Make sure ci visibility always uses real timers

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -3,7 +3,7 @@
 // TODO (new internal tracer): use DC events for lifecycle metrics and test them
 
 const opentracing = require('opentracing')
-const now = require('performance-now')
+const { now, dateNow } = require('./time')
 const semver = require('semver')
 const Span = opentracing.Span
 const SpanContext = require('./span_context')
@@ -91,7 +91,7 @@ class DatadogSpan extends Span {
     }
 
     spanContext._trace.started.push(this)
-    spanContext._trace.startTime = spanContext._trace.startTime || Date.now()
+    spanContext._trace.startTime = spanContext._trace.startTime || dateNow()
     spanContext._trace.ticks = spanContext._trace.ticks || now()
 
     return spanContext

--- a/packages/dd-trace/src/opentracing/time.js
+++ b/packages/dd-trace/src/opentracing/time.js
@@ -1,0 +1,34 @@
+const now = require('performance-now')
+const dateNow = Date.now
+
+let originalPerformanceNow, originalProcessHrTime
+
+if (performance) {
+  originalPerformanceNow = performance.now
+} else if (process.hrtime) {
+  originalProcessHrTime = process.hrtime
+}
+
+module.exports = {
+  dateNow,
+  now: function () {
+    let currentPerformanceNow, currentProcessHrTime
+
+    if (performance) {
+      currentPerformanceNow = performance.now
+      performance.now = originalPerformanceNow
+    } else if (process.hrtime) {
+      currentProcessHrTime = process.hrtime
+      process.hrtime = originalProcessHrTime
+    }
+
+    const result = now()
+
+    if (performance) {
+      performance.now = currentPerformanceNow
+    } else if (process.hrtime) {
+      process.hrtime = currentProcessHrTime
+    }
+    return result
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Fix reporting potentially bad times. 

### Motivation
Some libraries like https://github.com/sinonjs/fake-timers modify the global methods for calculating time (such as `Date.now`, `performance.now` or `process.hrtime`), so we might end up reporting wrong numbers in ci visibility. 

This PR makes sure we grasp the global references early on, so we use the correct instance always when calculating time.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
