### PR TITLE
[ci-visibility] Do not report spans other than suites and sessions in the test session trace

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -156,34 +156,31 @@ class JestPlugin extends Plugin {
       if (!this.config.isAgentlessEnabled) {
         return
       }
-      const store = storage.getStore()
       const childOf = getTestParentSpan(this.tracer)
       const testSessionSpanMetadata = getTestSessionCommonTags(command, this.tracer._version)
 
-      const testSessionSpan = this.tracer.startSpan('jest.test_session', {
+      this.testSessionSpan = this.tracer.startSpan('jest.test_session', {
         childOf,
         tags: {
           ...this.testEnvironmentMetadata,
           ...testSessionSpanMetadata
         }
       })
-      this.enter(testSessionSpan, store)
     })
 
     this.addSub('ci:jest:session:finish', ({ status, isTestsSkipped, testCodeCoverageLinesTotal }) => {
       if (!this.config.isAgentlessEnabled) {
         return
       }
-      const testSessionSpan = storage.getStore().span
-      testSessionSpan.setTag(TEST_STATUS, status)
+      this.testSessionSpan.setTag(TEST_STATUS, status)
       if (isTestsSkipped) {
-        testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, 'true')
+        this.testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, 'true')
       }
       if (testCodeCoverageLinesTotal !== undefined) {
-        testSessionSpan.setTag(TEST_CODE_COVERAGE_LINES_TOTAL, testCodeCoverageLinesTotal)
+        this.testSessionSpan.setTag(TEST_CODE_COVERAGE_LINES_TOTAL, testCodeCoverageLinesTotal)
       }
-      testSessionSpan.finish()
-      finishAllTraceSpans(testSessionSpan)
+      this.testSessionSpan.finish()
+      finishAllTraceSpans(this.testSessionSpan)
       this.tracer._exporter._writer.flush()
     })
 
@@ -194,10 +191,9 @@ class JestPlugin extends Plugin {
       if (!this.config.isAgentlessEnabled) {
         return
       }
-      const testSessionSpan = storage.getStore().span
       configs.forEach(config => {
-        config._ddTestSessionId = testSessionSpan.context()._traceId.toString(10)
-        config._ddTestCommand = testSessionSpan.context()._tags[TEST_COMMAND]
+        config._ddTestSessionId = this.testSessionSpan.context()._traceId.toString(10)
+        config._ddTestCommand = this.testSessionSpan.context()._tags[TEST_COMMAND]
       })
     })
 
