### PR TITLE
[ci-visibility] Remove `fs` configuration in ci visibility

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -29,7 +29,6 @@ so dd-trace will not be initialized.`)
 
 if (shouldInit) {
   tracer.init(options)
-  tracer.use('fs', false)
 }
 
 module.exports = tracer

--- a/ci/jest/env.js
+++ b/ci/jest/env.js
@@ -33,6 +33,4 @@ so dd-trace will not be initialized.`)
   })
 }
 
-tracer.use('fs', false)
-
 module.exports = tracer


### PR DESCRIPTION
### What does this PR do?
Remove `'fs'` init in ci visibility's entrypoint.

### Motivation
Remove `fs` from ci visibility now that we've removed the plugin.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
