### PR TITLE
[ci-visibility] Fix CI Visibility tests

### DIFF
--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -5,13 +5,12 @@ const { storage } = require('../../datadog-core')
 
 const {
   TEST_SKIP_REASON,
-  ERROR_MESSAGE,
   TEST_STATUS,
   finishAllTraceSpans,
   getTestSuitePath
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
-const { COMPONENT } = require('../../dd-trace/src/constants')
+const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
 
 class CucumberPlugin extends CiPlugin {
   static get name () {

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -6,7 +6,7 @@ const proxyquire = require('proxyquire').noPreserveCache()
 const nock = require('nock')
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
+const { ORIGIN_KEY, COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
 const { SAMPLING_PRIORITY } = require('../../../ext/tags')
 const { AUTO_KEEP } = require('../../../ext/priority')
 const {
@@ -17,7 +17,6 @@ const {
   TEST_SOURCE_FILE,
   TEST_STATUS,
   CI_APP_ORIGIN,
-  ERROR_MESSAGE,
   TEST_SKIP_REASON,
   TEST_FRAMEWORK_VERSION,
   LIBRARY_VERSION

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -22,6 +22,8 @@ const {
 
 const { version: ddTraceVersion } = require('../../../package.json')
 
+const testTimeout = 60000
+
 describe('Plugin', function () {
   let cypressExecutable
   let appPort
@@ -42,7 +44,7 @@ describe('Plugin', function () {
     afterEach(done => appServer.close(done))
 
     describe('cypress', function () {
-      this.timeout(120000)
+      this.timeout(testTimeout)
       it('instruments tests', function (done) {
         process.env.DD_TRACE_AGENT_PORT = agentListenPort
         cypressExecutable.run({
@@ -78,7 +80,7 @@ describe('Plugin', function () {
             [COMPONENT]: 'cypress'
           })
           expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-        }, { timeoutMs: 20000 })
+        }, { timeoutMs: testTimeout })
         const failingTestPromise = agent.use(traces => {
           const testSpan = traces[0][0]
           expect(testSpan.name).to.equal('cypress.test')
@@ -108,7 +110,7 @@ describe('Plugin', function () {
           expect(testSpan.meta[ERROR_MESSAGE]).to.contain(
             "expected '<div.hello-world>' to have text 'Bye World', but the text was 'Hello World'"
           )
-        }, { timeoutMs: 20000 })
+        }, { timeoutMs: testTimeout })
         Promise.all([passingTestPromise, failingTestPromise]).then(() => done()).catch(done)
       })
     })

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const nock = require('nock')
 
-const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
+const { ORIGIN_KEY, COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const {
   TEST_FRAMEWORK,
@@ -16,7 +16,6 @@ const {
   CI_APP_ORIGIN,
   TEST_FRAMEWORK_VERSION,
   JEST_TEST_RUNNER,
-  ERROR_MESSAGE,
   TEST_CODE_OWNERS,
   LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')

--- a/packages/datadog-plugin-jest/test/jest-test.js
+++ b/packages/datadog-plugin-jest/test/jest-test.js
@@ -2,6 +2,8 @@ const http = require('http')
 const tracer = require('dd-trace')
 
 describe('jest-test-suite', () => {
+  // eslint-disable-next-line
+  jest.setTimeout(400)
   it('tracer and active span are available', () => {
     expect(global._ddtrace).not.toEqual(undefined)
     const testSpan = tracer.scope().active()
@@ -12,7 +14,7 @@ describe('jest-test-suite', () => {
     setTimeout(() => {
       expect(100).toEqual(100)
       done()
-    }, 100)
+    }, 50)
   })
   it('done fail', (done) => {
     setTimeout(() => {
@@ -22,13 +24,13 @@ describe('jest-test-suite', () => {
       } catch (e) {
         done(e)
       }
-    }, 100)
+    }, 50)
   })
   it('done fail uncaught', (done) => {
     setTimeout(() => {
       expect(100).toEqual(200)
       done()
-    }, 100)
+    }, 50)
   })
   it('can do integration http', (done) => {
     const req = http.request('http://test:123', (res) => {
@@ -49,7 +51,7 @@ describe('jest-test-suite', () => {
       setTimeout(() => {
         expect(100).toEqual(100)
         resolve()
-      }, 100)
+      }, 50)
     )
   })
   it('promise fails', () => {
@@ -57,7 +59,7 @@ describe('jest-test-suite', () => {
       setTimeout(() => {
         expect(100).toEqual(200)
         resolve()
-      }, 100)
+      }, 50)
     )
   })
   // eslint-disable-next-line


### PR DESCRIPTION
### What does this PR do?
Fix CI Visibility tests.

### Motivation
#2551 broke some CI Visibility tests. The errors were deemed flakiness (because the tests are indeed flaky), and errors messages were not helpful to pinpoint that there was an actual issue. Also, `yarn lint` didn't fail even though we were importing variables that _were not there_. 

This PR fixes the issues coming from #2551 and hopefully improve flakiness (by speeding up some tests and increasing timeout on others).
 
