### PR TITLE
Remove sql.query tag from oracledb

### DIFF
--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -17,7 +17,6 @@ class OracledbPlugin extends DatabasePlugin {
       type: 'sql',
       kind: 'client',
       meta: {
-        'sql.query': query,
         'db.user': this.config.user,
         'db.instance': url.pathname && url.pathname.substring(1),
         'db.hostname': url.hostname,

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -67,7 +67,6 @@ describe('Plugin', () => {
               expect(traces[0][0]).to.have.property('type', 'sql')
               expect(traces[0][0].meta).to.have.property('service', 'test')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('sql.query', 'select current_timestamp from dual')
               if (url) {
                 expect(traces[0][0].meta).to.have.property('db.instance', url.pathname.slice(1))
                 expect(traces[0][0].meta).to.have.property('db.hostname', url.hostname)
@@ -93,7 +92,6 @@ describe('Plugin', () => {
               expect(traces[0][0]).to.have.property('type', 'sql')
               expect(traces[0][0].meta).to.have.property('service', 'test')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('sql.query', 'select current_timestamp from dual')
               if (url) {
                 expect(traces[0][0].meta).to.have.property('db.instance', url.pathname.slice(1))
                 expect(traces[0][0].meta).to.have.property('db.hostname', url.hostname)
@@ -127,7 +125,6 @@ describe('Plugin', () => {
               expect(traces[0][0]).to.have.property('type', 'sql')
               expect(traces[0][0].meta).to.have.property('service', 'test')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('sql.query', 'invalid')
               if (url) {
                 expect(traces[0][0].meta).to.have.property('db.instance', url.pathname.slice(1))
                 expect(traces[0][0].meta).to.have.property('db.hostname', url.hostname)
@@ -186,7 +183,6 @@ describe('Plugin', () => {
               expect(traces[0][0]).to.have.property('type', 'sql')
               expect(traces[0][0].meta).to.have.property('service', 'test')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('sql.query', 'select current_timestamp from dual')
               if (url) {
                 expect(traces[0][0].meta).to.have.property('db.instance', url.pathname.slice(1))
                 expect(traces[0][0].meta).to.have.property('db.hostname', url.hostname)
@@ -211,7 +207,6 @@ describe('Plugin', () => {
               expect(traces[0][0]).to.have.property('type', 'sql')
               expect(traces[0][0].meta).to.have.property('service', 'test')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('sql.query', 'invalid')
               if (url) {
                 expect(traces[0][0].meta).to.have.property('db.instance', url.pathname.slice(1))
                 expect(traces[0][0].meta).to.have.property('db.hostname', url.hostname)


### PR DESCRIPTION
### What does this PR do?

Removes the `sql.query` tag from oracledb spans.

### Motivation

The `sql.query` tag should be omitted as it will be set by the agent. Including it prevents the agent from obfuscating the query.

### Plugin Checklist

- [x] Unit tests.
