### PR TITLE
Remove `performance-now` and make sure the reference is fetched at the beginning

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -18,7 +18,6 @@ require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk
 require,module-details-from-path,MIT,Copyright 2016 Thomas Watson Steen
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
-require,performance-now,MIT,Copyright 2013 Braveg1rl
 require,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,autocannon,MIT,Copyright 2016 Matteo Collina

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "module-details-from-path": "^1.0.3",
     "opentracing": ">=0.12.1",
     "path-to-regexp": "^0.1.2",
-    "performance-now": "^2.1.0",
     "retry": "^0.10.1",
     "semver": "^5.5.0"
   },

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -1,9 +1,9 @@
 'use strict'
 
 // TODO (new internal tracer): use DC events for lifecycle metrics and test them
-
 const opentracing = require('opentracing')
-const now = require('performance-now')
+const now = require('perf_hooks').performance.now
+const dateNow = Date.now
 const semver = require('semver')
 const Span = opentracing.Span
 const SpanContext = require('./span_context')
@@ -91,7 +91,7 @@ class DatadogSpan extends Span {
     }
 
     spanContext._trace.started.push(this)
-    spanContext._trace.startTime = spanContext._trace.startTime || Date.now()
+    spanContext._trace.startTime = spanContext._trace.startTime || dateNow()
     spanContext._trace.ticks = spanContext._trace.ticks || now()
 
     return spanContext

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -44,7 +44,11 @@ describe('Span', () => {
     }
 
     Span = proxyquire('../src/opentracing/span', {
-      'performance-now': now,
+      'perf_hooks': {
+        performance: {
+          now
+        }
+      },
       '../id': id,
       '../tagger': tagger,
       '../metrics': metrics

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,11 +2856,6 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"


### PR DESCRIPTION
### What does this PR do?
* Remove `performance-now`
* Substitute by `perf_hooks`
* Fetch reference to `perf_hooks` and `Date.now` right away

### Motivation
It can be safely substituted by `require('perf_hooks').performance.now`.

Also, we want to make sure that even if users mock `performance.now` or `Date.now`, the calculated times are correct.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
