### PR TITLE
Fix querystring obfuscation benchmark

### DIFF
--- a/benchmark/sirun/plugin-http/client.js
+++ b/benchmark/sirun/plugin-http/client.js
@@ -27,7 +27,7 @@ function request (url) {
 let url = `http://localhost:${port}/`
 
 if (Number(process.env.CLIENT_LONG_QUERYSTRING)) {
-  url += 'token=secret&'.repeat(100) + 'a'.repeat(1500)
+  url += '?' + 'token=secret&'.repeat(100) + 'a'.repeat(1500)
 }
 
 request(url)


### PR DESCRIPTION
Make the querystring obfuscation benchmark actually work as intended.

New benchmark figures:
### Benchmark diff `node-bench-sirun-plugin-http-16` instructions [[link]](https://app.circleci.com/pipelines/github/DataDog/dd-trace-js/7979/workflows/861fedd7-f1c6-44c8-8bc5-e14582ce24bc/jobs/938444)
`0784351340` - `server-control`
`2027874959` - `server-with-tracer`
`2279573553` - `server-querystring-obfuscation`
