### PR TITLE
move labels and package size actions to pull_request_target trigger

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,7 +1,7 @@
 name: Package Size
 
 on:
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: '0 4 * * *'
 

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,6 +1,6 @@
 name: Pull Request Labels
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
     branches:
       - 'master'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Move labels and package size actions to `pull_request_target` trigger.

### Motivation
<!-- What inspired you to submit this pull request? -->

They otherwise fail on forks.

### Additional Notes

This is recommended in the [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).