### PR TITLE
remove documentation about event emitter scope binding

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -288,26 +288,15 @@ someFunction() // null because called outside the scope
 
 <h4>scope.bind(target, [span])</h4>
 
-This method binds a target to the specified span, or to the active span if
-unspecified. It supports binding functions, promises and event emitters.
+This method binds a function to the specified span, or to the active span if
+unspecified.
 
-When a span is provided, the target is always bound to that span. Explicitly
+When a span is provided, the function is always bound to that span. Explicitly
 passing `null` as the span will actually bind to `null` or no span. When a span
-is not provided, the binding uses the following rules:
+is not provided, the function is bound to the span that is active when
+`scope.bind(fn)` is called.
 
-* Functions are bound to the span that is active when `scope.bind(fn)` is called.
-* Promise handlers are bound to the active span in the scope where `.then()` was
-called. This also applies to any equivalent method such as `.catch()`.
-* Event emitter listeners are bound to the active span in the scope where
-`.addEventListener()` was called. This also applies to any equivalent method
-such as `.on()`
-
-**Note**: Native promises and promises from `bluebird`, `q` and `when` are
-already bound by default and don't need to be explicitly bound.
-
-<h5>Examples</h5>
-
-<h6>Function binding</h6>
+<h5>Example</h5>
 
 ```javascript
 const tracer = require('dd-trace').init()
@@ -332,70 +321,7 @@ scope.activate(outerSpan, () => {
 })
 ```
 
-<h6>Promise binding</h6>
-
-```javascript
-const tracer = require('dd-trace').init()
-const scope = tracer.scope()
-const log = console.log
-
-const outerSpan = tracer.startSpan('web.request')
-const innerPromise = Promise.resolve()
-const outerPromise = Promise.resolve()
-
-scope.activate(outerSpan, () => {
-  const innerSpan = tracer.startSpan('web.middleware')
-
-  scope.bind(innerPromise, innerSpan)
-  scope.bind(outerPromise)
-
-  innerPromise.then(() => {
-    log(scope.active()) // innerSpan because explicitly bound
-  })
-
-  outerPromise.then(() => {
-    log(scope.active()) // outerSpan because implicitly bound on `then()` call
-  })
-})
-```
-
-**Note**: `async/await` cannot be bound and always execute in the scope where
-`await` was called. If binding `async/await` is needed, the promise must be
-wrapped by a function.
-
-<h6>Event emitter binding</h6>
-
-```javascript
-const tracer = require('dd-trace').init()
-const scope = tracer.scope()
-const log = console.log
-const EventEmitter = require('events').EventEmitter
-
-const outerSpan = tracer.startSpan('web.request')
-const innerEmitter = new EventEmitter()
-const outerEmitter = new EventEmitter()
-
-scope.activate(outerSpan, async () => {
-  const innerSpan = tracer.startSpan('web.middleware')
-
-  scope.bind(innerEmitter, innerSpan)
-  scope.bind(outerEmitter)
-
-  innerEmitter.on('request', () => {
-    log(scope.active()) // innerSpan because explicitly bound
-  })
-
-  outerEmitter.on('request', () => {
-    log(scope.active()) // outerSpan because implicitly bound on `then()` call
-  })
-})
-
-innerEmitter.emit('request')
-outerEmitter.emit('request')
-```
-
 See the [API documentation](./interfaces/scope.html) for more details.
-
 
 <h2 id="opentracing-api">OpenTracing Compatibility</h2>
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -320,24 +320,6 @@ Promise.resolve();
 scope.bind(promise);
 scope.bind(promise, span);
 
-const simpleEmitter = {
-  emit (eventName: string, arg1: boolean, arg2: number): void {}
-};
-
-scope.bind(simpleEmitter);
-scope.bind(simpleEmitter, span);
-
-const emitter = {
-  emit (eventName: string, arg1: boolean, arg2: number): void {},
-  on (eventName: string, listener: (arg1: boolean, arg2: number) => void) {},
-  off (eventName: string, listener: (arg1: boolean, arg2: number) => void) {},
-  addListener (eventName: string, listener: (arg1: boolean, arg2: number) => void) {},
-  removeListener (eventName: string, listener: (arg1: boolean, arg2: number) => void) {}
-};
-
-scope.bind(emitter);
-scope.bind(emitter, span);
-
 tracer.wrap('x', () => {
   const rumData: string = tracer.getRumData();
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -492,15 +492,6 @@ export declare interface TracerOptions {
 }
 
 /** @hidden */
-interface EventEmitter {
-  emit(eventName: string | symbol, ...args: any[]): any;
-  on?(eventName: string | symbol, listener: (...args: any[]) => any): any;
-  off?(eventName: string | symbol, listener: (...args: any[]) => any): any;
-  addListener?(eventName: string | symbol, listener: (...args: any[]) => any): any;
-  removeListener?(eventName: string | symbol, listener: (...args: any[]) => any): any;
-}
-
-/** @hidden */
 declare type anyObject = {
   [key: string]: any;
 };
@@ -537,14 +528,13 @@ export declare interface Scope {
   /**
    * Binds a target to the provided span, or the active span if omitted.
    *
-   * @param {Function|Promise|EventEmitter} target Target that will have the span activated on its scope.
+   * @param {Function|Promise} target Target that will have the span activated on its scope.
    * @param {Span} [span=scope.active()] The span to activate.
    * @returns The bound target.
    */
   bind<T extends (...args: any[]) => void>(fn: T, span?: Span | null): T;
   bind<V, T extends (...args: any[]) => V>(fn: T, span?: Span | null): T;
   bind<T>(fn: Promise<T>, span?: Span | null): Promise<T>;
-  bind(emitter: EventEmitter, span?: Span | null): EventEmitter;
 }
 
 /** @hidden */


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove documentation about event emitter scope binding. I also removed documentation for binding promises since this should never be needed at this point and should be removed completely in the next major (after 3.0).

### Motivation
<!-- What inspired you to submit this pull request? -->

Support for binding event emitters was removed and should no longer documented.