### PR TITLE
[ci-visibility] Fix playwright integration tests

### DIFF
--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -17,7 +17,7 @@ const { TEST_STATUS } = require('../packages/dd-trace/src/plugins/util/test')
 const versions = ['1.18.0', 'latest']
 
 versions.forEach((version) => {
-  describe(`playwright@${version}`, () => {
+  describe.only(`playwright@${version}`, () => {
     let sandbox, cwd, receiver, childProcess, webAppPort
     before(async () => {
       sandbox = await createSandbox([`@playwright/test@${version}`], true)
@@ -51,7 +51,7 @@ versions.forEach((version) => {
             ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
           const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
 
-          receiver.gatherPayloads(({ url }) => url === reportUrl, 10000).then((payloads) => {
+          receiver.gatherPayloads(({ url }) => url === reportUrl).then((payloads) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSessionEvent = events.find(event => event.type === 'test_session_end')

--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -17,7 +17,7 @@ const { TEST_STATUS } = require('../packages/dd-trace/src/plugins/util/test')
 const versions = ['1.18.0', 'latest']
 
 versions.forEach((version) => {
-  describe.only(`playwright@${version}`, () => {
+  describe(`playwright@${version}`, () => {
     let sandbox, cwd, receiver, childProcess, webAppPort
     before(async () => {
       sandbox = await createSandbox([`@playwright/test@${version}`], true)

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -173,7 +173,7 @@ function dispatcherHookNew (dispatcherExport) {
     worker.on('testEnd', ({ testId, status, errors }) => {
       const { test } = dispatcher._testById.get(testId)
 
-      testEndHandler(test, STATUS_TO_TEST_STATUS[status], errors[0])
+      testEndHandler(test, STATUS_TO_TEST_STATUS[status], errors && errors[0])
     })
 
     return worker


### PR DESCRIPTION
### What does this PR do?
Increase the time we wait until we have every ingested payload when running `playwright` from 10 to 15 seconds.

### Motivation
Fix integration tests.

