### PR TITLE
Improve error logging in `request` and git

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -73,7 +73,7 @@ function getCommitsToExclude ({ url, repositoryUrl }, callback) {
 
   request(localCommitData, options, (err, response, statusCode) => {
     if (err) {
-      const error = new Error(`search_commits returned an error: status code ${statusCode}`)
+      const error = new Error(`search_commits returned a status code ${statusCode}: ${err.message}`)
       return callback(error)
     }
     let commitsToExclude
@@ -129,7 +129,7 @@ function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, c
   }
   request(form, options, (err, _, statusCode) => {
     if (err) {
-      const error = new Error(`Could not upload packfiles: status code ${statusCode}`)
+      const error = new Error(`Could not upload packfiles: status code ${statusCode}: ${err.message}`)
       return callback(error)
     }
     callback(null)

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -35,9 +35,7 @@ function getCommonRequestOptions (url) {
       'dd-api-key': process.env.DATADOG_API_KEY || process.env.DD_API_KEY
     },
     timeout: 15000,
-    protocol: url.protocol,
-    hostname: url.hostname,
-    port: url.port
+    url
   }
 }
 
@@ -71,16 +69,16 @@ function getCommitsToExclude ({ url, repositoryUrl }, callback) {
     }))
   })
 
-  request(localCommitData, options, (err, response, statusCode) => {
+  request(localCommitData, options, (err, response) => {
     if (err) {
-      const error = new Error(`search_commits returned a status code ${statusCode}: ${err.message}`)
+      const error = new Error(`Error fetching commits to exclude: ${err.message}`)
       return callback(error)
     }
     let commitsToExclude
     try {
       commitsToExclude = sanitizeCommits(JSON.parse(response).data)
     } catch (e) {
-      return callback(new Error(`Can't parse search_commits response: ${e.message}`))
+      return callback(new Error(`Can't parse commits to exclude response: ${e.message}`))
     }
     callback(null, commitsToExclude, headCommit)
   })

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -36,9 +36,7 @@ function getItrConfiguration ({
       'dd-application-key': appKey,
       'Content-Type': 'application/json'
     },
-    protocol: intakeUrl.protocol,
-    hostname: intakeUrl.hostname,
-    port: intakeUrl.port
+    url: intakeUrl
   }
 
   const data = JSON.stringify({

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -34,9 +34,7 @@ function getSkippableSuites ({
       'Content-Type': 'application/json'
     },
     timeout: 15000,
-    protocol: intakeUrl.protocol,
-    hostname: intakeUrl.hostname,
-    port: intakeUrl.port
+    url: intakeUrl
   }
 
   const data = JSON.stringify({

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -66,7 +66,12 @@ function request (data, options, callback) {
       if (res.statusCode >= 200 && res.statusCode <= 299) {
         callback(null, responseData, res.statusCode)
       } else {
-        const error = new Error(`Error from the endpoint: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`)
+        let errorMessage =
+          `Error from ${options.hostname}${options.pathname}: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`
+        if (responseData) {
+          errorMessage += ` Response from the endpoint: ${responseData}`
+        }
+        const error = new Error(errorMessage)
         error.status = res.statusCode
 
         callback(error, null, res.statusCode)

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -66,10 +66,11 @@ function request (data, options, callback) {
       if (res.statusCode >= 200 && res.statusCode <= 299) {
         callback(null, responseData, res.statusCode)
       } else {
-        let errorMessage =
-          `Error from ${options.hostname}${options.pathname}: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`
+        const fullUrl = `${options.url || options.hostname || `localhost:${options.port}`}${options.path}`
+        // eslint-disable-next-line
+        let errorMessage = `Error from ${fullUrl}: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}.`
         if (responseData) {
-          errorMessage += ` Response from the endpoint: ${responseData}`
+          errorMessage += ` Response from the endpoint: "${responseData}"`
         }
         const error = new Error(errorMessage)
         error.status = res.statusCode

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -65,7 +65,7 @@ class Tracer extends NoopProxy {
       if (config.isGitUploadEnabled) {
         sendGitMetadata(config.site, (err) => {
           if (err) {
-            log.error(`Error uploading git metadata: ${err}`)
+            log.error(`Error uploading git metadata: ${err.message}`)
           } else {
             log.debug('Successfully uploaded git metadata')
           }

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -85,12 +85,13 @@ describe('git_metadata', () => {
   it('should fail and not continue if first query results in anything other than 200', (done) => {
     const scope = nock('https://api.test.com')
       .post('/api/v2/git/repository/search_commits')
-      .reply(500)
+      .reply(404, 'Not found SHA')
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
     gitMetadata.sendGitMetadata('test.com', (err) => {
-      expect(err.message).to.contain('search_commits returned an error: status code 500')
+      // eslint-disable-next-line
+      expect(err.message).to.contain('Error fetching commits to exclude: Error from https://api.test.com//api/v2/git/repository/search_commits: 404 Not Found. Response from the endpoint: "Not found SHA"')
       // to check that it is not called
       expect(scope.isDone()).to.be.false
       expect(scope.pendingMocks()).to.contain('POST https://api.test.com:443/api/v2/git/repository/packfile')
@@ -106,7 +107,7 @@ describe('git_metadata', () => {
       .reply(204)
 
     gitMetadata.sendGitMetadata('test.com', (err) => {
-      expect(err.message).to.contain("Can't parse search_commits response: Invalid commit type response")
+      expect(err.message).to.contain("Can't parse commits to exclude response: Invalid commit type response")
       // to check that it is not called
       expect(scope.isDone()).to.be.false
       expect(scope.pendingMocks()).to.contain('POST https://api.test.com:443/api/v2/git/repository/packfile')

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -85,10 +85,11 @@ describe('request', function () {
 
     request(Buffer.from(''), {
       path: '/path',
-      method: 'PUT'
+      method: 'PUT',
+      port: 80
     }, err => {
       expect(err).to.be.instanceof(Error)
-      expect(err.message).to.equal('Error from the endpoint: 400 Bad Request')
+      expect(err.message).to.equal('Error from localhost:80/path: 400 Bad Request.')
       done()
     })
   })


### PR DESCRIPTION
### What does this PR do?
* Improve error message in `request`, including the requested endpoint and the response data from the server.
* Improve error message in `git_metadata`.
* Some unrelated minor fixes: use `url` whenever possible for input to `request`.

### Motivation
Now that `request` module is used for multiple endpoints, some of them which return valuable data for debugging, we should improve the error message we report from the module.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
