### PR TITLE
[ci-visibility] New `CiPlugin` for CI Vis plugins 

### DIFF
--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -50,7 +50,7 @@ function wrapRun (pl, isLatestVersion) {
 
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     return asyncResource.runInAsyncScope(() => {
-      runStartCh.publish({ pickleName: this.pickle.name, pickleUri: this.pickle.uri })
+      runStartCh.publish({ testName: this.pickle.name, fullTestSuite: this.pickle.uri })
       try {
         const promise = run.apply(this, arguments)
         promise.finally(() => {

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -317,7 +317,7 @@ addHook({
    * If ITR is disabled, `onDone` is called immediately on the subscriber
    */
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
-    const onReceivedSkippableSuites = (err, skippableSuites) => {
+    const onReceivedSkippableSuites = ({ err, skippableSuites }) => {
       if (err) {
         log.error(err)
         suitesToSkip = []
@@ -327,7 +327,7 @@ addHook({
       run.apply(this, arguments)
     }
 
-    const onReceivedConfiguration = (err) => {
+    const onReceivedConfiguration = ({ err }) => {
       if (err) {
         log.error(err)
         return run.apply(this, arguments)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -192,7 +192,6 @@ class JestPlugin extends CiPlugin {
     const extraTags = {
       [JEST_TEST_RUNNER]: runner,
       [TEST_PARAMETERS]: testParameters,
-      [COMPONENT]: this.constructor.name,
       ...suiteTags
     }
 

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -181,8 +181,7 @@ class MochaPlugin extends CiPlugin {
     const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.sourceRoot)
 
     const extraTags = {
-      ...testSuiteTags,
-      [COMPONENT]: this.constructor.name
+      ...testSuiteTags
     }
 
     const testParametersString = getTestParametersString(this._testNameToParams, test.title)

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -1,0 +1,98 @@
+const { channel } = require('diagnostics_channel')
+
+const { getTestEnvironmentMetadata, getCodeOwnersFileEntries } = require('./util/test')
+const { getItrConfiguration } = require('../ci-visibility/intelligent-test-runner/get-itr-configuration')
+const { getSkippableSuites } = require('../ci-visibility/intelligent-test-runner/get-skippable-suites')
+
+const Plugin = require('./plugin')
+
+module.exports = class CiPlugin extends Plugin {
+  constructor (...args) {
+    super(...args)
+
+    const gitMetadataUploadFinishCh = channel('ci:git-metadata-upload:finish')
+    // `gitMetadataPromise` is used to wait until git metadata is uploaded to
+    // proceed with calculating the suites to skip
+    // TODO: add timeout after which the promise is resolved
+    const gitMetadataPromise = new Promise(resolve => {
+      gitMetadataUploadFinishCh.subscribe(err => {
+        resolve(err)
+      })
+    })
+
+    this.testEnvironmentMetadata = getTestEnvironmentMetadata(this.constructor.name, this.config)
+    this.codeOwnersEntries = getCodeOwnersFileEntries()
+
+    const {
+      'git.repository_url': repositoryUrl,
+      'git.commit.sha': sha,
+      'os.version': osVersion,
+      'os.platform': osPlatform,
+      'os.architecture': osArchitecture,
+      'runtime.name': runtimeName,
+      'runtime.version': runtimeVersion,
+      'git.branch': branch
+    } = this.testEnvironmentMetadata
+
+    const testConfiguration = {
+      repositoryUrl,
+      sha,
+      osVersion,
+      osPlatform,
+      osArchitecture,
+      runtimeName,
+      runtimeVersion,
+      branch
+    }
+
+    this.addSub(`ci:${this.constructor.name}:configuration`, ({ onDone }) => {
+      if (!this.config.isAgentlessEnabled || !this.config.isIntelligentTestRunnerEnabled) {
+        onDone({ config: {} })
+        return
+      }
+      getItrConfiguration({
+        ...testConfiguration,
+        url: this.config.url,
+        site: this.config.site,
+        env: this.tracer._env,
+        service: this.config.service || this.tracer._service
+      }, (err, config) => {
+        if (err) {
+          onDone({ err })
+        } else {
+          this.itrConfig = config
+          onDone({ config })
+        }
+      })
+    })
+
+    // jest one
+    this.addSub(`ci:${this.constructor.name}:test-suite:skippable`, ({ onDone }) => {
+      if (!this.config.isAgentlessEnabled || !this.config.isIntelligentTestRunnerEnabled) {
+        return onDone({ skippableSuites: [] })
+      }
+      // we only request after git upload has happened, if it didn't fail
+      gitMetadataPromise.then((gitUploadError) => {
+        if (gitUploadError) {
+          return onDone({ err: gitUploadError })
+        }
+        if (!this.itrConfig || !this.itrConfig.isSuitesSkippingEnabled) {
+          return onDone(null, [])
+        }
+        getSkippableSuites({
+          ...testConfiguration,
+          url: this.config.url,
+          site: this.config.site,
+          env: this.tracer._env,
+          service: this.config.service || this.tracer._service
+        }, (err, skippableSuites) => {
+          if (err) {
+            onDone({ err })
+          } else {
+            onDone({ skippableSuites })
+          }
+        })
+      })
+    })
+  }
+}

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -11,6 +11,7 @@ const {
 } = require('./util/test')
 const { getItrConfiguration } = require('../ci-visibility/intelligent-test-runner/get-itr-configuration')
 const { getSkippableSuites } = require('../ci-visibility/intelligent-test-runner/get-skippable-suites')
+const { COMPONENT } = require('../constants')
 
 const Plugin = require('./plugin')
 
@@ -103,12 +104,13 @@ module.exports = class CiPlugin extends Plugin {
     })
   }
 
-  startTestSpan (name, suite, extraTags) {
-    const childOf = getTestParentSpan(this.tracer)
+  startTestSpan (name, suite, extraTags, childOf) {
+    const parent = childOf || getTestParentSpan(this.tracer)
     const testCommonTags = getTestCommonTags(name, suite, this.tracer._version)
 
     const testTags = {
       ...testCommonTags,
+      [COMPONENT]: this.constructor.name,
       ...extraTags
     }
 
@@ -120,7 +122,7 @@ module.exports = class CiPlugin extends Plugin {
 
     const testSpan = this.tracer
       .startSpan(`${this.constructor.name}.test`, {
-        childOf,
+        childOf: parent,
         tags: {
           ...this.testEnvironmentMetadata,
           ...testTags

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -84,7 +84,7 @@ module.exports = class CiPlugin extends Plugin {
           return onDone({ err: gitUploadError })
         }
         if (!this.itrConfig || !this.itrConfig.isSuitesSkippingEnabled) {
-          return onDone(null, [])
+          return onDone({ skippableSuites: [] })
         }
         getSkippableSuites({
           ...testConfiguration,
@@ -119,7 +119,7 @@ module.exports = class CiPlugin extends Plugin {
     }
 
     const testSpan = this.tracer
-      .startSpan('jest.test', {
+      .startSpan(`${this.constructor.name}.test`, {
         childOf,
         tags: {
           ...this.testEnvironmentMetadata,
@@ -128,5 +128,7 @@ module.exports = class CiPlugin extends Plugin {
       })
 
     testSpan.context()._trace.origin = CI_APP_ORIGIN
+
+    return testSpan
   }
 }


### PR DESCRIPTION
### What does this PR do?
* Move common plugin logic to `CiPlugin`
* Make `jest`, `mocha` and `cucumber` plugins extend from `CiPlugin`

### Motivation
CI Visibility plugins look alike. This `CiPlugin` includes the most common functionality, so the testing framework plugins are lighter and there's less repetition of code.

### Additional Notes
If everything's working, tests should not need to be modified. 