### PR TITLE
Trace function should keep rejected promises as unhandled

### DIFF
--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -44,11 +44,15 @@ class DatadogTracer extends Tracer {
       const result = this.scope().activate(span, () => fn(span))
 
       if (result && typeof result.then === 'function') {
-        result.then(
-          () => span.finish(),
+        return result.then(
+          value => {
+            span.finish()
+            return value
+          },
           err => {
             addError(span, err)
             span.finish()
+            throw err
           }
         )
       } else {

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -4,6 +4,7 @@ const Span = require('../src/opentracing/span')
 const { storage } = require('../../datadog-core')
 const Config = require('../src/config')
 const tags = require('../../../ext/tags')
+const { expect } = require('chai')
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
@@ -223,6 +224,20 @@ describe('Tracer', () => {
             done()
           })
           .catch(done)
+      })
+
+      it('should not treat rejections as handled', done => {
+        const err = new Error('boom')
+
+        tracer
+          .trace('name', {}, () => {
+            return Promise.reject(err)
+          })
+
+        process.once('unhandledRejection', (received) => {
+          expect(received).to.equal(err)
+          done()
+        })
       })
     })
 


### PR DESCRIPTION
### What does this PR do?

Fixes #2456

### Motivation

Currently promises passed through the trace function will be considered as handled due to attaching a `promise.then(...)` out-of-band. We should instead return a _new_ promise with a rethrown error so _that_ can be considered unhandled.