### PR TITLE
APM DBM Link for MySQL & MySQL2

### DIFF
--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -18,14 +18,14 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
     }
 
     const sqlStatement = arguments
-    const sql = arguments[0].sql || arguments[0]
+    const sql = arguments[0].sql ? arguments[0].sql : arguments[0]
     const conf = this.config
 
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
 
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ sqlStatement: sqlStatement, sql: sql, conf })
+      startCh.publish({ sqlStatement: sqlStatement, sql, conf })
 
       try {
         const res = query.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -17,14 +17,15 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
       return query.apply(this, arguments)
     }
 
-    const sql = arguments[0].sql ? arguments[0].sql : arguments[0]
+    const sqlStatement = arguments
+    const sql = arguments[0].sql || arguments[0]
     const conf = this.config
 
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
 
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ sql, conf })
+      startCh.publish({ sqlStatement: sqlStatement, sql: sql, conf })
 
       try {
         const res = query.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -25,7 +25,7 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
     const asyncResource = new AsyncResource('bound-anonymous-fn')
 
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ sqlStatement: sqlStatement, sql, conf })
+      startCh.publish({ sqlStatement, sql, conf })
 
       try {
         const res = query.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -17,16 +17,21 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
       return query.apply(this, arguments)
     }
 
-    const sqlStatement = arguments
     const sql = arguments[0].sql ? arguments[0].sql : arguments[0]
     const conf = this.config
+    const payload = { sql, conf }
 
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
 
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ sqlStatement, sql, conf })
+      startCh.publish(payload)
 
