### PR TITLE
add support for http client request filtering

### DIFF
--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -9,6 +9,7 @@ const tags = require('../../../ext/tags')
 const kinds = require('../../../ext/kinds')
 const formats = require('../../../ext/formats')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
+const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
 
 const HTTP_HEADERS = formats.HTTP_HEADERS
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
@@ -36,9 +37,10 @@ class Http2ClientPlugin extends Plugin {
       const pathname = path.split(/[?#]/)[0]
       const method = headers[HTTP2_HEADER_METHOD] || HTTP2_METHOD_GET
       const uri = `${sessionDetails.protocol}//${sessionDetails.host}:${sessionDetails.port}${pathname}`
+      const allowed = this.config.filter(uri)
 
       const store = storage.getStore()
-      const childOf = store ? store.span : store
+      const childOf = store && allowed ? store.span : null
       const span = this.tracer.startSpan('http.request', {
         childOf,
         tags: {
@@ -50,6 +52,11 @@ class Http2ClientPlugin extends Plugin {
           'http.url': uri
         }
       })
+
+      // TODO: Figure out a better way to do this for any span.
+      if (!allowed) {
+        span._spanContext._trace.record = false
+      }
 
       addHeaderTags(span, headers, HTTP_REQUEST_HEADERS, this.config)
 
@@ -155,12 +162,22 @@ function getStatusValidator (config) {
 
 function normalizeConfig (config) {
   const validateStatus = getStatusValidator(config)
+  const filter = getFilter(config)
   const headers = getHeaders(config)
 
   return Object.assign({}, config, {
     validateStatus,
+    filter,
     headers
   })
+}
+
+function getFilter (config) {
+  config = Object.assign({}, config, {
+    blocklist: config.blocklist || []
+  })
+
+  return urlFilter.getFilter(config)
 }
 
 function addHeaderTags (span, headers, prefix, config) {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -27,6 +27,7 @@ class SpanProcessor {
     const { flushMinSpans } = this._config
     const { started, finished } = trace
 
+    if (trace.record === false) return
     if (started.length === finished.length || finished.length >= flushMinSpans) {
       this._prioritySampler.sample(spanContext)
       this._spanSampler.sample(spanContext)

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -71,6 +71,15 @@ describe('SpanProcessor', () => {
   it('should skip traces with unfinished spans', () => {
     trace.started = [activeSpan, finishedSpan]
     trace.finished = [finishedSpan]
+    processor.process(finishedSpan)
+
+    expect(exporter.export).not.to.have.been.called
+  })
+
+  it('should skip unrecorded traces', () => {
+    trace.record = false
+    trace.started = [finishedSpan]
+    trace.finished = [finishedSpan]
     processor.process(activeSpan)
 
     expect(exporter.export).not.to.have.been.called


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for HTTP client request filtering.

### Motivation
<!-- What inspired you to submit this pull request? -->

This functionality was removed in 2.0 as it was using client sampling which was also removed in that version. However, there are many use cases for this, especially for health checks or to prevent tracing requests to other observability tools.

Closes #2208