### PR TITLE
[ci-visibility] ITR related requests can use EVP Proxy

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -7,7 +7,8 @@ const options = {
   startupLogs: false,
   tags: {
     [ORIGIN_KEY]: 'ciapp-test'
-  }
+  },
+  isCiVisibility: true
 }
 
 let shouldInit = true

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -15,12 +15,20 @@ const DEFAULT_SETTINGS = {
 
 const DEFAULT_SUITES_TO_SKIP = []
 const DEFAULT_GIT_UPLOAD_STATUS = 200
+const DEFAULT_INFO_RESPONSE = {
+  endpoints: ['/evp_proxy/v2']
+}
 
 let settings = DEFAULT_SETTINGS
 let suitesToSkip = DEFAULT_SUITES_TO_SKIP
 let gitUploadStatus = DEFAULT_GIT_UPLOAD_STATUS
+let infoResponse = DEFAULT_INFO_RESPONSE
 
 class FakeCiVisIntake extends FakeAgent {
+  setInfoResponse (newInfoResponse) {
+    infoResponse = newInfoResponse
+  }
+
   setGitUploadStatus (newStatus) {
     gitUploadStatus = newStatus
   }
@@ -37,7 +45,25 @@ class FakeCiVisIntake extends FakeAgent {
     const app = express()
     app.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
 
-    app.post('/api/v2/citestcycle', (req, res) => {
+    app.put('/v0.4/traces', (req, res) => {
+      if (req.body.length === 0) return res.status(200).send()
+      res.status(200).send({ rate_by_service: { 'service:,env:': 1 } })
+      this.emit('message', {
+        headers: req.headers,
+        payload: msgpack.decode(req.body, { codec }),
+        url: req.url
+      })
+    })
+
+    app.get('/info', (req, res) => {
+      res.status(200).send(JSON.stringify(infoResponse))
+      this.emit('message', {
+        headers: req.headers,
+        url: req.url
+      })
+    })
+
+    app.post(['/api/v2/citestcycle', '/evp_proxy/v2/api/v2/citestcycle'], (req, res) => {
       res.status(200).send('OK')
       this.emit('message', {
         headers: req.headers,
@@ -46,7 +72,10 @@ class FakeCiVisIntake extends FakeAgent {
       })
     })
 
-    app.post('/api/v2/git/repository/search_commits', (req, res) => {
+    app.post([
+      '/api/v2/git/repository/search_commits',
+      '/evp_proxy/v2/api/v2/git/repository/search_commits'
+    ], (req, res) => {
       res.status(gitUploadStatus).send(JSON.stringify({ data: [] }))
       this.emit('message', {
         headers: req.headers,
@@ -55,7 +84,10 @@ class FakeCiVisIntake extends FakeAgent {
       })
     })
 
-    app.post('/api/v2/git/repository/packfile', (req, res) => {
+    app.post([
+      '/api/v2/git/repository/packfile',
+      '/evp_proxy/v2/api/v2/git/repository/packfile'
+    ], (req, res) => {
       res.status(202).send('')
       this.emit('message', {
         headers: req.headers,
@@ -63,7 +95,10 @@ class FakeCiVisIntake extends FakeAgent {
       })
     })
 
-    app.post('/api/v2/citestcov', upload.any(), (req, res) => {
+    app.post([
+      '/api/v2/citestcov',
+      '/evp_proxy/v2/api/v2/citestcov'
+    ], upload.any(), (req, res) => {
       res.status(200).send('OK')
 
       const coveragePayloads = req.files
@@ -84,7 +119,10 @@ class FakeCiVisIntake extends FakeAgent {
       })
     })
 
-    app.post('/api/v2/libraries/tests/services/setting', (req, res) => {
+    app.post([
+      '/api/v2/libraries/tests/services/setting',
+      '/evp_proxy/v2/api/v2/libraries/tests/services/setting'
+    ], (req, res) => {
       res.status(200).send(JSON.stringify({
         data: {
           attributes: settings
@@ -96,7 +134,10 @@ class FakeCiVisIntake extends FakeAgent {
       })
     })
 
-    app.post('/api/v2/ci/tests/skippable', (req, res) => {
+    app.post([
+      '/api/v2/ci/tests/skippable',
+      '/evp_proxy/v2/api/v2/ci/tests/skippable'
+    ], (req, res) => {
       res.status(200).send(JSON.stringify({
         data: suitesToSkip
       }))
@@ -125,6 +166,7 @@ class FakeCiVisIntake extends FakeAgent {
     settings = DEFAULT_SETTINGS
     suitesToSkip = DEFAULT_SUITES_TO_SKIP
     gitUploadStatus = DEFAULT_GIT_UPLOAD_STATUS
+    infoResponse = DEFAULT_INFO_RESPONSE
   }
 
   assertPayloadReceived (fn, messageMatch, timeout) {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -19,7 +19,7 @@ const testRunFinishCh = channel('ci:jest:test:finish')
 const testErrCh = channel('ci:jest:test:err')
 
 const skippableSuitesCh = channel('ci:jest:test-suite:skippable')
-const jestConfigurationCh = channel('ci:jest:configuration')
+const jestItrConfigurationCh = channel('ci:jest:itr-configuration')
 
 let skippableSuites = []
 let isCodeCoverageEnabled = false
@@ -176,21 +176,21 @@ function cliWrapper (cli) {
     const configurationPromise = new Promise((resolve) => {
       onDone = resolve
     })
-    if (!jestConfigurationCh.hasSubscribers) {
+    if (!jestItrConfigurationCh.hasSubscribers) {
       return runCLI.apply(this, arguments)
     }
 
     sessionAsyncResource.runInAsyncScope(() => {
-      jestConfigurationCh.publish({ onDone })
+      jestItrConfigurationCh.publish({ onDone })
     })
 
     try {
-      const { err, config } = await configurationPromise
+      const { err, itrConfig } = await configurationPromise
       if (err) {
         log.error(err)
       }
-      isCodeCoverageEnabled = config.isCodeCoverageEnabled
-      isSuitesSkippingEnabled = config.isSuitesSkippingEnabled
+      isCodeCoverageEnabled = itrConfig.isCodeCoverageEnabled
+      isSuitesSkippingEnabled = itrConfig.isSuitesSkippingEnabled
     } catch (e) {
       log.error(e)
     }
@@ -307,6 +307,11 @@ function jestAdapterWrapper (jestAdapter) {
         const coverageFiles = getCoveredFilenamesFromCoverage(environment.global.__coverage__)
           .map(filename => getTestSuitePath(filename, environment.rootDir))
 
+        /**
+         * Child processes do not each request ITR configuration, so the jest's parent process
+         * needs to pass them the configuration. This is done via _ddTestCodeCoverageEnabled, which
+         * controls whether coverage is reported.
+         */
         if (coverageFiles &&
           environment.testEnvironmentOptions &&
           environment.testEnvironmentOptions._ddTestCodeCoverageEnabled) {

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -17,7 +17,7 @@ const skipCh = channel('ci:mocha:test:skip')
 const testFinishCh = channel('ci:mocha:test:finish')
 const parameterizedTestCh = channel('ci:mocha:test:parameterize')
 
-const configurationCh = channel('ci:mocha:configuration')
+const itrConfigurationCh = channel('ci:mocha:itr-configuration')
 const skippableSuitesCh = channel('ci:mocha:test-suite:skippable')
 
 const testSessionStartCh = channel('ci:mocha:session:start')
@@ -317,7 +317,7 @@ addHook({
    * If ITR is disabled, `onDone` is called immediately on the subscriber
    */
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
-    if (!configurationCh.hasSubscribers) {
+    if (!itrConfigurationCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
     const onReceivedSkippableSuites = ({ err, skippableSuites }) => {
@@ -345,7 +345,7 @@ addHook({
     }
 
     mochaRunAsyncResource.runInAsyncScope(() => {
-      configurationCh.publish({
+      itrConfigurationCh.publish({
         onDone: mochaRunAsyncResource.bind(onReceivedConfiguration)
       })
     })

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -126,7 +126,7 @@ class JestPlugin extends CiPlugin {
     })
 
     /**
-     * This can't use `this._itrConfig` like `ci:mocha:test-suite:code-coverage`
+     * This can't use `this.itrConfig` like `ci:mocha:test-suite:code-coverage`
      * because this subscription happens in a different process from the one
      * fetching the ITR config.
      */

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -125,10 +125,12 @@ class JestPlugin extends CiPlugin {
       finishAllTraceSpans(testSuiteSpan)
     })
 
+    /**
+     * This can't use `this._itrConfig` like `ci:mocha:test-suite:code-coverage`
+     * because this subscription happens in a different process from the one
+     * fetching the ITR config.
+     */
     this.addSub('ci:jest:test-suite:code-coverage', (coverageFiles) => {
-      if (!this.config.isIntelligentTestRunnerEnabled) {
-        return
-      }
       const testSuiteSpan = storage.getStore().span
       this.tracer._exporter.exportCoverage({ span: testSuiteSpan, coverageFiles })
     })

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -35,6 +35,32 @@ const { version: ddTraceVersion } = require('../../../package.json')
 const assertionTimeout = 15000
 const testTimeout = 20000
 
+function loadAgent (moduleName, version, isAgentlessTest, isEvpProxyTest) {
+  const exporter = isAgentlessTest ? 'datadog' : 'agent_proxy'
+  if (!isEvpProxyTest) {
+    agent.setAvailableEndpoints([])
+  }
+  return agent.load(['jest', 'http'], { service: 'test' }, { experimental: { exporter } }).then(() => {
+    global.__libraryName__ = moduleName
+    global.__libraryVersion__ = version
+
+    return {
+      jestExecutable: require(`../../../versions/jest@${version}`).get(),
+      jestCommonOptions: {
+        projects: [__dirname],
+        testPathIgnorePatterns: ['/node_modules/'],
+        coverageReporters: ['none'],
+        reporters: [],
+        silent: true,
+        testEnvironment: path.join(__dirname, 'env.js'),
+        testRunner: require(`../../../versions/jest-circus@${version}`).getPath('jest-circus/runner'),
+        cache: false,
+        maxWorkers: '50%'
+      }
+    }
+  })
+}
+
 describe('Plugin', function () {
   let jestExecutable
   let jestCommonOptions
@@ -44,6 +70,8 @@ describe('Plugin', function () {
 
   withVersions('jest', ['jest-environment-node', 'jest-environment-jsdom'], (version, moduleName) => {
     afterEach(() => {
+      delete process.env.DD_API_KEY
+      delete process.env.DD_APP_KEY
       const jestTestFile = fs.readdirSync(__dirname).filter(name => name.startsWith('jest-'))
       jestTestFile.forEach((testFile) => {
         delete require.cache[require.resolve(path.join(__dirname, testFile))]
@@ -53,240 +81,104 @@ describe('Plugin', function () {
       return agent.close({ ritmReset: false, wipe: true })
     })
     beforeEach(function () {
-      // for http integration tests
-      nock('http://test:123')
-        .get('/')
-        .reply(200, 'OK')
-
       process.env.DD_API_KEY = 'key'
       process.env.DD_APP_KEY = 'app-key'
-      const isAgentlessTest = this.currentTest.parent.title === 'reporting through agentless'
-      const isEvpProxyTest = this.currentTest.parent.title === 'reporting through evp proxy'
-
-      const exporter = isAgentlessTest ? 'datadog' : 'agent_proxy'
-
-      if (!isEvpProxyTest) {
-        agent.setAvailableEndpoints([])
-      }
-
-      return agent.load(['jest', 'http'], { service: 'test' }, { experimental: { exporter } }).then(() => {
-        global.__libraryName__ = moduleName
-        global.__libraryVersion__ = version
-        jestExecutable = require(`../../../versions/jest@${version}`).get()
-
-        jestCommonOptions = {
-          projects: [__dirname],
-          testPathIgnorePatterns: ['/node_modules/'],
-          coverageReporters: ['none'],
-          reporters: [],
-          silent: true,
-          testEnvironment: path.join(__dirname, 'env.js'),
-          testRunner: require(`../../../versions/jest-circus@${version}`).getPath('jest-circus/runner'),
-          cache: false,
-          maxWorkers: '50%'
-        }
-      })
     })
     describe('jest with jest-circus', () => {
-      it('should create test spans for sync, async, integration, parameterized and retried tests', (done) => {
-        const tests = [
-          {
-            name: 'jest-test-suite tracer and active span are available',
-            status: 'pass',
-            extraTags: { 'test.add.stuff': 'stuff' }
-          },
-          { name: 'jest-test-suite done', status: 'pass' },
-          { name: 'jest-test-suite done fail', status: 'fail' },
-          { name: 'jest-test-suite done fail uncaught', status: 'fail' },
-          { name: 'jest-test-suite can do integration http', status: 'pass' },
-          {
-            name: 'jest-test-suite can do parameterized test',
-            status: 'pass',
-            parameters: { arguments: [1, 2, 3], metadata: {} }
-          },
-          {
-            name: 'jest-test-suite can do parameterized test',
-            status: 'pass',
-            parameters: { arguments: [2, 3, 5], metadata: {} }
-          },
-          { name: 'jest-test-suite promise passes', status: 'pass' },
-          { name: 'jest-test-suite promise fails', status: 'fail' },
-          { name: 'jest-test-suite timeout', status: 'fail', error: 'Exceeded timeout' },
-          { name: 'jest-test-suite passes', status: 'pass' },
-          { name: 'jest-test-suite fails', status: 'fail' },
-          { name: 'jest-test-suite does not crash with missing stack', status: 'fail' },
-          { name: 'jest-test-suite skips', status: 'skip' },
-          { name: 'jest-test-suite skips todo', status: 'skip' },
-          { name: 'jest-circus-test-retry can retry', status: 'fail' },
-          { name: 'jest-circus-test-retry can retry', status: 'fail' },
-          { name: 'jest-circus-test-retry can retry', status: 'pass' }
-        ]
+      describe('older versions of the agent', () => {
+        beforeEach(async () => {
+          nock('http://test:123')
+            .get('/')
+            .reply(200, 'OK')
 
-        const assertionPromises = tests.map(({ name, status, error, parameters, extraTags }) => {
-          return agent.use(trace => {
-            const testSpan = trace[0][0]
-            expect(testSpan.parent_id.toString()).to.equal('0')
-            expect(testSpan.meta).to.contain({
-              language: 'javascript',
-              service: 'test',
-              [ORIGIN_KEY]: CI_APP_ORIGIN,
-              [TEST_FRAMEWORK]: 'jest',
-              [TEST_NAME]: name,
-              [TEST_STATUS]: status,
-              [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-test.js',
-              [TEST_SOURCE_FILE]: 'packages/datadog-plugin-jest/test/jest-test.js',
-              [TEST_TYPE]: 'test',
-              [JEST_TEST_RUNNER]: 'jest-circus',
-              [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/dd-trace-js']), // reads from dd-trace-js
-              [LIBRARY_VERSION]: ddTraceVersion,
-              [COMPONENT]: 'jest'
-            })
-            if (extraTags) {
-              expect(testSpan.meta).to.contain(extraTags)
-            }
-            if (error) {
-              expect(testSpan.meta[ERROR_MESSAGE]).to.include(error)
-            }
-            if (name === 'jest-test-suite can do integration http') {
-              const httpSpan = trace[0].find(span => span.name === 'http.request')
-              expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-              expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
-              expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
-            }
-            if (parameters) {
-              expect(testSpan.meta[TEST_PARAMETERS]).to.equal(JSON.stringify(parameters))
-            }
-            expect(testSpan.type).to.equal('test')
-            expect(testSpan.name).to.equal('jest.test')
-            expect(testSpan.service).to.equal('test')
-            expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
-            expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-          }, {
-            timeoutMs: assertionTimeout,
-            spanResourceMatch: new RegExp(`${name}$`)
-          })
+          const loadedAgent = await loadAgent(moduleName, version, false, false)
+          jestExecutable = loadedAgent.jestExecutable
+          jestCommonOptions = loadedAgent.jestCommonOptions
         })
+        it('should create test spans for sync, async, integration, parameterized and retried tests', (done) => {
+          const tests = [
+            {
+              name: 'jest-test-suite tracer and active span are available',
+              status: 'pass',
+              extraTags: { 'test.add.stuff': 'stuff' }
+            },
+            { name: 'jest-test-suite done', status: 'pass' },
+            { name: 'jest-test-suite done fail', status: 'fail' },
+            { name: 'jest-test-suite done fail uncaught', status: 'fail' },
+            { name: 'jest-test-suite can do integration http', status: 'pass' },
+            {
+              name: 'jest-test-suite can do parameterized test',
+              status: 'pass',
+              parameters: { arguments: [1, 2, 3], metadata: {} }
+            },
+            {
+              name: 'jest-test-suite can do parameterized test',
+              status: 'pass',
+              parameters: { arguments: [2, 3, 5], metadata: {} }
+            },
+            { name: 'jest-test-suite promise passes', status: 'pass' },
+            { name: 'jest-test-suite promise fails', status: 'fail' },
+            { name: 'jest-test-suite timeout', status: 'fail', error: 'Exceeded timeout' },
+            { name: 'jest-test-suite passes', status: 'pass' },
+            { name: 'jest-test-suite fails', status: 'fail' },
+            { name: 'jest-test-suite does not crash with missing stack', status: 'fail' },
+            { name: 'jest-test-suite skips', status: 'skip' },
+            { name: 'jest-test-suite skips todo', status: 'skip' },
+            { name: 'jest-circus-test-retry can retry', status: 'fail' },
+            { name: 'jest-circus-test-retry can retry', status: 'fail' },
+            { name: 'jest-circus-test-retry can retry', status: 'pass' }
+          ]
 
-        Promise.all(assertionPromises).then(() => done()).catch(done)
-
-        const options = {
-          ...jestCommonOptions,
-          testRegex: 'jest-test.js'
-        }
-
-        jestExecutable.runCLI(
-          options,
-          options.projects
-        )
-      })
-
-      it('should detect an error in hooks', (done) => {
-        const tests = [
-          { name: 'jest-hook-failure will not run', error: 'hey, hook error before' },
-          { name: 'jest-hook-failure-after will not run', error: 'hey, hook error after' }
-        ]
-        const assertionPromises = tests.map(({ name, error }) => {
-          return agent.use(trace => {
-            const testSpan = trace[0][0]
-            expect(testSpan.parent_id.toString()).to.equal('0')
-            expect(testSpan.meta).to.contain({
-              language: 'javascript',
-              service: 'test',
-              [ORIGIN_KEY]: CI_APP_ORIGIN,
-              [TEST_FRAMEWORK]: 'jest',
-              [TEST_NAME]: name,
-              [TEST_STATUS]: 'fail',
-              [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-hook-failure.js',
-              [TEST_SOURCE_FILE]: 'packages/datadog-plugin-jest/test/jest-hook-failure.js',
-              [TEST_TYPE]: 'test',
-              [JEST_TEST_RUNNER]: 'jest-circus',
-              [COMPONENT]: 'jest'
+          const assertionPromises = tests.map(({ name, status, error, parameters, extraTags }) => {
+            return agent.use(trace => {
+              const testSpan = trace[0][0]
+              expect(testSpan.parent_id.toString()).to.equal('0')
+              expect(testSpan.meta).to.contain({
+                language: 'javascript',
+                service: 'test',
+                [ORIGIN_KEY]: CI_APP_ORIGIN,
+                [TEST_FRAMEWORK]: 'jest',
+                [TEST_NAME]: name,
+                [TEST_STATUS]: status,
+                [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-test.js',
+                [TEST_SOURCE_FILE]: 'packages/datadog-plugin-jest/test/jest-test.js',
+                [TEST_TYPE]: 'test',
+                [JEST_TEST_RUNNER]: 'jest-circus',
+                [TEST_CODE_OWNERS]: JSON.stringify(['@DataDog/dd-trace-js']), // reads from dd-trace-js
+                [LIBRARY_VERSION]: ddTraceVersion,
+                [COMPONENT]: 'jest'
+              })
+              if (extraTags) {
+                expect(testSpan.meta).to.contain(extraTags)
+              }
+              if (error) {
+                expect(testSpan.meta[ERROR_MESSAGE]).to.include(error)
+              }
+              if (name === 'jest-test-suite can do integration http') {
+                const httpSpan = trace[0].find(span => span.name === 'http.request')
+                expect(httpSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+                expect(httpSpan.meta['http.url']).to.equal('http://test:123/')
+                expect(httpSpan.parent_id.toString()).to.equal(testSpan.span_id.toString())
+              }
+              if (parameters) {
+                expect(testSpan.meta[TEST_PARAMETERS]).to.equal(JSON.stringify(parameters))
+              }
+              expect(testSpan.type).to.equal('test')
+              expect(testSpan.name).to.equal('jest.test')
+              expect(testSpan.service).to.equal('test')
+              expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
+              expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+            }, {
+              timeoutMs: assertionTimeout,
+              spanResourceMatch: new RegExp(`${name}$`)
             })
-            expect(testSpan.meta[ERROR_MESSAGE]).to.equal(error)
-            expect(testSpan.type).to.equal('test')
-            expect(testSpan.name).to.equal('jest.test')
-            expect(testSpan.service).to.equal('test')
-            expect(testSpan.resource).to.equal(
-              `packages/datadog-plugin-jest/test/jest-hook-failure.js.${name}`
-            )
-            expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-          }, {
-            timeoutMs: assertionTimeout,
-            spanResourceMatch: new RegExp(`${name}$`)
           })
-        })
 
-        Promise.all(assertionPromises).then(() => done()).catch(done)
-
-        const options = {
-          ...jestCommonOptions,
-          testRegex: 'jest-hook-failure.js'
-        }
-
-        jestExecutable.runCLI(
-          options,
-          options.projects
-        )
-      })
-
-      it('should work with focused tests', (done) => {
-        const tests = [
-          { name: 'jest-test-focused will be skipped', status: 'skip' },
-          { name: 'jest-test-focused-2 will be skipped too', status: 'skip' },
-          { name: 'jest-test-focused can do focused test', status: 'pass' }
-        ]
-
-        const assertionPromises = tests.map(({ name, status }) => {
-          return agent.use(trace => {
-            const testSpan = trace[0].find(span => span.type === 'test')
-            expect(testSpan.parent_id.toString()).to.equal('0')
-            expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
-            expect(testSpan.meta).to.contain({
-              language: 'javascript',
-              service: 'test',
-              [TEST_NAME]: name,
-              [TEST_STATUS]: status,
-              [TEST_FRAMEWORK]: 'jest',
-              [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-focus.js',
-              [TEST_SOURCE_FILE]: 'packages/datadog-plugin-jest/test/jest-focus.js',
-              [COMPONENT]: 'jest'
-            })
-          }, {
-            timeoutMs: assertionTimeout,
-            spanResourceMatch: new RegExp(`${name}$`)
-          })
-        })
-
-        Promise.all(assertionPromises).then(() => done()).catch(done)
-
-        const options = {
-          ...jestCommonOptions,
-          testRegex: 'jest-focus.js'
-        }
-
-        jestExecutable.runCLI(
-          options,
-          options.projects
-        )
-      })
-
-      // option available from 26.5.0:
-      // https://github.com/facebook/jest/blob/7f2731ef8bebac7f226cfc0d2446854603a557a9/CHANGELOG.md#2650
-      if (semver.intersects(version, '>=26.5.0')) {
-        it('does not crash when injectGlobals is false', (done) => {
-          agent.use(trace => {
-            const testSpan = trace[0].find(span => span.type === 'test')
-            expect(testSpan.meta).to.contain({
-              [TEST_NAME]: 'jest-inject-globals will be run',
-              [TEST_STATUS]: 'pass',
-              [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-inject-globals.js'
-            })
-          }, { timeoutMs: assertionTimeout }).then(() => done()).catch(done)
+          Promise.all(assertionPromises).then(() => done()).catch(done)
 
           const options = {
             ...jestCommonOptions,
-            testRegex: 'jest-inject-globals.js',
-            injectGlobals: false
+            testRegex: 'jest-test.js'
           }
 
           jestExecutable.runCLI(
@@ -294,12 +186,136 @@ describe('Plugin', function () {
             options.projects
           )
         })
-      }
+
+        it('should detect an error in hooks', (done) => {
+          const tests = [
+            { name: 'jest-hook-failure will not run', error: 'hey, hook error before' },
+            { name: 'jest-hook-failure-after will not run', error: 'hey, hook error after' }
+          ]
+          const assertionPromises = tests.map(({ name, error }) => {
+            return agent.use(trace => {
+              const testSpan = trace[0][0]
+              expect(testSpan.parent_id.toString()).to.equal('0')
+              expect(testSpan.meta).to.contain({
+                language: 'javascript',
+                service: 'test',
+                [ORIGIN_KEY]: CI_APP_ORIGIN,
+                [TEST_FRAMEWORK]: 'jest',
+                [TEST_NAME]: name,
+                [TEST_STATUS]: 'fail',
+                [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-hook-failure.js',
+                [TEST_SOURCE_FILE]: 'packages/datadog-plugin-jest/test/jest-hook-failure.js',
+                [TEST_TYPE]: 'test',
+                [JEST_TEST_RUNNER]: 'jest-circus',
+                [COMPONENT]: 'jest'
+              })
+              expect(testSpan.meta[ERROR_MESSAGE]).to.equal(error)
+              expect(testSpan.type).to.equal('test')
+              expect(testSpan.name).to.equal('jest.test')
+              expect(testSpan.service).to.equal('test')
+              expect(testSpan.resource).to.equal(
+                `packages/datadog-plugin-jest/test/jest-hook-failure.js.${name}`
+              )
+              expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+            }, {
+              timeoutMs: assertionTimeout,
+              spanResourceMatch: new RegExp(`${name}$`)
+            })
+          })
+
+          Promise.all(assertionPromises).then(() => done()).catch(done)
+
+          const options = {
+            ...jestCommonOptions,
+            testRegex: 'jest-hook-failure.js'
+          }
+
+          jestExecutable.runCLI(
+            options,
+            options.projects
+          )
+        })
+
+        it('should work with focused tests', (done) => {
+          const tests = [
+            { name: 'jest-test-focused will be skipped', status: 'skip' },
+            { name: 'jest-test-focused-2 will be skipped too', status: 'skip' },
+            { name: 'jest-test-focused can do focused test', status: 'pass' }
+          ]
+
+          const assertionPromises = tests.map(({ name, status }) => {
+            return agent.use(trace => {
+              const testSpan = trace[0].find(span => span.type === 'test')
+              expect(testSpan.parent_id.toString()).to.equal('0')
+              expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
+              expect(testSpan.meta).to.contain({
+                language: 'javascript',
+                service: 'test',
+                [TEST_NAME]: name,
+                [TEST_STATUS]: status,
+                [TEST_FRAMEWORK]: 'jest',
+                [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-focus.js',
+                [TEST_SOURCE_FILE]: 'packages/datadog-plugin-jest/test/jest-focus.js',
+                [COMPONENT]: 'jest'
+              })
+            }, {
+              timeoutMs: assertionTimeout,
+              spanResourceMatch: new RegExp(`${name}$`)
+            })
+          })
+
+          Promise.all(assertionPromises).then(() => done()).catch(done)
+
+          const options = {
+            ...jestCommonOptions,
+            testRegex: 'jest-focus.js'
+          }
+
+          jestExecutable.runCLI(
+            options,
+            options.projects
+          )
+        })
+
+        // option available from 26.5.0:
+        // https://github.com/facebook/jest/blob/7f2731ef8bebac7f226cfc0d2446854603a557a9/CHANGELOG.md#2650
+        if (semver.intersects(version, '>=26.5.0')) {
+          it('does not crash when injectGlobals is false', (done) => {
+            agent.use(trace => {
+              const testSpan = trace[0].find(span => span.type === 'test')
+              expect(testSpan.meta).to.contain({
+                [TEST_NAME]: 'jest-inject-globals will be run',
+                [TEST_STATUS]: 'pass',
+                [TEST_SUITE]: 'packages/datadog-plugin-jest/test/jest-inject-globals.js'
+              })
+            }, { timeoutMs: assertionTimeout }).then(() => done()).catch(done)
+
+            const options = {
+              ...jestCommonOptions,
+              testRegex: 'jest-inject-globals.js',
+              injectGlobals: false
+            }
+
+            jestExecutable.runCLI(
+              options,
+              options.projects
+            )
+          })
+        }
+      })
 
       const initOptions = ['agentless', 'evp proxy']
 
       initOptions.forEach(option => {
         describe(`reporting through ${option}`, () => {
+          beforeEach(async () => {
+            const isAgentlessTest = option === 'agentless'
+            const isEvpProxyTest = option === 'evp proxy'
+
+            const loadedAgent = await loadAgent(moduleName, version, isAgentlessTest, isEvpProxyTest)
+            jestExecutable = loadedAgent.jestExecutable
+            jestCommonOptions = loadedAgent.jestCommonOptions
+          })
           it('should create events for session, suite and test', (done) => {
             const events = [
               {

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -31,7 +31,6 @@ describe('Plugin', function () {
     testPathIgnorePatterns: ['/node_modules/'],
     coverageReporters: [],
     reporters: [],
-    silent: true,
     cache: false,
     maxWorkers: '50%',
     testEnvironment: 'node'
@@ -51,7 +50,11 @@ describe('Plugin', function () {
         .get('/')
         .reply(200, 'OK')
 
-      return agent.load(['jest', 'http'], { service: 'test' }).then(() => {
+      agent.setAvailableEndpoints([])
+
+      return agent.load(
+        ['jest', 'http'], { service: 'test' }, { experimental: { exporter: 'agent_proxy' } }
+      ).then(() => {
         jestCommonOptions.testRunner =
           require(`../../../versions/jest@${version}`).getPath('jest-jasmine2')
 

--- a/packages/datadog-plugin-jest/test/jest-coverage.js
+++ b/packages/datadog-plugin-jest/test/jest-coverage.js
@@ -1,7 +1,0 @@
-const sum = require('./sum-coverage-test.js')
-
-describe('jest-coverage', () => {
-  it('can sum', () => {
-    expect(sum(1, 2)).toEqual(3)
-  })
-})

--- a/packages/datadog-plugin-jest/test/jest-itr-pass.js
+++ b/packages/datadog-plugin-jest/test/jest-itr-pass.js
@@ -1,7 +1,0 @@
-const sum = require('./sum-coverage-test.js')
-
-describe('jest-itr-pass', () => {
-  it('will be run', () => {
-    expect(sum(1, 2)).toEqual(3)
-  })
-})

--- a/packages/datadog-plugin-jest/test/jest-itr-skip.js
+++ b/packages/datadog-plugin-jest/test/jest-itr-skip.js
@@ -1,5 +1,0 @@
-describe('jest-itr-skip', () => {
-  it('will be skipped through ITR', () => {
-    expect(true).toEqual(true)
-  })
-})

--- a/packages/datadog-plugin-jest/test/sum-coverage-test.js
+++ b/packages/datadog-plugin-jest/test/sum-coverage-test.js
@@ -1,3 +1,0 @@
-module.exports = function (a, b) {
-  return a + b
-}

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -31,9 +31,6 @@ class MochaPlugin extends CiPlugin {
     this.sourceRoot = process.cwd()
 
     this.addSub('ci:mocha:test-suite:code-coverage', ({ coverageFiles, suiteFile }) => {
-      if (!this.config.isIntelligentTestRunnerEnabled) {
-        return
-      }
       if (!this.itrConfig || !this.itrConfig.isCodeCoverageEnabled) {
         return
       }

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -3,8 +3,7 @@
 const AgentWriter = require('../../../exporters/agent/writer')
 const AgentlessWriter = require('../agentless/writer')
 const CoverageWriter = require('../agentless/coverage-writer')
-const AgentInfoExporter = require('../../../exporters/common/agent-info-exporter')
-const log = require('../../../log')
+const CiVisibilityExporter = require('../ci-visibility-exporter')
 
 const AGENT_EVP_PROXY_PATH = '/evp_proxy/v2'
 
@@ -12,28 +11,24 @@ function getIsEvpCompatible (err, agentInfo) {
   return !err && agentInfo.endpoints.some(url => url.includes(AGENT_EVP_PROXY_PATH))
 }
 
-const getIsTestSessionTrace = (trace) => {
-  return trace.some(span =>
-    span.type === 'test_session_end' || span.type === 'test_suite_end'
-  )
-}
-
-/**
- * AgentProxyCiVisibilityExporter extends from AgentInfoExporter to get the agent information.
- * If the agent is event platform proxy compatible,
- * it will initialize the AgentlessWriter and CoverageWriter, else it will fall back to AgentWriter.
- */
-class AgentProxyCiVisibilityExporter extends AgentInfoExporter {
+class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
   constructor (config) {
     super(config)
 
-    this._coverageBuffer = []
-    const { tags, prioritySampler, lookup, protocolVersion, headers } = config
+    const {
+      tags,
+      prioritySampler,
+      lookup,
+      protocolVersion,
+      headers,
+      isGitUploadEnabled
+    } = config
 
     this.getAgentInfo((err, agentInfo) => {
       this._isInitialized = true
-      this._isEvpCompatible = getIsEvpCompatible(err, agentInfo)
-      if (this._isEvpCompatible) {
+      const isEvpCompatible = getIsEvpCompatible(err, agentInfo)
+      this._isUsingEvpProxy = true
+      if (isEvpCompatible) {
         this._writer = new AgentlessWriter({
           url: this._url,
           tags,
@@ -43,6 +38,9 @@ class AgentProxyCiVisibilityExporter extends AgentInfoExporter {
           url: this._url,
           evpProxyPrefix: AGENT_EVP_PROXY_PATH
         })
+        if (isGitUploadEnabled) {
+          this.sendGitMetadata({ url: this._url, isEvpProxy: true })
+        }
       } else {
         this._writer = new AgentWriter({
           url: this._url,
@@ -54,17 +52,9 @@ class AgentProxyCiVisibilityExporter extends AgentInfoExporter {
         // coverages will never be used, so we discard them
         this._coverageBuffer = []
       }
+      this._resolveCanUseCiVisProtocol(isEvpCompatible)
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
-    })
-
-    process.once('beforeExit', () => {
-      if (this._writer) {
-        this._writer.flush()
-      }
-      if (this._coverageWriter) {
-        this._coverageWriter.flush()
-      }
     })
   }
 
@@ -80,65 +70,6 @@ class AgentProxyCiVisibilityExporter extends AgentInfoExporter {
       this.exportCoverage(oldCoveragePayload)
     })
     this._coverageBuffer = []
-  }
-
-  export (trace) {
-    // Until it's initialized, we just store the traces as is
-    if (!this._isInitialized) {
-      this._traceBuffer.push(trace)
-      return
-    }
-    if (!this._isEvpCompatible && getIsTestSessionTrace(trace)) {
-      return
-    }
-    this._export(trace)
-  }
-
-  exportCoverage (coveragePayload) {
-    // Until it's initialized, we just store the coverages as is
-    if (!this._isInitialized) {
-      this._coverageBuffer.push(coveragePayload)
-      return
-    }
-    // We can't process coverages if it's not evp compatible
-    if (!this._isEvpCompatible) {
-      return
-    }
-
-    const { span, coverageFiles } = coveragePayload
-    const formattedCoverage = {
-      traceId: span.context()._traceId,
-      spanId: span.context()._spanId,
-      files: coverageFiles
-    }
-
-    this._export(formattedCoverage, this._coverageWriter, '_coverageTimer')
-  }
-
-  flush (done = () => {}) {
-    if (!this._isInitialized) {
-      return done()
-    }
-    this._writer.flush(() => {
-      if (this._coverageWriter) {
-        this._coverageWriter.flush(done)
-      } else {
-        done()
-      }
-    })
-  }
-
-  setUrl (url, coverageUrl = url) {
-    super.setUrl(url)
-    try {
-      if (this._coverageWriter) {
-        coverageUrl = new URL(coverageUrl)
-        this._coverageUrl = coverageUrl
-        this._coverageWriter.setUrl(coverageUrl)
-      }
-    } catch (e) {
-      log.error(e)
-    }
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -27,8 +27,8 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
     this.getAgentInfo((err, agentInfo) => {
       this._isInitialized = true
       const isEvpCompatible = getIsEvpCompatible(err, agentInfo)
-      this._isUsingEvpProxy = true
       if (isEvpCompatible) {
+        this._isUsingEvpProxy = true
         this._writer = new AgentlessWriter({
           url: this._url,
           tags,
@@ -56,20 +56,6 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
     })
-  }
-
-  exportUncodedTraces () {
-    this.getUncodedTraces().forEach(uncodedTrace => {
-      this.export(uncodedTrace)
-    })
-    this.resetUncodedTraces()
-  }
-
-  exportUncodedCoverages () {
-    this._coverageBuffer.forEach(oldCoveragePayload => {
-      this.exportCoverage(oldCoveragePayload)
-    })
-    this._coverageBuffer = []
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -3,81 +3,25 @@
 const URL = require('url').URL
 const Writer = require('./writer')
 const CoverageWriter = require('./coverage-writer')
+const CiVisibilityExporter = require('../ci-visibility-exporter')
 
-const log = require('../../../log')
-
-class AgentlessCiVisibilityExporter {
+class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
   constructor (config) {
-    this._config = config
-    const { tags, site, url } = config
+    super(config)
+    const { tags, site, url, isGitUploadEnabled } = config
+    // we don't need to request /info because we are using agentless by configuration
+    this._isInitialized = true
+    this._resolveCanUseCiVisProtocol(true)
+
     this._url = url || new URL(`https://citestcycle-intake.${site}`)
     this._writer = new Writer({ url: this._url, tags })
-    this._timer = undefined
-    this._coverageTimer = undefined
 
     this._coverageUrl = url || new URL(`https://event-platform-intake.${site}`)
     this._coverageWriter = new CoverageWriter({ url: this._coverageUrl })
 
-    process.once('beforeExit', () => {
-      this._writer.flush()
-      this._coverageWriter.flush()
-    })
-  }
-
-  exportCoverage ({ span, coverageFiles }) {
-    const formattedCoverage = {
-      traceId: span.context()._traceId,
-      spanId: span.context()._spanId,
-      files: coverageFiles
-    }
-    this._coverageWriter.append(formattedCoverage)
-
-    const { flushInterval } = this._config
-
-    if (flushInterval === 0) {
-      this._coverageWriter.flush()
-    } else if (flushInterval > 0 && !this._coverageTimer) {
-      this._coverageTimer = setTimeout(() => {
-        this._coverageWriter.flush()
-        this._coverageTimer = clearTimeout(this._coverageTimer)
-      }, flushInterval).unref()
-    }
-  }
-
-  export (trace) {
-    this._writer.append(trace)
-
-    const { flushInterval } = this._config
-
-    if (flushInterval === 0) {
-      this._writer.flush()
-    } else if (flushInterval > 0 && !this._timer) {
-      this._timer = setTimeout(() => {
-        this._writer.flush()
-        this._timer = clearTimeout(this._timer)
-      }, flushInterval).unref()
-    }
-  }
-
-  flush (done = () => {}) {
-    if (!this._isInitialized) {
-      return done()
-    }
-    this._writer.flush(() => {
-      this._coverageWriter.flush(done)
-    })
-  }
-
-  setUrl (url, coverageUrl = url) {
-    try {
-      url = new URL(url)
-      coverageUrl = new URL(coverageUrl)
-      this._url = url
-      this._coverageUrl = coverageUrl
-      this._writer.setUrl(url)
-      this._coverageWriter.setUrl(coverageUrl)
-    } catch (e) {
-      log.error(e)
+    if (isGitUploadEnabled) {
+      const gitUrl = url || new URL(`https://api.${site}`)
+      this.sendGitMetadata({ url: gitUrl })
     }
   }
 }

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -1,0 +1,191 @@
+'use strict'
+
+const URL = require('url').URL
+
+const { sendGitMetadata: sendGitMetadataRequest } = require('./git/git_metadata')
+const { getItrConfiguration: getItrConfigurationRequest } = require('../intelligent-test-runner/get-itr-configuration')
+const { getSkippableSuites: getSkippableSuitesRequest } = require('../intelligent-test-runner/get-skippable-suites')
+const log = require('../../log')
+const AgentInfoExporter = require('../../exporters/common/agent-info-exporter')
+
+function getIsTestSessionTrace (trace) {
+  return trace.some(span =>
+    span.type === 'test_session_end' || span.type === 'test_suite_end'
+  )
+}
+
+class CiVisibilityExporter extends AgentInfoExporter {
+  constructor (config) {
+    super(config)
+    this._timer = undefined
+    this._coverageTimer = undefined
+    this._coverageBuffer = []
+    // The library can use new features like ITR and test suite level visibility
+    // AKA CI Vis Protocol
+    this._canUseCiVisProtocol = false
+
+    // TODO: add timeout to reject this promise
+    this._gitUploadPromise = new Promise(resolve => {
+      this._resolveGit = resolve
+    })
+
+    // TODO: add timeout to reject this promise
+    this._canUseCiVisProtocolPromise = new Promise(resolve => {
+      this._resolveCanUseCiVisProtocol = (canUseCiVisProtocol) => {
+        this._canUseCiVisProtocol = canUseCiVisProtocol
+        resolve(canUseCiVisProtocol)
+      }
+    })
+
+    process.once('beforeExit', () => {
+      if (this._writer) {
+        this._writer.flush()
+      }
+      if (this._coverageWriter) {
+        this._coverageWriter.flush()
+      }
+    })
+  }
+
+  shouldRequestSkippableSuites () {
+    return !!(this._config.isIntelligentTestRunnerEnabled &&
+      this._canUseCiVisProtocol &&
+      this._itrConfig &&
+      this._itrConfig.isSuitesSkippingEnabled)
+  }
+
+  shouldRequestItrConfiguration () {
+    return this._config.isIntelligentTestRunnerEnabled
+  }
+
+  canReportSessionTraces () {
+    return this._canUseCiVisProtocol
+  }
+
+  canReportCodeCoverage () {
+    return this._canUseCiVisProtocol
+  }
+
+  // We can't call the skippable endpoint until git upload has finished,
+  // hence the this._gitUploadPromise.then
+  getSkippableSuites (testConfiguration, callback) {
+    if (!this.shouldRequestSkippableSuites()) {
+      return callback({ skippableSuites: [] })
+    }
+    this._gitUploadPromise.then(gitUploadError => {
+      if (gitUploadError) {
+        return callback({ err: gitUploadError, skippableSuites: [] })
+      }
+      const configuration = {
+        url: this._url,
+        site: this._config.site,
+        env: this._config.env,
+        service: this._config.service,
+        isEvpProxy: !!this._isUsingEvpProxy,
+        ...testConfiguration
+      }
+      getSkippableSuitesRequest(configuration, ({ err, skippableSuites }) => {
+        callback({ err, skippableSuites })
+      })
+    })
+  }
+
+  /**
+   * We can't request ITR configuration until we know whether we can use the
+   * CI Visibility Protocol, hence the this._canUseCiVisProtocol promise.
+   */
+  getItrConfiguration (testConfiguration, callback) {
+    if (!this.shouldRequestItrConfiguration()) {
+      return callback({ itrConfig: {} })
+    }
+    this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {
+      if (!canUseCiVisProtocol) {
+        return callback({ itrConfig: {} })
+      }
+      const configuration = {
+        url: this._url,
+        env: this._config.env,
+        service: this._config.service,
+        isEvpProxy: !!this._isUsingEvpProxy,
+        ...testConfiguration
+      }
+      getItrConfigurationRequest(configuration, ({ err, itrConfig }) => {
+        this._itrConfig = itrConfig
+        callback({ err, itrConfig })
+      })
+    })
+  }
+
+  sendGitMetadata ({ url, isEvpProxy }) {
+    sendGitMetadataRequest(url, isEvpProxy, (err) => {
+      if (err) {
+        log.error(`Error uploading git metadata: ${err.message}`)
+      } else {
+        log.debug('Successfully uploaded git metadata')
+      }
+      this._resolveGit(err)
+    })
+  }
+
+  export (trace) {
+    // Until it's initialized, we just store the traces as is
+    if (!this._isInitialized) {
+      this._traceBuffer.push(trace)
+      return
+    }
+    if (!this.canReportSessionTraces() && getIsTestSessionTrace(trace)) {
+      return
+    }
+    this._export(trace)
+  }
+
+  // TODO: CHECK IF _ITRCONFIG includes isCodeCoverageEnabled
+  // this does not work for jest, because it runs in a different process
+  exportCoverage (coveragePayload) {
+    // Until it's initialized, we just store the coverages as is
+    if (!this._isInitialized) {
+      this._coverageBuffer.push(coveragePayload)
+      return
+    }
+    if (!this.canReportCodeCoverage()) {
+      return
+    }
+
+    const { span, coverageFiles } = coveragePayload
+    const formattedCoverage = {
+      traceId: span.context()._traceId,
+      spanId: span.context()._spanId,
+      files: coverageFiles
+    }
+
+    this._export(formattedCoverage, this._coverageWriter, '_coverageTimer')
+  }
+
+  flush (done = () => {}) {
+    if (!this._isInitialized) {
+      return done()
+    }
+    this._writer.flush(() => {
+      if (this._coverageWriter) {
+        this._coverageWriter.flush(done)
+      } else {
+        done()
+      }
+    })
+  }
+
+  setUrl (url, coverageUrl = url) {
+    try {
+      url = new URL(url)
+      coverageUrl = new URL(coverageUrl)
+      this._url = url
+      this._coverageUrl = coverageUrl
+      this._writer.setUrl(url)
+      this._coverageWriter.setUrl(coverageUrl)
+    } catch (e) {
+      log.error(e)
+    }
+  }
+}
+
+module.exports = CiVisibilityExporter

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -63,7 +63,9 @@ class CiVisibilityExporter extends AgentInfoExporter {
   }
 
   canReportCodeCoverage () {
-    return this._canUseCiVisProtocol
+    return this._canUseCiVisProtocol &&
+      this._itrConfig &&
+      this._itrConfig.isCodeCoverageEnabled
   }
 
   // We can't call the skippable endpoint until git upload has finished,
@@ -139,8 +141,6 @@ class CiVisibilityExporter extends AgentInfoExporter {
     this._export(trace)
   }
 
-  // TODO: CHECK IF _ITRCONFIG includes isCodeCoverageEnabled
-  // this does not work for jest, because it runs in a different process
   exportCoverage (coveragePayload) {
     // Until it's initialized, we just store the coverages as is
     if (!this._isInitialized) {
@@ -172,6 +172,13 @@ class CiVisibilityExporter extends AgentInfoExporter {
         done()
       }
     })
+  }
+
+  exportUncodedCoverages () {
+    this._coverageBuffer.forEach(oldCoveragePayload => {
+      this.exportCoverage(oldCoveragePayload)
+    })
+    this._coverageBuffer = []
   }
 
   setUrl (url, coverageUrl = url) {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -72,11 +72,11 @@ class CiVisibilityExporter extends AgentInfoExporter {
   // hence the this._gitUploadPromise.then
   getSkippableSuites (testConfiguration, callback) {
     if (!this.shouldRequestSkippableSuites()) {
-      return callback({ skippableSuites: [] })
+      return callback(null, [])
     }
     this._gitUploadPromise.then(gitUploadError => {
       if (gitUploadError) {
-        return callback({ err: gitUploadError, skippableSuites: [] })
+        return callback(gitUploadError, [])
       }
       const configuration = {
         url: this._url,
@@ -86,9 +86,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         isEvpProxy: !!this._isUsingEvpProxy,
         ...testConfiguration
       }
-      getSkippableSuitesRequest(configuration, ({ err, skippableSuites }) => {
-        callback({ err, skippableSuites })
-      })
+      getSkippableSuitesRequest(configuration, callback)
     })
   }
 
@@ -98,11 +96,11 @@ class CiVisibilityExporter extends AgentInfoExporter {
    */
   getItrConfiguration (testConfiguration, callback) {
     if (!this.shouldRequestItrConfiguration()) {
-      return callback({ itrConfig: {} })
+      return callback(null, {})
     }
     this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {
       if (!canUseCiVisProtocol) {
-        return callback({ itrConfig: {} })
+        return callback(null, {})
       }
       const configuration = {
         url: this._url,
@@ -111,9 +109,9 @@ class CiVisibilityExporter extends AgentInfoExporter {
         isEvpProxy: !!this._isUsingEvpProxy,
         ...testConfiguration
       }
-      getItrConfigurationRequest(configuration, ({ err, itrConfig }) => {
+      getItrConfigurationRequest(configuration, (err, itrConfig) => {
         this._itrConfig = itrConfig
-        callback({ err, itrConfig })
+        callback(err, itrConfig)
       })
     })
   }

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -44,7 +44,7 @@ function getCommonRequestOptions (url) {
  * The response are the commits for which the backend already has information
  * This response is used to know which commits can be ignored from there on
  */
-function getCommitsToExclude ({ url, repositoryUrl }, callback) {
+function getCommitsToExclude ({ url, isEvpProxy, repositoryUrl }, callback) {
   const latestCommits = getLatestCommits()
   const [headCommit] = latestCommits
 
@@ -57,6 +57,12 @@ function getCommitsToExclude ({ url, repositoryUrl }, callback) {
       'Content-Type': 'application/json'
     },
     path: '/api/v2/git/repository/search_commits'
+  }
+
+  if (isEvpProxy) {
+    options.path = '/evp_proxy/v2/api/v2/git/repository/search_commits'
+    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    delete options.headers['dd-api-key']
   }
 
   const localCommitData = JSON.stringify({
@@ -87,7 +93,7 @@ function getCommitsToExclude ({ url, repositoryUrl }, callback) {
 /**
  * This function uploads a git packfile
  */
-function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, callback) {
+function uploadPackFile ({ url, isEvpProxy, packFileToUpload, repositoryUrl, headCommit }, callback) {
   const form = new FormData()
 
   const pushedSha = JSON.stringify({
@@ -125,6 +131,13 @@ function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, c
       ...form.getHeaders()
     }
   }
+
+  if (isEvpProxy) {
+    options.path = '/evp_proxy/v2/api/v2/git/repository/packfile'
+    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    delete options.headers['dd-api-key']
+  }
+
   request(form, options, (err, _, statusCode) => {
     if (err) {
       const error = new Error(`Could not upload packfiles: status code ${statusCode}: ${err.message}`)
@@ -137,16 +150,14 @@ function uploadPackFile ({ url, packFileToUpload, repositoryUrl, headCommit }, c
 /**
  * This function uploads git metadata to CI Visibility's backend.
 */
-function sendGitMetadata (intakeUrl, site, callback) {
-  const url = intakeUrl || new URL(`https://api.${site}`)
-
+function sendGitMetadata (url, isEvpProxy, callback) {
   const repositoryUrl = getRepositoryUrl()
 
   if (!repositoryUrl) {
     return callback(new Error('Repository URL is empty'))
   }
 
-  getCommitsToExclude({ url, repositoryUrl }, (err, commitsToExclude, headCommit) => {
+  getCommitsToExclude({ url, repositoryUrl, isEvpProxy }, (err, commitsToExclude, headCommit) => {
     if (err) {
       return callback(err)
     }
@@ -172,6 +183,7 @@ function sendGitMetadata (intakeUrl, site, callback) {
         {
           packFileToUpload: packFilesToUpload[packFileIndex++],
           url,
+          isEvpProxy,
           repositoryUrl,
           headCommit
         },
@@ -181,8 +193,9 @@ function sendGitMetadata (intakeUrl, site, callback) {
 
     uploadPackFile(
       {
-        url,
         packFileToUpload: packFilesToUpload[packFileIndex++],
+        url,
+        isEvpProxy,
         repositoryUrl,
         headCommit
       },

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -66,7 +66,7 @@ function getItrConfiguration ({
 
   request(data, options, (err, res) => {
     if (err) {
-      done({ err })
+      done({ err, itrConfig: {} })
     } else {
       try {
         const {
@@ -80,7 +80,7 @@ function getItrConfiguration ({
 
         done({ itrConfig: { isCodeCoverageEnabled, isSuitesSkippingEnabled } })
       } catch (err) {
-        done({ err })
+        done({ err, itrConfig: {} })
       }
     }
   })

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -36,7 +36,7 @@ function getItrConfiguration ({
       process.env.DD_APPLICATION_KEY
 
     if (!apiKey || !appKey) {
-      return done({ err: new Error('App key or API key undefined') })
+      return done(new Error('App key or API key undefined'))
     }
     options.headers['dd-api-key'] = apiKey
     options.headers['dd-application-key'] = appKey
@@ -66,7 +66,7 @@ function getItrConfiguration ({
 
   request(data, options, (err, res) => {
     if (err) {
-      done({ err, itrConfig: {} })
+      done(err)
     } else {
       try {
         const {
@@ -78,9 +78,9 @@ function getItrConfiguration ({
           }
         } = JSON.parse(res)
 
-        done({ itrConfig: { isCodeCoverageEnabled, isSuitesSkippingEnabled } })
+        done(null, { isCodeCoverageEnabled, isSuitesSkippingEnabled })
       } catch (err) {
-        done({ err, itrConfig: {} })
+        done(err)
       }
     }
   })

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -2,7 +2,7 @@ const request = require('../../exporters/common/request')
 
 function getSkippableSuites ({
   url,
-  site,
+  isEvpProxy,
   env,
   service,
   repositoryUrl,
@@ -13,28 +13,32 @@ function getSkippableSuites ({
   runtimeName,
   runtimeVersion
 }, done) {
-  const intakeUrl = url || new URL(`https://api.${site}`)
-
-  const apiKey = process.env.DATADOG_API_KEY || process.env.DD_API_KEY
-  const appKey = process.env.DATADOG_APP_KEY ||
-    process.env.DD_APP_KEY ||
-    process.env.DATADOG_APPLICATION_KEY ||
-    process.env.DD_APPLICATION_KEY
-
-  if (!apiKey || !appKey) {
-    return done(new Error('API key or Application key are undefined.'))
-  }
-
   const options = {
     path: '/api/v2/ci/tests/skippable',
     method: 'POST',
     headers: {
-      'dd-api-key': apiKey,
-      'dd-application-key': appKey,
       'Content-Type': 'application/json'
     },
     timeout: 15000,
-    url: intakeUrl
+    url
+  }
+
+  if (isEvpProxy) {
+    options.path = '/evp_proxy/v2/api/v2/ci/tests/skippable'
+    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+    options.headers['X-Datadog-NeedsAppKey'] = 'true'
+  } else {
+    const apiKey = process.env.DATADOG_API_KEY || process.env.DD_API_KEY
+    const appKey = process.env.DATADOG_APP_KEY ||
+      process.env.DD_APP_KEY ||
+      process.env.DATADOG_APPLICATION_KEY ||
+      process.env.DD_APPLICATION_KEY
+
+    if (!apiKey || !appKey) {
+      return done({ err: new Error('App key or API key undefined') })
+    }
+    options.headers['dd-api-key'] = apiKey
+    options.headers['dd-application-key'] = appKey
   }
 
   const data = JSON.stringify({
@@ -59,7 +63,7 @@ function getSkippableSuites ({
 
   request(data, options, (err, res) => {
     if (err) {
-      done(err)
+      done({ err })
     } else {
       let skippableSuites = []
       try {
@@ -67,9 +71,9 @@ function getSkippableSuites ({
           .data
           .filter(({ type }) => type === 'suite')
           .map(({ attributes: { suite } }) => suite)
-        done(null, skippableSuites)
-      } catch (e) {
-        done(e)
+        done({ err: null, skippableSuites })
+      } catch (err) {
+        done({ err })
       }
     }
   })

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -35,7 +35,7 @@ function getSkippableSuites ({
       process.env.DD_APPLICATION_KEY
 
     if (!apiKey || !appKey) {
-      return done({ err: new Error('App key or API key undefined') })
+      return done(new Error('App key or API key undefined'))
     }
     options.headers['dd-api-key'] = apiKey
     options.headers['dd-application-key'] = appKey
@@ -63,7 +63,7 @@ function getSkippableSuites ({
 
   request(data, options, (err, res) => {
     if (err) {
-      done({ err })
+      done(err)
     } else {
       let skippableSuites = []
       try {
@@ -71,9 +71,9 @@ function getSkippableSuites ({
           .data
           .filter(({ type }) => type === 'suite')
           .map(({ attributes: { suite } }) => suite)
-        done({ err: null, skippableSuites })
+        done(null, skippableSuites)
       } catch (err) {
-        done({ err })
+        done(err)
       }
     }
   })

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -117,8 +117,11 @@ class Config {
       process.env.DD_TRACE_URL,
       null
     )
+    const DD_IS_CIVISIBILITY = coalesce(
+      options.isCiVisibility,
+      false
+    )
     const DD_CIVISIBILITY_AGENTLESS_URL = process.env.DD_CIVISIBILITY_AGENTLESS_URL
-    const DD_CIVISIBILITY_AGENTLESS_ENABLED = process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED
 
     const DD_CIVISIBILITY_ITR_ENABLED = coalesce(
       process.env.DD_CIVISIBILITY_ITR_ENABLED,
@@ -382,10 +385,11 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       maxContextOperations: DD_IAST_MAX_CONTEXT_OPERATIONS
     }
 
-    const isCiVisibilityAgentlessEnabled = isTrue(DD_CIVISIBILITY_AGENTLESS_ENABLED)
-    this.isIntelligentTestRunnerEnabled = isCiVisibilityAgentlessEnabled && isTrue(DD_CIVISIBILITY_ITR_ENABLED)
-    this.isGitUploadEnabled = this.isIntelligentTestRunnerEnabled ||
-      (isCiVisibilityAgentlessEnabled && isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED))
+    this.isCiVisibility = isTrue(DD_IS_CIVISIBILITY)
+
+    this.isIntelligentTestRunnerEnabled = this.isCiVisibility && isTrue(DD_CIVISIBILITY_ITR_ENABLED)
+    this.isGitUploadEnabled = this.isCiVisibility &&
+      (this.isIntelligentTestRunnerEnabled || isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED))
 
     this.stats = {
       enabled: isTrue(DD_TRACE_STATS_COMPUTATION_ENABLED)

--- a/packages/dd-trace/src/exporters/common/agent-info-exporter.js
+++ b/packages/dd-trace/src/exporters/common/agent-info-exporter.js
@@ -1,7 +1,6 @@
 const { URL, format } = require('url')
 
 const request = require('./request')
-const log = require('../../log')
 
 function fetchAgentInfo (url, callback) {
   request('', {
@@ -70,16 +69,6 @@ class AgentInfoExporter {
 
   resetUncodedTraces () {
     this._traceBuffer = []
-  }
-
-  setUrl (url) {
-    url = new URL(url)
-    this._url = url
-    try {
-      this._writer.setUrl(url)
-    } catch (e) {
-      log.error(e)
-    }
   }
 }
 

--- a/packages/dd-trace/src/exporters/common/agent-info-exporter.js
+++ b/packages/dd-trace/src/exporters/common/agent-info-exporter.js
@@ -67,6 +67,13 @@ class AgentInfoExporter {
     return this._traceBuffer
   }
 
+  exportUncodedTraces () {
+    this.getUncodedTraces().forEach(uncodedTrace => {
+      this.export(uncodedTrace)
+    })
+    this.resetUncodedTraces()
+  }
+
   resetUncodedTraces () {
     this._traceBuffer = []
   }

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -122,7 +122,6 @@ module.exports = class PluginManager {
       queryStringObfuscation,
       clientIpHeaderDisabled,
       clientIpHeader,
-      isIntelligentTestRunnerEnabled,
       site,
       url,
       dbmPropagationMode
@@ -145,8 +144,6 @@ module.exports = class PluginManager {
     if (clientIpHeader !== undefined) {
       sharedConfig.clientIpHeader = clientIpHeader
     }
-
-    sharedConfig.isIntelligentTestRunnerEnabled = isIntelligentTestRunnerEnabled
 
     sharedConfig.dbmPropagationMode = dbmPropagationMode
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -16,7 +16,7 @@ module.exports = class CiPlugin extends Plugin {
     super(...args)
 
     this.addSub(`ci:${this.constructor.name}:itr-configuration`, ({ onDone }) => {
-      this.tracer._exporter.getItrConfiguration(this.testConfiguration, ({ err, itrConfig }) => {
+      this.tracer._exporter.getItrConfiguration(this.testConfiguration, (err, itrConfig) => {
         if (!err) {
           this.itrConfig = itrConfig
         }
@@ -25,7 +25,9 @@ module.exports = class CiPlugin extends Plugin {
     })
 
     this.addSub(`ci:${this.constructor.name}:test-suite:skippable`, ({ onDone }) => {
-      this.tracer._exporter.getSkippableSuites(this.testConfiguration, onDone)
+      this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites) => {
+        onDone({ err, skippableSuites })
+      })
     })
   }
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -30,7 +30,9 @@ class Tracer extends NoopProxy {
     try {
       const config = new Config(options) // TODO: support dynamic config
 
-      remoteConfig.enable(config)
+      if (!config.isCiVisibility) {
+        remoteConfig.enable(config)
+      }
 
       if (config.profiling.enabled) {
         // do not stop tracer initialization if the profiler fails to be imported

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -1,6 +1,4 @@
 'use strict'
-const { channel } = require('diagnostics_channel')
-
 const NoopProxy = require('./noop/proxy')
 const DatadogTracer = require('./tracer')
 const Config = require('./config')
@@ -9,10 +7,7 @@ const log = require('./log')
 const { setStartupLogPluginManager } = require('./startup-log')
 const telemetry = require('./telemetry')
 const PluginManager = require('./plugin_manager')
-const { sendGitMetadata } = require('./ci-visibility/exporters/git/git_metadata')
 const remoteConfig = require('./appsec/remote_config')
-
-const gitMetadataUploadFinishCh = channel('ci:git-metadata-upload:finish')
 
 class Tracer extends NoopProxy {
   constructor () {
@@ -62,17 +57,6 @@ class Tracer extends NoopProxy {
         this._pluginManager.configure(config)
         setStartupLogPluginManager(this._pluginManager)
         telemetry.start(config, this._pluginManager)
-      }
-
-      if (config.isGitUploadEnabled) {
-        sendGitMetadata(config.url, config.site, (err) => {
-          if (err) {
-            log.error(`Error uploading git metadata: ${err.message}`)
-          } else {
-            log.debug('Successfully uploaded git metadata')
-          }
-          gitMetadataUploadFinishCh.publish(err)
-        })
       }
     } catch (e) {
       log.error(e)

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -115,6 +115,7 @@ describe('AgentProxyCiVisibilityExporter', () => {
       setTimeout(() => {
         agentProxyCiVisibilityExporter._coverageWriter = mockWriter
         const coverage = { span: { context: () => ({ _traceId: '1', _spanId: '1' }) }, coverageFiles: [] }
+        agentProxyCiVisibilityExporter._itrConfig = { isCodeCoverageEnabled: true }
         agentProxyCiVisibilityExporter.exportCoverage(coverage)
         expect(mockWriter.append).to.have.been.calledWith({ spanId: '1', traceId: '1', files: [] })
         done()
@@ -224,6 +225,7 @@ describe('AgentProxyCiVisibilityExporter', () => {
         agentProxyCiVisibilityExporter._coverageWriter = mockWriter
 
         const coverage = { span: { context: () => ({ _traceId: '1', _spanId: '1' }) }, coverageFiles: [] }
+        agentProxyCiVisibilityExporter._itrConfig = { isCodeCoverageEnabled: true }
         agentProxyCiVisibilityExporter.exportCoverage(coverage)
         expect(mockWriter.append).to.have.been.calledWith({ traceId: '1', spanId: '1', files: [] })
         setTimeout(() => {

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -73,6 +73,22 @@ describe('AgentProxyCiVisibilityExporter', () => {
         done()
       }, queryDelay + 20)
     })
+    it('should upload git metadata if configured', (done) => {
+      const scope = nock('http://localhost:8126')
+        .post('/evp_proxy/v2/api/v2/git/repository/search_commits')
+        .reply(200, JSON.stringify({ data: [] }))
+        .post('/evp_proxy/v2/api/v2/git/repository/packfile')
+        .reply(204)
+
+      const agentProxyCiVisibilityExporter = new AgentProxyCiVisibilityExporter({
+        port, tags, isGitUploadEnabled: true
+      })
+      agentProxyCiVisibilityExporter._gitUploadPromise.then(() => {
+        expect(scope.isDone()).to.be.true
+        done()
+      })
+    })
+
     it('should process test suite level visibility spans', (done) => {
       const mockWriter = {
         append: sinon.spy(),

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -105,7 +105,7 @@ describe('CI Visibility Agentless Exporter', () => {
         url, isGitUploadEnabled: true, isIntelligentTestRunnerEnabled: true, tags: {}
       })
       expect(agentlessExporter.shouldRequestItrConfiguration()).to.be.true
-      agentlessExporter.getItrConfiguration({}, ({ err }) => {
+      agentlessExporter.getItrConfiguration({}, (err) => {
         expect(scope.isDone()).not.to.be.true
         expect(err.message).to.contain('App key or API key undefined')
         expect(agentlessExporter.shouldRequestSkippableSuites()).to.be.false

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -1,0 +1,317 @@
+'use strict'
+
+const CiVisibilityExporter = require('../../../src/ci-visibility/exporters/ci-visibility-exporter')
+const nock = require('nock')
+
+describe('CI Visibility Exporter', () => {
+  const port = 8126
+
+  beforeEach(() => {
+    process.env.DD_API_KEY = '1'
+    process.env.DD_APP_KEY = '1'
+    nock.cleanAll()
+  })
+
+  describe('sendGitMetadata', () => {
+    it('should resolve _gitUploadPromise when git metadata is fetched', (done) => {
+      const scope = nock(`http://localhost:${port}`)
+        .post('/api/v2/git/repository/search_commits')
+        .reply(200, JSON.stringify({
+          data: []
+        }))
+        .post('/api/v2/git/repository/packfile')
+        .reply(202, '')
+
+      const ciVisibilityExporter = new CiVisibilityExporter({ port })
+
+      ciVisibilityExporter._gitUploadPromise.then((err) => {
+        expect(err).not.to.exist
+        expect(scope.isDone()).to.be.true
+        done()
+      })
+
+      const url = new URL(`http://localhost:${port}`)
+      ciVisibilityExporter.sendGitMetadata({ url, isEvpProxy: false })
+    })
+    it('should resolve _gitUploadPromise with an error when git metadata request fails', (done) => {
+      const scope = nock(`http://localhost:${port}`)
+        .post('/api/v2/git/repository/search_commits')
+        .reply(404)
+
+      const ciVisibilityExporter = new CiVisibilityExporter({ port })
+
+      ciVisibilityExporter._gitUploadPromise.then((err) => {
+        expect(err.message).to.include('Error fetching commits to exclude')
+        expect(scope.isDone()).to.be.true
+        done()
+      })
+
+      const url = new URL(`http://localhost:${port}`)
+      ciVisibilityExporter.sendGitMetadata({ url, isEvpProxy: false })
+    })
+  })
+
+  describe('getItrConfiguration', () => {
+    context('if ITR is not enabled', () => {
+      it('should resolve immediately if ITR is not enabled', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/libraries/tests/services/setting')
+          .reply(200)
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter.getItrConfiguration({}, ({ err, itrConfig }) => {
+          expect(itrConfig).to.eql({})
+          expect(err).to.be.undefined
+          expect(scope.isDone()).not.to.be.true
+          done()
+        })
+      })
+    })
+    context('if ITR is enabled', () => {
+      it('should request the API after EVP proxy is resolved if ITR is enabled', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/libraries/tests/services/setting')
+          .reply(200, JSON.stringify({
+            data: {
+              attributes: {
+                code_coverage: true,
+                tests_skipping: true
+              }
+            }
+          }))
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
+
+        ciVisibilityExporter.getItrConfiguration({}, ({ err, itrConfig }) => {
+          expect(itrConfig).to.eql({
+            isCodeCoverageEnabled: true,
+            isSuitesSkippingEnabled: true
+          })
+          expect(err).not.to.exist
+          expect(scope.isDone()).to.be.true
+          done()
+        })
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      })
+      it('should update shouldRequestSkippableSuites if test skipping is enabled', (done) => {
+        nock(`http://localhost:${port}`)
+          .post('/api/v2/libraries/tests/services/setting')
+          .reply(200, JSON.stringify({
+            data: {
+              attributes: {
+                code_coverage: true,
+                tests_skipping: true
+              }
+            }
+          }))
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
+        expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.false
+
+        ciVisibilityExporter.getItrConfiguration({}, () => {
+          expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.true
+          done()
+        })
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      })
+    })
+  })
+
+  describe('getSkippableSuites', () => {
+    context('if ITR is not enabled', () => {
+      it('should resolve immediately with an empty array', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/tests/skippable')
+          .reply(200)
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter.getSkippableSuites({}, ({ skippableSuites }) => {
+          expect(skippableSuites).to.eql([])
+          expect(scope.isDone()).not.to.be.true
+          done()
+        })
+      })
+    })
+    context('if ITR is enabled but the tracer can not use CI Vis protocol', () => {
+      it('should resolve immediately with an empty array', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/tests/skippable')
+          .reply(200)
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
+
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(false)
+        ciVisibilityExporter._resolveGit()
+
+        ciVisibilityExporter.getSkippableSuites({}, ({ skippableSuites }) => {
+          expect(skippableSuites).to.eql([])
+          expect(scope.isDone()).not.to.be.true
+          done()
+        })
+      })
+    })
+    context('if ITR is enabled and the tracer can use CI Vis Protocol', () => {
+      it('should request the API after git upload promise is resolved', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/tests/skippable')
+          .reply(200, JSON.stringify({
+            data: [{
+              type: 'suite',
+              attributes: {
+                suite: 'ci-visibility/test/ci-visibility-test.js'
+              }
+            }]
+          }))
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
+
+        ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+
+        ciVisibilityExporter.getSkippableSuites({}, ({ skippableSuites }) => {
+          expect(skippableSuites).to.eql(['ci-visibility/test/ci-visibility-test.js'])
+          expect(scope.isDone()).to.be.true
+          done()
+        })
+        ciVisibilityExporter._resolveGit()
+      })
+    })
+    context('if ITR is enabled and the tracer can use CI Vis Protocol but git upload fails', () => {
+      it('should not request the API and resolve with an empty array', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/tests/skippable')
+          .reply(200)
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
+
+        ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+
+        ciVisibilityExporter.getSkippableSuites({}, ({ err, skippableSuites }) => {
+          expect(err.message).to.include('could not upload git metadata')
+          expect(skippableSuites).to.eql([])
+          expect(scope.isDone()).not.to.be.true
+          done()
+        })
+        ciVisibilityExporter._resolveGit(new Error('could not upload git metadata'))
+      })
+    })
+  })
+
+  describe('export', () => {
+    context('is not initialized', () => {
+      it('should store traces in a buffer', () => {
+        const trace = []
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter.export(trace)
+        ciVisibilityExporter._export = sinon.spy()
+        expect(ciVisibilityExporter._traceBuffer).to.include(trace)
+        expect(ciVisibilityExporter._export).not.to.be.called
+      })
+    })
+    context('is initialized', () => {
+      it('should export traces', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(),
+          setUrl: sinon.spy()
+        }
+        const trace = []
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter.export(trace)
+        expect(ciVisibilityExporter._traceBuffer).not.to.include(trace)
+        expect(ciVisibilityExporter._writer.append).to.be.called
+      })
+    })
+    context('is initialized and can not use CI Vis protocol', () => {
+      it('should not export session traces', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(),
+          setUrl: sinon.spy()
+        }
+        const trace = [{
+          type: 'test_session_end'
+        }]
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter.export(trace)
+        expect(ciVisibilityExporter._traceBuffer).not.to.include(trace)
+        expect(ciVisibilityExporter._writer.append).not.to.be.called
+      })
+    })
+    context('is initialized and can use CI Vis protocol', () => {
+      it('should export session traces', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(),
+          setUrl: sinon.spy()
+        }
+        const trace = [{
+          type: 'test_session_end'
+        }]
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._writer = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+        ciVisibilityExporter.export(trace)
+        expect(ciVisibilityExporter._traceBuffer).not.to.include(trace)
+        expect(ciVisibilityExporter._writer.append).to.be.called
+      })
+    })
+  })
+
+  describe('exportCoverage', () => {
+    context('is not initialized', () => {
+      it('should store coverages in a buffer', () => {
+        const coverage = {}
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter.exportCoverage(coverage)
+        ciVisibilityExporter._export = sinon.spy()
+        expect(ciVisibilityExporter._coverageBuffer).to.include(coverage)
+        expect(ciVisibilityExporter._export).not.to.be.called
+      })
+    })
+    context('is initialized but can not use CI Vis protocol', () => {
+      it('should not export coverages', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(),
+          setUrl: sinon.spy()
+        }
+        const coverage = {}
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._coverageWriter = writer
+        ciVisibilityExporter.exportCoverage(coverage)
+        expect(ciVisibilityExporter._coverageBuffer).not.to.include(coverage)
+        expect(ciVisibilityExporter._coverageWriter.append).not.to.be.called
+      })
+    })
+    context('is initialized and can use CI Vis protocol', () => {
+      it('should export coverages', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(),
+          setUrl: sinon.spy()
+        }
+        const coverage = {
+          span: {
+            context: () => ({})
+          }
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._coverageWriter = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+
+        ciVisibilityExporter.exportCoverage(coverage)
+        expect(ciVisibilityExporter._coverageBuffer).not.to.include(coverage)
+        expect(ciVisibilityExporter._coverageWriter.append).to.be.called
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -291,7 +291,29 @@ describe('CI Visibility Exporter', () => {
         expect(ciVisibilityExporter._coverageWriter.append).not.to.be.called
       })
     })
-    context('is initialized and can use CI Vis protocol', () => {
+    context('is initialized, can use CI Vis protocol but code coverage is disabled', () => {
+      it('should not export coverages', () => {
+        const writer = {
+          append: sinon.spy(),
+          flush: sinon.spy(),
+          setUrl: sinon.spy()
+        }
+        const coverage = {
+          span: {
+            context: () => ({})
+          }
+        }
+        const ciVisibilityExporter = new CiVisibilityExporter({ port })
+        ciVisibilityExporter._isInitialized = true
+        ciVisibilityExporter._coverageWriter = writer
+        ciVisibilityExporter._canUseCiVisProtocol = true
+
+        ciVisibilityExporter.exportCoverage(coverage)
+        expect(ciVisibilityExporter._coverageBuffer).not.to.include(coverage)
+        expect(ciVisibilityExporter._coverageWriter.append).not.to.be.called
+      })
+    })
+    context('is initialized, can use CI Vis protocol and code coverage is enabled', () => {
       it('should export coverages', () => {
         const writer = {
           append: sinon.spy(),
@@ -307,6 +329,7 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter._isInitialized = true
         ciVisibilityExporter._coverageWriter = writer
         ciVisibilityExporter._canUseCiVisProtocol = true
+        ciVisibilityExporter._itrConfig = { isCodeCoverageEnabled: true }
 
         ciVisibilityExporter.exportCoverage(coverage)
         expect(ciVisibilityExporter._coverageBuffer).not.to.include(coverage)

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -59,9 +59,9 @@ describe('CI Visibility Exporter', () => {
           .reply(200)
 
         const ciVisibilityExporter = new CiVisibilityExporter({ port })
-        ciVisibilityExporter.getItrConfiguration({}, ({ err, itrConfig }) => {
+        ciVisibilityExporter.getItrConfiguration({}, (err, itrConfig) => {
           expect(itrConfig).to.eql({})
-          expect(err).to.be.undefined
+          expect(err).to.be.null
           expect(scope.isDone()).not.to.be.true
           done()
         })
@@ -82,7 +82,7 @@ describe('CI Visibility Exporter', () => {
 
         const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
 
-        ciVisibilityExporter.getItrConfiguration({}, ({ err, itrConfig }) => {
+        ciVisibilityExporter.getItrConfiguration({}, (err, itrConfig) => {
           expect(itrConfig).to.eql({
             isCodeCoverageEnabled: true,
             isSuitesSkippingEnabled: true
@@ -125,7 +125,8 @@ describe('CI Visibility Exporter', () => {
           .reply(200)
 
         const ciVisibilityExporter = new CiVisibilityExporter({ port })
-        ciVisibilityExporter.getSkippableSuites({}, ({ skippableSuites }) => {
+        ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites) => {
+          expect(err).to.be.null
           expect(skippableSuites).to.eql([])
           expect(scope.isDone()).not.to.be.true
           done()
@@ -143,7 +144,8 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter._resolveCanUseCiVisProtocol(false)
         ciVisibilityExporter._resolveGit()
 
-        ciVisibilityExporter.getSkippableSuites({}, ({ skippableSuites }) => {
+        ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites) => {
+          expect(err).to.be.null
           expect(skippableSuites).to.eql([])
           expect(scope.isDone()).not.to.be.true
           done()
@@ -168,7 +170,8 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
 
-        ciVisibilityExporter.getSkippableSuites({}, ({ skippableSuites }) => {
+        ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites) => {
+          expect(err).to.be.null
           expect(skippableSuites).to.eql(['ci-visibility/test/ci-visibility-test.js'])
           expect(scope.isDone()).to.be.true
           done()
@@ -187,7 +190,7 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
 
-        ciVisibilityExporter.getSkippableSuites({}, ({ err, skippableSuites }) => {
+        ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites) => {
           expect(err.message).to.include('could not upload git metadata')
           expect(skippableSuites).to.eql([])
           expect(scope.isDone()).not.to.be.true

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -57,7 +57,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
       done()
@@ -73,7 +73,7 @@ describe('git_metadata', () => {
 
     getCommitsToUploadStub.returns([])
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err).to.be.null
       // to check that it is not called
       expect(scope.isDone()).to.be.false
@@ -89,7 +89,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       // eslint-disable-next-line
       expect(err.message).to.contain('Error fetching commits to exclude: Error from https://api.test.com//api/v2/git/repository/search_commits: 404 Not Found. Response from the endpoint: "Not found SHA"')
       // to check that it is not called
@@ -106,7 +106,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err.message).to.contain("Can't parse commits to exclude response: Invalid commit type response")
       // to check that it is not called
       expect(scope.isDone()).to.be.false
@@ -122,7 +122,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(502)
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err.message).to.contain('Could not upload packfiles: status code 502')
       expect(scope.isDone()).to.be.true
       done()
@@ -149,7 +149,7 @@ describe('git_metadata', () => {
       secondTemporaryPackFile
     ])
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
       done()
@@ -168,7 +168,7 @@ describe('git_metadata', () => {
       'not there either'
     ])
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err.message).to.contain('Could not read "not-there"')
       expect(scope.isDone()).to.be.false
       done()
@@ -184,7 +184,7 @@ describe('git_metadata', () => {
 
     generatePackFilesForCommitsStub.returns([])
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err.message).to.contain('Failed to generate packfiles')
       expect(scope.isDone()).to.be.false
       done()
@@ -200,7 +200,7 @@ describe('git_metadata', () => {
 
     getRepositoryUrlStub.returns('')
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err.message).to.contain('Repository URL is empty')
       expect(scope.isDone()).to.be.false
       done()
@@ -218,28 +218,26 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(null, 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
       done()
     })
   })
 
-  it('works when a url is passed', (done) => {
-    const scope = nock('https://www.test.com')
-      .post('/api/v2/git/repository/search_commits')
-      .replyWithError('Server unavailable')
-      .post('/api/v2/git/repository/search_commits')
+  it('should append evp proxy prefix if configured', (done) => {
+    const scope = nock('https://api.test.com')
+      .post('/evp_proxy/v2/api/v2/git/repository/search_commits')
       .reply(200, JSON.stringify({ data: [] }))
-      .post('/api/v2/git/repository/packfile')
-      .replyWithError('Server unavailable')
-      .post('/api/v2/git/repository/packfile')
-      .reply(204)
+      .post('/evp_proxy/v2/api/v2/git/repository/packfile')
+      .reply(204, function (uri, body) {
+        expect(this.req.headers['x-datadog-evp-subdomain']).to.equal('api')
+        done()
+      })
 
-    gitMetadata.sendGitMetadata(new URL('https://www.test.com'), 'test.com', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), true, (err) => {
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
-      done()
     })
   })
 })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -763,40 +763,38 @@ describe('Config', () => {
   })
 
   context('ci visibility config', () => {
+    let options = {}
     beforeEach(() => {
       delete process.env.DD_CIVISIBILITY_ITR_ENABLED
-      delete process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED
       delete process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED
+      options = {}
     })
-    context('agentless is enabled', () => {
+    context('ci visibility mode is enabled', () => {
       beforeEach(() => {
-        process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED = 'true'
+        options = { isCiVisibility: true }
       })
       it('should activate git upload if the env var is passed', () => {
         process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'true'
-        const config = new Config()
+        const config = new Config(options)
         expect(config).to.have.property('isGitUploadEnabled', true)
       })
       it('should activate intelligent test runner if the env var is passed', () => {
         process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
-        const config = new Config()
+        const config = new Config(options)
         expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
       })
       it('should activate git upload automatically if intelligent test runner is activated', () => {
         process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
-        const config = new Config()
+        const config = new Config(options)
         expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
         expect(config).to.have.property('isGitUploadEnabled', true)
       })
     })
-    context('agentless is disabled', () => {
-      beforeEach(() => {
-        process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED = 'false'
-      })
+    context('ci visibility mode is not enabled', () => {
       it('should not activate intelligent test runner or git metadata upload', () => {
         process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
         process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'true'
-        const config = new Config()
+        const config = new Config(options)
         expect(config).to.have.property('isIntelligentTestRunnerEnabled', false)
         expect(config).to.have.property('isGitUploadEnabled', false)
       })


### PR DESCRIPTION
### Motivation
Now that `/evp_proxy/v2` endpoint is available in the datadog agent, we can route _every_ CI Visibility request to it. This was started in https://github.com/DataDog/dd-trace-js/pull/2566 for traces and coverage payloads. This PR is the continuation of that work for the requests used by the intelligent test runner: git metadata, configuration and skippable requests. 

### What does this PR do?

#### New `CiVisibilityExporter`
`CiVisibilityExporter` centralizes all the request logic for CI Visibility:
* request to `/info` endpoint of the agent
* upload git info
* requests to configuration and skippable APIs
* upload traces and coverages

Centralizing the requests in `CiVisibilityExporter` makes it simpler to add the necessary async logic for ITR: we need to wait for the request to `/info` to know whether we can use ITR, and then the request to skippable needs to wait for the git upload. This logic was at the plugin level before but with `CiVisibilityExporter` we have it all there. 

#### Other
The rest of the PR includes:
* Add integration tests for EVP proxy.
* Simplify further the `mocha` and `jest` plugin tests, now that ITR logic is tested in the integration tests.
* Add a `isCiVisibility` configuration parameter to disable remote config calls when using CI Visibility. 


### Commit breakdown
The PR is big so I broke it down into commits for easier review: 
1. https://github.com/DataDog/dd-trace-js/pull/2584/commits/03a61a1a3a300339afdcb33d4dd91151c6e0d4b4  Add integration tests for EVP proxy.
2. https://github.com/DataDog/dd-trace-js/pull/2584/commits/a35272c726be4ad8ae93eeca133d8c8d7f2894e8 Add new `isCiVisibility` option to exclude remote config calls.
3. https://github.com/DataDog/dd-trace-js/pull/2584/commits/4bdaf366cb7a20e27c5699d5c9dda4961e28474b Simplify `mocha` and `jest` plugins not to depend on git upload async request.
4. https://github.com/DataDog/dd-trace-js/pull/2584/commits/1ccb0e484b7146767abad99af46f4cb93b77aea5 Simplify `mocha` and `jest` plugin tests (ITR logic is now covered by integration tests).
5. https://github.com/DataDog/dd-trace-js/pull/2584/commits/5835c5a3d8f8d2007433cb81445345b0fecc1245 Update ITR related requests to include EVP proxy option.
6.  https://github.com/DataDog/dd-trace-js/pull/2584/commits/99becd2c112a0515e09915ad4c21da79f3ec3e2c Create `CiVisibilityExporter` to centralise requests for CI Visibility.


