### PR TITLE
Pin buildx

### DIFF
--- a/.github/actions/injection/action.yml
+++ b/.github/actions/injection/action.yml
@@ -8,6 +8,8 @@ runs:
   steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
+      with:
+        version: v0.9.1 # https://github.com/docker/buildx/issues/1533
     - name: Build injection image and push to github packages
       shell: bash
       run: |


### PR DESCRIPTION
lib injection images cannot be pushed to GCR due to changes to buildx.