### PR TITLE
simplify mariadb instrumentation and add support for >=2.5.1

### DIFF
--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -47,7 +47,7 @@ function wrapCommandStart (start) {
 }
 
 const name = 'mariadb'
-const versions = ['>=2.5.1']
+const versions = ['>=2.0.3']
 
 addHook({ name, file: 'lib/cmd/query.js', versions }, (Query) => {
   shimmer.wrap(Query.prototype, 'start', wrapCommandStart)

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -8,82 +8,55 @@ const startCh = channel('apm:mariadb:query:start')
 const finishCh = channel('apm:mariadb:query:finish')
 const errorCh = channel('apm:mariadb:query:error')
 
-function wrapConnectionAddCommand (addCommand) {
-  return function (cmd) {
-    if (!startCh.hasSubscribers) return addCommand.apply(this, arguments)
+function wrapCommandStart (start) {
+  return function () {
+    if (!startCh.hasSubscribers) return start.apply(this, arguments)
 
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-    const name = cmd && cmd.constructor && cmd.constructor.name
-    const isCommand = typeof cmd.start === 'function'
-    const isQuery = isCommand && (name === 'Execute' || name === 'Query')
-
-    // TODO: consider supporting all commands and not just queries
-    cmd.start = isQuery
-      ? wrapStart(cmd, cmd.start, asyncResource, this.opts)
-      : bindStart(cmd, cmd.start, asyncResource)
-
-    return asyncResource.bind(addCommand, this).apply(this, arguments)
-  }
-}
-
-function bindStart (cmd, start, asyncResource) {
-  return asyncResource.bind(function (packet, connection) {
-    if (this.resolve) {
-      this.resolve = asyncResource.bind(this.resolve)
-    }
-
-    if (this.reject) {
-      this.reject = asyncResource.bind(this.reject)
-    }
-
-    return start.apply(this, arguments)
-  }, cmd)
-}
-
-function wrapStart (cmd, start, asyncResource, config) {
-  const callbackResource = new AsyncResource('bound-anonymous-fn')
-
-  return asyncResource.bind(function (packet, connection) {
-    if (!this.resolve || !this.reject) return start.apply(this, arguments)
-
-    const sql = cmd.statement ? cmd.statement.query : cmd.sql
-
-    startCh.publish({ sql, conf: config })
+    const callbackResource = new AsyncResource('bound-anonymous-fn')
 
     const resolve = callbackResource.bind(this.resolve)
     const reject = callbackResource.bind(this.reject)
 
-    this.resolve = asyncResource.bind(function () {
-      finishCh.publish(undefined)
-      resolve.apply(this, arguments)
-    }, 'bound-anonymous-fn', this)
+    const asyncResource = new AsyncResource('bound-anonymous-fn')
+    shimmer.wrap(this, 'resolve', function wrapResolve () {
+      return function () {
+        asyncResource.runInAsyncScope(() => {
+          finishCh.publish()
+        })
 
-    this.reject = asyncResource.bind(function (error) {
-      errorCh.publish(error)
-      finishCh.publish(undefined)
-      reject.apply(this, arguments)
-    }, 'bound-anonymous-fn', this)
+        return resolve.apply(this, arguments)
+      }
+    })
 
-    this.start = start
+    shimmer.wrap(this, 'reject', function wrapReject () {
+      return function (error) {
+        asyncResource.runInAsyncScope(() => {
+          errorCh.publish(error)
+          finishCh.publish()
+        })
 
-    try {
+        return reject.apply(this, arguments)
+      }
+    })
+
+    return asyncResource.runInAsyncScope(() => {
+      startCh.publish({ sql: this.sql, conf: this.opts })
       return start.apply(this, arguments)
-    } catch (err) {
-      errorCh.publish(err)
-    }
-  }, cmd)
+    })
+  }
 }
 
-addHook(
-  {
-    name: 'mariadb',
-    file: 'lib/connection.js',
-    versions: ['>=3']
-  },
-  (Connection) => {
-    shimmer.wrap(Connection.prototype, 'addCommandEnable', wrapConnectionAddCommand)
-    shimmer.wrap(Connection.prototype, 'addCommandEnablePipeline', wrapConnectionAddCommand)
+const name = 'mariadb'
+const versions = ['>=2.5.1']
 
-    return Connection
-  }
-)
+addHook({ name, file: 'lib/cmd/query.js', versions }, (Query) => {
+  shimmer.wrap(Query.prototype, 'start', wrapCommandStart)
+
+  return Query
+})
+
+addHook({ name, file: 'lib/cmd/execute.js', versions }, (Query) => {
+  shimmer.wrap(Query.prototype, 'start', wrapCommandStart)
+
+  return Query
+})

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -18,6 +18,7 @@ function wrapCommandStart (start) {
     const reject = callbackResource.bind(this.reject)
 
     const asyncResource = new AsyncResource('bound-anonymous-fn')
+
     shimmer.wrap(this, 'resolve', function wrapResolve () {
       return function () {
         asyncResource.runInAsyncScope(() => {

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 
@@ -98,53 +99,53 @@ describe('Plugin', () => {
           })
         })
 
-        it('should support prepared statement shorthand', done => {
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'test-mariadb')
-              expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('db.name', 'db')
-              expect(traces[0][0].meta).to.have.property('db.user', 'root')
-              expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-            })
-            .then(done)
-            .catch(done)
+        if (semver.intersects(version, '>=3')) {
+          it('should support prepared statement shorthand', done => {
+            agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+                expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
+                expect(traces[0][0]).to.have.property('type', 'sql')
+                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                expect(traces[0][0].meta).to.have.property('db.name', 'db')
+                expect(traces[0][0].meta).to.have.property('db.user', 'root')
+                expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
+                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              })
+              .then(done)
+              .catch(done)
 
-          connection.execute('SELECT ? + ? AS solution', [1, 1], (error, results, fields) => {
-            if (error) throw error
-          })
-
-          // connection.unprepare('SELECT ? + ? AS solution')
-        })
-
-        it('should support prepared statements', done => {
-          agent
-            .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'test-mariadb')
-              expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('db.name', 'db')
-              expect(traces[0][0].meta).to.have.property('db.user', 'root')
-              expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-            })
-            .then(done)
-            .catch(done)
-
-          connection.prepare('SELECT ? + ? AS solution', (err, statement) => {
-            if (err) throw err
-
-            statement.execute([1, 1], (error, rows, columns) => {
+            connection.execute('SELECT ? + ? AS solution', [1, 1], (error, results, fields) => {
               if (error) throw error
             })
-
-            statement.close()
           })
-        })
+
+          it('should support prepared statements', done => {
+            agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('service', 'test-mariadb')
+                expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
+                expect(traces[0][0]).to.have.property('type', 'sql')
+                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                expect(traces[0][0].meta).to.have.property('db.name', 'db')
+                expect(traces[0][0].meta).to.have.property('db.user', 'root')
+                expect(traces[0][0].meta).to.have.property('db.type', 'mariadb')
+                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+              })
+              .then(done)
+              .catch(done)
+
+            connection.prepare('SELECT ? + ? AS solution', (err, statement) => {
+              if (err) throw err
+
+              statement.execute([1, 1], (error, rows, columns) => {
+                if (error) throw error
+              })
+
+              statement.close()
+            })
+          })
+        }
 
         it('should handle errors', done => {
           let error

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -4,12 +4,15 @@ const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 
+// https://github.com/mariadb-corporation/mariadb-connector-nodejs/commit/0a90b71ab20ab4e8b6a86a77ba291bba8ba6a34e
+const range = semver.gte(process.version, '15.0.0') ? '>=2.5.1' : '>=2'
+
 describe('Plugin', () => {
   let mariadb
   let tracer
 
   describe('mariadb', () => {
-    withVersions('mariadb', 'mariadb', version => {
+    withVersions('mariadb', 'mariadb', range, version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
       })

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -85,6 +85,12 @@
       "versions": ["6.1.0"]
     }
   ],
+  "mariadb": [
+    {
+      "name": "mariadb",
+      "versions": ["2.5.6", "3.0.0"]
+    }
+  ],
   "mocha": [
     {
       "name": "mocha",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Simplify `mariadb` instrumentation and add support for >=2

### Motivation
<!-- What inspired you to submit this pull request? -->

Version 3.x of `mariadb` was released version recently, and many users might not have upgraded from 2.x yet.