### PR TITLE
increase profiler agent test timeout

### DIFF
--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -50,7 +50,9 @@ async function createProfile (periodType) {
 
 const describeOnUnix = os.platform() === 'win32' ? describe.skip : describe
 
-describe('exporters/agent', () => {
+describe('exporters/agent', function () {
+  this.timeout(10000)
+
   let AgentExporter
   let sockets
   let url
@@ -133,9 +135,7 @@ describe('exporters/agent', () => {
       sockets.forEach(socket => socket.end())
     })
 
-    it('should send profiles as pprof to the intake', async function () {
-      this.timeout(10000)
-
+    it('should send profiles as pprof to the intake', async () => {
       const exporter = new AgentExporter({ url, logger, uploadTimeout: 100 })
       const start = new Date()
       const end = new Date()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase profiler agent test timeout.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests are flaky because the timeout if often reached.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

@Qard Could this be hiding an underlying issue? It's odd that most of the time the tests run within milliseconds, and sometimes it takes several seconds. Could there be a bug in the backoff strategy?