### PR TITLE
[ci-visibility] Improve coverage writer

### DIFF
--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -271,7 +271,7 @@ describe('Plugin', function () {
             expect(eventContentDisposition).to.contain(
               'Content-Disposition: form-data; name="event"; filename="event.json"'
             )
-            expect(eventPayload).to.equal('{}')
+            expect(eventPayload).to.equal('{"dummy":true}')
             done()
           })
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -15,7 +15,7 @@ class Writer extends BaseWriter {
   constructor ({ url }) {
     super(...arguments)
     this._url = url
-    this._encoder = new CoverageCIVisibilityEncoder()
+    this._encoder = new CoverageCIVisibilityEncoder(this)
   }
 
   _sendPayload (form, _, done) {

--- a/packages/dd-trace/src/encode/coverage-ci-visibility.js
+++ b/packages/dd-trace/src/encode/coverage-ci-visibility.js
@@ -78,6 +78,8 @@ class CoverageCIVisibilityEncoder extends AgentEncoder {
   makePayload () {
     this.form.append(
       'event',
+      // The intake requires a populated dictionary here. Simply having {} is not valid.
+      // We use dummy: true but any other key/value pair would be valid.
       JSON.stringify({ dummy: true }),
       { filename: 'event.json', contentType: 'application/json' }
     )


### PR DESCRIPTION
### What does this PR do?
* Append coverage payloads to `this.form` as they come, instead of doing it at once in `makePayload`. 
* Pass `writer` instance so that we can flush when we reach the limit of number of payloads (following other encoders).

### Motivation
Improve coverage writer.
