### PR TITLE
[lambda] Remove minimum version requirement for patch

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -60,7 +60,5 @@ function filename (name, file) {
 
 module.exports = {
   filename,
-  getVersion,
-  matchVersion,
   pathSepExpr
 }

--- a/packages/dd-trace/src/lambda/runtime/patch.js
+++ b/packages/dd-trace/src/lambda/runtime/patch.js
@@ -70,5 +70,5 @@ if (originalLambdaHandler !== undefined) {
   addHook({ name: lambdaFilePath }, patchLambdaModule(handlerPath))
 } else {
   // Instrumentation is done manually.
-  addHook({ name: 'datadog-lambda-js', versions: ['>=6.85.0'] }, patchDatadogLambdaModule)
+  addHook({ name: 'datadog-lambda-js' }, patchDatadogLambdaModule)
 }

--- a/packages/dd-trace/src/lambda/runtime/ritm.js
+++ b/packages/dd-trace/src/lambda/runtime/ritm.js
@@ -15,8 +15,6 @@ const Hook = require('../../../../datadog-instrumentations/src/helpers/hook')
 const instrumentations = require('../../../../datadog-instrumentations/src/helpers/instrumentations')
 const {
   filename,
-  getVersion,
-  matchVersion,
   pathSepExpr
 } = require('../../../../datadog-instrumentations/src/helpers/register')
 
@@ -111,21 +109,18 @@ const registerLambdaHook = () => {
     })
   } else {
     const moduleToPatch = 'datadog-lambda-js'
-    Hook([moduleToPatch], (moduleExports, moduleName, moduleBaseDir) => {
+    Hook([moduleToPatch], (moduleExports, moduleName, _) => {
       moduleName = moduleName.replace(pathSepExpr, '/')
 
       require('./patch')
 
-      for (const { name, file, versions, hook } of instrumentations[moduleToPatch]) {
+      for (const { name, file, hook } of instrumentations[moduleToPatch]) {
         const fullFilename = filename(name, file)
         if (moduleName === fullFilename) {
-          const version = getVersion(moduleBaseDir)
-          if (matchVersion(version, versions)) {
-            try {
-              moduleExports = hook(moduleExports)
-            } catch (e) {
-              log.error(e)
-            }
+          try {
+            moduleExports = hook(moduleExports)
+          } catch (e) {
+            log.error(e)
           }
         }
       }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the need to have a minimum version to patch `datadog-lambda-js`. 

### Motivation
<!-- What inspired you to submit this pull request? -->
The layer sometimes is packed without a package.json, causing errors when patching functions. Although this didn't affect the run of the function, it was not properly patching the new features. 

Also, since this is a non-breaking change, every version should support this if the user mixes versions of `dd-trace-js` and `datadog-lambda-js`.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
