### PR TITLE
[ci-visibility] Fix `mocha` wrong status calculation

### DIFF
--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -371,6 +371,10 @@ describe('Plugin', () => {
             name: 'mocha-fail-hook-async-other-second-after will run and be reported as failed',
             status: 'fail',
             errorMsg: '"after each" hook for "will run and be reported as failed": yeah error'
+          },
+          {
+            name: 'mocha-fail-test-after-each-passes will fail and be reported as failed',
+            status: 'fail'
           }
         ]
 

--- a/packages/datadog-plugin-mocha/test/mocha-fail-hook-async.js
+++ b/packages/datadog-plugin-mocha/test/mocha-fail-hook-async.js
@@ -45,3 +45,12 @@ describe('mocha-fail-hook-async-other-second-after', function () {
     expect(true).to.equal(true)
   })
 })
+
+describe('mocha-fail-test-after-each-passes', function () {
+  afterEach((done) => {
+    done()
+  })
+  it('will fail and be reported as failed', () => {
+    expect(true).to.equal(false)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Fix status calculation when an `afterEach` hook passes but the test had failed.

Thanks @ostrovanka for this!

### Motivation
https://github.com/DataDog/dd-trace-js/issues/2157#issuecomment-1198094940

### Plugin Checklist
- [x] Unit tests.
