### PR TITLE
[ci-visibility] Update test session tags to include info about ITR config

### DIFF
--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -111,7 +111,10 @@ function mochaHook (Runner) {
         status = 'fail'
       }
       testFileToSuiteAr.clear()
-      testSessionFinishCh.publish(status)
+
+      const isSuitesSkipped = !!suitesToSkip.length
+
+      testSessionFinishCh.publish({ status, isSuitesSkipped })
       // restore the original coverage
       global.__coverage__ = fromCoverageMapToCoverage(originalCoverageMap)
     }))

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -15,6 +15,8 @@ const {
   TEST_SUITE_ID,
   TEST_COMMAND,
   TEST_ITR_TESTS_SKIPPED,
+  TEST_SESSION_ITR_CODE_COVERAGE_ENABLED,
+  TEST_SESSION_ITR_SKIPPING_ENABLED,
   TEST_CODE_COVERAGE_LINES_TOTAL
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -63,14 +65,20 @@ class JestPlugin extends CiPlugin {
       this.enter(testSessionSpan, store)
     })
 
-    this.addSub('ci:jest:session:finish', ({ status, isTestsSkipped, testCodeCoverageLinesTotal }) => {
+    this.addSub('ci:jest:session:finish', ({
+      status,
+      isSuitesSkipped,
+      isSuitesSkippingEnabled,
+      isCodeCoverageEnabled,
+      testCodeCoverageLinesTotal
+    }) => {
       const testSessionSpan = storage.getStore().span
+
       testSessionSpan.setTag(TEST_STATUS, status)
-      if (isTestsSkipped) {
-        testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, 'true')
-      } else {
-        testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, 'false')
-      }
+      testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
+      testSessionSpan.setTag(TEST_SESSION_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
+      testSessionSpan.setTag(TEST_SESSION_ITR_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
+
       if (testCodeCoverageLinesTotal !== undefined) {
         testSessionSpan.setTag(TEST_CODE_COVERAGE_LINES_TOTAL, testCodeCoverageLinesTotal)
       }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -14,7 +14,10 @@ const {
   getTestSuiteCommonTags,
   TEST_SUITE_ID,
   TEST_SESSION_ID,
-  TEST_COMMAND
+  TEST_COMMAND,
+  TEST_ITR_TESTS_SKIPPED,
+  TEST_SESSION_ITR_CODE_COVERAGE_ENABLED,
+  TEST_SESSION_ITR_SKIPPING_ENABLED
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
@@ -139,9 +142,14 @@ class MochaPlugin extends CiPlugin {
       this._testNameToParams[name] = params
     })
 
-    this.addSub('ci:mocha:session:finish', (status) => {
+    this.addSub('ci:mocha:session:finish', ({ status, isSuitesSkipped }) => {
       if (this.testSessionSpan) {
+        const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig
         this.testSessionSpan.setTag(TEST_STATUS, status)
+        this.testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
+        this.testSessionSpan.setTag(TEST_SESSION_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
+        this.testSessionSpan.setTag(TEST_SESSION_ITR_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
+
         this.testSessionSpan.finish()
         finishAllTraceSpans(this.testSessionSpan)
       }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -144,7 +144,7 @@ class MochaPlugin extends CiPlugin {
 
     this.addSub('ci:mocha:session:finish', ({ status, isSuitesSkipped }) => {
       if (this.testSessionSpan) {
-        const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig
+        const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig || {}
         this.testSessionSpan.setTag(TEST_STATUS, status)
         this.testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
         this.testSessionSpan.setTag(TEST_SESSION_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -46,6 +46,8 @@ const CI_APP_ORIGIN = 'ciapp-test'
 const JEST_TEST_RUNNER = 'test.jest.test_runner'
 
 const TEST_ITR_TESTS_SKIPPED = '_dd.ci.itr.tests_skipped'
+const TEST_SESSION_ITR_SKIPPING_ENABLED = 'test_session.itr.tests_skipping.enabled'
+const TEST_SESSION_ITR_CODE_COVERAGE_ENABLED = 'test_session.itr.code_coverage.enabled'
 
 const TEST_CODE_COVERAGE_LINES_TOTAL = 'test.codecov_lines_total'
 
@@ -78,6 +80,8 @@ module.exports = {
   TEST_SESSION_ID,
   TEST_SUITE_ID,
   TEST_ITR_TESTS_SKIPPED,
+  TEST_SESSION_ITR_SKIPPING_ENABLED,
+  TEST_SESSION_ITR_CODE_COVERAGE_ENABLED,
   TEST_CODE_COVERAGE_LINES_TOTAL,
   getCoveredFilenamesFromCoverage,
   resetCoverage,


### PR DESCRIPTION
### What does this PR do?
* Update test session to include tags about the ITR configuration.
* Additionally, we pass the `passWithNoTests` flag to `jest`, to make sure that it does not fail if we ever skip every test in the suite.
* Update integration tests.

### Motivation
Be able to know what the ITR configuration in the test session span.

