### PR TITLE
increase encode test timeout to 30 seconds

### DIFF
--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -119,7 +119,7 @@ describe('encode', () => {
   })
 
   it('should work when the buffer is resized', function () {
-    this.timeout(6000)
+    this.timeout(30000)
     // big enough to trigger a resize
     const dataToEncode = Array(15000).fill({
       trace_id: id('1234abcd1234abcd'),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase encode test timeout to 30 seconds.

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/dd-trace-js/runs/8099617168?check_suite_focus=true