### PR TITLE
Configurable remote config poll interval

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -84,7 +84,10 @@ tracer.init({
   reportHostname: true,
   logLevel: 'debug',
   dbmPropagationMode: 'full',
-  appsec: true
+  appsec: true,
+  remoteConfig: {
+    pollInterval: 5
+  }
 });
 
 tracer.init({

--- a/index.d.ts
+++ b/index.d.ts
@@ -521,6 +521,17 @@ export declare interface TracerOptions {
      */
     blockedTemplateJson?: string,
   };
+
+  /**
+   * Configuration of ASM Remote Configuration
+   */
+  remoteConfig?: {
+    /**
+     * Specifies the remote configuration polling interval
+     * @default 5000
+     */
+    pollInterval?: number,
+  }
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -527,8 +527,8 @@ export declare interface TracerOptions {
    */
   remoteConfig?: {
     /**
-     * Specifies the remote configuration polling interval
-     * @default 5000
+     * Specifies the remote configuration polling interval in seconds
+     * @default 5
      */
     pollInterval?: number,
   }

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -9,7 +9,6 @@ const log = require('../../log')
 
 const clientId = uuid()
 
-const POLL_INTERVAL = 5e3
 const DEFAULT_CAPABILITY = Buffer.alloc(1).toString('base64') // 0x00
 
 // There MUST NOT exist separate instances of RC clients in a tracer making separate ClientGetConfigsRequest
@@ -18,7 +17,8 @@ class RemoteConfigManager extends EventEmitter {
   constructor (config) {
     super()
 
-    this.scheduler = new Scheduler((cb) => this.poll(cb), POLL_INTERVAL)
+    const pollInterval = config.remoteConfig.pollInterval * 1000;
+    this.scheduler = new Scheduler((cb) => this.poll(cb), pollInterval)
 
     this.requestOptions = {
       url: config.url,

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -17,7 +17,7 @@ class RemoteConfigManager extends EventEmitter {
   constructor (config) {
     super()
 
-    const pollInterval = config.remoteConfig.pollInterval * 1000;
+    const pollInterval = config.remoteConfig.pollInterval * 1000
     this.scheduler = new Scheduler((cb) => this.poll(cb), pollInterval)
 
     this.requestOptions = {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -274,6 +274,13 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       path.join(__dirname, 'appsec', 'templates', 'blocked.json')
     )
 
+    const remoteConfigOptions = options.remoteConfig || {}
+    const DD_REMOTE_CONFIG_POLL_INTERVAL = coalesce(
+      parseInt(remoteConfigOptions.pollInterval),
+      parseInt(process.env.DD_REMOTE_CONFIGURATION_POLLING_INTERVAL),
+      5 // seconds
+    )
+
     const iastOptions = options.experimental && options.experimental.iast
     const DD_IAST_ENABLED = coalesce(
       iastOptions &&
@@ -397,6 +404,9 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       obfuscatorValueRegex: DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP,
       blockedTemplateHtml: DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML,
       blockedTemplateJson: DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON
+    }
+    this.remoteConfig = {
+      pollInterval: DD_REMOTE_CONFIG_POLL_INTERVAL
     }
     this.iast = {
       enabled: isTrue(DD_IAST_ENABLED),

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -275,7 +275,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     )
 
     const remoteConfigOptions = options.remoteConfig || {}
-    const DD_REMOTE_CONFIG_POLL_INTERVAL = coalesce(
+    const DD_REMOTE_CONFIGURATION_POLLING_INTERVAL = coalesce(
       parseInt(remoteConfigOptions.pollInterval),
       parseInt(process.env.DD_REMOTE_CONFIGURATION_POLLING_INTERVAL),
       5 // seconds
@@ -406,7 +406,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       blockedTemplateJson: DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON
     }
     this.remoteConfig = {
-      pollInterval: DD_REMOTE_CONFIG_POLL_INTERVAL
+      pollInterval: DD_REMOTE_CONFIGURATION_POLLING_INTERVAL
     }
     this.iast = {
       enabled: isTrue(DD_IAST_ENABLED),

--- a/packages/dd-trace/test/appsec/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/manager.spec.js
@@ -47,7 +47,10 @@ describe('RemoteConfigManager', () => {
       },
       service: 'serviceName',
       env: 'serviceEnv',
-      version: 'appVersion'
+      version: 'appVersion',
+      remoteConfig: {
+        pollInterval: 5
+      }
     }
 
     rc = new RemoteConfigManager(config)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -85,6 +85,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.wafTimeout', 5e3)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex').with.length(155)
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex').with.length(443)
+    expect(config).to.have.nested.property('remoteConfig.pollInterval', 5)
     expect(config).to.have.nested.property('iast.enabled', false)
   })
 
@@ -158,6 +159,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = '42'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '.*'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '.*'
+    process.env.DD_REMOTE_CONFIGURATION_POLLING_INTERVAL = '42'
     process.env.DD_IAST_ENABLED = 'true'
     process.env.DD_IAST_REQUEST_SAMPLING = '40'
     process.env.DD_IAST_MAX_CONCURRENT_REQUESTS = '3'
@@ -208,6 +210,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
+    expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 40)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 3)
@@ -304,7 +307,10 @@ describe('Config', () => {
           maxContextOperations: 5
         }
       },
-      appsec: false
+      appsec: false,
+      remoteConfig: {
+        pollInterval: 42
+      }
     })
 
     expect(config).to.have.property('protocolVersion', '0.5')
@@ -338,6 +344,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.exporter', 'log')
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
     expect(config).to.have.nested.property('appsec.enabled', false)
+    expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 50)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 4)
@@ -432,6 +439,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = 11
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '^$'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '^$'
+    process.env.DD_REMOTE_CONFIGURATION_POLLING_INTERVAL = 11
     process.env.DD_IAST_ENABLED = 'false'
 
     const config = new Config({
@@ -471,6 +479,9 @@ describe('Config', () => {
         obfuscatorValueRegex: '.*',
         blockedTemplateHtml: __filename,
         blockedTemplateJson: __filename
+      },
+      remoteConfig: {
+        pollInterval: 42
       }
     })
 
@@ -502,6 +513,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
     expect(config).to.have.nested.property('appsec.blockedTemplateHtml', __filename)
     expect(config).to.have.nested.property('appsec.blockedTemplateJson', __filename)
+    expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 30)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 2)


### PR DESCRIPTION
### What does this PR do?
Provides a way to configure the Remote Configuration Poll interval via environment variable.
