### PR TITLE
[ci-visibility] Fix `mocha#run` wrapper

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -30,6 +30,7 @@ const testFrameworks = [
     dependencies: [isOldNode ? 'mocha@9' : 'mocha', 'chai', 'nyc'],
     testFile: 'ci-visibility/run-mocha.js',
     expectedStdout: '2 passing',
+    extraStdout: 'end event: can add event listeners to mocha',
     expectedCoverageFiles: [
       'ci-visibility/run-mocha.js',
       'ci-visibility/test/sum.js',
@@ -57,6 +58,7 @@ testFrameworks.forEach(({
   dependencies,
   testFile,
   expectedStdout,
+  extraStdout,
   expectedCoverageFiles,
   runTestsWithCoverageCommand
 }) => {
@@ -104,6 +106,9 @@ testFrameworks.forEach(({
         const areAllTestSpans = testSpans.every(span => span.name === `${name}.test`)
         assert.isTrue(areAllTestSpans)
         assert.include(testOutput, expectedStdout)
+        if (extraStdout) {
+          assert.include(testOutput, extraStdout)
+        }
         done()
       })
 
@@ -334,7 +339,8 @@ testFrameworks.forEach(({
           assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'true')
           assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'true')
           done()
-        })
+        }).catch(done)
+
         childProcess = exec(
           runTestsWithCoverageCommand,
           {
@@ -495,7 +501,7 @@ testFrameworks.forEach(({
           )
           assert.equal(numSuites, 2)
           done()
-        })
+        }).catch(done)
 
         childProcess = fork(startupTestFile, {
           cwd,
@@ -625,7 +631,7 @@ testFrameworks.forEach(({
           )
           assert.equal(numSuites, 1)
           done()
-        })
+        }).catch(done)
 
         childProcess = exec(
           runTestsWithCoverageCommand,

--- a/integration-tests/ci-visibility/run-mocha.js
+++ b/integration-tests/ci-visibility/run-mocha.js
@@ -7,4 +7,7 @@ mocha.run(() => {
   if (process.send) {
     process.send('finished')
   }
+}).on('end', () => {
+  // eslint-disable-next-line
+  console.log('end event: can add event listeners to mocha')
 })

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -123,6 +123,7 @@ async function createSandbox (dependencies = [], isGitRepo = false) {
     await exec('echo "node_modules/" > .gitignore', { cwd: folder })
     await exec('git config user.email "john@doe.com"', { cwd: folder })
     await exec('git config user.name "John Doe"', { cwd: folder })
+    await exec('git config commit.gpgsign false', { cwd: folder })
     await exec(
       'git add -A && git commit -m "first commit" --no-verify && git remote add origin git@git.com:datadog/example',
       { cwd: folder }

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -324,6 +324,8 @@ addHook({
     if (!itrConfigurationCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
+    this.options.delay = true
+
     const runner = run.apply(this, arguments)
 
     const onReceivedSkippableSuites = ({ err, skippableSuites }) => {

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -324,12 +324,6 @@ addHook({
     if (!itrConfigurationCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
-    /**
-     * This attaches `run` to the global context, which we'll call after
-     * our configuration and skippable suites requests
-     */
-    this.options.delay = true
-
     const runner = run.apply(this, arguments)
 
     const onReceivedSkippableSuites = ({ err, skippableSuites }) => {
@@ -373,6 +367,23 @@ addHook({
   versions: ['>=5.2.0'],
   file: 'lib/runner.js'
 }, mochaHook)
+
+addHook({
+  name: 'mocha',
+  versions: ['>=5.2.0'],
+  file: 'lib/cli/run-helpers.js'
+}, (run) => {
+  shimmer.wrap(run, 'runMocha', runMocha => async function () {
+    const mocha = arguments[0]
+    /**
+     * This attaches `run` to the global context, which we'll call after
+     * our configuration and skippable suites requests
+     */
+    mocha.options.delay = true
+    return runMocha.apply(this, arguments)
+  })
+  return run
+})
 
 addHook({
   name: 'mocha',


### PR DESCRIPTION
### What does this PR do?
Do not delay calling `Mocha#run` on its wrapper, as it breaks the programmatic API. Instead, use `delay` option to fire the necessary async requests before starting the mocha run. 

### Motivation
Fixes #2690

