### PR TITLE
Split dd_tags on spaces

### DIFF
--- a/packages/dd-trace/src/profiling/tagger.js
+++ b/packages/dd-trace/src/profiling/tagger.js
@@ -22,7 +22,7 @@ const tagger = {
             .map(key => `${key}:${tags[key]}`))
         }
       case 'string':
-        return tagger.parse(tags.split(','))
+        return tagger.parse(tags.split('/[, ]+/'))
       default:
         return {}
     }

--- a/packages/dd-trace/src/profiling/tagger.js
+++ b/packages/dd-trace/src/profiling/tagger.js
@@ -22,7 +22,7 @@ const tagger = {
             .map(key => `${key}:${tags[key]}`))
         }
       case 'string':
-        return tagger.parse(tags.split('/[, ]+/'))
+        return tagger.parse(tags.split(/[, ]+/))
       default:
         return {}
     }

--- a/packages/dd-trace/test/profiling/tagger.spec.js
+++ b/packages/dd-trace/test/profiling/tagger.spec.js
@@ -37,8 +37,28 @@ describe('tagger', () => {
     })
   })
 
-  it('should support strings', () => {
+  it('should support strings with comma', () => {
     const tags = 'foo:bar,baz:qux'
+    const parsed = tagger.parse(tags)
+
+    expect(parsed).to.deep.equal({
+      foo: 'bar',
+      baz: 'qux'
+    })
+  })
+
+  it('should support strings with space', () => {
+    const tags = 'foo:bar baz:qux'
+    const parsed = tagger.parse(tags)
+
+    expect(parsed).to.deep.equal({
+      foo: 'bar',
+      baz: 'qux'
+    })
+  })
+
+  it('should support strings with with comma and space', () => {
+    const tags = 'foo:bar, baz:qux'
     const parsed = tagger.parse(tags)
 
     expect(parsed).to.deep.equal({
@@ -68,13 +88,6 @@ describe('tagger', () => {
 
   it('should ignore empty keys in strings', () => {
     const tags = ':bar'
-    const parsed = tagger.parse(tags)
-
-    expect(parsed).to.deep.equal({})
-  })
-
-  it('should ignore empty values in strings', () => {
-    const tags = 'foo:'
     const parsed = tagger.parse(tags)
 
     expect(parsed).to.deep.equal({})


### PR DESCRIPTION
### What does this PR do?
Allows dd_tags to be broken up by spaces

### Motivation
In most other language teams, dd_tags are broken up by spaces, ours is broken up by commas. 
