### PR TITLE
Update types to use primitive number instead of Number wrapper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -176,7 +176,7 @@ export declare interface SamplingRule {
   /**
    * Sampling rate for this rule.
    */
-  sampleRate: Number
+  sampleRate: number
 
   /**
    * Service on which to apply this rule. The rule will apply to all services if not provided.
@@ -196,12 +196,12 @@ export declare interface SpanSamplingRule {
   /**
    * Sampling rate for this rule. Will default to 1.0 (always) if not provided.
    */
-  sampleRate?: Number
+  sampleRate?: number
 
   /**
    * Maximum number of spans matching a span sampling rule to be allowed per second.
    */
-  maxPerSecond?: Number
+  maxPerSecond?: number
 
   /**
    * Service name or pattern on which to apply this rule. The rule will apply to all services if not provided.
@@ -297,7 +297,7 @@ export declare interface TracerOptions {
    * and controls the ingestion rate limit between the agent and the backend.
    * Defaults to deferring the decision to the agent.
    */
-  rateLimit?: Number,
+  rateLimit?: number,
 
   /**
    * Sampling rules to apply to priority samplin. Each rule is a JSON,


### PR DESCRIPTION
### What does this PR do?
Update the typescript types so that they consistently use `number` rather than `Number`.

### Motivation
Just spotted it in the type definitions when looking through docs.

### Additional Notes
This doesnt really change much as the config is only read by dd-trace and primitive numbers can be used for Number args. This keeps things consistent with the other number args though.
