### PR TITLE
[ci-visibility] Add support for test modules

### DIFF
--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -55,6 +55,7 @@ versions.forEach((version) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSessionEvent = events.find(event => event.type === 'test_session_end')
+            const testModuleEvent = events.find(event => event.type === 'test_module_end')
             const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
             const testEvents = events.filter(event => event.type === 'test')
 
@@ -62,6 +63,8 @@ versions.forEach((version) => {
 
             assert.equal(testSessionEvent.content.resource, 'test_session.playwright test')
             assert.equal(testSessionEvent.content.meta[TEST_STATUS], 'fail')
+            assert.equal(testModuleEvent.content.resource, 'test_module.playwright test')
+            assert.equal(testModuleEvent.content.meta[TEST_STATUS], 'fail')
 
             assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
               'test_suite.todo-list-page-test.js',

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -218,9 +218,19 @@ function cliWrapper (cli) {
 
     const isSuitesSkipped = !!skippableSuites.length
 
+    let testFrameworkVersion
+    try {
+      testFrameworkVersion = this.getVersion()
+    } catch (e) {
+      try {
+        testFrameworkVersion = this.default.getVersion()
+      } catch (e) {
+        // ignore errors
+      }
+    }
     const processArgv = process.argv.slice(2).join(' ')
     sessionAsyncResource.runInAsyncScope(() => {
-      testSessionStartCh.publish(`jest ${processArgv}`)
+      testSessionStartCh.publish({ command: `jest ${processArgv}`, testFrameworkVersion })
     })
 
     const result = await runCLI.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -39,6 +39,7 @@ const testFileToSuiteAr = new Map()
 const originalCoverageMap = createCoverageMap()
 
 let suitesToSkip = []
+let mochaVersion
 
 function getSuitesByTestFile (root) {
   const suitesByTestFile = {}
@@ -128,7 +129,7 @@ function mochaHook (Runner) {
     this.once('start', testRunAsyncResource.bind(function () {
       const processArgv = process.argv.slice(2).join(' ')
       const command = `mocha ${processArgv}`
-      testSessionStartCh.publish(command)
+      testSessionStartCh.publish({ command, frameworkVersion: mochaVersion })
     }))
 
     this.on('suite', function (suite) {
@@ -315,12 +316,12 @@ addHook({
   file: 'lib/mocha.js'
 }, (Mocha) => {
   const mochaRunAsyncResource = new AsyncResource('bound-anonymous-fn')
-
   /**
    * Get ITR configuration and skippable suites
    * If ITR is disabled, `onDone` is called immediately on the subscriber
    */
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
+    mochaVersion = this.version
     if (!itrConfigurationCh.hasSubscribers) {
       return run.apply(this, arguments)
     }

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -186,6 +186,7 @@ class JestPlugin extends CiPlugin {
   }
 
   startTestSpan (test) {
+    let childOf
     const suiteTags = {}
     const store = storage.getStore()
     const testSuiteSpan = store ? store.span : undefined
@@ -195,6 +196,9 @@ class JestPlugin extends CiPlugin {
       suiteTags[TEST_SESSION_ID] = testSuiteSpan.context().toTraceId()
       suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)
       suiteTags[TEST_COMMAND] = testSuiteSpan.context()._tags[TEST_COMMAND]
+      childOf = getTestParentSpan(this.tracer)
+      childOf._trace.startTime = testSuiteSpan.context()._trace.startTime
+      childOf._trace.ticks = testSuiteSpan.context()._trace.ticks
     }
 
     const { suite, name, runner, testParameters } = test
@@ -205,7 +209,7 @@ class JestPlugin extends CiPlugin {
       ...suiteTags
     }
 
-    return super.startTestSpan(name, suite, extraTags)
+    return super.startTestSpan(name, suite, extraTags, childOf)
   }
 }
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -54,8 +54,8 @@ class JestPlugin extends CiPlugin {
 
     this.addSub('ci:jest:session:start', ({ command, testFrameworkVersion }) => {
       const childOf = getTestParentSpan(this.tracer)
-      const testSessionSpanMetadata = getTestSessionCommonTags(command, testFrameworkVersion || this.tracer._version)
-      const testModuleSpanMetadata = getTestModuleCommonTags(command, testFrameworkVersion || this.tracer._version)
+      const testSessionSpanMetadata = getTestSessionCommonTags(command, testFrameworkVersion)
+      const testModuleSpanMetadata = getTestModuleCommonTags(command, testFrameworkVersion)
 
       this.testSessionSpan = this.tracer.startSpan('jest.test_session', {
         childOf,
@@ -198,6 +198,8 @@ class JestPlugin extends CiPlugin {
       suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)
       suiteTags[TEST_COMMAND] = testSuiteSpan.context()._tags[TEST_COMMAND]
       suiteTags[TEST_BUNDLE] = testSuiteSpan.context()._tags[TEST_COMMAND]
+      // This is a hack to get good time resolution on test events, while keeping
+      // the test event as the root span of its trace.
       childOf = getTestParentSpan(this.tracer)
       childOf._trace.startTime = testSuiteSpan.context()._trace.startTime
       childOf._trace.ticks = testSuiteSpan.context()._trace.ticks

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -19,7 +19,8 @@ const {
   TEST_ITR_TESTS_SKIPPED,
   TEST_SESSION_CODE_COVERAGE_ENABLED,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
-  TEST_CODE_COVERAGE_LINES_TOTAL
+  TEST_CODE_COVERAGE_LINES_TOTAL,
+  TEST_BUNDLE
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
@@ -196,6 +197,7 @@ class JestPlugin extends CiPlugin {
       suiteTags[TEST_SESSION_ID] = testSuiteSpan.context().toTraceId()
       suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)
       suiteTags[TEST_COMMAND] = testSuiteSpan.context()._tags[TEST_COMMAND]
+      suiteTags[TEST_BUNDLE] = testSuiteSpan.context()._tags[TEST_COMMAND]
       childOf = getTestParentSpan(this.tracer)
       childOf._trace.startTime = testSuiteSpan.context()._trace.startTime
       childOf._trace.ticks = testSuiteSpan.context()._trace.ticks

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -67,7 +67,7 @@ describe('Plugin', function () {
   let jestCommonOptions
 
   this.timeout(testTimeout)
-  this.retries(0)
+  this.retries(2)
 
   withVersions('jest', ['jest-environment-node', 'jest-environment-jsdom'], (version, moduleName) => {
     afterEach(() => {
@@ -305,7 +305,7 @@ describe('Plugin', function () {
         }
       })
 
-      const initOptions = ['agentless']
+      const initOptions = ['agentless', 'evp proxy']
 
       initOptions.forEach(option => {
         describe(`reporting through ${option}`, () => {
@@ -317,7 +317,7 @@ describe('Plugin', function () {
             jestExecutable = loadedAgent.jestExecutable
             jestCommonOptions = loadedAgent.jestCommonOptions
           })
-          it.only('should create events for session, suite and test', (done) => {
+          it('should create events for session, suite and test', (done) => {
             const events = [
               {
                 type: 'test_session_end',

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -51,9 +51,9 @@ class MochaPlugin extends CiPlugin {
       })
     })
 
-    this.addSub('ci:mocha:session:start', (command) => {
+    this.addSub('ci:mocha:session:start', ({ command, frameworkVersion }) => {
       const childOf = getTestParentSpan(this.tracer)
-      const testSessionSpanMetadata = getTestSessionCommonTags(command, this.tracer._version)
+      const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion)
 
       this.command = command
       this.testSessionSpan = this.tracer.startSpan('mocha.test_session', {
@@ -65,7 +65,7 @@ class MochaPlugin extends CiPlugin {
         }
       })
 
-      const testModuleSpanMetadata = getTestModuleCommonTags(command, this.tracer._version)
+      const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion)
       this.testModuleSpan = this.tracer.startSpan('mocha.test_module', {
         childOf: this.testSessionSpan,
         tags: {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -180,18 +180,18 @@ class MochaPlugin extends CiPlugin {
     const testSuiteTags = {}
     const testSuiteSpan = this._testSuites.get(test.parent.file)
     if (testSuiteSpan) {
-      const testSuiteId = testSuiteSpan.context()._spanId.toString(10)
+      const testSuiteId = testSuiteSpan.context().toSpanId()
       testSuiteTags[TEST_SUITE_ID] = testSuiteId
     }
 
     if (this.testSessionSpan) {
-      const testSessionId = this.testSessionSpan.context()._traceId.toString(10)
+      const testSessionId = this.testSessionSpan.context().toTraceId()
       testSuiteTags[TEST_SESSION_ID] = testSessionId
       testSuiteTags[TEST_COMMAND] = this.command
     }
 
     if (this.testModuleSpan) {
-      const testModuleId = this.testModuleSpan.context()._traceId.toString(10)
+      const testModuleId = this.testModuleSpan.context().toSpanId()
       testSuiteTags[TEST_MODULE_ID] = testModuleId
       testSuiteTags[TEST_COMMAND] = this.command
       testSuiteTags[TEST_BUNDLE] = this.command

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -503,7 +503,7 @@ describe('Plugin', () => {
 
       initOptions.forEach(option => {
         describe(`reporting through ${option}`, () => {
-          it.only('should create events for session, modules, suites and test', (done) => {
+          it('should create events for session, modules, suites and test', (done) => {
             const testFilePaths = fs.readdirSync(__dirname)
               .filter(name => name.startsWith('mocha-test-suite-level'))
               .map(relativePath => path.join(__dirname, relativePath))

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -503,7 +503,7 @@ describe('Plugin', () => {
 
       initOptions.forEach(option => {
         describe(`reporting through ${option}`, () => {
-          it('should create events for session, suites and test', (done) => {
+          it.only('should create events for session, modules, suites and test', (done) => {
             const testFilePaths = fs.readdirSync(__dirname)
               .filter(name => name.startsWith('mocha-test-suite-level'))
               .map(relativePath => path.join(__dirname, relativePath))
@@ -529,9 +529,11 @@ describe('Plugin', () => {
               }
 
               const testSessionEvent = events.find(span => span.type === 'test_session_end')
+              const testModuleEvent = events.find(span => span.type === 'test_module_end')
               const testSuiteEvents = events.filter(span => span.type === 'test_suite_end')
 
               expect(testSessionEvent.meta[TEST_STATUS]).to.equal('fail')
+              expect(testModuleEvent.meta[TEST_STATUS]).to.equal('fail')
               expect(testSuiteEvents.length).to.equal(4)
 
               expect(
@@ -539,6 +541,13 @@ describe('Plugin', () => {
                   span => span.test_session_id.toString() === testSessionEvent.test_session_id.toString()
                 )
               ).to.be.true
+
+              expect(
+                testSuiteEvents.every(
+                  span => span.test_module_id.toString() === testModuleEvent.test_module_id.toString()
+                )
+              ).to.be.true
+
               expect(testSuiteEvents.every(suite => suite.test_suite_id !== undefined)).to.be.true
               expect(testSuiteEvents.every(suite => suites.includes(suite.meta[TEST_SUITE]))).to.be.true
 

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -10,7 +10,7 @@ const AgentInfoExporter = require('../../exporters/common/agent-info-exporter')
 
 function getIsTestSessionTrace (trace) {
   return trace.some(span =>
-    span.type === 'test_session_end' || span.type === 'test_suite_end'
+    span.type === 'test_session_end' || span.type === 'test_suite_end' || span.type === 'test_module_end'
   )
 }
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -246,38 +246,39 @@ function getCodeOwnersForFilename (filename, entries) {
   return null
 }
 
-function getTestModuleCommonTags (command, frameworkVersion) {
+function getTestLevelCommonTags (command, testFrameworkVersion) {
   return {
-    [SPAN_TYPE]: 'test_module_end',
-    [TEST_TYPE]: 'test',
-    [RESOURCE_NAME]: `test_module.${command}`,
-    [TEST_FRAMEWORK_VERSION]: frameworkVersion,
+    [TEST_FRAMEWORK_VERSION]: testFrameworkVersion,
     [LIBRARY_VERSION]: ddTraceVersion,
     [TEST_COMMAND]: command,
-    [TEST_BUNDLE]: command
+    [TEST_TYPE]: 'test'
   }
 }
 
-function getTestSessionCommonTags (command, frameworkVersion) {
+function getTestSessionCommonTags (command, testFrameworkVersion) {
   return {
     [SPAN_TYPE]: 'test_session_end',
-    [TEST_TYPE]: 'test',
     [RESOURCE_NAME]: `test_session.${command}`,
-    [TEST_FRAMEWORK_VERSION]: frameworkVersion,
-    [LIBRARY_VERSION]: ddTraceVersion,
-    [TEST_COMMAND]: command
+    ...getTestLevelCommonTags(command, testFrameworkVersion)
   }
 }
 
-function getTestSuiteCommonTags (command, frameworkVersion, testSuite) {
+function getTestModuleCommonTags (command, testFrameworkVersion) {
+  return {
+    [SPAN_TYPE]: 'test_module_end',
+    [RESOURCE_NAME]: `test_module.${command}`,
+    [TEST_BUNDLE]: command,
+    ...getTestLevelCommonTags(command, testFrameworkVersion)
+  }
+}
+
+function getTestSuiteCommonTags (command, testFrameworkVersion, testSuite) {
   return {
     [SPAN_TYPE]: 'test_suite_end',
-    [TEST_TYPE]: 'test',
     [RESOURCE_NAME]: `test_suite.${testSuite}`,
-    [TEST_FRAMEWORK_VERSION]: frameworkVersion,
-    [LIBRARY_VERSION]: ddTraceVersion,
+    [TEST_BUNDLE]: command,
     [TEST_SUITE]: testSuite,
-    [TEST_COMMAND]: command
+    ...getTestLevelCommonTags(command, testFrameworkVersion)
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -38,7 +38,9 @@ const TEST_CODE_OWNERS = 'test.codeowners'
 const TEST_SOURCE_FILE = 'test.source.file'
 const LIBRARY_VERSION = 'library_version'
 const TEST_COMMAND = 'test.command'
+const TEST_BUNDLE = 'test.bundle'
 const TEST_SESSION_ID = 'test_session_id'
+const TEST_MODULE_ID = 'test_module_id'
 const TEST_SUITE_ID = 'test_suite_id'
 
 const CI_APP_ORIGIN = 'ciapp-test'
@@ -75,9 +77,11 @@ module.exports = {
   getCodeOwnersForFilename,
   getTestCommonTags,
   getTestSessionCommonTags,
+  getTestModuleCommonTags,
   getTestSuiteCommonTags,
   TEST_COMMAND,
   TEST_SESSION_ID,
+  TEST_MODULE_ID,
   TEST_SUITE_ID,
   TEST_ITR_TESTS_SKIPPED,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
@@ -242,23 +246,35 @@ function getCodeOwnersForFilename (filename, entries) {
   return null
 }
 
-function getTestSessionCommonTags (command, version) {
+function getTestModuleCommonTags (command, frameworkVersion) {
+  return {
+    [SPAN_TYPE]: 'test_module_end',
+    [TEST_TYPE]: 'test',
+    [RESOURCE_NAME]: `test_module.${command}`,
+    [TEST_FRAMEWORK_VERSION]: frameworkVersion,
+    [LIBRARY_VERSION]: ddTraceVersion,
+    [TEST_COMMAND]: command,
+    [TEST_BUNDLE]: command
+  }
+}
+
+function getTestSessionCommonTags (command, frameworkVersion) {
   return {
     [SPAN_TYPE]: 'test_session_end',
     [TEST_TYPE]: 'test',
     [RESOURCE_NAME]: `test_session.${command}`,
-    [TEST_FRAMEWORK_VERSION]: version,
+    [TEST_FRAMEWORK_VERSION]: frameworkVersion,
     [LIBRARY_VERSION]: ddTraceVersion,
     [TEST_COMMAND]: command
   }
 }
 
-function getTestSuiteCommonTags (command, version, testSuite) {
+function getTestSuiteCommonTags (command, frameworkVersion, testSuite) {
   return {
     [SPAN_TYPE]: 'test_suite_end',
     [TEST_TYPE]: 'test',
     [RESOURCE_NAME]: `test_suite.${testSuite}`,
-    [TEST_FRAMEWORK_VERSION]: version,
+    [TEST_FRAMEWORK_VERSION]: frameworkVersion,
     [LIBRARY_VERSION]: ddTraceVersion,
     [TEST_SUITE]: testSuite,
     [TEST_COMMAND]: command


### PR DESCRIPTION
### What does this PR do?
* Add test modules for every framework that supports suite visibility.
* Update test framework version calculation for `jest`.
* Improve start time calculation for tests within a test session trace for `mocha` and `jest`.

### Motivation
Every testing framework is slightly different so CI Visibility settled on 4 different levels: session, modules, suites and tests. This covers every testing framework of the languages CI Vis currently supports. At first, we thought every framework could decide what levels to report, but this turns fast into a cumbersome architecture in the datadog's backend and UI, which can't assume anything about the received events. 

We decided that every library should report the same levels, even if it means that some levels are not really meaningful for some frameworks/languages. 


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

