### PR TITLE
stop loading the entire library when disabled

### DIFF
--- a/packages/dd-trace/index.js
+++ b/packages/dd-trace/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 if (!global._ddtrace) {
-  const TracerProxy = require('./src/proxy')
+  const TracerProxy = require('./src')
 
   Object.defineProperty(global, '_ddtrace', {
     value: new TracerProxy(),

--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { isFalse } = require('./util')
+
+module.exports = isFalse(process.env.DD_TRACE_ENABLED)
+  ? require('./noop/proxy')
+  : require('./proxy')

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -69,7 +69,8 @@ class Tracer {
   }
 
   setUser () {
-    return this._tracer.setUser.apply(this.tracer, arguments)
+    this._tracer.setUser.apply(this._tracer, arguments)
+    return this
   }
 }
 

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const NoopTracer = require('./tracer')
+
+const noop = new NoopTracer()
+
+class Tracer {
+  constructor () {
+    this._tracer = noop
+  }
+
+  init () {
+    return this
+  }
+
+  use () {
+    return this
+  }
+
+  trace (name, options, fn) {
+    if (!fn) {
+      fn = options
+      options = {}
+    }
+
+    if (typeof fn !== 'function') return
+
+    options = options || {}
+
+    return this._tracer.trace(name, options, fn)
+  }
+
+  wrap (name, options, fn) {
+    if (!fn) {
+      fn = options
+      options = {}
+    }
+
+    if (typeof fn !== 'function') return fn
+
+    options = options || {}
+
+    return this._tracer.wrap(name, options, fn)
+  }
+
+  setUrl () {
+    this._tracer.setUrl.apply(this._tracer, arguments)
+    return this
+  }
+
+  startSpan () {
+    return this._tracer.startSpan.apply(this._tracer, arguments)
+  }
+
+  inject () {
+    return this._tracer.inject.apply(this._tracer, arguments)
+  }
+
+  extract () {
+    return this._tracer.extract.apply(this._tracer, arguments)
+  }
+
+  scope () {
+    return this._tracer.scope.apply(this._tracer, arguments)
+  }
+
+  getRumData () {
+    return this._tracer.getRumData.apply(this._tracer, arguments)
+  }
+
+  setUser () {
+    return this._tracer.setUser.apply(this.tracer, arguments)
+  }
+}
+
+module.exports = Tracer

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -1,27 +1,25 @@
 'use strict'
 
-const NoopTracer = require('./noop/tracer')
+const NoopProxy = require('./noop/proxy')
 const DatadogTracer = require('./tracer')
 const Config = require('./config')
 const metrics = require('./metrics')
 const log = require('./log')
-const { isFalse } = require('./util')
 const { setStartupLogPluginManager } = require('./startup-log')
 const telemetry = require('./telemetry')
 const PluginManager = require('./plugin_manager')
 const { sendGitMetadata } = require('./ci-visibility/exporters/git/git_metadata')
 
-const noop = new NoopTracer()
-
-class Tracer {
+class Tracer extends NoopProxy {
   constructor () {
+    super()
+
     this._initialized = false
-    this._tracer = noop
     this._pluginManager = new PluginManager(this)
   }
 
   init (options) {
-    if (isFalse(process.env.DD_TRACE_ENABLED) || this._initialized) return this
+    if (this._initialized) return this
 
     this._initialized = true
 
@@ -76,61 +74,6 @@ class Tracer {
   use () {
     this._pluginManager.configurePlugin(...arguments)
     return this
-  }
-
-  trace (name, options, fn) {
-    if (!fn) {
-      fn = options
-      options = {}
-    }
-
-    if (typeof fn !== 'function') return
-
-    options = options || {}
-
-    return this._tracer.trace(name, options, fn)
-  }
-
-  wrap (name, options, fn) {
-    if (!fn) {
-      fn = options
-      options = {}
-    }
-
-    if (typeof fn !== 'function') return fn
-
-    options = options || {}
-
-    return this._tracer.wrap(name, options, fn)
-  }
-
-  setUrl () {
-    this._tracer.setUrl.apply(this._tracer, arguments)
-    return this
-  }
-
-  startSpan () {
-    return this._tracer.startSpan.apply(this._tracer, arguments)
-  }
-
-  inject () {
-    return this._tracer.inject.apply(this._tracer, arguments)
-  }
-
-  extract () {
-    return this._tracer.extract.apply(this._tracer, arguments)
-  }
-
-  scope () {
-    return this._tracer.scope.apply(this._tracer, arguments)
-  }
-
-  getRumData () {
-    return this._tracer.getRumData.apply(this._tracer, arguments)
-  }
-
-  setUser () {
-    return this._tracer.setUser.apply(this.tracer, arguments)
   }
 }
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -6,6 +6,7 @@ describe('TracerProxy', () => {
   let DatadogTracer
   let NoopTracer
   let tracer
+  let NoopProxy
   let noop
   let Config
   let config
@@ -72,9 +73,13 @@ describe('TracerProxy', () => {
       start: sinon.spy()
     }
 
+    NoopProxy = proxyquire('../src/noop/proxy', {
+      './tracer': NoopTracer
+    })
+
     Proxy = proxyquire('../src/proxy', {
       './tracer': DatadogTracer,
-      './noop/tracer': NoopTracer,
+      './noop/proxy': NoopProxy,
       './config': Config,
       './metrics': metrics,
       './log': log,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop loading the entire library when disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now when dd-trace is imported, all of its dependencies are also imported, some of which are initialized as well, like the instrumentation and the plugin manager. This means that it's not truly disabled which can cause issues in some cases, like when instrumentation fails or when something else interacts with the module system like Jest.