### PR TITLE
Fix dependencies telemetry in windows

### DIFF
--- a/packages/dd-trace/src/telemetry/dependencies.js
+++ b/packages/dd-trace/src/telemetry/dependencies.js
@@ -71,7 +71,7 @@ function start (_config, _application, _host) {
 }
 
 function isDependency (filename, request) {
-  return request.indexOf(`.${path.sep}`) !== 0 && request.indexOf(path.sep) !== 0
+  return request.indexOf(`..${path.sep}`) !== 0 && request.indexOf(`.${path.sep}`) !== 0 && request.indexOf(path.sep) !== 0
 }
 
 function stop () {

--- a/packages/dd-trace/src/telemetry/dependencies.js
+++ b/packages/dd-trace/src/telemetry/dependencies.js
@@ -71,11 +71,11 @@ function start (_config, _application, _host) {
 }
 
 function isDependency (filename, request) {
-  const result = isDependencyWithSeparator(filename, request, '/')
-  if (result && path.sep !== '/') {
+  const isDependencyWithSlash = isDependencyWithSeparator(filename, request, '/')
+  if (isDependencyWithSlash && process.platform === 'win32') {
     return isDependencyWithSeparator(filename, request, path.sep)
   }
-  return result
+  return isDependencyWithSlash
 }
 function isDependencyWithSeparator (filename, request, sep) {
   return request.indexOf(`..${sep}`) !== 0 &&

--- a/packages/dd-trace/src/telemetry/dependencies.js
+++ b/packages/dd-trace/src/telemetry/dependencies.js
@@ -71,7 +71,17 @@ function start (_config, _application, _host) {
 }
 
 function isDependency (filename, request) {
-  return request.indexOf(`..${path.sep}`) !== 0 && request.indexOf(`.${path.sep}`) !== 0 && request.indexOf(path.sep) !== 0
+  const result = isDependencyWithSeparator(filename, request, '/')
+  if (result && path.sep !== '/') {
+    return isDependencyWithSeparator(filename, request, path.sep)
+  }
+  return result
+}
+function isDependencyWithSeparator (filename, request, sep) {
+  return request.indexOf(`..${sep}`) !== 0 &&
+    request.indexOf(`.${sep}`) !== 0 &&
+    request.indexOf(sep) !== 0 &&
+    request.indexOf(`:${sep}`) !== 1
 }
 
 function stop () {

--- a/packages/dd-trace/test/telemetry/dependencies.spec.js
+++ b/packages/dd-trace/test/telemetry/dependencies.spec.js
@@ -96,27 +96,16 @@ describe('dependencies', () => {
       '../index.js',
       `..${path.sep}index.js`,
       './index.js', `.${path.sep}index.js`,
-      './index.js', `.${path.sep}index.js`,
       path.join(basepathWithoutNodeModules, 'index.js'),
       '/some/absolute/path/index.js']
     requests.forEach(request => {
       it(`should not call to sendData with file paths request: ${request}`, () => {
-        // const request = '../index.js'
         requirePackageJson.returns({ version: '1.0.0' })
         const filename = path.join(basepathWithoutNodeModules, 'node_modules', 'custom-module', 'index.js')
         dependencies.start(config, application, host)
         moduleLoadStartChannel.publish({ request, filename })
         expect(sendData).not.to.have.been.called
       })
-    })
-
-    it('should not call to sendData with relative parent  request with system sep', () => {
-      const request = '..' + path.sep + 'index.js'
-      requirePackageJson.returns({ version: '1.0.0' })
-      const filename = path.join(basepathWithoutNodeModules, 'node_modules', 'custom-module', 'index.js')
-      dependencies.start(config, application, host)
-      moduleLoadStartChannel.publish({ request, filename })
-      expect(sendData).not.to.have.been.called
     })
 
     it('should call sendData', () => {

--- a/packages/dd-trace/test/telemetry/dependencies.spec.js
+++ b/packages/dd-trace/test/telemetry/dependencies.spec.js
@@ -92,6 +92,32 @@ describe('dependencies', () => {
       moduleLoadStartChannel.publish({ request, filename })
       expect(sendData).not.to.have.been.called
     })
+    const requests = [
+      '../index.js',
+      `..${path.sep}index.js`,
+      './index.js', `.${path.sep}index.js`,
+      './index.js', `.${path.sep}index.js`,
+      path.join(basepathWithoutNodeModules, 'index.js'),
+      '/some/absolute/path/index.js']
+    requests.forEach(request => {
+      it(`should not call to sendData with file paths request: ${request}`, () => {
+        // const request = '../index.js'
+        requirePackageJson.returns({ version: '1.0.0' })
+        const filename = path.join(basepathWithoutNodeModules, 'node_modules', 'custom-module', 'index.js')
+        dependencies.start(config, application, host)
+        moduleLoadStartChannel.publish({ request, filename })
+        expect(sendData).not.to.have.been.called
+      })
+    })
+
+    it('should not call to sendData with relative parent  request with system sep', () => {
+      const request = '..' + path.sep + 'index.js'
+      requirePackageJson.returns({ version: '1.0.0' })
+      const filename = path.join(basepathWithoutNodeModules, 'node_modules', 'custom-module', 'index.js')
+      dependencies.start(config, application, host)
+      moduleLoadStartChannel.publish({ request, filename })
+      expect(sendData).not.to.have.been.called
+    })
 
     it('should call sendData', () => {
       const request = 'custom-module'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix dependencies detection in windows and with parent relative requires
### Motivation
<!-- What inspired you to submit this pull request? -->
We are using `path.sep` to check the relative paths, but in windows `\` and `/` are supported.
We aren't working correctly with `../file` requires
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

