### PR TITLE
Send relative path for the vulnerability instead of the absolute path

### DIFF
--- a/packages/dd-trace/src/appsec/iast/path-line.js
+++ b/packages/dd-trace/src/appsec/iast/path-line.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const process = require('process')
 const pathLine = {
   getFirstNonDDPathAndLine,
   getFirstNonDDPathAndLineFromCallsites, // Exported only for test purposes
@@ -7,7 +8,7 @@ const pathLine = {
 }
 
 const EXCLUDED_PATHS = [
-  '/node_modules/diagnostics_channel'
+  path.join(path.sep, 'node_modules', 'diagnostics_channel')
 ]
 const EXCLUDED_PATH_PREFIXES = [
   'node:diagnostics_channel',
@@ -20,7 +21,7 @@ const EXCLUDED_PATH_PREFIXES = [
 
 function calculateDDBasePath (dirname) {
   const dirSteps = dirname.split(path.sep)
-  const packagesIndex = dirSteps.indexOf('packages')
+  const packagesIndex = dirSteps.lastIndexOf('packages')
   return dirSteps.slice(0, packagesIndex).join(path.sep) + path.sep
 }
 
@@ -43,10 +44,10 @@ function getFirstNonDDPathAndLineFromCallsites (callsites) {
   if (callsites) {
     for (let i = 0; i < callsites.length; i++) {
       const callsite = callsites[i]
-      const path = callsite.getFileName()
-      if (!isExcluded(callsite) && path.indexOf(pathLine.ddBasePath) === -1) {
+      const filepath = callsite.getFileName()
+      if (!isExcluded(callsite) && filepath.indexOf(pathLine.ddBasePath) === -1) {
         return {
-          path,
+          path: path.relative(process.cwd(), filepath),
           line: callsite.getLineNumber()
         }
       }

--- a/packages/dd-trace/test/appsec/iast/path-line.spec.js
+++ b/packages/dd-trace/test/appsec/iast/path-line.spec.js
@@ -1,5 +1,7 @@
-const pathLine = require('../../../src/appsec/iast/path-line')
+const proxyquire = require('proxyquire')
 const path = require('path')
+const os = require('os')
+
 class CallSiteMock {
   constructor (fileName, lineNumber) {
     this.fileName = fileName
@@ -18,14 +20,26 @@ class CallSiteMock {
 }
 
 describe('path-line', function () {
-  const PATH_LINE_PATH = ['packages', 'dd-trace', 'src', 'appsec', 'iast', 'path-line.js'].join(path.sep)
+  const PATH_LINE_PATH = path.join('packages', 'dd-trace', 'src', 'appsec', 'iast', 'path-line.js')
+
+  const tmpdir = os.tmpdir()
+  const firstSep = tmpdir.indexOf(path.sep)
+  const rootPath = tmpdir.slice(0, firstSep + 1)
 
   const DIAGNOSTICS_CHANNEL_PATHS = [
-    '/path/node_modules/diagnostics_channel/index.js',
+    path.join(rootPath, 'path', 'node_modules', 'diagnostics_channel', 'index.js'),
     'node:diagnostics_channel',
     'diagnostics_channel'
   ]
-
+  let mockPath, pathLine, mockProcess
+  beforeEach(() => {
+    mockPath = {}
+    mockProcess = {}
+    pathLine = proxyquire('../../../src/appsec/iast/path-line', {
+      'path': mockPath,
+      'process': mockProcess
+    })
+  })
   describe('getFirstNonDDPathAndLine', () => {
     it('call does not fail', () => {
       const obj = pathLine.getFirstNonDDPathAndLine()
@@ -35,24 +49,22 @@ describe('path-line', function () {
 
   describe('calculateDDBasePath', () => {
     it('/node_modules/dd-trace', () => {
-      const basePath = ['', 'node_modules', 'dd-trace', ''].join(path.sep)
-      const result = pathLine.calculateDDBasePath(`${basePath}${PATH_LINE_PATH}`)
+      const basePath = path.join(rootPath, 'node_modules', 'dd-trace', path.sep)
+      const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
+      expect(result).to.be.equals(basePath)
+    })
+
+    it('/packages/project/path/node_modules/dd-trace', () => {
+      const basePath = path.join(rootPath, 'packages', 'project', 'path', 'node_modules', 'dd-trace', path.sep)
+      const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
       expect(result).to.be.equals(basePath)
     })
 
     it('/project/path/node_modules/dd-trace', () => {
-      const basePath = ['', 'project', 'path', 'node_modules', 'dd-trace', ''].join(path.sep)
-      const result = pathLine.calculateDDBasePath(`${basePath}${PATH_LINE_PATH}`)
+      const basePath = path.join(rootPath, 'project', 'path', 'node_modules', 'dd-trace', path.sep)
+      const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
       expect(result).to.be.equals(basePath)
     })
-
-    it('still working after path-line file refactor', () => {
-      const pathLinePath = ['packages', 'maintain', 'packages', 'but', 'not', 'other', 'path.js'].join(path.sep)
-      const basePath = ['', 'project', 'path', 'node_modules', 'dd-trace', ''].join(path.sep)
-      const result = pathLine.calculateDDBasePath(`${basePath}${pathLinePath}`)
-      expect(result).to.be.equals(basePath)
-    })
-    // TODO Add windows path style test
   })
 
   describe('getFirstNonDDPathAndLineFromCallsites', () => {
@@ -71,40 +83,43 @@ describe('path-line', function () {
     })
 
     describe('when dd-trace is in node_modules', () => {
-      const PROJECT_PATH = '/project-path'
-      const DD_BASE_PATH = `${PROJECT_PATH}/node_modules/dd-trace`
-      const PATH_AND_LINE_PATH = `${DD_BASE_PATH}/${PATH_LINE_PATH}`
+      const PROJECT_PATH = path.join(rootPath, 'project-path')
+      const DD_BASE_PATH = path.join(PROJECT_PATH, 'node_modules', 'dd-trace')
+      const PATH_AND_LINE_PATH = path.join(DD_BASE_PATH, PATH_LINE_PATH)
       const PATH_AND_LINE_LINE = 15
       let prevDDBasePath
 
-      before(() => {
+      beforeEach(() => {
         prevDDBasePath = pathLine.ddBasePath
         pathLine.ddBasePath = DD_BASE_PATH
+        mockProcess.cwd = () => PROJECT_PATH
       })
 
-      after(() => {
+      afterEach(() => {
         pathLine.ddBasePath = prevDDBasePath
       })
 
       it('should return first non DD library when two stack are in dd-trace files and the next is the client line',
         () => {
           const callsites = []
-          const firstFileOutOfDD = `${PROJECT_PATH}/first/file/out/of/dd.js`
+          const expectedFirstFileOutOfDD = path.join('first', 'file', 'out', 'of', 'dd.js')
+          const firstFileOutOfDD = path.join(PROJECT_PATH, expectedFirstFileOutOfDD)
           const firstFileOutOfDDLineNumber = 13
+
           callsites.push(new CallSiteMock(PATH_AND_LINE_PATH, PATH_AND_LINE_LINE))
-          callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 89))
-          callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 5))
+          callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 89))
+          callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 5))
           callsites.push(new CallSiteMock(firstFileOutOfDD, firstFileOutOfDDLineNumber))
-          const { path, line } = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
-          expect(path).to.be.equals(firstFileOutOfDD)
-          expect(line).to.be.equals(firstFileOutOfDDLineNumber)
+          const pathAndLine = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
+          expect(pathAndLine.path).to.be.equals(expectedFirstFileOutOfDD)
+          expect(pathAndLine.line).to.be.equals(firstFileOutOfDDLineNumber)
         })
 
       it('should return null when all stack is in dd trace', () => {
         const callsites = []
         callsites.push(new CallSiteMock(PATH_AND_LINE_PATH, PATH_AND_LINE_LINE))
-        callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 89))
-        callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 5))
+        callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 89))
+        callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 5))
         const pathAndLine = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
         expect(pathAndLine).to.be.null
       })
@@ -112,62 +127,67 @@ describe('path-line', function () {
       DIAGNOSTICS_CHANNEL_PATHS.forEach((dcPath) => {
         it(`should not return ${dcPath} path`, () => {
           const callsites = []
-          const firstFileOutOfDD = `${PROJECT_PATH}/first/file/out/of/dd.js`
+          const expectedFirstFileOutOfDD = path.join('first', 'file', 'out', 'of', 'dd.js')
+          const firstFileOutOfDD = path.join(PROJECT_PATH, expectedFirstFileOutOfDD)
           const firstFileOutOfDDLineNumber = 13
           callsites.push(new CallSiteMock(PATH_AND_LINE_PATH, PATH_AND_LINE_LINE))
-          callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 89))
+          callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 89))
           callsites.push(new CallSiteMock(dcPath, 25))
-          callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 5))
+          callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 5))
           callsites.push(new CallSiteMock(firstFileOutOfDD, firstFileOutOfDDLineNumber))
-          const { path, line } = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
-          expect(path).to.be.equals(firstFileOutOfDD)
-          expect(line).to.be.equals(firstFileOutOfDDLineNumber)
+          const pathAndLine = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
+          expect(pathAndLine.path).to.be.equals(expectedFirstFileOutOfDD)
+          expect(pathAndLine.line).to.be.equals(firstFileOutOfDDLineNumber)
         })
       })
     })
 
     describe('dd-trace is in other directory', () => {
-      const PROJECT_PATH = '/project-path'
-      const DD_BASE_PATH = '/dd-tracer-path'
-      const PATH_AND_LINE_PATH = `${DD_BASE_PATH}/packages/dd-trace/src/appsec/iast/path-line.js`
+      const PROJECT_PATH = path.join(tmpdir, 'project-path')
+      const DD_BASE_PATH = path.join(tmpdir, 'dd-tracer-path')
+      const PATH_AND_LINE_PATH = path.join(DD_BASE_PATH, 'packages',
+        'dd-trace', 'src', 'appsec', 'iast', 'path-line.js')
       const PATH_AND_LINE_LINE = 15
       let previousDDBasePath
 
-      before(() => {
+      beforeEach(() => {
         previousDDBasePath = pathLine.ddBasePath
         pathLine.ddBasePath = DD_BASE_PATH
+        mockProcess.cwd = () => PROJECT_PATH
       })
 
-      after(() => {
+      afterEach(() => {
         pathLine.ddBasePath = previousDDBasePath
       })
 
       it('two in dd-trace files and the next is the client line', () => {
         const callsites = []
-        const firstFileOutOfDD = `${PROJECT_PATH}/first/file/out/of/dd.js`
+        const expectedFilePath = path.join('first', 'file', 'out', 'of', 'dd.js')
+        const firstFileOutOfDD = path.join(PROJECT_PATH, expectedFilePath)
         const firstFileOutOfDDLineNumber = 13
         callsites.push(new CallSiteMock(PATH_AND_LINE_PATH, PATH_AND_LINE_LINE))
-        callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 89))
-        callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 5))
+        callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 89))
+        callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 5))
         callsites.push(new CallSiteMock(firstFileOutOfDD, firstFileOutOfDDLineNumber))
-        const { path, line } = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
-        expect(path).to.be.equals(firstFileOutOfDD)
-        expect(line).to.be.equals(firstFileOutOfDDLineNumber)
+        const pathAndLine = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
+        expect(pathAndLine.path).to.be.equals(expectedFilePath)
+        expect(pathAndLine.line).to.be.equals(firstFileOutOfDDLineNumber)
       })
 
       DIAGNOSTICS_CHANNEL_PATHS.forEach((dcPath) => {
         it(`should not return ${dcPath} path`, () => {
           const callsites = []
-          const firstFileOutOfDD = `${PROJECT_PATH}/first/file/out/of/dd.js`
+          const expectedFilePath = path.join('first', 'file', 'out', 'of', 'dd.js')
+          const firstFileOutOfDD = path.join(PROJECT_PATH, expectedFilePath)
           const firstFileOutOfDDLineNumber = 13
           callsites.push(new CallSiteMock(PATH_AND_LINE_PATH, PATH_AND_LINE_LINE))
-          callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 89))
+          callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 89))
           callsites.push(new CallSiteMock(dcPath, 25))
-          callsites.push(new CallSiteMock(`${DD_BASE_PATH}/other/file/in/dd.js`, 5))
+          callsites.push(new CallSiteMock(path.join(DD_BASE_PATH, 'other', 'file', 'in', 'dd.js'), 5))
           callsites.push(new CallSiteMock(firstFileOutOfDD, firstFileOutOfDDLineNumber))
-          const { path, line } = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
-          expect(path).to.be.equals(firstFileOutOfDD)
-          expect(line).to.be.equals(firstFileOutOfDDLineNumber)
+          const pathAndLine = pathLine.getFirstNonDDPathAndLineFromCallsites(callsites)
+          expect(pathAndLine.path).to.be.equals(expectedFilePath)
+          expect(pathAndLine.line).to.be.equals(firstFileOutOfDDLineNumber)
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
Get the relative path of the customer file instead of the absolute

### Motivation
We were sending full path to backend, should be enough with the relative

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
