### PR TITLE
Detect transitive dependencies

### DIFF
--- a/packages/dd-trace/test/telemetry.spec.js
+++ b/packages/dd-trace/test/telemetry.spec.js
@@ -4,6 +4,7 @@ const tracerVersion = require('../../../package.json').version
 const proxyquire = require('proxyquire')
 const requirePackageJson = require('../src/require-package-json')
 const http = require('http')
+const path = require('path')
 const { once } = require('events')
 const { storage } = require('../../datadog-core')
 
@@ -333,14 +334,14 @@ describe('telemetry.getDependencies', () => {
       'test_dep': '^1.0.0'
     }
     requirePackageJson.callsFake((modulePath) => {
-      if (modulePath.indexOf('node_modules/test_dep') > -1) {
+      if (modulePath.indexOf(path.join('node_modules', 'test_dep')) > -1) {
         return {
           dependencies: {
             'transitive_dep': '~2.4.2'
           },
           version: '1.0.8'
         }
-      } else if (modulePath.indexOf('node_modules/transitive_dep') > -1) {
+      } else if (modulePath.indexOf(path.join('node_modules', 'transitive_dep')) > -1) {
         return {
           version: '2.4.2'
         }
@@ -363,21 +364,21 @@ describe('telemetry.getDependencies', () => {
       'test_dep2': '^2.0.1'
     }
     requirePackageJson.callsFake((modulePath) => {
-      if (modulePath.indexOf('node_modules/test_dep1') > -1) {
+      if (modulePath.indexOf(path.join('node_modules', 'test_dep1')) > -1) {
         return {
           dependencies: {
             'transitive_dep': '~2.4.2'
           },
           version: '1.0.8'
         }
-      } else if (modulePath.indexOf('node_modules/test_dep2') > -1) {
+      } else if (modulePath.indexOf(path.join('node_modules', 'test_dep2')) > -1) {
         return {
           dependencies: {
             'transitive_dep': '~2.4.1'
           },
           version: '2.0.2'
         }
-      } else if (modulePath.indexOf('node_modules/transitive_dep') > -1) {
+      } else if (modulePath.indexOf(path.join('node_modules', 'transitive_dep')) > -1) {
         return {
           version: '2.4.2'
         }

--- a/packages/dd-trace/test/telemetry.spec.js
+++ b/packages/dd-trace/test/telemetry.spec.js
@@ -181,8 +181,8 @@ describe('telemetry', () => {
       }, 10)
     })
   })
-
 })
+
 async function testSeq (seqId, reqType, validatePayload) {
   while (traceAgent.reqs.length < seqId) {
     await once(traceAgent, 'handled-req')
@@ -274,7 +274,9 @@ describe('telemetry.getDependencies', () => {
   afterEach(() => {
     telemetry.stop()
     global.setInterval = origSetInterval
-    sinon.reset()
+    request.reset()
+    requirePackageJson.reset()
+    sinon.restore()
   })
 
   it('should not fail without dependencies', () => {


### PR DESCRIPTION
### What does this PR do?
Detect transitive dependencies on the customer application, not only the dependencies defined in the main `package.json` file.

### Motivation
<!-- What inspired you to submit this pull request? -->
The transitive dependencies are part of the dependencies used by the application and they have to be sent to backend to detect third party vulnerable libraries.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
