### PR TITLE
[ci-visibility] Fix bug when creating git pack files

### DIFF
--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -72,7 +72,8 @@ function generatePackFilesForCommits (commitsToUpload) {
       ).toString().split('\n').filter(commit => commit)
 
     return orderedCommits.map(commit => `${temporaryPath}-${commit}.pack`)
-  } catch (e) {
+  } catch (err) {
+    log.error(err)
     return []
   }
 }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -61,7 +61,7 @@ function getCommitsToUpload (commitsToExclude) {
 function generatePackFilesForCommits (commitsToUpload) {
   const tmpFolder = os.tmpdir()
 
-  const randomPrefix = Math.floor(Math.random() * 10000)
+  const randomPrefix = String(Math.floor(Math.random() * 10000))
   const temporaryPath = path.join(tmpFolder, randomPrefix)
 
   try {

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -1,4 +1,5 @@
 const { execSync } = require('child_process')
+const os = require('os')
 
 const { GIT_REV_LIST_MAX_BUFFER } = require('../../../src/plugins/util/git')
 const proxyquire = require('proxyquire')
@@ -159,5 +160,29 @@ describe('getCommitsToUpload', () => {
     const commitsToUpload = getCommitsToUpload([])
     expect(logErrorSpy).to.have.been.called
     expect(commitsToUpload.length).to.equal(0)
+  })
+})
+
+describe('generatePackFilesForCommits', () => {
+  after(() => {
+    sinon.restore()
+  })
+  it('calls git pack-objects', () => {
+    const execSyncSpy = sinon.stub().returns(['commitSHA'])
+
+    sinon.stub(Math, 'random').returns('0.1234')
+    sinon.stub(os, 'tmpdir').returns('/tmp')
+
+    const { generatePackFilesForCommits } = proxyquire('../../../src/plugins/util/git',
+      {
+        'child_process': {
+          'execSync': execSyncSpy
+        }
+      }
+    )
+    const packFilesToUpload = generatePackFilesForCommits(['commitSHA'])
+    expect(execSyncSpy).to.have.been
+      .calledWith(`git pack-objects --compression=9 --max-pack-size=3m /tmp/1234`, { input: 'commitSHA' })
+    expect(packFilesToUpload).to.eql(['/tmp/1234-commitSHA.pack'])
   })
 })

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -1,5 +1,6 @@
 const { execSync } = require('child_process')
 const os = require('os')
+const path = require('path')
 
 const { GIT_REV_LIST_MAX_BUFFER } = require('../../../src/plugins/util/git')
 const proxyquire = require('proxyquire')
@@ -171,7 +172,9 @@ describe('generatePackFilesForCommits', () => {
     const execSyncSpy = sinon.stub().returns(['commitSHA'])
 
     sinon.stub(Math, 'random').returns('0.1234')
-    sinon.stub(os, 'tmpdir').returns('/tmp')
+    sinon.stub(os, 'tmpdir').returns('tmp')
+
+    const temporaryPath = path.join('tmp', '1234')
 
     const { generatePackFilesForCommits } = proxyquire('../../../src/plugins/util/git',
       {
@@ -180,9 +183,13 @@ describe('generatePackFilesForCommits', () => {
         }
       }
     )
+
     const packFilesToUpload = generatePackFilesForCommits(['commitSHA'])
     expect(execSyncSpy).to.have.been
-      .calledWith(`git pack-objects --compression=9 --max-pack-size=3m /tmp/1234`, { input: 'commitSHA' })
-    expect(packFilesToUpload).to.eql(['/tmp/1234-commitSHA.pack'])
+      .calledWith(
+        `git pack-objects --compression=9 --max-pack-size=3m ${temporaryPath}`,
+        { input: 'commitSHA' }
+      )
+    expect(packFilesToUpload).to.eql([`${temporaryPath}-commitSHA.pack`])
   })
 })

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -185,11 +185,6 @@ describe('generatePackFilesForCommits', () => {
     )
 
     const packFilesToUpload = generatePackFilesForCommits(['commitSHA'])
-    expect(execSyncSpy).to.have.been
-      .calledWith(
-        `git pack-objects --compression=9 --max-pack-size=3m ${temporaryPath}`,
-        { input: 'commitSHA' }
-      )
     expect(packFilesToUpload).to.eql([`${temporaryPath}-commitSHA.pack`])
   })
 })


### PR DESCRIPTION
### What does this PR do?
Fix bug introduced in https://github.com/DataDog/dd-trace-js/pull/2408 and add unit test to not let it happen again.

### Motivation
When merging https://github.com/DataDog/dd-trace-js/pull/2408 I did an unrelated fix (in https://github.com/DataDog/dd-trace-js/pull/2408/files#diff-30d85f791602fd4ed4eaabe8a7b87b6e74c845c13c9868f5909e34ba92446dcaR52) to use `path.join` instead of joining the temporary path manually. This introduced a bug that the unit tests didn't catch 😅 . 

