### PR TITLE
fix w3c trace context inject/extract not propagating IDs properly

### DIFF
--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -161,12 +161,12 @@ class MochaPlugin extends Plugin {
     const testSuiteSpan = this._testSuites.get(test.parent)
 
     if (testSuiteSpan) {
-      const testSuiteId = testSuiteSpan.context()._spanId.toString('hex')
+      const testSuiteId = testSuiteSpan.context()._spanId.toString(16)
       testSuiteTags[TEST_SUITE_ID] = testSuiteId
     }
 
     if (this.testSessionSpan) {
-      const testSessionId = this.testSessionSpan.context()._traceId.toString('hex')
+      const testSessionId = this.testSessionSpan.context()._traceId.toString(16)
       testSuiteTags[TEST_SESSION_ID] = testSessionId
       testSuiteTags[TEST_COMMAND] = this.command
     }

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -14,17 +14,17 @@ let batch = 0
 
 // Internal representation of a trace or span ID.
 class Identifier {
-  constructor (value, radix) {
+  constructor (value, radix = 16) {
     this._isUint64BE = true // msgpack-lite compatibility
-    this._buffer = typeof radix === 'number'
-      ? fromString(value, radix)
-      : createBuffer(value)
+    this._buffer = radix === 16
+      ? createBuffer(value)
+      : fromString(value, radix)
   }
 
-  toString (radix) {
-    return typeof radix === 'number'
-      ? toNumberString(this._buffer, radix)
-      : toHexString(this._buffer)
+  toString (radix = 16) {
+    return radix === 16
+      ? toHexString(this._buffer)
+      : toNumberString(this._buffer, radix)
   }
 
   toBuffer () {
@@ -49,10 +49,13 @@ function createBuffer (value) {
   if (value === '0') return zeroId
   if (!value) return pseudoRandom()
 
-  const size = Math.ceil(value.length / 2)
-  const buffer = new Array(size)
+  const size = Math.ceil(value.length / 16) * 16
+  const bytes = size / 2
+  const buffer = new Array(bytes)
 
-  for (let i = 0; i < size; i++) {
+  value = value.padStart(size, '0')
+
+  for (let i = 0; i < bytes; i++) {
     buffer[i] = parseInt(value.substring(i * 2, i * 2 + 2), 16)
   }
 

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -103,8 +103,8 @@ function fromString (str, raddix) {
 
 // Convert a buffer to a numerical string.
 function toNumberString (buffer, radix) {
-  let high = readInt32(buffer, 0)
-  let low = readInt32(buffer, 4)
+  let high = readInt32(buffer, buffer.length - 8)
+  let low = readInt32(buffer, buffer.length - 4)
   let str = ''
 
   radix = radix || 10

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -82,8 +82,8 @@ class TextMapPropagator {
   _injectB3 (spanContext, carrier) {
     if (!this._config.experimental.b3) return
 
-    carrier[b3TraceKey] = spanContext._traceId.toString('hex')
-    carrier[b3SpanKey] = spanContext._spanId.toString('hex')
+    carrier[b3TraceKey] = spanContext._traceId.toString(16)
+    carrier[b3SpanKey] = spanContext._spanId.toString(16)
     carrier[b3SampledKey] = spanContext._sampling.priority >= AUTO_KEEP ? '1' : '0'
 
     if (spanContext._sampling.priority > AUTO_KEEP) {
@@ -91,7 +91,7 @@ class TextMapPropagator {
     }
 
     if (spanContext._parentId) {
-      carrier[b3ParentKey] = spanContext._parentId.toString('hex')
+      carrier[b3ParentKey] = spanContext._parentId.toString(16)
     }
   }
 
@@ -99,8 +99,8 @@ class TextMapPropagator {
     if (!this._config.experimental.traceparent) return
 
     const sampling = spanContext._sampling.priority >= AUTO_KEEP ? '01' : '00'
-    const traceId = spanContext._traceId.toString('hex').padStart(32, '0')
-    const spanId = spanContext._spanId.toString('hex').padStart(16, '0')
+    const traceId = spanContext._traceId.toString(16).padStart(32, '0')
+    const spanId = spanContext._spanId.toString(16).padStart(16, '0')
     carrier[traceparentKey] = `01-${traceId}-${spanId}-${sampling}`
   }
 
@@ -129,7 +129,7 @@ class TextMapPropagator {
     const b3 = this._extractB3Headers(carrier)
     const debug = b3[b3FlagsKey] === '1'
     const priority = this._getPriority(b3[b3SampledKey], debug)
-    const spanContext = this._extractGenericContext(b3, b3TraceKey, b3SpanKey)
+    const spanContext = this._extractGenericContext(b3, b3TraceKey, b3SpanKey, 16)
 
     if (priority !== undefined) {
       if (!spanContext) {

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -53,7 +53,19 @@ describe('id', () => {
     expect(json).to.equal('"7f00ff00ff00ff00"')
   })
 
-  it('should support hex strings', () => {
+  it('should support small hex strings', () => {
+    const spanId = id('abcd', 16)
+
+    expect(spanId.toString()).to.equal('abcd')
+  })
+
+  it('should support large hex strings', () => {
+    const spanId = id('12293a8527e70a7f27c8d624ace0f559', 16)
+
+    expect(spanId.toString()).to.equal('12293a8527e70a7f27c8d624ace0f559')
+  })
+
+  it('should use hex strings by default', () => {
     const spanId = id('abcd')
 
     expect(spanId.toString()).to.equal('abcd')

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -63,6 +63,7 @@ describe('id', () => {
     const spanId = id('12293a8527e70a7f27c8d624ace0f559', 16)
 
     expect(spanId.toString()).to.equal('12293a8527e70a7f27c8d624ace0f559')
+    expect(spanId.toString(10)).to.equal('2866776615828911449')
   })
 
   it('should use hex strings by default', () => {

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -56,7 +56,7 @@ describe('id', () => {
   it('should support small hex strings', () => {
     const spanId = id('abcd', 16)
 
-    expect(spanId.toString()).to.equal('abcd')
+    expect(spanId.toString()).to.equal('000000000000abcd')
   })
 
   it('should support large hex strings', () => {
@@ -69,7 +69,7 @@ describe('id', () => {
   it('should use hex strings by default', () => {
     const spanId = id('abcd')
 
-    expect(spanId.toString()).to.equal('abcd')
+    expect(spanId.toString()).to.equal('000000000000abcd')
   })
 
   it('should support number strings', () => {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -120,8 +120,8 @@ describe('TextMapPropagator', () => {
     it('should inject the traceparent header', () => {
       const carrier = {}
       const spanContext = new SpanContext({
-        traceId: id('123', 16),
-        spanId: id('456', 16),
+        traceId: id('1111aaaa2222bbbb3333cccc4444dddd', 16),
+        spanId: id('5555eeee6666ffff', 16),
         sampling: {
           priority: USER_KEEP
         }
@@ -131,7 +131,7 @@ describe('TextMapPropagator', () => {
 
       propagator.inject(spanContext, carrier)
 
-      expect(carrier).to.have.property('traceparent', '01-00000000000000000000000000000123-0000000000000456-01')
+      expect(carrier).to.have.property('traceparent', '01-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01')
     })
 
     it('should skip injection of B3 headers without the feature flag', () => {
@@ -397,18 +397,14 @@ describe('TextMapPropagator', () => {
       })
 
       it('should extract the header', () => {
-        textMap['traceparent'] = '00-000000000000000000000000000004d2-000000000000162e-01'
+        textMap['traceparent'] = '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01'
         config.experimental.traceparent = true
 
         const carrier = textMap
         const spanContext = propagator.extract(carrier)
-        expect(spanContext).to.deep.equal(new SpanContext({
-          traceId: id('4d2', 16),
-          spanId: id('162e', 16),
-          sampling: {
-            priority: AUTO_KEEP
-          }
-        }))
+        expect(spanContext._traceId.toString(16)).to.equal('1111aaaa2222bbbb3333cccc4444dddd')
+        expect(spanContext._spanId.toString(16)).to.equal('5555eeee6666ffff')
+        expect(spanContext._sampling.priority).to.equal(AUTO_KEEP)
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix W3C trace context injection/extraction not propagating IDs properly.

### Motivation
<!-- What inspired you to submit this pull request? -->

Hexadecimal IDs ended up being truncated regardless of their size, corrupting the values.