### PR TITLE
Check if `DD_API_KEY` is defined before uploading tracing tests to CI Visibility

### DIFF
--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -22,8 +22,8 @@ jobs:
       - run: yarn install
       - run: MOCHA_FILE=test-results/tracing/macos.xml yarn test:trace:core:ci
       - uses: ./.github/actions/datadog-ci
-      - run: |
-          datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:darwin --tags runtime.version:14 test-results/tracing/macos.xml
+      - run: datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:darwin --tags runtime.version:14 test-results/tracing/macos.xml
+        if: ${{ env.DD_API_KEY !== '' }}
       - uses: codecov/codecov-action@v2
 
   ubuntu:
@@ -45,6 +45,7 @@ jobs:
           datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:linux --tags runtime.version:14 test-results/tracing/linux-14.xml
           datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:linux --tags runtime.version:16 test-results/tracing/linux-16.xml
           datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:linux --tags runtime.version:18 test-results/tracing/linux-latest.xml
+        if: ${{ env.DD_API_KEY !== '' }}
       - uses: codecov/codecov-action@v2
 
   windows:
@@ -59,4 +60,5 @@ jobs:
       - run: yarn test:trace:core:ci
       - uses: ./.github/actions/datadog-ci
       - run: .\datadog-ci.exe junit upload --service dd-trace-js-tests --tags os.platform:windows --tags runtime.version:14 test-results/tracing/windows.xml
+        if: ${{ env.DD_API_KEY !== '' }}
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -23,7 +23,7 @@ jobs:
       - run: MOCHA_FILE=test-results/tracing/macos.xml yarn test:trace:core:ci
       - uses: ./.github/actions/datadog-ci
       - run: datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:darwin --tags runtime.version:14 test-results/tracing/macos.xml
-        if: ${{ env.DD_API_KEY !== '' }}
+        if: ${{ env.DD_API_KEY != '' }}
       - uses: codecov/codecov-action@v2
 
   ubuntu:
@@ -45,7 +45,7 @@ jobs:
           datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:linux --tags runtime.version:14 test-results/tracing/linux-14.xml
           datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:linux --tags runtime.version:16 test-results/tracing/linux-16.xml
           datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:linux --tags runtime.version:18 test-results/tracing/linux-latest.xml
-        if: ${{ env.DD_API_KEY !== '' }}
+        if: ${{ env.DD_API_KEY != '' }}
       - uses: codecov/codecov-action@v2
 
   windows:
@@ -60,5 +60,5 @@ jobs:
       - run: yarn test:trace:core:ci
       - uses: ./.github/actions/datadog-ci
       - run: .\datadog-ci.exe junit upload --service dd-trace-js-tests --tags os.platform:windows --tags runtime.version:14 test-results/tracing/windows.xml
-        if: ${{ env.DD_API_KEY !== '' }}
+        if: ${{ env.DD_API_KEY != '' }}
       - uses: codecov/codecov-action@v2


### PR DESCRIPTION
### What does this PR do?
Check if `DD_API_KEY` is defined before attempting to use `datadog-ci junit upload`

### Motivation
Prevent errors in forks and whenever the API key is undefined.

