### PR TITLE
Fix http plugin restoring to prior store state in exit

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -42,7 +42,8 @@ class HttpServerPlugin extends Plugin {
     })
 
     this.addSub('apm:http:server:request:exit', ({ req }) => {
-      this.enter(this._parentStore)
+      const span = this._parentStore && this._parentStore.span
+      this.enter(span, this._parentStore)
       this._parentStore = undefined
     })
 


### PR DESCRIPTION
### What does this PR do?

Correctly restores store state in http plugin exit.

### Motivation

The way this is handled currently, it will capture the entire store contents and then set that to the span value when the exit is reached. It _should_ be setting it to the _store_ value, not the _span_ value.

### Plugin Checklist

Not entirely sure how to test this given that it only emerges randomly at load. 🤔 

- [ ] Unit tests.
