### PR TITLE
Publishing init images for k8s

### DIFF
--- a/.github/actions/injection/action.yml
+++ b/.github/actions/injection/action.yml
@@ -1,0 +1,23 @@
+name: Build/Publish Injection Image
+inputs:
+  init-image-version:
+    description: Image version to use for publishing
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
+      with:
+        install: true
+        config-inline: |
+          [worker.oci]
+            max-parallelism = 1
+    - name: Build injection image and push to github packages
+      run: |
+        mv dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
+        docker buildx create --name lib-injection
+        docker buildx use lib-injection
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # https://stackoverflow.com/questions/72167570/docker-buildx-nodejs-fail
+        docker buildx build --platform=linux/amd64,linux/arm/v7,linux/arm64/v8 --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ inputs.init-image-version }} --push k8s/auto-inst
+

--- a/.github/actions/injection/action.yml
+++ b/.github/actions/injection/action.yml
@@ -19,5 +19,5 @@ runs:
         docker buildx create --name lib-injection
         docker buildx use lib-injection
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # https://stackoverflow.com/questions/72167570/docker-buildx-nodejs-fail
-        docker buildx build --platform=linux/amd64,linux/arm/v7,linux/arm64/v8 --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ inputs.init-image-version }} --push k8s/auto-inst
+        docker buildx build --platform=linux/amd64,linux/arm/v7,linux/arm64/v8 -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ inputs.init-image-version }} --push k8s/auto-inst
 

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -39,11 +39,11 @@ jobs:
         run: |
           node scripts/set-version-for-init-image.js ${{ fromJson(steps.pkg.outputs.json).version }}
           npm pack dd-trace@${{ fromJson(steps.pkg.outputs.json).version }}
-          cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
+          cp dd-trace-${{ fromJson(steps.pkg.outputs.json).version }}.tgz k8s/auto-inst/dd-trace.tgz
           docker buildx create --name lib-injection
           docker buildx use lib-injection
-          BUILDX_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le
-          docker buildx build --platform ${BUILDX_PLATFORMS} --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }} --push k8s/auto-inst
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # https://stackoverflow.com/questions/72167570/docker-buildx-nodejs-fail
+          docker buildx build --platform=linux/amd64,linux/arm/v7,linux/arm64/v8 --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }} --push k8s/auto-inst
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -28,6 +28,13 @@ jobs:
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
+      - name: Build injection image and push to github packages
+        run: |
+          node scripts/set-version-for-init-image.js ${{ fromJson(steps.pkg.outputs.json).version }}
+          npm pack dd-trace@${{ fromJson(steps.pkg.outputs.json).version }}
+          cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
+          docker build k8s/auto-inst --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-trace-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
+          docker push ghcr.io/datadog/dd-trace-js/dd-trace-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -28,22 +28,17 @@ jobs:
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
-        with:
-          install: true
-          config-inline: |
-            [worker.oci]
-              max-parallelism = 1
-      - name: Build injection image and push to github packages
+
+  injection-image-publish:
+    runs-on: ubuntu-latest
+    needs: ['publish']
+    steps:
+      - name: npm pack for injection image
         run: |
-          node scripts/set-version-for-init-image.js ${{ fromJson(steps.pkg.outputs.json).version }}
           npm pack dd-trace@${{ fromJson(steps.pkg.outputs.json).version }}
-          cp dd-trace-${{ fromJson(steps.pkg.outputs.json).version }}.tgz k8s/auto-inst/dd-trace.tgz
-          docker buildx create --name lib-injection
-          docker buildx use lib-injection
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # https://stackoverflow.com/questions/72167570/docker-buildx-nodejs-fail
-          docker buildx build --platform=linux/amd64,linux/arm/v7,linux/arm64/v8 --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }} --push k8s/auto-inst
+      - uses: .github/actions/injection
+        with:
+          init-image-version: ${{ fromJson(steps.pkg.outputs.json).version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -42,7 +42,7 @@ jobs:
           cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
           docker buildx create --name lib-injection
           docker buildx use lib-injection
-          BUILDX_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          BUILDX_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le
           docker buildx build --platform ${BUILDX_PLATFORMS} --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }} --push k8s/auto-inst
 
   docs:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -28,13 +28,22 @@ jobs:
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
+        with:
+          install: true
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
       - name: Build injection image and push to github packages
         run: |
           node scripts/set-version-for-init-image.js ${{ fromJson(steps.pkg.outputs.json).version }}
           npm pack dd-trace@${{ fromJson(steps.pkg.outputs.json).version }}
           cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
-          docker build k8s/auto-inst --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
-          docker push ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
+          docker buildx create --name lib-injection
+          docker buildx use lib-injection
+          BUILDX_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          docker buildx build --platform ${BUILDX_PLATFORMS} --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }} --push k8s/auto-inst
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -33,8 +33,8 @@ jobs:
           node scripts/set-version-for-init-image.js ${{ fromJson(steps.pkg.outputs.json).version }}
           npm pack dd-trace@${{ fromJson(steps.pkg.outputs.json).version }}
           cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
