### PR TITLE
Remap sample_rate to sampleRate in DD_TRACE_SAMPLING_RULES

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -24,6 +24,16 @@ function safeJsonParse (input) {
   }
 }
 
+// Shallow clone with property name remapping
+function remapify (input, mappings) {
+  if (!input) return
+  const output = {}
+  for (const [key, value] of Object.entries(input)) {
+    output[key in mappings ? mappings[key] : key] = value
+  }
+  return output
+}
+
 class Config {
   constructor (options) {
     options = options || {}
@@ -257,7 +267,11 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
         ingestion.sampleRate
       ),
       rateLimit: coalesce(options.rateLimit, process.env.DD_TRACE_RATE_LIMIT, ingestion.rateLimit),
-      rules: coalesce(options.samplingRules, safeJsonParse(process.env.DD_TRACE_SAMPLING_RULES), [])
+      rules: coalesce(options.samplingRules, safeJsonParse(process.env.DD_TRACE_SAMPLING_RULES), []).map(rule => {
+        return remapify(rule, {
+          sample_rate: 'sampleRate'
+        })
+      })
     }
 
     const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -123,10 +123,10 @@ describe('Config', () => {
     process.env.DD_TRACE_RATE_LIMIT = '-1'
     /* eslint-disable-next-line */
     process.env.DD_TRACE_SAMPLING_RULES = '[ \
-      {"service":"usersvc","name":"healthcheck","sampleRate":0.0 }, \
-      {"service":"usersvc","sampleRate":0.5}, \
-      {"service":"authsvc","sampleRate":1.0}, \
-      {"sampleRate":0.1}]'
+      {"service":"usersvc","name":"healthcheck","sample_rate":0.0 }, \
+      {"service":"usersvc","sample_rate":0.5}, \
+      {"service":"authsvc","sample_rate":1.0}, \
+      {"sample_rate":0.1}]'
     process.env.DD_TRACE_EXPERIMENTAL_B3_ENABLED = 'true'
     process.env.DD_TRACE_EXPERIMENTAL_TRACEPARENT_ENABLED = 'true'
     process.env.DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED = 'true'


### PR DESCRIPTION
### What does this PR do?

This ensures the DD_TRACE_SAMPLING_RULES value structure is consistent with the other languages which all use `sample_rate` rather than `sampleRate`.

### Motivation

Maintaining consistency of environment variable behaviour across languages.
