### PR TITLE
fix: Publish request finish on close or finish, but only once for a r…

### DIFF
--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -31,7 +31,7 @@ function wrapResponseEmit (emit) {
       return emit.apply(this, arguments)
     }
 
-    if (['finish','close'].includes(eventName) && !requestFinishedSet.has(this)) {
+    if (['finish', 'close'].includes(eventName) && !requestFinishedSet.has(this)) {
       finishServerCh.publish({ req: this.req })
       requestFinishedSet.add(this)
     }

--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -31,9 +31,9 @@ function wrapResponseEmit (emit) {
       return emit.apply(this, arguments)
     }
 
-    if (['finish','close'].includes(eventName) && !requestFinishedSet.has(this.req)) {
+    if (['finish','close'].includes(eventName) && !requestFinishedSet.has(this)) {
       finishServerCh.publish({ req: this.req })
-      requestFinishedSet.add(this.req)
+      requestFinishedSet.add(this)
     }
 
     return emit.apply(this, arguments)


### PR DESCRIPTION
…equest. Use weakset to ensure idempotency.

### What does this PR do?
Closes https://github.com/DataDog/serverless-plugin-datadog/issues/324

### Motivation
Popular serverless-specific libraries which implement `express` don't emit `close` events, however they do emit `finish`.
This behavior was changed [here](https://github.com/DataDog/dd-trace-js/commit/8516eb4e4629839067633b0765471e6847264df9#diff-ad8a4b6c1995fe7076441f10c5b239987cc1c32464620aefe2dab78211be86dcR32), and we do not want to revert this as `close` also represents the end of a request, and there are cases where it's correct to emit `close` but not `finish` (eg: client disconnects midway through receiving a response).

This change introduces a weakset to track whether we've received `close` or `finish` for a given request, and only emit on the first occurrence.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
