### PR TITLE
[ci-visibility] Fix `CiPlugin` crashing when no CI Vis init is used

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -158,6 +158,33 @@ testFrameworks.forEach(({
         })
       })
     })
+    context('when no ci visibility init is used', () => {
+      it('does not crash', (done) => {
+        receiver.assertMessageReceived(() => {
+          done(new Error('Should not create spans'))
+        })
+        childProcess = fork(startupTestFile, {
+          cwd,
+          env: {
+            DD_TRACE_AGENT_PORT: receiver.port,
+            NODE_OPTIONS: '-r dd-trace/init'
+          },
+          stdio: 'pipe'
+        })
+        childProcess.stdout.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.on('message', () => {
+          assert.notInclude(testOutput, 'TypeError')
+          assert.notInclude(testOutput, 'Uncaught error outside test suite')
+          assert.include(testOutput, expectedStdout)
+          done()
+        })
+      })
+    })
 
     describe('agentless', () => {
       it('does not init if DD_API_KEY is not set', (done) => {

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -160,9 +160,6 @@ testFrameworks.forEach(({
     })
     context('when no ci visibility init is used', () => {
       it('does not crash', (done) => {
-        receiver.assertMessageReceived(() => {
-          done(new Error('Should not create spans'))
-        })
         childProcess = fork(startupTestFile, {
           cwd,
           env: {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -28,7 +28,7 @@ module.exports = class CiPlugin extends Plugin {
     })
 
     this.addSub(`ci:${this.constructor.name}:test-suite:skippable`, ({ onDone }) => {
-      if (!this.tracer._exporter.getSkippableSuites) {
+      if (!this.tracer._exporter || !this.tracer._exporter.getSkippableSuites) {
         return onDone({ err: new Error('CI Visibility was not initialized correctly') })
       }
       this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites) => {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -16,7 +16,7 @@ module.exports = class CiPlugin extends Plugin {
     super(...args)
 
     this.addSub(`ci:${this.constructor.name}:itr-configuration`, ({ onDone }) => {
-      if (!this.tracer._exporter.getItrConfiguration) {
+      if (!this.tracer._exporter || !this.tracer._exporter.getItrConfiguration) {
         return onDone({ err: new Error('CI Visibility was not initialized correctly') })
       }
       this.tracer._exporter.getItrConfiguration(this.testConfiguration, (err, itrConfig) => {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -16,6 +16,9 @@ module.exports = class CiPlugin extends Plugin {
     super(...args)
 
     this.addSub(`ci:${this.constructor.name}:itr-configuration`, ({ onDone }) => {
+      if (!this.tracer._exporter.getItrConfiguration) {
+        return onDone({ err: new Error('CI Visibility was not initialized correctly') })
+      }
       this.tracer._exporter.getItrConfiguration(this.testConfiguration, (err, itrConfig) => {
         if (!err) {
           this.itrConfig = itrConfig
@@ -25,6 +28,9 @@ module.exports = class CiPlugin extends Plugin {
     })
 
     this.addSub(`ci:${this.constructor.name}:test-suite:skippable`, ({ onDone }) => {
+      if (!this.tracer._exporter.getSkippableSuites) {
+        return onDone({ err: new Error('CI Visibility was not initialized correctly') })
+      }
       this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites) => {
         onDone({ err, skippableSuites })
       })


### PR DESCRIPTION
### What does this PR do?
When the tracer is initialised without using ci visibility (`ci/init`) and a ci vis plugin is used, such as a `mocha`, the plugin has the invalid assumption that `getItrConfiguration` is available in the exporter. 

This PR fixes that. 

### Motivation
Fix #2709 

