### PR TITLE
allow next('route') and next('router') in router plugin

### DIFF
--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -90,7 +90,7 @@ function createWrapRouterMethod (name) {
 
   function wrapNext (req, next) {
     return function (error) {
-      if (error) {
+      if (error && error !== 'route' && error !== 'router') {
         errorChannel.publish({ req, error })
       }
 

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -4,6 +4,7 @@
 
 const axios = require('axios')
 const http = require('http')
+const { once } = require('events')
 const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
 const web = require('../../dd-trace/src/plugins/util/web')
@@ -15,16 +16,20 @@ describe('Plugin', () => {
   let Router
   let appListener
 
-  function server (router) {
+  function defaultErrorHandler (req, res) {
+    return err => {
+      res.writeHead(err ? 500 : 404)
+      res.end()
+    }
+  }
+
+  function server (router, errorHandler = defaultErrorHandler) {
     return http.createServer((req, res) => {
       const config = web.normalizeConfig({})
 
       web.instrument(tracer, config, req, res, 'web.request')
 
-      return router(req, res, err => {
-        res.writeHead(err ? 500 : 404)
-        res.end()
-      })
+      return router(req, res, errorHandler(req, res))
     })
   }
 
@@ -98,6 +103,54 @@ describe('Plugin', () => {
                 .catch(done)
             })
           })
+        })
+
+        it('should not error a span when using next("route") with a string', async () => {
+          const router = Router()
+
+          router.use((req, res, next) => {
+            return next('route')
+          })
+          router.get('/foo', (req, res) => {
+            res.end()
+          })
+
+          const port = await getPort()
+          const agentPromise = agent.use(traces => {
+            for (const span of traces[0]) {
+              expect(span.error).to.equal(0)
+            }
+          }, { rejectFirst: true })
+
+          const httpd = server(router).listen(port, 'localhost')
+          await once(httpd, 'listening')
+          const reqPromise = axios.get(`http://localhost:${port}/foo`)
+
+          return Promise.all([agentPromise, reqPromise])
+        })
+
+        it('should not error a span when using next("router") with a string', async () => {
+          const router = Router()
+
+          router.use((req, res, next) => {
+            return next('router')
+          })
+          router.get('/foo', (req, res) => {
+            res.end()
+          })
+
+          const port = await getPort()
+          const agentPromise = agent.use(traces => {
+            for (const span of traces[0]) {
+              expect(span.error).to.equal(0)
+            }
+          }, { rejectFirst: true })
+
+          const httpd = server(router, (req, res) => err => res.end()).listen(port, 'localhost')
+          await once(httpd, 'listening')
+          const reqPromise = axios.get(`http://localhost:${port}/foo`)
+
+          return Promise.all([agentPromise, reqPromise])
         })
       })
     })

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -148,6 +148,7 @@ module.exports = {
    * @param {(traces: Array<Array<object>>) => void} callback - A function that tests trace data as it's received.
    * @param {Object} [options] - An options object
    * @param {number} [options.timeoutMs=1000] - The timeout in ms.
+   * @param {boolean} [options.rejectFirst=false] - If true, reject the first time the callback throws.
    * @returns {Promise<void>} A promise resolving if expectations are met
    */
   use (callback, options) {
@@ -175,7 +176,12 @@ module.exports = {
         clearTimeout(timeout)
         deferred.resolve()
       } catch (e) {
-        error = error || e
+        if (options && options.rejectFirst) {
+          clearTimeout(timeout)
+          deferred.reject(e)
+        } else {
+          error = error || e
+        }
       }
     }
 


### PR DESCRIPTION
Previously these were being treated as errors, when in fact these are normal in Router.

Fixes https://github.com/DataDog/dd-trace-js/issues/2607

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
