### PR TITLE
[ci-visibility] Remove user credentials from user provided git

### DIFF
--- a/packages/dd-trace/src/plugins/util/user-provided-git.js
+++ b/packages/dd-trace/src/plugins/util/user-provided-git.js
@@ -26,6 +26,19 @@ function removeEmptyValues (tags) {
   }, {})
 }
 
+function filterSensitiveInfoFromRepository (repositoryUrl) {
+  try {
+    if (repositoryUrl.startsWith('git@')) {
+      return repositoryUrl
+    }
+    const { protocol, hostname, pathname } = new URL(repositoryUrl)
+
+    return `${protocol}//${hostname}${pathname}`
+  } catch (e) {
+    return repositoryUrl
+  }
+}
+
 function getUserProviderGitMetadata () {
   const {
     DD_GIT_COMMIT_SHA,
@@ -57,7 +70,7 @@ function getUserProviderGitMetadata () {
   return removeEmptyValues({
     [GIT_COMMIT_SHA]: DD_GIT_COMMIT_SHA,
     [GIT_BRANCH]: branch,
-    [GIT_REPOSITORY_URL]: DD_GIT_REPOSITORY_URL,
+    [GIT_REPOSITORY_URL]: filterSensitiveInfoFromRepository(DD_GIT_REPOSITORY_URL),
     [GIT_TAG]: tag,
     [GIT_COMMIT_MESSAGE]: DD_GIT_COMMIT_MESSAGE,
     [GIT_COMMIT_COMMITTER_NAME]: DD_GIT_COMMIT_COMMITTER_NAME,

--- a/packages/dd-trace/test/plugins/util/ci-env/azurepipelines.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/azurepipelines.json
@@ -631,5 +631,32 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "https://user:password@dev.azure.com/fabrikamfiber/",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "https://dev.azure.com/fabrikamfiber/"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/bitbucket.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/bitbucket.json
@@ -375,5 +375,24 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "https://user:password@bitbucket.org/DataDog/dogweb.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "https://bitbucket.org/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/bitrise.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/bitrise.json
@@ -454,5 +454,26 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/buildkite.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/buildkite.json
@@ -672,5 +672,36 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "https://user:password@github.com/DataDog/dogweb.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/circleci.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/circleci.json
@@ -518,5 +518,28 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/gitlab.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/gitlab.json
@@ -854,5 +854,39 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "gitlab-project-url",
+      "CI_REPOSITORY_URL": "https://user:password@gitlab.com/DataDog/dogweb.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"gitlab-project-url\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "https://gitlab.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/jenkins.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/jenkins.json
@@ -665,5 +665,26 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL_1": "https://user:password@github.com/DataDog/dogweb.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "jenkins-job-url"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/travisci.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/travisci.json
@@ -493,5 +493,33 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/tags/0.1.0",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo",
+      "TRAVIS_TAG": "origin/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.message": "travis-commit-message",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git",
+      "git.tag": "0.1.0"
+    }
   ]
 ]

--- a/packages/dd-trace/test/plugins/util/ci-env/usersupplied.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/usersupplied.json
@@ -154,5 +154,29 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]


### PR DESCRIPTION
### What does this PR do?
Remove credentials from repository URL when the user is providing it via `DD_GIT_REPOSITORY_URL`. It's already done for CI providers so there's no need to change that.

### Motivation
Do not send user credentials to datadog.

