### PR TITLE
update tracer to not extend from opentracing

### DIFF
--- a/ext/formats.js
+++ b/ext/formats.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const opentracing = require('opentracing')
-
 module.exports = {
-  TEXT_MAP: opentracing.FORMAT_TEXT_MAP,
-  HTTP_HEADERS: opentracing.FORMAT_HTTP_HEADERS,
-  BINARY: opentracing.FORMAT_BINARY,
+  TEXT_MAP: 'text_map',
+  HTTP_HEADERS: 'http_headers',
+  BINARY: 'binary',
   LOG: 'log'
 }

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Tags = require('opentracing').Tags
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const Plugin = require('../../dd-trace/src/plugins/plugin')
 const { storage } = require('../../datadog-core')
@@ -33,7 +32,7 @@ class BaseAwsSdkPlugin extends Plugin {
       const serviceName = this.getServiceName(serviceIdentifier)
       const childOf = this.tracer.scope().active()
       const tags = {
-        [Tags.SPAN_KIND]: 'client',
+        'span.kind': 'client',
         'service.name': serviceName,
         'aws.operation': operation,
         'aws.region': awsRegion,

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Tags = require('opentracing').Tags
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 const { storage } = require('../../../datadog-core')
@@ -25,7 +24,7 @@ class Sqs extends BaseAwsSdkPlugin {
           tags: Object.assign(
             {},
             this.requestTags.get(request) || {},
-            { [Tags.SPAN_KIND]: 'server' }
+            { 'span.kind': 'server' }
           )
         }
         const span = plugin.tracer.startSpan('aws.response', options)

--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -1,26 +1,26 @@
 'use strict'
 
-const Span = require('opentracing').Span
-const NoopSpanContext = require('../noop/span_context')
+const NoopSpanContext = require('./span_context')
 const id = require('../id')
 const { storage } = require('../../../datadog-core') // TODO: noop storage?
 
-class NoopSpan extends Span {
+class NoopSpan {
   constructor (tracer, parent) {
-    super()
-
     this._store = storage.getStore()
     this._noopTracer = tracer
     this._noopContext = this._createContext(parent)
   }
 
-  _context () {
-    return this._noopContext
-  }
-
-  _tracer () {
-    return this._noopTracer
-  }
+  context () { return this._noopContext }
+  tracer () { return this._noopTracer }
+  setOperationName (name) { return this }
+  setBaggageItem (key, value) { return this }
+  getBaggageItem (key) {}
+  setTag (key, value) { return this }
+  addTags (keyValueMap) { return this }
+  log () { return this }
+  logEvent () {}
+  finish (finishTime) {}
 
   _createContext (parent) {
     const spanId = id()

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const Tracer = require('opentracing').Tracer
 const Scope = require('../noop/scope')
 const Span = require('./span')
 
-class NoopTracer extends Tracer {
+class NoopTracer {
   constructor (config) {
-    super(config)
-
     this._scope = new Scope()
     this._span = new Span(this)
   }
@@ -31,8 +28,14 @@ class NoopTracer extends Tracer {
   setUrl () {
   }
 
-  _startSpan (name, options) {
+  startSpan (name, options) {
     return this._span
+  }
+
+  inject (spanContext, format, carrier) {}
+
+  extract (format, carrier) {
+    return this._span.context()
   }
 
   setUser () {

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -2,10 +2,8 @@
 
 // TODO (new internal tracer): use DC events for lifecycle metrics and test them
 
-const opentracing = require('opentracing')
 const now = require('performance-now')
 const semver = require('semver')
-const Span = opentracing.Span
 const SpanContext = require('./span_context')
 const id = require('../id')
 const tagger = require('../tagger')
@@ -21,10 +19,8 @@ const {
 const unfinishedRegistry = createRegistry('unfinished')
 const finishedRegistry = createRegistry('finished')
 
-class DatadogSpan extends Span {
+class DatadogSpan {
   constructor (tracer, processor, prioritySampler, fields, debug) {
-    super()
-
     const operationName = fields.operationName
     const parent = fields.parent || null
     const tags = Object.assign({}, fields.tags)
@@ -70,6 +66,73 @@ class DatadogSpan extends Span {
     return `Span${json}`
   }
 
+  context () {
+    return this._spanContext
+  }
+
+  tracer () {
+    return this._parentTracer
+  }
+
+  setOperationName (name) {
+    this._spanContext._name = name
+    return this
+  }
+
+  setBaggageItem (key, value) {
+    this._spanContext._baggageItems[key] = value
+    return this
+  }
+
+  getBaggageItem (key) {
+    return this._spanContext._baggageItems[key]
+  }
+
+  setTag (key, value) {
+    this._addTags({ [key]: value })
+    return this
+  }
+
+  addTags (keyValueMap) {
+    this._addTags(keyValueMap)
+    return this
+  }
+
+  log () {
+    return this
+  }
+
+  logEvent () {}
+
+  finish (finishTime) {
+    if (this._duration !== undefined) {
+      return
+    }
+
+    if (DD_TRACE_EXPERIMENTAL_STATE_TRACKING === 'true') {
+      if (!this._spanContext._tags['service.name']) {
+        log.error(`Finishing invalid span: ${this}`)
+      }
+    }
+
+    if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
+      metrics.decrement('runtime.node.spans.unfinished')
+      metrics.decrement('runtime.node.spans.unfinished.by.name', `span_name:${this._name}`)
+      metrics.increment('runtime.node.spans.finished')
+      metrics.increment('runtime.node.spans.finished.by.name', `span_name:${this._name}`)
+
+      unfinishedRegistry.unregister(this)
+      finishedRegistry.register(this, this._name)
+    }
+
+    finishTime = parseFloat(finishTime) || this._getTime()
+
+    this._duration = finishTime - this._startTime
+    this._spanContext._trace.finished.push(this)
+    this._spanContext._isFinished = true
+    this._processor.process(this)
+  }
+
   _createContext (parent) {
     let spanContext
 
@@ -103,59 +166,10 @@ class DatadogSpan extends Span {
     return startTime + now() - ticks
   }
 
-  _context () {
-    return this._spanContext
-  }
-
-  _tracer () {
-    return this._parentTracer
-  }
-
-  _setOperationName (name) {
-    this._spanContext._name = name
-  }
-
-  _setBaggageItem (key, value) {
-    this._spanContext._baggageItems[key] = value
-  }
-
-  _getBaggageItem (key) {
-    return this._spanContext._baggageItems[key]
-  }
-
   _addTags (keyValuePairs) {
     tagger.add(this._spanContext._tags, keyValuePairs)
 
     this._prioritySampler.sample(this, false)
-  }
-
-  _finish (finishTime) {
-    if (this._duration !== undefined) {
-      return
-    }
-
-    if (DD_TRACE_EXPERIMENTAL_STATE_TRACKING === 'true') {
-      if (!this._spanContext._tags['service.name']) {
-        log.error(`Finishing invalid span: ${this}`)
-      }
-    }
-
-    if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
-      metrics.decrement('runtime.node.spans.unfinished')
-      metrics.decrement('runtime.node.spans.unfinished.by.name', `span_name:${this._name}`)
-      metrics.increment('runtime.node.spans.finished')
-      metrics.increment('runtime.node.spans.finished.by.name', `span_name:${this._name}`)
-
-      unfinishedRegistry.unregister(this)
-      finishedRegistry.register(this, this._name)
-    }
-
-    finishTime = parseFloat(finishTime) || this._getTime()
-
-    this._duration = finishTime - this._startTime
-    this._spanContext._trace.finished.push(this)
-    this._spanContext._isFinished = true
-    this._processor.process(this)
   }
 }
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -1,11 +1,7 @@
 'use strict'
 
-const SpanContext = require('opentracing').SpanContext
-
-class DatadogSpanContext extends SpanContext {
+class DatadogSpanContext {
   constructor (props) {
-    super()
-
     props = props || {}
 
     this._traceId = props.traceId

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -2,7 +2,7 @@
 
 const uniq = require('lodash.uniq')
 const analyticsSampler = require('../../analytics_sampler')
-const FORMAT_HTTP_HEADERS = require('opentracing').FORMAT_HTTP_HEADERS
+const FORMAT_HTTP_HEADERS = 'http_headers'
 const log = require('../../log')
 const tags = require('../../../../../ext/tags')
 const types = require('../../../../../ext/types')

--- a/packages/dd-trace/src/profiling/profilers/cpu.js
+++ b/packages/dd-trace/src/profiling/profilers/cpu.js
@@ -20,7 +20,7 @@ function getStartedSpans (activeSpan) {
 }
 
 function getSpanContextTags (span) {
-  return span._context()._tags
+  return span.context()._tags
 }
 
 function isWebServerSpan (tags) {
@@ -55,13 +55,13 @@ class NativeCpuProfiler {
     const active = getActiveSpan()
     if (!active) return
 
-    const activeCtx = active._context()
+    const activeCtx = active.context()
     if (!activeCtx) return
 
     const spans = getStartedSpans(active)
     if (!spans || !spans.length) return
 
-    const firstCtx = spans[0]._context()
+    const firstCtx = spans[0].context()
     if (!firstCtx) return
 
     const labels = {

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const BaseTracer = require('opentracing').Tracer
 const NoopTracer = require('./noop/tracer')
 const DatadogTracer = require('./tracer')
 const Config = require('./config')
@@ -14,10 +13,8 @@ const telemetry = require('./telemetry')
 
 const noop = new NoopTracer()
 
-class Tracer extends BaseTracer {
+class Tracer {
   constructor () {
-    super()
-
     this._initialized = false
     this._tracer = noop
     this._instrumenter = new Instrumenter(this)

--- a/packages/dd-trace/test/noop.spec.js
+++ b/packages/dd-trace/test/noop.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Span = require('opentracing').Span
+const Span = require('../src/noop/span')
 
 describe('NoopTracer', () => {
   let NoopTracer

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -211,32 +211,6 @@ describe('Tracer', () => {
       })
     })
 
-    it('should ignore references that are not references', () => {
-      fields.references = [{}]
-
-      tracer = new Tracer(config)
-      tracer.startSpan('name', fields)
-
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
-        operationName: 'name',
-        parent: null
-      })
-    })
-
-    it('should ignore references to objects other than span contexts', () => {
-      fields.references = [
-        new Reference(opentracing.REFERENCE_CHILD_OF, {})
-      ]
-
-      tracer = new Tracer(config)
-      tracer.startSpan('name', fields)
-
-      expect(Span).to.have.been.calledWithMatch(tracer, processor, prioritySampler, {
-        operationName: 'name',
-        parent: null
-      })
-    })
-
     it('should merge default tracer tags with span tags', () => {
       config.tags = {
         'foo': 'tracer',

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Span = require('opentracing').Span
+const Span = require('../src/opentracing/span')
 const { storage } = require('../../datadog-core')
 const Config = require('../src/config')
 const tags = require('../../../ext/tags')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update tracer to not extend from `opentracing`.

### Motivation
<!-- What inspired you to submit this pull request? -->

While dd-trace API is compatible with OpenTracing it no longer is a direct implementation and shouldn't extend directly from it. `opentracing` also loads dev dependencies in memory making it much slower to load than necessary. 