### PR TITLE
Revert "Disable CI Vis Performance Test (#2333)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,18 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+  node-ci-visibility-performance-benchmark:
+    docker:
+      - image: node
+    resource_class: medium
+    working_directory: ~/dd-trace-js
+
+    steps:
+      - checkout-and-yarn-install
+      - run:
+          name: CI Visibility Performance Overhead Test
+          command: yarn bench:e2e:ci-visibility
+
   # Node upstream tests
 
   node-upstream-node:
@@ -239,6 +251,7 @@ workflows:
             - node-bench-sirun-plugin-dns
             - node-bench-sirun-plugin-graphql
             - node-bench-sirun-appsec
+      - node-ci-visibility-performance-benchmark
 
   nightly-bench:
     triggers:


### PR DESCRIPTION
This reverts commit 7a55760c2bf67f3f0615b9a7cee5691a4f22a8d0.

### What does this PR do?
Add ci visibility performance tests back

### Motivation
They have been updated to (hopefully) remove all flakiness. They've run hundreds of times with no failures. 

