### PR TITLE
Change the user in the Docker image

### DIFF
--- a/k8s/auto-inst/Dockerfile
+++ b/k8s/auto-inst/Dockerfile
@@ -7,4 +7,6 @@ COPY . .
 
 RUN npm install ./dd-trace.tgz
 
+USER node
+
 ADD copy-lib.sh /operator-build/copy-lib.sh


### PR DESCRIPTION
### What does this PR do?
This PR makes containers started from `dd-lib-js-init` image use the non-root `node` user.
Resolves https://github.com/DataDog/dd-trace-js/issues/2506

### Motivation
In Kubernetes Pod definitions where the following configuration is used, the init-container created from this image fails to start
```
securityContext:
        runAsNonRoot: true
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
