### PR TITLE
Configure logging earlier to allow warnings from other configs

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const os = require('os')
 const URL = require('url').URL
 const path = require('path')
+const log = require('./log')
 const pkg = require('./pkg')
 const coalesce = require('koalas')
 const tagger = require('./tagger')
@@ -46,6 +47,21 @@ function remapify (input, mappings) {
 class Config {
   constructor (options) {
     options = options || {}
+
+    // Configure the logger first so it can be used to warn about other configs
+    this.debug = isTrue(coalesce(
+      process.env.DD_TRACE_DEBUG,
+      false
+    ))
+    this.logger = options.logger
+    this.logLevel = coalesce(
+      options.logLevel,
+      process.env.DD_TRACE_LOG_LEVEL,
+      'debug'
+    )
+
+    log.use(this.logger)
+    log.toggle(this.debug, this.logLevel, this)
 
     this.tags = {}
 
@@ -130,10 +146,6 @@ class Config {
     const DD_TRACE_TELEMETRY_ENABLED = coalesce(
       process.env.DD_TRACE_TELEMETRY_ENABLED,
       !process.env.AWS_LAMBDA_FUNCTION_NAME
-    )
-    const DD_TRACE_DEBUG = coalesce(
-      process.env.DD_TRACE_DEBUG,
-      false
     )
     const DD_TRACE_AGENT_PROTOCOL_VERSION = coalesce(
       options.protocolVersion,
@@ -298,7 +310,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     const defaultFlushInterval = inAWSLambda ? 0 : 2000
 
     this.tracing = !isFalse(DD_TRACING_ENABLED)
-    this.debug = isTrue(DD_TRACE_DEBUG)
     this.logInjection = isTrue(DD_LOGS_INJECTION)
     this.env = DD_ENV
     this.url = DD_CIVISIBILITY_AGENTLESS_URL ? new URL(DD_CIVISIBILITY_AGENTLESS_URL)
@@ -312,7 +323,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.queryStringObfuscation = DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP
     this.clientIpHeaderDisabled = !isTrue(DD_APPSEC_ENABLED)
     this.clientIpHeader = DD_TRACE_CLIENT_IP_HEADER
-    this.logger = options.logger
     this.plugins = !!coalesce(options.plugins, true)
     this.service = DD_SERVICE
     this.serviceMapping = DD_SERVICE_MAPPING.length ? fromEntries(
@@ -334,11 +344,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.sampler = sampler
     this.reportHostname = isTrue(coalesce(options.reportHostname, process.env.DD_TRACE_REPORT_HOSTNAME, false))
     this.scope = process.env.DD_TRACE_SCOPE
-    this.logLevel = coalesce(
-      options.logLevel,
-      process.env.DD_TRACE_LOG_LEVEL,
-      'debug'
-    )
     this.profiling = {
       enabled: isTrue(DD_PROFILING_ENABLED),
       sourceMap: !isFalse(DD_PROFILING_SOURCE_MAP),

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -29,9 +29,6 @@ class Tracer extends NoopProxy {
     try {
       const config = new Config(options) // TODO: support dynamic config
 
-      log.use(config.logger)
-      log.toggle(config.debug, config.logLevel, this)
-
       if (config.profiling.enabled) {
         // do not stop tracer initialization if the profiler fails to be imported
         try {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -6,6 +6,7 @@ const path = require('path')
 
 describe('Config', () => {
   let Config
+  let log
   let pkg
   let env
   let fs
@@ -18,6 +19,12 @@ describe('Config', () => {
     pkg = {
       name: '',
       version: ''
+    }
+
+    log = {
+      use: sinon.spy(),
+      toggle: sinon.spy(),
+      warn: sinon.spy()
     }
 
     env = process.env
@@ -37,6 +44,7 @@ describe('Config', () => {
 
     Config = proxyquire('../src/config', {
       './pkg': pkg,
+      './log': log,
       fs,
       os
     })
@@ -82,6 +90,16 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex').with.length(155)
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex').with.length(443)
     expect(config).to.have.nested.property('iast.enabled', false)
+  })
+
+  it('should support logging', () => {
+    const config = new Config({
+      logger: {},
+      debug: true
+    })
+
+    expect(log.use).to.have.been.calledWith(config.logger)
+    expect(log.toggle).to.have.been.calledWith(config.debug)
   })
 
   it('should initialize from the default service', () => {

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -40,8 +40,6 @@ describe('TracerProxy', () => {
     }
 
     log = {
-      use: sinon.spy(),
-      toggle: sinon.spy(),
       error: sinon.spy()
     }
 
@@ -126,13 +124,6 @@ describe('TracerProxy', () => {
         proxy.init()
 
         expect(DatadogTracer).to.not.have.been.called
-      })
-
-      it('should support logging', () => {
-        proxy.init()
-
-        expect(log.use).to.have.been.calledWith(config.logger)
-        expect(log.toggle).to.have.been.calledWith(config.debug)
       })
 
       it('should not capture metrics by default', () => {


### PR DESCRIPTION
### What does this PR do?

This configures the logger before anything else in the config class to allow it to be used for warnings from other configs.

### Motivation

We want to be able to warn the user when configs are invalid or unexpected in some way. This enables the logger to work during the rest of the Config constructor.