### PR TITLE
hapi v21 does not support node v12

### DIFF
--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
           })
       })
 
-      if (semver.intersects(version, '>=17')) {
+      if (semver.intersects(version, '>=17 <21')) {
         beforeEach(() => {
           return getPort()
             .then(_port => {


### PR DESCRIPTION
### What does this PR do?
- if this passes I'll add the change to the v2.x branch before releasing
- node v12 is not supported by hapi v21
- customers probably aren't using old v2 of dd-trace with new hapi v21
