### PR TITLE
throw on error in next.js

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -104,7 +104,7 @@ function instrument (req, res, handler) {
         err => finish(req, res, null, err)
       )
     } catch (e) {
-      finish(req, res, null, e)
+      throw finish(req, res, null, e)
     }
   })
 }

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -99,12 +99,16 @@ function instrument (req, res, handler) {
     try {
       const promise = handler()
 
+      // promise should only reject when propagateError is true:
+      // https://github.com/vercel/next.js/blob/cee656238a175b8bb75434c013c79279e546381c/packages/next/server/api-utils/node.ts#L547
       return promise.then(
         result => finish(req, res, result),
         err => finish(req, res, null, err)
       )
     } catch (e) {
-      return finish(req, res, null, e) // TODO: This needs to be tested
+      // this will probably never happen as the handler caller is an async function:
+      // https://github.com/vercel/next.js/blob/cee656238a175b8bb75434c013c79279e546381c/packages/next/server/api-utils/node.ts#L420
+      return finish(req, res, null, e)
     }
   })
 }

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -104,7 +104,7 @@ function instrument (req, res, handler) {
         err => finish(req, res, null, err)
       )
     } catch (e) {
-      throw finish(req, res, null, e)
+      throw finish(req, res, null, e) // TODO: This needs to be tested
     }
   })
 }

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -104,7 +104,7 @@ function instrument (req, res, handler) {
         err => finish(req, res, null, err)
       )
     } catch (e) {
-      throw finish(req, res, null, e) // TODO: This needs to be tested
+      return finish(req, res, null, e) // TODO: This needs to be tested
     }
   })
 }
@@ -116,7 +116,11 @@ function finish (req, res, result, err) {
 
   finishChannel.publish({ req, res })
 
-  return result || err
+  if (err) {
+    throw err
+  }
+
+  return result
 }
 
 addHook({ name: 'next', versions: ['>=11.1'], file: 'dist/server/next-server.js' }, nextServer => {

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -100,14 +100,14 @@ function instrument (req, res, handler) {
       const promise = handler()
 
       // promise should only reject when propagateError is true:
-      // https://github.com/vercel/next.js/blob/cee656238a175b8bb75434c013c79279e546381c/packages/next/server/api-utils/node.ts#L547
+      // https://github.com/vercel/next.js/blob/cee656238a/packages/next/server/api-utils/node.ts#L547
       return promise.then(
         result => finish(req, res, result),
         err => finish(req, res, null, err)
       )
     } catch (e) {
       // this will probably never happen as the handler caller is an async function:
-      // https://github.com/vercel/next.js/blob/cee656238a175b8bb75434c013c79279e546381c/packages/next/server/api-utils/node.ts#L420
+      // https://github.com/vercel/next.js/blob/cee656238a/packages/next/server/api-utils/node.ts#L420
       return finish(req, res, null, e)
     }
   })

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -99,16 +99,16 @@ function instrument (req, res, handler) {
     try {
       const promise = handler()
 
-      // promise should only reject when `propagateError` is true:
+      // promise should only reject when propagateError is true:
       // https://github.com/vercel/next.js/blob/cee656238a/packages/next/server/api-utils/node.ts#L547
       return promise.then(
         result => finish(req, res, result),
-        err => Promise.reject(finish(req, res, null, err))
+        err => finish(req, res, null, err)
       )
     } catch (e) {
       // this will probably never happen as the handler caller is an async function:
       // https://github.com/vercel/next.js/blob/cee656238a/packages/next/server/api-utils/node.ts#L420
-      return Promise.reject(finish(req, res, null, e))
+      return finish(req, res, null, e)
     }
   })
 }
@@ -120,7 +120,11 @@ function finish (req, res, result, err) {
 
   finishChannel.publish({ req, res })
 
-  return result || err
+  if (err) {
+    throw err
+  }
+
+  return result
 }
 
 addHook({ name: 'next', versions: ['>=11.1'], file: 'dist/server/next-server.js' }, nextServer => {

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -99,16 +99,16 @@ function instrument (req, res, handler) {
     try {
       const promise = handler()
 
-      // promise should only reject when propagateError is true:
+      // promise should only reject when `propagateError` is true:
       // https://github.com/vercel/next.js/blob/cee656238a/packages/next/server/api-utils/node.ts#L547
       return promise.then(
         result => finish(req, res, result),
-        err => finish(req, res, null, err)
+        err => Promise.reject(finish(req, res, null, err))
       )
     } catch (e) {
       // this will probably never happen as the handler caller is an async function:
       // https://github.com/vercel/next.js/blob/cee656238a/packages/next/server/api-utils/node.ts#L420
-      return finish(req, res, null, e)
+      return Promise.reject(finish(req, res, null, e))
     }
   })
 }
