### PR TITLE
execute all sirun benchmarks in a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,8 @@
 stages:
+  - benchmarks
   - deploy
+
+include: ".gitlab/benchmarks.yml"
 
 .common: &common
   tags: [ "runner:main", "size:large" ]

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,0 +1,49 @@
+variables:
+  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/relenv-microbenchmarking-platform:dd-trace-js
+
+.benchmarks:
+  stage: benchmarks
+  when: on_success
+  tags: ["runner:apm-k8s-tweaked-metal"]
+  image: $BASE_CI_IMAGE
+  interruptible: true
+  timeout: 1h
+  script:
+    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
+    - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
+    - git clone --branch dd-trace-js https://github.com/DataDog/relenv-microbenchmarking-platform /platform && cd /platform
+    - ./steps/install-benchmark-analyzer.sh
+    - ./steps/install-pr-commenter.sh
+    - ./steps/capture-hardware-software-info.sh
+    - ./steps/run-benchmarks.sh
+    - ./steps/analyze-results.sh
+    - "./steps/upload-results-to-s3.sh || :"
+    - "./steps/post-pr-comment.sh || :"
+  artifacts:
+    name: "reports"
+    paths:
+      - reports/
+    expire_in: 3 months
+  variables:
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
+
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+benchmark-v14:
+  extends: .benchmarks
+  variables:
+    MAJOR_VERSION: 14
+
+benchmark-v16:
+  extends: .benchmarks
+  variables:
+    MAJOR_VERSION: 16
+
+benchmark-v18:
+  extends: .benchmarks
+  variables:
+    MAJOR_VERSION: 18

--- a/benchmark/sirun/.gitignore
+++ b/benchmark/sirun/.gitignore
@@ -1,0 +1,2 @@
+results.ndjson
+meta-temp.json

--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -1,0 +1,35 @@
+FROM --platform=linux/amd64 debian:buster-slim
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+	wget curl ca-certificates valgrind \
+	    git hwinfo jq procps \
+      software-properties-common build-essential libnss3-dev zlib1g-dev libgdbm-dev libncurses5-dev libssl-dev libffi-dev libreadline-dev libsqlite3-dev libbz2-dev
+
+RUN git clone --depth 1 https://github.com/pyenv/pyenv.git --branch "v2.0.4" --single-branch /pyenv
+ENV PYENV_ROOT "/pyenv"
+ENV PATH "/pyenv/shims:/pyenv/bin:$PATH"
+RUN eval "$(pyenv init -)"
+RUN pyenv install 3.9.6 && pyenv global 3.9.6
+RUN pip3 install awscli virtualenv setuptools
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 -
+
+# nvm works much better with bash than sh
+SHELL ["/bin/bash", "--login", "-c"]
+
+WORKDIR /app
+
+ENV NVM_DIR /usr/local/nvm
+
+RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.9/sirun-v0.1.9-x86_64-unknown-linux-gnu.tar.gz \
+	&& tar -xzf sirun.tar.gz \
+	&& rm sirun.tar.gz \
+	&& mv sirun /usr/bin/sirun
+
+RUN mkdir -p /usr/local/nvm \
+	&& wget -q -O - https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
+	&& . $NVM_DIR/nvm.sh \
+	&& nvm install --no-progress 14.20.1 \
+	&& nvm install --no-progress 16.17.1 \
+	&& nvm install --no-progress 18.10.0 \
+	&& nvm alias default 18 \
+	&& nvm use 18

