### PR TITLE
fix k8s image publish

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -35,12 +35,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: ['publish']
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: pkg
+        run: |
+          content=`cat ./package.json | tr '\n' ' '`
+          echo "::set-output name=json::$content"
       - name: npm pack for injection image
         run: |
-          npm pack dd-trace@${{ fromJson(needs.publish.outputs.pkgjson).version }}
+          npm pack dd-trace@${{ fromJson(steps.pkg.outputs.json).version }}
       - uses: ./.github/actions/injection
         with:
-          init-image-version: ${{ fromJson(needs.publish.outputs.pkgjson).version }}
+          init-image-version: v${{ fromJson(steps.pkg.outputs.json).version }}
 
   docs:
     runs-on: ubuntu-latest
@@ -69,5 +81,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add -A
-          git commit -m ${{ fromJson(needs.publish.outputs.pkgjson).version }}
+          git commit -m ${{ fromJson(steps.pkg.outputs.json).version }}
           git push

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,3 +33,21 @@ deploy_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-js-init:$CI_COMMIT_TAG
     IMG_SIGNING: "false"
+
+deploy_latest_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_TAG
+    IMG_DESTINATIONS: dd-lib-js-init:latest
+    IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,6 @@ deploy_to_docker_registries:
     branch: main
     strategy: depend
   variables:
-    IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_SHA
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-js-init:$CI_COMMIT_TAG
     IMG_SIGNING: "false"

--- a/k8s/auto-inst/Dockerfile
+++ b/k8s/auto-inst/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 AS build
+FROM node:16-alpine AS build
 
 ARG npm_pkg
 


### PR DESCRIPTION
Fixes the k8s image publish by using the github token and using the tag everywhere.

The following patch was used to test it.

 [03c708aed26c836af0087141290f3caaab3c61fa](https://gist.github.com/bengl/d1f95e79f237595bb52301f1f2241697)
 
 **Note to reviewers:** please verify that the patch above makes sense for testing this.