### PR TITLE
migrating node.js APM configuration to documentation repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 
 [1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
 [2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
-[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
+[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
 [4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
 [5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 Most of the documentation for `dd-trace` is available on these webpages:
 
 - [Tracing Node.js Applications](https://docs.datadoghq.com/tracing/languages/nodejs/) - most project documentation, including setup instructions
+- [Configuring the NodeJS Tracing Library](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs) - environment variables and config options
 - [API Documentation](https://datadog.github.io/dd-trace-js) - method signatures, plugin list, and some usage examples
 - [APM Terms and Concepts](https://docs.datadoghq.com/tracing/visualization/) - a glossary of concepts applicable across all languages
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -347,47 +347,7 @@ The following tags are available to override Datadog specific options:
 
 <h3 id="tracer-settings">Tracer settings</h3>
 
-Options can be configured as a parameter to the [init()](./interfaces/tracer.html#init) method or as environment variables.
-
-| Config          | Environment Variable               | Default     | Description |
-| --------------- | ---------------------------------- | ----------- | ----------- |
-| -               | `DD_TRACE_ENABLED`                 | `true`         | Whether to enable dd-trace. Setting this to `false` will disable all features of the library. |
-| -               | `DD_TRACE_DEBUG`                   | `false`        | Enable debug logging. |
-| -               | `DD_TRACING_ENABLED`               | `true`         | Whether to enable tracing. |
-| service         | `DD_SERVICE`                       | -              | The service name to be used for this program. Defaults to value of the `name` field in `package.json`. |
-| version         | `DD_VERSION`                       | -              | The version number of the application. Defaults to value of the `version` field in `package.json`. |
-| url             | `DD_TRACE_AGENT_URL`               | -              | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
-| hostname        | `DD_TRACE_AGENT_HOSTNAME`          | `localhost`    | The address of the agent that the tracer will submit to. |
-| port            | `DD_TRACE_AGENT_PORT`              | `8126`         | The port of the trace agent that the tracer will submit to. |
-| dogstatsd.port  | `DD_DOGSTATSD_PORT`                | `8125`         | The port of the Dogstatsd agent that metrics will be submitted to. |
-| env             | `DD_ENV`                           | -              | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
-| logInjection    | `DD_LOGS_INJECTION`                | `false`        | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| tags            | `DD_TAGS`                          | `{}`           | Set global tags that should be applied to all spans and metrics. When passed as an environment variable, the format is `key:value,key:value` |
-| sampleRate      | `DD_TRACE_SAMPLE_RATE`             | -              | Controls the ingestion sample rate (between 0 and 1) between the agent and the backend. Defaults to deferring the decision to the agent. |
-| rateLimit       | `DD_TRACE_RATE_LIMIT`              | -              | Global rate limit that is applied on the global sample rate and all rules, and controls the ingestion rate limit between the agent and the backend. Defaults to deferring the decision to the agent. |
-| samplingRules   | `DD_TRACE_SAMPLING_RULES`          | `[]`           | Sampling rules to apply to priority samplin. Each rule is a JSON, consisting of `service` and `name`, which are regexes to match against a trace's `service` and `name`, and a corresponding `sampleRate`. If not specified, will defer to global sampling rate for all spans. |
-| spanSamplingRules | `DD_SPAN_SAMPLING_RULES`         | `[]`           | Span sampling rules for ingesting single spans, in cases where the whole trace is dropped. |
-| -               | `DD_SPAN_SAMPLING_RULES_FILE`      | -              | Points to a JSON file that contains the span sampling rules. `DD_SPAN_SAMPLING_RULES` takes precedence over this variable.
-| flushInterval   | -                                  | `2000`         | Interval in milliseconds at which the tracer will submit traces to the agent. |
-| flushMinSpans   | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` | `1000`         | Number of spans before partially exporting a trace. This prevents keeping all the spans in memory for very large traces. |
-| -               | `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` | -      | A regex to redact sensitive data from incoming requests' querystring reported in the `http.url` tag (matches will be replaced with `<redacted>`). Can be an empty string to disable redaction or `.*` to redact all querystring. **WARNING: this regex will execute for every incoming request on an unsafe input (url), please make sure you use a safe regex.** |
-| -               | `DD_TRACE_CLIENT_IP_HEADER`        | -              | Custom header name to source the `http.client_ip` tag from. |
-| lookup          | -                                  | `dns.lookup()` | Custom function for DNS lookups when sending requests to the agent. |
-| protocolVersion | `DD_TRACE_AGENT_PROTOCOL_VERSION`  | `0.4`          | Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped. |
-| runtimeMetrics  | `DD_RUNTIME_METRICS_ENABLED`      | `false`        | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
-| profiling       | `DD_PROFILING_ENABLED`             | `false`        | Whether to enable profiling. |
-| reportHostname  | `DD_TRACE_REPORT_HOSTNAME`         | `false`        | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |
-| experimental    | -                                  | `{}`           | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Please contact us to learn more about the available experimental features. |
-| plugins         | -                                  | `true`         | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
-| -               | `DD_TRACE_DISABLED_PLUGINS`        | -              | A comma-separated string of integration names automatically disabled when tracer is initialized. Environment variable only e.g. `DD_TRACE_DISABLED_PLUGINS=express,dns`. |
-| logLevel        | `DD_TRACE_LOG_LEVEL`               | `debug`        | A string for the minimum log level for the tracer to use when debug logging is enabled, e.g. `'error'`, `'debug'`. |
-| startupLogs     | `DD_TRACE_STARTUP_LOGS`            | `false`        | Enable tracer startup configuration and diagnostic log. |
-| appsec.enabled              | `DD_APPSEC_ENABLED`                            | `false` | Enable AppSec protection. |
-| appsec.rules                | `DD_APPSEC_RULES`                              | -       | A path to a custom AppSec rules file. |
-| appsec.wafTimeout           | `DD_APPSEC_WAF_TIMEOUT`                        | `5000`  | Limits the WAF synchronous execution time (in microseconds). |
-| appsec.obfuscatorKeyRegex   | `DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP`   | -       | A regex to redact sensitive data by its key in attack reports. |
-| appsec.obfuscatorValueRegex | `DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP` | -       | A regex to redact sensitive data by its value in attack reports. |
-| dbmPropagationMode           | `DD_DBM_PROPAGATION_MODE`                        | `'disabled'`  | To enable DBM to APM link using tag injection, can be set to 'service' or 'full'. `'service'` will enable the connection between DB and APM services; while `'full'` will enable connection between database spans with database query events. This is currently available for Postgres.|
+Options can be configured as a parameter to the [init()](./interfaces/tracer.html#init) method or as environment variables. These are documented over on [Configuring the NodeJS Tracing Library](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs).
 
 <h3 id="custom-logging">Custom Logging</h3>
 


### PR DESCRIPTION
### What does this PR do?
- don't merge until https://github.com/DataDog/documentation/pull/16219 has merged
- moves configuration docs to documentation repo

### Motivation
- neither location had the complete list of configuration settings
- maintaining docs in two places is painful