### PR TITLE
[IAST] Remove OCE global context scheduler

### DIFF
--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -18,7 +18,6 @@ function enable (config) {
   requestClose.subscribe(onIncomingHttpRequestClose)
 
   overheadController.configureOCE(config.iast.oce)
-  overheadController.startGlobalContextResetScheduler()
 }
 
 function disable () {
@@ -27,7 +26,6 @@ function disable () {
   if (requestStart.hasSubscribers) requestStart.unsubscribe(onIncomingHttpRequestStart)
   if (requestFinish.hasSubscribers) requestFinish.unsubscribe(onIncomingHttpRequestEnd)
   if (requestClose.hasSubscribers) requestClose.unsubscribe(onIncomingHttpRequestClose)
-  overheadController.stopGlobalContextResetScheduler()
 }
 
 function onIncomingHttpRequestStart (data) {

--- a/packages/dd-trace/src/appsec/iast/overhead-controller.js
+++ b/packages/dd-trace/src/appsec/iast/overhead-controller.js
@@ -1,9 +1,6 @@
 'use strict'
-const Scheduler = require('../../exporters/scheduler')
 
 const OVERHEAD_CONTROLLER_CONTEXT_KEY = 'oce'
-const GLOBAL_CONTEXT_RESET_INTERVAL = 30000
-
 const REPORT_VULNERABILITY = 'REPORT_VULNERABILITY'
 
 const GLOBAL_OCE_CONTEXT = {}
@@ -51,9 +48,6 @@ function _resetGlobalContext () {
   Object.assign(GLOBAL_OCE_CONTEXT, _getNewContext())
 }
 
-const _globalContextResetScheduler = new Scheduler(_resetGlobalContext, GLOBAL_CONTEXT_RESET_INTERVAL)
-_resetGlobalContext()
-
 function acquireRequest (rootSpan) {
   if (availableRequest > 0) {
     const sampling = oceConfig && typeof oceConfig.requestSampling === 'number'
@@ -81,25 +75,17 @@ function initializeRequestContext (iastContext) {
   if (iastContext) iastContext[OVERHEAD_CONTROLLER_CONTEXT_KEY] = _getNewContext()
 }
 
-function startGlobalContextResetScheduler () {
-  _globalContextResetScheduler.start()
-}
-
-function stopGlobalContextResetScheduler () {
-  _globalContextResetScheduler.stop()
-}
-
 function configureOCE (cfg) {
   oceConfig = cfg
   availableRequest = oceConfig.maxConcurrentRequest
 }
 
+_resetGlobalContext()
+
 module.exports = {
   OVERHEAD_CONTROLLER_CONTEXT_KEY,
   OPERATIONS,
   _resetGlobalContext,
-  startGlobalContextResetScheduler,
-  stopGlobalContextResetScheduler,
   initializeRequestContext,
   hasQuota,
   acquireRequest,

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -44,9 +44,7 @@ describe('IAST Index', () => {
     overheadController = {
       acquireRequest: sinon.stub(),
       releaseRequest: sinon.stub(),
-      initializeRequestContext: sinon.stub(),
-      startGlobalContextResetScheduler: sinon.stub(),
-      stopGlobalContextResetScheduler: sinon.stub()
+      initializeRequestContext: sinon.stub()
     }
     iastContext = {
       getIastContext: sinon.stub(),
@@ -78,10 +76,6 @@ describe('IAST Index', () => {
       expect(requestFinish.hasSubscribers).to.be.true
       expect(requestClose.hasSubscribers).to.be.true
     })
-    it('should start OCE global context', () => {
-      IAST.enable(config)
-      expect(overheadController.startGlobalContextResetScheduler).to.have.been.calledOnce
-    })
     it('should enable all analyzers', () => {
       IAST.enable(config)
       expect(analyzers.enableAllAnalyzers).to.have.been.calledOnce
@@ -99,11 +93,6 @@ describe('IAST Index', () => {
     it('should disable all analyzers', () => {
       IAST.disable()
       expect(analyzers.disableAllAnalyzers).to.have.been.calledOnce
-    })
-
-    it('should stop OCE global context', () => {
-      IAST.disable()
-      expect(overheadController.stopGlobalContextResetScheduler).to.have.been.calledOnce
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
Removes OCE global context scheduler which resets the context in a time basis.

### Motivation
This is not going to be used in IAST chapter 0

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
