### PR TITLE
[ci-visibility] Pin version in ci visibility integration tests

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -1,24 +1,30 @@
 'use strict'
 
 const { fork } = require('child_process')
+const path = require('path')
+
 const {
   FakeAgent,
   createSandbox
 } = require('./helpers')
-const path = require('path')
 const { assert } = require('chai')
+const semver = require('semver')
 const getPort = require('get-port')
+
+// TODO: remove when 2.x support is removed.
+// This is done because newest versions of mocha and jest do not support node@12
+const isOldNode = semver.satisfies(process.version, '<=12')
 
 const tests = [
   {
     name: 'mocha',
-    dependencies: ['mocha', 'chai'],
+    dependencies: [isOldNode ? 'mocha@9' : 'mocha', 'chai'],
     testFile: 'ci-visibility/run-mocha.js',
     expectedStdout: '1 passing'
   },
   {
     name: 'jest',
-    dependencies: ['jest', 'chai'],
+    dependencies: [isOldNode ? 'jest@28' : 'jest', 'chai'],
     testFile: 'ci-visibility/run-jest.js',
     expectedStdout: 'Test Suites: 1 passed'
   }


### PR DESCRIPTION
### What does this PR do?
Fix ci visibility integration tests failing in `node@12`: https://github.com/DataDog/dd-trace-js/actions/runs/3656628774/jobs/6183729479

### Motivation
We run integration tests with `node@12` in `v2.x` and that's incompatible with newest versions of `mocha` and `jest`. With this change we pin an older version when using node@12.

