### PR TITLE
[ci-visibility] Add github job name to the extracted CI metadata 

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -235,7 +235,8 @@ module.exports = {
         GITHUB_SHA,
         GITHUB_REPOSITORY,
         GITHUB_SERVER_URL,
-        GITHUB_RUN_ATTEMPT
+        GITHUB_RUN_ATTEMPT,
+        GITHUB_JOB
       } = env
 
       const repositoryURL = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git`
@@ -259,6 +260,7 @@ module.exports = {
         [GIT_COMMIT_SHA]: GITHUB_SHA,
         [GIT_REPOSITORY_URL]: repositoryURL,
         [CI_JOB_URL]: jobUrl,
+        [CI_JOB_NAME]: GITHUB_JOB,
         [CI_WORKSPACE_PATH]: GITHUB_WORKSPACE,
         [refKey]: ref,
         [CI_ENV_VARS]: JSON.stringify({

--- a/packages/dd-trace/test/plugins/util/ci-env/buddy.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/buddy.json
@@ -3,7 +3,7 @@
     {
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "master",
-      "BUDDY_EXECUTION_ID": "12",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
       "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
@@ -15,9 +15,9 @@
       "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project"
     },
     {
-      "ci.pipeline.id": "456/12",
+      "ci.pipeline.id": "456/buddy-execution-id",
       "ci.pipeline.name": "Deploy to Production",
-      "ci.pipeline.number": "12",
+      "ci.pipeline.number": "buddy-execution-id",
       "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "ci.provider.name": "buddy",
       "git.branch": "master",
@@ -33,7 +33,7 @@
     {
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "refs/heads/feature/one",
-      "BUDDY_EXECUTION_ID": "12",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
       "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
@@ -45,9 +45,9 @@
       "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project"
     },
     {
-      "ci.pipeline.id": "456/12",
+      "ci.pipeline.id": "456/buddy-execution-id",
       "ci.pipeline.name": "Deploy to Production",
-      "ci.pipeline.number": "12",
+      "ci.pipeline.number": "buddy-execution-id",
       "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "ci.provider.name": "buddy",
       "git.branch": "feature/one",
@@ -63,7 +63,7 @@
     {
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "master",
-      "BUDDY_EXECUTION_ID": "12",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
       "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
@@ -86,9 +86,9 @@
       "DD_GIT_TAG": "user-supplied-tag"
     },
     {
-      "ci.pipeline.id": "456/12",
+      "ci.pipeline.id": "456/buddy-execution-id",
       "ci.pipeline.name": "Deploy to Production",
-      "ci.pipeline.number": "12",
+      "ci.pipeline.number": "buddy-execution-id",
       "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "ci.provider.name": "buddy",
       "git.branch": "master",
@@ -108,7 +108,7 @@
     {
       "BUDDY": "true",
       "BUDDY_EXECUTION_BRANCH": "master",
-      "BUDDY_EXECUTION_ID": "12",
+      "BUDDY_EXECUTION_ID": "buddy-execution-id",
       "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
       "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
       "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson",
@@ -130,9 +130,9 @@
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
     },
     {
-      "ci.pipeline.id": "456/12",
+      "ci.pipeline.id": "456/buddy-execution-id",
       "ci.pipeline.name": "Deploy to Production",
-      "ci.pipeline.number": "12",
+      "ci.pipeline.number": "buddy-execution-id",
       "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
       "ci.provider.name": "buddy",
       "git.branch": "user-supplied-branch",

--- a/packages/dd-trace/test/plugins/util/ci-env/github.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/github.json
@@ -2,6 +2,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
@@ -13,6 +14,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://ghenterprise.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -28,6 +30,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -40,6 +43,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -55,6 +59,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -67,6 +72,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -82,6 +88,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -94,6 +101,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -109,6 +117,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -121,6 +130,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -136,6 +146,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -150,6 +161,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -165,6 +177,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -179,6 +192,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -194,6 +208,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -208,6 +223,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -223,6 +239,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "origin/master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -235,6 +252,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -250,6 +268,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "refs/heads/master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -262,6 +281,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -277,6 +297,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "refs/heads/feature/one",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -289,6 +310,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -304,6 +326,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "origin/tags/0.1.0",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -316,6 +339,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -331,6 +355,7 @@
   [
     {
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "refs/heads/tags/0.1.0",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -343,6 +368,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -359,6 +385,7 @@
     {
       "GITHUB_ACTION": "run",
       "GITHUB_HEAD_REF": "origin/other",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "origin/master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -371,6 +398,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -387,6 +415,7 @@
     {
       "GITHUB_ACTION": "run",
       "GITHUB_HEAD_REF": "refs/heads/other",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "refs/heads/master",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -399,6 +428,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -415,6 +445,7 @@
     {
       "GITHUB_ACTION": "run",
       "GITHUB_HEAD_REF": "refs/heads/feature/other",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REF": "refs/heads/feature/one",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
@@ -427,6 +458,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -452,6 +484,7 @@
       "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
@@ -463,6 +496,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",
@@ -495,6 +529,7 @@
       "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
       "DD_GIT_TAG": "0.0.2",
       "GITHUB_ACTION": "run",
+      "GITHUB_JOB": "github-job-name",
       "GITHUB_REPOSITORY": "ghactions-repo",
       "GITHUB_RUN_ATTEMPT": "ghactions-run-attempt",
       "GITHUB_RUN_ID": "ghactions-pipeline-id",
@@ -506,6 +541,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
       "ci.pipeline.name": "ghactions-pipeline-name",


### PR DESCRIPTION
### What does this PR do?
* Read `GITHUB_JOB` when running in github actions.
* Update fixtures. 

### Motivation
`GITHUB_JOB` is now available as an environment variable in github actions (see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables for more info), so we want to read it and attach it as a span tag.

