### PR TITLE
Revert "web spans should not inherit active context unless it's a lambda wrapper span (#2581)

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -265,11 +265,7 @@ const web = {
 
   // Extract the parent span from the headers and start a new span as its child
   startChildSpan (tracer, name, headers) {
-    const activeSpan = tracer.scope().active()
-    const spanContext = activeSpan && activeSpan.context()
-    const isLambda = spanContext && spanContext._name === 'aws.lambda'
-
-    const childOf = (isLambda && activeSpan) || tracer.extract(FORMAT_HTTP_HEADERS, headers)
+    const childOf = tracer.scope().active() || tracer.extract(FORMAT_HTTP_HEADERS, headers)
 
     const span = tracer.startSpan(name, { childOf })
 

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -153,20 +153,11 @@ describe('plugins/util/web', () => {
         })
       })
 
-      it('should set the parent from the active context if it is an aws.lambda span', () => {
+      it('should set the parent from the active context if any', () => {
         tracer.trace('aws.lambda', parentSpan => {
           web.instrument(tracer, config, req, res, 'test.request', span => {
             expect(span.context()._traceId.toString(10)).to.equal(parentSpan.context()._traceId.toString(10))
             expect(span.context()._parentId.toString(10)).to.equal(parentSpan.context()._spanId.toString(10))
-          })
-        })
-      })
-
-      it('should not set the parent from the active context only it is not an aws.lambda span', () => {
-        tracer.trace('other', parentSpan => {
-          web.instrument(tracer, config, req, res, 'test.request', span => {
-            expect(span.context()._traceId.toString(10)).to.not.equal(parentSpan.context()._traceId.toString(10))
-            expect(span.context()._parentId).to.be.null
           })
         })
       })


### PR DESCRIPTION
This reverts commit 707d4d636d229052429e18b284cc5650ac874ed2.

Should fix https://github.com/DataDog/dd-trace-js/issues/2593 `TypeError: activeSpan.context is not a function`