### PR TITLE
Accept space- and comma- separated tags

### DIFF
--- a/packages/dd-trace/src/tagger.js
+++ b/packages/dd-trace/src/tagger.js
@@ -2,6 +2,20 @@
 
 const log = require('./log')
 
+function chooseSeparator (keyValuePairs) {
+  const tagSeparatorCount = keyValuePairs.split(':').length - 1
+  for (const separator of [',', ' ']) {
+    const segments = keyValuePairs.split(separator)
+    // The separator is chosen if number of split segments 
+    // equals number of counted colons
+    if (segments.length === tagSeparatorCount) {
+      return separator
+    }
+  }
+  // fallback on legacy behaviour and return comma
+  return ','
+}
+
 function add (carrier, keyValuePairs) {
   if (!carrier || !keyValuePairs) return
 
@@ -11,7 +25,9 @@ function add (carrier, keyValuePairs) {
 
   try {
     if (typeof keyValuePairs === 'string') {
-      const segments = keyValuePairs.split(',')
+      const chosenSeparator = chooseSeparator(keyValuePairs)
+      const segments = keyValuePairs.split(chosenSeparator)
+
       for (const segment of segments) {
         const separatorIndex = segment.indexOf(':')
         if (separatorIndex === -1) continue


### PR DESCRIPTION
### What does this PR do?
To be consistent with https://github.com/DataDog/dd-trace-rb/pull/2011 and
https://github.com/DataDog/dd-trace-java/pull/2011, modify tagger.js to recognise
spaces as well as commas as a tag separator.

Either comma or space is chosen depending on the number of
valid key-value pairs obtained from splitting on the separator.

### Motivation
This PR is made to be consistent with DataDog/dd-trace-rb#2011, 
DataDog/dd-trace-java#2011 and DataDog/dd-trace-py#2196. These 
PRs collectively recognise the support of spaces and commas to
separate tags in the `DD_TAGS` env var supported by datadog-agent.

### Other notes
Given we are in the middle of Hacktoberfest, I would like to request that
this PR is labelled with `hacktoberfest-accepted`, so that it can count
towards my contributions for the event.
