### PR TITLE
Fix taint tracking return values

### DIFF
--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -92,14 +92,14 @@ function isTainted (iastContext, string) {
 }
 
 function getRanges (iastContext, string) {
-  let ret = []
+  let result = []
   if (iastContext && iastContext[IAST_TRANSACTION_ID]) {
     const transactionId = iastContext[IAST_TRANSACTION_ID]
-    ret = TaintedUtils.getRanges(transactionId, string)
+    result = TaintedUtils.getRanges(transactionId, string)
   } else {
-    ret = []
+    result = []
   }
-  return ret
+  return result
 }
 
 function enableTaintOperations () {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -44,10 +44,14 @@ function removeTransaction (iastContext) {
 }
 
 function newTaintedString (iastContext, string, name, type) {
+  let result = string
   if (iastContext && iastContext[IAST_TRANSACTION_ID]) {
     const transactionId = iastContext[IAST_TRANSACTION_ID]
-    return TaintedUtils.newTaintedString(transactionId, string, name, type)
+    result = TaintedUtils.newTaintedString(transactionId, string, name, type)
+  } else {
+    result = string
   }
+  return result
 }
 
 function taintObject (iastContext, object, type) {
@@ -77,19 +81,25 @@ function taintObject (iastContext, object, type) {
 }
 
 function isTainted (iastContext, string) {
+  let result = false
   if (iastContext && iastContext[IAST_TRANSACTION_ID]) {
     const transactionId = iastContext[IAST_TRANSACTION_ID]
-    return TaintedUtils.isTainted(transactionId, string)
+    result = TaintedUtils.isTainted(transactionId, string)
   } else {
-    return false
+    result = false
   }
+  return result
 }
 
 function getRanges (iastContext, string) {
+  let ret = []
   if (iastContext && iastContext[IAST_TRANSACTION_ID]) {
     const transactionId = iastContext[IAST_TRANSACTION_ID]
-    return TaintedUtils.getRanges(transactionId, string)
+    ret = TaintedUtils.getRanges(transactionId, string)
+  } else {
+    ret = []
   }
+  return ret
 }
 
 function enableTaintOperations () {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
@@ -151,6 +151,13 @@ describe('IAST TaintTracking Operations', () => {
       taintTrackingOperations.newTaintedString(iastContext)
       expect(taintedUtils.newTaintedString).not.to.be.called
     })
+
+    it('Given null iastContext should return the string passed as parameter', () => {
+      const iastContext = null
+      const value = 'test'
+      const result = taintTrackingOperations.newTaintedString(iastContext, value)
+      expect(result).to.be.equal('test')
+    })
   })
 
   describe('isTainted', () => {
@@ -192,6 +199,7 @@ describe('IAST TaintTracking Operations', () => {
         value
       )
     })
+
     it('Given iastContext with undefined IAST_TRANSACTION_ID should not call TaintedUtils.getRanges', () => {
       const iastContext = {}
       taintTrackingOperations.getRanges(iastContext)
@@ -202,6 +210,12 @@ describe('IAST TaintTracking Operations', () => {
       const iastContext = null
       taintTrackingOperations.getRanges(iastContext)
       expect(taintedUtils.getRanges).not.to.be.called
+    })
+
+    it('Given null iastContext should return empty array', () => {
+      const result = taintTrackingOperations.getRanges(null)
+      expect(result).to.be.instanceof(Array)
+      expect(result).to.have.length(0)
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
Refactor `newTaintedString` and `getRanges` in order to return a meaningful value and not let the value become undefined.
