### PR TITLE
remove AsyncResource usage from http server and web frameworks

### DIFF
--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -9,6 +9,7 @@ const handleChannel = channel('apm:restify:request:handle')
 const errorChannel = channel('apm:restify:middleware:error')
 const enterChannel = channel('apm:restify:middleware:enter')
 const exitChannel = channel('apm:restify:middleware:exit')
+const finishChannel = channel('apm:restify:middleware:finish')
 const nextChannel = channel('apm:restify:middleware:next')
 
 function wrapSetupRequest (setupRequest) {
@@ -53,8 +54,10 @@ function wrapFn (fn) {
     } catch (error) {
       errorChannel.publish({ req, error })
       nextChannel.publish({ req })
-      exitChannel.publish({ req })
+      finishChannel.publish({ req })
       throw error
+    } finally {
+      exitChannel.publish({ req })
     }
   }
 }
@@ -62,7 +65,7 @@ function wrapFn (fn) {
 function wrapNext (req, next) {
   return function () {
     nextChannel.publish({ req })
-    exitChannel.publish({ req })
+    finishChannel.publish({ req })
 
     next.apply(this, arguments)
   }

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -14,12 +14,15 @@ class HttpServerPlugin extends Plugin {
   constructor (...args) {
     super(...args)
 
+    this._storeStack = []
+
     this.addSub('apm:http:server:request:start', ({ req, res }) => {
       const store = storage.getStore()
       const span = web.startSpan(this.tracer, this.config, req, res, 'web.request')
 
       span.setTag(COMPONENT, this.constructor.name)
 
+      this._storeStack.push(store)
       this.enter(span, { ...store, req })
 
       const context = web.getContext(req)
@@ -36,6 +39,10 @@ class HttpServerPlugin extends Plugin {
 
     this.addSub('apm:http:server:request:error', (error) => {
       web.addError(error)
+    })
+
+    this.addSub('apm:http:server:request:exit', ({ req }) => {
+      this.enter(this._storeStack.pop())
     })
 
     this.addSub('apm:http:server:request:finish', ({ req }) => {

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -14,7 +14,7 @@ class HttpServerPlugin extends Plugin {
   constructor (...args) {
     super(...args)
 
-    this._storeStack = []
+    this._parentStore = undefined
 
     this.addSub('apm:http:server:request:start', ({ req, res }) => {
       const store = storage.getStore()
@@ -22,7 +22,7 @@ class HttpServerPlugin extends Plugin {
 
       span.setTag(COMPONENT, this.constructor.name)
 
-      this._storeStack.push(store)
+      this._parentStore = store
       this.enter(span, { ...store, req })
 
       const context = web.getContext(req)
@@ -42,7 +42,8 @@ class HttpServerPlugin extends Plugin {
     })
 
     this.addSub('apm:http:server:request:exit', ({ req }) => {
-      this.enter(this._storeStack.pop())
+      this.enter(this._parentStore)
+      this._parentStore = undefined
     })
 
     this.addSub('apm:http:server:request:finish', ({ req }) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove `AsyncResource` usage from HTTP server and web frameworks.

### Motivation
<!-- What inspired you to submit this pull request? -->

Additional `AsyncResource` instances can add unnecessary overhead and can alter the behaviour of user-defined `AsyncLocalStorage` storages. While we're already planning to do this in the future for everything based on the work in #2494, we suspect this to be the cause of additional CPU usage in certain cases, so I figured we should only do web frameworks right away since they're by far the most widely used integrations.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I went a little bit random with the naming of events, so I'm open to better suggestions. Also, for now I added the store stack to individual plugins, but once we settle on a final approach it should be moved to the base class.