### PR TITLE
[ci-visibility] Fix URL for intelligent test runner when using agentless

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -38,6 +38,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
           url: this._url,
           evpProxyPrefix: AGENT_EVP_PROXY_PATH
         })
+        this._apiUrl = this._url
         if (isGitUploadEnabled) {
           this.sendGitMetadata({ url: this._url, isEvpProxy: true })
         }

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -38,7 +38,6 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
           url: this._url,
           evpProxyPrefix: AGENT_EVP_PROXY_PATH
         })
-        this._apiUrl = this._url
         if (isGitUploadEnabled) {
           this.sendGitMetadata({ url: this._url, isEvpProxy: true })
         }
@@ -57,6 +56,14 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
     })
+  }
+
+  setUrl (url, coverageUrl) {
+    this._setUrl(url, coverageUrl)
+  }
+
+  getApiUrl () {
+    return this._getApiUrl()
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -61,10 +61,6 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
   setUrl (url, coverageUrl) {
     this._setUrl(url, coverageUrl)
   }
-
-  getApiUrl () {
-    return this._getApiUrl()
-  }
 }
 
 module.exports = AgentProxyCiVisibilityExporter

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -37,7 +37,7 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     }
   }
 
-  getApiUrl () {
+  _getApiUrl () {
     return this._apiUrl
   }
 }

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -19,9 +19,10 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     this._coverageUrl = url || new URL(`https://event-platform-intake.${site}`)
     this._coverageWriter = new CoverageWriter({ url: this._coverageUrl })
 
+    this._apiUrl = url || new URL(`https://api.${site}`)
+
     if (isGitUploadEnabled) {
-      const gitUrl = url || new URL(`https://api.${site}`)
-      this.sendGitMetadata({ url: gitUrl })
+      this.sendGitMetadata({ url: this._apiUrl })
     }
   }
 }

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -4,6 +4,7 @@ const URL = require('url').URL
 const Writer = require('./writer')
 const CoverageWriter = require('./coverage-writer')
 const CiVisibilityExporter = require('../ci-visibility-exporter')
