### PR TITLE
Add taint tracking support for concat, substring, substr, slice and replace methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/native-appsec": "2.0.0",
     "@datadog/native-iast-rewriter": "1.1.2",
-    "@datadog/native-iast-taint-tracking": "1.0.0",
+    "@datadog/native-iast-taint-tracking": "1.1.0",
     "@datadog/native-metrics": "^1.5.0",
     "@datadog/pprof": "^1.1.1",
     "@datadog/sketches-js": "^2.1.0",

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -5,7 +5,11 @@ const csiMethods = [
   { src: 'trim' },
   { src: 'trimStart', dst: 'trim' },
   { src: 'trimEnd' },
-  { src: 'concat' }
+  { src: 'concat' },
+  { src: 'substring' },
+  { src: 'substr' },
+  { src: 'slice' },
+  { src: 'replace' }
 ]
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -4,7 +4,8 @@ const csiMethods = [
   { src: 'plusOperator', operator: true },
   { src: 'trim' },
   { src: 'trimStart', dst: 'trim' },
-  { src: 'trimEnd' }
+  { src: 'trimEnd' },
+  { src: 'concat' }
 ]
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -9,7 +9,8 @@ function noop (res) { return res }
 const TaintTrackingDummy = {
   plusOperator: noop,
   trim: noop,
-  trimEnd: noop
+  trimEnd: noop,
+  concat: noop
 }
 
 function getTransactionId () {
@@ -76,6 +77,10 @@ const TaintTracking = {
   trimEnd: getCsiFn(
     (transactionId, res, target) => TaintedUtils.trimEnd(transactionId, res, target),
     String.prototype.trimEnd
+  ),
+  concat: getCsiFn(
+    (transactionId, res, target, ...rest) => TaintedUtils.concat(transactionId, res, target, ...rest),
+    String.prototype.concat
   )
 }
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -10,7 +10,11 @@ const TaintTrackingDummy = {
   plusOperator: noop,
   trim: noop,
   trimEnd: noop,
-  concat: noop
+  concat: noop,
+  substring: noop,
+  substr: noop,
+  slice: noop,
+  replace: noop
 }
 
 function getTransactionId () {
@@ -81,6 +85,22 @@ const TaintTracking = {
   concat: getCsiFn(
     (transactionId, res, target, ...rest) => TaintedUtils.concat(transactionId, res, target, ...rest),
     String.prototype.concat
+  ),
+  substring: getCsiFn(
+    (transactionId, res, target, ...rest) => TaintedUtils.substring(transactionId, res, target, ...rest),
+    String.prototype.substring
+  ),
+  substr: getCsiFn(
+    (transactionId, res, target, ...rest) => TaintedUtils.substr(transactionId, res, target, ...rest),
+    String.prototype.substr
+  ),
+  slice: getCsiFn(
+    (transactionId, res, target, ...rest) => TaintedUtils.slice(transactionId, res, target, ...rest),
+    String.prototype.slice
+  ),
+  replace: getCsiFn(
+    (transactionId, res, target, ...rest) => TaintedUtils.replace(transactionId, res, target, ...rest),
+    String.prototype.replace
   )
 }
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -24,11 +24,31 @@ function trimEndStr (str) {
   return str.trimEnd()
 }
 
+function trimProtoStr (str) {
+  return String.prototype.trim.call(str)
+}
+
+function concatStr (str) {
+  return str.concat(' ', 'b', 'c')
+}
+
+function concatTaintedStr (str) {
+  return 'ls '.concat(' ', str, 'c')
+}
+
+function concatProtoStr (str) {
+  return String.prototype.concat.call(str, ' a ', ' b ')
+}
+
 module.exports = {
   concatSuffix,
   insertStr,
   appendStr,
   trimStr,
   trimStartStr,
-  trimEndStr
+  trimEndStr,
+  trimProtoStr,
+  concatStr,
+  concatTaintedStr,
+  concatProtoStr
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -40,6 +40,26 @@ function concatProtoStr (str) {
   return String.prototype.concat.call(str, ' a ', ' b ')
 }
 
+function substringStr (str) {
+  return str.substring(1, 4)
+}
+
+function substrStr (str) {
+  return str.substr(1, 4)
+}
+
+function sliceStr (str) {
+  return str.slice(1, 4)
+}
+
+function replaceStr (str) {
+  return str.replace('ls', 'sl')
+}
+
+function replaceRegexStr (str) {
+  return str.replace(/ls/g, 'ls')
+}
+
 module.exports = {
   concatSuffix,
   insertStr,
@@ -50,5 +70,10 @@ module.exports = {
   trimProtoStr,
   concatStr,
   concatTaintedStr,
-  concatProtoStr
+  concatProtoStr,
+  substringStr,
+  substrStr,
+  sliceStr,
+  replaceStr,
+  replaceRegexStr
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -16,7 +16,11 @@ const propagationFns = [
   'appendStr',
   'trimStr',
   'trimStartStr',
-  'trimEndStr'
+  'trimEndStr',
+  'trimProtoStr',
+  'concatStr',
+  'concatTaintedStr',
+  'concatProtoStr'
 ]
 
 const commands = [
@@ -76,7 +80,9 @@ describe('TaintTracking', () => {
   })
 
   describe('should not catch original Error', () => {
-    propagationFns.slice(3).forEach((propFn) => {
+    const filtered = ['concatSuffix', 'insertStr', 'appendStr', 'concatTaintedStr']
+    propagationFns.forEach((propFn) => {
+      if (filtered.indexOf(propFn) !== -1) return
       it(`invoking ${propFn} with null argument`, () => {
         const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
         expect(() => propFnInstrumented(null)).to.throw()

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -87,7 +87,7 @@ describe('TaintTracking', () => {
   describe('should not catch original Error', () => {
     const filtered = ['concatSuffix', 'insertStr', 'appendStr', 'concatTaintedStr']
     propagationFns.forEach((propFn) => {
-      if (filtered.indexOf(propFn) !== -1) return
+      if (filtered.includes(propFn)) return
       it(`invoking ${propFn} with null argument`, () => {
         const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
         expect(() => propFnInstrumented(null)).to.throw()

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -20,7 +20,12 @@ const propagationFns = [
   'trimProtoStr',
   'concatStr',
   'concatTaintedStr',
-  'concatProtoStr'
+  'concatProtoStr',
+  'substringStr',
+  'substrStr',
+  'sliceStr',
+  'replaceStr',
+  'replaceRegexStr'
 ]
 
 const commands = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,10 +203,10 @@
   dependencies:
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.0.0.tgz#d875cf0a3ef3907c27311386f85b3f3a9d99431b"
-  integrity sha512-fS7XoRE5T4JQ7UzWjNT/wZQhS6nmLDwt12IDcSBZfRRJ2VyFth5GvOlQtCPa6Q0k7WMIrt9UXIl/v807cVq1SQ==
+"@datadog/native-iast-taint-tracking@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.1.0.tgz#8f7d0016157b32dbf5c01b15b8afb1c4286b4a18"
+  integrity sha512-TOrngpt6Qh52zWFOz1CkFXw0g43rnuUziFBtIMUsOLGzSHr9wdnTnE6HAyuvKy3f3ecAoZESlMfilGRKP93hXQ==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
This PR enables the substitution in client's code of concat, substring, substr, slice and replace methods in order to track tainted values whenever they are called.


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
Addons and minimum version needed: @datadog/native-iast-taint-tracking v1.1.0 and @datadog/native-iast-rewriter v1.1.1.
