### PR TITLE
Add Process ID to Postgres Span Tags

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -40,9 +40,10 @@ function wrapQuery (query) {
     const statement = pgQuery.text
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
+    const processId = this.processID;
 
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ params: this.connectionParameters, statement })
+      startCh.publish({ params: this.connectionParameters, statement, processId })
 
       const finish = asyncResource.bind(function (error) {
         if (error) {

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -40,7 +40,7 @@ function wrapQuery (query) {
     const statement = pgQuery.text
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
-    const processId = this.processID;
+    const processId = this.processID
 
     return asyncResource.runInAsyncScope(() => {
       startCh.publish({ params: this.connectionParameters, statement, processId })

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -7,7 +7,7 @@ class PGPlugin extends DatabasePlugin {
   static get operation () { return 'query' }
   static get system () { return 'postgres' }
 
-  start ({ params = {}, statement }) {
+  start ({ params = {}, statement, processId }) {
     const service = getServiceName(this.config, params)
 
     this.startSpan('pg.query', {
@@ -17,6 +17,7 @@ class PGPlugin extends DatabasePlugin {
       kind: 'client',
       meta: {
         'db.type': 'postgres',
+        'db.pid': processId,
         'db.name': params.database,
         'db.user': params.user,
         'out.host': params.host,

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -57,6 +57,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
               expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].metrics).to.have.property('db.pid')
 
               done()
             })
@@ -81,6 +82,7 @@ describe('Plugin', () => {
                 expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
                 expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
                 expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                expect(traces[0][0].metrics).to.have.property('db.pid')
 
                 done()
               })

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -57,7 +57,10 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
               expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].metrics).to.have.property('db.pid')
+
+              if (implementation !== 'pg.native') {
+                expect(traces[0][0].metrics).to.have.property('db.pid')
+              }
 
               done()
             })
@@ -82,7 +85,10 @@ describe('Plugin', () => {
                 expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
                 expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
                 expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-                expect(traces[0][0].metrics).to.have.property('db.pid')
+
+                if (implementation !== 'pg.native') {
+                  expect(traces[0][0].metrics).to.have.property('db.pid')
+                }
 
                 done()
               })


### PR DESCRIPTION
### What does this PR do?

This PR will make it so that the `pg` instrumentation picks up the Postgres Connection ID, and adds it as a Span Tag.

### Motivation
This change will make it easier to connect slow/erroring queries in APM with the corresponding Postgres Server logs.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

Discussion in/Closes https://github.com/DataDog/dd-trace-js/issues/2420 
