### PR TITLE
Implement trace stats

### DIFF
--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -12,7 +12,10 @@ const config = {
   url: 'http://localhost:8126',
   flushInterval: 2000,
   flushMinSpans: 1000,
-  protocolVersion: process.env.ENCODER_VERSION
+  protocolVersion: process.env.ENCODER_VERSION,
+  stats: {
+    enabled: false
+  }
 }
 const prioritySampler = new PrioritySampler()
 const exporter = new Exporter(config, prioritySampler)

--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -14,7 +14,7 @@ const config = {
   flushMinSpans: 1000,
   protocolVersion: process.env.ENCODER_VERSION,
   stats: {
-    enabled: false
+    enabled: process.env.WITH_STATS === '1'
   }
 }
 const prioritySampler = new PrioritySampler()

--- a/benchmark/sirun/exporting-pipeline/meta.json
+++ b/benchmark/sirun/exporting-pipeline/meta.json
@@ -5,7 +5,29 @@
   "iterations": 10,
   "cachegrind": true,
   "variants": {
-    "0.4": { "env": { "ENCODER_VERSION": "0.4" } },
-    "0.5": { "env": { "ENCODER_VERSION": "0.5" } }
+    "0.4": {
+      "env": {
+        "ENCODER_VERSION": "0.4",
+        "WITH_STATS": "0"
+      }
+    },
+    "0.5": {
+      "env": {
+        "ENCODER_VERSION": "0.5",
+        "WITH_STATS": "0"
+      }
+    },
+    "0.4_with_stats": {
+      "env": {
+        "ENCODER_VERSION": "0.4",
+        "WITH_STATS": "1"
+      }
+    },
+    "0.5_with_stats": {
+      "env": {
+        "ENCODER_VERSION": "0.5",
+        "WITH_STATS": "1"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@datadog/native-appsec": "^1.2.1",
     "@datadog/native-metrics": "^1.4.2",
     "@datadog/pprof": "^1.0.2",
-    "@datadog/sketches-js": "^2.0.0",
+    "@datadog/sketches-js": "^2.1.0",
     "cidr-matcher": "^2.1.1",
     "crypto-randomuuid": "^1.0.0",
     "diagnostics_channel": "^1.1.0",

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -165,11 +165,6 @@ class Config {
       process.env.DD_TRACE_STATS_COMPUTATION_ENABLED,
       false
     )
-    const DD_TRACE_STATS_WRITER_INTERVAL = coalesce(
-      options.stats && options.stats.interval,
-      process.env.DD_TRACE_STATS_WRITER_INTERVAL,
-      10
-    )
 
     let appsec = options.appsec || (options.experimental && options.experimental.appsec)
 
@@ -332,8 +327,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.isGitUploadEnabled = isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED)
     this.isIntelligentTestRunnerEnabled = isTrue(DD_CIVISIBILITY_ITR_ENABLED)
     this.stats = {
-      enabled: DD_TRACE_STATS_COMPUTATION_ENABLED,
-      interval: DD_TRACE_STATS_WRITER_INTERVAL
+      enabled: DD_TRACE_STATS_COMPUTATION_ENABLED
     }
 
     tagger.add(this.tags, {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -327,7 +327,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.isGitUploadEnabled = isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED)
     this.isIntelligentTestRunnerEnabled = isTrue(DD_CIVISIBILITY_ITR_ENABLED)
     this.stats = {
-      enabled: DD_TRACE_STATS_COMPUTATION_ENABLED
+      enabled: isTrue(DD_TRACE_STATS_COMPUTATION_ENABLED)
     }
 
     tagger.add(this.tags, {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -160,6 +160,17 @@ class Config {
       '512'
     )
 
+    const DD_TRACE_STATS_COMPUTATION_ENABLED = coalesce(
+      options.stats,
+      process.env.DD_TRACE_STATS_COMPUTATION_ENABLED,
+      false
+    )
+    const DD_TRACE_STATS_WRITER_INTERVAL = coalesce(
+      options.stats && options.stats.interval,
+      process.env.DD_TRACE_STATS_WRITER_INTERVAL,
+      10
+    )
+
     let appsec = options.appsec || (options.experimental && options.experimental.appsec)
 
     const DD_APPSEC_ENABLED = coalesce(
@@ -320,6 +331,10 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     }
     this.isGitUploadEnabled = isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED)
     this.isIntelligentTestRunnerEnabled = isTrue(DD_CIVISIBILITY_ITR_ENABLED)
+    this.stats = {
+      enabled: DD_TRACE_STATS_COMPUTATION_ENABLED,
+      interval: DD_TRACE_STATS_WRITER_INTERVAL
+    }
 
     tagger.add(this.tags, {
       service: this.service,

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -5,6 +5,7 @@ module.exports = {
   ANALYTICS_KEY: '_dd1.sr.eausr',
   ORIGIN_KEY: '_dd.origin',
   HOSTNAME_KEY: '_dd.hostname',
+  TOP_LEVEL_KEY: '_dd.top_level',
   SAMPLING_RULE_DECISION: '_dd.rule_psr',
   SAMPLING_LIMIT_DECISION: '_dd.limit_psr',
   SAMPLING_AGENT_DECISION: '_dd.agent_psr',

--- a/packages/dd-trace/src/encode/span-stats.js
+++ b/packages/dd-trace/src/encode/span-stats.js
@@ -1,0 +1,155 @@
+'use strict'
+
+const { AgentEncoder } = require('./0.4')
+
+const {
+  MAX_NAME_LENGTH,
+  MAX_SERVICE_LENGTH,
+  MAX_RESOURCE_NAME_LENGTH,
+  MAX_TYPE_LENGTH,
+  DEFAULT_SPAN_NAME,
+  DEFAULT_SERVICE_NAME
+} = require('./tags-processors')
+
+function truncate (value, maxLength, suffix = '') {
+  if (!value) {
+    return value
+  }
+  if (value.length > maxLength) {
+    return `${value.slice(0, maxLength)}${suffix}`
+  }
+  return value
+}
+
+class SpanStatsEncoder extends AgentEncoder {
+  _encodeBool (bytes, value) {
+    this._encodeByte(bytes, value ? 0xc3 : 0xc2)
+  }
+
+  makePayload () {
+    const traceSize = this._traceBytes.length
+    const buffer = Buffer.allocUnsafe(traceSize)
+    this._traceBytes.copy(buffer, 0, traceSize)
+    this._reset()
+    return buffer
+  }
+
+  _encodeMapPrefix (bytes, length) {
+    const offset = bytes.length
+
+    bytes.reserve(1)
+    bytes.length += 1
+
+    bytes.buffer[offset] = 0x80 + length
+  }
+
+  _encodeBuffer (bytes, buffer) {
+    const length = buffer.length
+    const offset = bytes.length
+
+    bytes.reserve(5)
+    bytes.length += 5
+
+    bytes.buffer[offset] = 0xc6
+    bytes.buffer[offset + 1] = length >> 24
+    bytes.buffer[offset + 2] = length >> 16
+    bytes.buffer[offset + 3] = length >> 8
+    bytes.buffer[offset + 4] = length
+
+    buffer.copy(bytes.buffer, offset + 5)
+    bytes.length += length
+  }
+
+  _encodeStat (bytes, stat) {
+    this._encodeMapPrefix(bytes, 12)
+
+    this._encodeString(bytes, 'Service')
+    const service = stat.Service || DEFAULT_SERVICE_NAME
+    this._encodeString(bytes, truncate(service, MAX_SERVICE_LENGTH))
+
+    this._encodeString(bytes, 'Name')
+    const name = stat.Name || DEFAULT_SPAN_NAME
+    this._encodeString(bytes, truncate(name, MAX_NAME_LENGTH))
+
+    this._encodeString(bytes, 'Resource')
+    this._encodeString(bytes, truncate(stat.Resource, MAX_RESOURCE_NAME_LENGTH, '...'))
+
+    this._encodeString(bytes, 'HTTPStatusCode')
+    this._encodeInteger(bytes, stat.HTTPStatusCode)
+
+    this._encodeString(bytes, 'Type')
+    this._encodeString(bytes, truncate(stat.Type, MAX_TYPE_LENGTH))
+
+    this._encodeString(bytes, 'Hits')
+    this._encodeLong(bytes, stat.Hits)
+
+    this._encodeString(bytes, 'Errors')
+    this._encodeLong(bytes, stat.Errors)
+
+    this._encodeString(bytes, 'Duration')
+    this._encodeLong(bytes, stat.Duration)
+
+    this._encodeString(bytes, 'OkSummary')
+    this._encodeBuffer(bytes, stat.OkSummary)
+
+    this._encodeString(bytes, 'ErrorSummary')
+    this._encodeBuffer(bytes, stat.ErrorSummary)
+
+    this._encodeString(bytes, 'Synthetics')
+    this._encodeBool(bytes, stat.Synthetics)
+
+    this._encodeString(bytes, 'TopLevelHits')
+    this._encodeLong(bytes, stat.TopLevelHits)
+  }
+
+  _encodeBucket (bytes, bucket) {
+    this._encodeMapPrefix(bytes, 3)
+
+    this._encodeString(bytes, 'Start')
+    this._encodeLong(bytes, bucket.Start)
+
+    this._encodeString(bytes, 'Duration')
+    this._encodeLong(bytes, bucket.Duration)
+
+    this._encodeString(bytes, 'Stats')
+    this._encodeArrayPrefix(bytes, bucket.Stats)
+    for (const stat of bucket.Stats) {
+      this._encodeStat(bytes, stat)
+    }
+  }
+
+  _encode (bytes, stats) {
+    this._encodeMapPrefix(bytes, 8)
+
+    this._encodeString(bytes, 'Hostname')
+    this._encodeString(bytes, stats.Hostname)
+
+    this._encodeString(bytes, 'Env')
+    this._encodeString(bytes, stats.Env)
+
+    this._encodeString(bytes, 'Version')
+    this._encodeString(bytes, stats.Version)
+
+    this._encodeString(bytes, 'Stats')
+    this._encodeArrayPrefix(bytes, stats.Stats)
+    for (const bucket of stats.Stats) {
+      this._encodeBucket(bytes, bucket)
+    }
+
+    this._encodeString(bytes, 'Lang')
+    this._encodeString(bytes, stats.Lang)
+
+    this._encodeString(bytes, 'TracerVersion')
+    this._encodeString(bytes, stats.TracerVersion)
+
+    this._encodeString(bytes, 'RuntimeID')
+    this._encodeString(bytes, stats.RuntimeID)
+
+    this._encodeString(bytes, 'Sequence')
+    this._encodeLong(bytes, stats.Sequence)
+  }
+}
+
+module.exports = {
+  SpanStatsEncoder
+}

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -7,9 +7,21 @@ const Writer = require('./writer')
 class AgentExporter {
   constructor (config, prioritySampler) {
     this._config = config
-    const { url, hostname, port, lookup, protocolVersion } = config
+    const { url, hostname, port, lookup, protocolVersion, stats = {} } = config
     this._url = url || new URL(`http://${hostname || 'localhost'}:${port}`)
-    this._writer = new Writer({ url: this._url, prioritySampler, lookup, protocolVersion })
+
+    const headers = {}
+    if (stats.enabled) {
+      headers['Datadog-Client-Computed-Stats'] = 'yes'
+    }
+
+    this._writer = new Writer({
+      url: this._url,
+      prioritySampler,
+      lookup,
+      protocolVersion,
+      headers
+    })
 
     this._timer = undefined
     process.once('beforeExit', () => this._writer.flush())

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -10,7 +10,7 @@ const BaseWriter = require('../common/writer')
 const METRIC_PREFIX = 'datadog.tracer.node.exporter.agent'
 
 class Writer extends BaseWriter {
-  constructor ({ prioritySampler, lookup, protocolVersion }) {
+  constructor ({ prioritySampler, lookup, protocolVersion, headers }) {
     super(...arguments)
     const AgentEncoder = getEncoder(protocolVersion)
 
@@ -18,12 +18,14 @@ class Writer extends BaseWriter {
     this._lookup = lookup
     this._protocolVersion = protocolVersion
     this._encoder = new AgentEncoder(this)
+    this._headers = headers
   }
 
   _sendPayload (data, count, done) {
     metrics.increment(`${METRIC_PREFIX}.requests`, true)
 
-    makeRequest(this._protocolVersion, data, count, this._url, this._lookup, true, (err, res, status) => {
+    const { _headers, _lookup, _protocolVersion, _url } = this
+    makeRequest(_protocolVersion, data, count, _url, _headers, _lookup, true, (err, res, status) => {
       if (status) {
         metrics.increment(`${METRIC_PREFIX}.responses`, true)
         metrics.increment(`${METRIC_PREFIX}.responses.by.status`, `status:${status}`, true)
@@ -73,11 +75,12 @@ function getEncoder (protocolVersion) {
   }
 }
 
-function makeRequest (version, data, count, url, lookup, needsStartupLog, cb) {
+function makeRequest (version, data, count, url, headers, lookup, needsStartupLog, cb) {
   const options = {
     path: `/v${version}/traces`,
     method: 'PUT',
     headers: {
+      ...headers,
       'Content-Type': 'application/msgpack',
       'Datadog-Meta-Tracer-Version': tracerVersion,
       'X-Datadog-Trace-Count': String(count)

--- a/packages/dd-trace/src/exporters/span-stats/index.js
+++ b/packages/dd-trace/src/exporters/span-stats/index.js
@@ -1,0 +1,20 @@
+const { URL } = require('url')
+
+const { Writer } = require('./writer')
+
+class SpanStatsExporter {
+  constructor (config) {
+    const { hostname = '127.0.0.1', port = 8126, tags, url } = config
+    this._url = url || new URL(`http://${hostname || 'localhost'}:${port}`)
+    this._writer = new Writer({ url: this._url, tags })
+  }
+
+  export (payload) {
+    this._writer.append(payload)
+    this._writer.flush()
+  }
+}
+
+module.exports = {
+  SpanStatsExporter
+}

--- a/packages/dd-trace/src/exporters/span-stats/writer.js
+++ b/packages/dd-trace/src/exporters/span-stats/writer.js
@@ -1,0 +1,55 @@
+
+const { SpanStatsEncoder } = require('../../encode/span-stats')
+
+const pkg = require('../../../../../package.json')
+
+const BaseWriter = require('../common/writer')
+const request = require('../common/request')
+const log = require('../../log')
+
+class Writer extends BaseWriter {
+  constructor ({ url }) {
+    super(...arguments)
+    this._url = url
+    this._encoder = new SpanStatsEncoder(this)
+  }
+
+  _sendPayload (data, _, done) {
+    makeRequest(data, this._url, (err, res) => {
+      if (err) {
+        log.error(err)
+        done()
+        return
+      }
+      log.debug(`Response from the intake: ${res}`)
+      done()
+    })
+  }
+}
+
+function makeRequest (data, url, cb) {
+  const options = {
+    path: '/v0.6/stats',
+    method: 'PUT',
+    headers: {
+      'Datadog-Meta-Lang': 'javascript',
+      'Datadog-Meta-Tracer-Version': pkg.version,
+      'Content-Type': 'application/msgpack'
+    },
+    timeout: 15000
+  }
+
+  options.protocol = url.protocol
+  options.hostname = url.hostname
+  options.port = url.port
+
+  log.debug(() => `Request to the intake: ${JSON.stringify(options)}`)
+
+  request(data, options, false, (err, res) => {
+    cb(err, res)
+  })
+}
+
+module.exports = {
+  Writer
+}

--- a/packages/dd-trace/src/exporters/span-stats/writer.js
+++ b/packages/dd-trace/src/exporters/span-stats/writer.js
@@ -45,7 +45,7 @@ function makeRequest (data, url, cb) {
 
   log.debug(() => `Request to the intake: ${JSON.stringify(options)}`)
 
-  request(data, options, false, (err, res) => {
+  request(data, options, (err, res) => {
     cb(err, res)
   })
 }

--- a/packages/dd-trace/src/exporters/span-stats/writer.js
+++ b/packages/dd-trace/src/exporters/span-stats/writer.js
@@ -35,8 +35,7 @@ function makeRequest (data, url, cb) {
       'Datadog-Meta-Lang': 'javascript',
       'Datadog-Meta-Tracer-Version': pkg.version,
       'Content-Type': 'application/msgpack'
-    },
-    timeout: 15000
+    }
   }
 
   options.protocol = url.protocol

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -12,6 +12,7 @@ const SAMPLING_AGENT_DECISION = constants.SAMPLING_AGENT_DECISION
 const MEASURED = tags.MEASURED
 const ORIGIN_KEY = constants.ORIGIN_KEY
 const HOSTNAME_KEY = constants.HOSTNAME_KEY
+const TOP_LEVEL_KEY = constants.TOP_LEVEL_KEY
 
 const map = {
   'service.name': 'service',
@@ -110,6 +111,7 @@ function extractRootTags (trace, span) {
   addTag({}, trace.metrics, SAMPLING_RULE_DECISION, context._trace[SAMPLING_RULE_DECISION])
   addTag({}, trace.metrics, SAMPLING_LIMIT_DECISION, context._trace[SAMPLING_LIMIT_DECISION])
   addTag({}, trace.metrics, SAMPLING_AGENT_DECISION, context._trace[SAMPLING_AGENT_DECISION])
+  addTag({}, trace.metrics, TOP_LEVEL_KEY, 1)
 }
 
 function extractChunkTags (trace, span) {

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -11,6 +11,8 @@ const metrics = require('../metrics')
 const log = require('../log')
 const { storage } = require('../../../datadog-core')
 
+const { TOP_LEVEL_KEY } = require('../constants')
+
 const {
   DD_TRACE_EXPERIMENTAL_STATE_TRACKING,
   DD_TRACE_EXPERIMENTAL_SPAN_COUNTS
@@ -23,7 +25,6 @@ class DatadogSpan {
   constructor (tracer, processor, prioritySampler, fields, debug) {
     const operationName = fields.operationName
     const parent = fields.parent || null
-    const tags = Object.assign({}, fields.tags)
     const hostname = fields.hostname
 
     this._parentTracer = tracer
@@ -34,8 +35,8 @@ class DatadogSpan {
     this._name = operationName
 
     this._spanContext = this._createContext(parent)
+    Object.assign(this._spanContext._tags, fields.tags)
     this._spanContext._name = operationName
-    this._spanContext._tags = tags
     this._spanContext._hostname = hostname
 
     this._startTime = fields.startTime || this._getTime()
@@ -150,6 +151,9 @@ class DatadogSpan {
       spanContext = new SpanContext({
         traceId: spanId,
         spanId
+      })
+      tagger.add(spanContext._tags, {
+        [TOP_LEVEL_KEY]: 1
       })
     }
 

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -11,8 +11,6 @@ const metrics = require('../metrics')
 const log = require('../log')
 const { storage } = require('../../../datadog-core')
 
-const { TOP_LEVEL_KEY } = require('../constants')
-
 const {
   DD_TRACE_EXPERIMENTAL_STATE_TRACKING,
   DD_TRACE_EXPERIMENTAL_SPAN_COUNTS
@@ -25,6 +23,7 @@ class DatadogSpan {
   constructor (tracer, processor, prioritySampler, fields, debug) {
     const operationName = fields.operationName
     const parent = fields.parent || null
+    const tags = Object.assign({}, fields.tags)
     const hostname = fields.hostname
 
     this._parentTracer = tracer
@@ -35,8 +34,8 @@ class DatadogSpan {
     this._name = operationName
 
     this._spanContext = this._createContext(parent)
-    Object.assign(this._spanContext._tags, fields.tags)
     this._spanContext._name = operationName
+    this._spanContext._tags = tags
     this._spanContext._hostname = hostname
 
     this._startTime = fields.startTime || this._getTime()
@@ -151,9 +150,6 @@ class DatadogSpan {
       spanContext = new SpanContext({
         traceId: spanId,
         spanId
-      })
-      tagger.add(spanContext._tags, {
-        [TOP_LEVEL_KEY]: 1
       })
     }
 

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -3,6 +3,8 @@
 const log = require('./log')
 const format = require('./format')
 
+const { SpanStatsProcessor } = require('./span_stats')
+
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
 
@@ -11,6 +13,8 @@ class SpanProcessor {
     this._exporter = exporter
     this._prioritySampler = prioritySampler
     this._config = config
+
+    this._stats = new SpanStatsProcessor(config)
   }
 
   process (span) {
@@ -26,6 +30,7 @@ class SpanProcessor {
 
       for (const span of started) {
         if (span._duration !== undefined) {
+          this._stats.onSpanFinished(span)
           formatted.push(format(span))
         } else {
           active.push(span)

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -30,8 +30,9 @@ class SpanProcessor {
 
       for (const span of started) {
         if (span._duration !== undefined) {
-          this._stats.onSpanFinished(span)
-          formatted.push(format(span))
+          const formattedSpan = format(span)
+          this._stats.onSpanFinished(formattedSpan)
+          formatted.push(formattedSpan)
         } else {
           active.push(span)
         }

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -1,0 +1,218 @@
+const os = require('os')
+const { version } = require('./pkg')
+const pkg = require('../../../package.json')
+
+const { LogCollapsingLowestDenseDDSketch } = require('@datadog/sketches-js')
+const { ORIGIN_KEY, TOP_LEVEL_KEY } = require('./constants')
+const { ERROR } = require('../../../ext/tags')
+const {
+  MEASURED,
+  HTTP_STATUS_CODE,
+  SPAN_TYPE,
+  RESOURCE_NAME,
+  SERVICE_NAME
+} = require('../../../ext/tags')
+
+function getTag (span, key) {
+  if (!span || !span._spanContext || !span._spanContext._tags) return
+  return span._spanContext._tags[key]
+}
+
+const { SpanStatsExporter } = require('./exporters/span-stats')
+
+const {
+  DEFAULT_SPAN_NAME,
+  DEFAULT_SERVICE_NAME
+} = require('./encode/tags-processors')
+
+class SpanAggStats {
+  constructor (aggKey) {
+    this.aggKey = aggKey
+    this.hits = 0
+    this.topLevelHits = 0
+    this.errors = 0
+    this.duration = 0
+    this.okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    this.errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+  }
+
+  record (span) {
+    const durationNs = span._duration * 1e6
+    this.hits++
+    this.duration += durationNs
+
+    if (getTag(span, TOP_LEVEL_KEY)) {
+      this.topLevelHits++
+    }
+
+    if (getTag(span, ERROR)) {
+      this.errors++
+      this.errorDistribution.accept(durationNs)
+    } else {
+      this.okDistribution.accept(durationNs)
+    }
+  }
+
+  toJSON () {
+    const {
+      name,
+      service,
+      resource,
+      type,
+      statusCode,
+      synthetics
+    } = this.aggKey
+
+    return {
+      Name: name,
+      Service: service,
+      Resource: resource,
+      Type: type,
+      HTTPStatusCode: statusCode,
+      Synthetics: synthetics,
+      Hits: this.hits,
+      TopLevelHits: this.topLevelHits,
+      Errors: this.errors,
+      Duration: this.duration,
+      OkSummary: this.okDistribution.toProto(),
+      ErrorSummary: this.errorDistribution.toProto()
+    }
+  }
+}
+
+class SpanAggKey {
+  constructor (span) {
+    this.name = ((span || {})._spanContext || {})._name || DEFAULT_SPAN_NAME
+    this.service = getTag(span, SERVICE_NAME) || DEFAULT_SERVICE_NAME
+    this.resource = getTag(span, RESOURCE_NAME) || ''
+    this.type = getTag(span, SPAN_TYPE) || ''
+    this.statusCode = getTag(span, HTTP_STATUS_CODE) || 0
+    this.synthetics = getTag(span, ORIGIN_KEY) === 'synthetics'
+  }
+
+  toString () {
+    return [
+      this.name,
+      this.service,
+      this.resource,
+      this.type,
+      this.statusCode,
+      this.synthetics
+    ].join(',')
+  }
+}
+
+class SpanBuckets extends Map {
+  forSpan (span) {
+    const aggKey = new SpanAggKey(span)
+    const key = aggKey.toString()
+
+    if (!this.has(key)) {
+      this.set(key, new SpanAggStats(aggKey))
+    }
+
+    return this.get(key)
+  }
+}
+
+class TimeBuckets extends Map {
+  forTime (time) {
+    if (!this.has(time)) {
+      this.set(time, new SpanBuckets())
+    }
+
+    return this.get(time)
+  }
+}
+
+class SpanStatsProcessor {
+  constructor ({
+    stats: {
+      enabled,
+      interval
+    },
+    hostname,
+    port,
+    url,
+    env,
+    tags
+  } = {}) {
+    this.exporter = new SpanStatsExporter({
+      hostname,
+      port,
+      tags,
+      url
+    })
+    this.interval = interval
+    this.buckets = new TimeBuckets()
+    this.hostname = os.hostname()
+    this.enabled = enabled
+    this.env = env
+    this.tags = tags
+    this.sequence = 0
+
+    if (enabled) {
+      this.timer = setInterval(this.onInterval.bind(this), interval * 1e3)
+      this.timer.unref()
+    }
+  }
+
+  onInterval () {
+    const serialized = this._serializeBuckets()
+    if (!serialized) return
+
+    this.exporter.export({
+      Hostname: this.hostname,
+      Env: this.env,
+      Version: version,
+      Stats: serialized,
+      Lang: 'javascript',
+      TracerVersion: pkg.version,
+      RuntimeID: this.tags['runtime-id'],
+      Sequence: ++this.sequence
+    })
+  }
+
+  onSpanFinished (span) {
+    if (!this.enabled) return
+    if (!getTag(span, TOP_LEVEL_KEY) && !getTag(span, MEASURED)) return
+
+    const spanEnd = span._startTime + span._duration
+    const bucketTime = spanEnd - (spanEnd % (this.interval * 1e3))
+
+    this.buckets.forTime(bucketTime)
+      .forSpan(span)
+      .record(span)
+  }
+
+  _serializeBuckets () {
+    const bucketSizeNs = this.interval * 1e9
+    const serializedBuckets = []
+
+    for (const [ timeNs, bucket ] of this.buckets.entries()) {
+      const bucketAggStats = []
+
+      for (const stats of bucket.values()) {
+        bucketAggStats.push(stats.toJSON())
+      }
+
+      serializedBuckets.push({
+        Start: timeNs * 1e6,
+        Duration: bucketSizeNs,
+        Stats: bucketAggStats
+      })
+    }
+
+    this.buckets.clear()
+
+    return serializedBuckets
+  }
+}
+
+module.exports = {
+  SpanAggStats,
+  SpanAggKey,
+  SpanBuckets,
+  TimeBuckets,
+  SpanStatsProcessor
+}

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -128,8 +128,8 @@ class TimeBuckets extends Map {
 class SpanStatsProcessor {
   constructor ({
     stats: {
-      enabled,
-      interval
+      enabled = false,
+      interval = 10
     },
     hostname,
     port,
@@ -148,7 +148,7 @@ class SpanStatsProcessor {
     this.hostname = os.hostname()
     this.enabled = enabled
     this.env = env
-    this.tags = tags
+    this.tags = tags || {}
     this.sequence = 0
 
     if (enabled) {

--- a/packages/dd-trace/test/encode/span-stats.spec.js
+++ b/packages/dd-trace/test/encode/span-stats.spec.js
@@ -1,0 +1,160 @@
+'use strict'
+
+const { expect } = require('chai')
+const msgpack = require('msgpack-lite')
+const codec = msgpack.createCodec()
+
+const {
+  MAX_NAME_LENGTH,
+  MAX_SERVICE_LENGTH,
+  MAX_RESOURCE_NAME_LENGTH,
+  MAX_TYPE_LENGTH,
+  DEFAULT_SPAN_NAME,
+  DEFAULT_SERVICE_NAME
+} = require('../../src/encode/tags-processors')
+
+describe('span-stats-encode', () => {
+  let encoder
+  let writer
+  let logger
+  let stats
+  let bucket
+  let stat
+
+  beforeEach(() => {
+    logger = {
+      debug: sinon.stub()
+    }
+    const { SpanStatsEncoder } = proxyquire('../src/encode/span-stats', {
+      '../log': logger
+    })
+    writer = { flush: sinon.spy() }
+    encoder = new SpanStatsEncoder(writer)
+
+    stat = {
+      Name: 'web.request',
+      Type: 'web',
+      Service: 'dd-trace',
+      Resource: 'GET',
+      Synthetics: false,
+      HTTPStatusCode: 200,
+      Hits: 30799,
+      TopLevelHits: 30799,
+      Duration: 1230,
+      Errors: 0,
+      OkSummary: Buffer.from(''),
+      ErrorSummary: Buffer.from('')
+    }
+
+    bucket = {
+      Start: 1660000000000,
+      Duration: 10000000000,
+      Stats: [
+        stat
+      ]
+    }
+
+    stats = {
+      Hostname: 'COMP-C02F806TML87',
+      Env: 'env',
+      Version: '4.0.0-pre',
+      Stats: [
+        bucket
+      ],
+      Lang: 'javascript',
+      TracerVersion: '1.2.3',
+      RuntimeID: 'some-runtime-id',
+      Sequence: 1
+    }
+  })
+
+  it('should encode to msgpack', () => {
+    encoder.encode(stats)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer, { codec })
+
+    expect(decoded).to.deep.equal(stats)
+  })
+
+  it('should report its count', () => {
+    expect(encoder.count()).to.equal(0)
+
+    encoder.encode(stats)
+
+    expect(encoder.count()).to.equal(1)
+
+    encoder.encode(stats)
+
+    expect(encoder.count()).to.equal(2)
+  })
+
+  it('should reset after making a payload', () => {
+    encoder.encode(stats)
+    encoder.makePayload()
+
+    expect(encoder.count()).to.equal(0)
+  })
+
+  it('should truncate name, service, type and resource when they are too long', () => {
+    const tooLongString = new Array(500).fill('a').join('')
+    const resourceTooLongString = new Array(10000).fill('a').join('')
+    const statsToTruncate = {
+      ...stats,
+      Stats: [
+        {
+          ...bucket,
+          Stats: [
+            {
+              ...stat,
+              Name: tooLongString,
+              Type: tooLongString,
+              Service: tooLongString,
+              Resource: resourceTooLongString
+            }
+          ]
+        }
+      ]
+    }
+    encoder.encode(statsToTruncate)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer, { codec })
+
+    expect(decoded)
+    const decodedStat = decoded.Stats[0].Stats[0]
+    expect(decodedStat.Type.length).to.equal(MAX_TYPE_LENGTH)
+    expect(decodedStat.Name.length).to.equal(MAX_NAME_LENGTH)
+    expect(decodedStat.Service.length).to.equal(MAX_SERVICE_LENGTH)
+    // ellipsis is added
+    expect(decodedStat.Resource.length).to.equal(MAX_RESOURCE_NAME_LENGTH + 3)
+  })
+
+  it('should fallback to a default name and service if they are not present', () => {
+    const statsToTruncate = {
+      ...stats,
+      Stats: [
+        {
+          ...bucket,
+          Stats: [
+            {
+              ...stat,
+              Name: undefined,
+              Service: undefined
+            }
+          ]
+        }
+      ]
+    }
+    encoder.encode(statsToTruncate)
+
+    const buffer = encoder.makePayload()
+    const decodedStats = msgpack.decode(buffer, { codec })
+    expect(decodedStats)
+
+    const decodedStat = decodedStats.Stats[0].Stats[0]
+    expect(decodedStat)
+    expect(decodedStat.Service).to.equal(DEFAULT_SERVICE_NAME)
+    expect(decodedStat.Name).to.equal(DEFAULT_SPAN_NAME)
+  })
+})

--- a/packages/dd-trace/test/exporters/agent/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agent/exporter.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { expect } = require('chai')
+
 const URL = require('url').URL
 
 describe('Exporter', () => {
@@ -26,6 +28,16 @@ describe('Exporter', () => {
 
     Exporter = proxyquire('../src/exporters/agent', {
       './writer': Writer
+    })
+  })
+
+  it('should pass computed stats header through to writer', () => {
+    const stats = { enabled: true }
+    exporter = new Exporter({ url, flushInterval, stats }, prioritySampler)
+    expect(Writer).to.have.been.calledWithMatch({
+      headers: {
+        'Datadog-Client-Computed-Stats': 'yes'
+      }
     })
   })
 

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -132,6 +132,27 @@ function describeWriter (protocolVersion) {
       })
     })
 
+    it('should pass through headers', (done) => {
+      const headers = {
+        'My-Header': 'bar'
+      }
+      writer = new Writer({ url, prioritySampler, protocolVersion, headers })
+      encoder.count.returns(2)
+      encoder.makePayload.returns([Buffer.from('data')])
+      writer.flush(() => {
+        expect(request.getCall(0).args[1].headers).to.eql({
+          ...headers,
+          'Content-Type': 'application/msgpack',
+          'Datadog-Meta-Lang': 'nodejs',
+          'Datadog-Meta-Lang-Version': process.version,
+          'Datadog-Meta-Lang-Interpreter': 'v8',
+          'Datadog-Meta-Tracer-Version': 'tracerVersion',
+          'X-Datadog-Trace-Count': '2'
+        })
+        done()
+      })
+    })
+
     it('should log request errors', done => {
       const error = new Error('boom')
 

--- a/packages/dd-trace/test/exporters/span-stats/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/span-stats/exporter.spec.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const { expect } = require('chai')
+
+const URL = require('url').URL
+
+describe('span-stats exporter', () => {
+  let url
+  let Exporter
+  let exporter
+  let Writer
+  let writer
+
+  beforeEach(() => {
+    url = 'www.example.com'
+    writer = {
+      append: sinon.spy(),
+      flush: sinon.spy()
+    }
+    Writer = sinon.stub().returns(writer)
+
+    Exporter = proxyquire('../src/exporters/span-stats', {
+      './writer': { Writer }
+    }).SpanStatsExporter
+  })
+
+  it('should flush immediately on export', () => {
+    exporter = new Exporter({ url })
+
+    expect(writer.append).to.have.not.been.called
+    expect(writer.flush).to.have.not.been.called
+
+    exporter.export('')
+
+    expect(writer.append).to.have.been.called
+    expect(writer.flush).to.have.been.called
+  })
+
+  it('should set url from hostname and port', () => {
+    const hostname = '0.0.0.0'
+    const port = '1234'
+    const url = new URL(`http://${hostname}:${port}`)
+
+    exporter = new Exporter({ hostname, port })
+
+    expect(exporter._url).to.be.deep.equal(url)
+    expect(Writer).to.have.been.calledWith({
+      url: exporter._url,
+      tags: undefined
+    })
+  })
+
+  it('should pass tags through to writer', () => {
+    const tags = { foo: 'bar' }
+
+    exporter = new Exporter({ url, tags })
+
+    expect(Writer).to.have.been.calledWith({
+      url: exporter._url,
+      tags
+    })
+  })
+})

--- a/packages/dd-trace/test/exporters/span-stats/writer.spec.js
+++ b/packages/dd-trace/test/exporters/span-stats/writer.spec.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const { expect } = require('chai')
+
+const pkg = require('../../../../../package.json')
+
+let Writer
+let writer
+let span
+let request
+let encoder
+let url
+let log
+
+describe('span-stats writer', () => {
+  beforeEach(() => {
+    span = 'formatted'
+
+    request = sinon.stub().yieldsAsync(null, 'OK', 200)
+
+    encoder = {
+      encode: sinon.stub(),
+      count: sinon.stub().returns(0),
+      makePayload: sinon.stub().returns([])
+    }
+
+    url = {
+      protocol: 'https:',
+      hostname: '127.0.0.1:8126'
+    }
+
+    log = {
+      error: sinon.spy()
+    }
+
+    const SpanStatsEncoder = function () {
+      return encoder
+    }
+
+    Writer = proxyquire('../../../src/exporters/span-stats/writer', {
+      '../common/request': request,
+      '../../encode/span-stats': { SpanStatsEncoder },
+      '../../log': log
+    }).Writer
+    writer = new Writer({ url, tags: { 'runtime-id': 'runtime-id' } })
+  })
+
+  describe('append', () => {
+    it('should encode a trace', () => {
+      writer.append([span])
+
+      expect(encoder.encode).to.have.been.calledWith([span])
+    })
+  })
+
+  describe('flush', () => {
+    it('should skip flushing if empty', () => {
+      writer.flush()
+
+      expect(encoder.makePayload).to.not.have.been.called
+    })
+
+    it('should empty the internal queue', () => {
+      encoder.count.returns(1)
+
+      writer.flush()
+
+      expect(encoder.makePayload).to.have.been.called
+    })
+
+    it('should call callback when empty', (done) => {
+      writer.flush(done)
+    })
+
+    it('should flush to the agent, and call callback', (done) => {
+      const expectedData = Buffer.from('prefixed')
+
+      encoder.count.returns(2)
+      encoder.makePayload.returns([expectedData])
+
+      writer.flush(() => {
+        expect(request).to.have.been.calledWithMatch([expectedData], {
+          protocol: url.protocol,
+          hostname: url.hostname,
+          path: '/v0.6/stats',
+          method: 'PUT',
+          headers: {
+            'Datadog-Meta-Lang': 'javascript',
+            'Datadog-Meta-Tracer-Version': pkg.version,
+            'Content-Type': 'application/msgpack'
+          }
+        })
+        done()
+      })
+    })
+
+    describe('when request fails', function () {
+      this.timeout(100000)
+      it('should log request errors', done => {
+        const error = new Error('boom')
+
+        request.yields(error)
+
+        encoder.count.returns(1)
+
+        writer.flush(() => {
+          expect(log.error).to.have.been.calledWith(error)
+          done()
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -38,7 +38,10 @@ describe('SpanProcessor', () => {
       sample: sinon.stub()
     }
     config = {
-      flushMinSpans: 3
+      flushMinSpans: 3,
+      stats: {
+        enabled: false
+      }
     }
     format = sinon.stub().returns({ formatted: true })
 

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -46,11 +46,11 @@ const errorSpan = {
   error: 1,
   meta: {
     ...basicSpan.meta,
-    [HTTP_STATUS_CODE]: 500,
+    [HTTP_STATUS_CODE]: 500
   },
   metrics: {
     ...basicSpan.metrics,
-    [MEASURED]: 1,
+    [MEASURED]: 1
   }
 }
 

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -1,0 +1,333 @@
+'use strict'
+
+const { hostname } = require('os')
+
+const { LogCollapsingLowestDenseDDSketch } = require('@datadog/sketches-js')
+
+const { version } = require('../src/pkg')
+const pkg = require('../../../package.json')
+const { ERROR } = require('../../../ext/tags')
+const { ORIGIN_KEY, TOP_LEVEL_KEY } = require('../src/constants')
+const {
+  MEASURED,
+  HTTP_STATUS_CODE,
+  SPAN_TYPE,
+  RESOURCE_NAME,
+  SERVICE_NAME
+} = require('../../../ext/tags')
+const {
+  DEFAULT_SPAN_NAME,
+  DEFAULT_SERVICE_NAME
+} = require('../src/encode/tags-processors')
+
+// Mock spans
+const basicSpan = {
+  _startTime: 14 * 1e9,
+  _duration: 1234,
+  error: false,
+  _spanContext: {
+    _name: 'basic-span',
+    _tags: {
+      [MEASURED]: 0,
+      [HTTP_STATUS_CODE]: 200,
+      [SPAN_TYPE]: 'span-type',
+      [RESOURCE_NAME]: 'resource-name',
+      [SERVICE_NAME]: 'service-name'
+    }
+  }
+}
+
+const topLevelSpan = {
+  ...basicSpan,
+  _spanContext: {
+    _name: 'top-level-span',
+    _tags: {
+      ...basicSpan._spanContext._tags,
+      [TOP_LEVEL_KEY]: 1
+    }
+  }
+}
+
+const errorSpan = {
+  ...basicSpan,
+  _spanContext: {
+    _name: 'error-span',
+    _tags: {
+      ...basicSpan._spanContext._tags,
+      [HTTP_STATUS_CODE]: 500,
+      [MEASURED]: 1,
+      [ERROR]: true
+    }
+  }
+}
+
+const syntheticSpan = {
+  ...basicSpan,
+  _spanContext: {
+    _name: 'synthetic-span',
+    _tags: {
+      ...basicSpan._spanContext._tags,
+      [ORIGIN_KEY]: 'synthetics'
+    }
+  }
+}
+
+const exporter = {
+  export: sinon.stub()
+}
+
+const SpanStatsExporter = sinon.stub().returns(exporter)
+
+const {
+  SpanAggStats,
+  SpanAggKey,
+  SpanBuckets,
+  TimeBuckets,
+  SpanStatsProcessor
+} = proxyquire('../src/span_stats', {
+  './exporters/span-stats': {
+    SpanStatsExporter
+  }
+})
+
+describe('SpanAggKey', () => {
+  it('should make aggregation key for a basic span', () => {
+    const key = new SpanAggKey(basicSpan)
+    expect(key.toString()).to.equal('basic-span,service-name,resource-name,span-type,200,false')
+  })
+
+  it('should make aggregation key for a synthetic span', () => {
+    const key = new SpanAggKey(syntheticSpan)
+    expect(key.toString()).to.equal('synthetic-span,service-name,resource-name,span-type,200,true')
+  })
+
+  it('should make aggregation key for an error span', () => {
+    const key = new SpanAggKey(errorSpan)
+    expect(key.toString()).to.equal('error-span,service-name,resource-name,span-type,500,false')
+  })
+
+  it('should use sensible defaults', () => {
+    const key = new SpanAggKey({})
+    expect(key.toString()).to.equal(`${DEFAULT_SPAN_NAME},${DEFAULT_SERVICE_NAME},,,0,false`)
+  })
+})
+
+describe('SpanAggStats', () => {
+  it('should record a basic span', () => {
+    const aggKey = new SpanAggKey(basicSpan)
+    const aggStats = new SpanAggStats(aggKey)
+    aggStats.record(basicSpan)
+
+    const okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    const errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    okDistribution.accept(basicSpan._duration * 1e6)
+
+    expect(aggStats.toJSON()).to.deep.equal({
+      Name: aggKey.name,
+      Type: aggKey.type,
+      Resource: aggKey.resource,
+      Service: aggKey.service,
+      HTTPStatusCode: aggKey.statusCode,
+      Synthetics: aggKey.synthetics,
+      Hits: 1,
+      TopLevelHits: 0,
+      Errors: 0,
+      Duration: basicSpan._duration * 1e6,
+      OkSummary: okDistribution.toProto(),
+      ErrorSummary: errorDistribution.toProto()
+    })
+  })
+
+  it('should record a top-level span', () => {
+    const aggKey = new SpanAggKey(topLevelSpan)
+    const aggStats = new SpanAggStats(aggKey)
+    aggStats.record(topLevelSpan)
+
+    const okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    const errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    okDistribution.accept(topLevelSpan._duration * 1e6)
+
+    expect(aggStats.toJSON()).to.deep.equal({
+      Name: aggKey.name,
+      Type: aggKey.type,
+      Resource: aggKey.resource,
+      Service: aggKey.service,
+      HTTPStatusCode: aggKey.statusCode,
+      Synthetics: aggKey.synthetics,
+      Hits: 1,
+      TopLevelHits: 1,
+      Errors: 0,
+      Duration: topLevelSpan._duration * 1e6,
+      OkSummary: okDistribution.toProto(),
+      ErrorSummary: errorDistribution.toProto()
+    })
+  })
+
+  it('should record an error span', () => {
+    const aggKey = new SpanAggKey(errorSpan)
+    const aggStats = new SpanAggStats(aggKey)
+    aggStats.record(errorSpan)
+
+    const okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    const errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    errorDistribution.accept(errorSpan._duration * 1e6)
+
+    expect(aggStats.toJSON()).to.deep.equal({
+      Name: aggKey.name,
+      Type: aggKey.type,
+      Resource: aggKey.resource,
+      Service: aggKey.service,
+      HTTPStatusCode: aggKey.statusCode,
+      Synthetics: aggKey.synthetics,
+      Hits: 1,
+      TopLevelHits: 0,
+      Errors: 1,
+      Duration: errorSpan._duration * 1e6,
+      OkSummary: okDistribution.toProto(),
+      ErrorSummary: errorDistribution.toProto()
+    })
+  })
+})
+
+describe('SpanBuckets', () => {
+  const buckets = new SpanBuckets()
+
+  it('should start empty', () => {
+    expect(buckets.size).to.equal(0)
+  })
+
+  it('should add a new entry when no matching span agg key is found', () => {
+    const bucket = buckets.forSpan(basicSpan)
+    expect(bucket).to.be.an.instanceOf(SpanAggStats)
+    expect(buckets.size).to.equal(1)
+    const [key, value] = Array.from(buckets.entries())[0]
+    expect(key).to.equal((new SpanAggKey(basicSpan)).toString())
+    expect(value).to.be.instanceOf(SpanAggStats)
+  })
+
+  it('should not add a new entry if matching span agg key is found', () => {
+    buckets.forSpan(basicSpan)
+    expect(buckets.size).to.equal(1)
+  })
+
+  it('should add a new entry when new span does not match existing agg keys', () => {
+    buckets.forSpan(errorSpan)
+    expect(buckets.size).to.equal(2)
+  })
+})
+
+describe('TimeBuckets', () => {
+  it('should acquire a span agg bucket for the given time', () => {
+    const buckets = new TimeBuckets()
+    expect(buckets.size).to.equal(0)
+    const bucket = buckets.forTime(12345)
+    expect(buckets.size).to.equal(1)
+    expect(bucket).to.be.an.instanceOf(SpanBuckets)
+  })
+})
+
+describe('SpanStatsProcessor', () => {
+  let errorDistribution
+  let okDistribution
+  let processor
+  const n = 100
+
+  const config = {
+    stats: {
+      enabled: true,
+      interval: 10
+    },
+    hostname: '127.0.0.1',
+    port: 8126,
+    url: new URL('http://127.0.0.1:8126'),
+    env: 'test',
+    tags: { tag: 'some tag' }
+  }
+
+  it('should construct', () => {
+    processor = new SpanStatsProcessor(config)
+    clearTimeout(processor.timer)
+
+    expect(SpanStatsExporter).to.be.calledWith({
+      hostname: config.hostname,
+      port: config.port,
+      url: config.url,
+      tags: config.tags
+    })
+    expect(processor.interval).to.equal(config.stats.interval)
+    expect(processor.buckets).to.be.instanceOf(TimeBuckets)
+    expect(processor.hostname).to.equal(hostname())
+    expect(processor.enabled).to.equal(config.stats.enabled)
+    expect(processor.env).to.equal(config.env)
+    expect(processor.tags).to.deep.equal(config.tags)
+  })
+
+  it('should track span stats', () => {
+    expect(processor.buckets.size).to.equal(0)
+    for (let i = 0; i < n; i++) {
+      processor.onSpanFinished(topLevelSpan)
+    }
+    expect(processor.buckets.size).to.equal(1)
+
+    const timeBucket = processor.buckets.values().next().value
+    expect(timeBucket).to.be.instanceOf(SpanBuckets)
+    expect(timeBucket.size).to.equal(1)
+
+    const spanBucket = timeBucket.forSpan(topLevelSpan)
+    expect(timeBucket.size).to.equal(1)
+    expect(spanBucket).to.be.instanceOf(SpanAggStats)
+
+    okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
+    for (let i = 0; i < n; i++) {
+      okDistribution.accept(topLevelSpan._duration * 1e6)
+    }
+
+    expect(spanBucket.toJSON()).to.deep.equal({
+      Name: 'top-level-span',
+      Service: 'service-name',
+      Resource: 'resource-name',
+      Type: 'span-type',
+      HTTPStatusCode: 200,
+      Synthetics: false,
+      Hits: n,
+      TopLevelHits: n,
+      Errors: 0,
+      Duration: (topLevelSpan._duration * 1e6) * n,
+      OkSummary: okDistribution.toProto(),
+      ErrorSummary: errorDistribution.toProto()
+    })
+  })
+
+  it('should export on interval', () => {
+    processor.onInterval()
+
+    expect(exporter.export).to.be.calledWith({
+      Hostname: hostname(),
+      Env: config.env,
+      Version: version,
+      Stats: [{
+        Start: 14000000000000000,
+        Duration: 10000000000,
+        Stats: [{
+          Name: 'top-level-span',
+          Service: 'service-name',
+          Resource: 'resource-name',
+          Type: 'span-type',
+          HTTPStatusCode: 200,
+          Synthetics: false,
+          Hits: n,
+          TopLevelHits: n,
+          Errors: 0,
+          Duration: (topLevelSpan._duration * 1e6) * n,
+          OkSummary: okDistribution.toProto(),
+          ErrorSummary: errorDistribution.toProto()
+        }]
+      }],
+      Lang: 'javascript',
+      TracerVersion: pkg.version,
+      RuntimeID: processor.tags['runtime-id'],
+      Sequence: processor.sequence
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Implements trace stats calculation.

### Motivation

We want to be able to compute trace stats without needing to send every trace to the agent.

Depends on DataDog/sketches-js#21