### PR TITLE
tracking open spans

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -43,6 +43,8 @@ class DatadogSpan {
     if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       metrics.increment('runtime.node.spans.unfinished')
       metrics.increment('runtime.node.spans.unfinished.by.name', `span_name:${operationName}`)
+      metrics.increment('runtime.node.spans.open') // unfinished for real
+      metrics.increment('runtime.node.spans.open.by.name', `span_name:${operationName}`)
 
       unfinishedRegistry.register(this, operationName, this)
     }
@@ -120,6 +122,8 @@ class DatadogSpan {
       metrics.decrement('runtime.node.spans.unfinished.by.name', `span_name:${this._name}`)
       metrics.increment('runtime.node.spans.finished')
       metrics.increment('runtime.node.spans.finished.by.name', `span_name:${this._name}`)
+      metrics.decrement('runtime.node.spans.open') // unfinished for real
+      metrics.decrement('runtime.node.spans.open.by.name', `span_name:${this._name}`)
 
       unfinishedRegistry.unregister(this)
       finishedRegistry.register(this, this._name)

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -43,6 +43,7 @@ class DatadogSpan {
     if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       metrics.increment('runtime.node.spans.unfinished')
       metrics.increment('runtime.node.spans.unfinished.by.name', `span_name:${operationName}`)
+
       metrics.increment('runtime.node.spans.open') // unfinished for real
       metrics.increment('runtime.node.spans.open.by.name', `span_name:${operationName}`)
 
@@ -122,6 +123,7 @@ class DatadogSpan {
       metrics.decrement('runtime.node.spans.unfinished.by.name', `span_name:${this._name}`)
       metrics.increment('runtime.node.spans.finished')
       metrics.increment('runtime.node.spans.finished.by.name', `span_name:${this._name}`)
+
       metrics.decrement('runtime.node.spans.open') // unfinished for real
       metrics.decrement('runtime.node.spans.open.by.name', `span_name:${this._name}`)
 


### PR DESCRIPTION
### What does this PR do?

- adds metrics for spans that are truly unfinished

### Motivation

- a customer is having an issue with span correlations and this should help track it down

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

- paired on this with @rochdev 
