### PR TITLE
[ci-visibility] Minor mocha and cucumber improvements

### DIFF
--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -142,5 +142,3 @@ addHook({
 
   return Runtime
 })
-
-module.exports = { pickleHook, testCaseHook }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -53,7 +53,7 @@ class MochaPlugin extends Plugin {
     this.sourceRoot = process.cwd()
     this.codeOwnersEntries = getCodeOwnersFileEntries(this.sourceRoot)
 
-    this.addSub('ci:mocha:run:start', (command) => {
+    this.addSub('ci:mocha:session:start', (command) => {
       if (!this.config.isAgentlessEnabled) {
         return
       }
@@ -154,7 +154,7 @@ class MochaPlugin extends Plugin {
       this._testNameToParams[name] = params
     })
 
-    this.addSub('ci:mocha:run:finish', (status) => {
+    this.addSub('ci:mocha:session:finish', (status) => {
       if (this.testSessionSpan) {
         this.testSessionSpan.setTag(TEST_STATUS, status)
         this.testSessionSpan.finish()


### PR DESCRIPTION
### What does this PR do?

* Do not export wrap functions for `mocha` and `cucumber`: this used to be needed but not anymore.
* Use `session` terminology instead of `run` for test sessions in mocha. 
* Do not run `Runnable.prototype.run` wrap function if dd-trace is not initialised. 

### Motivation
* Improve readability and do not run unnecessary code. 

