### PR TITLE
[ci-visibility] Add query to configuration API for intelligent test runner

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -19,7 +19,7 @@ const testRunFinishCh = channel('ci:jest:test:finish')
 const testErrCh = channel('ci:jest:test:err')
 
 const skippableSuitesCh = channel('ci:jest:test-suite:skippable')
-const libraryConfigurationCh = channel('ci:library:configuration')
+const jestConfigurationCh = channel('ci:jest:configuration')
 
 let skippableSuites = []
 let isCodeCoverageEnabled = false
@@ -193,7 +193,7 @@ function cliWrapper (cli) {
     })
 
     sessionAsyncResource.runInAsyncScope(() => {
-      libraryConfigurationCh.publish({ onResponse, onError })
+      jestConfigurationCh.publish({ onResponse, onError })
     })
 
     let isSuitesSkippingEnabled = false

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -19,8 +19,10 @@ const testRunFinishCh = channel('ci:jest:test:finish')
 const testErrCh = channel('ci:jest:test:err')
 
 const skippableSuitesCh = channel('ci:jest:test-suite:skippable')
+const libraryConfigurationCh = channel('ci:library:configuration')
 
 let skippableSuites = []
+let isCodeCoverageEnabled = false
 
 const {
   getTestSuitePath,
@@ -185,20 +187,42 @@ addHook({
 function cliWrapper (cli) {
   const wrapped = shimmer.wrap(cli, 'runCLI', runCLI => async function () {
     let onResponse, onError
-    const skippableSuitesPromise = new Promise((resolve, reject) => {
+    const configurationPromise = new Promise((resolve, reject) => {
       onResponse = resolve
       onError = reject
     })
 
     sessionAsyncResource.runInAsyncScope(() => {
-      skippableSuitesCh.publish({ onResponse, onError })
+      libraryConfigurationCh.publish({ onResponse, onError })
     })
 
+    let isSuitesSkippingEnabled = false
+
     try {
-      skippableSuites = await skippableSuitesPromise
+      const config = await configurationPromise
+      isCodeCoverageEnabled = config.isCodeCoverageEnabled
+      isSuitesSkippingEnabled = config.isSuitesSkippingEnabled
     } catch (e) {
-      log.error(e)
+      // ignore error
     }
+
+    if (isSuitesSkippingEnabled) {
+      const skippableSuitesPromise = new Promise((resolve, reject) => {
+        onResponse = resolve
+        onError = reject
+      })
+
+      sessionAsyncResource.runInAsyncScope(() => {
+        skippableSuitesCh.publish({ onResponse, onError })
+      })
+
+      try {
+        skippableSuites = await skippableSuitesPromise
+      } catch (e) {
+        log.error(e)
+      }
+    }
+
     const isTestsSkipped = !!skippableSuites.length
 
     const processArgv = process.argv.slice(2).join(' ')
@@ -290,6 +314,14 @@ function configureTestEnvironment (readConfigsResult) {
   sessionAsyncResource.runInAsyncScope(() => {
     testSessionConfigurationCh.publish(configs.map(config => config.testEnvironmentOptions))
   })
+  if (isCodeCoverageEnabled) {
+    const globalConfig = {
+      ...readConfigsResult.globalConfig,
+      collectCoverage: true
+    }
+    readConfigsResult.globalConfig = globalConfig
+  }
+  return readConfigsResult
 }
 
 function jestConfigAsyncWrapper (jestConfig) {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -95,7 +95,7 @@ class JestPlugin extends Plugin {
       isGitUploadFailed = true
     })
 
-    this.addSub('ci:library:configuration', ({ onResponse, onError }) => {
+    this.addSub('ci:jest:configuration', ({ onResponse, onError }) => {
       if (!this.config.isAgentlessEnabled || !this.config.isIntelligentTestRunnerEnabled) {
         onResponse({})
         return

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -35,7 +35,6 @@ function getItrConfiguration ({
       'dd-application-key': appKey,
       'Content-Type': 'application/json'
     },
-    timeout: 15000,
     protocol: url.protocol,
     hostname: url.hostname,
     port: url.port

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -1,0 +1,88 @@
+const request = require('../../exporters/common/request')
+const id = require('../../id')
+
+function getItrConfiguration ({
+  site,
+  env,
+  service,
+  repositoryUrl,
+  sha,
+  osVersion,
+  osPlatform,
+  osArchitecture,
+  runtimeName,
+  runtimeVersion,
+  branch
+}, done) {
+  const url = new URL(`https://api.${site}`)
+
+  const apiKey = process.env.DATADOG_API_KEY || process.env.DD_API_KEY
+  const appKey = process.env.DATADOG_APP_KEY ||
+    process.env.DD_APP_KEY ||
+    process.env.DATADOG_APPLICATION_KEY ||
+    process.env.DD_APPLICATION_KEY
+
+  if (!apiKey || !appKey) {
+    done(new Error('App key or API key undefined'))
+    return
+  }
+
+  const options = {
+    path: '/api/v2/libraries/tests/services/setting',
+    method: 'POST',
+    headers: {
+      'dd-api-key': apiKey,
+      'dd-application-key': appKey,
+      'Content-Type': 'application/json'
+    },
+    timeout: 15000,
+    protocol: url.protocol,
+    hostname: url.hostname,
+    port: url.port
+  }
+
+  const data = JSON.stringify({
+    data: {
+      id: id().toString(10),
+      type: 'ci_app_test_service_libraries_settings',
+      attributes: {
+        test_level: 'suite',
+        configurations: {
+          'os.platform': osPlatform,
+          'os.version': osVersion,
+          'os.architecture': osArchitecture,
+          'runtime.name': runtimeName,
+          'runtime.version': runtimeVersion
+        },
+        service,
+        env,
+        repository_url: repositoryUrl,
+        sha,
+        branch
+      }
+    }
+  })
+
+  request(data, options, (err, res) => {
+    if (err) {
+      done(err)
+    } else {
+      try {
+        const {
+          data: {
+            attributes: {
+              code_coverage: isCodeCoverageEnabled,
+              tests_skipping: isSuitesSkippingEnabled
+            }
+          }
+        } = JSON.parse(res)
+
+        done(null, { isCodeCoverageEnabled, isSuitesSkippingEnabled })
+      } catch (e) {
+        done(e)
+      }
+    }
+  })
+}
+
+module.exports = { getItrConfiguration }


### PR DESCRIPTION
### What does this PR do?
Add a query to CI Visibility's configuration API for determining whether test skipping and code coverage is enabled. 

### Motivation
Move control of the intelligent test runner to datadog's UI.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
