### PR TITLE
Add _dd.iast.enabled tag

### DIFF
--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -7,6 +7,8 @@ const dc = require('diagnostics_channel')
 const iastContextFunctions = require('./iast-context')
 const { enableTaintTracking, disableTaintTracking, createTransaction, removeTransaction } = require('./taint-tracking')
 
+const IAST_ENABLED_TAG_KEY = '_dd.iast.enabled'
+
 // TODO Change to `apm:http:server:request:[start|close]` when the subscription
 //  order of the callbacks can be enforce
 const requestStart = dc.channel('dd-trace:incomingHttpRequestStart')
@@ -39,6 +41,11 @@ function onIncomingHttpRequestStart (data) {
           const iastContext = iastContextFunctions.saveIastContext(store, topContext, { rootSpan, req: data.req })
           createTransaction(rootSpan.context().toSpanId(), iastContext)
           overheadController.initializeRequestContext(iastContext)
+        }
+        if (rootSpan.addTags) {
+          rootSpan.addTags({
+            [IAST_ENABLED_TAG_KEY]: isRequestAcquired.toString()
+          })
         }
       }
     }

--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -44,7 +44,7 @@ function onIncomingHttpRequestStart (data) {
         }
         if (rootSpan.addTags) {
           rootSpan.addTags({
-            [IAST_ENABLED_TAG_KEY]: isRequestAcquired.toString()
+            [IAST_ENABLED_TAG_KEY]: isRequestAcquired ? '1' : '0'
           })
         }
       }

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -186,14 +186,17 @@ describe('Overhead controller', () => {
       const THIRD_REQUEST = '/third'
       const FOURTH_REQUEST = '/fourth'
       const FIFTH_REQUEST = '/fifth'
+      const SECURE_REQUEST = '/secure'
 
       const testRequestEventEmitter = new EventEmitter()
       let requestResolvers = {}
 
       function app (req) {
         return new Promise((resolve) => {
-          const crypto = require('crypto')
-          crypto.createHash('sha1')
+          if (req.url.indexOf('secure') === -1) {
+            const crypto = require('crypto')
+            crypto.createHash('sha1')
+          }
           requestResolvers[req.url] = () => {
             resolve()
             testRequestEventEmitter.emit(TEST_REQUEST_FINISHED, req.url)
@@ -402,6 +405,51 @@ describe('Overhead controller', () => {
           })
 
           axios.get(`http://localhost:${serverConfig.port}${FIRST_REQUEST}`).then().catch(done)
+        })
+
+        it('should add _dd.iast.enabled tag even when no vulnerability is detected', (done) => {
+          const config = new Config({
+            experimental: {
+              iast: {
+                enabled: true,
+                requestSampling: 100,
+                maxConcurrentRequests: 1
+              }
+            }
+          })
+          iast.enable(config)
+
+          const handler = function (traces) {
+            try {
+              for (let i = 0; i < traces.length; i++) {
+                for (let j = 0; j < traces[i].length; j++) {
+                  const trace = traces[i][j]
+                  if (trace.type === 'web') {
+                    const url = trace.meta['http.url']
+                    if (url.includes(SECURE_REQUEST)) {
+                      expect(trace.meta['_dd.iast.json']).to.be.undefined
+                      expect(trace.meta['_dd.iast.enabled']).eq('1')
+                    }
+                    done()
+                  }
+                }
+              }
+            } catch (e) {
+              agent.unsubscribe(handler)
+              done(e)
+            }
+          }
+          handlers.push(handler)
+          agent.subscribe(handler)
+
+          testRequestEventEmitter.on(TEST_REQUEST_STARTED, (url) => {
+            if (url === SECURE_REQUEST) {
+              setImmediate(() => {
+                requestResolvers[SECURE_REQUEST]()
+              })
+            }
+          })
+          axios.get(`http://localhost:${serverConfig.port}${SECURE_REQUEST}`).then().catch(done)
         })
       }
 

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -429,8 +429,8 @@ describe('Overhead controller', () => {
                     if (url.includes(SECURE_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).to.be.undefined
                       expect(trace.meta['_dd.iast.enabled']).eq('1')
+                      done()
                     }
-                    done()
                   }
                 }
               }

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -243,9 +243,11 @@ describe('Overhead controller', () => {
                     const url = trace.meta['http.url']
                     if (url.includes(FIRST_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).not.to.be.undefined
+                      expect(trace.meta['_dd.iast.enabled']).to.be.true
                       urlCounter++
                     } else if (url.includes(SECOND_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).to.be.undefined
+                      expect(trace.meta['_dd.iast.enabled']).to.be.false
                       urlCounter++
                     }
                     if (urlCounter === 2) {

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -243,11 +243,11 @@ describe('Overhead controller', () => {
                     const url = trace.meta['http.url']
                     if (url.includes(FIRST_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).not.to.be.undefined
-                      expect(trace.meta['_dd.iast.enabled']).to.be.true
+                      expect(trace.meta['_dd.iast.enabled']).eq('true')
                       urlCounter++
                     } else if (url.includes(SECOND_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).to.be.undefined
-                      expect(trace.meta['_dd.iast.enabled']).to.be.false
+                      expect(trace.meta['_dd.iast.enabled']).eq('false')
                       urlCounter++
                     }
                     if (urlCounter === 2) {
@@ -294,6 +294,7 @@ describe('Overhead controller', () => {
                   if (trace.type === 'web') {
                     urlCounter++
                     expect(trace.meta['_dd.iast.json']).not.to.be.undefined
+                    expect(trace.meta['_dd.iast.enabled']).eq('true')
                     if (urlCounter === 2) {
                       done()
                     }

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -243,11 +243,11 @@ describe('Overhead controller', () => {
                     const url = trace.meta['http.url']
                     if (url.includes(FIRST_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).not.to.be.undefined
-                      expect(trace.meta['_dd.iast.enabled']).eq('true')
+                      expect(trace.meta['_dd.iast.enabled']).eq('1')
                       urlCounter++
                     } else if (url.includes(SECOND_REQUEST)) {
                       expect(trace.meta['_dd.iast.json']).to.be.undefined
-                      expect(trace.meta['_dd.iast.enabled']).eq('false')
+                      expect(trace.meta['_dd.iast.enabled']).eq('0')
                       urlCounter++
                     }
                     if (urlCounter === 2) {
@@ -294,7 +294,7 @@ describe('Overhead controller', () => {
                   if (trace.type === 'web') {
                     urlCounter++
                     expect(trace.meta['_dd.iast.json']).not.to.be.undefined
-                    expect(trace.meta['_dd.iast.enabled']).eq('true')
+                    expect(trace.meta['_dd.iast.enabled']).eq('1')
                     if (urlCounter === 2) {
                       done()
                     }


### PR DESCRIPTION
### What does this PR do?

IAST not active, `_dd.iast.enabled = undefined`
IAST active but request ignored, `_dd.iast.enabled = 0`
IAST active and request analyzed: `_dd.iast.enabled = 1`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
