### PR TITLE
Span resource match for test agent  

### DIFF
--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -174,7 +174,7 @@ describe('Plugin', function () {
             expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
           }, {
-            timeoutMs: testTimeout,
+            timeoutMs: assertionTimeout,
             traceMatch: (traces) => {
               const spans = traces.flatMap(span => span)
               return spans.find(span => span.meta[TEST_NAME] === name)

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -418,7 +418,6 @@ describe('Plugin', function () {
 
           const assertionPromises = events.map(({ name, suite, status, type, spanResourceMatch }) => {
             return agent.use(agentlessPayload => {
-              // debugger
               const { events } = agentlessPayload
               const span = events.find(event => event.type === type).content
               expect(span.meta[TEST_STATUS]).to.equal(status)

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -45,7 +45,7 @@ describe('Plugin', function () {
 
   this.timeout(testTimeout)
 
-  withVersions('jest', ['jest-environment-node'], (version, moduleName) => {
+  withVersions('jest', ['jest-environment-node', 'jest-environment-jsdom'], (version, moduleName) => {
     afterEach(() => {
       delete process.env.DD_CIVISIBILITY_ITR_ENABLED
       delete process.env.DD_API_KEY

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -100,7 +100,7 @@ describe('Plugin', function () {
       })
     })
     describe('jest with jest-circus', () => {
-      it.only('should create test spans for sync, async, integration, parameterized and retried tests', (done) => {
+      it('should create test spans for sync, async, integration, parameterized and retried tests', (done) => {
         const tests = [
           {
             name: 'jest-test-suite tracer and active span are available',
@@ -157,7 +157,7 @@ describe('Plugin', function () {
               expect(testSpan.meta).to.contain(extraTags)
             }
             if (error) {
-              expect(testSpan.meta['error.message']).to.include(error)
+              expect(testSpan.meta[ERROR_MESSAGE]).to.include(error)
             }
             if (name === 'jest-test-suite can do integration http') {
               const httpSpan = trace[0].find(span => span.name === 'http.request')

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -115,7 +115,7 @@ describe('Plugin', () => {
             expect(testSpan.service).to.equal('test')
             expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-          }, { timeoutMs: 30000 })
+          }, { timeoutMs: 30000, spanResourceMatch: new RegExp(`${name}$`) })
         })
 
         Promise.all(assertionPromises).then(() => done()).catch(done)
@@ -162,7 +162,7 @@ describe('Plugin', () => {
               `packages/datadog-plugin-jest/test/jest-hook-failure.js.${name}`
             )
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-          }, { timeoutMs: 30000 })
+          }, { timeoutMs: 30000, spanResourceMatch: new RegExp(`${name}$`) })
         })
 
         Promise.all(assertionPromises).then(() => done()).catch(done)
@@ -200,7 +200,7 @@ describe('Plugin', () => {
               [TEST_SOURCE_FILE]: 'packages/datadog-plugin-jest/test/jest-focus.js',
               [COMPONENT]: 'jest'
             })
-          }, { timeoutMs: 30000 })
+          }, { timeoutMs: 30000, spanResourceMatch: new RegExp(`${name}$`) })
         })
 
         Promise.all(assertionPromises).then(() => done()).catch(done)

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -138,7 +138,7 @@ describe('Plugin', () => {
             )
             expect(testSpan.meta[LIBRARY_VERSION]).to.equal(ddTraceVersion)
             expect(testSpan.meta[COMPONENT]).to.equal('mocha')
-          })
+          }, { spanResourceMatch: new RegExp(`${testName}$`) })
         })
         Promise.all(assertionPromises)
           .then(() => done())
@@ -201,7 +201,7 @@ describe('Plugin', () => {
             expect(testSpan.meta[TEST_NAME]).to.equal(testName)
             expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
             expect(testSpan.meta[COMPONENT]).to.equal('mocha')
-          })
+          }, { spanResourceMatch: new RegExp(`${testName}$`) })
         })
         Promise.all(assertionPromises)
           .then(() => done())
@@ -358,7 +358,7 @@ describe('Plugin', () => {
             expect(testSpan.meta[TEST_NAME]).to.equal(name)
             expect(testSpan.meta[TEST_STATUS]).to.equal(status)
             expect(testSpan.meta[COMPONENT]).to.equal('mocha')
-          })
+          }, { spanResourceMatch: new RegExp(`${name}$`) })
         })
 
         Promise.all(assertionPromises)
