### PR TITLE
add missing telemetry host data

### DIFF
--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -76,9 +76,30 @@ function createAppObject () {
 }
 
 function createHostObject () {
+  let osName = os.type()
+  if (osName === 'Linux' || osName === 'Darwin'){
+    return {
+      hostname: os.hostname(),
+      os: osName,
+      architecture: os.arch(),
+      kernel_version: os.version(),
+      kernel_release: os.release(),
+      kernel_name: osName
+    }
+  }
+
+  else if (osName === 'Windows_NT') {
+    return {
+      hostname: os.hostname(),
+      os: osName,
+      os_version: os.version(),
+      architecture: os.arch()
+    }
+  }
+
   return {
     hostname: os.hostname(), // TODO is this enough?
-    container_id: containerId
+    os: osName
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds telemetry host data based on the telemetry docs [here](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/auto-commit/GeneratedDocumentation/ApiDocs/v1/SchemaDocumentation/Schemas/host.md)

### Motivation
Fix to reflect telemetry requirements.

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
