### PR TITLE
Add package size reporting to CI

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,0 +1,25 @@
+name: Package Size
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 4 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  package-size-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: yarn
+      - name: Compute module size tree and report
+        uses: qard/heaviest-objects-in-the-universe@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this PR do?

Adds size reporting of dd-trace itself, and of any dependencies changed in a PR.

### Motivation

To track package sizes over time to avoid growing needlessly.
