### PR TITLE
[ci-visibility] Increase buffer for `git rev-list`

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -175,7 +175,13 @@ function sendGitMetadata (site, callback) {
       callback(err)
       return
     }
-    const commitsToUpload = getCommitsToUpload(commitsToExclude)
+    let commitsToUpload = []
+
+    try {
+      commitsToUpload = getCommitsToUpload(commitsToExclude)
+    } catch (err) {
+      return callback(err)
+    }
 
     if (!commitsToUpload.length) {
       log.debug('No commits to upload')

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -17,6 +17,8 @@ const {
   CI_WORKSPACE_PATH
 } = require('./tags')
 
+const GIT_REV_LIST_MAX_BUFFER = 8 * 1024 * 1024 // 8MB
+
 function getRepositoryUrl () {
   return sanitizedExec('git config --get remote.origin.url', { stdio: 'pipe' })
 }
@@ -36,7 +38,7 @@ function getCommitsToUpload (commitsToExclude) {
     gitCommandToGetCommitsToUpload = `${gitCommandToGetCommitsToUpload} ^${commit}`
   })
 
-  return execSync(gitCommandToGetCommitsToUpload, { stdio: 'pipe' })
+  return execSync(gitCommandToGetCommitsToUpload, { stdio: 'pipe', maxBuffer: GIT_REV_LIST_MAX_BUFFER })
     .toString()
     .split('\n')
     .filter(commit => !!commit)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
