### PR TITLE
Ensure spans are truncated when encoded

### DIFF
--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -62,7 +62,7 @@ function processSpans () {
   sp.process(finished[0])
   trace.finished = finished
   trace.started = finished
-  if (++iterations < 25000) {
+  if (++iterations < 2500) {
     setImmediate(processSpans)
   }
 }

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -71,8 +71,8 @@ class AgentEncoder {
   _encode (bytes, trace) {
     this._encodeArrayPrefix(bytes, trace)
 
-    const events = trace.map(formatSpan)
-    for (const span of events) {
+    for (let span of trace) {
+      span = formatSpan(span)
       bytes.reserve(1)
 
       if (span.type) {

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { truncateSpan, normalizeSpan } = require('./tags-processors')
 const Chunk = require('./chunk')
 const log = require('../log')
 
@@ -11,6 +12,10 @@ const uInt8Float64Array = new Uint8Array(float64Array.buffer)
 float64Array[0] = -1
 
 const bigEndian = uInt8Float64Array[7] === 0
+
+function formatSpan (span) {
+  return normalizeSpan(truncateSpan(span))
+}
 
 class AgentEncoder {
   constructor (writer, limit = SOFT_LIMIT) {
@@ -66,7 +71,8 @@ class AgentEncoder {
   _encode (bytes, trace) {
     this._encodeArrayPrefix(bytes, trace)
 
-    for (const span of trace) {
+    const events = trace.map(formatSpan)
+    for (const span of events) {
       bytes.reserve(1)
 
       if (span.type) {

--- a/packages/dd-trace/src/encode/0.5.js
+++ b/packages/dd-trace/src/encode/0.5.js
@@ -1,9 +1,14 @@
 'use strict'
 
+const { truncateSpan, normalizeSpan } = require('./tags-processors')
 const { AgentEncoder: BaseEncoder } = require('./0.4')
 
 const ARRAY_OF_TWO = 0x92
 const ARRAY_OF_TWELVE = 0x9c
+
+function formatSpan (span) {
+  return normalizeSpan(truncateSpan(span))
+}
 
 class AgentEncoder extends BaseEncoder {
   makePayload () {
@@ -27,7 +32,8 @@ class AgentEncoder extends BaseEncoder {
   _encode (bytes, trace) {
     this._encodeArrayPrefix(bytes, trace)
 
-    for (const span of trace) {
+    const events = trace.map(formatSpan)
+    for (const span of events) {
       this._encodeByte(bytes, ARRAY_OF_TWELVE)
       this._encodeString(bytes, span.service)
       this._encodeString(bytes, span.name)

--- a/packages/dd-trace/src/encode/0.5.js
+++ b/packages/dd-trace/src/encode/0.5.js
@@ -32,8 +32,8 @@ class AgentEncoder extends BaseEncoder {
   _encode (bytes, trace) {
     this._encodeArrayPrefix(bytes, trace)
 
-    const events = trace.map(formatSpan)
-    for (const span of events) {
+    for (let span of trace) {
+      span = formatSpan(span)
       this._encodeByte(bytes, ARRAY_OF_TWELVE)
       this._encodeString(bytes, span.service)
       this._encodeString(bytes, span.name)

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -5,6 +5,12 @@ const msgpack = require('msgpack-lite')
 const codec = msgpack.createCodec({ int64: true })
 const id = require('../../src/id')
 
+function randString (length) {
+  return Array.from({ length }, () => {
+    return String.fromCharCode(Math.floor(Math.random() * 256))
+  }).join('')
+}
+
 describe('encode', () => {
   let encoder
   let writer
@@ -75,6 +81,23 @@ describe('encode', () => {
     expect(trace[0].parent_id.toString(16)).to.equal('1234abcd1234abcd')
   })
 
+  it('should truncate long fields', function () {
+    this.timeout(5000)
+    const flushSize = 8 * 1024 * 1024
+    const tooLongString = randString(flushSize)
+
+    data[0].service = tooLongString
+    data[0].name = tooLongString
+    data[0].type = tooLongString
+    data[0].resource = tooLongString
+    data[0].meta.foo = tooLongString
+    data[0].metrics.foo = tooLongString
+
+    encoder.encode(data)
+
+    expect(writer.flush).to.not.have.been.called
+  })
+
   it('should report its count', () => {
     expect(encoder.count()).to.equal(0)
 
@@ -87,8 +110,12 @@ describe('encode', () => {
     expect(encoder.count()).to.equal(2)
   })
 
-  it('should flush when the payload size limit is reached', () => {
-    data[0].meta.foo = new Array(8 * 1024 * 1024).join('a')
+  it('should flush when the payload size limit is reached', function () {
+    this.timeout(5000)
+    // Make 8mb of data
+    for (let i = 0; i < 8 * 1024; i++) {
+      data[0].meta[`foo${i}`] = randString(1024)
+    }
 
     encoder.encode(data)
 

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -4,6 +4,12 @@ const msgpack = require('msgpack-lite')
 const codec = msgpack.createCodec({ int64: true })
 const id = require('../../src/id')
 
+function randString (length) {
+  return Array.from({ length }, () => {
+    return String.fromCharCode(Math.floor(Math.random() * 256))
+  }).join('')
+}
+
 describe('encode 0.5', () => {
   let encoder
   let writer
@@ -72,6 +78,23 @@ describe('encode 0.5', () => {
     expect(trace[0][5].toString(16)).to.equal('1234abcd1234abcd')
   })
 
+  it('should truncate long fields', function () {
+    this.timeout(5000)
+    const flushSize = 8 * 1024 * 1024
+    const tooLongString = randString(flushSize)
+
+    data[0].service = tooLongString
+    data[0].name = tooLongString
+    data[0].type = tooLongString
+    data[0].resource = tooLongString
+    data[0].meta.foo = tooLongString
+    data[0].metrics.foo = tooLongString
+
+    encoder.encode(data)
+
+    expect(writer.flush).to.not.have.been.called
+  })
+
   it('should report its count', () => {
     expect(encoder.count()).to.equal(0)
 
@@ -84,8 +107,12 @@ describe('encode 0.5', () => {
     expect(encoder.count()).to.equal(2)
   })
 
-  it('should flush when the payload size limit is reached', () => {
-    data[0].meta.foo = new Array(8 * 1024 * 1024).join('a')
+  it('should flush when the payload size limit is reached', function () {
+    this.timeout(5000)
+    // Make 8mb of data
+    for (let i = 0; i < 8 * 1024; i++) {
+      data[0].meta[`foo${i}`] = randString(1024)
+    }
 
     encoder.encode(data)
 


### PR DESCRIPTION
### What does this PR do?

This ensures trace spans are normalized and truncated properly.

### Motivation

Very large queries may be costly when encoded in the `resource.name` so we should ensure that fields are truncated if they're too long. This is also done in the agent, however the agent can still get overloaded if decoding and then re-encoding enough data with long fields.

We had already copied the truncation and normalization logic for the agentless-ci-visibility encoder, so this just reuses that logic.