### PR TITLE
Change OCE test check for trace type instead of name

### DIFF
--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -239,7 +239,7 @@ describe('Overhead controller', () => {
               for (let i = 0; i < traces.length; i++) {
                 for (let j = 0; j < traces[i].length; j++) {
                   const trace = traces[i][j]
-                  if (trace.name === 'web.request') {
+                  if (trace.type === 'web') {
                     const url = trace.meta['http.url']
                     if (url.includes(FIRST_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).not.to.be.undefined
@@ -289,7 +289,7 @@ describe('Overhead controller', () => {
               for (let i = 0; i < traces.length; i++) {
                 for (let j = 0; j < traces[i].length; j++) {
                   const trace = traces[i][j]
-                  if (trace.name === 'web.request') {
+                  if (trace.type === 'web') {
                     urlCounter++
                     expect(trace.meta['_dd.iast.json']).not.to.be.undefined
                     if (urlCounter === 2) {
@@ -346,7 +346,7 @@ describe('Overhead controller', () => {
               for (let i = 0; i < traces.length; i++) {
                 for (let j = 0; j < traces[i].length; j++) {
                   const trace = traces[i][j]
-                  if (trace.name === 'web.request') {
+                  if (trace.type === 'web') {
                     counter++
                     const url = trace.meta['http.url']
                     if (url.includes(FIRST_REQUEST)) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
