### PR TITLE
updating sirun base image to be same version used for building

### DIFF
--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 debian:buster-slim
+FROM --platform=linux/amd64 ubuntu:22.04
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
 	wget curl ca-certificates valgrind \


### PR DESCRIPTION
### What does this PR do?
- updates base image that benchmarks run in to better match the [image that's used to build sirun](https://github.com/DataDog/sirun/blob/9506ccb2afaa51d50661478fe1fe8562e5ec2cf7/.github/workflows/release.yml#L8)

### Motivation
- the debian image that was previously used comes with GLIBC 2.28
- the ubuntu latest image comes with GLIBC 2.35
- sirun 0.1.9 depends on GLIBC up to 2.18
- sirun 0.1.10 depends on GLIBC up to 2.29

```
$ objdump -T ./sirun-v0.1.9-glibc | grep GLIBC | sed 's/.GLIBC_([.0-9])./\1/g' | sort -Vu
2.2.5 2.3 2.3.2 2.3.3
2.3.4 2.7 2.9 2.14
2.15 2.17 2.18

$ objdump -T ./sirun-v0.1.10-glibc | grep GLIBC | sed 's/.GLIBC_([.0-9])./\1/g' | sort -Vu
2.2.5 2.3 2.3.2 2.3.4
2.7 2.9 2.14 2.15
2.17 2.18 2.25 2.28
2.29
```