### PR TITLE
Ignore profiler source map finder errors

### DIFF
--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -36,9 +36,16 @@ class Profiler extends EventEmitter {
     this._logger = config.logger
     this._enabled = true
 
+    // Log errors if the source map finder fails, but don't prevent the rest
+    // of the profiler from running without source maps.
+    let mapper
     try {
-      const mapper = await maybeSourceMap(config.sourceMap)
+      mapper = await maybeSourceMap(config.sourceMap)
+    } catch (err) {
+      this._logger.error(err)
+    }
 
+    try {
       for (const profiler of config.profilers) {
         // TODO: move this out of Profiler when restoring sourcemap support
         profiler.start({ mapper })


### PR DESCRIPTION
### What does this PR do?

If the profiler source map finder crashes for any reason, log the error but don't prevent the profilers from running without it.

### Motivation

Currently if the source map finder fails it stops the profiler from running entirely. There are some edge cases where it may fail when it shouldn't such as if running with root as the current working directory as it may try to scan `/proc` and fail due to not being real files. The scanner itself should be fixed too, but the problems is deep in its dependencies somewhere so for now it's easier to just ignore source map finder errors given that their often won't be any source map files anyway.