@@ -120,11 +120,7 @@ function finish (req, res, result, err) {
 
   finishChannel.publish({ req, res })
 
-  if (err) {
-    throw err
-  }
-
-  return result
+  return result || err
 }
 
 addHook({ name: 'next', versions: ['>=11.1'], file: 'dist/server/next-server.js' }, nextServer => {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -247,7 +247,9 @@ describe('Plugin', function () {
 
             axios
               .get(`http://localhost:${port}/puke`)
-              .catch(done)
+              .catch((response) => {
+                expect(response.statusCode).to.eql(500)
+              })
           })
         })
       })

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -230,18 +230,7 @@ describe('Plugin', function () {
         describe('when an error happens', () => {
           it('should not die', done => {
             agent
-              .use(traces => {
-                console.log('TRACES', traces);
-                // const spans = traces[0]
-
-                // expect(spans[0]).to.have.property('name', 'next.request')
-                // expect(spans[0]).to.have.property('service', 'test')
-                // expect(spans[0]).to.have.property('type', 'web')
-                // expect(spans[0]).to.have.property('resource', 'GET')
-                // expect(spans[0].meta).to.have.property('span.kind', 'server')
-                // expect(spans[0].meta).to.have.property('http.method', 'GET')
-                // expect(spans[0].meta).to.have.property('http.status_code', '200')
-              })
+              .use(_traces => { })
               .then(done)
               .catch(done)
 

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -235,7 +235,7 @@ describe('Plugin', function () {
               .catch(done)
 
             axios
-              .get(`http://localhost:${port}/puke`)
+              .get(`http://localhost:${port}/boom`)
               .catch((response) => {
                 expect(response.statusCode).to.eql(500)
               })

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -226,6 +226,30 @@ describe('Plugin', function () {
               .catch(done)
           })
         })
+
+        describe('when an error happens', () => {
+          it('should not die', done => {
+            agent
+              .use(traces => {
+                console.log('TRACES', traces);
+                // const spans = traces[0]
+
+                // expect(spans[0]).to.have.property('name', 'next.request')
+                // expect(spans[0]).to.have.property('service', 'test')
+                // expect(spans[0]).to.have.property('type', 'web')
+                // expect(spans[0]).to.have.property('resource', 'GET')
+                // expect(spans[0].meta).to.have.property('span.kind', 'server')
+                // expect(spans[0].meta).to.have.property('http.method', 'GET')
+                // expect(spans[0].meta).to.have.property('http.status_code', '200')
+              })
+              .then(done)
+              .catch(done)
+
+            axios
+              .get(`http://localhost:${port}/puke`)
+              .catch(done)
+          })
+        })
       })
 
       describe('with configuration', () => {

--- a/packages/datadog-plugin-next/test/pages/api/error/[name].js
+++ b/packages/datadog-plugin-next/test/pages/api/error/[name].js
@@ -1,3 +1,3 @@
 export default (_req, _res) => {
-  throw new Error('oh no');
+  throw new Error('oh no')
 }

--- a/packages/datadog-plugin-next/test/pages/api/error/[name].js
+++ b/packages/datadog-plugin-next/test/pages/api/error/[name].js
@@ -1,0 +1,3 @@
+export default (_req, _res) => {
+  throw new Error('oh no');
+}

--- a/packages/datadog-plugin-next/test/server.js
+++ b/packages/datadog-plugin-next/test/server.js
@@ -26,10 +26,8 @@ app.prepare().then(() => {
   const server = createServer((req, res) => {
     const parsedUrl = parse(req.url, true)
 
-    if (req.path === '/exit') {
+    if (parsedUrl.path === '/exit') {
       server.close()
-    } else if (req.path === '/puke') {
-      throw new Error('oh no');
     } else {
       handle(req, res, parsedUrl)
     }

--- a/packages/datadog-plugin-next/test/server.js
+++ b/packages/datadog-plugin-next/test/server.js
@@ -28,6 +28,8 @@ app.prepare().then(() => {
 
     if (req.path === '/exit') {
       server.close()
+    } else if (req.path === '/puke') {
+      throw new Error('oh no');
     } else {
       handle(req, res, parsedUrl)
     }


### PR DESCRIPTION
### What does this PR do?

Modifies the next.js instrumentation so that when a handler throws an error, the error is re-thrown within the error handler.

### Motivation

In the next.js codebase the user route handler is invoked within an async function:

https://github.com/vercel/next.js/blob/980095d59e0f108019415641a724910cd41a7630/packages/next/server/api-utils/node.ts#L522

The code is wrapped within a try/catch statement. When an error happens the async function doesn't throw/reject. Instead, the response object is mutated. In most codebases I believe the code is unable to reject.

However, it is possible to set an argument called `propagateError` which will then allow the promise to reject: 

https://github.com/vercel/next.js/blob/980095d59e0f108019415641a724910cd41a7630/packages/next/server/api-utils/node.ts#L546-L548

It's possible that some customers will have this enabled. Specifically it happens when in [minimalMode](https://github.com/vercel/next.js/discussions/29801).

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
