### PR TITLE
[ci-visibility] Do not run coverage on untested file when ITR is enabled

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -8,6 +8,7 @@ module.exports = {
   '@grpc/grpc-js': () => require('../grpc'),
   '@hapi/hapi': () => require('../hapi'),
   '@jest/core': () => require('../jest'),
+  '@jest/reporters': () => require('../jest'),
   '@koa/router': () => require('../koa'),
   '@node-redis/client': () => require('../redis'),
   '@opensearch-project/opensearch': () => require('../opensearch'),

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -207,8 +207,6 @@ function cliWrapper (cli) {
       }
     }
 
-    skippableSuites = skippableSuites.slice(0, -10)
-
     const isTestsSkipped = !!skippableSuites.length
 
     const processArgv = process.argv.slice(2).join(' ')

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -248,11 +248,12 @@ addHook({
    * If ITR is active, we're running fewer tests, so of course the total code coverage is reduced.
    * This calculation adds no value, so we'll skip it.
    */
-  if (isSuitesSkippingEnabled) {
-    shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => async function () {
+  shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => async function () {
+    if (isSuitesSkippingEnabled) {
       return Promise.resolve()
-    })
-  }
+    }
+    return addUntestedFiles.apply(this, arguments)
+  })
 
   return coverageReporter
 })

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -239,6 +239,20 @@ function cliWrapper (cli) {
 }
 
 addHook({
+  name: '@jest/reporters',
+  file: 'build/CoverageReporter.js',
+  versions: ['>=24.8.0']
+}, (coverageReporter) => {
+  const CoverageReporter = coverageReporter.default ? coverageReporter.default : coverageReporter
+
+  shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => async function () {
+    return
+  })
+
+  return coverageReporter
+})
+
+addHook({
   name: '@jest/core',
   file: 'build/cli/index.js',
   versions: ['>=24.8.0']

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -603,6 +603,13 @@ describe('Plugin', function () {
           gitMetadataUploadFinishCh.publish()
         })
         it('reports code coverage also when there are suites to skip', (done) => {
+          // trick to check what jest prints in the stdout
+          let buffer = ''
+          const oldStdout = process.stdout.write
+          process.stdout.write = (input) => {
+            buffer += input
+          }
+
           nock('https://api.datad0g.com/')
             .post('/api/v2/libraries/tests/services/setting')
             .reply(200, JSON.stringify({
@@ -649,6 +656,8 @@ describe('Plugin', function () {
                 'Content-Disposition: form-data; name="event"; filename="event.json"'
               )
               expect(eventPayload).to.equal(JSON.stringify({ dummy: true }))
+              process.stdout.write = oldStdout
+              expect(buffer).not.to.include('Coverage summary')
               done()
             })
             .post('/api/v2/citestcov')


### PR DESCRIPTION
### What does this PR do?
* Do not run coverage on untested files when ITR is enabled.

### Motivation
`jest` runs a heavy process in https://github.com/facebook/jest/blob/6e5b1d60a1214e792b5229993b5475445e9c1a6e/packages/jest-reporters/src/CoverageReporter.ts#L107 to calculate the total number of uncovered lines in your code, to show code coverage totals. This calculation is useless and misleading when ITR is enabled, as of course fewer tests will be run (and hence the total coverage is reduced). 

In this PR we remove this calculation (whenever ITR is enabled) and we stop the totals from showing up in the stdout.

