### PR TITLE
fix log injection with existing properties or non-extensible objects

### DIFF
--- a/packages/datadog-plugin-winston/test/index.spec.js
+++ b/packages/datadog-plugin-winston/test/index.spec.js
@@ -232,26 +232,33 @@ describe('Plugin', () => {
             })
           }
 
-          it('should overwrite any existing "dd" property', async () => {
-            const meta = {
-              dd: {
-                trace_id: span.context().toTraceId(),
-                span_id: span.context().toSpanId()
-              }
-            }
-
+          it('should not overwrite any existing "dd" property', async () => {
             tracer.scope().activate(span, () => {
-              const logObj = {
-                some: 'data',
+              const meta = {
                 dd: 'something else'
               }
-              winston.info(logObj)
-              expect(logObj.dd).to.equal('something else')
+              winston.log('info', 'test', meta)
+              expect(meta.dd).to.equal('something else')
 
-              expect(spy).to.have.been.calledWithMatch(meta.dd)
+              expect(spy).to.have.been.calledWithMatch('something else')
             })
-            expect(await logServer.logPromise).to.include(meta.dd)
+            expect(await logServer.logPromise).to.include('something else')
           })
+
+          // New versions clone the meta object so it's always extensible.
+          if (semver.intersects(version, '<3')) {
+            it('should not add "dd" property to non-extensible objects', async () => {
+              tracer.scope().activate(span, () => {
+                const meta = {}
+                Object.preventExtensions(meta)
+                winston.log('info', 'test', meta)
+                expect(meta.dd).to.be.undefined
+
+                expect(spy).to.have.been.calledWith()
+              })
+              expect(await logServer.logPromise).to.be.undefined
+            })
+          }
 
           it('should skip injection without a store', async () => {
             expect(() => winston.info('message')).to.not.throw()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix log injection with existing properties or non-extensible objects.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fixes #2322 which was also reported in https://github.com/DataDog/dd-trace-js/issues/2277#issuecomment-1218270202