### PR TITLE
Restore 2.x apm:fs:hook channel

### DIFF
--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -7,6 +7,8 @@ const {
 const shimmer = require('../../datadog-shimmer')
 
 const fsChannel = channel('datadog:fs:access')
+const hookChannel = channel('apm:fs:hook')
+
 const onePathMethods = ['access', 'appendFile', 'chmod', 'lchown', 'mkdir', 'mkdtemp', 'mkdtempSync', 'open',
   'openSync', 'opendir', 'readdir', 'readFile', 'readlink', 'realpath', 'rm', 'rmdir', 'stat', 'truncate', 'unlink',
   'utimes', 'writeFile', 'watch']
@@ -22,6 +24,9 @@ addHook({ name: 'fs' }, fs => {
 
   shimmer.massWrap(fs.promises, onePathMethods, wrapFsMethod(fsChannel, 1))
   shimmer.massWrap(fs.promises, twoPathMethods, wrapFsMethod(fsChannel, 2))
+  if (hookChannel.hasSubscribers) {
+    hookChannel.publish(fs)
+  }
   return fs
 })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Restore 2.x apm:fs:hook channel pusblish to prevent conficts in the future

### Motivation
<!-- What inspired you to submit this pull request? -->
Resolve conflicts in 2.x branch consistently

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
