### PR TITLE
Revert "Use the existing context if any to start the web spans (#1647)"

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -265,8 +265,7 @@ const web = {
 
   // Extract the parent span from the headers and start a new span as its child
   startChildSpan (tracer, name, headers) {
-    const childOf = tracer.scope().active() || tracer.extract(FORMAT_HTTP_HEADERS, headers)
-
+    const childOf = tracer.extract(FORMAT_HTTP_HEADERS, headers)
     const span = tracer.startSpan(name, { childOf })
 
     return span

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -153,15 +153,6 @@ describe('plugins/util/web', () => {
         })
       })
 
-      it('should set the parent from the active context if any', () => {
-        tracer.trace('aws.lambda', parentSpan => {
-          web.instrument(tracer, config, req, res, 'test.request', span => {
-            expect(span.context()._traceId.toString(10)).to.equal(parentSpan.context()._traceId.toString(10))
-            expect(span.context()._parentId.toString(10)).to.equal(parentSpan.context()._spanId.toString(10))
-          })
-        })
-      })
-
       it('should set the service name', () => {
         config.service = 'custom'
 


### PR DESCRIPTION
### What does this PR do?

This reverts commit 6c551682b33e7a559cbebf6af7ee2c823c940671.

### Motivation

The change was originally made to get AWS Lambda to connect web framework traces to an outer lambda span. The change however turns out to be unnecessary and caused issues for the tracer due to inheriting the active context if bootstrap code started a trace before starting the http server. This code is actually unreachable on Lambda so it should just be removed.