### PR TITLE
fix moleculer test timing out in latest version

### DIFF
--- a/packages/datadog-plugin-moleculer/test/index.spec.js
+++ b/packages/datadog-plugin-moleculer/test/index.spec.js
@@ -198,7 +198,8 @@ describe('Plugin', () => {
         before(() => startBroker())
 
         before(function () {
-          this.timeout(10000) // wait for discovery
+          const waitTimeout = 10000
+          this.timeout(waitTimeout) // wait for discovery
           const { ServiceBroker } = require(`../../../versions/moleculer@${version}`).get()
 
           clientBroker = new ServiceBroker({
@@ -217,7 +218,7 @@ describe('Plugin', () => {
           })
 
           return clientBroker.start()
-            .then(() => clientBroker.waitForServices('math'))
+            .then(() => clientBroker.waitForServices('math', waitTimeout))
         })
 
         after(() => clientBroker.stop())


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix moleculer test timing out in latest version.

### Motivation
<!-- What inspired you to submit this pull request? -->

Latest release has a [bug](https://github.com/moleculerjs/moleculer/issues/1123) where the default timeout is 0 instead of infinity.