### PR TITLE
Update import-in-the-middle

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "crypto-randomuuid": "^1.0.0",
     "diagnostics_channel": "^1.1.0",
     "ignore": "^5.2.0",
-    "import-in-the-middle": "^1.3.0",
+    "import-in-the-middle": "^1.3.1",
     "istanbul-lib-coverage": "3.2.0",
     "koalas": "^1.0.2",
     "limiter": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,10 +1896,10 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.3.0.tgz#314983e57887013a9c32b90ce5625a6871d71798"
-  integrity sha512-esDCEWyzzg0bGShz1N5ybRrPIJFvKaJ7TfTaIFP1XovxFo98In2GiDpOR/Cn/8J1cfRO8i/RrQToQ9j0WL2b0Q==
+import-in-the-middle@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.3.1.tgz#2c2b0641a3533cbffdaf8b37f9ad54aa87bb4e15"
+  integrity sha512-pstt7M2IKSzacY08+plJPhzDStIfa/LkqiUluNcW3M89Sm+Ed4Mz1JcPTMJU7gRcAas90bB6goutveRxHTXY8g==
   dependencies:
     module-details-from-path "^1.0.3"
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
 Update `import-in-the-middle` dependency
### Motivation
<!-- What inspired you to submit this pull request? -->
iitm was not working correctly in node 16.17.0. The library has been updated, now the dependency has to be updated.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
fix in the library: https://github.com/DataDog/import-in-the-middle/pull/21