### PR TITLE
Update import-in-the-middle

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "crypto-randomuuid": "^1.0.0",
     "diagnostics_channel": "^1.1.0",
     "ignore": "^5.2.0",
-    "import-in-the-middle": "^1.3.1",
+    "import-in-the-middle": "^1.3.2",
     "istanbul-lib-coverage": "3.2.0",
     "koalas": "^1.0.2",
     "limiter": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,10 +1923,10 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.3.1.tgz#2c2b0641a3533cbffdaf8b37f9ad54aa87bb4e15"
-  integrity sha512-pstt7M2IKSzacY08+plJPhzDStIfa/LkqiUluNcW3M89Sm+Ed4Mz1JcPTMJU7gRcAas90bB6goutveRxHTXY8g==
+import-in-the-middle@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.3.2.tgz#9fa2ae10248ffb37530d29eed76cff62c7ae017d"
+  integrity sha512-TW2Zor1MmNL2e051F+B9pK3fPqMWUSBXzWjcJqfb1VBJgB+89OBh2n2rj3c16EGYeDJpt4eBdrOnrjAIR/6oRA==
   dependencies:
     module-details-from-path "^1.0.3"
 


### PR DESCRIPTION
### What does this PR do?
Update `import-in-the-middle` dependency

### Motivation
iitm was not working correctly in windows. The library has been updated, now the dependency has to be updated.

### Additional Notes
fix in the library: [IITM PR](https://github.com/DataDog/import-in-the-middle/pull/22)