### PR TITLE
Support IPv6 URLs for agent address

### DIFF
--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -20,16 +20,48 @@ const containerId = docker.id()
 
 let activeRequests = 0
 
+// TODO: Replace with `url.urlToHttpOptions` when supported by all versions
+function urlToOptions (url) {
+  const agent = url.agent || http.globalAgent
+  const options = {
+    protocol: url.protocol || agent.protocol,
+    hostname: typeof url.hostname === 'string' && url.hostname.startsWith('[')
+      ? url.hostname.slice(1, -1)
+      : url.hostname ||
+      url.host ||
+      'localhost',
+    hash: url.hash,
+    search: url.search,
+    pathname: url.pathname,
+    path: `${url.pathname || ''}${url.search || ''}`,
+    href: url.href
+  }
+  if (url.port !== '') {
+    options.port = Number(url.port)
+  }
+  if (url.username || url.password) {
+    options.auth = `${url.username}:${url.password}`
+  }
+  return options
+}
+
+function fromUrlString (url) {
+  return typeof urlToHttpOptions === 'function'
+    ? urlToOptions(new URL(url))
+    : urlParse(url)
+}
+
 function request (data, options, callback) {
   if (!options.headers) {
     options.headers = {}
   }
 
   if (options.url) {
-    const url = typeof options.url === 'object' ? options.url : urlParse(options.url)
+    const url = typeof options.url === 'object' ? options.url : fromUrlString(options.url)
     if (url.protocol === 'unix:') {
       options.socketPath = url.pathname
     } else {
+      if (!options.path) options.path = url.path
       options.protocol = url.protocol
       options.hostname = url.hostname
       options.port = url.port

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -235,4 +235,28 @@ describe('request', function () {
       })
     })
   })
+
+  it('should support ipv6 with brackets', (done) => {
+    nock('http://[2607:f0d0:1002:51::4]:123', {
+      reqheaders: {
+        'content-type': 'application/octet-stream',
+        'content-length': '13'
+      }
+    })
+      .put('/path')
+      .reply(200, 'OK')
+
+    request(
+      Buffer.from(JSON.stringify({ foo: 'bar' })), {
+        url: 'http://[2607:f0d0:1002:51::4]:123/path',
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/octet-stream'
+        }
+      },
+      (err, res) => {
+        expect(res).to.equal('OK')
+        done(err)
+      })
+  })
 })


### PR DESCRIPTION
Fixes #2449

### What does this PR do?

Makes IPv6 URLs for agent address work. This basically copy/pastes the `urlToOptions` helper from the http client instrumentation which itself is somewhat a copy of `url.urlToHttpOptions` which is not yet supported across all our supported versions so I can't use that.

### Motivation

IPv6 agent URLs were not working correctly.
