### PR TITLE
Set `maxSockets` instead of `maxTotalSockets`

### DIFF
--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -11,10 +11,10 @@ const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const keepAlive = true
-const maxTotalSockets = 1
+const maxSockets = 1
 const maxActiveRequests = 8
-const httpAgent = new http.Agent({ keepAlive, maxTotalSockets })
-const httpsAgent = new https.Agent({ keepAlive, maxTotalSockets })
+const httpAgent = new http.Agent({ keepAlive, maxSockets })
+const httpsAgent = new https.Agent({ keepAlive, maxSockets })
 const containerId = docker.id()
 
 let activeRequests = 0


### PR DESCRIPTION
### What does this PR do?
Remove `maxTotalSockets` and pass `maxSockets` instead to the `http.Agent`. 

### Motivation
`maxTotalSockets` works if we assume there's only one origin we want to hit, but this is not the case for CI Visibility.

More info for the difference between the two parameters in https://nodejs.org/api/http.html#agentmaxsockets.
