### PR TITLE
CSI trim methods rewriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@datadog/native-appsec": "2.0.0",
-    "@datadog/native-iast-rewriter": "1.0.0",
+    "@datadog/native-iast-rewriter": "1.1.0",
     "@datadog/native-iast-taint-tracking": "1.0.0",
     "@datadog/native-metrics": "^1.5.0",
     "@datadog/pprof": "^1.1.1",

--- a/packages/dd-trace/src/appsec/iast/iast-context.js
+++ b/packages/dd-trace/src/appsec/iast/iast-context.js
@@ -1,4 +1,5 @@
 const IAST_CONTEXT_KEY = Symbol('_dd.iast.context')
+const IAST_TRANSACTION_ID = Symbol('_dd.iast.transactionId')
 
 function getIastContext (store) {
   return store && store[IAST_CONTEXT_KEY]
@@ -46,5 +47,6 @@ module.exports = {
   getIastContext,
   saveIastContext,
   cleanIastContext,
-  IAST_CONTEXT_KEY
+  IAST_CONTEXT_KEY,
+  IAST_TRANSACTION_ID
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -20,7 +20,7 @@ const prototypes = csiMethodDefinition
   .filter(proto => proto)
 
 function isValidCsiMethod (fn) {
-  return prototypes.indexOf(fn) === -1
+  return prototypes.indexOf(fn) !== -1
 }
 
 const csiMethods = csiMethodDefinition.map(method => {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -1,0 +1,36 @@
+const csiMethodDefinition = [
+  { src: 'plusOperator', operator: true },
+  { src: String.prototype.trim },
+  { src: String.prototype.trimStart, dst: String.prototype.trim },
+  { src: String.prototype.trimEnd }
+]
+
+function isFunction (fn) {
+  return typeof fn === 'function'
+}
+
+function getCsiMethodName (def) {
+  return isFunction(def) ? def.name : def
+}
+
+const prototypes = csiMethodDefinition
+  .map(method => isFunction(method.src) ? method.src : null)
+  .filter(proto => proto)
+
+const csiMethods = csiMethodDefinition.map(method => {
+  const csiMethod = {
+    src: getCsiMethodName(method.src)
+  }
+  if (method.dst) {
+    csiMethod.dst = getCsiMethodName(method.dst)
+  }
+  if (method.operator) {
+    csiMethod.operator = method.operator
+  }
+  return csiMethod
+})
+
+module.exports = {
+  prototypes,
+  csiMethods
+}

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const csiMethodDefinition = [
   { src: 'plusOperator', operator: true },
   { src: String.prototype.trim },
@@ -17,6 +19,10 @@ const prototypes = csiMethodDefinition
   .map(method => isFunction(method.src) ? method.src : null)
   .filter(proto => proto)
 
+function isValidCsiMethod (fn) {
+  return prototypes.indexOf(fn) === -1
+}
+
 const csiMethods = csiMethodDefinition.map(method => {
   const csiMethod = {
     src: getCsiMethodName(method.src)
@@ -31,6 +37,6 @@ const csiMethods = csiMethodDefinition.map(method => {
 })
 
 module.exports = {
-  prototypes,
+  isValidCsiMethod,
   csiMethods
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -1,42 +1,12 @@
 'use strict'
 
-const csiMethodDefinition = [
+const csiMethods = [
   { src: 'plusOperator', operator: true },
-  { src: String.prototype.trim },
-  { src: String.prototype.trimStart, dst: String.prototype.trim },
-  { src: String.prototype.trimEnd }
+  { src: 'trim' },
+  { src: 'trimStart', dst: 'trim' },
+  { src: 'trimEnd' }
 ]
 
-function isFunction (fn) {
-  return typeof fn === 'function'
-}
-
-function getCsiMethodName (def) {
-  return isFunction(def) ? def.name : def
-}
-
-const prototypes = csiMethodDefinition
-  .map(method => isFunction(method.src) ? method.src : null)
-  .filter(proto => proto)
-
-function isValidCsiMethod (fn) {
-  return prototypes.indexOf(fn) !== -1
-}
-
-const csiMethods = csiMethodDefinition.map(method => {
-  const csiMethod = {
-    src: getCsiMethodName(method.src)
-  }
-  if (method.dst) {
-    csiMethod.dst = getCsiMethodName(method.dst)
-  }
-  if (method.operator) {
-    csiMethod.operator = method.operator
-  }
-  return csiMethod
-})
-
 module.exports = {
-  isValidCsiMethod,
   csiMethods
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -1,33 +1,6 @@
-const { storage } = require('../../../../../datadog-core')
-const iastContextFunctions = require('../iast-context')
-const log = require('../../../log')
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
-
-const IAST_TRANSACTION_ID = Symbol('_dd.iast.transactionId')
-
-function noop (res) { return res }
-const TaintTrackingDummy = {
-  plusOperator: noop
-}
-
-const TaintTracking = {
-  plusOperator: function (res, op1, op2) {
-    try {
-      if (typeof res !== 'string' ||
-        (typeof op1 !== 'string' && typeof op2 !== 'string')) { return res }
-
-      const store = storage.getStore()
-      const iastContext = iastContextFunctions.getIastContext(store)
-      const transactionId = iastContext && iastContext[IAST_TRANSACTION_ID]
-      if (transactionId) {
-        return TaintedUtils.concat(transactionId, res, op1, op2)
-      }
-    } catch (e) {
-      log.debug(e)
-    }
-    return res
-  }
-}
+const { IAST_TRANSACTION_ID } = require('../iast-context')
+const { TaintTracking, TaintTrackingDummy } = require('./taint-tracking-impl')
 
 function createTransaction (id, iastContext) {
   if (id && iastContext) {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -4,13 +4,7 @@ const Module = require('module')
 const shimmer = require('../../../../../datadog-shimmer')
 const log = require('../../../log')
 const { isPrivateModule, isNotLibraryFile } = require('./filter')
-
-const csiMethods = [
-  { src: 'plusOperator', operator: true },
-  { src: 'trim' },
-  { src: 'trimStart', dst: 'trim' },
-  { src: 'trimEnd' }
-]
+const { csiMethods } = require('./csi-methods')
 
 let rewriter
 let getPrepareStackTrace

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -51,14 +51,20 @@ function getCsiFn (cb, ...protos) {
   return getFilteredCsiFn(cb, filter)
 }
 
-function getPlusOperatorFn (cb) {
-  return getFilteredCsiFn(cb, (res, op1, op2) => notString(res) || (notString(op1) && notString(op2)))
-}
-
 const TaintTracking = {
-  plusOperator: getPlusOperatorFn(
-    (transactionId, res, op1, op2) => TaintedUtils.concat(transactionId, res, op1, op2)
-  ),
+  plusOperator: function (res, op1, op2) {
+    try {
+      if (notString(res) || (notString(op1) && notString(op2))) { return res }
+      const transactionId = getTransactionId()
+      if (transactionId) {
+        return TaintedUtils.concat(transactionId, res, op1, op2)
+      }
+    } catch (e) {
+      log.debug(e)
+    }
+    return res
+  },
+
   trim: getCsiFn(
     (transactionId, res, target) => TaintedUtils.trim(transactionId, res, target),
     String.prototype.trim,

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -37,7 +37,7 @@ function notString () {
   return Array.prototype.some.call(arguments, (p) => typeof p !== 'string')
 }
 
-function isValidCsiMethod (fn, ...protos) {
+function isValidCsiMethod (fn, protos) {
   return protos.some(proto => fn === proto)
 }
 
@@ -49,7 +49,7 @@ function getCsiFn (cb, ...protos) {
     const protoFn = protos[0]
     filter = (res, fn, target) => notString(res, target) || fn !== protoFn
   } else {
-    filter = (res, fn, target) => notString(res, target) || !isValidCsiMethod(fn, ...protos)
+    filter = (res, fn, target) => notString(res, target) || !isValidCsiMethod(fn, protos)
   }
   return getFilteredCsiFn(cb, filter)
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -1,7 +1,9 @@
+'use strict'
+
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
 const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
-const { prototypes } = require('./csi-methods')
+const { isValidCsiMethod } = require('./csi-methods')
 
 const log = require('../../../log')
 
@@ -23,7 +25,7 @@ function notString () {
 function getCsiFn (cb) {
   return function csiCall (res, fn, target) {
     try {
-      if (notString(res, target) || prototypes.indexOf(fn) === -1) { return res }
+      if (notString(res, target) || isValidCsiMethod(fn)) { return res }
       const transactionId = getTransactionId()
       if (transactionId) {
         const [,, ...rest] = arguments

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -1,6 +1,7 @@
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
 const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
+const { prototypes } = require('./csi-methods')
 
 const log = require('../../../log')
 
@@ -14,12 +15,6 @@ function getTransactionId () {
   const iastContext = iastContextFunctions.getIastContext(store)
   return iastContext && iastContext[iastContextFunctions.IAST_TRANSACTION_ID]
 }
-
-const prototypes = [
-  String.prototype.trim,
-  String.prototype.trimStart,
-  String.prototype.trimEnd
-]
 
 function notString () {
   return [...arguments].some(p => typeof p !== 'string')

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -1,0 +1,65 @@
+const TaintedUtils = require('@datadog/native-iast-taint-tracking')
+const { storage } = require('../../../../../datadog-core')
+const iastContextFunctions = require('../iast-context')
+
+const log = require('../../../log')
+
+function noop (res) { return res }
+const TaintTrackingDummy = {
+  plusOperator: noop
+}
+
+function getTransactionId () {
+  const store = storage.getStore()
+  const iastContext = iastContextFunctions.getIastContext(store)
+  return iastContext && iastContext[iastContextFunctions.IAST_TRANSACTION_ID]
+}
+
+const prototypes = [
+  String.prototype.trim,
+  String.prototype.trimStart,
+  String.prototype.trimEnd
+]
+
+function notString () {
+  return [...arguments].some(p => typeof p !== 'string')
+}
+
+function getCsiFn (cb) {
+  return function csiCall (res, fn, target) {
+    try {
+      if (notString(res, target) || prototypes.indexOf(fn) === -1) { return res }
+      const transactionId = getTransactionId()
+      if (transactionId) {
+        const [,, ...rest] = arguments
+        return cb(transactionId, res, ...rest)
+      }
+    } catch (e) {
+      log.debug(e)
+    }
+    return res
+  }
+}
+
+const TaintTracking = {
+  plusOperator: function (res, op1, op2) {
+    try {
+      if (notString(res) || (notString(op1) && notString(op2))) { return res }
+
+      const transactionId = getTransactionId()
+      if (transactionId) {
+        return TaintedUtils.concat(transactionId, res, op1, op2)
+      }
+    } catch (e) {
+      log.debug(e)
+    }
+    return res
+  },
+  trim: getCsiFn((transactionId, res, target) => TaintedUtils.trim(transactionId, res, target)),
+  trimEnd: getCsiFn((transactionId, res, target) => TaintedUtils.trimEnd(transactionId, res, target))
+}
+
+module.exports = {
+  TaintTracking,
+  TaintTrackingDummy
+}

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -24,7 +24,7 @@ function getFilteredCsiFn (cb, filter) {
       if (filter(res, fn, target)) { return res }
       const transactionId = getTransactionId()
       if (transactionId) {
-        return cb(transactionId, res, target, ...rest)
+        return cb(transactionId, res, fn, target, ...rest)
       }
     } catch (e) {
       log.debug(e)
@@ -44,34 +44,29 @@ function isValidCsiMethod (fn, ...protos) {
 function getCsiFn (cb, ...protos) {
   let filter
   if (protos.length === 1) {
-    filter = (res, fn, target) => notString(res, target) || fn !== protos[0]
+    const protoFn = protos[0]
+    filter = (res, fn, target) => notString(res, target) || fn !== protoFn
   } else {
     filter = (res, fn, target) => notString(res, target) || !isValidCsiMethod(fn, ...protos)
   }
   return getFilteredCsiFn(cb, filter)
 }
 
-const TaintTracking = {
-  plusOperator: function (res, op1, op2) {
-    try {
-      if (notString(res) || (notString(op1) && notString(op2))) { return res }
-      const transactionId = getTransactionId()
-      if (transactionId) {
-        return TaintedUtils.concat(transactionId, res, op1, op2)
-      }
-    } catch (e) {
-      log.debug(e)
-    }
-    return res
-  },
+function getPlusOperatorFn (cb) {
+  return getFilteredCsiFn(cb, (res, op1, op2) => notString(res) || (notString(op1) && notString(op2)))
+}
 
+const TaintTracking = {
+  plusOperator: getPlusOperatorFn(
+    (transactionId, res, op1, op2) => TaintedUtils.concat(transactionId, res, op1, op2)
+  ),
   trim: getCsiFn(
-    (transactionId, res, target) => TaintedUtils.trim(transactionId, res, target),
+    (transactionId, res, fn, target) => TaintedUtils.trim(transactionId, res, target),
     String.prototype.trim,
     String.prototype.trimStart
   ),
   trimEnd: getCsiFn(
-    (transactionId, res, target) => TaintedUtils.trimEnd(transactionId, res, target),
+    (transactionId, res, fn, target) => TaintedUtils.trimEnd(transactionId, res, target),
     String.prototype.trimEnd
   )
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -3,13 +3,13 @@
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
 const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
-const { isValidCsiMethod } = require('./csi-methods')
-
 const log = require('../../../log')
 
 function noop (res) { return res }
 const TaintTrackingDummy = {
-  plusOperator: noop
+  plusOperator: noop,
+  trim: noop,
+  trimEnd: noop
 }
 
 function getTransactionId () {
@@ -18,20 +18,12 @@ function getTransactionId () {
   return iastContext && iastContext[iastContextFunctions.IAST_TRANSACTION_ID]
 }
 
-function notString () {
-  return [...arguments].some(p => typeof p !== 'string')
-}
-
-const defaultFilter = (res, fn, target) => notString(res, target) || !isValidCsiMethod(fn)
-
-function getCsiFn (cb, filter) {
-  filter = filter || defaultFilter
-  return function csiCall (res, fn, target) {
+function getFilteredCsiFn (cb, filter) {
+  return function csiCall (res, fn, target, ...rest) {
     try {
       if (filter(res, fn, target)) { return res }
       const transactionId = getTransactionId()
       if (transactionId) {
-        const [,, ...rest] = arguments
         return cb(transactionId, res, ...rest)
       }
     } catch (e) {
@@ -41,14 +33,35 @@ function getCsiFn (cb, filter) {
   }
 }
 
+function notString () {
+  return Array.prototype.some.call(arguments, (p) => typeof p !== 'string')
+}
+
+function isValidCsiMethod (fn, ...protos) {
+  return protos.some(proto => fn === proto)
+}
+
+function getCsiFn (cb, ...protos) {
+  return getFilteredCsiFn(cb, (res, fn, target) => notString(res, target) || !isValidCsiMethod(fn, ...protos))
+}
+
 function getPlusOperatorFn (cb) {
-  return getCsiFn(cb, (res, op1, op2) => notString(res) || (notString(op1) && notString(op2)))
+  return getFilteredCsiFn(cb, (res, op1, op2) => notString(res) || (notString(op1) && notString(op2)))
 }
 
 const TaintTracking = {
-  plusOperator: getPlusOperatorFn((transactionId, res, op1, op2) => TaintedUtils.concat(transactionId, res, op1, op2)),
-  trim: getCsiFn((transactionId, res, target) => TaintedUtils.trim(transactionId, res, target)),
-  trimEnd: getCsiFn((transactionId, res, target) => TaintedUtils.trimEnd(transactionId, res, target))
+  plusOperator: getPlusOperatorFn(
+    (transactionId, res, op1, op2) => TaintedUtils.concat(transactionId, res, op1, op2)
+  ),
+  trim: getCsiFn(
+    (transactionId, res, target) => TaintedUtils.trim(transactionId, res, target),
+    String.prototype.trim,
+    String.prototype.trimStart
+  ),
+  trimEnd: getCsiFn(
+    (transactionId, res, target) => TaintedUtils.trimEnd(transactionId, res, target),
+    String.prototype.trimEnd
+  )
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -24,7 +24,7 @@ function getFilteredCsiFn (cb, filter) {
       if (filter(res, fn, target)) { return res }
       const transactionId = getTransactionId()
       if (transactionId) {
-        return cb(transactionId, res, ...rest)
+        return cb(transactionId, res, target, ...rest)
       }
     } catch (e) {
       log.debug(e)
@@ -42,7 +42,13 @@ function isValidCsiMethod (fn, ...protos) {
 }
 
 function getCsiFn (cb, ...protos) {
-  return getFilteredCsiFn(cb, (res, fn, target) => notString(res, target) || !isValidCsiMethod(fn, ...protos))
+  let filter
+  if (protos.length === 1) {
+    filter = (res, fn, target) => notString(res, target) || fn !== protos[0]
+  } else {
+    filter = (res, fn, target) => notString(res, target) || !isValidCsiMethod(fn, ...protos)
+  }
+  return getFilteredCsiFn(cb, filter)
 }
 
 function getPlusOperatorFn (cb) {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -1,0 +1,17 @@
+function trimStr (str) {
+  return str.trim()
+}
+
+function trimStartStr (str) {
+  return str.trimStart()
+}
+
+function trimEndStr (str) {
+  return str.trimEnd()
+}
+
+module.exports = {
+  trimStr,
+  trimStartStr,
+  trimEndStr
+}

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -1,3 +1,17 @@
+function concatSuffix (str) {
+  return str + '_suffix'
+}
+
+function insertStr (str) {
+  return `pre_${str}_suf`
+}
+
+function appendStr (str) {
+  let pre = 'pre_'
+  pre += str
+  return pre
+}
+
 function trimStr (str) {
   return str.trim()
 }
@@ -10,13 +24,11 @@ function trimEndStr (str) {
   return str.trimEnd()
 }
 
-function concatSuffix (str) {
-  return str + '_suffix'
-}
-
 module.exports = {
+  concatSuffix,
+  insertStr,
+  appendStr,
   trimStr,
   trimStartStr,
-  trimEndStr,
-  concatSuffix
+  trimEndStr
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -10,8 +10,13 @@ function trimEndStr (str) {
   return str.trimEnd()
 }
 
+function concatSuffix (str) {
+  return str + '_suffix'
+}
+
 module.exports = {
   trimStr,
   trimStartStr,
-  trimEndStr
+  trimEndStr,
+  concatSuffix
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const { testThatRequestHasVulnerability, copyFileToTmp } = require('../utils')
+const { storage } = require('../../../../../datadog-core')
+const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
+const { newTaintedString, isTainted } = require('../../../../src/appsec/iast/taint-tracking/operations')
+const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
+const { expect } = require('chai')
+
+const propagationFns = [
+  'trimStr',
+  'trimStartStr',
+  'trimEndStr'
+]
+
+const commands = [
+  '  ls -la  ',
+  '  ls -la',
+  'ls -la  ',
+  'ls -la',
+  ' ls -la  人 ',
+  ' ls -la  // ',
+  ' ls -la  " '
+]
+
+const propagationFunctionsFile = path.join(__dirname, 'resources/propagationFunctions.js')
+
+describe('TaintTracking', () => {
+  describe('should propagate strings', () => {
+    let instrumentedFunctionsFile
+    beforeEach(() => {
+      instrumentedFunctionsFile = copyFileToTmp(propagationFunctionsFile)
+    })
+
+    afterEach(() => {
+      fs.unlinkSync(instrumentedFunctionsFile)
+      clearCache()
+    })
+
+    propagationFns.forEach((propFn) => {
+      describe(`using ${propFn}()`, () => {
+        commands.forEach((command) => {
+          describe(`with command: '${command}'`, () => {
+            testThatRequestHasVulnerability(function () {
+              const store = storage.getStore()
+              const iastContext = iastContextFunctions.getIastContext(store)
+              const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
+
+              expect(isTainted(iastContext, commandTainted)).to.be.true
+
+              const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
+              const proFnOriginal = require(propagationFunctionsFile)[propFn]
+
+              const commandTrimmed = propFnInstrumented(commandTainted)
+              const commandTrimmedOrig = proFnOriginal(commandTainted)
+              expect(commandTrimmed).eq(commandTrimmedOrig)
+
+              try {
+                const childProcess = require('child_process')
+                childProcess.execSync(commandTrimmed, { stdio: 'ignore' })
+              } catch (e) {
+                // do nothing
+              }
+            }, 'COMMAND_INJECTION')
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -11,10 +11,12 @@ const { clearCache } = require('../../../../src/appsec/iast/vulnerability-report
 const { expect } = require('chai')
 
 const propagationFns = [
+  'concatSuffix',
+  'insertStr',
+  'appendStr',
   'trimStr',
   'trimStartStr',
-  'trimEndStr',
-  'concatSuffix'
+  'trimEndStr'
 ]
 
 const commands = [
@@ -51,17 +53,17 @@ describe('TaintTracking', () => {
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
               const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
-              const proFnOriginal = require(propagationFunctionsFile)[propFn]
+              const propFnOriginal = require(propagationFunctionsFile)[propFn]
 
-              const commandTrimmed = propFnInstrumented(commandTainted)
-              expect(isTainted(iastContext, commandTrimmed)).to.be.true
+              const commandResult = propFnInstrumented(commandTainted)
+              expect(isTainted(iastContext, commandResult)).to.be.true
 
-              const commandTrimmedOrig = proFnOriginal(commandTainted)
-              expect(commandTrimmed).eq(commandTrimmedOrig)
+              const commandResultOrig = propFnOriginal(commandTainted)
+              expect(commandResult).eq(commandResultOrig)
 
               try {
                 const childProcess = require('child_process')
-                childProcess.execSync(commandTrimmed, { stdio: 'ignore' })
+                childProcess.execSync(commandResult, { stdio: 'ignore' })
               } catch (e) {
                 // do nothing
               }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -22,8 +22,8 @@ const commands = [
   'ls -la  ',
   'ls -la',
   ' ls -la  人 ',
-  ' ls -la  // ',
-  ' ls -la  " '
+  ' ls -la  𠆢𠆢𠆢 ',
+  ' ls -ls �'
 ]
 
 const propagationFunctionsFile = path.join(__dirname, 'resources/propagationFunctions.js')

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -30,6 +30,7 @@ const commands = [
 ]
 
 const propagationFunctionsFile = path.join(__dirname, 'resources/propagationFunctions.js')
+const propagationFunctions = require(propagationFunctionsFile)
 
 describe('TaintTracking', () => {
   let instrumentedFunctionsFile
@@ -53,7 +54,7 @@ describe('TaintTracking', () => {
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
               const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
-              const propFnOriginal = require(propagationFunctionsFile)[propFn]
+              const propFnOriginal = propagationFunctions[propFn]
 
               const commandResult = propFnInstrumented(commandTainted)
               expect(isTainted(iastContext, commandResult)).to.be.true

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -13,7 +13,8 @@ const { expect } = require('chai')
 const propagationFns = [
   'trimStr',
   'trimStartStr',
-  'trimEndStr'
+  'trimEndStr',
+  'concatSuffix'
 ]
 
 const commands = [
@@ -49,12 +50,12 @@ describe('TaintTracking', () => {
               const iastContext = iastContextFunctions.getIastContext(store)
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
-              expect(isTainted(iastContext, commandTainted)).to.be.true
-
               const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
               const proFnOriginal = require(propagationFunctionsFile)[propFn]
 
               const commandTrimmed = propFnInstrumented(commandTainted)
+              expect(isTainted(iastContext, commandTrimmed)).to.be.true
+
               const commandTrimmedOrig = proFnOriginal(commandTainted)
               expect(commandTrimmed).eq(commandTrimmedOrig)
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
@@ -11,11 +11,11 @@ describe('IAST TaintTracking Operations', () => {
   const taintedUtils = {
     createTransaction: id => id,
     removeTransaction: id => id,
-    newTaintedString: (id) => id,
+    newTaintedString: id => id,
     isTainted: id => id,
     getRanges: id => id,
-    concat: (id) => id,
-    trim: (id) => id
+    concat: id => id,
+    trim: id => id
   }
 
   const store = {}

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
@@ -328,4 +328,13 @@ describe('IAST TaintTracking Operations', () => {
       expect(result).eq(a.trim())
     })
   })
+
+  describe('TaintTrackingDummy', () => {
+    it('should have the same properties as TaintTracking', () => {
+      const tt = taintTrackingImpl.TaintTracking
+      const dummy = taintTrackingImpl.TaintTrackingDummy
+
+      expect(dummy).to.have.all.keys(Object.keys(tt))
+    })
+  })
 })

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -112,9 +112,9 @@ function testThatRequestHasNoVulnerability (app, vulnerability) {
   testInRequest(app, tests)
 }
 
+let index = 0
 function copyFileToTmp (src) {
-  const prefix = Math.floor(Math.random() * 1000000)
-  const srcName = `dd-iast-${prefix}-${path.basename(src)}`
+  const srcName = `dd-iast-${index++}-${path.basename(src)}`
   const dest = path.join(os.tmpdir(), srcName)
   fs.copyFileSync(src, dest)
   return dest

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -1,3 +1,9 @@
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
 const getPort = require('get-port')
 const agent = require('../../plugins/agent')
 const axios = require('axios')
@@ -106,4 +112,12 @@ function testThatRequestHasNoVulnerability (app, vulnerability) {
   testInRequest(app, tests)
 }
 
-module.exports = { testThatRequestHasNoVulnerability, testThatRequestHasVulnerability, testInRequest }
+function copyFileToTmp (src) {
+  const prefix = Math.floor(Math.random() * 1000000)
+  const srcName = `dd-iast-${prefix}-${path.basename(src)}`
+  const dest = path.join(os.tmpdir(), srcName)
+  fs.copyFileSync(src, dest)
+  return dest
+}
+
+module.exports = { testThatRequestHasNoVulnerability, testThatRequestHasVulnerability, testInRequest, copyFileToTmp }

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,10 +196,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-1.0.0.tgz#02bf338055cdcd3c5b3e8d528afe6d967985cf11"
-  integrity sha512-DGN4cQd30mUaAB349gKeoDTt7acviBERnNYlyk8G+PlobuomTSEohJri5Jo4X+/5oRJPJngGX2VBq7YwMHiing==
+"@datadog/native-iast-rewriter@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-1.1.0.tgz#8ee175bb38b44b006bf5183ffb17b1c93505c064"
+  integrity sha512-rQpm4tjIAzKmQjVY3jIqKesTQJVRiqGiCl5GXIlWanpYCF1OOfgBglLXseH+zXASULnvjiFgKxkNVAXay6dIoQ==
   dependencies:
     node-gyp-build "^4.5.0"
 


### PR DESCRIPTION
### What does this PR do?
Enables `trim`, `trimStart` and `trimEnd` methods rewriting

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
