### PR TITLE
Fix msgpack encoding when there is a buffer resize

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -113,29 +113,25 @@ class AgentEncoder {
 
   _encodeArrayPrefix (bytes, value) {
     const length = value.length
-    const buffer = bytes.buffer
     const offset = bytes.length
 
     bytes.reserve(5)
     bytes.length += 5
 
-    buffer[offset] = 0xdd
-    buffer[offset + 1] = length >> 24
-    buffer[offset + 2] = length >> 16
-    buffer[offset + 3] = length >> 8
-    buffer[offset + 4] = length
+    bytes.buffer[offset] = 0xdd
+    bytes.buffer[offset + 1] = length >> 24
+    bytes.buffer[offset + 2] = length >> 16
+    bytes.buffer[offset + 3] = length >> 8
+    bytes.buffer[offset + 4] = length
   }
 
   _encodeByte (bytes, value) {
-    const buffer = bytes.buffer
-
     bytes.reserve(1)
 
-    buffer[bytes.length++] = value
+    bytes.buffer[bytes.length++] = value
   }
 
   _encodeId (bytes, id) {
-    const buffer = bytes.buffer
     const offset = bytes.length
 
     bytes.reserve(9)
@@ -143,33 +139,31 @@ class AgentEncoder {
 
     id = id.toArray()
 
-    buffer[offset] = 0xcf
-    buffer[offset + 1] = id[0]
-    buffer[offset + 2] = id[1]
-    buffer[offset + 3] = id[2]
-    buffer[offset + 4] = id[3]
-    buffer[offset + 5] = id[4]
-    buffer[offset + 6] = id[5]
-    buffer[offset + 7] = id[6]
-    buffer[offset + 8] = id[7]
+    bytes.buffer[offset] = 0xcf
+    bytes.buffer[offset + 1] = id[0]
+    bytes.buffer[offset + 2] = id[1]
+    bytes.buffer[offset + 3] = id[2]
+    bytes.buffer[offset + 4] = id[3]
+    bytes.buffer[offset + 5] = id[4]
+    bytes.buffer[offset + 6] = id[5]
+    bytes.buffer[offset + 7] = id[6]
+    bytes.buffer[offset + 8] = id[7]
   }
 
   _encodeInteger (bytes, value) {
-    const buffer = bytes.buffer
     const offset = bytes.length
 
     bytes.reserve(5)
     bytes.length += 5
 
-    buffer[offset] = 0xce
-    buffer[offset + 1] = value >> 24
-    buffer[offset + 2] = value >> 16
-    buffer[offset + 3] = value >> 8
-    buffer[offset + 4] = value
+    bytes.buffer[offset] = 0xce
+    bytes.buffer[offset + 1] = value >> 24
+    bytes.buffer[offset + 2] = value >> 16
+    bytes.buffer[offset + 3] = value >> 8
+    bytes.buffer[offset + 4] = value
   }
 
   _encodeLong (bytes, value) {
-    const buffer = bytes.buffer
     const offset = bytes.length
     const hi = (value / Math.pow(2, 32)) >> 0
     const lo = value >>> 0
@@ -177,20 +171,19 @@ class AgentEncoder {
     bytes.reserve(9)
     bytes.length += 9
 
-    buffer[offset] = 0xcf
-    buffer[offset + 1] = hi >> 24
-    buffer[offset + 2] = hi >> 16
-    buffer[offset + 3] = hi >> 8
-    buffer[offset + 4] = hi
-    buffer[offset + 5] = lo >> 24
-    buffer[offset + 6] = lo >> 16
-    buffer[offset + 7] = lo >> 8
-    buffer[offset + 8] = lo
+    bytes.buffer[offset] = 0xcf
+    bytes.buffer[offset + 1] = hi >> 24
+    bytes.buffer[offset + 2] = hi >> 16
+    bytes.buffer[offset + 3] = hi >> 8
+    bytes.buffer[offset + 4] = hi
+    bytes.buffer[offset + 5] = lo >> 24
+    bytes.buffer[offset + 6] = lo >> 16
+    bytes.buffer[offset + 7] = lo >> 8
+    bytes.buffer[offset + 8] = lo
   }
 
   _encodeMap (bytes, value) {
     const keys = Object.keys(value)
-    const buffer = bytes.buffer
     const offset = bytes.length
 
     bytes.reserve(5)
@@ -206,11 +199,11 @@ class AgentEncoder {
       this._encodeValue(bytes, value[key])
     }
 
-    buffer[offset] = 0xdf
-    buffer[offset + 1] = length >> 24
-    buffer[offset + 2] = length >> 16
-    buffer[offset + 3] = length >> 8
-    buffer[offset + 4] = length
+    bytes.buffer[offset] = 0xdf
+    bytes.buffer[offset + 1] = length >> 24
+    bytes.buffer[offset + 2] = length >> 16
+    bytes.buffer[offset + 3] = length >> 8
+    bytes.buffer[offset + 4] = length
   }
 
   _encodeValue (bytes, value) {
@@ -237,21 +230,19 @@ class AgentEncoder {
   _encodeFloat (bytes, value) {
     float64Array[0] = value
 
-    const buffer = bytes.buffer
     const offset = bytes.length
-
     bytes.reserve(9)
     bytes.length += 9
 
-    buffer[offset] = 0xcb
+    bytes.buffer[offset] = 0xcb
 
     if (bigEndian) {
       for (let i = 0; i <= 7; i++) {
-        buffer[offset + i + 1] = uInt8Float64Array[i]
+        bytes.buffer[offset + i + 1] = uInt8Float64Array[i]
       }
     } else {
       for (let i = 7; i >= 0; i--) {
-        buffer[bytes.length - i - 1] = uInt8Float64Array[i]
+        bytes.buffer[bytes.length - i - 1] = uInt8Float64Array[i]
       }
     }
   }

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -186,35 +186,33 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     const lo = value >>> 0
     const flag = isPositive ? 0xcf : 0xd3
 
-    const buffer = bytes.buffer
     const offset = bytes.length
 
     // int 64
     bytes.reserve(9)
     bytes.length += 9
 
-    buffer[offset] = flag
-    buffer[offset + 1] = hi >> 24
-    buffer[offset + 2] = hi >> 16
-    buffer[offset + 3] = hi >> 8
-    buffer[offset + 4] = hi
-    buffer[offset + 5] = lo >> 24
-    buffer[offset + 6] = lo >> 16
-    buffer[offset + 7] = lo >> 8
-    buffer[offset + 8] = lo
+    bytes.buffer[offset] = flag
+    bytes.buffer[offset + 1] = hi >> 24
+    bytes.buffer[offset + 2] = hi >> 16
+    bytes.buffer[offset + 3] = hi >> 8
+    bytes.buffer[offset + 4] = hi
+    bytes.buffer[offset + 5] = lo >> 24
+    bytes.buffer[offset + 6] = lo >> 16
+    bytes.buffer[offset + 7] = lo >> 8
+    bytes.buffer[offset + 8] = lo
   }
 
   _encodeMapPrefix (bytes, keysLength) {
-    const buffer = bytes.buffer
     const offset = bytes.length
 
     bytes.reserve(5)
     bytes.length += 5
-    buffer[offset] = 0xdf
-    buffer[offset + 1] = keysLength >> 24
-    buffer[offset + 2] = keysLength >> 16
-    buffer[offset + 3] = keysLength >> 8
-    buffer[offset + 4] = keysLength
+    bytes.buffer[offset] = 0xdf
+    bytes.buffer[offset + 1] = keysLength >> 24
+    bytes.buffer[offset + 2] = keysLength >> 16
+    bytes.buffer[offset + 3] = keysLength >> 8
+    bytes.buffer[offset + 4] = keysLength
   }
 
   _encode (bytes, trace) {

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -38,6 +38,7 @@ describe('encode', () => {
       start: 123,
       duration: 456
     }]
+    sinon.spy(encoder._traceBytes, '_resize')
   })
 
   it('should encode to msgpack', () => {
@@ -116,5 +117,55 @@ describe('encode', () => {
     const message = logger.debug.firstCall.args[0]()
 
     expect(message).to.match(/^Adding encoded trace to buffer:(\s[a-f\d]{2})+$/)
+  })
+
+  it('should work when the buffer is resized', () => {
+    // big enough to trigger a resize
+    const dataToEncode = Array(15000).fill({
+      trace_id: id('1234abcd1234abcd'),
+      span_id: id('1234abcd1234abcd'),
+      parent_id: id('1234abcd1234abcd'),
+      name: 'bigger name than expected',
+      resource: 'test-r',
+      service: 'test-s',
+      type: 'foo',
+      error: 0,
+      meta: {
+        bar: 'baz'
+      },
+      metrics: {
+        example: 1,
+        moreExample: 2
+      },
+      start: 123,
+      duration: 456
+    })
+    encoder.encode(dataToEncode)
+
+    expect(encoder._traceBytes._resize).to.have.been.called
+
+    const buffer = encoder.makePayload()
+    const [decodedPayload] = msgpack.decode(buffer, { codec })
+    decodedPayload.forEach(decodedData => {
+      expect(decodedData).to.include({
+        name: 'bigger name than expected',
+        resource: 'test-r',
+        service: 'test-s',
+        type: 'foo',
+        error: 0
+      })
+      expect(decodedData.start.toNumber()).to.equal(123)
+      expect(decodedData.duration.toNumber()).to.equal(456)
+      expect(decodedData.meta).to.eql({
+        bar: 'baz'
+      })
+      expect(decodedData.metrics).to.eql({
+        example: 1,
+        moreExample: 2
+      })
+      expect(decodedData.trace_id.toString(16)).to.equal('1234abcd1234abcd')
+      expect(decodedData.span_id.toString(16)).to.equal('1234abcd1234abcd')
+      expect(decodedData.parent_id.toString(16)).to.equal('1234abcd1234abcd')
+    })
   })
 })

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -38,7 +38,6 @@ describe('encode', () => {
       start: 123,
       duration: 456
     }]
-    sinon.spy(encoder._traceBytes, '_resize')
   })
 
   it('should encode to msgpack', () => {
@@ -142,8 +141,6 @@ describe('encode', () => {
       duration: 456
     })
     encoder.encode(dataToEncode)
-
-    expect(encoder._traceBytes._resize).to.have.been.called
 
     const buffer = encoder.makePayload()
     const [decodedPayload] = msgpack.decode(buffer, { codec })

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -119,7 +119,8 @@ describe('encode', () => {
     expect(message).to.match(/^Adding encoded trace to buffer:(\s[a-f\d]{2})+$/)
   })
 
-  it('should work when the buffer is resized', () => {
+  it('should work when the buffer is resized', function () {
+    this.timeout(5000)
     // big enough to trigger a resize
     const dataToEncode = Array(15000).fill({
       trace_id: id('1234abcd1234abcd'),


### PR DESCRIPTION
### What does this PR do?
When a chunk is resized in [here](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/encode/chunk.js#L58-L62), its `buffer` is changed: the old content is copied to the new buffer, but its identify changes. 

This means that in places like [here](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/encode/0.4.js#L138), we were using a reference that was no longer valid: 

```javascript
const buffer = bytes.buffer // old buffer
bytes.reserve(9) // potentially bytes.buffer changes!

// do stuff with buffer, but it's now potentially old!
buffer[offset] = ...
```

### Motivation
Fix uncommon msgpack encoding error. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
