### PR TITLE
Remove query string from resource.name by default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1254,7 +1254,12 @@ declare namespace plugins {
    * This plugin automatically instruments the
    * [mongodb-core](https://github.com/mongodb-js/mongodb-core) module.
    */
-  interface mongodb_core extends Instrumentation {}
+  interface mongodb_core extends Instrumentation {
+    /**
+     * Whether to include the query contents in the resource name.
+     */
+    queryInResourceName?: boolean;
+  }
 
   /**
    * This plugin automatically instruments the

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -8,7 +8,7 @@ class MongodbCorePlugin extends DatabasePlugin {
 
   start ({ ns, ops, options = {}, name }) {
     const query = getQuery(ops)
-    const resource = truncate(getResource(ns, query, name))
+    const resource = truncate(getResource(this, ns, query, name))
 
     this.startSpan('mongodb.query', {
       service: this.config.service,
@@ -31,10 +31,10 @@ function getQuery (cmd) {
   if (cmd.filter) return JSON.stringify(limitDepth(cmd.filter))
 }
 
-function getResource (ns, query, operationName) {
+function getResource (plugin, ns, query, operationName) {
   const parts = [operationName, ns]
 
-  if (query) {
+  if (plugin.config.queryInResourceName && query) {
     parts.push(query)
   }
 

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -98,7 +98,7 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `planCacheListPlans test.${collection} {}`
+                const resource = `planCacheListPlans test.${collection}`
 
                 expect(span).to.have.property('resource', resource)
               })
@@ -115,9 +115,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collection} {"_id":"?"}`
+                const resource = `find test.${collection}`
+                const query = `{"_id":"?"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -137,9 +139,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collection} {"_id":"${id}"}`
+                const resource = `find test.${collection}`
+                const query = `{"_id":"${id}"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -156,9 +160,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collection} {"_id":"1234"}`
+                const resource = `find test.${collection}`
+                const query = `{"_id":"1234"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -214,7 +220,7 @@ describe('Plugin', () => {
             Promise.all([
               agent
                 .use(traces => {
-                  expect(traces[0][0].resource).to.equal(`find test.${collection} {}`)
+                  expect(traces[0][0].resource).to.equal(`find test.${collection}`)
                 }),
               agent
                 .use(traces => {
@@ -243,9 +249,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collection} {"foo":1,"bar":{"baz":[1,2,3]}}`
+                const resource = `find test.${collection}`
+                const query = `{"foo":1,"bar":{"baz":[1,2,3]}}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -98,9 +98,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `planCacheListPlans test.$cmd {}`
+                const resource = `planCacheListPlans test.$cmd`
+                const query = `{}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -115,9 +117,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collectionName} {"_id":"?"}`
+                const resource = `find test.${collectionName}`
+                const query = `{"_id":"?"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -131,9 +135,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collectionName} {"_bin":"?"}`
+                const resource = `find test.${collectionName}`
+                const query = `{"_bin":"?"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -149,9 +155,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collectionName} {"_id":"${id}"}`
+                const resource = `find test.${collectionName}`
+                const query = `{"_id":"${id}"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -165,9 +173,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collectionName} {"_time":{"$timestamp":"0"}}`
+                const resource = `find test.${collectionName}`
+                const query = `{"_time":{"$timestamp":"0"}}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -181,9 +191,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collectionName} {"_id":"?"}`
+                const resource = `find test.${collectionName}`
+                const query = `{"_id":"?"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -197,9 +209,11 @@ describe('Plugin', () => {
             agent
               .use(traces => {
                 const span = traces[0][0]
-                const resource = `find test.${collectionName} {"_id":"1234"}`
+                const resource = `find test.${collectionName}`
+                const query = `{"_id":"1234"}`
 
                 expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
               .catch(done)
@@ -221,7 +235,10 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load('mongodb-core', { service: 'custom' })
+          return agent.load('mongodb-core', {
+            service: 'custom',
+            queryInResourceName: true
+          })
         })
 
         after(() => {
@@ -242,7 +259,23 @@ describe('Plugin', () => {
             .then(done)
             .catch(done)
 
-          collection.insertOne({ a: 1 }, () => {})
+          collection.insertOne({ a: 1 }, {}, () => {})
+        })
+
+        it('should include sanitized query in resource when configured', done => {
+          agent
+            .use(traces => {
+              const span = traces[0][0]
+              const resource = `find test.${collectionName} {"_bin":"?"}`
+
+              expect(span).to.have.property('resource', resource)
+            })
+            .then(done)
+            .catch(done)
+
+          collection.find({
+            _bin: new BSON.Binary()
+          }).toArray()
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?

This removes the query string from `resource.name` by default, allowing it to be restored with an additional config.

### Motivation

Queries may contain private data so should not be included in resource.name by default, but with the `queryInResourceName` configuration it can be optionally restored.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] API [documentation][3].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

Fixes #2536
Fixes #2622 