### PR TITLE
Handle google-cloud-pubsub subscription closing

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
@@ -28,6 +28,8 @@ class GoogleCloudPubsubConsumerPlugin extends ConsumerPlugin {
   finish (message) {
     const span = this.activeSpan
 
+    if (!span) return
+
     if (message.message._handled) {
       span.setTag('pubsub.ack', 1)
     }

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -269,6 +269,24 @@ describe('Plugin', () => {
             await pubsub.createTopic(topicName)
           })
         })
+
+        it('should handle manual subscription close', async () => {
+          const [topic] = await pubsub.createTopic(topicName)
+          const [sub] = await topic.createSubscription('foo')
+
+          // message handler takes a while, subscription is closed while it's still running
+          sub.on('message', msg => {
+            setTimeout(() => { msg.ack() }, 2000)
+          })
+
+          await publish(topic, { data: Buffer.from('hello') })
+
+          setTimeout(() => { sub.close() }, 500)
+
+          return new Promise((resolve) => {
+            sub.on('close', resolve)
+          })
+        })
       })
 
       describe('with configuration', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This fixes an unhandled exception in the  google-cloud-pubsub plugin

### Motivation
<!-- What inspired you to submit this pull request? -->
When using google cloud Pubsub, when manually closing a subscription - `subscription.close` an unhandled exception would be thrown - `Uncaught TypeError: Cannot read properties of undefined (reading 'finish')`

The reason is that the `finish()` method would be called in a different context than the original message consume method. The active span is not available in the scenario.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
