### PR TITLE
Fix flaky test in iast overhead controller

### DIFF
--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -192,9 +192,6 @@ describe('Overhead controller', () => {
             }
           }
           finishRequestChannel.subscribe(resolvePromise)
-          // setTimeout(() => {
-          //   resolve()
-          // }, 500)
         })
       }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Synchronize actions in iast overhead controller test by channel instead of by setTimeout to prevent flaky test

### Motivation
<!-- What inspired you to submit this pull request? -->
Flaky test detected


### Additional Notes
<!-- Anything else we should know when reviewing? -->
