### PR TITLE
Make client_ip reporting opt-in

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -371,7 +371,6 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | flushInterval   | -                                  | `2000`         | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | flushMinSpans   | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` | `1000`         | Number of spans before partially exporting a trace. This prevents keeping all the spans in memory for very large traces. |
 | -               | `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` | -      | A regex to redact sensitive data from incoming requests' querystring reported in the `http.url` tag (matches will be replaced with `<redacted>`). Can be an empty string to disable redaction or `.*` to redact all querystring. **WARNING: this regex will execute for every incoming request on an unsafe input (url), please make sure you use a safe regex.** |
-| -               | `DD_TRACE_CLIENT_IP_HEADER_DISABLED` | `true`      | Whether to disable HTTP client IP reporting. Setting this to `false` will enable collection of the `http.client_ip` tag. |
 | -               | `DD_TRACE_CLIENT_IP_HEADER`        | -              | Custom header name to source the `http.client_ip` tag from. |
 | lookup          | -                                  | `dns.lookup()` | Custom function for DNS lookups when sending requests to the agent. |
 | protocolVersion | `DD_TRACE_AGENT_PROTOCOL_VERSION`  | `0.4`          | Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -371,7 +371,7 @@ Options can be configured as a parameter to the [init()](./interfaces/tracer.htm
 | flushInterval   | -                                  | `2000`         | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | flushMinSpans   | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` | `1000`         | Number of spans before partially exporting a trace. This prevents keeping all the spans in memory for very large traces. |
 | -               | `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` | -      | A regex to redact sensitive data from incoming requests' querystring reported in the `http.url` tag (matches will be replaced with `<redacted>`). Can be an empty string to disable redaction or `.*` to redact all querystring. **WARNING: this regex will execute for every incoming request on an unsafe input (url), please make sure you use a safe regex.** |
-| -               | `DD_TRACE_CLIENT_IP_HEADER_DISABLED` | `false`      | Whether to enable HTTP client IP reporting. Setting this to `true` will disable collection of the `http.client_ip` tag. |
+| -               | `DD_TRACE_CLIENT_IP_HEADER_DISABLED` | `true`      | Whether to disable HTTP client IP reporting. Setting this to `false` will enable collection of the `http.client_ip` tag. |
 | -               | `DD_TRACE_CLIENT_IP_HEADER`        | -              | Custom header name to source the `http.client_ip` tag from. |
 | lookup          | -                                  | `dns.lookup()` | Custom function for DNS lookups when sending requests to the agent. |
 | protocolVersion | `DD_TRACE_AGENT_PROTOCOL_VERSION`  | `0.4`          | Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped. |

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -149,10 +149,6 @@ class Config {
       process.env.DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP,
       qsRegex
     )
-    // const DD_TRACE_CLIENT_IP_HEADER_DISABLED = coalesce(
-    //   process.env.DD_TRACE_CLIENT_IP_HEADER_DISABLED,
-    //   true
-    // )
     const DD_TRACE_CLIENT_IP_HEADER = coalesce(
       process.env.DD_TRACE_CLIENT_IP_HEADER,
       null

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -149,10 +149,10 @@ class Config {
       process.env.DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP,
       qsRegex
     )
-    const DD_TRACE_CLIENT_IP_HEADER_DISABLED = coalesce(
-      process.env.DD_TRACE_CLIENT_IP_HEADER_DISABLED,
-      true
-    )
+    // const DD_TRACE_CLIENT_IP_HEADER_DISABLED = coalesce(
+    //   process.env.DD_TRACE_CLIENT_IP_HEADER_DISABLED,
+    //   true
+    // )
     const DD_TRACE_CLIENT_IP_HEADER = coalesce(
       process.env.DD_TRACE_CLIENT_IP_HEADER,
       null
@@ -314,7 +314,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.flushMinSpans = DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
     this.sampleRate = coalesce(Math.min(Math.max(sampler.sampleRate, 0), 1), 1)
     this.queryStringObfuscation = DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP
-    this.clientIpHeaderDisabled = isTrue(DD_TRACE_CLIENT_IP_HEADER_DISABLED)
+    this.clientIpHeaderDisabled = !isTrue(DD_APPSEC_ENABLED)
     this.clientIpHeader = DD_TRACE_CLIENT_IP_HEADER
     this.logger = options.logger
     this.plugins = !!coalesce(options.plugins, true)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -151,7 +151,7 @@ class Config {
     )
     const DD_TRACE_CLIENT_IP_HEADER_DISABLED = coalesce(
       process.env.DD_TRACE_CLIENT_IP_HEADER_DISABLED,
-      false
+      true
     )
     const DD_TRACE_CLIENT_IP_HEADER = coalesce(
       process.env.DD_TRACE_CLIENT_IP_HEADER,

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -59,7 +59,7 @@ describe('Config', () => {
     expect(config).to.have.property('flushInterval', 2000)
     expect(config).to.have.property('flushMinSpans', 1000)
     expect(config).to.have.property('queryStringObfuscation').with.length(626)
-    expect(config).to.have.property('clientIpHeaderDisabled', false)
+    expect(config).to.have.property('clientIpHeaderDisabled', true)
     expect(config).to.have.property('clientIpHeader', null)
     expect(config).to.have.property('sampleRate', 1)
     expect(config).to.have.property('runtimeMetrics', false)
@@ -113,7 +113,7 @@ describe('Config', () => {
     process.env.DD_SERVICE = 'service'
     process.env.DD_VERSION = '1.0.0'
     process.env.DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP = '.*'
-    process.env.DD_TRACE_CLIENT_IP_HEADER_DISABLED = 'true'
+    process.env.DD_TRACE_CLIENT_IP_HEADER_DISABLED = 'false'
     process.env.DD_TRACE_CLIENT_IP_HEADER = 'x-true-client-ip'
     process.env.DD_RUNTIME_METRICS_ENABLED = 'true'
     process.env.DD_TRACE_REPORT_HOSTNAME = 'true'
@@ -161,7 +161,7 @@ describe('Config', () => {
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('version', '1.0.0')
     expect(config).to.have.property('queryStringObfuscation', '.*')
-    expect(config).to.have.property('clientIpHeaderDisabled', true)
+    expect(config).to.have.property('clientIpHeaderDisabled', false)
     expect(config).to.have.property('clientIpHeader', 'x-true-client-ip')
     expect(config).to.have.property('runtimeMetrics', true)
     expect(config).to.have.property('reportHostname', true)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -113,7 +113,6 @@ describe('Config', () => {
     process.env.DD_SERVICE = 'service'
     process.env.DD_VERSION = '1.0.0'
     process.env.DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP = '.*'
-    process.env.DD_TRACE_CLIENT_IP_HEADER_DISABLED = 'false'
     process.env.DD_TRACE_CLIENT_IP_HEADER = 'x-true-client-ip'
     process.env.DD_RUNTIME_METRICS_ENABLED = 'true'
     process.env.DD_TRACE_REPORT_HOSTNAME = 'true'


### PR DESCRIPTION
### What does this PR do?
This PR removes the `DD_TRACE_CLIENT_IP_HEADER_DISABLED` and change its internal value to only activate the feature when `DD_APPSEC_ENABLED` is true, thus making it opt-in instead of the previous opt-out.

System tests: passes the `APPSEC_DISABLED` scenario and the `Test_StandardTagsClientIp` class in the default scenario.

### Motivation
This has been reported by customers to be counter-intuitive and unproductive.
