### PR TITLE
Fix error on wrap fs.promises

### DIFF
--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -21,10 +21,17 @@ const twoPathMethods = ['copyFile', 'link', 'rename', 'symlink']
 const twoPathMethodsSync = ['copyFileSync', 'linkSync', 'renameSync', 'symlinkSync']
 
 addHook({ name: 'fs' }, fs => {
-  shimmer.massWrap(fs, onePathMethods.concat(onePathMethodsSync), wrapFsMethod(fsChannel, 1))
-  shimmer.massWrap(fs, twoPathMethods.concat(twoPathMethodsSync), wrapFsMethod(fsChannel, 2))
-  shimmer.massWrap(fs.promises, onePathPromiseMethods, wrapFsMethod(fsChannel, 1))
-  shimmer.massWrap(fs.promises, twoPathMethods, wrapFsMethod(fsChannel, 2))
+  const fsKeys = Object.keys(fs)
+  shimmer.massWrap(fs, onePathMethods.concat(onePathMethodsSync).filter(key => fsKeys.includes(key)),
+    wrapFsMethod(fsChannel, 1))
+  shimmer.massWrap(fs, twoPathMethods.concat(twoPathMethodsSync).filter(key => fsKeys.includes(key)),
+    wrapFsMethod(fsChannel, 2))
+
+  const fsPromisesKeys = Object.keys(fs.promises)
+  shimmer.massWrap(fs.promises, onePathPromiseMethods.filter(key => fsPromisesKeys.includes(key)),
+    wrapFsMethod(fsChannel, 1))
+  shimmer.massWrap(fs.promises, twoPathMethods.filter(key => fsPromisesKeys.includes(key)),
+    wrapFsMethod(fsChannel, 2))
 
   if (hookChannel.hasSubscribers) {
     hookChannel.publish(fs)

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -12,6 +12,8 @@ const hookChannel = channel('apm:fs:hook')
 const onePathMethods = ['access', 'appendFile', 'chmod', 'lchown', 'mkdir', 'mkdtemp', 'mkdtempSync', 'open',
   'openSync', 'opendir', 'readdir', 'readFile', 'readlink', 'realpath', 'rm', 'rmdir', 'stat', 'truncate', 'unlink',
   'utimes', 'writeFile', 'watch']
+const onePathPromiseMethods = ['access', 'open', 'opendir', 'truncate', 'rm', 'rmdir', 'mkdir', 'readdir', 'readlink',
+  'stat', 'unlink', 'chmod', 'lchown', 'utimes', 'realpath', 'mkdtemp', 'writeFile', 'appendFile', 'readFile', 'watch']
 const onePathMethodsSync = ['accessSync', 'appendFileSync', 'chmodSync', 'chownSync', 'lchownSync', 'mkdirSync',
   'opendirSync', 'readdirSync', 'readFileSync', 'readlinkSync', 'realpathSync', 'rmSync', 'rmdirSync', 'statSync',
   'truncateSync', 'unlinkSync', 'utimesSync', 'writeFileSync']
@@ -19,17 +21,10 @@ const twoPathMethods = ['copyFile', 'link', 'rename', 'symlink']
 const twoPathMethodsSync = ['copyFileSync', 'linkSync', 'renameSync', 'symlinkSync']
 
 addHook({ name: 'fs' }, fs => {
-  const allOnePathMethods = onePathMethods.concat(onePathMethodsSync)
-  const allTwoPathMethods = twoPathMethods.concat(twoPathMethodsSync)
-  const allFsProperties = Object.keys(fs)
-  const allFsPromisesProperties = Object.keys(fs.promises)
-  shimmer.massWrap(fs, allFsProperties.filter(name => allOnePathMethods.includes(name)), wrapFsMethod(fsChannel, 1))
-  shimmer.massWrap(fs, allFsProperties.filter(name => allTwoPathMethods.includes(name)), wrapFsMethod(fsChannel, 2))
-
-  shimmer.massWrap(fs.promises, allFsPromisesProperties.filter(name => onePathMethods.includes(name)),
-    wrapFsMethod(fsChannel, 1))
-  shimmer.massWrap(fs.promises, allFsPromisesProperties.filter(name => twoPathMethods.includes(name)),
-    wrapFsMethod(fsChannel, 2))
+  shimmer.massWrap(fs, onePathMethods.concat(onePathMethodsSync), wrapFsMethod(fsChannel, 1))
+  shimmer.massWrap(fs, twoPathMethods.concat(twoPathMethodsSync), wrapFsMethod(fsChannel, 2))
+  shimmer.massWrap(fs.promises, onePathPromiseMethods, wrapFsMethod(fsChannel, 1))
+  shimmer.massWrap(fs.promises, twoPathMethods, wrapFsMethod(fsChannel, 2))
 
   if (hookChannel.hasSubscribers) {
     hookChannel.publish(fs)

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -19,11 +19,18 @@ const twoPathMethods = ['copyFile', 'link', 'rename', 'symlink']
 const twoPathMethodsSync = ['copyFileSync', 'linkSync', 'renameSync', 'symlinkSync']
 
 addHook({ name: 'fs' }, fs => {
-  shimmer.massWrap(fs, onePathMethods.concat(onePathMethodsSync), wrapFsMethod(fsChannel, 1))
-  shimmer.massWrap(fs, twoPathMethods.concat(twoPathMethodsSync), wrapFsMethod(fsChannel, 2))
+  const allOnePathMethods = onePathMethods.concat(onePathMethodsSync)
+  const allTwoPathMethods = twoPathMethods.concat(twoPathMethodsSync)
+  const allFsProperties = Object.keys(fs)
+  const allFsPromisesProperties = Object.keys(fs.promises)
+  shimmer.massWrap(fs, allFsProperties.filter(name => allOnePathMethods.includes(name)), wrapFsMethod(fsChannel, 1))
+  shimmer.massWrap(fs, allFsProperties.filter(name => allTwoPathMethods.includes(name)), wrapFsMethod(fsChannel, 2))
 
-  shimmer.massWrap(fs.promises, onePathMethods, wrapFsMethod(fsChannel, 1))
-  shimmer.massWrap(fs.promises, twoPathMethods, wrapFsMethod(fsChannel, 2))
+  shimmer.massWrap(fs.promises, allFsPromisesProperties.filter(name => onePathMethods.includes(name)),
+    wrapFsMethod(fsChannel, 1))
+  shimmer.massWrap(fs.promises, allFsPromisesProperties.filter(name => twoPathMethods.includes(name)),
+    wrapFsMethod(fsChannel, 2))
+
   if (hookChannel.hasSubscribers) {
     hookChannel.publish(fs)
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix failure on wrap methods that does not exist in `fs.promises`

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
