### PR TITLE
fix distributed tracing for rhea externally encoded messages

### DIFF
--- a/packages/datadog-instrumentations/src/rhea.js
+++ b/packages/datadog-instrumentations/src/rhea.js
@@ -47,14 +47,7 @@ addHook({ name: 'rhea', versions: ['>=1'], file: 'lib/link.js' }, obj => {
 
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     return asyncResource.runInAsyncScope(() => {
-      // TODO: Figure out how to do this without re-encoding in instrumentation.
-      if (Buffer.isBuffer(msg) && format !== undefined) {
-        msg = this.connection.container.message.decode(msg)
-        startSendCh.publish({ targetAddress, host, port, msg })
-        arguments[0] = this.connection.container.message.encode(msg)
-      } else {
-        startSendCh.publish({ targetAddress, host, port, msg })
-      }
+      startSendCh.publish({ targetAddress, host, port, msg })
 
       const delivery = send.apply(this, arguments)
       const context = {

--- a/packages/datadog-instrumentations/src/rhea.js
+++ b/packages/datadog-instrumentations/src/rhea.js
@@ -48,7 +48,6 @@ addHook({ name: 'rhea', versions: ['>=1'], file: 'lib/link.js' }, obj => {
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     return asyncResource.runInAsyncScope(() => {
       startSendCh.publish({ targetAddress, host, port, msg })
-
       const delivery = send.apply(this, arguments)
       const context = {
         asyncResource

--- a/packages/datadog-plugin-rhea/src/index.js
+++ b/packages/datadog-plugin-rhea/src/index.js
@@ -30,9 +30,12 @@ class RheaPlugin extends Plugin {
         }
       })
       analyticsSampler.sample(span, this.config.measured)
-      addDeliveryAnnotations(msg, this.tracer, span)
 
       this.enter(span, store)
+    })
+
+    this.addSub('apm:rhea:encode', msg => {
+      addDeliveryAnnotations(msg, this.tracer, this.tracer.scope().active())
     })
 
     this.addSub(`apm:rhea:receive:start`, ({ msgObj, connection }) => {

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -79,6 +79,19 @@ describe('Plugin', () => {
               })
               context.sender.send({ body: 'Hello World!' })
             })
+
+            it('should inject span context with encoded messages', (done) => {
+              container.once('message', msg => {
+                const keys = Object.keys(msg.message.delivery_annotations)
+                expect(keys).to.include('x-datadog-trace-id')
+                expect(keys).to.include('x-datadog-parent-id')
+                done()
+              })
+              tracer.trace('web.request', () => {
+                const encodedMessage = container.message.encode({ body: 'Hello World!' })
+                context.sender.send(encodedMessage, undefined, 0)
+              })
+            })
           })
 
           describe('receiving a message', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix distributed tracing for rhea externally encoded messages.

### Motivation
<!-- What inspired you to submit this pull request? -->

When a format is not provided, `sender.send` will automatically encode the message. However, there are cases in which a format is provided, and the message is expected to have been encoded externally. A good example of this is the [Azure Service Bus SDK](https://github.com/Azure/azure-sdk-for-js/blob/f6c54e192be25ea48735a2ce4e1a0ad2222f31b1/sdk/servicebus/service-bus/src/core/messageSender.ts#L357). In order to support this, we have to inject at encode time instead of at send time.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I tried implementing this by decoding and re-encoding the message that is received by `sender.send`, but it ended up not being feasible because Azure Service Bus supports a custom batch format that is encoded internally within the SDK and is unknown to `rhea`.