### PR TITLE
run package size on pull_request

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,7 +1,7 @@
 name: Package Size
 
 on:
-  pull_request_target:
+  pull_request:
   schedule:
     - cron: '0 4 * * *'
 


### PR DESCRIPTION
### What does this PR do?
- should allow package size comments again on PRs with approved actions

### Motivation
- previous configuration gets packages size from base branch (e.g. `master`) instead of PR branch
