### PR TITLE
hapi@21 tests are broken due to node v12

### DIFF
--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
           })
       })
 
-      if (semver.intersects(version, '>=17')) {
+      if (semver.intersects(version, '>=17 <20')) {
         beforeEach(() => {
           return getPort()
             .then(_port => {
@@ -192,7 +192,7 @@ describe('Plugin', () => {
           .catch(done)
       })
 
-      if (semver.intersects(version, '>=11')) {
+      if (semver.intersects(version, '>=11 <20')) {
         it('should run extension events in the request scope', done => {
           server.route({
             method: 'POST',

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
           })
       })
 
-      if (semver.intersects(version, '>=17 <20')) {
+      if (semver.intersects(version, '>=17 <=20')) {
         beforeEach(() => {
           return getPort()
             .then(_port => {
@@ -192,7 +192,7 @@ describe('Plugin', () => {
           .catch(done)
       })
 
-      if (semver.intersects(version, '>=11 <20')) {
+      if (semver.intersects(version, '>=11 <=20')) {
         it('should run extension events in the request scope', done => {
           server.route({
             method: 'POST',


### PR DESCRIPTION
Attempting to fix failing tests. Currently we're running all of the hapi tests with node.js v12, which is no longer supported with hapi v21.

```
  103 passing (3s)
  1 failing

  1) Plugin
       hapi
         with @hapi/hapi >=17.9 (21.0.0)
           "before all" hook for "should do automatic instrumentation on routes":
     /home/runner/work/dd-trace-js/dd-trace-js/versions/@hapi/hapi@>=17.9/node_modules/@hapi/hapi/lib/server.js:103
        this._core.controlled = this._core.controlled ?? [];                                                  ^
```

This is a stopgap to fix master and get deployments working. Long term fix is to have the tests not run strictly on a single node version.