### PR TITLE
[ci-visibility] Fix skipping of whole `describe` clauses

### DIFF
--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -163,7 +163,7 @@ function mochaHook (Runner) {
       const status = getTestStatus(test)
 
       // if there are afterEach to be run, we don't finish the test yet
-      if (!test.parent._afterEach.length) {
+      if (asyncResource && !test.parent._afterEach.length) {
         asyncResource.runInAsyncScope(() => {
           testFinishCh.publish(status)
         })
@@ -231,7 +231,11 @@ function mochaHook (Runner) {
       } else {
         // if there is no async resource, the test has been skipped through `test.skip``
         const skippedTestAsyncResource = new AsyncResource('bound-anonymous-fn')
-        testToAr.set(test, skippedTestAsyncResource)
+        if (test.fn) {
+          testToAr.set(test.fn, skippedTestAsyncResource)
+        } else {
+          testToAr.set(test, skippedTestAsyncResource)
+        }
         skippedTestAsyncResource.runInAsyncScope(() => {
           skipCh.publish(test)
         })

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -507,6 +507,33 @@ describe('Plugin', () => {
         })
         mocha.run()
       })
+
+      it('works when skipping suites', function (done) {
+        const testFilePath = path.join(__dirname, 'mocha-test-skip-describe.js')
+
+        const testNames = [
+          ['mocha-test-skip-describe will be skipped', 'skip'],
+          ['mocha-test-skip-describe-pass will pass', 'pass']
+        ]
+
+        const assertionPromises = testNames.map(([testName, status]) => {
+          return agent.use(trace => {
+            const testSpan = trace[0][0]
+            expect(testSpan.meta[TEST_STATUS]).to.equal(status)
+            expect(testSpan.meta[TEST_NAME]).to.equal(testName)
+          })
+        })
+
+        Promise.all(assertionPromises)
+          .then(() => done())
+          .catch(done)
+
+        const mocha = new Mocha({
+          reporter: function () {} // silent on internal tests
+        })
+        mocha.addFile(testFilePath)
+        mocha.run()
+      })
     })
   })
 })

--- a/packages/datadog-plugin-mocha/test/mocha-test-skip-describe.js
+++ b/packages/datadog-plugin-mocha/test/mocha-test-skip-describe.js
@@ -1,0 +1,16 @@
+const { expect } = require('chai')
+
+describe('mocha-test-skip-describe', () => {
+  before(function () {
+    this.skip()
+  })
+  it('will be skipped', () => {
+    expect(true).to.equal(true)
+  })
+})
+
+describe('mocha-test-skip-describe-pass', () => {
+  it('will pass', function () {
+    expect(true).to.equal(true)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Do not use `test` for storing the async resource of a skipped test but `test.fn` if it's available (which is what's used for fetching the async resource later on).

### Motivation
Fixes #2355 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