-          docker build k8s/auto-inst --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-trace-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
-          docker push ghcr.io/datadog/dd-trace-js/dd-trace-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
+          docker build k8s/auto-inst --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
+          docker push ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${{ fromJson(steps.pkg.outputs.json).version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-k8s-lib-injection.yaml
+++ b/.github/workflows/test-k8s-lib-injection.yaml
@@ -39,8 +39,10 @@ jobs:
         run: |
           npm pack
           cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
-          docker build k8s/auto-inst --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${GITHUB_SHA}
-          docker push ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${GITHUB_SHA}
+          docker buildx create --name lib-injection
+          docker buildx use lib-injection
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # https://stackoverflow.com/questions/72167570/docker-buildx-nodejs-fail
+          docker buildx build --platform=linux/amd64,linux/arm/v7,linux/arm64/v8 --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${GITHUB_SHA} --push k8s/auto-inst
 
       - name: Build sample app image
         run: |

--- a/.github/workflows/test-k8s-lib-injection.yaml
+++ b/.github/workflows/test-k8s-lib-injection.yaml
@@ -39,8 +39,8 @@ jobs:
         run: |
           npm pack
           cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
-          docker build k8s/auto-inst --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-trace-js-init:${GITHUB_SHA}
-          docker push ghcr.io/datadog/dd-trace-js/dd-trace-js-init:${GITHUB_SHA}
+          docker build k8s/auto-inst --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${GITHUB_SHA}
+          docker push ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${GITHUB_SHA}
 
       - name: Build sample app image
         run: |

--- a/.github/workflows/test-k8s-lib-injection.yaml
+++ b/.github/workflows/test-k8s-lib-injection.yaml
@@ -35,14 +35,13 @@ jobs:
           kubectl wait $(kubectl get pods -l app=datadog-agent -o name) --for condition=ready
           sleep 5
 
-      - name: Build injection image
+      - name: Npm pack for injection image
         run: |
           npm pack
-          cp dd-trace-*.tgz k8s/auto-inst/dd-trace.tgz
-          docker buildx create --name lib-injection
-          docker buildx use lib-injection
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # https://stackoverflow.com/questions/72167570/docker-buildx-nodejs-fail
-          docker buildx build --platform=linux/amd64,linux/arm/v7,linux/arm64/v8 --build-arg npm_pkg=./dd-trace.tgz -t ghcr.io/datadog/dd-trace-js/dd-lib-js-init:${GITHUB_SHA} --push k8s/auto-inst
+
+      - uses: .github/actions/injection
+        with:
+          init-image-version: ${GITHUB_SHA}
 
       - name: Build sample app image
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,6 @@ deploy_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master"'
-      when: on_success
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success
     - when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,3 +15,23 @@ deploy_to_reliability_env:
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
+
+deploy_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: on_success
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-trace-js-init:$CI_COMMIT_SHA
+    IMG_DESTINATIONS: dd-trace-js-init:$CI_COMMIT_TAG
+    IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,6 @@ deploy_to_docker_registries:
     branch: main
     strategy: depend
   variables:
-    IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-trace-js-init:$CI_COMMIT_SHA
-    IMG_DESTINATIONS: dd-trace-js-init:$CI_COMMIT_TAG
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_SHA
+    IMG_DESTINATIONS: dd-lib-js-init:$CI_COMMIT_TAG
     IMG_SIGNING: "false"

--- a/k8s/auto-inst/Dockerfile
+++ b/k8s/auto-inst/Dockerfile
@@ -5,6 +5,6 @@ ARG npm_pkg
 WORKDIR /operator-build
 COPY . .
 
-RUN npm install ${npm_pkg}
+RUN npm install ./dd-trace.tgz
 
 ADD copy-lib.sh /operator-build/copy-lib.sh

--- a/k8s/auto-inst/package.json
+++ b/k8s/auto-inst/package.json
@@ -2,7 +2,5 @@
   "name": "@datadog/k8s-autoinstrumentation",
   "version": "0.0.1",
   "private": true,
-  "dependencies": {
-    "dd-trace": "*"
-  }
+  "dependencies": {}
 }

--- a/k8s/test-pod.yaml
+++ b/k8s/test-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   initContainers:
     - name: node-init
-      image: ghcr.io/datadog/dd-trace-js/dd-trace-js-init:LATEST
+      image: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:LATEST
       command: ["sh", "copy-lib.sh", "/autoinstrumentation"]
       volumeMounts:
         - name: autoinstrumentation

--- a/scripts/set-version-for-init-image.js
+++ b/scripts/set-version-for-init-image.js
@@ -1,0 +1,9 @@
+'use strict'
+const fs = require('fs')
+
+const file = require.resolve('../k8s/auto-inst/package.json')
+const pkgJson = JSON.parse(fs.readFileSync(file).toString())
+
+pkgJson.dependencies['dd-trace'] = process.argv[2]
+
+fs.writeFileSync(file, JSON.stringify(pkgJson, null, 2))

--- a/scripts/set-version-for-init-image.js
+++ b/scripts/set-version-for-init-image.js
@@ -1,9 +1,0 @@
-'use strict'
-const fs = require('fs')
-
-const file = require.resolve('../k8s/auto-inst/package.json')
-const pkgJson = JSON.parse(fs.readFileSync(file).toString())
-
-pkgJson.dependencies['dd-trace'] = process.argv[2]
-
-fs.writeFileSync(file, JSON.stringify(pkgJson, null, 2))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds publishing of release images to github packages, dockerhub, GCR, and ECR.

### Motivation
<!-- What inspired you to submit this pull request? -->
This way lib injection can be done by the admission controller.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Draft for now since:

1. Repos need to be created/renamed on dockerhub and ECR.
2. Need to create a multiarch image.
