### PR TITLE
Update addRequestHeaders to stringify header value when an array

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -117,7 +117,7 @@ function addRequestHeaders (req, span, config) {
     const value = req.getHeader(key)
 
     if (value) {
-      span.setTag(`${HTTP_REQUEST_HEADERS}.${key}`, value)
+      span.setTag(`${HTTP_REQUEST_HEADERS}.${key}`, Array.isArray(value) ? value.toString() : value)
     }
   })
 }

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -1146,7 +1146,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const meta = traces[0][0].meta
 
-                expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-foo`, `bar`)
+                expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-foo`, `bar1,bar2`)
               })
               .then(done)
               .catch(done)
@@ -1156,7 +1156,7 @@ describe('Plugin', () => {
                 res.on('data', () => { })
               })
 
-              req.setHeader('x-foo', ['bar'])
+              req.setHeader('x-foo', ['bar1', 'bar2'])
               req.end()
             })
           })

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -1133,6 +1133,34 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('should support adding request headers when header set as an array', done => {
+          const app = express()
+
+          app.get('/user', (req, res) => {
+            res.status(200).send()
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const meta = traces[0][0].meta
+
+                expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-foo`, `bar`)
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(app, port, () => {
+              const req = http.request(`${protocol}://localhost:${port}/user`, res => {
+                res.on('data', () => { })
+              })
+
+              req.setHeader('x-foo', ['bar'])
+              req.end()
+            })
+          })
+        })
       })
 
       describe('with hooks configuration', () => {


### PR DESCRIPTION
### What does this PR do?
Addresses https://github.com/DataDog/dd-trace-js/issues/2660

### Motivation
http libraries like make-fetch-happen/minipass-fetch request headers when fetched from ClientRequest request.getHeader(string) are arrays, even when they have a single value.

When http client plugin client.js populates tags from this, it blindly sets the tag value to the returned value, and therefore the spans for this use case do not get sent with the headers as intended.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

Will attempt to add unit tests once maintainers provide feedback/indicate this is the right direction to fix this problem.

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
