### PR TITLE
upgrade sirun 0.1.9 -> 0.1.10 to enable instruction counting

### DIFF
--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 
 ENV NVM_DIR /usr/local/nvm
 
-RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.9/sirun-v0.1.9-x86_64-unknown-linux-gnu.tar.gz \
+RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-gnu.tar.gz \
 	&& tar -xzf sirun.tar.gz \
 	&& rm sirun.tar.gz \
 	&& mv sirun /usr/bin/sirun


### PR DESCRIPTION
### What does this PR do?
- introduces sirun with hardware counting enabled
- see https://github.com/DataDog/sirun/pull/61

### Motivation
- diminish benchmark flakiness (follow up PR)