### PR TITLE
[ci-visibility] Do not upload git or use ITR if agentless is disabled

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -113,6 +113,7 @@ class Config {
       null
     )
     const DD_CIVISIBILITY_AGENTLESS_URL = process.env.DD_CIVISIBILITY_AGENTLESS_URL
+    const DD_CIVISIBILITY_AGENTLESS_ENABLED = process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED
 
     const DD_CIVISIBILITY_ITR_ENABLED = coalesce(
       process.env.DD_CIVISIBILITY_ITR_ENABLED,
@@ -369,8 +370,11 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       maxConcurrentRequests: DD_IAST_MAX_CONCURRENT_REQUESTS,
       maxContextOperations: DD_IAST_MAX_CONTEXT_OPERATIONS
     }
-    this.isGitUploadEnabled = isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED)
-    this.isIntelligentTestRunnerEnabled = isTrue(DD_CIVISIBILITY_ITR_ENABLED)
+
+    const isCiVisibilityAgentlessEnabled = isTrue(DD_CIVISIBILITY_AGENTLESS_ENABLED)
+    this.isGitUploadEnabled = isCiVisibilityAgentlessEnabled && isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED)
+    this.isIntelligentTestRunnerEnabled = isCiVisibilityAgentlessEnabled && isTrue(DD_CIVISIBILITY_ITR_ENABLED)
+
     this.stats = {
       enabled: isTrue(DD_TRACE_STATS_COMPUTATION_ENABLED)
     }

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -761,4 +761,34 @@ describe('Config', () => {
       })
     })
   })
+
+  context('ci visibility config', () => {
+    beforeEach(() => {
+      delete process.env.DD_CIVISIBILITY_ITR_ENABLED
+      delete process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED
+      delete process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED
+    })
+    context('agentless is enabled', () => {
+      beforeEach(() => {
+        process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED = 'true'
+      })
+      it('should activate intelligent test runner if the env var is passed', () => {
+        process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
+        const config = new Config()
+        expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
+      })
+    })
+    context('agentless is disabled', () => {
+      beforeEach(() => {
+        process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED = 'false'
+      })
+      it('should not activate intelligent test runner or git metadata upload', () => {
+        process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
+        process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'true'
+        const config = new Config()
+        expect(config).to.have.property('isIntelligentTestRunnerEnabled', false)
+        expect(config).to.have.property('isGitUploadEnabled', false)
+      })
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Do not enable git upload or ITR if agentless for ci vis is not enabled.

### Motivation
There should be no external requests if agentless is not enabled. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
