### PR TITLE
fix possible disconnected middleware spans for web frameworks

### DIFF
--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -16,11 +16,15 @@ class RouterPlugin extends WebPlugin {
     this._contexts = new WeakMap()
 
     this.addSub(`apm:${this.constructor.name}:middleware:enter`, ({ req, name, route }) => {
-      const store = storage.getStore()
-      const context = this._createContext(req, route)
-      const span = this._getMiddlewareSpan(context, store, name)
+      const childOf = this._getActive(req)
+      const span = this._getMiddlewareSpan(name, childOf)
+      const context = this._createContext(req, route, span)
 
-      this.enter(span, store)
+      if (childOf !== span) {
+        context.middleware.push(span)
+      }
+
+      this.enter(span)
 
       web.patch(req)
       web.setRoute(req, context.route)
@@ -57,9 +61,22 @@ class RouterPlugin extends WebPlugin {
     })
   }
 
-  _getMiddlewareSpan (context, store, name) {
-    const childOf = store && store.span
+  _getActive (req) {
+    const context = this._contexts.get(req)
 
+    if (!context) return this._getStoreSpan()
+    if (context.middleware.length === 0) return context.span
+
+    return context.middleware[context.middleware.length - 1]
+  }
+
+  _getStoreSpan () {
+    const store = storage.getStore()
+
+    return store && store.span
+  }
+
+  _getMiddlewareSpan (name, childOf) {
     if (this.config.middleware === false) {
       return childOf
     }
@@ -71,14 +88,12 @@ class RouterPlugin extends WebPlugin {
       }
     })
 
-    context.middleware.push(span)
-
     analyticsSampler.sample(span, this.config.measured)
 
     return span
   }
 
-  _createContext (req, route) {
+  _createContext (req, route, span) {
     let context = this._contexts.get(req)
 
     if (!route || route === '/' || route === '*') {
@@ -96,6 +111,7 @@ class RouterPlugin extends WebPlugin {
       }
     } else {
       context = {
+        span,
         stack: [route],
         route,
         middleware: []


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix possible disconnected middleware spans for web frameworks.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some middleware can lose the asynchronous context resulting in disconnected traces. We originally assumed this would be a rare occurrence and was not handled in the plugin rewrite, but it turns out body-parser has this issue in versions prior to 1.20.0 and it's an extremely commonly used middleware.

Fixes #2204
