### PR TITLE
Get the correct property from pg query start channel

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -6,7 +6,7 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
     super('SQL_INJECTION')
     this.addSub('apm:mysql:query:start', ({ sql }) => this.analyze(sql))
     this.addSub('apm:mysql2:query:start', ({ sql }) => this.analyze(sql))
-    this.addSub('apm:pg:query:start', ({ query }) => this.analyze(query.text))
+    this.addSub('apm:pg:query:start', ({ query }) => query && this.analyze(query.text))
   }
 }
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -6,7 +6,7 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
     super('SQL_INJECTION')
     this.addSub('apm:mysql:query:start', ({ sql }) => this.analyze(sql))
     this.addSub('apm:mysql2:query:start', ({ sql }) => this.analyze(sql))
-    this.addSub('apm:pg:query:start', ({ statement }) => this.analyze(statement))
+    this.addSub('apm:pg:query:start', ({ query }) => this.analyze(query.text))
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Get the correct value in `apm:pg:query:start` channel subscription to analyze the query.

### Motivation
The message published by `pg` instrumentation has changed, so `statement` property is no longer present in the message in favor of `pgQuery` object. The changes in this PR extracts the query from the received object to be analyzed by `SQLi analyzer`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