@@ -414,7 +414,7 @@ describe('Plugin', () => {
               expect(testSpan.meta[ERROR_TYPE]).to.equal('Error')
               expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
             }
-          })
+          }, { spanResourceMatch: new RegExp(`${name}$`) })
         })
 
         Promise.all(assertionPromises)
@@ -492,7 +492,7 @@ describe('Plugin', () => {
             expect(testSpan.meta[TEST_STATUS]).to.equal(status)
             expect(testSpan.meta[TEST_NAME]).to.equal(testName)
             expect(testSpan.meta[COMPONENT]).to.equal('mocha')
-          })
+          }, { spanResourceMatch: new RegExp(`${testName}$`) })
         })
 
         Promise.all(assertionPromises)

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -17,7 +17,7 @@ let listener = null
 let tracer = null
 let plugins = []
 
-const isMatchingTrace = (spans, spanResourceMatch) => {
+function isMatchingTrace (spans, spanResourceMatch) {
   if (!spanResourceMatch) {
     return true
   }

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -148,9 +148,9 @@ module.exports = {
     }, timeoutMs)
 
     let error
-    let handlerPayload
+    const handlerPayload = { handler, traceMatch: options && options.traceMatch }
 
-    const handler = function () {
+    function handler () {
       try {
         callback.apply(null, arguments)
         handlers.delete(handlerPayload)
@@ -160,7 +160,6 @@ module.exports = {
         error = error || e
       }
     }
-    handlerPayload = { handler, traceMatch: options && options.traceMatch }
 
     handler.promise = promise
     handlers.add(handlerPayload)

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -112,7 +112,7 @@ module.exports = {
 
   // Register handler to be executed each agent call, multiple times
   subscribe (handler) {
-    handlers.add(handler)
+    handlers.add({ handler })
   },
 
   // Remove a handler
@@ -160,7 +160,7 @@ module.exports = {
         error = error || e
       }
     }
-    handlerPayload = { handler, traceMatch: options.traceMatch }
+    handlerPayload = { handler, traceMatch: options && options.traceMatch }
 
     handler.promise = promise
     handlers.add(handlerPayload)


### PR DESCRIPTION
### What does this PR do?
Before this change, the error I introduced in https://github.com/DataDog/dd-trace-js/pull/2576/files#diff-a84ba93b9843a5603ddc9400131e1def252527e682d4e0edbd0a301a53905248R126
was reported as: 
```
1) Plugin
       with jest-environment-node >=24.8.0 (29.3.1)
         jest with jest-circus
           should create test spans for sync, async, integration, parameterized and retried tests:

      AssertionError: expected { '_dd.p.dm': '-4', …(34) } to have property 'test.name' of 'jest-test-suite timeout', but got 'jest-test-suite tracer and active spa…'
      + expected - actual

      -jest-test-suite tracer and active span are available
      +jest-test-suite timeout
```
which tells us nothing about what happened, because the callback reports an error of a trace that _does not match with the callback_ (see that it talks about a different test altogether).


After this change the error is reported as: 
```
1) Plugin
       with jest-environment-node >=24.8.0 (29.3.1)
         jest with jest-circus
           should create test spans for sync, async, integration, parameterized and retried tests:
     AssertionError: expected 'Exceeded timeout of 200 ms for a test…' to include 'dsd timeout'
```

which tells us what failed within the callback _that matches the trace_ that it's supposed to test, which is exactly what we're looking for. 

See logs of the test in https://github.com/DataDog/dd-trace-js/actions/runs/3574988341/jobs/6010961257

### Motivation
<!-- What inspired you to submit this pull request? -->

