### PR TITLE
[ci-visibility] Only run git commands when `jest` is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,8 @@ jobs:
 
   node-bench-sirun-plugin-http: *node-bench-sirun-base
 
+  node-bench-sirun-plugin-jest: *node-bench-sirun-base
+
   node-bench-sirun-scope: *node-bench-sirun-base
 
   node-bench-sirun-exporting-pipeline: *node-bench-sirun-base
@@ -227,6 +229,7 @@ workflows:
       - node-bench-sirun-plugin-q: *matrix-exact-supported-node-versions
       - node-bench-sirun-plugin-bluebird: *matrix-exact-supported-node-versions
       - node-bench-sirun-plugin-http: *matrix-exact-supported-node-versions
+      - node-bench-sirun-plugin-jest: *matrix-exact-supported-node-versions
       - node-bench-sirun-plugin-net: *matrix-exact-supported-node-versions
       - node-bench-sirun-scope: *matrix-exact-supported-node-versions
       - node-bench-sirun-exporting-pipeline: *matrix-exact-supported-node-versions
@@ -244,6 +247,7 @@ workflows:
             - node-bench-sirun-plugin-q
             - node-bench-sirun-plugin-bluebird
             - node-bench-sirun-plugin-http
+            - node-bench-sirun-plugin-jest
             - node-bench-sirun-plugin-net
             - node-bench-sirun-scope
             - node-bench-sirun-exporting-pipeline

--- a/benchmark/sirun/plugin-jest/env.js
+++ b/benchmark/sirun/plugin-jest/env.js
@@ -1,0 +1,7 @@
+if (Number(process.env.USE_TRACER)) {
+  require('../../../ci/jest/env')
+}
+
+const env = require('../../../versions/jest-environment-node').get()
+
+module.exports = env.default ? env.default : env

--- a/benchmark/sirun/plugin-jest/jest-test.js
+++ b/benchmark/sirun/plugin-jest/jest-test.js
@@ -1,0 +1,36 @@
+/* eslint-disable */
+describe('test suite', () => {
+  it('can run', () => {
+    expect(1+1).toEqual(2)
+  })
+})
+
+describe('test suite 2', () => {
+  it('can run', () => {
+    expect(1+1).toEqual(2)
+  })
+})
+
+describe('test suite 3', () => {
+  it('can run', (done) => {
+    setTimeout(() => {
+      done()
+    }, 200)
+  })
+})
+
+describe('test suite 4', () => {
+  it('can run', (done) => {
+    setTimeout(() => {
+      done()
+    }, 200)
+  })
+})
+
+describe('test suite 5', () => {
+  it('can run', (done) => {
+    setTimeout(() => {
+      done()
+    }, 200)
+  })
+})

--- a/benchmark/sirun/plugin-jest/meta.json
+++ b/benchmark/sirun/plugin-jest/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-jest",
   "cachegrind": true,
-  "iterations": 10,
+  "iterations": 3,
   "variants": {
     "control": {
       "run": "node run-test.js"

--- a/benchmark/sirun/plugin-jest/meta.json
+++ b/benchmark/sirun/plugin-jest/meta.json
@@ -1,0 +1,17 @@
+{
+  "name": "plugin-jest",
+  "cachegrind": true,
+  "iterations": 10,
+  "variants": {
+    "control": {
+      "run": "node run-test.js"
+    },
+    "ci-visibility-enabled": {
+      "run": "node run-test.js",
+      "baseline": "control",
+      "env": {
+        "USE_TRACER": "1"
+      }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-jest/run-test.js
+++ b/benchmark/sirun/plugin-jest/run-test.js
@@ -1,0 +1,19 @@
+'use strict'
+const path = require('path')
+
+const jest = require('../../../versions/jest').get()
+
+const options = {
+  projects: [__dirname],
+  testPathIgnorePatterns: ['/node_modules/'],
+  coverageReporters: [],
+  reporters: [],
+  silent: true,
+  testEnvironment: path.join(__dirname, 'env.js'),
+  cache: false,
+  testRegex: 'jest-test.js'
+}
+jest.runCLI(
+  options,
+  options.projects
+)


### PR DESCRIPTION
### What does this PR do?
Related #2206

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
