### PR TITLE
[ci-visibility] Do not reset coverage counters and report suite coverage

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -224,7 +224,9 @@ function jestAdapterWrapper (jestAdapter) {
         testSuiteFinishCh.publish({ status, errorMessage })
         if (environment.global.__coverage__) {
           const coverageFiles = extractCoverageInformation(environment.global.__coverage__, environment.rootDir)
-          testSuiteCodeCoverageCh.publish([...coverageFiles, environment.testSuite])
+          if (coverageFiles.length) {
+            testSuiteCodeCoverageCh.publish([...coverageFiles, environment.testSuite])
+          }
         }
         return suiteResults
       })

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -9,14 +9,13 @@ const testSessionFinishCh = channel('ci:jest:session:finish')
 const testSessionConfigurationCh = channel('ci:jest:session:configuration')
 
 const testSuiteStartCh = channel('ci:jest:test-suite:start')
-const testSuiteFinish = channel('ci:jest:test-suite:finish')
+const testSuiteFinishCh = channel('ci:jest:test-suite:finish')
+const testSuiteCodeCoverageCh = channel('ci:jest:test-suite:code-coverage')
 
 const testStartCh = channel('ci:jest:test:start')
 const testSkippedCh = channel('ci:jest:test:skip')
 const testRunFinishCh = channel('ci:jest:test:finish')
 const testErrCh = channel('ci:jest:test:err')
-
-const testCodeCoverageCh = channel('ci:jest:test:code-coverage')
 
 const {
   getTestSuitePath,
@@ -27,7 +26,6 @@ const { getFormattedJestTestParameters, getJestTestName } = require('../../datad
 
 const sessionAsyncResource = new AsyncResource('bound-anonymous-fn')
 
-// This function also resets the coverage counters
 function extractCoverageInformation (coverage, rootDir) {
   const coverageMap = istanbul.createCoverageMap(coverage)
 
@@ -37,8 +35,6 @@ function extractCoverageInformation (coverage, rootDir) {
       const fileCoverage = coverageMap.fileCoverageFor(filename)
       const lineCoverage = fileCoverage.getLineCoverage()
       const isAnyLineExecuted = Object.entries(lineCoverage).some(([, numExecutions]) => !!numExecutions)
-
-      fileCoverage.resetHits()
 
       return isAnyLineExecuted
     })
@@ -136,10 +132,6 @@ function getWrappedEnvironment (BaseEnvironment) {
       if (event.name === 'test_done') {
         const asyncResource = asyncResources.get(event.test)
         asyncResource.runInAsyncScope(() => {
-          if (this.global.__coverage__) {
-            const coverageFiles = extractCoverageInformation(this.global.__coverage__, this.rootDir)
-            testCodeCoverageCh.publish(coverageFiles)
-          }
           let status = 'pass'
           if (event.test.errors && event.test.errors.length) {
             status = 'fail'
@@ -229,7 +221,11 @@ function jestAdapterWrapper (jestAdapter) {
         } else if (numFailingTests !== 0) {
           status = 'fail'
         }
-        testSuiteFinish.publish({ status, errorMessage })
+        testSuiteFinishCh.publish({ status, errorMessage })
+        if (environment.global.__coverage__) {
+          const coverageFiles = extractCoverageInformation(environment.global.__coverage__, environment.rootDir)
+          testSuiteCodeCoverageCh.publish([...coverageFiles, environment.testSuite])
+        }
         return suiteResults
       })
     })

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -144,12 +144,12 @@ class JestPlugin extends Plugin {
       testSuiteSpan.finish()
     })
 
-    this.addSub('ci:jest:test:code-coverage', (coverageFiles) => {
+    this.addSub('ci:jest:test-suite:code-coverage', (coverageFiles) => {
       if (!this.config.isAgentlessEnabled || !this.config.isIntelligentTestRunnerEnabled) {
         return
       }
-      const testSpan = storage.getStore().span
-      this.tracer._exporter.exportCoverage({ testSpan, coverageFiles })
+      const testSuiteSpan = storage.getStore().span
+      this.tracer._exporter.exportCoverage({ span: testSuiteSpan, coverageFiles })
     })
 
     this.addSub('ci:jest:test:start', (test) => {

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -293,8 +293,12 @@ describe('Plugin', function () {
 
               expect(contentTypeHeader).to.contain('multipart/form-data')
               expect(coveragePayload.version).to.equal(1)
-              expect(coveragePayload.files.map(file => file.filename))
+              const coverageFiles = coveragePayload.files.map(file => file.filename)
+
+              expect(coverageFiles)
                 .to.include('packages/datadog-plugin-jest/test/sum-coverage-test.js')
+              expect(coverageFiles)
+                .to.include('packages/datadog-plugin-jest/test/jest-coverage.js')
               expect(contentDisposition).to.contain(
                 'Content-Disposition: form-data; name="coverage1"; filename="coverage1.msgpack"'
               )

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -25,10 +25,10 @@ class AgentlessCiVisibilityExporter {
     })
   }
 
-  exportCoverage ({ testSpan, coverageFiles }) {
+  exportCoverage ({ span, coverageFiles }) {
     const formattedCoverage = {
-      traceId: testSpan.context()._traceId,
-      spanId: testSpan.context()._spanId,
+      traceId: span.context()._traceId,
+      spanId: span.context()._spanId,
       files: coverageFiles
     }
     this._coverageWriter.append(formattedCoverage)

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -70,10 +70,10 @@ describe('CI Visibility Exporter', () => {
 
   describe('when ITR is enabled', () => {
     it('should append a code coverage payload when exportCoverage is called', () => {
-      const testSpan = {
+      const span = {
         context: () => ({ _traceId: '1', _spanId: '2' })
       }
-      const payload = { testSpan, coverageFiles: ['file.js'] }
+      const payload = { span, coverageFiles: ['file.js'] }
 
       exporter = new Exporter({ url, flushInterval: 0, isIntelligentTestRunnerEnabled: true })
 
@@ -89,10 +89,10 @@ describe('CI Visibility Exporter', () => {
       this.timeout(3000)
       exporter = new Exporter({ url, flushInterval, isIntelligentTestRunnerEnabled: true })
 
-      const testSpan = {
+      const span = {
         context: () => ({ _traceId: '1', _spanId: '2' })
       }
-      const payload = { testSpan, coverageFiles: ['file.js'] }
+      const payload = { span, coverageFiles: ['file.js'] }
 
       exporter.exportCoverage(payload)
 


### PR DESCRIPTION
### What does this PR do?
* Report _suite_ coverage rather than test coverage in `jest`. This plays better with `jest`: each test file and coverage is independent so we don't need to reset counters. It also allows us to skip complete suites rather than tests (which is way faster).
* Do not reset coverage counters (no need to now).

### Motivation
Test suite skipping makes more sense in `jest`, so we'll move the unit of coverage to test suites. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
