### PR TITLE
Update typing for `tracer.trace`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,8 @@ export declare interface Tracer extends opentracing.Tracer {
    * unless there is already an active span or `childOf` option. Note that this
    * option is deprecated and has been removed in version 4.0.
    */
-  trace<T> (name: string, fn: (span?: Span, fn?: (error?: Error) => any) => T): T;
+  trace<T> (name: string, fn: (span: Span) => T): T;
+  trace<T> (name: string, fn: (span: Span, done: (error?: Error) => string) => T): T;
   trace<T> (name: string, options: TraceOptions & SpanOptions, fn: (span?: Span, done?: (error?: Error) => string) => T): T;
 
   /**


### PR DESCRIPTION
### What does this PR do?
Corrects the typings of `tracer.trace`: `span` (and the `done` callback, if provided) will never be undefined if no `options` argument is passed.

### Motivation
If options are not passed to `trace` (and therefore if `options.orphanable !== false`), then it is guaranteed that `span` (and `done`, if provided) will _not_ be `undefined`.
