### PR TITLE
Disable fs plugin

### DIFF
--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -25,7 +25,6 @@ module.exports = {
   get 'express' () { return require('../../../datadog-plugin-express/src') },
   get 'fastify' () { return require('../../../datadog-plugin-fastify/src') },
   get 'find-my-way' () { return require('../../../datadog-plugin-find-my-way/src') },
-  get 'fs' () { return require('../../../datadog-plugin-fs/src') },
   get 'graphql' () { return require('../../../datadog-plugin-graphql/src') },
   get 'grpc' () { return require('../../../datadog-plugin-grpc/src') },
   get 'hapi' () { return require('../../../datadog-plugin-hapi/src') },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Disables the plugin added in https://github.com/DataDog/dd-trace-js/pull/2587 
This PR has `dont-land-on-v2.x` tag to disable it only in 3.x and master.