--- a/benchmark/sirun/README.md
+++ b/benchmark/sirun/README.md
@@ -1,0 +1,26 @@
+# Benchmarks
+
+This directory contains several different types of benchmarks.
+
+Some of these benchmarks rely on [sirun](https://github.com/DataDog/sirun/) for execution.
+
+## Running Benchmarks via Docker
+
+Docker allows the execution of benchmarks without needing to install and configure your development environment. For example, package installation and installation of sirun is performed automatically.
+
+In order to run benchmarks using Docker, issue the following commands from the root of the project:
+
+```sh
+# Build the Docker Image
+$ docker build -t dd-trace-benchmark -f benchmark/sirun/Dockerfile .
+
+# Run the Docker Container
+$ docker run -it -v "$(pwd)":/app --platform=linux/amd64 dd-trace-benchmark bash
+cd /app/benchmark/sirun
+./runall.sh
+cat results.ndjson
+```
+
+The `--platform` flag is required when running benchmarks on a non-x86 system, such as a macOS computer with the M1 chip.
+
+`-v "$(pwd)":/app` mounts dd-trace-js source code root directory to /app inside container.

--- a/benchmark/sirun/appsec/common.js
+++ b/benchmark/sirun/appsec/common.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports = {
-  port: 3030,
+  port: 3032,
   reqs: 1000
 }

--- a/benchmark/sirun/appsec/meta.json
+++ b/benchmark/sirun/appsec/meta.json
@@ -1,11 +1,12 @@
 {
   "name": "appsec",
-  "cachegrind": true,
-  "iterations": 10,
+  "cachegrind": false,
+  "iterations": 24,
   "variants": {
     "control": {
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
       "run": "node server.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node server.js\"",
       "env": {
         "DD_APPSEC_ENABLED": "0"
       }
@@ -13,6 +14,7 @@
     "appsec-enabled": {
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
       "run": "node server.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node server.js\"",
       "baseline": "control",
       "env": {
         "DD_APPSEC_ENABLED": "1"
@@ -21,6 +23,7 @@
     "control-with-attacks": {
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
       "run": "node server.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node server.js\"",
       "env": {
         "DD_APPSEC_ENABLED": "0",
         "ATTACK_UA": "1",
@@ -31,6 +34,7 @@
     "appsec-enabled-with-attacks": {
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
       "run": "node server.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node server.js\"",
       "baseline": "control-with-attacks",
       "env": {
         "DD_APPSEC_ENABLED": "1",

--- a/benchmark/sirun/async_hooks/meta.json
+++ b/benchmark/sirun/async_hooks/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "async_hooks",
   "run": "node -r ../monitor .",
-  "cachegrind": true,
-  "iterations": 5,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node -r ../monitor .\"",
+  "cachegrind": false,
+  "iterations": 24,
   "variants": {
     "no-hooks": { "env": { "ASYNC_HOOKS": "" } },
     "init-only": {

--- a/benchmark/sirun/encoding/index.js
+++ b/benchmark/sirun/encoding/index.js
@@ -42,6 +42,6 @@ for (let parent = null, i = 0; i < 30; i++) {
 
 const encoder = new AgentEncoder(writer)
 
-for (let j = 0; j < 10000; j++) {
+for (let j = 0; j < 5000; j++) {
   encoder.encode(trace)
 }

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "encoders",
   "run": "node index.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 22,
   "variants": {
     "0.4": { "env": { "ENCODER_VERSION": "0.4" } },
     "0.5": { "env": { "ENCODER_VERSION": "0.5" } }

--- a/benchmark/sirun/exporting-pipeline/meta.json
+++ b/benchmark/sirun/exporting-pipeline/meta.json
@@ -2,8 +2,9 @@
   "name": "exporting-pipeline",
   "setup": "bash -c \"nohup node ../../e2e/fake-agent.js >/dev/null 2>&1 &\"",
   "run": "node index.js",
-  "iterations": 10,
-  "cachegrind": true,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "iterations": 22,
+  "cachegrind": false,
   "variants": {
     "0.4": {
       "env": {

--- a/benchmark/sirun/log/meta.json
+++ b/benchmark/sirun/log/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "log",
   "run": "node index.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 190,
   "variants": {
     "without-log": { "env": { "DD_TRACE_DEBUG": "false" } },
     "skip-log": { "env": { "WITH_LEVEL": "debug", "DD_TRACE_LOG_LEVEL": "error" } },

--- a/benchmark/sirun/plugin-bluebird/meta.json
+++ b/benchmark/sirun/plugin-bluebird/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "plugin-bluebird",
   "run": "node index.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 250,
   "variants": {
     "control": {
       "env": {

--- a/benchmark/sirun/plugin-dns/index.js
+++ b/benchmark/sirun/plugin-dns/index.js
@@ -7,7 +7,7 @@ if (Number(process.env.USE_TRACER)) {
 const dns = require('dns')
 
 function testRun (count) {
-  if (++count === 10000) return
+  if (++count === 1000) return
   dns.lookup('localhost', () => testRun(count))
 }
 

--- a/benchmark/sirun/plugin-dns/meta.json
+++ b/benchmark/sirun/plugin-dns/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "plugin-dns",
   "run": "node index.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 40,
   "variants": {
     "control": {
       "env": { "USE_TRACER": "0" }

--- a/benchmark/sirun/plugin-graphql/index.js
+++ b/benchmark/sirun/plugin-graphql/index.js
@@ -47,6 +47,6 @@ const source = `
 
 const variableValues = { who: 'world' }
 
-for (let i = 0; i < 5; i++) {
+for (let i = 0; i < 6; i++) {
   graphql.graphql({ schema, source, variableValues })
 }

--- a/benchmark/sirun/plugin-graphql/meta.json
+++ b/benchmark/sirun/plugin-graphql/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "plugin-graphql",
   "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 3,
+  "iterations": 2,
   "variants": {
     "control": {},
     "with-async-hooks": {
@@ -12,7 +13,8 @@
     "with-depth-off": {
       "baseline": "control",
       "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0"}
-    },"with-depth-on-max": {
+    },
+    "with-depth-on-max": {
       "baseline": "control",
       "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4"}
     },

--- a/benchmark/sirun/plugin-http/common.js
+++ b/benchmark/sirun/plugin-http/common.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports = {
-  port: 3030,
-  reqs: 1000
+  port: 3031,
+  reqs: 700
 }

--- a/benchmark/sirun/plugin-http/meta.json
+++ b/benchmark/sirun/plugin-http/meta.json
@@ -1,41 +1,51 @@
 {
   "name": "plugin-http",
-  "cachegrind": true,
-  "iterations": 10,
+  "cachegrind": false,
+  "iterations": 20,
   "variants": {
     "client-control": {
       "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node server.js >/dev/null 2>&1 &\"",
       "run": "node client.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node client.js\"",
       "env": {
         "CLIENT_USE_TRACER": "0"
       }
     },
     "client-with-tracer": {
       "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node server.js >/dev/null 2>&1 &\"",
       "run": "node client.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node client.js\"",
       "baseline": "client-control",
       "env": {
         "CLIENT_USE_TRACER": "1"
       }
     },
     "server-control": {
-      "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
-      "run": "node server.js",
+      "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node server.js >/dev/null 2>&1 &\"",
+      "run": "node client.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node client.js\"",
       "env": {
         "SERVER_USE_TRACER": "0"
       }
     },
     "server-with-tracer": {
-      "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
-      "run": "node server.js",
+      "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node server.js >/dev/null 2>&1 &\"",
+      "run": "node client.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node client.js\"",
       "baseline": "server-control",
       "env": {
         "SERVER_USE_TRACER": "1"
       }
     },
     "server-querystring-obfuscation": {
-      "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",
-      "run": "node server.js",
+      "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node server.js >/dev/null 2>&1 &\"",
+      "run": "node client.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node client.js\"",
       "baseline": "server-with-tracer",
       "env": {
         "SERVER_USE_TRACER": "1",

--- a/benchmark/sirun/plugin-net/common.js
+++ b/benchmark/sirun/plugin-net/common.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports = {
-  port: 3030,
+  port: 3033,
   reqs: 1000
 }

--- a/benchmark/sirun/plugin-net/meta.json
+++ b/benchmark/sirun/plugin-net/meta.json
@@ -1,14 +1,17 @@
 {
   "name": "net",
-  "cachegrind": true,
-  "iterations": 10,
+  "cachegrind": false,
+  "iterations": 50,
   "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
+  "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node server.js >/dev/null 2>&1 &\"",
   "variants": {
     "control": {
-      "run": "node client.js"
+      "run": "node client.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node client.js\""
     },
     "with-tracer": {
       "run": "node -r ../../../init.js client.js",
+      "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node -r ../../../init.js client.js\"",
       "baseline": "control"
     }
   }

--- a/benchmark/sirun/plugin-q/meta.json
+++ b/benchmark/sirun/plugin-q/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "plugin-q",
   "run": "node index.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 75,
   "variants": {
     "control": {
       "env": {

--- a/benchmark/sirun/profiler/meta.json
+++ b/benchmark/sirun/profiler/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "profiler",
   "run": "node -r ../monitor index.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node -r ../monitor index.js\"",
+  "cachegrind": false,
+  "iterations": 5,
   "variants": {
     "control": {
       "env": {

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if test -f ~/.nvm/nvm.sh; then
+  source ~/.nvm/nvm.sh
+else
+  source /usr/local/nvm/nvm.sh
+fi
+
+nvm use 18
+
+# using Node.js v18 for the global yarn package
+(
+  cd ../../ &&
+  npm install --global yarn \
+    && yarn install --ignore-engines \
+    && PLUGINS="bluebird|q|graphql" yarn services
+)
+
+# run each test in parallel for a given version of Node.js
+# once all of the tests have complete move on to the next version
+
+export CPU_AFFINITY=24 # Benchmarking Platform convention
+
+nvm use $MAJOR_VERSION # provided by each benchmark stage
+export VERSION=`nvm current`
+export ENABLE_AFFINITY=true
+echo "using Node.js ${VERSION}"
+CPU_AFFINITY=24 # reset for each node.js version
+
+for D in *; do
+  if [ -d "${D}" ]; then
+    echo "running ${D} in background, pinned to core ${CPU_AFFINITY}..."
+    cd "${D}"
+    (time node ../run-all-variants.js >> ../results.ndjson && echo "${D} finished.") &
+    cd ..
+    ((CPU_AFFINITY=CPU_AFFINITY+1))
+  fi
+done
+
+wait
+
+echo "all tests for ${VERSION} have now completed."

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -1,34 +1,35 @@
 {
   "name": "scope-manager",
   "run": "node index.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 20,
   "variants": {
     "base": {
       "env": {
         "DD_TRACE_SCOPE": "noop",
-        "COUNT": "5000"
+        "COUNT": "1250"
       }
     },
     "async_hooks": {
       "baseline": "base",
       "env": {
         "DD_TRACE_SCOPE": "async_hooks",
-        "COUNT": "5000"
+        "COUNT": "1250"
       }
     },
     "async_local_storage": {
       "baseline": "base",
       "env": {
         "DD_TRACE_SCOPE": "async_local_storage",
-        "COUNT": "5000"
+        "COUNT": "1250"
       }
     },
     "async_resource": {
       "baseline": "base",
       "env": {
         "DD_TRACE_SCOPE": "async_resource",
-        "COUNT": "5000"
+        "COUNT": "1250"
       }
     }
   }

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "spans",
   "run": "node spans.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node spans.js\"",
+  "cachegrind": false,
+  "iterations": 80,
   "variants": {
     "finish-immediately": {
       "env": {

--- a/benchmark/sirun/startup/meta.json
+++ b/benchmark/sirun/startup/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "startup",
   "run": "node startup-test.js",
-  "cachegrind": true,
-  "iterations": 10,
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node startup-test.js\"",
+  "cachegrind": false,
+  "iterations": 40,
   "variants": {
     "control": {
       "env": {


### PR DESCRIPTION
### What does this PR do?

This PR allows all of the sirun-based benchmarks to be run in a docker container using the latest three even versions of Node.js.

To build the container, run the following from the root of the repository:

```sh
docker build -t dd-trace-benchmark -f benchmark/sirun/Dockerfile .
```

Executing the benchmarks are done by running `runall.sh` within a container. Output is written to `/app/benchmark/sirun/results.ndjson`.

```sh
docker run -it --platform=linux/amd64 dd-trace-benchmark bash -c 'cd /app/benchmark/sirun && ./runall.sh'
```

### Motivation

This will allow us to check PRs for performance regressions.

### TODO

- [x] wire up CI so that these benchmarks run against PRs made by Datadog employees
- [x] clean up the interface for running tests
- [x] fix all of the tests - several of them fail to run (missing modules)
- [x] add a README to the benchmarks directory
- [x] parallelize by node.js version -- should shave off a few minutes (`MAJOR_VERSION` stuff)
- [x] increase test sample sizes

### Follow Ups

- enable metrics for every commit to master
  - disable old CircleCI
- enable instruction counting (`cachegrind` stuff)