### PR TITLE
Proposal for adding a hook for `stealthy-require` 

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -9,6 +9,7 @@ module.exports = {
   '@hapi/hapi': () => require('../hapi'),
   '@jest/core': () => require('../jest'),
   '@jest/reporters': () => require('../jest'),
+  'stealthy-require': () => require('../stealthy-require'),
   '@koa/router': () => require('../koa'),
   '@node-redis/client': () => require('../redis'),
   '@opensearch-project/opensearch': () => require('../opensearch'),

--- a/packages/datadog-instrumentations/src/stealthy-require.js
+++ b/packages/datadog-instrumentations/src/stealthy-require.js
@@ -9,7 +9,6 @@ addHook({
     const ddTraceCache = Object.entries(requireCache).reduce((acc, [path, cache]) => {
       if (path.includes('dd-trace')) {
         acc[path] = cache
-        return acc
       }
       return acc
     }, {})
@@ -20,9 +19,7 @@ addHook({
       return callback.apply(this, arguments)
     }
 
-    const result = stealthyRequire.apply(this, arguments)
-
-    return result
+    return stealthyRequire.apply(this, arguments)
   })
 })
 function restoreCache (origin, target) {

--- a/packages/datadog-instrumentations/src/stealthy-require.js
+++ b/packages/datadog-instrumentations/src/stealthy-require.js
@@ -3,7 +3,7 @@ const shimmer = require('../../datadog-shimmer')
 
 addHook({
   name: 'stealthy-require',
-  versions: ['>=0.1.0']
+  versions: ['>=1.0.0']
 }, (stealthyRequire) => {
   return shimmer.wrap(stealthyRequire, function (requireCache) {
     const ddTraceCache = Object.entries(requireCache).reduce((acc, [path, cache]) => {

--- a/packages/datadog-instrumentations/src/stealthy-require.js
+++ b/packages/datadog-instrumentations/src/stealthy-require.js
@@ -1,0 +1,32 @@
+const { addHook } = require('./helpers/instrument')
+const shimmer = require('../../datadog-shimmer')
+
+addHook({
+  name: 'stealthy-require',
+  versions: ['>=0.1.0']
+}, (stealthyRequire) => {
+  return shimmer.wrap(stealthyRequire, function (requireCache) {
+    const ddTraceCache = Object.entries(requireCache).reduce((acc, [path, cache]) => {
+      if (path.includes('dd-trace')) {
+        acc[path] = cache
+        return acc
+      }
+      return acc
+    }, {})
+
+    const callback = arguments[1]
+    arguments[1] = function () {
+      restoreCache(ddTraceCache, requireCache)
+      return callback.apply(this, arguments)
+    }
+
+    const result = stealthyRequire.apply(this, arguments)
+
+    return result
+  })
+})
+function restoreCache (origin, target) {
+  Object.entries(origin).forEach(([file, cache]) => {
+    target[file] = cache
+  })
+}


### PR DESCRIPTION
### What does this PR do?

⚠️ **Just a proposal**

Add a hook for `stealthy-require`. As long as dd-trace is initialized before `stealthy-require` (it should be the case), we can prevent `dd-trace` related modules from being removed from the cache. 

https://github.com/analog-nico/stealthy-require/blob/v1.0.0/lib/index.js

### Motivation
Some assumptions that we do in our code do not work if `stealthy-require` removes the cache in the middle of a normal execution. For example, our `storage` instance needs to be a singleton, and it isn't if `require.cache` is wiped. 


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
