### PR TITLE
 Make sure that current profiles are collected and exported when process exits

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -16,6 +16,7 @@ const os = require('os')
 const path = require('path')
 const rimraf = promisify(require('rimraf'))
 const id = require('../packages/dd-trace/src/id')
+const upload = require('multer')()
 
 class FakeAgent extends EventEmitter {
   constructor (port = 0) {
@@ -32,6 +33,14 @@ class FakeAgent extends EventEmitter {
       this.emit('message', {
         headers: req.headers,
         payload: msgpack.decode(req.body, { codec })
+      })
+    })
+    app.post('/profiling/v1/input', upload.any(), (req, res) => {
+      res.status(200).send()
+      this.emit('message', {
+        headers: req.headers,
+        payload: req.body,
+        files: req.files
       })
     })
 

--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const {
+  FakeAgent,
+  spawnProc,
+  createSandbox
+} = require('./helpers')
+const path = require('path')
+const { assert } = require('chai')
+
+async function checkProfiles (agent, proc, timeout) {
+  const resultPromise = agent.assertMessageReceived(({ headers, payload, files }) => {
+    assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+    assert.propertyVal(payload, 'format', 'pprof')
+    assert.deepPropertyVal(payload, 'types', ['wall', 'space'])
+    assert.propertyVal(files[0], 'originalname', 'wall.pb.gz')
+    assert.propertyVal(files[1], 'originalname', 'space.pb.gz')
+  }, timeout)
+
+  await new Promise((resolve, reject) => {
+    const timeoutObj = setTimeout(() => {
+      reject(new Error('Process timed out'))
+    }, timeout)
+
+    proc.on('exit', code => {
+      clearTimeout(timeoutObj)
+      if (code !== 0) {
+        reject(new Error(`Process exited with status code ${code}.`))
+      } else {
+        resolve()
+      }
+    })
+  })
+
+  return resultPromise
+}
+
+describe('profiler', () => {
+  let agent
+  let proc
+  let sandbox
+  let cwd
+  let profilerTestFile
+
+  before(async () => {
+    sandbox = await createSandbox()
+    cwd = sandbox.folder
+    profilerTestFile = path.join(cwd, 'profiler/index.js')
+  })
+
+  after(async () => {
+    await sandbox.remove()
+  })
+
+  context('shutdown', () => {
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc.kill()
+      await agent.stop()
+    })
+
+    it('records profile on process exit', async () => {
+      proc = await spawnProc(profilerTestFile, {
+        cwd,
+        env: {
+          DD_TRACE_AGENT_PORT: agent.port,
+          DD_PROFILING_ENABLED: 1
+        }
+      })
+      return checkProfiles(agent, proc, 5000)
+    })
+  })
+})

--- a/integration-tests/profiler/index.js
+++ b/integration-tests/profiler/index.js
@@ -1,0 +1,27 @@
+'use strict'
+
+require('dd-trace').init()
+
+function busyWait (ms) {
+  return new Promise(resolve => {
+    let done = false
+    function work () {
+      if (done) return
+      let sum = 0
+      for (let i = 0; i < 1e6; i++) {
+        sum += sum
+      }
+      setImmediate(work, sum)
+    }
+    setImmediate(work)
+    setTimeout(() => {
+      done = true
+      resolve(undefined)
+    }, ms)
+  })
+}
+
+// Runner expects child process to end a port
+process.send({ port: 0 })
+
+setImmediate(async () => busyWait(500))

--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -3,6 +3,9 @@
 const log = require('./log')
 const { profiler } = require('./profiling')
 
+// Stop profiler upon exit in order to collect and export the current profile
+process.once('beforeExit', () => { profiler.stop() })
+
 module.exports = {
   start: config => {
     const { service, version, env, url, hostname, port, tags } = config

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -35,6 +35,7 @@ class NativeWallProfiler {
   stop () {
     if (!this._stop) return
     this._stop()
+    this._stop = undefined
   }
 
   _record () {

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -202,6 +202,16 @@ describe('profiler', function () {
       sinon.assert.calledOnce(exporter.export)
     })
 
+    it('should flush when the profiler is stopped', async () => {
+      await profiler._start({ profilers, exporters })
+
+      profiler.stop()
+
+      await waitForExport()
+
+      sinon.assert.calledOnce(exporter.export)
+    })
+
     it('should export profiles', async () => {
       await profiler._start({ profilers, exporters, tags: { foo: 'foo' } })
 

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -55,10 +55,28 @@ describe('profilers/native/wall', () => {
     sinon.assert.calledWith(pprof.time.start, samplingInterval)
   })
 
+  it('should not stop when not started', () => {
+    const profiler = new NativeWallProfiler()
+
+    profiler.stop()
+
+    sinon.assert.notCalled(stop)
+  })
+
   it('should stop the internal time profiler', () => {
     const profiler = new NativeWallProfiler()
 
     profiler.start()
+    profiler.stop()
+
+    sinon.assert.calledOnce(stop)
+  })
+
+  it('should stop the internal time profiler only once', () => {
+    const profiler = new NativeWallProfiler()
+
+    profiler.start()
+    profiler.stop()
     profiler.stop()
 
     sinon.assert.calledOnce(stop)


### PR DESCRIPTION
### What does this PR do?
This collects and exports the current profiles before the process exits.

### Motivation
This makes the profiler easier to test and more usable for short running applications.
