### PR TITLE
[ci-visibility] Fix `before` hooks errors stopping execution in `mocha`

### DIFF
--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -153,7 +153,10 @@ function mochaHook (Runner) {
       if (isHook && testOrHook.ctx) {
         test = testOrHook.ctx.currentTest
       }
-      const asyncResource = getTestAsyncResource(test)
+      let asyncResource
+      if (test) {
+        asyncResource = getTestAsyncResource(test)
+      }
       if (asyncResource) {
         asyncResource.runInAsyncScope(() => {
           if (isHook) {

--- a/packages/datadog-plugin-mocha/test/mocha-fail-hook-async.js
+++ b/packages/datadog-plugin-mocha/test/mocha-fail-hook-async.js
@@ -1,5 +1,14 @@
 const { expect } = require('chai')
 
+describe('mocha-fail-before-all', function () {
+  before((done) => {
+    done(new Error('this should not stop execution'))
+  })
+  it('will not be reported because it will not run', () => {
+    expect(true).to.equal(true)
+  })
+})
+
 describe('mocha-fail-hook-async', function () {
   afterEach((done) => {
     setTimeout(() => {


### PR DESCRIPTION
Credit to @ostrovanka for finding about this bug and proposing a solution! Thanks!

### What does this PR do?
When `before` throws, `dd-trace` attempts to get the current test, but there is none, so the execution crashes. This PR fixes that.

### Motivation
Fixes #2251

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
