### PR TITLE
Create spans for vulnerabilities outside of requests 

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -58,15 +58,11 @@ class Analyzer extends Plugin {
 
   analyze (value) {
     const iastContext = getIastContext(storage.getStore())
-    if (!iastContext) return
-
     this._reportIfVulnerable(value, iastContext)
   }
 
   analyzeAll (...values) {
     const iastContext = getIastContext(storage.getStore())
-    if (!iastContext) return
-
     for (let i = 0; i < values.length; i++) {
       const value = values[i]
       if (this._isVulnerable(value, iastContext)) {

--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -57,12 +57,16 @@ class Analyzer extends Plugin {
   }
 
   analyze (value) {
-    const iastContext = getIastContext(storage.getStore())
+    const store = storage.getStore()
+    const iastContext = getIastContext(store)
+    if (store && !iastContext) return
     this._reportIfVulnerable(value, iastContext)
   }
 
   analyzeAll (...values) {
-    const iastContext = getIastContext(storage.getStore())
+    const store = storage.getStore()
+    const iastContext = getIastContext(store)
+    if (store && !iastContext) return
     for (let i = 0; i < values.length; i++) {
       const value = values[i]
       if (this._isVulnerable(value, iastContext)) {

--- a/packages/dd-trace/src/appsec/iast/overhead-controller.js
+++ b/packages/dd-trace/src/appsec/iast/overhead-controller.js
@@ -2,8 +2,11 @@
 
 const OVERHEAD_CONTROLLER_CONTEXT_KEY = 'oce'
 const REPORT_VULNERABILITY = 'REPORT_VULNERABILITY'
+const INTERVAL_RESET_GLOBAL_CONTEXT = 60 * 1000
 
 const GLOBAL_OCE_CONTEXT = {}
+
+let resetGlobalContextInterval
 let config = {}
 let availableRequest = 0
 const OPERATIONS = {
@@ -80,11 +83,27 @@ function configure (cfg) {
   availableRequest = config.maxConcurrentRequests
 }
 
-_resetGlobalContext()
+function startGlobalContext () {
+  if (resetGlobalContextInterval) return
+  _resetGlobalContext()
+  resetGlobalContextInterval = setInterval(() => {
+    _resetGlobalContext()
+  }, INTERVAL_RESET_GLOBAL_CONTEXT)
+}
+
+function finishGlobalContext () {
+  if (resetGlobalContextInterval) {
+    clearInterval(resetGlobalContextInterval)
+    resetGlobalContextInterval.unref && resetGlobalContextInterval.unref()
+    resetGlobalContextInterval = null
+  }
+}
 
 module.exports = {
   OVERHEAD_CONTROLLER_CONTEXT_KEY,
   OPERATIONS,
+  startGlobalContext,
+  finishGlobalContext,
   _resetGlobalContext,
   initializeRequestContext,
   hasQuota,

--- a/packages/dd-trace/src/appsec/iast/overhead-controller.js
+++ b/packages/dd-trace/src/appsec/iast/overhead-controller.js
@@ -89,12 +89,12 @@ function startGlobalContext () {
   resetGlobalContextInterval = setInterval(() => {
     _resetGlobalContext()
   }, INTERVAL_RESET_GLOBAL_CONTEXT)
+  resetGlobalContextInterval.unref && resetGlobalContextInterval.unref()
 }
 
 function finishGlobalContext () {
   if (resetGlobalContextInterval) {
     clearInterval(resetGlobalContextInterval)
-    resetGlobalContextInterval.unref && resetGlobalContextInterval.unref()
     resetGlobalContextInterval = null
   }
 }

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -5,13 +5,16 @@ const IAST_JSON_TAG_KEY = '_dd.iast.json'
 const VULNERABILITY_HASHES_MAX_SIZE = 1000
 const VULNERABILITY_HASHES = new LRU({ max: VULNERABILITY_HASHES_MAX_SIZE })
 
+let tracer
+
 function createVulnerability (type, evidence, spanId, location) {
-  if (type && evidence && spanId) {
+  if (type && evidence) {
+    const _spanId = spanId || 0
     return {
       type,
       evidence,
       location: {
-        spanId,
+        spanId: _spanId,
         ...location
       },
       hash: createHash(type, location)
@@ -37,10 +40,14 @@ function createHash (type, location) {
 }
 
 function addVulnerability (iastContext, vulnerability) {
-  if (iastContext && vulnerability && vulnerability.evidence && vulnerability.type &&
-    vulnerability.location && vulnerability.location.spanId) {
-    iastContext[VULNERABILITIES_KEY] = iastContext[VULNERABILITIES_KEY] || []
-    iastContext[VULNERABILITIES_KEY].push(vulnerability)
+  if (vulnerability && vulnerability.evidence && vulnerability.type &&
+    vulnerability.location) {
+    if (iastContext && iastContext.rootSpan) {
+      iastContext[VULNERABILITIES_KEY] = iastContext[VULNERABILITIES_KEY] || []
+      iastContext[VULNERABILITIES_KEY].push(vulnerability)
+    } else {
+      sendVulnerabilities([vulnerability])
+    }
   }
 }
 
@@ -101,43 +108,53 @@ function jsonVulnerabilityFromVulnerability (vulnerability, sourcesIndexes) {
   return jsonVulnerability
 }
 
-function sendVulnerabilities (iastContext) {
-  if (iastContext && iastContext.rootSpan && iastContext[VULNERABILITIES_KEY] &&
-    iastContext[VULNERABILITIES_KEY].length && iastContext.rootSpan.addTags) {
-    const span = iastContext.rootSpan
-    const allVulnerabilities = iastContext[VULNERABILITIES_KEY]
-    const jsonToSend = {
-      sources: [],
-      vulnerabilities: []
+function sendVulnerabilities (vulnerabilities, rootSpan) {
+  if (vulnerabilities && vulnerabilities.length) {
+    let span = rootSpan
+    if (!span && tracer) {
+      span = tracer.startSpan('vulnerability', {
+        type: 'vulnerability'
+      })
+      vulnerabilities.forEach((vulnerability) => {
+        vulnerability.location.spanId = span.context().toSpanId()
+      })
     }
 
-    deduplicateVulnerabilities(allVulnerabilities).forEach((vulnerability) => {
-      if (isValidVulnerability(vulnerability)) {
-        const sourcesIndexes = []
-        const vulnerabilitySources = extractSourcesFromVulnerability(vulnerability)
-        vulnerabilitySources.forEach((source) => {
-          let sourceIndex = jsonToSend.sources.findIndex(
-            existingSource =>
-              existingSource.origin === source.origin &&
-              existingSource.name === source.name &&
-              existingSource.value === source.value
-          )
-          if (sourceIndex === -1) {
-            sourceIndex = jsonToSend.sources.length
-            jsonToSend.sources.push(source)
-          }
-          sourcesIndexes.push(sourceIndex)
-        })
-        jsonToSend.vulnerabilities.push(jsonVulnerabilityFromVulnerability(vulnerability, sourcesIndexes))
+    if (span && span.addTags) {
+      const jsonToSend = {
+        sources: [],
+        vulnerabilities: []
       }
-    })
 
-    if (jsonToSend.vulnerabilities.length > 0) {
-      const tags = {}
-      // TODO: Store this outside of the span and set the tag in the exporter.
-      tags[IAST_JSON_TAG_KEY] = JSON.stringify(jsonToSend)
-      tags[MANUAL_KEEP] = 'true'
-      span.addTags(tags)
+      deduplicateVulnerabilities(vulnerabilities).forEach((vulnerability) => {
+        if (isValidVulnerability(vulnerability)) {
+          const sourcesIndexes = []
+          const vulnerabilitySources = extractSourcesFromVulnerability(vulnerability)
+          vulnerabilitySources.forEach((source) => {
+            let sourceIndex = jsonToSend.sources.findIndex(
+              existingSource =>
+                existingSource.origin === source.origin &&
+                existingSource.name === source.name &&
+                existingSource.value === source.value
+            )
+            if (sourceIndex === -1) {
+              sourceIndex = jsonToSend.sources.length
+              jsonToSend.sources.push(source)
+            }
+            sourcesIndexes.push(sourceIndex)
+          })
+          jsonToSend.vulnerabilities.push(jsonVulnerabilityFromVulnerability(vulnerability, sourcesIndexes))
+        }
+      })
+
+      if (jsonToSend.vulnerabilities.length > 0) {
+        const tags = {}
+        // TODO: Store this outside of the span and set the tag in the exporter.
+        tags[IAST_JSON_TAG_KEY] = JSON.stringify(jsonToSend)
+        tags[MANUAL_KEEP] = 'true'
+        span.addTags(tags)
+        if (!rootSpan) span.finish()
+      }
     }
   }
   return IAST_JSON_TAG_KEY
@@ -159,9 +176,14 @@ function deduplicateVulnerabilities (vulnerabilities) {
   return deduplicated
 }
 
+function setTracer (_tracer) {
+  tracer = _tracer
+}
+
 module.exports = {
   createVulnerability,
   addVulnerability,
   sendVulnerabilities,
-  clearCache
+  clearCache,
+  setTracer
 }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -49,11 +49,12 @@ class Tracer extends NoopProxy {
           require('./appsec').enable(config)
         }
 
+        this._tracer = new DatadogTracer(config)
+
         if (config.iast.enabled) {
-          require('./appsec/iast').enable(config)
+          require('./appsec/iast').enable(config, this._tracer)
         }
 
-        this._tracer = new DatadogTracer(config)
         this._pluginManager.configure(config)
         setStartupLogPluginManager(this._pluginManager)
         telemetry.start(config, this._pluginManager)

--- a/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.spec.js
@@ -69,7 +69,7 @@ describe('vulnerability-analyzer', () => {
       iastContext: undefined,
       oceResult: true,
       isVulnerable: true,
-      reported: false
+      reported: true
     }
   ]
   shouldReportCasesData.forEach((shouldReportCaseData) => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/weak-hash-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/weak-hash-analyzer.spec.js
@@ -2,7 +2,7 @@
 
 const weakHashAnalyzer = require('../../../../src/appsec/iast/analyzers/weak-hash-analyzer')
 const proxyquire = require('proxyquire')
-const { testThatRequestHasVulnerability } = require('../utils')
+const { testThatRequestHasVulnerability, testOutsideRequestHasVulnerability } = require('../utils')
 
 describe('weak-hash-analyzer', () => {
   const VULNERABLE_ALGORITHM = 'sha1'
@@ -62,9 +62,18 @@ describe('weak-hash-analyzer', () => {
   })
 
   describe('full feature', () => {
-    testThatRequestHasVulnerability(() => {
-      const crypto = require('crypto')
-      crypto.createHash(VULNERABLE_ALGORITHM)
-    }, 'WEAK_HASH')
+    describe('inside request', () => {
+      testThatRequestHasVulnerability(() => {
+        const crypto = require('crypto')
+        crypto.createHash(VULNERABLE_ALGORITHM)
+      }, 'WEAK_HASH')
+    })
+
+    describe('outside request', () => {
+      testOutsideRequestHasVulnerability(() => {
+        const crypto = require('crypto')
+        crypto.createHash(VULNERABLE_ALGORITHM)
+      }, 'WEAK_HASH')
+    })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -103,6 +103,15 @@ describe('IAST Index', () => {
     let mockIast
     let mockOverheadController
 
+    const config = new Config({
+      experimental: {
+        iast: {
+          enabled: true,
+          requestSampling: 100
+        }
+      }
+    })
+
     beforeEach(() => {
       mockVulnerabilityReporter = {
         sendVulnerabilities: sinon.stub()
@@ -110,7 +119,9 @@ describe('IAST Index', () => {
       mockOverheadController = {
         acquireRequest: sinon.stub(),
         releaseRequest: sinon.stub(),
-        initializeRequestContext: sinon.stub()
+        initializeRequestContext: sinon.stub(),
+        startGlobalContext: sinon.stub(),
+        finishGlobalContext: sinon.stub()
       }
       mockIast = proxyquire('../../../src/appsec/iast', {
         './vulnerability-reporter': mockVulnerabilityReporter,
@@ -121,6 +132,18 @@ describe('IAST Index', () => {
     afterEach(() => {
       sinon.restore()
       mockIast.disable()
+    })
+
+    describe('managing overhead controller global context', () => {
+      it('should start global context refresher on iast enabled', () => {
+        mockIast.enable(config)
+        expect(mockOverheadController.startGlobalContext).to.have.been.calledOnce
+      })
+
+      it('should finish global context refresher on iast disabled', () => {
+        mockIast.disable()
+        expect(mockOverheadController.finishGlobalContext).to.have.been.calledOnce
+      })
     })
 
     describe('onIncomingHttpRequestStart', () => {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -18,8 +18,6 @@ describe('vulnerability-reporter', () => {
       expect(createVulnerability(null, null, undefined, null)).to.be.null
       expect(createVulnerability(null, null, undefined, undefined)).to.be.null
       expect(createVulnerability('WEAK_HASHING', null, undefined, undefined)).to.be.null
-      expect(createVulnerability('WEAK_HASHING', {}, undefined, undefined)).to.be.null
-      expect(createVulnerability('WEAK_HASHING', {}, undefined, {})).to.be.null
     })
 
     it('creates the object with all properties', () => {
@@ -61,44 +59,52 @@ describe('vulnerability-reporter', () => {
       addVulnerability({})
     })
 
-    it('should not add null vulnerability', () => {
-      const iastContext = {}
-      addVulnerability(iastContext, null)
-      expect(iastContext).not.to.have.property('vulnerabilities')
-      iastContext.vulnerabilities = []
-      addVulnerability(iastContext, undefined)
-      expect(iastContext.vulnerabilities).to.have.length(0)
-    })
+    describe('with rootSpan', () => {
+      let iastContext = {
+        rootSpan: true
+      }
 
-    it('should create vulnerability array if it does not exist', () => {
-      const iastContext = {}
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
-      expect(iastContext).to.have.property('vulnerabilities')
-      expect(iastContext.vulnerabilities).to.be.an('array')
-    })
+      afterEach(() => {
+        iastContext = {
+          rootSpan: true
+        }
+      })
 
-    it('should add multiple vulnerabilities', () => {
-      const iastContext = {}
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, -555))
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 123))
-      expect(iastContext.vulnerabilities).to.have.length(3)
-    })
+      it('should not add null vulnerability', () => {
+        addVulnerability(iastContext, null)
+        expect(iastContext).not.to.have.property('vulnerabilities')
+        iastContext.vulnerabilities = []
+        addVulnerability(iastContext, undefined)
+        expect(iastContext.vulnerabilities).to.have.length(0)
+      })
 
-    it('should add in the context evidence properties', () => {
-      const iastContext = {}
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
-      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'md5' },
-        -123, { path: 'path.js', line: 12 }))
-      expect(iastContext.vulnerabilities).to.have.length(2)
-      expect(iastContext).to.have.nested.property('vulnerabilities.0.type', 'INSECURE_HASHING')
-      expect(iastContext).to.have.nested.property('vulnerabilities.0.evidence.value', 'sha1')
-      expect(iastContext).to.have.nested.property('vulnerabilities.0.location.spanId', 888)
-      expect(iastContext).to.have.nested.property('vulnerabilities.1.type', 'INSECURE_HASHING')
-      expect(iastContext).to.have.nested.property('vulnerabilities.1.evidence.value', 'md5')
-      expect(iastContext).to.have.nested.property('vulnerabilities.1.location.spanId', -123)
-      expect(iastContext).to.have.nested.property('vulnerabilities.1.location.path', 'path.js')
-      expect(iastContext).to.have.nested.property('vulnerabilities.1.location.line', 12)
+      it('should create vulnerability array if it does not exist', () => {
+        addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
+        expect(iastContext).to.have.property('vulnerabilities')
+        expect(iastContext.vulnerabilities).to.be.an('array')
+      })
+
+      it('should add multiple vulnerabilities', () => {
+        addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, -555))
+        addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
+        addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 123))
+        expect(iastContext.vulnerabilities).to.have.length(3)
+      })
+
+      it('should add in the context evidence properties', () => {
+        addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
+        addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'md5' },
+          -123, { path: 'path.js', line: 12 }))
+        expect(iastContext.vulnerabilities).to.have.length(2)
+        expect(iastContext).to.have.nested.property('vulnerabilities.0.type', 'INSECURE_HASHING')
+        expect(iastContext).to.have.nested.property('vulnerabilities.0.evidence.value', 'sha1')
+        expect(iastContext).to.have.nested.property('vulnerabilities.0.location.spanId', 888)
+        expect(iastContext).to.have.nested.property('vulnerabilities.1.type', 'INSECURE_HASHING')
+        expect(iastContext).to.have.nested.property('vulnerabilities.1.evidence.value', 'md5')
+        expect(iastContext).to.have.nested.property('vulnerabilities.1.location.spanId', -123)
+        expect(iastContext).to.have.nested.property('vulnerabilities.1.location.path', 'path.js')
+        expect(iastContext).to.have.nested.property('vulnerabilities.1.location.line', 12)
+      })
     })
   })
 
@@ -122,20 +128,15 @@ describe('vulnerability-reporter', () => {
       sendVulnerabilities({})
     })
 
-    it('should not send vulnerability with empty context', () => {
-      sendVulnerabilities({ rootSpan: span })
-      expect(span.addTags).not.to.have.been.called
-    })
-
     it('should not send invalid vulnerability', () => {
-      sendVulnerabilities({ vulnerabilities: [{ invalid: 'vulnerability' }], rootSpan: span })
+      sendVulnerabilities([{ invalid: 'vulnerability' }], span)
       expect(span.addTags).not.to.have.been.called
     })
 
     it('should send one with one vulnerability', () => {
       const iastContext = { rootSpan: span }
       addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3254801297,' +
@@ -147,7 +148,7 @@ describe('vulnerability-reporter', () => {
       const iastContext = { rootSpan: span }
       addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
       iastContext.vulnerabilities.push({ invalid: 'vulnerability' })
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3254801297,' +
@@ -195,7 +196,7 @@ describe('vulnerability-reporter', () => {
         createVulnerability('SQL_INJECTION', evidence2, 888, { path: 'filename.js', line: 99 })
       )
 
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[{"origin":"ORIGIN_TYPE_1","name":"PARAMETER_NAME_1","value":"joe"},' +
@@ -249,7 +250,7 @@ describe('vulnerability-reporter', () => {
         createVulnerability('SQL_INJECTION', evidence2, 888, { path: 'filename.js', line: 99 })
       )
 
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[{"origin":"ORIGIN_TYPE_1","name":"PARAMETER_NAME_1","value":"joe"}],' +
@@ -270,7 +271,7 @@ describe('vulnerability-reporter', () => {
         { path: '/path/to/file2.js', line: 1 }))
       addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'md5' }, -5,
         { path: '/path/to/file3.js', line: 3 }))
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[],"vulnerabilities":[' +
@@ -287,7 +288,7 @@ describe('vulnerability-reporter', () => {
       const iastContext = { rootSpan: span }
       addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
         { path: 'filename.js', line: 88 }))
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512691,' +
@@ -301,7 +302,7 @@ describe('vulnerability-reporter', () => {
         { path: 'filename.js', line: 88 }))
       addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
         { path: 'filename.js', line: 88 }))
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512691,' +
@@ -315,8 +316,8 @@ describe('vulnerability-reporter', () => {
         { path: 'filename.js', line: 88 }))
       addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
         { path: 'filename.js', line: 88 }))
-      sendVulnerabilities(iastContext)
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnceWithExactly({
         'manual.keep': 'true',
         '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512691,' +
@@ -334,12 +335,12 @@ describe('vulnerability-reporter', () => {
         addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
           { path: 'filename.js', line: i }))
       }
-      sendVulnerabilities(iastContext)
+      sendVulnerabilities(iastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledOnce
 
       const nextIastContext = { rootSpan: span }
       addVulnerability(nextIastContext, vulnerabilityToRepeatInTheNext)
-      sendVulnerabilities(nextIastContext)
+      sendVulnerabilities(nextIastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledTwice
     })
   })

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -46,6 +46,19 @@ describe('vulnerability-reporter', () => {
       expect(vulnerability.location.line).to.be.undefined
       expect(vulnerability.location.spanId).to.be.equal(spanId)
     })
+
+    it('creates the object without spanId', () => {
+      const type = 'WEAK_HASHING'
+      const evidence = { value: 'md5' }
+      const location = { path: 'file-name.js', line: 15 }
+      const vulnerability = createVulnerability(type, evidence, undefined, location)
+      expect(vulnerability).not.to.be.null
+      expect(vulnerability.type).to.be.equal(type)
+      expect(vulnerability.evidence).to.be.equal(evidence)
+      expect(vulnerability.location.path).to.be.equal(location.path)
+      expect(vulnerability.location.line).to.be.equal(location.line)
+      expect(vulnerability.location.spanId).to.be.equal(0)
+    })
   })
 
   describe('addVulnerability', () => {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -1,4 +1,4 @@
-const { createVulnerability, addVulnerability, sendVulnerabilities, clearCache } =
+const { createVulnerability, addVulnerability, sendVulnerabilities, clearCache, setTracer } =
   require('../../../src/appsec/iast/vulnerability-reporter')
 
 describe('vulnerability-reporter', () => {
@@ -117,6 +117,50 @@ describe('vulnerability-reporter', () => {
         expect(iastContext).to.have.nested.property('vulnerabilities.1.location.spanId', -123)
         expect(iastContext).to.have.nested.property('vulnerabilities.1.location.path', 'path.js')
         expect(iastContext).to.have.nested.property('vulnerabilities.1.location.line', 12)
+      })
+    })
+
+    describe('without rootSpan', () => {
+      let fakeTracer
+      let onTheFlySpan
+      beforeEach(() => {
+        onTheFlySpan = {
+          finish: sinon.spy(),
+          addTags: sinon.spy(),
+          context () {
+            return {
+              toSpanId () {
+                return 42
+              }
+            }
+          }
+        }
+        fakeTracer = {
+          startSpan: sinon.stub().returns(onTheFlySpan)
+        }
+        setTracer(fakeTracer)
+      })
+      afterEach(() => {
+        sinon.restore()
+        setTracer()
+      })
+      it('should create span on the fly', () => {
+        const vulnerability = createVulnerability('INSECURE_HASHING', { value: 'sha1' }, undefined,
+          { path: 'filename.js', line: 73 })
+        addVulnerability(undefined, vulnerability)
+        expect(fakeTracer.startSpan).to.have.been.calledOnceWithExactly('vulnerability', { type: 'vulnerability' })
+        expect(onTheFlySpan.addTags).to.have.been.calledOnceWithExactly({
+          'manual.keep': 'true',
+          '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512655,' +
+            '"evidence":{"value":"sha1"},"location":{"spanId":42,"path":"filename.js","line":73}}]}'
+        })
+        expect(onTheFlySpan.finish).to.have.been.calledOnce
+      })
+      it('should update spanId in vulnerability\'s location with the new id from created span', () => {
+        const vulnerability = createVulnerability('INSECURE_HASHING', { value: 'sha1' }, undefined,
+          { path: 'filename.js', line: 73 })
+        addVulnerability(undefined, vulnerability)
+        expect(vulnerability.location.spanId).to.be.equal(42)
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?
Creates a new span for vulnerabilities where there is no current context

### Motivation
Vulnerabilities are not only found during the execution of a request, they can be present at boot time, background processes ... this PR tries to enable the creation of custom spans when there is no requests.
