### PR TITLE
Always log inject service, version, and env

### DIFF
--- a/packages/datadog-plugin-bunyan/test/index.spec.js
+++ b/packages/datadog-plugin-bunyan/test/index.spec.js
@@ -89,14 +89,16 @@ describe('Plugin', () => {
           })
         })
 
-        it('should skip injection without an active span', () => {
+        it('should not inject trace_id or span_id without an active span', () => {
           logger.info('message')
 
           expect(stream.write).to.have.been.called
 
           const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
-          expect(record).to.not.have.property('dd')
+          expect(record).to.have.property('dd')
+          expect(record.dd).to.not.have.property('trace_id')
+          expect(record.dd).to.not.have.property('span_id')
         })
       })
     })

--- a/packages/datadog-plugin-paperplane/test/index.spec.js
+++ b/packages/datadog-plugin-paperplane/test/index.spec.js
@@ -605,7 +605,7 @@ describe('Plugin', () => {
             })
           })
 
-          it('should not alter logs with no active span', () => {
+          it('should not inject trace_id or span_id without an active span', () => {
             /* eslint-disable no-console */
             paperplane.logger({ message: ':datadoge:' })
 
@@ -613,7 +613,9 @@ describe('Plugin', () => {
 
             const record = JSON.parse(console.info.firstCall.args[0])
 
-            expect(record).to.not.have.property('dd')
+            expect(record).to.have.property('dd')
+            expect(record.dd).to.not.have.property('trace_id')
+            expect(record.dd).to.not.have.property('span_id')
             expect(record).to.have.property('message', ':datadoge:')
             /* eslint-enable no-console */
           })

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -149,14 +149,16 @@ describe('Plugin', () => {
             })
           })
 
-          it('should skip injection when there is no active span', () => {
+          it('should not inject trace_id or span_id without an active span', () => {
             logger.info('message')
 
             expect(stream.write).to.have.been.called
 
             const record = JSON.parse(stream.write.firstCall.args[0].toString())
 
-            expect(record).to.not.have.property('dd')
+            expect(record).to.have.property('dd')
+            expect(record.dd).to.not.have.property('trace_id')
+            expect(record.dd).to.not.have.property('span_id')
             expect(record).to.have.deep.property('msg', 'message')
           })
 

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -43,8 +43,8 @@ module.exports = class LogPlugin extends Plugin {
       const store = storage.getStore()
       const span = store && store.span
 
-      if (!span) return
-
+      // NOTE: This needs to run whether or not there is a span
+      // so service, version, and env will always get injected.
       const holder = {}
       this.tracer.inject(span, LOG, holder)
       arg.message = messageProxy(arg.message, holder)

--- a/packages/dd-trace/test/plugins/log_plugin.spec.js
+++ b/packages/dd-trace/test/plugins/log_plugin.spec.js
@@ -1,0 +1,64 @@
+const LogPlugin = require('../../src/plugins/log_plugin')
+const Tracer = require('../../src/tracer')
+const Config = require('../../src/config')
+
+const { channel } = require('diagnostics_channel')
+const { expect } = require('chai')
+
+const testLogChannel = channel('apm:test:log')
+
+class TestLog extends LogPlugin {
+  static get name () {
+    return 'test'
+  }
+}
+
+const config = {
+  env: 'my-env',
+  service: 'my-service',
+  version: '1.2.3'
+}
+
+const tracer = new Tracer(new Config({
+  logInjection: true,
+  enabled: true,
+  ...config
+}))
+
+const plugin = new TestLog({
+  _tracer: tracer
+})
+plugin.configure({
+  logInjection: true,
+  enabled: true
+})
+
+describe('LogPlugin', () => {
+  it('always adds service, version, and env', () => {
+    const data = { message: {} }
+    testLogChannel.publish(data)
+    const { message } = data
+
+    expect(message.dd).to.deep.equal(config)
+
+    // Should not have trace/span data when none is active
+    expect(message.dd).to.not.have.property('trace_id')
+    expect(message.dd).to.not.have.property('span_id')
+  })
+
+  it('should include trace_id and span_id when a span is active', () => {
+    const span = tracer.startSpan('test')
+
+    tracer.scope().activate(span, () => {
+      const data = { message: {} }
+      testLogChannel.publish(data)
+      const { message } = data
+
+      expect(message.dd).to.contain(config)
+
+      // Should have trace/span data when none is active
+      expect(message.dd).to.have.property('trace_id', span.context().toTraceId())
+      expect(message.dd).to.have.property('span_id', span.context().toSpanId())
+    })
+  })
+})


### PR DESCRIPTION
Fixes #2688

### What does this PR do?

Makes log injection _always_ run, even if there is no active span.

### Motivation

A user may still want to correlate logs to a given service, even if there was no active span at the time. To do this, it is necessary to _always_ include the service, version, and env data even when there is no active span.
