### PR TITLE
[ci-visibility] Fix code_coverage tag in test session

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -15,7 +15,7 @@ const {
 const { FakeCiVisIntake } = require('./ci-visibility-intake')
 
 const {
-  TEST_SESSION_ITR_CODE_COVERAGE_ENABLED,
+  TEST_SESSION_CODE_COVERAGE_ENABLED,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
   TEST_ITR_TESTS_SKIPPED
 } = require('../packages/dd-trace/src/plugins/util/test')
@@ -280,7 +280,7 @@ testFrameworks.forEach(({
           assert.includeMembers(eventTypes, ['test', 'test_session_end', 'test_suite_end'])
           const testSession = payload.events.find(event => event.type === 'test_session_end').content
           assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-          assert.propertyVal(testSession.meta, TEST_SESSION_ITR_CODE_COVERAGE_ENABLED, 'false')
+          assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'false')
           assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'false')
         }, ({ url }) => url === '/api/v2/citestcycle').then(() => done()).catch(done)
 
@@ -331,7 +331,7 @@ testFrameworks.forEach(({
           assert.equal(numSuites, 1)
           const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
           assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'true')
-          assert.propertyVal(testSession.meta, TEST_SESSION_ITR_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'true')
           assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'true')
           done()
         })
@@ -370,7 +370,7 @@ testFrameworks.forEach(({
           assert.equal(numSuites, 2)
           const testSession = payload.events.find(event => event.type === 'test_session_end').content
           assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-          assert.propertyVal(testSession.meta, TEST_SESSION_ITR_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'true')
           assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'true')
         }, ({ url }) => url === '/api/v2/citestcycle').then(() => done()).catch(done)
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -15,7 +15,7 @@ const {
   TEST_SUITE_ID,
   TEST_COMMAND,
   TEST_ITR_TESTS_SKIPPED,
-  TEST_SESSION_ITR_CODE_COVERAGE_ENABLED,
+  TEST_SESSION_CODE_COVERAGE_ENABLED,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
   TEST_CODE_COVERAGE_LINES_TOTAL
 } = require('../../dd-trace/src/plugins/util/test')
@@ -77,7 +77,7 @@ class JestPlugin extends CiPlugin {
       testSessionSpan.setTag(TEST_STATUS, status)
       testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
       testSessionSpan.setTag(TEST_SESSION_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
-      testSessionSpan.setTag(TEST_SESSION_ITR_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
+      testSessionSpan.setTag(TEST_SESSION_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
 
       if (testCodeCoverageLinesTotal !== undefined) {
         testSessionSpan.setTag(TEST_CODE_COVERAGE_LINES_TOTAL, testCodeCoverageLinesTotal)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -16,7 +16,7 @@ const {
   TEST_SESSION_ID,
   TEST_COMMAND,
   TEST_ITR_TESTS_SKIPPED,
-  TEST_SESSION_ITR_CODE_COVERAGE_ENABLED,
+  TEST_SESSION_CODE_COVERAGE_ENABLED,
   TEST_SESSION_ITR_SKIPPING_ENABLED
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -145,7 +145,7 @@ class MochaPlugin extends CiPlugin {
         this.testSessionSpan.setTag(TEST_STATUS, status)
         this.testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
         this.testSessionSpan.setTag(TEST_SESSION_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
-        this.testSessionSpan.setTag(TEST_SESSION_ITR_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
+        this.testSessionSpan.setTag(TEST_SESSION_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
 
         this.testSessionSpan.finish()
         finishAllTraceSpans(this.testSessionSpan)

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -47,7 +47,7 @@ const JEST_TEST_RUNNER = 'test.jest.test_runner'
 
 const TEST_ITR_TESTS_SKIPPED = '_dd.ci.itr.tests_skipped'
 const TEST_SESSION_ITR_SKIPPING_ENABLED = 'test_session.itr.tests_skipping.enabled'
-const TEST_SESSION_ITR_CODE_COVERAGE_ENABLED = 'test_session.itr.code_coverage.enabled'
+const TEST_SESSION_CODE_COVERAGE_ENABLED = 'test_session.code_coverage.enabled'
 
 const TEST_CODE_COVERAGE_LINES_TOTAL = 'test.codecov_lines_total'
 
@@ -81,7 +81,7 @@ module.exports = {
   TEST_SUITE_ID,
   TEST_ITR_TESTS_SKIPPED,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
-  TEST_SESSION_ITR_CODE_COVERAGE_ENABLED,
+  TEST_SESSION_CODE_COVERAGE_ENABLED,
   TEST_CODE_COVERAGE_LINES_TOTAL,
   getCoveredFilenamesFromCoverage,
   resetCoverage,


### PR DESCRIPTION
### What does this PR do?
Update the value of the tag name we use to check whether code coverage is enabled. The tag is not used yet publicly so no extra actions are needed. 

### Motivation
Use correct tag name.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
