### PR TITLE
support telemetry via uds

### DIFF
--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -3,9 +3,11 @@ let seqId = 0
 function sendData (config, application, host, reqType, payload = {}) {
   const {
     hostname,
-    port
+    port,
+    url
   } = config
   const options = {
+    url,
     hostname,
     port,
     method: 'POST',

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -8,8 +8,40 @@ describe('sendData', () => {
       '../exporters/common/request': request
     })
   })
-  it('should call to request', () => {
+  it('should call to request (TCP)', () => {
     sendDataModule.sendData({ hostname: '', port: '12345', tags: { 'runtime-id': '123' } }, 'test', 'test', 'req-type')
     expect(request).to.have.been.calledOnce
+    const options = request.getCall(0).args[1]
+
+    expect(options).to.deep.equal({
+      method: 'POST',
+      path: '/telemetry/proxy/api/v2/apmtelemetry',
+      headers: {
+        'content-type': 'application/json',
+        'dd-telemetry-api-version': 'v1',
+        'dd-telemetry-request-type': 'req-type'
+      },
+      url: undefined,
+      hostname: '',
+      port: '12345'
+    })
+  })
+  it('should call to request (UDP)', () => {
+    sendDataModule.sendData({ url: 'unix:/foo/bar/baz', tags: { 'runtime-id': '123' } }, 'test', 'test', 'req-type')
+    expect(request).to.have.been.calledOnce
+    const options = request.getCall(0).args[1]
+
+    expect(options).to.deep.equal({
+      method: 'POST',
+      path: '/telemetry/proxy/api/v2/apmtelemetry',
+      headers: {
+        'content-type': 'application/json',
+        'dd-telemetry-api-version': 'v1',
+        'dd-telemetry-request-type': 'req-type'
+      },
+      url: 'unix:/foo/bar/baz',
+      hostname: undefined,
+      port: undefined
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Corrects the code that was only passing hostname and port through to `request` for telemetry, so that it can pass URLs instead.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prior to this, telemetry was not working when UDS URLs were used.
