### PR TITLE
Add parametric system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -81,3 +81,22 @@ jobs:
       - name: Run
         run: ./lib-injection/run-lib-injection.sh
 
+  parametric:
+    runs-on: ubuntu-latest
+    env:
+      CLIENTS_ENABLED: nodejs
+      NODEJS_DDTRACE_MODULE: datadog/dd-trace-js#${{ github.sha }}
+    steps:
+      - name: Checkout system tests
+        uses: actions/checkout@v3
+        with:
+          repository: 'DataDog/system-tests'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Run
+        run: |
+          cd parametric
+          pip install wheel
+          pip install -r requirements.txt
+          ./run.sh


### PR DESCRIPTION
### What does this PR do?

Adds parametric system tests to the system tests workflow

### Motivation

A bunch of tests, including the ones for [Single Span Ingestion](https://github.com/DataDog/dd-trace-js/pull/2304) are in the parametric test suite which is intended to be run by installing the module via the git commit. The `NODEJS_DDTRACE_MODULE` env var is currently ignored by the system-tests repo but I'll be opening a separate PR to get it to support that.