### PR TITLE
update TSDoc to reflect the actual defaults for HttpClient ValidateStatus

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -706,7 +706,7 @@ declare namespace plugins {
      * status code as its only parameter and return `true` for success or `false`
      * for errors.
      *
-     * @default code => code < 400
+     * @default code => code < 400 || code >= 500
      */
     validateStatus?: (code: number) => boolean;
 
@@ -740,7 +740,7 @@ declare namespace plugins {
      * status code as its only parameter and return `true` for success or `false`
      * for errors.
      *
-     * @default code => code < 400
+     * @default code < 400 || code >= 500
      */
     validateStatus?: (code: number) => boolean;
   }


### PR DESCRIPTION
The behavior noted in #1563 is not actually reflected in dd-trace's TSDoc comments.  

The documented default states that any status-code over 400 will be treated as an error.  However, the actual implementation considers HTTP 500 (and higher) statuses to be a success for HTTP client requests.