### PR TITLE
[ci-visibility] [do not review - wip] Improve `cypress` `beforeEach` and `afterEach` handles

### DIFF
--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -1,11 +1,14 @@
 /* eslint-disable */
 beforeEach(() => {
-  cy.task('dd:beforeEach', {
-    testName: Cypress.mocha.getRunner().suite.ctx.currentTest.fullTitle(),
-    testSuite: Cypress.mocha.getRootSuite().file
-  }).then(traceId => {
-    Cypress.env('traceId', traceId)
-  })
+  cy.wrap(new Promise(resolve => {
+    cy.task('dd:beforeEach', {
+      testName: Cypress.mocha.getRunner().suite.ctx.currentTest.fullTitle(),
+      testSuite: Cypress.mocha.getRootSuite().file
+    }).then(traceId => {
+      Cypress.env('traceId', traceId)
+      resolve()
+    })
+  }))
 })
 
 after(() => {
@@ -16,17 +19,21 @@ after(() => {
 
 
 afterEach(() => {
-  cy.window().then(win => {
-    const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
-    const testInfo = {
-      testName: currentTest.fullTitle(),
-      testSuite: Cypress.mocha.getRootSuite().file,
-      state: currentTest.state,
-      error: currentTest.err,
-    }
-    if (win.DD_RUM) {
-      testInfo.isRUMActive = true
-    }
-    cy.task('dd:afterEach', testInfo)
-  })
+  cy.wrap(new Promise(resolve => {
+    cy.window().then(win => {
+      const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
+      const testInfo = {
+        testName: currentTest.fullTitle(),
+        testSuite: Cypress.mocha.getRootSuite().file,
+        state: currentTest.state,
+        error: currentTest.err,
+      }
+      if (win.DD_RUM) {
+        testInfo.isRUMActive = true
+      }
+      cy.task('dd:afterEach', testInfo).then(() => {
+        resolve()
+      })
+    })
+  }))
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
