### PR TITLE
Add `es2020` env in .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
     "standard"
   ],
   "env": {
-    "node" : true
+    "node" : true,
+    "es2020": true
   },
   "rules": {
     "max-len": [2, 120, 2],


### PR DESCRIPTION
### What does this PR do?
Adds the `es2020` env tag to the eslintrc file.

### Motivation
It makes the `BigInt` literal and constructor recognized by eslint. This is a known bug and needs the tag in the env object even if `ecmaVersion` is already `2020`
