### PR TITLE
[ci-visibility] Enable git metadata upload if ITR is enabled

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -372,8 +372,9 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     }
 
     const isCiVisibilityAgentlessEnabled = isTrue(DD_CIVISIBILITY_AGENTLESS_ENABLED)
-    this.isGitUploadEnabled = isCiVisibilityAgentlessEnabled && isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED)
     this.isIntelligentTestRunnerEnabled = isCiVisibilityAgentlessEnabled && isTrue(DD_CIVISIBILITY_ITR_ENABLED)
+    this.isGitUploadEnabled = this.isIntelligentTestRunnerEnabled ||
+      (isCiVisibilityAgentlessEnabled && isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED))
 
     this.stats = {
       enabled: isTrue(DD_TRACE_STATS_COMPUTATION_ENABLED)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -58,7 +58,7 @@ class Tracer extends NoopProxy {
         telemetry.start(config, this._pluginManager)
       }
 
-      if (config.isGitUploadEnabled) {
+      if (config.isGitUploadEnabled || config.isIntelligentTestRunnerEnabled) {
         sendGitMetadata(config.site, (err) => {
           if (err) {
             log.error(`Error uploading git metadata: ${err}`)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -58,7 +58,7 @@ class Tracer extends NoopProxy {
         telemetry.start(config, this._pluginManager)
       }
 
-      if (config.isGitUploadEnabled || config.isIntelligentTestRunnerEnabled) {
+      if (config.isGitUploadEnabled) {
         sendGitMetadata(config.site, (err) => {
           if (err) {
             log.error(`Error uploading git metadata: ${err}`)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -772,10 +772,21 @@ describe('Config', () => {
       beforeEach(() => {
         process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED = 'true'
       })
+      it('should activate git upload if the env var is passed', () => {
+        process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'true'
+        const config = new Config()
+        expect(config).to.have.property('isGitUploadEnabled', true)
+      })
       it('should activate intelligent test runner if the env var is passed', () => {
         process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
         const config = new Config()
         expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
+      })
+      it('should activate git upload automatically if intelligent test runner is activated', () => {
+        process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
+        const config = new Config()
+        expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
+        expect(config).to.have.property('isGitUploadEnabled', true)
       })
     })
     context('agentless is disabled', () => {


### PR DESCRIPTION
### What does this PR do?
Enable git metadata upload if ITR is enabled 

### Motivation
Git metadata upload is necessary for ITR to work, so it makes sense that it's not necessary to set an extra environment variable (`DD_CIVISIBILITY_GIT_UPLOAD_ENABLED`) when `DD_CIVISIBILITY_ITR_ENABLED` is already set.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
