### PR TITLE
fix restify disconnected trace when middleware breaks async context

### DIFF
--- a/packages/datadog-instrumentations/src/connect.js
+++ b/packages/datadog-instrumentations/src/connect.js
@@ -98,7 +98,7 @@ function wrapNext (req, next) {
     nextChannel.publish({ req })
     exitChannel.publish({ req })
 
-    next.apply(null, arguments)
+    next.apply(this, arguments)
   }
 }
 

--- a/packages/datadog-instrumentations/src/koa.js
+++ b/packages/datadog-instrumentations/src/koa.js
@@ -145,7 +145,7 @@ function wrapNext (req, next) {
   return function () {
     nextChannel.publish({ req })
 
-    return next.apply(null, arguments)
+    return next.apply(this, arguments)
   }
 }
 

--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -6,7 +6,10 @@ const handlers = ['use', 'pre']
 const methods = ['del', 'get', 'head', 'opts', 'post', 'put', 'patch']
 
 const handleChannel = channel('apm:restify:request:handle')
-const routeChannel = channel('apm:restify:request:route')
+const errorChannel = channel('apm:restify:middleware:error')
+const enterChannel = channel('apm:restify:middleware:enter')
+const exitChannel = channel('apm:restify:middleware:exit')
+const nextChannel = channel('apm:restify:middleware:next')
 
 function wrapSetupRequest (setupRequest) {
   return function (req, res) {
@@ -37,18 +40,37 @@ function wrapFn (fn) {
   if (Array.isArray(fn)) return wrapMiddleware(fn)
 
   return function (req, res, next) {
-    if (req.route) {
-      routeChannel.publish({ req, route: req.route })
+    if (typeof next === 'function') {
+      arguments[2] = wrapNext(req, next)
     }
 
-    return fn.apply(this, arguments)
+    const route = req.route && req.route.path
+
+    enterChannel.publish({ req, route })
+
+    try {
+      return fn.apply(this, arguments)
+    } catch (error) {
+      errorChannel.publish({ req, error })
+      nextChannel.publish({ req })
+      exitChannel.publish({ req })
+    }
+  }
+}
+
+function wrapNext (req, next) {
+  return function () {
+    nextChannel.publish({ req })
+    exitChannel.publish({ req })
+
+    next.apply(null, arguments)
   }
 }
 
 addHook({ name: 'restify', versions: ['>=3'], file: 'lib/server.js' }, Server => {
   shimmer.wrap(Server.prototype, '_setupRequest', wrapSetupRequest)
   shimmer.massWrap(Server.prototype, handlers, wrapHandler)
-  shimmer.wrap(Server.prototype, methods, wrapMethod)
+  shimmer.massWrap(Server.prototype, methods, wrapMethod)
 
   return Server
 })

--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -63,7 +63,7 @@ function wrapNext (req, next) {
     nextChannel.publish({ req })
     exitChannel.publish({ req })
 
-    next.apply(null, arguments)
+    next.apply(this, arguments)
   }
 }
 

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -97,7 +97,7 @@ function createWrapRouterMethod (name) {
       nextChannel.publish({ req })
       exitChannel.publish({ req })
 
-      next.apply(null, arguments)
+      next.apply(this, arguments)
     }
   }
 

--- a/packages/datadog-plugin-restify/src/index.js
+++ b/packages/datadog-plugin-restify/src/index.js
@@ -19,6 +19,13 @@ class RestifyPlugin extends RouterPlugin {
       web.setRoute(req, route)
     })
   }
+
+  configure (config) {
+    return super.configure({
+      ...config,
+      middleware: false // not supported
+    })
+  }
 }
 
 module.exports = RestifyPlugin

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -84,10 +84,20 @@ describe('Plugin', () => {
 
         it('should run handlers in the request scope', done => {
           const server = restify.createServer()
+          const interval = setInterval(() => {
+            next && next() && clearInterval(interval)
+          })
+
+          let next
 
           server.pre((req, res, next) => {
             expect(tracer.scope().active()).to.not.be.null
             next()
+          })
+
+          // break the async context
+          server.use((req, res, _next) => {
+            next = _next
           })
 
           server.use((req, res, next) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix restify disconnected trace when middleware breaks async context.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fixes #2248

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Regression from #2196