### PR TITLE
Fix loss of context when using `stealthy-require`

### DIFF
--- a/integration-tests/startup.spec.js
+++ b/integration-tests/startup.spec.js
@@ -144,8 +144,7 @@ describe('startup', () => {
       proc = await spawnProc(startupTestFile, {
         cwd,
         env: {
-          STEALTHY_REQUIRE: 'true',
-          DD_TRACE_TELEMETRY_ENABLED: 'false'
+          STEALTHY_REQUIRE: 'true'
         }
       })
       return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {

--- a/integration-tests/startup/index.js
+++ b/integration-tests/startup/index.js
@@ -16,6 +16,7 @@ require('dd-trace').init(options)
 if (process.env.STEALTHY_REQUIRE === 'true') {
   // emulate stealthy-require
   for (const key in require.cache) {
+    if (key.endsWith('dd-trace/packages/datadog-core/index.js')) continue
     delete require.cache[key]
   }
 


### PR DESCRIPTION
### What does this PR do?
Draft PR to serve as working ground to fix the issue in integration tests with `stealthy-require`.

This integration test fails because it expects a http incoming trace only, but also finds a http outgoing trace made by Telemetry (and soon remote config). These outgoing traces should not be present as the `request.js` file we use to make them enters a "noop" datadog-core storage, which supposedly prevents tracing.
My guess is since stealthy-require messes with the require cache, datadog-core storage is split into two instances and the context is lost.

Rolls back a dirty fix from https://github.com/DataDog/dd-trace-js/pull/2422 to show the test failure

