### PR TITLE
[ci-visibility] Improvements to git upload

### DIFF
--- a/integration-tests/startup.spec.js
+++ b/integration-tests/startup.spec.js
@@ -144,7 +144,8 @@ describe('startup', () => {
       proc = await spawnProc(startupTestFile, {
         cwd,
         env: {
-          STEALTHY_REQUIRE: 'true'
+          STEALTHY_REQUIRE: 'true',
+          DD_TRACE_TELEMETRY_ENABLED: 'false'
         }
       })
       return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -18,7 +18,7 @@ const isValidSha = (sha) => /[0-9a-f]{40}/.test(sha)
 function sanitizeCommits (commits) {
   return commits.map(({ id: commitSha, type }) => {
     if (type !== 'commit') {
-      throw new Error('Invalid commit response')
+      throw new Error('Invalid commit type response')
     }
     const sanitizedCommit = commitSha.replace(/[^0-9a-f]+/g, '')
     if (sanitizedCommit !== commitSha || !isValidSha(sanitizedCommit)) {
@@ -73,7 +73,7 @@ function getCommitsToExclude ({ url, repositoryUrl }, callback) {
 
   request(localCommitData, options, (err, response, statusCode) => {
     if (err) {
-      const error = new Error(`search_commits returned an error: ${statusCode}`)
+      const error = new Error(`search_commits returned an error: status code ${statusCode}`)
       return callback(error)
     }
     let commitsToExclude
@@ -113,7 +113,7 @@ function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, c
       contentType: 'application/octet-stream'
     })
   } catch (e) {
-    callback(new Error(`Could not read ${packFileToUpload}`))
+    callback(new Error(`Could not read "${packFileToUpload}"`))
     return
   }
 
@@ -129,7 +129,7 @@ function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, c
   }
   request(form, options, (err, _, statusCode) => {
     if (err) {
-      const error = new Error(`Could not upload packfiles: ${statusCode}`)
+      const error = new Error(`Could not upload packfiles: status code ${statusCode}`)
       return callback(error)
     }
     callback(null)

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -78,7 +78,7 @@ function generatePackFilesForCommits (commitsToUpload) {
     log.error(err)
     // The generation of pack files sometimes fail with
     // `unable to rename temporary pack file: Invalid cross-device link`
-    // This error from git itself and it is currently unclear how to fix it.
+    // This error comes from git itself and it is currently unclear how to fix it.
     // A temporary workaround is to attempt to generate the packfiles in process.cwd()
     try {
       return execGitPackObjects(cwdPath, commitsToUpload)


### PR DESCRIPTION
### What does this PR do?
* Use `request` module for git upload (reduces repetition of code and improves the request by adding retries).
* Improve execution of `git pack-objects`: retry with `cwd` if `tmpdir` fails.

### Motivation
* Increase likelihood of success in git upload

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
