### PR TITLE
fix(typing): update experimental exporter type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -382,10 +382,10 @@ export declare interface TracerOptions {
     runtimeId?: boolean
 
     /**
-     * Whether to write traces to log output, rather than send to an agent
+     * Whether to write traces to log output or agentless, rather than send to an agent
      * @default false
      */
-    exporter?: 'log' | 'agent'
+    exporter?: 'log' | 'agent' | 'datadog'
 
     /**
      * Whether to enable the experimental `getRumData` method.


### PR DESCRIPTION
### What does this PR do?

Adds `'datadog'` as a valid string input to `options.experimental.exporter` for the `Tracer` class

### Motivation

For the `Tracer` class, `options.experimental.exporter = 'datadog'` is the valid configuration to use Agentless reporting for CI visibility. This change ensures that it is a valid type, which became relevant when making a custom reporter for use within CircleCI
