### PR TITLE
Pass childOf to startSpan

### DIFF
--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -64,6 +64,7 @@ class TracingPlugin extends Plugin {
     }
 
     const span = this.tracer.startSpan(name, {
+      childOf,
       tags: {
         'service.name': service,
         'resource.name': resource,

--- a/packages/dd-trace/test/plugins/tracing.spec.js
+++ b/packages/dd-trace/test/plugins/tracing.spec.js
@@ -1,22 +1,22 @@
-const TracingPlugin = require("../../src/plugins/tracing")
+const TracingPlugin = require('../../src/plugins/tracing')
 
-describe("TracingPlugin", () => {
-  describe("startSpan method", () => {
-    it("passes given childOf relationship to the tracer", () => {
+describe('TracingPlugin', () => {
+  describe('startSpan method', () => {
+    it('passes given childOf relationship to the tracer', () => {
       const startSpanSpy = sinon.spy()
       const plugin = new TracingPlugin({
         _tracer: {
-          startSpan: startSpanSpy,
-        },
+          startSpan: startSpanSpy
+        }
       })
       plugin.configure({})
 
-      plugin.startSpan("Test span", { childOf: "some parent span" })
+      plugin.startSpan('Test span', { childOf: 'some parent span' })
 
       expect(startSpanSpy).to.have.been.calledWith(
-        "Test span",
+        'Test span',
         sinon.match({
-          childOf: "some parent span",
+          childOf: 'some parent span'
         })
       )
     })

--- a/packages/dd-trace/test/plugins/tracing.spec.js
+++ b/packages/dd-trace/test/plugins/tracing.spec.js
@@ -1,0 +1,24 @@
+const TracingPlugin = require("../../src/plugins/tracing")
+
+describe("TracingPlugin", () => {
+  describe("startSpan method", () => {
+    it("passes given childOf relationship to the tracer", () => {
+      const startSpanSpy = sinon.spy()
+      const plugin = new TracingPlugin({
+        _tracer: {
+          startSpan: startSpanSpy,
+        },
+      })
+      plugin.configure({})
+
+      plugin.startSpan("Test span", { childOf: "some parent span" })
+
+      expect(startSpanSpy).to.have.been.calledWith(
+        "Test span",
+        sinon.match({
+          childOf: "some parent span",
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/DataDog/dd-trace-js/issues/2432 (I hope).

### Motivation
I noticed that `childOf` is not being passed onto `startTrace`, which could be the reason for https://github.com/DataDog/dd-trace-js/issues/2432.
