### PR TITLE
add support for mariadb

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -614,7 +614,7 @@ jobs:
         ports:
           - 3306:3306
     env:
-      PLUGINS: mysql|mysql2 # TODO: move mysql2 to its own job
+      PLUGINS: mysql|mysql2|mariadb # TODO: move mysql2 to its own job
       SERVICES: mysql
     steps:
       - uses: actions/checkout@v2

--- a/docs/API.md
+++ b/docs/API.md
@@ -58,6 +58,7 @@ tracer.use('pg', {
 <h5 id="koa"></h5>
 <h5 id="koa-tags"></h5>
 <h5 id="koa-config"></h5>
+<h5 id="mariadb"></h5>
 <h5 id="memcached"></h5>
 <h5 id="memcached-tags"></h5>
 <h5 id="memcached-config"></h5>
@@ -119,7 +120,7 @@ tracer.use('pg', {
 * [kafkajs](./interfaces/plugins.kafkajs.html)
 * [knex](./interfaces/plugins.knex.html)
 * [koa](./interfaces/plugins.koa.html)
-* [ioredis](./interfaces/plugins.ioredis.html)
+* [mariadb](./interfaces/plugins.mariadb.html)
 * [microgateway--core](./interfaces/plugins.microgateway_core.html)
 * [mocha](./interfaces/plugins.mocha.html)
 * [mongodb-core](./interfaces/plugins.mongodb_core.html)
@@ -445,14 +446,14 @@ const tracer = require('dd-trace').init()
 function handle () {
   tracer.setUser({
     id: '123456789', // *REQUIRED* Unique identifier of the user.
-    
+
     // All other fields are optional.
     email: 'jane.doe@example.com', // Email of the user.
     name: 'Jane Doe', // User-friendly name of the user.
     session_id: '987654321', // Session ID of the user.
     role: 'admin', // Role the user is making the request under.
     scope: 'read:message, write:files', // Scopes or granted authorizations the user currently possesses.
-    
+
     // Arbitrary fields are also accepted to attach custom data to the user (RBAC, Oauth, etc…)
     custom_tag: 'custom data'
   })

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -245,6 +245,7 @@ tracer.use('kafkajs');
 tracer.use('knex');
 tracer.use('koa');
 tracer.use('koa', httpServerOptions);
+tracer.use('mariadb', { service: () => `my-custom-mariadb` })
 tracer.use('memcached');
 tracer.use('microgateway-core', httpServerOptions);
 tracer.use('mocha');

--- a/index.d.ts
+++ b/index.d.ts
@@ -587,6 +587,7 @@ interface Plugins {
   "kafkajs": plugins.kafkajs
   "knex": plugins.knex;
   "koa": plugins.koa;
+  "mariadb": plugins.mariadb;
   "memcached": plugins.memcached;
   "microgateway-core": plugins.microgateway_core;
   "mocha": plugins.mocha;
@@ -1163,6 +1164,12 @@ declare namespace plugins {
    * [kafkajs](https://kafka.js.org/) module.
    */
   interface kafkajs extends Instrumentation {}
+
+  /**
+   * This plugin automatically instruments the
+   * [mariadb](https://github.com/mariadb-corporation/mariadb-connector-nodejs) module.
+   */
+   interface mariadb extends mysql {}
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -42,6 +42,7 @@ module.exports = {
   'koa-router': () => require('../koa'),
   'kafkajs': () => require('../kafkajs'),
   'limitd-client': () => require('../limitd-client'),
+  'mariadb': () => require('../mariadb'),
   'memcached': () => require('../memcached'),
   'microgateway-core': () => require('../microgateway-core'),
   'mocha': () => require('../mocha'),

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const { channel, addHook, AsyncResource } = require('./helpers/instrument')
+
+const shimmer = require('../../datadog-shimmer')
+
+const startCh = channel('apm:mariadb:query:start')
+const finishCh = channel('apm:mariadb:query:finish')
+const errorCh = channel('apm:mariadb:query:error')
+
+function wrapConnectionAddCommand (addCommand) {
+  return function (cmd) {
+    if (!startCh.hasSubscribers) return addCommand.apply(this, arguments)
+
+    const asyncResource = new AsyncResource('bound-anonymous-fn')
+    const name = cmd && cmd.constructor && cmd.constructor.name
+    const isCommand = typeof cmd.start === 'function'
+    const isQuery = isCommand && (name === 'Execute' || name === 'Query')
+
+    // TODO: consider supporting all commands and not just queries
+    cmd.start = isQuery
+      ? wrapStart(cmd, cmd.start, asyncResource, this.opts)
+      : bindStart(cmd, cmd.start, asyncResource)
+
+    return asyncResource.bind(addCommand, this).apply(this, arguments)
+  }
+}
+
+function bindStart (cmd, start, asyncResource) {
+  return asyncResource.bind(function (packet, connection) {
+    if (this.resolve) {
+      this.resolve = asyncResource.bind(this.resolve)
+    }
+
+    if (this.reject) {
+      this.reject = asyncResource.bind(this.reject)
+    }
+
+    return start.apply(this, arguments)
+  }, cmd)
+}
+
+function wrapStart (cmd, start, asyncResource, config) {
+  const callbackResource = new AsyncResource('bound-anonymous-fn')
+
+  return asyncResource.bind(function (packet, connection) {
+    if (!this.resolve || !this.reject) return start.apply(this, arguments)
+
+    const sql = cmd.statement ? cmd.statement.query : cmd.sql
+
+    startCh.publish({ sql, conf: config })
+
+    const resolve = callbackResource.bind(this.resolve)
+    const reject = callbackResource.bind(this.reject)
+
+    this.resolve = asyncResource.bind(function () {
+      finishCh.publish(undefined)
+      resolve.apply(this, arguments)
+    }, 'bound-anonymous-fn', this)
+
+    this.reject = asyncResource.bind(function (error) {
+      errorCh.publish(error)
+      finishCh.publish(undefined)
+      reject.apply(this, arguments)
+    }, 'bound-anonymous-fn', this)
+
+    this.start = start
+
+    try {
+      return start.apply(this, arguments)
+    } catch (err) {
+      errorCh.publish(err)
+    }
+  }, cmd)
+}
+
+addHook(
+  {
+    name: 'mariadb',
+    file: 'lib/connection.js',
+    versions: ['>=3']
+  },
+  (Connection) => {
+    shimmer.wrap(Connection.prototype, 'addCommandEnable', wrapConnectionAddCommand)
+    shimmer.wrap(Connection.prototype, 'addCommandEnablePipeline', wrapConnectionAddCommand)
+
+    return Connection
+  }
+)

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const MySQLPlugin = require('../../datadog-plugin-mysql/src')
+
+class MariadbPlugin extends MySQLPlugin {
+  static get name () { return 'mariadb' }
+  static get system () { return 'mariadb' }
+}
+
+module.exports = MariadbPlugin

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -1,0 +1,329 @@
+'use strict'
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const proxyquire = require('proxyquire').noPreserveCache()
+
+describe('Plugin', () => {
+  let mariadb
+  let tracer
+
+  describe('mariadb', () => {
+    withVersions('mariadb', 'mariadb', version => {
+      beforeEach(() => {
+        tracer = require('../../dd-trace')
+      })
+
+      describe('without configuration', () => {
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
+
+          connection = mariadb.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          return new Promise((resolve, reject) => {
+            connection.connect(err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(connection)
+              }
+            })
+          })
+        })
+
+        it('should propagate context to callbacks, with correct callback args', done => {
+          const span = tracer.startSpan('test')
+
+          tracer.scope().activate(span, () => {
+            const span = tracer.scope().active()
+
+            connection.query('SELECT 1 + 1 AS solution', (err, results, fields) => {
+              try {
+                expect(results).to.not.be.null
+                expect(fields).to.not.be.null
+                expect(tracer.scope().active()).to.equal(span)
+              } catch (e) {
+                done(e)
+              }
+              done()
+            })
+          })
+        })
+
+        it('should run the callback in the parent context', done => {
+          connection.query('SELECT 1 + 1 AS solution', () => {
+            expect(tracer.scope().active()).to.be.null
+            done()
+          })
+        })
+
+        it('should run event listeners in the parent context', done => {
+          const query = connection.query('SELECT 1 + 1 AS solution')
+
+          query.on('end', () => {
+            expect(tracer.scope().active()).to.be.null
+            done()
+          })
+        })
+
+        it('should do automatic instrumentation', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+              expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
+              expect(traces[0][0]).to.have.property('type', 'sql')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].meta).to.have.property('db.name', 'db')
+              expect(traces[0][0].meta).to.have.property('db.user', 'root')
+              expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            })
+            .then(done)
+            .catch(done)
+
+          connection.query('SELECT 1 + 1 AS solution', (error, results, fields) => {
+            if (error) throw error
+          })
+        })
+
+        it('should support prepared statement shorthand', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+              expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
+              expect(traces[0][0]).to.have.property('type', 'sql')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].meta).to.have.property('db.name', 'db')
+              expect(traces[0][0].meta).to.have.property('db.user', 'root')
+              expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            })
+            .then(done)
+            .catch(done)
+
+          connection.execute('SELECT ? + ? AS solution', [1, 1], (error, results, fields) => {
+            if (error) throw error
+          })
+
+          // connection.unprepare('SELECT ? + ? AS solution')
+        })
+
+        it('should support prepared statements', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+              expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
+              expect(traces[0][0]).to.have.property('type', 'sql')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].meta).to.have.property('db.name', 'db')
+              expect(traces[0][0].meta).to.have.property('db.user', 'root')
+              expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            })
+            .then(done)
+            .catch(done)
+
+          connection.prepare('SELECT ? + ? AS solution', (err, statement) => {
+            if (err) throw err
+
+            statement.execute([1, 1], (error, rows, columns) => {
+              if (error) throw error
+            })
+
+            statement.close()
+          })
+        })
+
+        it('should handle errors', done => {
+          let error
+
+          agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property('error.type', error.name)
+              expect(traces[0][0].meta).to.have.property('error.msg', error.message)
+              expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
+            })
+            .then(done)
+            .catch(done)
+
+          connection.query('INVALID', (err, results, fields) => {
+            error = err
+          })
+        })
+
+        it('should work without a callback', done => {
+          agent
+            .use(() => {})
+            .then(done)
+            .catch(done)
+
+          connection.query('SELECT 1 + 1 AS solution')
+        })
+      })
+
+      describe('with configuration', () => {
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb', { service: 'custom' })
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
+
+          connection = mariadb.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          return new Promise((resolve, reject) => {
+            connection.connect(err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(connection)
+              }
+            })
+          })
+        })
+
+        it('should be configured with the correct values', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'custom')
+            })
+            .then(done)
+            .catch(done)
+
+          connection.query('SELECT 1 + 1 AS solution')
+        })
+      })
+
+      describe('with service configured as function', () => {
+        const serviceSpy = sinon.stub().returns('custom')
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb', { service: serviceSpy })
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
+
+          connection = mariadb.createConnection({
+            host: 'localhost',
+            user: 'root',
+            database: 'db'
+          })
+
+          return new Promise((resolve, reject) => {
+            connection.connect(err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(connection)
+              }
+            })
+          })
+        })
+
+        it('should be configured with the correct values', done => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'custom')
+            sinon.assert.calledWith(serviceSpy, sinon.match({
+              host: 'localhost',
+              user: 'root',
+              database: 'db'
+            }))
+            done()
+          })
+
+          connection.query('SELECT 1 + 1 AS solution', () => {})
+        })
+      })
+
+      describe('with a connection pool', () => {
+        let pool
+
+        afterEach((done) => {
+          pool.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mariadb')
+          mariadb = proxyquire(`../../../versions/mariadb@${version}`, {}).get('mariadb/callback')
+
+          pool = mariadb.createPool({
+            connectionLimit: 1,
+            host: 'localhost',
+            user: 'root'
+          })
+        })
+
+        it('should do automatic instrumentation', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+              expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
+              expect(traces[0][0]).to.have.property('type', 'sql')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              expect(traces[0][0].meta).to.have.property('db.user', 'root')
+              expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
+              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+            })
+            .then(done)
+            .catch(done)
+
+          pool.query('SELECT 1 + 1 AS solution')
+        })
+
+        it('should run the callback in the parent context', done => {
+          pool.query('SELECT 1 + 1 AS solution', () => {
+            expect(tracer.scope().active()).to.be.null
+            done()
+          })
+        })
+
+        it('should propagate context to callbacks', done => {
+          const span1 = tracer.startSpan('test1')
+          const span2 = tracer.startSpan('test2')
+
+          tracer.trace('test', () => {
+            tracer.scope().activate(span1, () => {
+              pool.query('SELECT 1 + 1 AS solution', () => {
+                expect(tracer.scope().active() === span1).to.eql(true)
+                tracer.scope().activate(span2, () => {
+                  pool.query('SELECT 1 + 1 AS solution', () => {
+                    expect(tracer.scope().active() === span2).to.eql(true)
+                    done()
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -9,13 +9,13 @@ class MySQLPlugin extends DatabasePlugin {
   start ({ sql, conf: dbConfig }) {
     const service = getServiceName(this.config, dbConfig)
 
-    this.startSpan('mysql.query', {
+    this.startSpan(`${this.system}.query`, {
       service,
       resource: sql,
       type: 'sql',
       kind: 'client',
       meta: {
-        'db.type': 'mysql',
+        'db.type': this.system,
         'db.user': dbConfig.user,
         'db.name': dbConfig.database,
         'out.host': dbConfig.host,

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -39,6 +39,7 @@ module.exports = {
   get 'koa' () { return require('../../../datadog-plugin-koa/src') },
   get 'koa-router' () { return require('../../../datadog-plugin-koa/src') },
   get 'kafkajs' () { return require('../../../datadog-plugin-kafkajs/src') },
+  get 'mariadb' () { return require('../../../datadog-plugin-mariadb/src') },
   get 'memcached' () { return require('../../../datadog-plugin-memcached/src') },
   get 'microgateway-core' () { return require('../../../datadog-plugin-microgateway-core/src') },
   get 'mocha' () { return require('../../../datadog-plugin-mocha/src') },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for MariaDB.

### Motivation
<!-- What inspired you to submit this pull request? -->

We do not currently have support for MariaDB while more and more users are switching from MySQL.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Big thanks to @jamiehodge who implemented the first iteration of this in https://github.com/DataDog/dd-trace-js/pull/2151
