### PR TITLE
Prevent release proposals with invalid labels

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -1,0 +1,19 @@
+name: Release Proposal PR check
+
+on:
+  pull_request:
+    branches:
+      - v[0-9]+.x
+jobs:
+  check_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+      - run: npm i -g @bengl/branch-diff
+      - run: |
+          mkdir -p ~/.config/changelog-maker
+          echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
+      - run: node ./scripts/check-proposal-labels.js

--- a/scripts/check-proposal-labels.js
+++ b/scripts/check-proposal-labels.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+
+const childProcess = require('child_process')
+const ORIGIN = 'origin/'
+
+let releaseBranch = process.env['GITHUB_BASE_REF'] // 'origin/v3.x'
+let releaseVersion = releaseBranch
+if (releaseBranch.startsWith(ORIGIN)) {
+  releaseVersion = releaseBranch.substring(ORIGIN.length)
+} else {
+  releaseBranch = ORIGIN + releaseBranch
+}
+let currentBranch = process.env['GITHUB_HEAD_REF'] // 'ugaitz/workflow-to-verify-dont-land-on-v3.x'
+if (!currentBranch.startsWith(ORIGIN)) {
+  currentBranch = ORIGIN + currentBranch
+}
+
+const getHashesCommandWithExclusions = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major' +
+  ` --exclude-label=dont-land-on-${releaseVersion} ${releaseBranch} ${currentBranch}`
+const getHashesCommandWithoutExclusions =
+  `branch-diff --user DataDog --repo dd-trace-js ${releaseBranch} ${currentBranch}`
+
+childProcess.exec(getHashesCommandWithExclusions, { timeout: 30000 },
+  (withExclusionError, withExclusionStdout, withExclusionStderr) => {
+    if (withExclusionError) {
+      console.error(`stdout:
+${withExclusionStdout}
+stderr:
+${withExclusionStderr}
+`, withExclusionError)
+      process.exit(1)
+      return
+    }
+    if (withExclusionStderr) {
+      console.error(withExclusionStderr)
+      process.exit(1)
+      return
+    }
+    const commitsHashesWithExclusions = withExclusionStdout.split('\n')
+
+    childProcess.exec(getHashesCommandWithoutExclusions,
+      (withoutExclusionError, withoutExclusionStdout, withoutExclusionStderr) => {
+        if (withoutExclusionError) {
+          console.error(`stdout:
+${withoutExclusionStdout}
+stderr:
+${withoutExclusionStderr}
+`, withoutExclusionError)
+          process.exit(1)
+          return
+        }
+        if (withoutExclusionStderr) {
+          console.error(withoutExclusionStderr)
+          process.exit(1)
+          return
+        }
+        const commitsHashesWithoutExclusions = withoutExclusionStdout.split('\n')
+        if (commitsHashesWithExclusions.length !== commitsHashesWithoutExclusions.length) {
+          const commitsWithInvalidLabels = []
+          commitsHashesWithoutExclusions.filter(c1 => {
+            if (!commitsHashesWithExclusions.some(c2 => c2 === c1)) {
+              commitsWithInvalidLabels.push(c1)
+            }
+          })
+          console.error('Some excluded label added in the release proposal', commitsWithInvalidLabels)
+          process.exit(1)
+        } else {
+          console.log('Commit PRs label looks OK')
+        }
+      })
+  })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
It adds a workflow that fails if a release proposal has a commit with invalid `do-not-land-on` tag.
### Motivation
<!-- What inspired you to submit this pull request? -->
Prevent releases with not compatible commits

### Examples
Error in 2.x proposal: https://github.com/DataDog/dd-trace-js/pull/2734
Error in 3.x proposal: https://github.com/DataDog/dd-trace-js/pull/2733

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
