### PR TITLE
remove promise binding from scope manager

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -315,11 +315,6 @@ const bindFunctionStringType: (arg1: string, arg2: number) => string = scope.bin
 const bindFunctionVoidType: (arg1: string, arg2: number) => void = scope.bind((arg1: string, arg2: number): void => {});
 const bindFunctionVoidTypeWithSpan: (arg1: string, arg2: number) => void = scope.bind((arg1: string, arg2: number): string => 'test', span);
 
-Promise.resolve();
-
-scope.bind(promise);
-scope.bind(promise, span);
-
 tracer.wrap('x', () => {
   const rumData: string = tracer.getRumData();
 })

--- a/packages/dd-trace/src/noop/scope.js
+++ b/packages/dd-trace/src/noop/scope.js
@@ -11,12 +11,8 @@ class Scope {
     return callback()
   }
 
-  bind (target, span) {
-    return target
-  }
-
-  unbind (target) {
-    return target
+  bind (fn, span) {
+    return fn
   }
 }
 

--- a/packages/dd-trace/test/scope.spec.js
+++ b/packages/dd-trace/test/scope.spec.js
@@ -158,36 +158,6 @@ describe('Scope', () => {
       })
     })
 
-    describe('with a promise', () => {
-      let promise
-
-      beforeEach(() => {
-        promise = Promise.resolve()
-      })
-
-      it('should bind the promise to the active span', () => {
-        return scope.activate(span, () => {
-          scope.bind(promise)
-
-          return promise.then(() => {
-            expect(scope.active()).to.equal(span)
-          })
-        })
-      })
-
-      it('should bind the promise to the provided span', () => {
-        scope.bind(promise, span)
-
-        return promise.then(() => {
-          expect(scope.active()).to.equal(span)
-        })
-      })
-
-      it('should return the promise', () => {
-        expect(scope.bind(promise, span)).to.equal(promise)
-      })
-    })
-
     describe('with an unsupported target', () => {
       it('should return the target', () => {
         expect(scope.bind('test', span)).to.equal('test')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove promise binding from scope manager.

### Motivation
<!-- What inspired you to submit this pull request? -->

Same reasoning as https://github.com/DataDog/dd-trace-js/pull/2139, where it shouldn't be needed and there shouldn't be much usage in the wild, and if there is the correct way to bind will be provided in the migration guide for 3.0.