### PR TITLE
update path-to-regexp to v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "module-details-from-path": "^1.0.3",
     "node-abort-controller": "^3.0.1",
     "opentracing": ">=0.12.1",
-    "path-to-regexp": "^0.1.2",
+    "path-to-regexp": "^3.2.0",
     "protobufjs": "^7.1.2",
     "retry": "^0.10.1",
     "semver": "^5.5.0"

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -145,7 +145,7 @@ function createWrapRouterMethod (name) {
     if (maybeCached) {
       return maybeCached
     }
-    const regexp = pathToRegExp(pattern)
+    const regexp = pathToRegExp.parse(pattern)
     regexpCache[pattern] = regexp
     return regexp
   }


### PR DESCRIPTION
### What does this PR do?
Updates `path-to-regexp` to v3.2.0 to fix version mismateches caused by using a very old version of `path-to-regexp@0.1.2`

### Motivation
https://github.com/DataDog/serverless-plugin-datadog/issues/321


### Additional Notes
I couldn't run the unit tests locally but I see your CI does run them. Please wait for them to finish ;)
