### PR TITLE
[ci-visibility] Fix mocha and jest not running tests when dd-trace is not init

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -1,0 +1,113 @@
+'use strict'
+
+const { fork } = require('child_process')
+const {
+  FakeAgent,
+  createSandbox
+} = require('./helpers')
+const path = require('path')
+const { assert } = require('chai')
+const getPort = require('get-port')
+
+const tests = [
+  {
+    name: 'mocha',
+    dependencies: ['mocha', 'chai'],
+    testFile: 'ci-visibility/run-mocha.js',
+    expectedStdout: '1 passing'
+  },
+  {
+    name: 'jest',
+    dependencies: ['jest', 'chai'],
+    testFile: 'ci-visibility/run-jest.js',
+    expectedStdout: 'Test Suites: 1 passed'
+  }
+]
+
+tests.forEach(({ name, dependencies, testFile, expectedStdout }) => {
+  describe(name, () => {
+    let agent
+    let childProcess
+    let sandbox
+    let cwd
+    let startupTestFile
+    let testOutput = ''
+
+    before(async () => {
+      sandbox = await createSandbox(dependencies)
+      cwd = sandbox.folder
+      startupTestFile = path.join(cwd, testFile)
+    })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      const port = await getPort()
+      agent = await new FakeAgent(port).start()
+    })
+
+    afterEach(async () => {
+      childProcess.kill()
+      testOutput = ''
+      await agent.stop()
+    })
+
+    it('can run tests and report spans', (done) => {
+      agent.assertMessageReceived(({ payload }) => {
+        const testSpan = payload[0][0]
+        assert.strictEqual(testSpan.resource, 'ci-visibility/test/ci-visibility-test.js.ci visibility can report tests')
+        assert.strictEqual(testSpan.name, `${name}.test`)
+        assert.include(testOutput, expectedStdout)
+        done()
+      }).catch(([e]) => done(e))
+
+      childProcess = fork(startupTestFile, {
+        cwd,
+        env: {
+          DD_TRACE_AGENT_PORT: agent.port,
+          NODE_OPTIONS: '-r dd-trace/ci/init'
+        },
+        stdio: 'pipe'
+      })
+      childProcess.stdout.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+    })
+    const inputs = ['DD_TRACING_ENABLED', 'DD_TRACE_ENABLED']
+
+    inputs.forEach(input => {
+      context(`when ${input}=false`, () => {
+        it('does not report spans but still runs tests', (done) => {
+          agent.assertMessageReceived(() => {
+            done(new Error('Should not create spans'))
+          })
+
+          childProcess = fork(startupTestFile, {
+            cwd,
+            env: {
+              DD_TRACE_AGENT_PORT: agent.port,
+              NODE_OPTIONS: '-r dd-trace/ci/init',
+              [input]: 'false'
+            },
+            stdio: 'pipe'
+          })
+          childProcess.stdout.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+          childProcess.stderr.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+          childProcess.on('message', () => {
+            assert.include(testOutput, expectedStdout)
+            done()
+          })
+        })
+      })
+    })
+  })
+})

--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -1,0 +1,16 @@
+const jest = require('jest')
+
+const options = {
+  projects: [__dirname],
+  testPathIgnorePatterns: ['/node_modules/'],
+  cache: false,
+  maxWorkers: '50%',
+  testRegex: 'test/ci-visibility-test.js'
+}
+
+jest.runCLI(
+  options,
+  options.projects
+).then(() => {
+  process.send('finished')
+})

--- a/integration-tests/ci-visibility/run-mocha.js
+++ b/integration-tests/ci-visibility/run-mocha.js
@@ -1,0 +1,7 @@
+const Mocha = require('mocha')
+
+const mocha = new Mocha()
+mocha.addFile(require.resolve('./test/ci-visibility-test.js'))
+mocha.run(() => {
+  process.send('finished')
+})

--- a/integration-tests/ci-visibility/test/ci-visibility-test.js
+++ b/integration-tests/ci-visibility/test/ci-visibility-test.js
@@ -1,0 +1,7 @@
+const { expect } = require('chai')
+
+describe('ci visibility', () => {
+  it('can report tests', () => {
+    expect(1 + 2).to.equal(3)
+  })
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -176,6 +176,9 @@ function cliWrapper (cli) {
     const configurationPromise = new Promise((resolve) => {
       onDone = resolve
     })
+    if (!jestConfigurationCh.hasSubscribers) {
+      return runCLI.apply(this, arguments)
+    }
 
     sessionAsyncResource.runInAsyncScope(() => {
       jestConfigurationCh.publish({ onDone })

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -317,6 +317,9 @@ addHook({
    * If ITR is disabled, `onDone` is called immediately on the subscriber
    */
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
+    if (!configurationCh.hasSubscribers) {
+      return run.apply(this, arguments)
+    }
     const onReceivedSkippableSuites = ({ err, skippableSuites }) => {
       if (err) {
         log.error(err)
@@ -330,6 +333,9 @@ addHook({
     const onReceivedConfiguration = ({ err }) => {
       if (err) {
         log.error(err)
+        return run.apply(this, arguments)
+      }
+      if (!skippableSuitesCh.hasSubscribers) {
         return run.apply(this, arguments)
       }
 


### PR DESCRIPTION
### What does this PR do?
* Do not stop tests from running if there are no subscribers to ITR config channels (such as when dd-trace is not init).

### Motivation
Fix #2595 

If `dd-trace` is not init, as is the case when agentless mode is enabled but no api key is provided (see [here](https://github.com/DataDog/dd-trace-js/blob/master/ci/init.js#L26)), there are no subscribers to the ITR config and skippable channels, so the testing process finishes without running tests. 

