### PR TITLE
Add appsec folder to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @DataDog/dd-trace-js
+/packages/dd-trace/src/appsec/ @DataDog/appsec-js

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 * @DataDog/dd-trace-js
 /packages/dd-trace/src/appsec/ @DataDog/appsec-js
+/packages/dd-trace/test/appsec/ @DataDog/appsec-js


### PR DESCRIPTION
### What does this PR do?
Add the appsec-js team to the CODEOWNERS file to own all files under appsec folder.

### Motivation
Since we're now a handful in the appsec-js team this will get useful.
