### PR TITLE
switching to musl build of sirun to avoid glibc issues

### DIFF
--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 
 ENV NVM_DIR /usr/local/nvm
 
-RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-gnu.tar.gz \
+RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-musl.tar.gz \
 	&& tar -xzf sirun.tar.gz \
 	&& rm sirun.tar.gz \
 	&& mv sirun /usr/bin/sirun


### PR DESCRIPTION
### What does this PR do?
- switches from glibc build of sirun to musl

### Motivation
- hopefully avoids any issues with glibc versions