### PR TITLE
lazy load ddsketch only when runtime metrics are used

### DIFF
--- a/packages/dd-trace/src/histogram.js
+++ b/packages/dd-trace/src/histogram.js
@@ -1,9 +1,13 @@
 'use strict'
 
-const { DDSketch } = require('@datadog/sketches-js')
+let DDSketch
 
 class Histogram {
   constructor () {
+    if (!DDSketch) {
+      DDSketch = require('@datadog/sketches-js').DDSketch
+    }
+
     this.reset()
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Only load DDSketch when runtime metrics are used.

### Motivation
<!-- What inspired you to submit this pull request? -->

DDSketch depends on Protobuf which is slow to load and has caused issues with CVEs before.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This change can be reversed when DDSketch no longer depends on Protobuf.