### PR TITLE
[ci-visibility] Do not fail process when packfile generation fails or git is missing

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -172,25 +172,28 @@ function sendGitMetadata (site, callback) {
 
   getCommitsToExclude({ url, repositoryUrl }, (err, commitsToExclude, headCommit) => {
     if (err) {
-      callback(err)
-      return
+      return callback(err)
     }
     const commitsToUpload = getCommitsToUpload(commitsToExclude)
 
     if (!commitsToUpload.length) {
       log.debug('No commits to upload')
-      callback(null)
-      return
+      return callback(null)
     }
+    let packFilesToUpload = []
 
-    const packFilesToUpload = generatePackFilesForCommits(commitsToUpload)
+    try {
+      packFilesToUpload = generatePackFilesForCommits(commitsToUpload)
+    } catch (err) {
+      log.error('generatePackFilesForCommits failed')
+      return callback(err)
+    }
 
     let packFileIndex = 0
     // This uploads packfiles sequentially
     const uploadPackFileCallback = (err) => {
       if (err || packFileIndex === packFilesToUpload.length) {
-        callback(err)
-        return
+        return callback(err)
       }
       return uploadPackFile(
         {

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -168,7 +168,12 @@ function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, c
 function sendGitMetadata (site, callback) {
   const url = new URL(`https://api.${site}`)
 
-  const repositoryUrl = getRepositoryUrl()
+  let repositoryUrl = ''
+  try {
+    repositoryUrl = getRepositoryUrl()
+  } catch (err) {
+    return callback(err)
+  }
 
   getCommitsToExclude({ url, repositoryUrl }, (err, commitsToExclude, headCommit) => {
     if (err) {

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -168,11 +168,10 @@ function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, c
 function sendGitMetadata (site, callback) {
   const url = new URL(`https://api.${site}`)
 
-  let repositoryUrl = ''
-  try {
-    repositoryUrl = getRepositoryUrl()
-  } catch (err) {
-    return callback(err)
+  const repositoryUrl = getRepositoryUrl()
+
+  if (!repositoryUrl) {
+    return callback(new Error('Repository URL is empty'))
   }
 
   getCommitsToExclude({ url, repositoryUrl }, (err, commitsToExclude, headCommit) => {
@@ -185,13 +184,10 @@ function sendGitMetadata (site, callback) {
       log.debug('No commits to upload')
       return callback(null)
     }
-    let packFilesToUpload = []
+    const packFilesToUpload = generatePackFilesForCommits(commitsToUpload)
 
-    try {
-      packFilesToUpload = generatePackFilesForCommits(commitsToUpload)
-    } catch (err) {
-      log.error('generatePackFilesForCommits failed')
-      return callback(err)
+    if (!packFilesToUpload.length) {
+      return callback(new Error('Failed to generate packfiles'))
     }
 
     let packFileIndex = 0

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -51,13 +51,17 @@ function generatePackFilesForCommits (commitsToUpload) {
   const randomPrefix = Math.floor(Math.random() * 10000)
   const temporaryPath = path.join(tmpFolder, randomPrefix)
 
-  const orderedCommits =
-    execSync(
-      `git pack-objects --compression=9 --max-pack-size=3m ${temporaryPath}`,
-      { input: commitsToUpload.join('\n') }
-    ).toString().split('\n').filter(commit => !!commit)
+  try {
+    const orderedCommits =
+      execSync(
+        `git pack-objects --compression=9 --max-pack-size=3m ${temporaryPath}`,
+        { input: commitsToUpload.join('\n') }
+      ).toString().split('\n').filter(commit => !!commit)
 
-  return orderedCommits.map(commit => `${temporaryPath}-${commit}.pack`)
+    return orderedCommits.map(commit => `${temporaryPath}-${commit}.pack`)
+  } catch (e) {
+    return []
+  }
 }
 
 // If there is ciMetadata, it takes precedence.

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -56,7 +56,7 @@ function generatePackFilesForCommits (commitsToUpload) {
       execSync(
         `git pack-objects --compression=9 --max-pack-size=3m ${temporaryPath}`,
         { input: commitsToUpload.join('\n') }
-      ).toString().split('\n').filter(commit => !!commit)
+      ).toString().split('\n').filter(commit => commit)
 
     return orderedCommits.map(commit => `${temporaryPath}-${commit}.pack`)
   } catch (e) {

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -1,5 +1,6 @@
 const { execSync } = require('child_process')
 const os = require('os')
+const path = require('path')
 
 const { sanitizedExec } = require('./exec')
 const {
@@ -47,16 +48,16 @@ function getCommitsToUpload (commitsToExclude) {
 function generatePackFilesForCommits (commitsToUpload) {
   const tmpFolder = os.tmpdir()
 
-  const prefix = Math.floor(Math.random() * 10000)
-  const path = `${tmpFolder}/${prefix}`
+  const randomPrefix = Math.floor(Math.random() * 10000)
+  const temporaryPath = path.join(tmpFolder, randomPrefix)
 
   const orderedCommits =
     execSync(
-      `git pack-objects --compression=9 --max-pack-size=3m ${path}`,
+      `git pack-objects --compression=9 --max-pack-size=3m ${temporaryPath}`,
       { input: commitsToUpload.join('\n') }
     ).toString().split('\n').filter(commit => !!commit)
 
-  return orderedCommits.map(commit => `${path}-${commit}.pack`)
+  return orderedCommits.map(commit => `${temporaryPath}-${commit}.pack`)
 }
 
 // If there is ciMetadata, it takes precedence.

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -189,4 +189,20 @@ describe('git_metadata', () => {
       done()
     })
   })
+
+  it('should not crash if git is missing', (done) => {
+    const scope = nock('https://api.test.com')
+      .post('/api/v2/git/repository/search_commits')
+      .reply(200, JSON.stringify({ data: [] }))
+      .post('/api/v2/git/repository/packfile')
+      .reply(204)
+
+    getRepositoryUrlStub.throws(new Error('git: command not found'))
+
+    gitMetadata.sendGitMetadata('test.com', (err) => {
+      expect(err.message).to.contain('git: command not found')
+      expect(scope.isDone()).to.be.false
+      done()
+    })
+  })
 })

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -174,14 +174,14 @@ describe('git_metadata', () => {
     })
   })
 
-  it('should not crash if generatePackFiles throws an error', (done) => {
+  it('should not crash if generatePackFiles returns an empty array', (done) => {
     const scope = nock('https://api.test.com')
       .post('/api/v2/git/repository/search_commits')
       .reply(200, JSON.stringify({ data: [] }))
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    generatePackFilesForCommitsStub.throws(new Error('Failed to generate packfiles'))
+    generatePackFilesForCommitsStub.returns([])
 
     gitMetadata.sendGitMetadata('test.com', (err) => {
       expect(err.message).to.contain('Failed to generate packfiles')
@@ -197,10 +197,10 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    getRepositoryUrlStub.throws(new Error('git: command not found'))
+    getRepositoryUrlStub.returns('')
 
     gitMetadata.sendGitMetadata('test.com', (err) => {
-      expect(err.message).to.contain('git: command not found')
+      expect(err.message).to.contain('Repository URL is empty')
       expect(scope.isDone()).to.be.false
       done()
     })

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -173,4 +173,20 @@ describe('git_metadata', () => {
       done()
     })
   })
+
+  it('should not crash if generatePackFiles throws an error', (done) => {
+    const scope = nock('https://api.test.com')
+      .post('/api/v2/git/repository/search_commits')
+      .reply(200, JSON.stringify({ data: [] }))
+      .post('/api/v2/git/repository/packfile')
+      .reply(204)
+
+    generatePackFilesForCommitsStub.throws(new Error('Failed to generate packfiles'))
+
+    gitMetadata.sendGitMetadata('test.com', (err) => {
+      expect(err.message).to.contain('Failed to generate packfiles')
+      expect(scope.isDone()).to.be.false
+      done()
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Do not fail process when the generation of packfiles for git metadata upload fails or git is missing.

### Motivation
Generation of packfiles can sometimes fail. Git can be missing too.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