+      if (arguments[0].sql) {
+        arguments[0].sql = payload.sql
+      } else {
+        arguments[0] = payload.sql
+      }
       try {
         const res = query.apply(this, arguments)
 

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -44,9 +44,10 @@ addHook({ name: 'mysql2', file: 'lib/connection.js', versions: ['>=1'] }, Connec
     const callbackResource = new AsyncResource('bound-anonymous-fn')
 
     return asyncResource.bind(function executeWithTrace (packet, connection) {
+      const sqlStatement = cmd
       const sql = cmd.statement ? cmd.statement.query : cmd.sql
 
-      startCh.publish({ sql, conf: config })
+      startCh.publish({ sqlStatement: sqlStatement, sql, conf: config })
 
       if (this.onResult) {
         const onResult = callbackResource.bind(this.onResult)

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -44,10 +44,15 @@ addHook({ name: 'mysql2', file: 'lib/connection.js', versions: ['>=1'] }, Connec
     const callbackResource = new AsyncResource('bound-anonymous-fn')
 
     return asyncResource.bind(function executeWithTrace (packet, connection) {
-      const sqlStatement = cmd
       const sql = cmd.statement ? cmd.statement.query : cmd.sql
+      const payload = { sql, conf: config }
+      startCh.publish(payload)
 
-      startCh.publish({ sqlStatement, sql, conf: config })
+      if (cmd.statement) {
+        cmd.statement.query = payload.sql
+      } else {
+        cmd.sql = payload.sql
+      }
 
       if (this.onResult) {
         const onResult = callbackResource.bind(this.onResult)

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -47,7 +47,7 @@ addHook({ name: 'mysql2', file: 'lib/connection.js', versions: ['>=1'] }, Connec
       const sqlStatement = cmd
       const sql = cmd.statement ? cmd.statement.query : cmd.sql
 
-      startCh.publish({ sqlStatement: sqlStatement, sql, conf: config })
+      startCh.publish({ sqlStatement, sql, conf: config })
 
       if (this.onResult) {
         const onResult = callbackResource.bind(this.onResult)

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -6,7 +6,7 @@ class MySQLPlugin extends DatabasePlugin {
   static get name () { return 'mysql' }
   static get system () { return 'mysql' }
 
-  start ({ sql, conf: dbConfig }) {
+  start ({ sqlStatement, sql, conf: dbConfig }) {
     const service = getServiceName(this.config, dbConfig)
 
     this.startSpan(`${this.system}.query`, {
@@ -22,6 +22,12 @@ class MySQLPlugin extends DatabasePlugin {
         'out.port': dbConfig.port
       }
     })
+    if (this.config.dbmPropagationMode !== 'disabled') {
+      if (sqlStatement[0].sql !== undefined) {
+        const key = 'sql'
+        sqlStatement[0][key] = this.injectDbmQuery(sqlStatement[0].sql)
+      } else sqlStatement[0] = this.injectDbmQuery(sqlStatement[0])
+    }
   }
 }
 

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -22,10 +22,10 @@ class MySQLPlugin extends DatabasePlugin {
         'out.port': dbConfig.port
       }
     })
+
     if (this.config.dbmPropagationMode !== 'disabled') {
       if (sqlStatement[0].sql !== undefined) {
-        const key = 'sql'
-        sqlStatement[0][key] = this.injectDbmQuery(sqlStatement[0].sql)
+        sqlStatement[0]['sql'] = this.injectDbmQuery(sqlStatement[0].sql)
       } else sqlStatement[0] = this.injectDbmQuery(sqlStatement[0])
     }
   }

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -22,15 +22,17 @@ class MySQLPlugin extends DatabasePlugin {
         'out.port': dbConfig.port
       }
     })
-
-    if (this.config.dbmPropagationMode !== 'disabled') {
-      if (sqlStatement[0].sql !== undefined) {
-        sqlStatement[0]['sql'] = this.injectDbmQuery(sqlStatement[0].sql)
-      } else sqlStatement[0] = this.injectDbmQuery(sqlStatement[0])
-    }
+    getPropagation(sqlStatement, service)
   }
 }
 
+function getPropagation (sqlStatement, service) {
+  if (this.config.dbmPropagationMode !== 'disabled') {
+    if (sqlStatement[0].sql !== undefined) {
+      sqlStatement[0]['sql'] = this.injectDbmQuery(sqlStatement[0].sql, service)
+    } else sqlStatement[0] = this.injectDbmQuery(sqlStatement[0], service)
+  }
+}
 function getServiceName (config, dbConfig) {
   if (typeof config.service === 'function') {
     return config.service(dbConfig)

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -22,15 +22,15 @@ class MySQLPlugin extends DatabasePlugin {
         'out.port': dbConfig.port
       }
     })
-    getPropagation(sqlStatement, service)
+    getPropagation(sqlStatement, service, this)
   }
 }
 
-function getPropagation (sqlStatement, service) {
-  if (this.config.dbmPropagationMode !== 'disabled') {
+function getPropagation (sqlStatement, service, source) {
+  if (source.config.dbmPropagationMode !== 'disabled') {
     if (sqlStatement[0].sql !== undefined) {
-      sqlStatement[0]['sql'] = this.injectDbmQuery(sqlStatement[0].sql, service)
-    } else sqlStatement[0] = this.injectDbmQuery(sqlStatement[0], service)
+      sqlStatement[0]['sql'] = source.injectDbmQuery(sqlStatement[0].sql, service)
+    } else sqlStatement[0] = source.injectDbmQuery(sqlStatement[0], service)
   }
 }
 function getServiceName (config, dbConfig) {

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -243,6 +243,200 @@ describe('Plugin', () => {
           })
         })
       })
+      describe('with DBM propagation enabled with service using plugin configurations', () => {
+        let connection
+
+        before(async () => {
+          await agent.load('mysql', [{ dbmPropagationMode: 'service', service: 'serviced' }])
+          mysql = proxyquire(`../../../versions/mysql@${version}`, {}).get()
+
+          connection = mysql.createConnection({
+            host: '127.0.0.1',
+            user: 'root',
+            database: 'db'
+          })
+          connection.connect()
+        })
+
+        it('should contain comment in query text', done => {
+          connection.query('SELECT 1 + 1 AS solution', () => {
+            try {
+              expect(connection._protocol._queue[0].sql).to.equal(
+                `/*dddbs='serviced',dde='tester',ddps='test',ddpv='8.4.0'*/ SELECT 1 + 1 AS solution`)
+            } catch (e) {
+              done(e)
+            }
+            done()
+          })
+        })
+        it('trace query resource should not be changed when propagation is enabled', done => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
+            done()
+          })
+          connection.query('SELECT 1 + 1 AS solution', (err) => {
+            if (err) return done(err)
+            connection.end((err) => {
+              if (err) return done(err)
+            })
+          })
+        })
+      })
+      describe('DBM propagation should handle special characters', () => {
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mysql', [{ dbmPropagationMode: 'service', service: '~!@#$%^&*()_+|??/<>' }])
+          mysql = proxyquire(`../../../versions/mysql@${version}`, {}).get()
+
+          connection = mysql.createConnection({
+            host: '127.0.0.1',
+            user: 'root',
+            database: 'db'
+          })
+          connection.connect()
+        })
+
+        it('DBM propagation should handle special characters', done => {
+          connection.query('SELECT 1 + 1 AS solution', () => {
+            try {
+              expect(connection._protocol._queue[0].sql).to.equal(
+                `/*dddbs='~!%40%23%24%25%5E%26*()_%2B%7C%3F%3F%2F%3C%3E',dde='tester',` +
+                `ddps='test',ddpv='8.4.0'*/ SELECT 1 + 1 AS solution`)
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+        })
+      })
+      describe('with DBM propagation enabled with full using tracer configurations', () => {
+        let connection
+
+        afterEach((done) => {
+          connection.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mysql', [{ dbmPropagationMode: 'full', service: 'post' }])
+          mysql = proxyquire(`../../../versions/mysql@${version}`, {}).get()
+
+          connection = mysql.createConnection({
+            host: '127.0.0.1',
+            user: 'root',
+            database: 'db'
+          })
+          connection.connect()
+        })
+
+        it('query text should contain traceparent', done => {
+          let queryText = ''
+          agent.use(traces => {
+            const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
+            const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
+
+            expect(queryText).to.equal(
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
+              `traceparent='01-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
+          }).then(done, done)
+          connection.query('SELECT 1 + 1 AS solution', () => {
+            queryText = connection._protocol._queue[0].sql
+          })
+        })
+        it('query should inject _dd.dbm_trace_injected into span', done => {
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
+            done()
+          })
+          connection.query('SELECT 1 + 1 AS solution', () => {
+          })
+        })
+      })
+      describe('with DBM propagation enabled with service using a connection pool', () => {
+        let pool
+
+        afterEach((done) => {
+          pool.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mysql', [{ dbmPropagationMode: 'service', service: 'post' }])
+          mysql = proxyquire(`../../../versions/mysql@${version}`, {}).get()
+
+          pool = mysql.createPool({
+            connectionLimit: 1,
+            host: '127.0.0.1',
+            user: 'root',
+            database: 'db'
+          })
+        })
+
+        it('should contain comment in query text', done => {
+          pool.query('SELECT 1 + 1 AS solution', () => {
+            try {
+              expect(pool._allConnections[0]._protocol._queue[0].sql).to.equal(
+                `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0'*/ SELECT 1 + 1 AS solution`)
+            } catch (e) {
+              done(e)
+            }
+            done()
+          })
+        })
+      })
+      describe('with DBM propagation enabled with service using a connection pool', () => {
+        let pool
+
+        afterEach((done) => {
+          pool.end(() => {
+            agent.close({ ritmReset: false }).then(done)
+          })
+        })
+
+        beforeEach(async () => {
+          await agent.load('mysql', [{ dbmPropagationMode: 'full', service: 'post' }])
+          mysql = proxyquire(`../../../versions/mysql@${version}`, {}).get()
+
+          pool = mysql.createPool({
+            connectionLimit: 1,
+            host: '127.0.0.1',
+            user: 'root',
+            database: 'db'
+          })
+        })
+
+        it('query text should contain traceparent', done => {
+          let queryText = ''
+          agent.use(traces => {
+            const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
+            const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
+
+            expect(queryText).to.equal(
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
+              `traceparent='01-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
+          }).then(done, done)
+          pool.query('SELECT 1 + 1 AS solution', () => {
+            queryText = pool._allConnections[0]._protocol._queue[0].sql
+          })
+        })
+        it('query should inject _dd.dbm_trace_injected into span', done => {
+          agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
+            done()
+          })
+          pool.query('SELECT 1 + 1 AS solution', () => {
+          })
+        })
+      })
     })
   })
 })

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -1,9 +1,43 @@
 'use strict'
 
-const MySQLPlugin = require('../../datadog-plugin-mysql/src')
+const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
-class MySQL2Plugin extends MySQLPlugin {
+class MySQL2Plugin extends DatabasePlugin {
   static get name () { return 'mysql2' }
+  static get system () { return 'mysql' }
+
+  start ({ sqlStatement, sql, conf: dbConfig }) {
+    const service = getServiceName(this.config, dbConfig)
+
+    this.startSpan(`${this.system}.query`, {
+      service,
+      resource: sql,
+      type: 'sql',
+      kind: 'client',
+      meta: {
+        'db.type': this.system,
+        'db.user': dbConfig.user,
+        'db.name': dbConfig.database,
+        'out.host': dbConfig.host,
+        'out.port': dbConfig.port
+      }
+    })
+    if (this.config.dbmPropagationMode !== 'disabled') {
+      if (sqlStatement.statement !== undefined) {
+        sqlStatement.statement.query = this.injectDbmQuery(sqlStatement.statement.query)
+      } else if (sqlStatement.sql) {
+        sqlStatement.sql = this.injectDbmQuery(sqlStatement.sql)
+      }
+    }
+  }
+}
+
+function getServiceName (config, dbConfig) {
+  if (typeof config.service === 'function') {
+    return config.service(dbConfig)
+  }
+
+  return config.service
 }
 
 module.exports = MySQL2Plugin

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -1,46 +1,9 @@
 'use strict'
 
-const DatabasePlugin = require('../../dd-trace/src/plugins/database')
+const MySQLPlugin = require('../../datadog-plugin-mysql/src')
 
-class MySQL2Plugin extends DatabasePlugin {
+class MySQL2Plugin extends MySQLPlugin {
   static get name () { return 'mysql2' }
-  static get system () { return 'mysql' }
-
-  start ({ sqlStatement, sql, conf: dbConfig }) {
-    const service = getServiceName(this.config, dbConfig)
-
-    this.startSpan(`${this.system}.query`, {
-      service,
-      resource: sql,
-      type: 'sql',
-      kind: 'client',
-      meta: {
-        'db.type': this.system,
-        'db.user': dbConfig.user,
-        'db.name': dbConfig.database,
-        'out.host': dbConfig.host,
-        'out.port': dbConfig.port
-      }
-    })
-    getPropagation(sqlStatement, service, this)
-  }
-}
-
-function getPropagation (sqlStatement, service, source) {
-  if (source.config.dbmPropagationMode !== 'disabled') {
-    if (sqlStatement.statement !== undefined) {
-      sqlStatement.statement.query = source.injectDbmQuery(sqlStatement.statement.query, service)
-    } else if (sqlStatement.sql) {
-      sqlStatement.sql = source.injectDbmQuery(sqlStatement.sql, service)
-    }
-  }
-}
-function getServiceName (config, dbConfig) {
-  if (typeof config.service === 'function') {
-    return config.service(dbConfig)
-  }
-
-  return config.service
 }
 
 module.exports = MySQL2Plugin

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -22,16 +22,16 @@ class MySQL2Plugin extends DatabasePlugin {
         'out.port': dbConfig.port
       }
     })
-    getPropagation(sqlStatement, service)
+    getPropagation(sqlStatement, service, this)
   }
 }
 
-function getPropagation (sqlStatement, service) {
-  if (this.config.dbmPropagationMode !== 'disabled') {
+function getPropagation (sqlStatement, service, source) {
+  if (source.config.dbmPropagationMode !== 'disabled') {
     if (sqlStatement.statement !== undefined) {
-      sqlStatement.statement.query = this.injectDbmQuery(sqlStatement.statement.query)
+      sqlStatement.statement.query = source.injectDbmQuery(sqlStatement.statement.query, service)
     } else if (sqlStatement.sql) {
-      sqlStatement.sql = this.injectDbmQuery(sqlStatement.sql)
+      sqlStatement.sql = source.injectDbmQuery(sqlStatement.sql, service)
     }
   }
 }

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -22,16 +22,19 @@ class MySQL2Plugin extends DatabasePlugin {
         'out.port': dbConfig.port
       }
     })
-    if (this.config.dbmPropagationMode !== 'disabled') {
-      if (sqlStatement.statement !== undefined) {
-        sqlStatement.statement.query = this.injectDbmQuery(sqlStatement.statement.query)
-      } else if (sqlStatement.sql) {
-        sqlStatement.sql = this.injectDbmQuery(sqlStatement.sql)
-      }
-    }
+    getPropagation(sqlStatement, service)
   }
 }
 
+function getPropagation (sqlStatement, service) {
+  if (this.config.dbmPropagationMode !== 'disabled') {
+    if (sqlStatement.statement !== undefined) {
+      sqlStatement.statement.query = this.injectDbmQuery(sqlStatement.statement.query)
+    } else if (sqlStatement.sql) {
+      sqlStatement.sql = this.injectDbmQuery(sqlStatement.sql)
+    }
+  }
+}
 function getServiceName (config, dbConfig) {
   if (typeof config.service === 'function') {
     return config.service(dbConfig)


### PR DESCRIPTION
### What does this PR do?
This PR is to add DBM propagation support for MySQL and MySQL2

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
