### PR TITLE
add remoteConfigEnabled config

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -280,7 +280,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     )
 
     const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
-    const defaultFlushInterval = inAWSLambda ? 0 : 2000
 
     const remoteConfigOptions = options.remoteConfig || {}
     const DD_REMOTE_CONFIGURATION_ENABLED = coalesce(
@@ -357,6 +356,8 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
         })
       })
     }
+    
+    const defaultFlushInterval = inAWSLambda ? 0 : 2000
 
     this.tracing = !isFalse(DD_TRACING_ENABLED)
     this.dbmPropagationMode = DD_DBM_PROPAGATION_MODE

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -285,8 +285,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     const remoteConfigOptions = options.remoteConfig || {}
     const DD_REMOTE_CONFIGURATION_ENABLED = coalesce(
       process.env.DD_REMOTE_CONFIGURATION_ENABLED && isTrue(process.env.DD_REMOTE_CONFIGURATION_ENABLED),
-      !inAWSLambda,
-      true
+      !inAWSLambda
     )
     const DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = coalesce(
       parseInt(remoteConfigOptions.pollInterval),

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -284,7 +284,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     const remoteConfigOptions = options.remoteConfig || {}
     const DD_REMOTE_CONFIGURATION_ENABLED = coalesce(
-      process.env.DD_REMOTE_CONFIGURATION_ENABLED,
+      isTrue(process.env.DD_REMOTE_CONFIGURATION_ENABLED),
       !inAWSLambda,
       true
     )
@@ -414,7 +414,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       blockedTemplateJson: DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON
     }
     this.remoteConfig = {
-      enabled: isTrue(DD_REMOTE_CONFIGURATION_ENABLED),
+      enabled: DD_REMOTE_CONFIGURATION_ENABLED,
       pollInterval: DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS
     }
     this.iast = {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -279,7 +279,15 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       path.join(__dirname, 'appsec', 'templates', 'blocked.json')
     )
 
+    const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
+    const defaultFlushInterval = inAWSLambda ? 0 : 2000
+
     const remoteConfigOptions = options.remoteConfig || {}
+    const DD_REMOTE_CONFIGURATION_ENABLED = coalesce(
+      process.env.DD_REMOTE_CONFIGURATION_ENABLED,
+      !inAWSLambda,
+      true
+    )
     const DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = coalesce(
       parseInt(remoteConfigOptions.pollInterval),
       parseInt(process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS),
@@ -351,8 +359,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       })
     }
 
-    const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
-    const defaultFlushInterval = inAWSLambda ? 0 : 2000
 
     this.tracing = !isFalse(DD_TRACING_ENABLED)
     this.dbmPropagationMode = DD_DBM_PROPAGATION_MODE
@@ -409,6 +415,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       blockedTemplateJson: DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON
     }
     this.remoteConfig = {
+      enabled: isTrue(DD_REMOTE_CONFIGURATION_ENABLED),
       pollInterval: DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS
     }
     this.iast = {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -359,7 +359,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       })
     }
 
-
     this.tracing = !isFalse(DD_TRACING_ENABLED)
     this.dbmPropagationMode = DD_DBM_PROPAGATION_MODE
     this.logInjection = isTrue(DD_LOGS_INJECTION)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -356,7 +356,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
         })
       })
     }
-    
     const defaultFlushInterval = inAWSLambda ? 0 : 2000
 
     this.tracing = !isFalse(DD_TRACING_ENABLED)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -356,6 +356,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
         })
       })
     }
