### PR TITLE
fix: do not overwrite server config if `config.server` provided to plugin

### DIFF
--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -193,6 +193,34 @@ describe('Plugin', () => {
       })
     })
 
+    describe('with a `server` configuration', () => {
+      beforeEach(() => {
+        return agent.load('http', { client: false, server: {} })
+          .then(() => {
+            http = require('http')
+          })
+      })
+
+      beforeEach(done => {
+        const server = new http.Server(listener)
+        appListener = server
+          .listen(port, 'localhost', () => done())
+      })
+
+      // see https://github.com/DataDog/dd-trace-js/issues/2453
+      it('should not have disabled tracing', (done) => {
+        const spy = sinon.spy(() => {})
+        agent.use(spy)
+
+        setTimeout(() => {
+          expect(spy).to.have.been.called
+          done()
+        }, 100)
+
+        axios.get(`http://localhost:${port}/user`).catch(done)
+      })
+    })
+
     describe('with a blocklist configuration', () => {
       beforeEach(() => {
         return agent.load('http', { client: false, blocklist: '/health' })

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -209,13 +209,9 @@ describe('Plugin', () => {
 
       // see https://github.com/DataDog/dd-trace-js/issues/2453
       it('should not have disabled tracing', (done) => {
-        const spy = sinon.spy(() => {})
-        agent.use(spy)
-
-        setTimeout(() => {
-          expect(spy).to.have.been.called
-          done()
-        }, 100)
+        agent.use(() => {})
+          .then(done)
+          .catch(done)
 
         axios.get(`http://localhost:${port}/user`).catch(done)
       })

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -51,8 +51,6 @@ const ends = new WeakMap()
 const web = {
   // Ensure the configuration has the correct structure and defaults.
   normalizeConfig (config) {
-    config = config.server || config
-
     const headers = getHeadersToRecord(config)
     const validateStatus = getStatusValidator(config)
     const hooks = getHooks(config)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -58,14 +58,15 @@ const web = {
     const middleware = getMiddlewareSetting(config)
     const queryStringObfuscation = getQsObfuscator(config)
 
-    return Object.assign({}, config, {
+    return {
+      ...config,
       headers,
       validateStatus,
       hooks,
       filter,
       middleware,
       queryStringObfuscation
-    })
+    }
   },
 
   setFramework (req, name, config) {

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -95,34 +95,6 @@ describe('plugins/util/web', () => {
       expect(config.hooks.request()).to.equal('test')
     })
 
-    it('should use the server config if set', () => {
-      const config = web.normalizeConfig({
-        server: {
-          headers: ['test'],
-          validateStatus: code => false,
-          hooks: {
-            request: () => 'test'
-          }
-        }
-      })
-
-      expect(config.headers).to.include('test')
-      expect(config.validateStatus(200)).to.equal(false)
-      expect(config).to.have.property('hooks')
-      expect(config.hooks.request()).to.equal('test')
-    })
-
-    it('should prioritize the server config over the shared config', () => {
-      const config = web.normalizeConfig({
-        headers: ['foo'],
-        server: {
-          headers: ['bar']
-        }
-      })
-
-      expect(config.headers).to.include('bar')
-    })
-
     describe('queryStringObfuscation', () => {
       it('should keep booleans as is', () => {
         const config = web.normalizeConfig({


### PR DESCRIPTION
### What does this PR do?
fixes https://github.com/DataDog/dd-trace-js/issues/2453

http plugin configured as composite plugin containing `server` and `client`: https://github.com/DataDog/dd-trace-js/blob/19c879d6082e93417be39d97842b2814d0f53a4b/packages/datadog-plugin-http/src/index.js#L10-L13

(`http2` plugin works similar way)

composite plugin will merge `server` and `client` into the root of the config: https://github.com/DataDog/dd-trace-js/blob/19c879d6082e93417be39d97842b2814d0f53a4b/packages/dd-trace/src/plugins/composite.js#L16-L19

server plugin calls `web.normalizeConfig`:
https://github.com/DataDog/dd-trace-js/blob/19c879d6082e93417be39d97842b2814d0f53a4b/packages/datadog-plugin-http/src/server.js#L48

(note the client plugin doesn't use this helper, hence doesn't have this bug)

`web.normalizeConfig` uses `config.server` if it's there, ignoring the root object (which already has `server` merged into it)

https://github.com/DataDog/dd-trace-js/blob/19c879d6082e93417be39d97842b2814d0f53a4b/packages/dd-trace/src/plugins/util/web.js#L54

There should be no need to take `config.server` there given `server` is already merged in to the root.

Alternative slightly safer fix could be to do `config = { ...config, ...config.server }` instead, but not sure if checking the `.server` property there is really needed?

### Motivation
Hit this bug locally trying to provide just a `server` config to the http plugin.

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

