### PR TITLE
Add 'bluebird' to the Plugins interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -542,6 +542,7 @@ interface Plugins {
   "amqp10": plugins.amqp10;
   "amqplib": plugins.amqplib;
   "aws-sdk": plugins.aws_sdk;
+  "bluebird": plugins.bluebird;
   "bunyan": plugins.bunyan;
   "cassandra-driver": plugins.cassandra_driver;
   "connect": plugins.connect;


### PR DESCRIPTION
### What does this PR do?

This change adds the `bluebird` plugin to the Plugins interface.

### Motivation

Without this, TypeScript will not recognize `bluebird` as a valid
argument for the `.use()` function:

> Argument of type '"bluebird"' is not assignable to parameter of type 'keyof Plugins'