@@ -208,8 +204,6 @@ class JestPlugin extends Plugin {
 
       const { _ddTestSessionId: testSessionId, _ddTestCommand: testCommand } = testEnvironmentOptions
 
-      const store = storage.getStore()
-
       const testSessionSpanContext = this.tracer.extract('text_map', {
         'x-datadog-trace-id': testSessionId,
         'x-datadog-parent-id': '0000000000000000'
@@ -217,34 +211,31 @@ class JestPlugin extends Plugin {
 
       const testSuiteMetadata = getTestSuiteCommonTags(testCommand, this.tracer._version, testSuite)
 
-      const testSuiteSpan = this.tracer.startSpan('jest.test_suite', {
+      this.testSuiteSpan = this.tracer.startSpan('jest.test_suite', {
         childOf: testSessionSpanContext,
         tags: {
           ...this.testEnvironmentMetadata,
           ...testSuiteMetadata
         }
       })
-      this.enter(testSuiteSpan, store)
     })
 
     this.addSub('ci:jest:test-suite:finish', ({ status, errorMessage }) => {
       if (!this.config.isAgentlessEnabled) {
         return
       }
-      const testSuiteSpan = storage.getStore().span
-      testSuiteSpan.setTag(TEST_STATUS, status)
+      this.testSuiteSpan.setTag(TEST_STATUS, status)
       if (errorMessage) {
-        testSuiteSpan.setTag('error', new Error(errorMessage))
+        this.testSuiteSpan.setTag('error', new Error(errorMessage))
       }
-      testSuiteSpan.finish()
+      this.testSuiteSpan.finish()
     })
 
     this.addSub('ci:jest:test-suite:code-coverage', (coverageFiles) => {
       if (!this.config.isAgentlessEnabled || !this.config.isIntelligentTestRunnerEnabled) {
         return
       }
-      const testSuiteSpan = storage.getStore().span
-      this.tracer._exporter.exportCoverage({ span: testSuiteSpan, coverageFiles })
+      this.tracer._exporter.exportCoverage({ span: this.testSuiteSpan, coverageFiles })
     })
 
     this.addSub('ci:jest:test:start', (test) => {
@@ -278,13 +269,11 @@ class JestPlugin extends Plugin {
 
   startTestSpan (test) {
     const suiteTags = {}
-    const store = storage.getStore()
-    const testSuiteSpan = store ? store.span : undefined
-    if (testSuiteSpan) {
-      const testSuiteId = testSuiteSpan.context()._spanId.toString(10)
+    if (this.testSuiteSpan) {
+      const testSuiteId = this.testSuiteSpan.context()._spanId.toString(10)
       suiteTags[TEST_SUITE_ID] = testSuiteId
-      suiteTags[TEST_SESSION_ID] = testSuiteSpan.context()._traceId.toString(10)
-      suiteTags[TEST_COMMAND] = testSuiteSpan.context()._tags[TEST_COMMAND]
+      suiteTags[TEST_SESSION_ID] = this.testSuiteSpan.context()._traceId.toString(10)
+      suiteTags[TEST_COMMAND] = this.testSuiteSpan.context()._tags[TEST_COMMAND]
     }
 
     const {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -237,6 +237,8 @@ class JestPlugin extends Plugin {
         testSuiteSpan.setTag('error', new Error(errorMessage))
       }
       testSuiteSpan.finish()
+      // Suites potentially run in a different process than the session,
+      // so calling finishAllTraceSpans on the session span is not enough
       finishAllTraceSpans(testSuiteSpan)
     })
 

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -198,7 +198,14 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
 
   _encode (bytes, trace) {
     this._eventCount += trace.length
-    const events = trace.map(formatSpan)
+    const rawEvents = trace.map(formatSpan)
+
+    const testSessionEvents = rawEvents.filter(
+      event => event.type === 'test_session_end' || event.type === 'test_suite_end'
+    )
+
+    const isTestSessionTrace = !!testSessionEvents.length
+    const events = isTestSessionTrace ? testSessionEvents : rawEvents
 
     for (const event of events) {
       this._encodeEvent(bytes, event)

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -197,7 +197,6 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   }
 
   _encode (bytes, trace) {
-    this._eventCount += trace.length
     const rawEvents = trace.map(formatSpan)
 
     const testSessionEvents = rawEvents.filter(
@@ -206,6 +205,8 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
 
     const isTestSessionTrace = !!testSessionEvents.length
     const events = isTestSessionTrace ? testSessionEvents : rawEvents
+
+    this._eventCount += events.length
 
     for (const event of events) {
       this._encodeEvent(bytes, event)

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -211,4 +211,45 @@ describe('agentless-ci-visibility-encode', () => {
       [`${tooLongKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`]: `${tooLongValue.slice(0, MAX_METRIC_VALUE_LENGTH)}...`
     })
   })
+
+  it('should not encode events other than sessions and suites if the trace is a test session', () => {
+    const traceToFilter = [
+      {
+        trace_id: id('1234abcd1234abcd'),
+        span_id: id('1234abcd1234abcd'),
+        parent_id: id('1234abcd1234abcd'),
+        error: 0,
+        meta: {},
+        metrics: {},
+        start: 123,
+        duration: 456,
+        type: 'test_session_end',
+        name: '',
+        resource: '',
+        service: ''
+      },
+      {
+        trace_id: id('1234abcd1234abcd'),
+        span_id: id('1234abcd1234abcd'),
+        parent_id: id('1234abcd1234abcd'),
+        error: 0,
+        meta: {},
+        metrics: {},
+        start: 123,
+        duration: 456,
+        type: 'http',
+        name: '',
+        resource: '',
+        service: ''
+      }
+    ]
+
+    encoder.encode(traceToFilter)
+
+    const buffer = encoder.makePayload()
+    const decodedTrace = msgpack.decode(buffer, { codec })
+    expect(decodedTrace.events.length).to.equal(1)
+    expect(decodedTrace.events[0].type).to.equal('test_session_end')
+    expect(decodedTrace.events[0].content.type).to.eql('test_session_end')
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Temporarily stop sending spans other than suites and sessions in a test session trace.

### Motivation
In the future we want to create spans for `before` and `after` hooks (suite level hooks), but we're not ready yet. Since we don't create those yet, http (or other) spans are associated to the suite / session, for which the visualisation is not ready. We'll add them back when we're ready. 

