### PR TITLE
web spans should not inherit active context unless it's a lambda span

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -265,7 +265,11 @@ const web = {
 
   // Extract the parent span from the headers and start a new span as its child
   startChildSpan (tracer, name, headers) {
-    const childOf = tracer.scope().active() || tracer.extract(FORMAT_HTTP_HEADERS, headers)
+    const activeSpan = tracer.scope().active()
+    const spanContext = activeSpan && activeSpan.context()
+    const isLambda = spanContext && spanContext._name === 'aws.lambda'
+
+    const childOf = (isLambda && activeSpan) || tracer.extract(FORMAT_HTTP_HEADERS, headers)
 
     const span = tracer.startSpan(name, { childOf })
 

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -153,11 +153,20 @@ describe('plugins/util/web', () => {
         })
       })
 
-      it('should set the parent from the active context if any', () => {
+      it('should set the parent from the active context if it is an aws.lambda span', () => {
         tracer.trace('aws.lambda', parentSpan => {
           web.instrument(tracer, config, req, res, 'test.request', span => {
             expect(span.context()._traceId.toString(10)).to.equal(parentSpan.context()._traceId.toString(10))
             expect(span.context()._parentId.toString(10)).to.equal(parentSpan.context()._spanId.toString(10))
+          })
+        })
+      })
+
+      it('should not set the parent from the active context only it is not an aws.lambda span', () => {
+        tracer.trace('other', parentSpan => {
+          web.instrument(tracer, config, req, res, 'test.request', span => {
+            expect(span.context()._traceId.toString(10)).to.not.equal(parentSpan.context()._traceId.toString(10))
+            expect(span.context()._parentId).to.be.null
           })
         })
       })


### PR DESCRIPTION
### What does this PR do?

Prevents http servers from rooting within outer traces rather than starting new traces when there is bootstrap activity which creates a trace and then starts the http server.

### Motivation

Lambda wants http layers to be wrapped in a lambda wrapper span so a change was made to make `web.startSpan(...)` inherit an active span if present, however this caused traced bootstrap activity to break request isolation for traces.

### Plugin Checklist

- [x] Unit tests.