### PR TITLE
fix excessive requests queueing when the agent is overloaded

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -57,6 +57,10 @@ class AgentEncoder {
     return buffer
   }
 
+  reset () {
+    this._reset()
+  }
+
   _encode (bytes, trace) {
     this._encodeArrayPrefix(bytes, trace)
 

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -9,7 +9,8 @@ const docker = require('./docker')
 const { storage } = require('../../../../datadog-core')
 
 const keepAlive = true
-const maxTotalSockets = 8
+const maxTotalSockets = 1
+const maxActiveRequests = 8
 const httpAgent = new http.Agent({ keepAlive, maxTotalSockets })
 const httpsAgent = new https.Agent({ keepAlive, maxTotalSockets })
 const containerId = docker.id()
@@ -90,7 +91,7 @@ function byteLength (data) {
 
 Object.defineProperty(request, 'writable', {
   get () {
-    return activeRequests < maxTotalSockets
+    return activeRequests < maxActiveRequests
   }
 })
 

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -1,22 +1,32 @@
 'use strict'
 
+// TODO: Add test with slow or unresponsive agent.
+// TODO: Add telemetry for things like dropped requests, errors, etc.
+
 const http = require('http')
 const https = require('https')
-const log = require('../../log')
 const docker = require('./docker')
 const { storage } = require('../../../../datadog-core')
 
-const httpAgent = new http.Agent({ keepAlive: true })
-const httpsAgent = new https.Agent({ keepAlive: true })
+const keepAlive = true
+const maxTotalSockets = 8
+const httpAgent = new http.Agent({ keepAlive, maxTotalSockets })
+const httpsAgent = new https.Agent({ keepAlive, maxTotalSockets })
 const containerId = docker.id()
+
+let activeRequests = 0
 
 function request (data, options, keepAlive, callback) {
   if (!options.headers) {
     options.headers = {}
   }
+
+  // The timeout should be kept low to avoid excessive queueing.
+  const timeout = options.timeout || 2000
   const isSecure = options.protocol === 'https:'
   const client = isSecure ? https : http
   const dataArray = [].concat(data)
+
   options.headers['Content-Length'] = byteLength(dataArray)
 
   if (containerId) {
@@ -27,39 +37,15 @@ function request (data, options, keepAlive, callback) {
     options.agent = isSecure ? httpsAgent : httpAgent
   }
 
-  const firstRequest = retriableRequest(options, client, callback)
-  dataArray.forEach(buffer => firstRequest.write(buffer))
-
-  // The first request will be retried
-  const firstRequestErrorHandler = () => {
-    log.debug('Retrying request to the intake')
-    const retriedReq = retriableRequest(options, client, callback)
-    dataArray.forEach(buffer => retriedReq.write(buffer))
-    // The retried request will fail normally
-    retriedReq.on('error', e => callback(new Error(`Network error trying to reach the intake: ${e.message}`)))
-    retriedReq.end()
-  }
-
-  firstRequest.on('error', firstRequestErrorHandler)
-  firstRequest.end()
-
-  return firstRequest
-}
-
-function retriableRequest (options, client, callback) {
-  const store = storage.getStore()
-
-  storage.enterWith({ noop: true })
-
-  const timeout = options.timeout || 15000
-
-  const request = client.request(options, res => {
+  const onResponse = res => {
     let responseData = ''
 
     res.setTimeout(timeout)
 
     res.on('data', chunk => { responseData += chunk })
     res.on('end', () => {
+      activeRequests--
+
       if (res.statusCode >= 200 && res.statusCode <= 299) {
         callback(null, responseData, res.statusCode)
       } else {
@@ -69,11 +55,34 @@ function retriableRequest (options, client, callback) {
         callback(error, null, res.statusCode)
       }
     })
-  })
-  request.setTimeout(timeout, request.abort)
-  storage.enterWith(store)
+  }
 
-  return request
+  const makeRequest = onError => {
+    // Limit to 1 request by socket, otherwise drop payload.
+    if (activeRequests >= maxTotalSockets) return
+
+    activeRequests++
+
+    const store = storage.getStore()
+
+    storage.enterWith({ noop: true })
+
+    const req = client.request(options, onResponse)
+
+    req.once('error', err => {
+      activeRequests--
+      onError(err)
+    })
+
+    dataArray.forEach(buffer => req.write(buffer))
+
+    req.setTimeout(timeout, req.abort)
+    req.end()
+
+    storage.enterWith(store)
+  }
+
+  makeRequest(() => makeRequest(callback))
 }
 
 function byteLength (data) {

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -59,7 +59,7 @@ function request (data, options, keepAlive, callback) {
 
   const makeRequest = onError => {
     // Limit to 1 request by socket, otherwise drop payload.
-    if (activeRequests >= maxTotalSockets) return
+    if (activeRequests >= maxTotalSockets) return callback(null)
 
     activeRequests++
 

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -58,8 +58,7 @@ function request (data, options, keepAlive, callback) {
   }
 
   const makeRequest = onError => {
-    // Limit to 1 request by socket, otherwise drop payload.
-    if (activeRequests >= maxTotalSockets) return callback(null)
+    if (!request.writable) return callback(null)
 
     activeRequests++
 
@@ -88,5 +87,11 @@ function request (data, options, keepAlive, callback) {
 function byteLength (data) {
   return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
 }
+
+Object.defineProperty(request, 'writable', {
+  get () {
+    return activeRequests < maxTotalSockets
+  }
+})
 
 module.exports = request

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -1,4 +1,6 @@
 'use strict'
+
+const request = require('./request')
 const log = require('../../log')
 
 class Writer {
@@ -9,7 +11,10 @@ class Writer {
   flush (done = () => {}) {
     const count = this._encoder.count()
 
-    if (count > 0) {
+    if (!request.writable) {
+      this._encoder.reset()
+      done()
+    } else if (count > 0) {
       const payload = this._encoder.makePayload()
 
       this._sendPayload(payload, count, done)
@@ -19,6 +24,8 @@ class Writer {
   }
 
   append (spans) {
+    if (!request.writable) return
+
     log.debug(() => `Encoding trace: ${JSON.stringify(spans)}`)
 
     this._encode(spans)

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -2,7 +2,7 @@
 
 const nock = require('nock')
 
-describe('request', function () {
+describe.only('request', function () {
   let request
   let log
   let docker
@@ -71,8 +71,8 @@ describe('request', function () {
     })
   })
 
-  it('should timeout after 15 seconds by default', function (done) {
-    this.timeout(16000)
+  it('should timeout after 2 seconds by default', function (done) {
+    this.timeout(2001)
     nock('http://localhost:80')
       .put('/path')
       .times(2)
@@ -84,7 +84,7 @@ describe('request', function () {
       method: 'PUT'
     }, true, err => {
       expect(err).to.be.instanceof(Error)
-      expect(err.message).to.equal('Network error trying to reach the intake: socket hang up')
+      expect(err.message).to.equal('socket hang up')
       done()
     })
   })
@@ -93,16 +93,16 @@ describe('request', function () {
     nock('http://localhost:80')
       .put('/path')
       .times(2)
-      .delay(2001)
+      .delay(1001)
       .reply(200)
 
     request(Buffer.from(''), {
       path: '/path',
       method: 'PUT',
-      timeout: 2000
+      timeout: 1000
     }, true, err => {
       expect(err).to.be.instanceof(Error)
-      expect(err.message).to.equal('Network error trying to reach the intake: socket hang up')
+      expect(err.message).to.equal('socket hang up')
       done()
     })
   })
@@ -132,33 +132,30 @@ describe('request', function () {
       .put('/path')
       .reply(200, 'OK')
 
-    const req = request(Buffer.from(''), {
+    request(Buffer.from(''), {
       path: '/path',
       method: 'PUT'
     }, true, (err, res) => {
-      expect(log.debug).to.have.been.calledOnceWith('Retrying request to the intake')
       expect(res).to.equal('OK')
       done()
     })
-    req.reusedSocket = true
   })
 
   it('should not retry more than once', (done) => {
+    const error = new Error('Error ECONNRESET')
+
     nock('http://localhost:80')
       .put('/path')
-      .replyWithError({ code: 'ECONNRESET', message: 'Error ECONNRESET' })
+      .replyWithError(error)
       .put('/path')
-      .replyWithError({ code: 'ECONNRESET', message: 'Error ECONNRESET' })
+      .replyWithError(error)
 
-    const req = request(Buffer.from(''), {
+    request(Buffer.from(''), {
       path: '/path',
       method: 'PUT'
     }, true, (err, res) => {
-      expect(log.debug).to.have.been.calledOnceWith('Retrying request to the intake')
-      expect(err).to.be.instanceof(Error)
-      expect(err.message).to.equal('Network error trying to reach the intake: Error ECONNRESET')
+      expect(err).to.equal(error)
       done()
     })
-    req.reusedSocket = true
   })
 })

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -2,7 +2,7 @@
 
 const nock = require('nock')
 
-describe.only('request', function () {
+describe('request', function () {
   let request
   let log
   let docker


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix excessive requests queueing when the agent is overloaded by limiting the client to 8 buffers of 8MB going through a single socket serially. The tracer will also stop writing traces entirely if all buffers are full to avoid consuming additional memory unnecessarily.

### Motivation
<!-- What inspired you to submit this pull request? -->

When the agent is overloaded, requests could cause infinite back pressure and use infinite sockets, resulting in very high resource usage. UDS also doesn't support multiple sockets properly, hence the single socket.