+
     const defaultFlushInterval = inAWSLambda ? 0 : 2000
 
     this.tracing = !isFalse(DD_TRACING_ENABLED)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -284,7 +284,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     const remoteConfigOptions = options.remoteConfig || {}
     const DD_REMOTE_CONFIGURATION_ENABLED = coalesce(
-      isTrue(process.env.DD_REMOTE_CONFIGURATION_ENABLED),
+      process.env.DD_REMOTE_CONFIGURATION_ENABLED && isTrue(process.env.DD_REMOTE_CONFIGURATION_ENABLED),
       !inAWSLambda,
       true
     )

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -25,7 +25,7 @@ class Tracer extends NoopProxy {
     try {
       const config = new Config(options) // TODO: support dynamic config
 
-      if (!config.isCiVisibility) {
+      if (config.remoteConfig.enabled && !config.isCiVisibility) {
         remoteConfig.enable(config)
       }
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -661,6 +661,7 @@ describe('Config', () => {
 
     expect(config.telemetryEnabled).to.be.false
   })
+
   it('should not set DD_REMOTE_CONFIGURATION_ENABLED if AWS_LAMBDA_FUNCTION_NAME is present', () => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-great-lambda-function'
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -661,7 +661,6 @@ describe('Config', () => {
 
     expect(config.telemetryEnabled).to.be.false
   })
-  
   it('should not set DD_REMOTE_CONFIGURATION_ENABLED if AWS_LAMBDA_FUNCTION_NAME is present', () => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-great-lambda-function'
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -86,6 +86,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.wafTimeout', 5e3)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex').with.length(155)
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex').with.length(443)
+    expect(config).to.have.nested.property('remoteConfig.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 5)
     expect(config).to.have.nested.property('iast.enabled', false)
   })
@@ -161,6 +162,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = '42'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '.*'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '.*'
+    process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'true'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = '42'
     process.env.DD_IAST_ENABLED = 'true'
     process.env.DD_IAST_REQUEST_SAMPLING = '40'
@@ -454,6 +456,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = 11
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '^$'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '^$'
+    process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'true'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
 
@@ -532,6 +535,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
     expect(config).to.have.nested.property('appsec.blockedTemplateHtml', __filename)
     expect(config).to.have.nested.property('appsec.blockedTemplateJson', __filename)
+    expect(config).to.have.nested.property('remoteConfig.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 30)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -162,7 +162,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = '42'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '.*'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '.*'
-    process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'true'
+    process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = '42'
     process.env.DD_IAST_ENABLED = 'true'
     process.env.DD_IAST_REQUEST_SAMPLING = '40'
@@ -218,6 +218,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
+    expect(config).to.have.nested.property('remoteConfig.enabled', false)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 40)
@@ -661,6 +662,14 @@ describe('Config', () => {
     const config = new Config()
 
     expect(config.telemetryEnabled).to.be.false
+  })
+  
+  it('should not set DD_REMOTE_CONFIGURATION_ENABLED if AWS_LAMBDA_FUNCTION_NAME is present', () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-great-lambda-function'
+
+    const config = new Config()
+
+    expect(config.remoteConfig.enabled).to.be.false
   })
 
   it('should ignore invalid iast.requestSampling', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -457,7 +457,6 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = 11
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '^$'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '^$'
-    process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'true'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
 
@@ -536,7 +535,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
     expect(config).to.have.nested.property('appsec.blockedTemplateHtml', __filename)
     expect(config).to.have.nested.property('appsec.blockedTemplateJson', __filename)
-    expect(config).to.have.nested.property('remoteConfig.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 30)

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -54,7 +54,10 @@ describe('TracerProxy', () => {
       debug: true,
       profiling: {},
       appsec: {},
-      iast: {}
+      iast: {},
+      remoteConfig: {
+        enabled: true
+      }
     }
     Config = sinon.stub().returns(config)
 

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -130,11 +130,9 @@ describe('TracerProxy', () => {
       })
 
       it('should not enable remote config when disabled', () => {
-        proxy.init({
-          remoteConfig: {
-            enabled: false
-          }
-        })
+        config.remoteConfig.enabled = false
+
+        proxy.init()
 
         expect(DatadogTracer).to.have.been.calledOnce
         expect(remoteConfig.enable).to.not.have.been.called

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -128,14 +128,14 @@ describe('TracerProxy', () => {
         expect(DatadogTracer).to.have.been.calledOnce
         expect(remoteConfig.enable).to.have.been.calledOnce
       })
-      
+
       it('should not enable remote config when disabled', () => {
         proxy.init({
           remoteConfig: {
             enabled: false
           }
         })
-        
+
         expect(DatadogTracer).to.have.been.calledOnce
         expect(remoteConfig.enable).to.not.have.been.called
       })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -128,6 +128,17 @@ describe('TracerProxy', () => {
         expect(DatadogTracer).to.have.been.calledOnce
         expect(remoteConfig.enable).to.have.been.calledOnce
       })
+      
+      it('should not enable remote config when disabled', () => {
+        proxy.init({
+          remoteConfig: {
+            enabled: false
+          }
+        })
+        
+        expect(DatadogTracer).to.have.been.calledOnce
+        expect(remoteConfig.enable).to.not.have.been.called
+      })
 
       it('should not initialize when disabled', () => {
         config.tracing = false


### PR DESCRIPTION
### What does this PR do?
Add a config `DD_REMOTE_CONFIGURATION_ENABLED` to explicitly enable(disable) the dd-trace/appsec/remoteConfig.enable call.

### Motivation
- With the added config option, the call can be skipped when necessary by setting the env variable `DD_REMOTE_CONFIGURATION_ENABLED` to `false`. 
- Why do we want to skip the call? Because dd-trace/appsec/remoteConfig.enable call is causing issues in AWS Lambda runtime Node14.
This is a [demo Lamdba in sandbox account](https://sa-east-1.console.aws.amazon.com/lambda/home?region=sa-east-1#/functions/joey-esm-test?tab=code) replicating the issue. And the code is stored in [this S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/esm-dd-trace-js-node14-issue?region=sa-east-1&tab=objects#). You can also easily replicate the issue by creating a lambda function and use the following 3 files + dd-trace-js@ version > 2.15.0)
   - esm.mjs file
```javascript
export async function handle(event){
    const response = {
        statusCode: 200,
        body: JSON.stringify('Hello from Lambda!'),
    };
    return response;
};
```
   - utils.js file:
```javascript
exports.initTracer = function () {
  const tracer = require("dd-trace").init();
  return tracer;
};
```
   - index.mjs
```javascript
import * as utils from "./utils.js";
utils.initTracer();  // no issue if comment out this line or call it after loaded.

const loaded = await import("./esm.mjs");
export const handler = loaded.handle;
```

This would fail on an error saying "connect ECONNREFUSED 127.0.0.1:8126", which I believe happens from this [request](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/appsec/remote_config/manager.js#L106).  
- This behavior is introduced since [this commit](https://github.com/DataDog/dd-trace-js/commit/f68bd74b52f46866a5a118648aa0c7ac78f9f418#diff-dae9ab64bee2d029cc08e9fdb70b3cd9d2f897e9b451d325e51033d457bb2994R33)


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
