### PR TITLE
Support serviceMapping programmatic config

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -78,6 +78,9 @@ tracer.init({
     { sampleRate: 0.5, service: 'ba?', name: 'ba?.*', maxPerSecond: 10 }
   ],
   service: 'test',
+  serviceMapping: {
+    http: 'new-http-service-name'
+  },
   tags: {
     foo: 'bar'
   },

--- a/index.d.ts
+++ b/index.d.ts
@@ -243,6 +243,11 @@ export declare interface TracerOptions {
   service?: string;
 
   /**
+   * Provide service name mappings for each plugin.
+   */
+  serviceMapping?: { [key: string]: string };
+
+  /**
    * The url of the trace agent that the tracer will submit to.
    * Takes priority over hostname and port, if set.
    */

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -145,7 +145,12 @@ class Config {
       process.env.AWS_LAMBDA_FUNCTION_NAME ||
       pkg.name ||
       'node'
-    const DD_SERVICE_MAPPING = process.env.DD_SERVICE_MAPPING || ''
+    const DD_SERVICE_MAPPING = coalesce(
+      options.serviceMapping,
+      process.env.DD_SERVICE_MAPPING ? fromEntries(
+        process.env.DD_SERVICE_MAPPING.split(',').map(x => x.trim().split(':'))
+      ) : {}
+    )
     const DD_ENV = coalesce(
       options.env,
       process.env.DD_ENV,
@@ -358,9 +363,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.clientIpHeader = DD_TRACE_CLIENT_IP_HEADER
     this.plugins = !!coalesce(options.plugins, true)
     this.service = DD_SERVICE
-    this.serviceMapping = DD_SERVICE_MAPPING.length ? fromEntries(
-      DD_SERVICE_MAPPING.split(',').map(x => x.trim().split(':'))
-    ) : {}
+    this.serviceMapping = DD_SERVICE_MAPPING
     this.version = DD_VERSION
     this.dogstatsd = {
       hostname: coalesce(dogstatsd.hostname, process.env.DD_DOGSTATSD_HOSTNAME, this.hostname),

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -74,6 +74,7 @@ describe('Config', () => {
     expect(config).to.have.property('reportHostname', false)
     expect(config).to.have.property('scope', undefined)
     expect(config).to.have.property('logLevel', 'debug')
+    expect(config).to.have.deep.property('serviceMapping', {})
     expect(config).to.have.nested.property('experimental.b3', false)
     expect(config).to.have.nested.property('experimental.traceparent', false)
     expect(config).to.have.nested.property('experimental.runtimeId', false)
@@ -125,6 +126,7 @@ describe('Config', () => {
     process.env.DD_TRACE_DEBUG = 'true'
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.5'
     process.env.DD_SERVICE = 'service'
+    process.env.DD_SERVICE_MAPPING = 'a:aa, b:bb'
     process.env.DD_VERSION = '1.0.0'
     process.env.DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP = '.*'
     process.env.DD_TRACE_CLIENT_IP_HEADER = 'x-true-client-ip'
@@ -196,6 +198,10 @@ describe('Config', () => {
         { service: 'mysql', sampleRate: 1.0 },
         { sampleRate: 0.1 }
       ]
+    })
+    expect(config).to.have.deep.property('serviceMapping', {
+      a: 'aa',
+      b: 'bb'
     })
     expect(config).to.have.nested.property('experimental.b3', true)
     expect(config).to.have.nested.property('experimental.traceparent', true)
@@ -283,6 +289,10 @@ describe('Config', () => {
         { service: 'mysql', sampleRate: 1.0 },
         { sampleRate: 0.1 }
       ],
+      serviceMapping: {
+        a: 'aa',
+        b: 'bb'
+      },
       logger,
       tags,
       flushInterval: 5000,
@@ -358,6 +368,10 @@ describe('Config', () => {
         { sampleRate: 0.1 }
       ]
     })
+    expect(config).to.have.deep.property('serviceMapping', {
+      a: 'aa',
+      b: 'bb'
+    })
   })
 
   it('should initialize from the options with url taking precedence', () => {
@@ -413,6 +427,7 @@ describe('Config', () => {
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.4'
     process.env.DD_TRACE_PARTIAL_FLUSH_MIN_SPANS = 2000
     process.env.DD_SERVICE = 'service'
+    process.env.DD_SERVICE_MAPPING = 'a:aa'
     process.env.DD_VERSION = '0.0.0'
     process.env.DD_RUNTIME_METRICS_ENABLED = 'true'
     process.env.DD_TRACE_REPORT_HOSTNAME = 'true'
@@ -452,6 +467,9 @@ describe('Config', () => {
       tags: {
         foo: 'foo'
       },
+      serviceMapping: {
+        b: 'bb'
+      },
       experimental: {
         b3: false,
         traceparent: false,
@@ -489,6 +507,7 @@ describe('Config', () => {
     expect(config).to.have.property('env', 'development')
     expect(config.tags).to.include({ foo: 'foo', baz: 'qux' })
     expect(config.tags).to.include({ service: 'test', version: '1.0.0', env: 'development' })
+    expect(config).to.have.deep.property('serviceMapping', { b: 'bb' })
     expect(config).to.have.nested.property('experimental.b3', false)
     expect(config).to.have.nested.property('experimental.traceparent', false)
     expect(config).to.have.nested.property('experimental.runtimeId', false)
@@ -610,30 +629,6 @@ describe('Config', () => {
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('version', '0.1.0')
     expect(config).to.have.property('env', 'test')
-  })
-
-  it('should support the serviceMapping environment variable', () => {
-    let origVar
-    if ('DD_SERVICE_MAPPING' in process.env) {
-      origVar = Object.getOwnPropertyDescriptor(process.env, 'DD_SERVICE')
-    }
-    process.env.DD_SERVICE_MAPPING = 'a:aa, b:bb'
-    let config = new Config()
-
-    expect(config.serviceMapping).to.deep.equal({
-      a: 'aa',
-      b: 'bb'
-    })
-
-    if (origVar) {
-      Object.defineProperty(process.env, 'DD_SERVICE', origVar)
-    } else {
-      delete process.env.DD_SERVICE_MAPPING
-    }
-
-    config = new Config()
-
-    expect(config.serviceMapping).to.deep.equal({})
   })
 
   it('should trim whitespace characters around keys', () => {


### PR DESCRIPTION
Fixes #2653

### What does this PR do?

Add support for programmatic config of service mapping

### Motivation

The [docs](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs/#instrumentation) imply that service mapping is supported via programmatic config. Currently it doesn't really specify support for an object form but we've generally gone for that so that's what I've done here. We could also update the docs to show object form or we could go for string form everywhere if we prefer.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
