### PR TITLE
IAST: Deduplicate vulnerabilities before send, and send the vulnerability with hash

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -10,10 +10,27 @@ function createVulnerability (type, evidence, spanId, location) {
       location: {
         spanId,
         ...location
-      }
+      },
+      hash: createHash(type, location)
     }
   }
   return null
+}
+
+function createHash (type, location) {
+  let hashSource
+  if (location) {
+    hashSource = `${type}:${location.path}:${location.line}`
+  } else {
+    hashSource = type
+  }
+  let hash = 0
+  let offset = 0
+  const size = hashSource.length
+  for (let i = 0; i < size; i++) {
+    hash = ((hash << 5) - hash) + hashSource.charCodeAt(offset++)
+  }
+  return hash
 }
 
 function addVulnerability (iastContext, vulnerability) {
@@ -34,6 +51,7 @@ function isValidVulnerability (vulnerability) {
 function jsonVulnerabilityFromVulnerability (vulnerability) {
   const jsonVulnerability = {
     type: vulnerability.type,
+    hash: vulnerability.hash,
     evidence: {
       value: vulnerability.evidence.value
     },
@@ -59,11 +77,13 @@ function sendVulnerabilities (iastContext) {
     const jsonToSend = {
       vulnerabilities: []
     }
-    allVulnerabilities.forEach((vulnerability) => {
+
+    deduplicateVulnerabilities(allVulnerabilities).forEach((vulnerability) => {
       if (isValidVulnerability(vulnerability)) {
         jsonToSend.vulnerabilities.push(jsonVulnerabilityFromVulnerability(vulnerability))
       }
     })
+
     if (jsonToSend.vulnerabilities.length > 0) {
       const tags = {}
       tags[IAST_JSON_TAG_KEY] = JSON.stringify(jsonToSend)
@@ -72,6 +92,18 @@ function sendVulnerabilities (iastContext) {
     }
   }
   return IAST_JSON_TAG_KEY
+}
+
+function deduplicateVulnerabilities (vulnerabilities) {
+  const uniqueVulnerabilities = new Set()
+  return vulnerabilities.filter((vulnerability) => {
+    const key = `${vulnerability.type}${vulnerability.hash}`
+    if (!uniqueVulnerabilities.has(key)) {
+      uniqueVulnerabilities.add(key)
+      return true
+    }
+    return false
+  })
 }
 
 module.exports = {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -135,7 +135,7 @@ describe('vulnerability-reporter', () => {
       sendVulnerabilities(iastContext)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
-        '_dd.iast.json': '{"vulnerabilities":[{"type":"INSECURE_HASHING",' +
+        '_dd.iast.json': '{"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3254801297,' +
           '"evidence":{"value":"sha1"},"location":{"spanId":888}}]}'
       })
     })
@@ -147,23 +147,29 @@ describe('vulnerability-reporter', () => {
       sendVulnerabilities(iastContext)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
-        '_dd.iast.json': '{"vulnerabilities":[{"type":"INSECURE_HASHING",' +
+        '_dd.iast.json': '{"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3254801297,' +
           '"evidence":{"value":"sha1"},"location":{"spanId":888}}]}'
       })
     })
 
     it('should send once with multiple vulnerabilities', () => {
       const iastContext = { rootSpan: span }
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'md5' }, 1))
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'md5' }, -5))
+      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
+        { path: '/path/to/file1.js', line: 1 }))
+      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'md5' }, 1,
+        { path: '/path/to/file2.js', line: 1 }))
+      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'md5' }, -5,
+        { path: '/path/to/file3.js', line: 3 }))
       sendVulnerabilities(iastContext)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
-        '_dd.iast.json': '{"vulnerabilities":' +
-          '[{"type":"INSECURE_HASHING","evidence":{"value":"sha1"},"location":{"spanId":888}},' +
-          '{"type":"INSECURE_HASHING","evidence":{"value":"md5"},"location":{"spanId":1}},' +
-          '{"type":"INSECURE_HASHING","evidence":{"value":"md5"},"location":{"spanId":-5}}]}'
+        '_dd.iast.json': '{"vulnerabilities":[' +
+          '{"type":"INSECURE_HASHING","hash":1697980169,"evidence":{"value":"sha1"},' +
+            '"location":{"spanId":888,"path":"/path/to/file1.js","line":1}},' +
+          '{"type":"INSECURE_HASHING","hash":1726609320,"evidence":{"value":"md5"},' +
+            '"location":{"spanId":1,"path":"/path/to/file2.js","line":1}},' +
+          '{"type":"INSECURE_HASHING","hash":1755238473,"evidence":{"value":"md5"},' +
+            '"location":{"spanId":-5,"path":"/path/to/file3.js","line":3}}]}'
       })
     })
 
@@ -174,7 +180,21 @@ describe('vulnerability-reporter', () => {
       sendVulnerabilities(iastContext)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
-        '_dd.iast.json': '{"vulnerabilities":[{"type":"INSECURE_HASHING",' +
+        '_dd.iast.json': '{"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512691,' +
+          '"evidence":{"value":"sha1"},"location":{"spanId":888,"path":"filename.js","line":88}}]}'
+      })
+    })
+
+    it('should not send duplicated vulnerabilities', () => {
+      const iastContext = { rootSpan: span }
+      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
+        { path: 'filename.js', line: 88 }))
+      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
+        { path: 'filename.js', line: 88 }))
+      sendVulnerabilities(iastContext)
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
+        'manual.keep': 'true',
+        '_dd.iast.json': '{"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512691,' +
           '"evidence":{"value":"sha1"},"location":{"spanId":888,"path":"filename.js","line":88}}]}'
       })
     })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
It calculates a hash of each vulnerability to deduplicate the vulnerability by hash.
It sends this hash in the vulnerability information to backend

### Motivation
<!-- What inspired you to submit this pull request? -->
Reduce transported data to backend
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts

### Additional Notes
<!-- Anything else we should know when reviewing? -->
