### PR TITLE
Use private symbol for ddResourceStore

### DIFF
--- a/packages/datadog-core/src/storage/async_resource.js
+++ b/packages/datadog-core/src/storage/async_resource.js
@@ -6,9 +6,27 @@ const { channel } = require('diagnostics_channel')
 const beforeCh = channel('dd-trace:storage:before')
 const afterCh = channel('dd-trace:storage:after')
 
+let PrivateSymbol = Symbol
+function makePrivateSymbol () {
+  // eslint-disable-next-line no-new-func
+  PrivateSymbol = new Function('name', 'return %CreatePrivateSymbol(name)')
+}
+
+try {
+  makePrivateSymbol()
+} catch (e) {
+  try {
+    const v8 = require('v8')
+    v8.setFlagsFromString('--allow-natives-syntax')
+    makePrivateSymbol()
+    v8.setFlagsFromString('--no-allow-natives-syntax')
+  // eslint-disable-next-line no-empty
+  } catch (e) {}
+}
+
 class AsyncResourceStorage {
   constructor () {
-    this._ddResourceStore = Symbol('ddResourceStore')
+    this._ddResourceStore = PrivateSymbol('ddResourceStore')
     this._enabled = false
     this._hook = createHook(this._createHook())
   }


### PR DESCRIPTION
### What does this PR do?

Hide the `ddResourceStore` field behind a private symbol.

### Motivation

If the user logs an async resource such as an http request object the output could be very large and expensive to generate as `console.log` and `util.inspect` will include regular symbol properties because they are enumerable by default. The `ddResourceStore` object structure can be very, very large so we should try to avoid situations where the user logs its contents accidentally.