### PR TITLE
disable dd-trace in jest workers

### DIFF
--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -2,6 +2,6 @@
 
 const { isFalse } = require('./util')
 
-module.exports = isFalse(process.env.DD_TRACE_ENABLED)
+module.exports = isFalse(process.env.DD_TRACE_ENABLED) || global.jest
   ? require('./noop/proxy')
   : require('./proxy')

--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -2,6 +2,13 @@
 
 const { isFalse } = require('./util')
 
-module.exports = isFalse(process.env.DD_TRACE_ENABLED) || global.jest
+let inJestWorker = true
+try {
+  jest // eslint-disable-line no-undef
+} catch (e) {
+  inJestWorker = false // global `jest` is only present in Jest workers
+}
+
+module.exports = isFalse(process.env.DD_TRACE_ENABLED) || inJestWorker
   ? require('./noop/proxy')
   : require('./proxy')

--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -2,12 +2,8 @@
 
 const { isFalse } = require('./util')
 
-let inJestWorker = true
-try {
-  jest // eslint-disable-line no-undef
-} catch (e) {
-  inJestWorker = false // global `jest` is only present in Jest workers
-}
+// Global `jest` is only present in Jest workers.
+const inJestWorker = typeof jest !== 'undefined'
 
 module.exports = isFalse(process.env.DD_TRACE_ENABLED) || inJestWorker
   ? require('./noop/proxy')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable dd-trace in Jest workers.

### Motivation
<!-- What inspired you to submit this pull request? -->

Initializing the tracer in Jest workers causes a new instance to be used in every worker, which can cause a lot of issues since the tracer requires having only 1 instance per process. When initialized according to our documentation, this wouldn't happen because it would be initialized outside of Jest, and then the global instance would be properly passed to workers.