### PR TITLE
fix agent exporter tracing itself on retries

### DIFF
--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -84,7 +84,7 @@ function request (data, options, callback) {
     req.setTimeout(timeout, req.abort)
 
     if (isReadable) {
-      data.pipe(req)
+      data.pipe(req) // TODO: Validate whether this is actually retriable.
     } else {
       dataArray.forEach(buffer => req.write(buffer))
       req.end()
@@ -93,7 +93,11 @@ function request (data, options, callback) {
     storage.enterWith(store)
   }
 
-  makeRequest(() => makeRequest(callback))
+  // TODO: Figure out why setTimeout is needed to avoid losing the async context
+  // in the retry request before socket.connect() is called.
+  // TODO: Test that this doesn't trace itself on retry when the diagnostics
+  // channel events are available in the agent exporter.
+  makeRequest(() => setTimeout(() => makeRequest(callback)))
 }
 
 function byteLength (data) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix agent exporter tracing itself on retries.

### Motivation
<!-- What inspired you to submit this pull request? -->

When a request to the agent fails, the retry request would end up losing the async context somewhere between when the HTTP request was started and when `socket.connect()` was called internally in Node. I don't know why, but adding a simple timer fixes the issue. We should get to the bottom of this later on but for now the immediate issue needs to be fixed.