+const log = require('../../../log')
 
 class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
   constructor (config) {
@@ -24,6 +25,20 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     if (isGitUploadEnabled) {
       this.sendGitMetadata({ url: this._apiUrl })
     }
+  }
+
+  setUrl (url, coverageUrl = url, apiUrl = url) {
+    this._setUrl(url, coverageUrl)
+    try {
+      apiUrl = new URL(apiUrl)
+      this._apiUrl = apiUrl
+    } catch (e) {
+      log.error(e)
+    }
+  }
+
+  getApiUrl () {
+    return this._apiUrl
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -23,7 +23,7 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     this._apiUrl = url || new URL(`https://api.${site}`)
 
     if (isGitUploadEnabled) {
-      this.sendGitMetadata({ url: this._apiUrl })
+      this.sendGitMetadata({ url: this._getApiUrl() })
     }
   }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -77,7 +77,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         return callback(gitUploadError, [])
       }
       const configuration = {
-        url: this.getApiUrl(),
+        url: this._getApiUrl(),
         site: this._config.site,
         env: this._config.env,
         service: this._config.service,
@@ -101,7 +101,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         return callback(null, {})
       }
       const configuration = {
-        url: this.getApiUrl(),
+        url: this._getApiUrl(),
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,
@@ -196,11 +196,6 @@ class CiVisibilityExporter extends AgentInfoExporter {
 
   _getApiUrl () {
     return this._url
-  }
-
-  // To be reimplemented by the class extending CiVisibilityExporter
-  getApiUrl () {
-    return this._getApiUrl()
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -37,9 +37,6 @@ class CiVisibilityExporter extends AgentInfoExporter {
       }
     })
 
-    // This should be overwritten by the class extending CiVisibilityExporter
-    this._apiUrl = this._url
-
     process.once('beforeExit', () => {
       if (this._writer) {
         this._writer.flush()
@@ -80,7 +77,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         return callback(gitUploadError, [])
       }
       const configuration = {
-        url: this._apiUrl,
+        url: this.getApiUrl(),
         site: this._config.site,
         env: this._config.env,
         service: this._config.service,
@@ -104,7 +101,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         return callback(null, {})
       }
       const configuration = {
-        url: this._apiUrl,
+        url: this.getApiUrl(),
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,
@@ -184,7 +181,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
     this._coverageBuffer = []
   }
 
-  setUrl (url, coverageUrl = url) {
+  _setUrl (url, coverageUrl = url) {
     try {
       url = new URL(url)
       coverageUrl = new URL(coverageUrl)
@@ -195,6 +192,15 @@ class CiVisibilityExporter extends AgentInfoExporter {
     } catch (e) {
       log.error(e)
     }
+  }
+
+  _getApiUrl () {
+    return this._url
+  }
+
+  // To be reimplemented by the class extending CiVisibilityExporter
+  getApiUrl () {
+    return this._getApiUrl()
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -66,9 +66,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
   }
 
   canReportCodeCoverage () {
-    return this._canUseCiVisProtocol &&
-      this._itrConfig &&
-      this._itrConfig.isCodeCoverageEnabled
+    return this._canUseCiVisProtocol
   }
 
   // We can't call the skippable endpoint until git upload has finished,
@@ -113,6 +111,10 @@ class CiVisibilityExporter extends AgentInfoExporter {
         ...testConfiguration
       }
       getItrConfigurationRequest(configuration, (err, itrConfig) => {
+        /**
+         * **Important**: this._itrConfig remains empty in testing frameworks
+         * where the tests run in a subprocess, because `getItrConfiguration` is called only once.
+         */
         this._itrConfig = itrConfig
         callback(err, itrConfig)
       })

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -37,6 +37,9 @@ class CiVisibilityExporter extends AgentInfoExporter {
       }
     })
 
+    // This should be overwritten by the class extending CiVisibilityExporter
+    this._apiUrl = this._url
+
     process.once('beforeExit', () => {
       if (this._writer) {
         this._writer.flush()
@@ -79,7 +82,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         return callback(gitUploadError, [])
       }
       const configuration = {
-        url: this._url,
+        url: this._apiUrl,
         site: this._config.site,
         env: this._config.env,
         service: this._config.service,
@@ -103,7 +106,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         return callback(null, {})
       }
       const configuration = {
-        url: this._url,
+        url: this._apiUrl,
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -294,29 +294,7 @@ describe('CI Visibility Exporter', () => {
         expect(ciVisibilityExporter._coverageWriter.append).not.to.be.called
       })
     })
-    context('is initialized, can use CI Vis protocol but code coverage is disabled', () => {
-      it('should not export coverages', () => {
-        const writer = {
-          append: sinon.spy(),
-          flush: sinon.spy(),
-          setUrl: sinon.spy()
-        }
-        const coverage = {
-          span: {
-            context: () => ({})
-          }
-        }
-        const ciVisibilityExporter = new CiVisibilityExporter({ port })
-        ciVisibilityExporter._isInitialized = true
-        ciVisibilityExporter._coverageWriter = writer
-        ciVisibilityExporter._canUseCiVisProtocol = true
-
-        ciVisibilityExporter.exportCoverage(coverage)
-        expect(ciVisibilityExporter._coverageBuffer).not.to.include(coverage)
-        expect(ciVisibilityExporter._coverageWriter.append).not.to.be.called
-      })
-    })
-    context('is initialized, can use CI Vis protocol and code coverage is enabled', () => {
+    context('is initialized and can use CI Vis protocol', () => {
       it('should export coverages', () => {
         const writer = {
           append: sinon.spy(),
@@ -332,7 +310,6 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter._isInitialized = true
         ciVisibilityExporter._coverageWriter = writer
         ciVisibilityExporter._canUseCiVisProtocol = true
-        ciVisibilityExporter._itrConfig = { isCodeCoverageEnabled: true }
 
         ciVisibilityExporter.exportCoverage(coverage)
         expect(ciVisibilityExporter._coverageBuffer).not.to.include(coverage)

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -68,7 +68,7 @@ describe('CI Visibility Exporter', () => {
       })
     })
     context('if ITR is enabled', () => {
-      it('should request the API after EVP proxy is resolved if ITR is enabled', (done) => {
+      it('should request the API after EVP proxy is resolved', (done) => {
         const scope = nock(`http://localhost:${port}`)
           .post('/api/v2/libraries/tests/services/setting')
           .reply(200, JSON.stringify({


### PR DESCRIPTION
### What does this PR do?
In agentless mode, fix the default URL used for requesting ITR configuration and ITR skippable suites. It should be `api.${site}` but it was being set to the URL where the traces are flushed (`citestcycle-intake.${site}`). 

### Motivation
Fix ITR configuration request.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
