### PR TITLE
require db name when calling injectDbmQuery()

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -41,7 +41,12 @@ function wrapQuery (query) {
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     const processId = this.processID
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ params: this.connectionParameters, originalQuery: pgQuery.text, query: pgQuery, processId })
+      startCh.publish({
+        params: this.connectionParameters,
+        originalQuery: pgQuery.text,
+        query: pgQuery,
+        processId
+      })
 
       const finish = asyncResource.bind(function (error) {
         if (error) {

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -26,7 +26,7 @@ class PGPlugin extends DatabasePlugin {
       }
     })
 
-    query.text = this.injectDbmQuery(query.text)
+    query.text = this.injectDbmQuery(query.text, service)
   }
 }
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -252,7 +252,7 @@ describe('Plugin', () => {
       })
       describe('with DBM propagation enabled with service using plugin configurations', () => {
         before(() => {
-          return agent.load('pg', [{ dbmPropagationMode: 'service', service: 'serviced' }])
+          return agent.load('pg', [{ dbmPropagationMode: 'service', service: () => 'serviced' }])
         })
 
         after(() => {

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -25,8 +25,8 @@ class DatabasePlugin extends StoragePlugin {
     }
   }
 
-  createDBMPropagationCommentService () {
-    this.encodingServiceTags('dddbs', 'encodedDddbs', this.config.service)
+  createDBMPropagationCommentService (serviceName) {
+    this.encodingServiceTags('dddbs', 'encodedDddbs', serviceName)
     this.encodingServiceTags('dde', 'encodedDde', this.tracer._env)
     this.encodingServiceTags('ddps', 'encodedDdps', this.tracer._service)
     this.encodingServiceTags('ddpv', 'encodedDdpv', this.tracer._version)
@@ -37,11 +37,11 @@ class DatabasePlugin extends StoragePlugin {
     `ddps='${encodedDdps}',ddpv='${encodedDdpv}'`
   }
 
-  injectDbmQuery (query) {
+  injectDbmQuery (query, serviceName) {
     if (this.config.dbmPropagationMode === 'disabled') {
       return query
     }
-    const servicePropagation = this.createDBMPropagationCommentService()
+    const servicePropagation = this.createDBMPropagationCommentService(serviceName)
     if (this.config.dbmPropagationMode === 'service') {
       return `/*${servicePropagation}*/ ${query}`
     } else if (this.config.dbmPropagationMode === 'full') {


### PR DESCRIPTION
### What does this PR do?

- database plugin provides database name to `injectDbmQuery()`
- database plugins can have dynamic names, cannot simply use `config.service` property

### Motivation

- fixes #2697
