### PR TITLE
fix support for new `@redis/client` package

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -10,6 +10,7 @@ module.exports = {
   '@jest/core': () => require('../jest'),
   '@koa/router': () => require('../koa'),
   '@node-redis/client': () => require('../redis'),
+  '@redis/client': () => require('../redis'),
   'amqp10': () => require('../amqp10'),
   'amqplib': () => require('../amqplib'),
   'aws-sdk': () => require('../aws-sdk'),

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -10,6 +10,7 @@ module.exports = {
   get '@jest/core' () { return require('../../../datadog-plugin-jest/src') },
   get '@koa/router' () { return require('../../../datadog-plugin-koa/src') },
   get '@node-redis/client' () { return require('../../../datadog-plugin-redis/src') },
+  get '@redis/client' () { return require('../../../datadog-plugin-redis/src') },
   get 'amqp10' () { return require('../../../datadog-plugin-amqp10/src') },
   get 'amqplib' () { return require('../../../datadog-plugin-amqplib/src') },
   get 'aws-sdk' () { return require('../../../datadog-plugin-aws-sdk/src') },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix support for new `@redis/client` package`

### Motivation
<!-- What inspired you to submit this pull request? -->

The `@node-redis/client` package was renamed to `@redis/client` since 4.1.0.

Fixes #2397