### PR TITLE
Do not crash when prototype-free objects used for tags

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -175,7 +175,7 @@ function addTag (meta, metrics, key, value, nested) {
         metrics[key] = value.toString()
       } else if (!Array.isArray(value) && !nested) {
         for (const prop in value) {
-          if (!value.hasOwnProperty(prop)) continue
+          if (!hasOwn(value, prop)) continue
 
           addTag(meta, metrics, `${key}.${prop}`, value[prop], true)
         }
@@ -183,6 +183,10 @@ function addTag (meta, metrics, key, value, nested) {
 
       break
   }
+}
+
+function hasOwn (object, prop) {
+  return Object.prototype.hasOwnProperty.call(object, prop)
 }
 
 function isNodeBuffer (obj) {

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -109,9 +109,9 @@ class PrioritySampler {
   }
 
   _getPriorityFromTags (tags) {
-    if (tags.hasOwnProperty(MANUAL_KEEP) && tags[MANUAL_KEEP] !== false) {
+    if (hasOwn(tags, MANUAL_KEEP) && tags[MANUAL_KEEP] !== false) {
       return USER_KEEP
-    } else if (tags.hasOwnProperty(MANUAL_DROP) && tags[MANUAL_DROP] !== false) {
+    } else if (hasOwn(tags, MANUAL_DROP) && tags[MANUAL_DROP] !== false) {
       return USER_REJECT
     } else {
       const priority = parseInt(tags[SAMPLING_PRIORITY], 10)
@@ -196,6 +196,10 @@ class PrioritySampler {
 
     return true
   }
+}
+
+function hasOwn (object, prop) {
+  return Object.prototype.hasOwnProperty.call(object, prop)
 }
 
 module.exports = PrioritySampler

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -412,5 +412,13 @@ describe('format', () => {
       trace = format(span)
       expect(trace.metrics[PROCESS_ID]).to.equal(process.pid)
     })
+
+    it('should not crash on prototype-free tags objects when nesting', () => {
+      const tags = Object.create(null)
+      tags['nested'] = { foo: 'bar' }
+      spanContext._tags['nested'] = tags
+
+      format(span)
+    })
   })
 })

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -389,7 +389,13 @@ describe('PrioritySampler', () => {
       expect(context._trace.tags).to.have.property(DECISION_MAKER_KEY, '-3')
     })
 
-    it.skip('should remove the decision maker tag when dropping the trace', () => {})
+    it.skip('should remove the decision maker tag when dropping the trace', () => { })
+
+    it('should not crash on prototype-free tags objects', () => {
+      context._tags = Object.create(null)
+
+      prioritySampler.sample(span)
+    })
   })
 
   describe('update', () => {


### PR DESCRIPTION
Fixes #2542

### What does this PR do?

Avoid using `object.hasOwnProperty(...)` directly when the validity of a tags object is unknown.

### Motivation

Because tags are user-supplied, they could be in unexpected forms. A relatively common one being null-prototype objects created with `Object.create(null)`. These types of objects don't have `Object` prototype methods so those should be referenced from the prototype rather than assuming the object has them.

### Plugin Checklist

- [x] Unit tests.
