### PR TITLE
Fix sql injection pg test for 2.x branch

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
@@ -21,8 +21,8 @@ describe('sql-injection-analyzer with pg', () => {
         client.connect(err => done(err))
       })
 
-      afterEach((done) => {
-        client.end(done)
+      afterEach(async () => {
+        await client.end()
       })
 
       describe('has vulnerability', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Sql injection test does not work correctly in 2.x branch, because in 2.x there are supported more pg versions, and the pg API is a bit different in pg@4.5.5 and in pg@8.0.0

In this other PR (that we will delete) we can check that the solution works in 2.x branch: https://github.com/DataDog/dd-trace-js/pull/2669
### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
