### PR TITLE
reduce sirun benchmark flakiness by running processes longer

### DIFF
--- a/benchmark/sirun/.gitignore
+++ b/benchmark/sirun/.gitignore
@@ -1,2 +1,2 @@
-results.ndjson
+*.ndjson
 meta-temp.json

--- a/benchmark/sirun/appsec/common.js
+++ b/benchmark/sirun/appsec/common.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   port: 3032,
-  reqs: 1000
+  reqs: 100
 }

--- a/benchmark/sirun/appsec/meta.json
+++ b/benchmark/sirun/appsec/meta.json
@@ -2,7 +2,7 @@
   "name": "appsec",
   "cachegrind": false,
   "instructions": true,
-  "iterations": 24,
+  "iterations": 100,
   "variants": {
     "control": {
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",

--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -10,8 +10,8 @@ const hostname = require('os').hostname()
 
 const config = {
   url: 'http://localhost:8126',
-  flushInterval: 2000,
-  flushMinSpans: 1000,
+  flushInterval: 1000,
+  flushMinSpans: 100,
   protocolVersion: process.env.ENCODER_VERSION,
   stats: {
     enabled: process.env.WITH_STATS === '1'
@@ -25,7 +25,7 @@ const finished = []
 const trace = { finished, started: finished, tags: {} }
 
 function createSpan (parent) {
-  const spanId = id()
+  const spanId = id(0)
   const context = {
     _trace: trace,
     _spanId: spanId,
@@ -62,7 +62,7 @@ function processSpans () {
   sp.process(finished[0])
   trace.finished = finished
   trace.started = finished
-  if (++iterations < 2500) {
+  if (++iterations < 250) {
     setImmediate(processSpans)
   }
 }

--- a/benchmark/sirun/exporting-pipeline/meta.json
+++ b/benchmark/sirun/exporting-pipeline/meta.json
@@ -3,7 +3,7 @@
   "setup": "bash -c \"nohup node ../../e2e/fake-agent.js >/dev/null 2>&1 &\"",
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
-  "iterations": 22,
+  "iterations": 100,
   "instructions": true,
   "cachegrind": false,
   "variants": {

--- a/benchmark/sirun/plugin-http/common.js
+++ b/benchmark/sirun/plugin-http/common.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   port: 3031,
-  reqs: 700
+  reqs: 350
 }

--- a/benchmark/sirun/plugin-http/meta.json
+++ b/benchmark/sirun/plugin-http/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-http",
   "cachegrind": false,
-  "iterations": 20,
+  "iterations": 40,
   "instructions": true,
   "variants": {
     "client-control": {

--- a/benchmark/sirun/plugin-net/common.js
+++ b/benchmark/sirun/plugin-net/common.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   port: 3033,
-  reqs: 1000
+  reqs: 100
 }

--- a/benchmark/sirun/plugin-net/meta.json
+++ b/benchmark/sirun/plugin-net/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "net",
   "cachegrind": false,
-  "iterations": 50,
+  "iterations": 300,
   "instructions": true,
   "setup": "bash -c \"nohup node server.js >/dev/null 2>&1 &\"",
   "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node server.js >/dev/null 2>&1 &\"",

--- a/benchmark/sirun/plugin-net/server.js
+++ b/benchmark/sirun/plugin-net/server.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const net = require('net')
-const { port } = require('./common')
+const { port, reqs } = require('./common')
 
 let connectionsMade = 0
 
 const server = net.createServer(c => {
-  if (++connectionsMade === 10000) {
+  if (++connectionsMade === reqs) {
     c.on('end', () => server.close())
   }
   c.pipe(c)

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -43,7 +43,9 @@ for D in *; do
   fi
 done
 
-wait
+wait # waits until all tests are complete before continuing
+
+node ./strip-unwanted-results.js
 
 echo "Benchmark Results:"
 cat ./results.ndjson

--- a/benchmark/sirun/strip-unwanted-results.js
+++ b/benchmark/sirun/strip-unwanted-results.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const IGNORE_TESTS = new Set([
+  'profiler'
+])
+
+const IGNORE_STATS = [
+  'system.time'
+]
+
+const lines = fs
+  .readFileSync(path.join(__dirname, 'results.ndjson'))
+  .toString()
+  .trim()
+  .split('\n')
+
+const results = []
+
+for (const line of lines) {
+  const obj = JSON.parse(line)
+
+  if (IGNORE_TESTS.has(obj.name)) {
+    continue
+  }
+
+  for (const iteration of obj.iterations) {
+    for (const stat of IGNORE_STATS) {
+      if (stat in iteration) {
+        delete iteration[stat]
+      }
+    }
+  }
+  results.push(JSON.stringify(obj))
+}
+
+fs.writeFileSync('./results.ndjson', results.join('\n'))


### PR DESCRIPTION
### What does this PR do?
- halves iterations and doubles length of iteration for two flaky benchmark tests
- this should make the tests more stable
- fixes a 10,000 / 1,000 value that was out of sync
- removes system time as it was the worst offender
- removes profiler test since it doesn't currently work

### Motivation
- sirun benchmarks are currently too flaky