### PR TITLE
[ci-visibility] Do not use `testMatch` to skip suites in `jest`

### DIFF
--- a/packages/datadog-plugin-jest/test/jest-itr-pass.js
+++ b/packages/datadog-plugin-jest/test/jest-itr-pass.js
@@ -1,5 +1,7 @@
+const sum = require('./sum-coverage-test.js')
+
 describe('jest-itr-pass', () => {
   it('will be run', () => {
-    expect(true).toEqual(true)
+    expect(sum(1, 2)).toEqual(3)
   })
 })


### PR DESCRIPTION
### What does this PR do?
* Wrap `build/SearchSource.js` to remove test suites to be skipped instead of modifying `testMatch` configuration in `jest`. 

### Motivation
This fixes a bug where setting `testMatch` to skip suites made that the code coverage instrumentation broke completely. I'm pretty sure this is a bug in `jest`. If `testMatch` is set to e.g. `!test_file_to_skip.js`, every file required by any test is _not_ instrumented by coverage.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
