### PR TITLE
Adds getLocalRootSpan() method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,12 @@ export declare interface Tracer extends opentracing.Tracer {
    * @returns {Tracer} The Tracer instance for chaining.
    */
   setUser(user: User): Tracer;
+
+  /**
+   * Returns the current loca root span
+   * @returns {Span} The local root span for the tracer
+   */
+  getLocalRootSpan(): Span;
 }
 
 export declare interface TraceOptions extends Analyzable {

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -72,6 +72,10 @@ class Tracer {
     this._tracer.setUser.apply(this._tracer, arguments)
     return this
   }
+
+  getLocalRootSpan(){
+    return this._tracer.getLocalRootSpan.apply(this._tracer)
+  }
 }
 
 module.exports = Tracer

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -73,7 +73,7 @@ class Tracer {
     return this
   }
 
-  getLocalRootSpan(){
+  getLocalRootSpan () {
     return this._tracer.getLocalRootSpan.apply(this._tracer)
   }
 }

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -41,6 +41,10 @@ class NoopTracer {
   setUser () {
     return this
   }
+
+  getLocalRootSpan(){
+    return this
+  }
 }
 
 module.exports = NoopTracer

--- a/packages/dd-trace/src/noop/tracer.js
+++ b/packages/dd-trace/src/noop/tracer.js
@@ -42,7 +42,7 @@ class NoopTracer {
     return this
   }
 
-  getLocalRootSpan(){
+  getLocalRootSpan () {
     return this
   }
 }

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -149,14 +149,15 @@ class DatadogSpan {
         parentId: parent._spanId,
         sampling: parent._sampling,
         baggageItems: Object.assign({}, parent._baggageItems),
-        trace: parent._trace
+        trace: parent._trace,
+        localRoot: parent._localRoot
       })
     } else {
       const spanId = id()
       spanContext = new SpanContext({
         traceId: spanId,
         spanId
-      })
+      }) 
     }
 
     spanContext._trace.started.push(this)

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -157,7 +157,7 @@ class DatadogSpan {
       spanContext = new SpanContext({
         traceId: spanId,
         spanId
-      }) 
+      })
     }
 
     spanContext._trace.started.push(this)

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -18,6 +18,7 @@ class DatadogSpanContext {
       finished: [],
       tags: {}
     }
+    this._localRoot = props.localRoot || null
   }
 
   toTraceId () {

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -65,7 +65,7 @@ class DatadogTracer {
     span.addTags(options.tags)
 
     const spanCtx = getContext(span)
-    if(parent && spanCtx){
+    if(parent === null && spanCtx !== null){
       spanCtx._localRoot = span
     }
     return span

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -65,7 +65,7 @@ class DatadogTracer {
     span.addTags(options.tags)
 
     const spanCtx = getContext(span)
-    if(parent === null && spanCtx !== null){
+    if (parent === null && spanCtx !== null) {
       spanCtx._localRoot = span
     }
     return span

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -64,6 +64,10 @@ class DatadogTracer {
     span.addTags(this._tags)
     span.addTags(options.tags)
 
+    const spanCtx = getContext(span)
+    if(parent && spanCtx){
+      spanCtx._localRoot = span
+    }
     return span
   }
 

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -138,6 +138,14 @@ class DatadogTracer extends Tracer {
 
     return this
   }
+
+  getLocalRootSpan (){
+    const span = this.scope().active()
+    if(span){
+      return span._spanContext._localRoot
+    }
+    return null
+  }
 }
 
 function addError (span, error) {

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -139,9 +139,9 @@ class DatadogTracer extends Tracer {
     return this
   }
 
-  getLocalRootSpan (){
+  getLocalRootSpan () {
     const span = this.scope().active()
-    if(span){
+    if (span) {
       return span._spanContext._localRoot
     }
     return null

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -27,7 +27,7 @@ describe('SpanContext', () => {
         finished: ['span1'],
         tags: { foo: 'bar' }
       },
-      localRoot: null,
+      localRoot: null
     }
     const spanContext = new SpanContext(props)
 
@@ -46,7 +46,7 @@ describe('SpanContext', () => {
         finished: ['span1'],
         tags: { foo: 'bar' }
       },
-      _localRoot: null,
+      _localRoot: null
     })
   })
 
@@ -71,7 +71,7 @@ describe('SpanContext', () => {
         finished: [],
         tags: {}
       },
-      _localRoot: null,
+      _localRoot: null
     })
   })
 

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -26,7 +26,8 @@ describe('SpanContext', () => {
         started: ['span1', 'span2'],
         finished: ['span1'],
         tags: { foo: 'bar' }
-      }
+      },
+      localRoot: null,
     }
     const spanContext = new SpanContext(props)
 
@@ -44,7 +45,8 @@ describe('SpanContext', () => {
         started: ['span1', 'span2'],
         finished: ['span1'],
         tags: { foo: 'bar' }
-      }
+      },
+      _localRoot: null,
     })
   })
 
@@ -68,7 +70,8 @@ describe('SpanContext', () => {
         started: [],
         finished: [],
         tags: {}
-      }
+      },
+      _localRoot: null,
     })
   })
 

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -573,14 +573,14 @@ describe('Tracer', () => {
     })
   })
 
-  describe('getLocalRootSpan', () =>{
-    it('A single span trace', () =>{
-      tracer.trace('name', {}, (span) =>{
+  describe('getLocalRootSpan', () => {
+    it('A single span trace', () => {
+      tracer.trace('name', {}, (span) => {
         expect(tracer.getLocalRootSpan()).to.equal(span)
       })
     })
 
-    it('A multi span trace', () =>{
+    it('A multi span trace', () => {
       const root = tracer.startSpan('parent')
 
       tracer.scope().activate(root, () => {
@@ -590,11 +590,11 @@ describe('Tracer', () => {
       })
     })
 
-    it('A multi span trace with different services', () =>{
+    it('A multi span trace with different services', () => {
       const root = tracer.startSpan('parent')
 
       tracer.scope().activate(root, () => {
-        tracer.trace('name', {service: 'foo'}, span => {
+        tracer.trace('name', { service: 'foo' }, span => {
           expect(tracer.getLocalRootSpan()).to.equal(root)
         })
       })

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -572,4 +572,32 @@ describe('Tracer', () => {
       })
     })
   })
+
+  describe('getLocalRootSpan', () =>{
+    it('A single span trace', () =>{
+      tracer.trace('name', {}, (span) =>{
+        expect(tracer.getLocalRootSpan()).to.equal(span)
+      })
+    })
+
+    it('A multi span trace', () =>{
+      const root = tracer.startSpan('parent')
+
+      tracer.scope().activate(root, () => {
+        tracer.trace('name', {}, span => {
+          expect(tracer.getLocalRootSpan()).to.equal(root)
+        })
+      })
+    })
+
+    it('A multi span trace with different services', () =>{
+      const root = tracer.startSpan('parent')
+
+      tracer.scope().activate(root, () => {
+        tracer.trace('name', {service: 'foo'}, span => {
+          expect(tracer.getLocalRootSpan()).to.equal(root)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Add the functionality to get the local root span from the tracer. 
```
tracer.getLocalRootSpan()
```

### Motivation
APMJS-105 

### Additional Notes

