### PR TITLE
suggested API doc changes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -413,7 +413,7 @@ app.get('/shopping_cart/:customer_id', (req, res) => {
 ```
 Related video guide: [![Creating Custom Spans for Method-Level Visibility](https://img.youtube.com/vi/pguPbIDN6hY/hqdefault.jpg)](https://youtu.be/pguPbIDN6hY)
 
-Alternatie ways of customizing spans: [![Adding Custom Tags to Spans](https://img.youtube.com/vi/gA68coge3Ro/hqdefault.jpg)](https://youtu.be/gA68coge3Ro)
+Alternative ways of customizing spans: [![Adding Custom Tags to Spans](https://img.youtube.com/vi/gA68coge3Ro/hqdefault.jpg)](https://youtu.be/gA68coge3Ro)
 
 <h3 id="span-hooks">Span Hooks</h3>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -405,15 +405,15 @@ For example:
 app.get('/shopping_cart/:customer_id', (req, res) => {
   // Get the active span
   const span = tracer.scope().active()
-  if (span !== null) {
+  if (span) {
     // customer_id -> 254889
     span.setTag('customer.id', req.params.customer_id)
   }
 })
 ```
-[Video guide](https://youtu.be/pguPbIDN6hY)
+Related video guide: [![Creating Custom Spans for Method-Level Visibility](https://img.youtube.com/vi/pguPbIDN6hY/hqdefault.jpg)](https://youtu.be/pguPbIDN6hY)
 
-[This](https://youtu.be/gA68coge3Ro) shows some of the other ways to add span tags.
+Alternatie ways of customizing spans: [![Adding Custom Tags to Spans](https://img.youtube.com/vi/gA68coge3Ro/hqdefault.jpg)](https://youtu.be/gA68coge3Ro)
 
 <h3 id="span-hooks">Span Hooks</h3>
 
@@ -432,7 +432,7 @@ tracer.use('express', {
   }
 })
 ```
-[Video guide](https://youtu.be/wtt5Zz7aZhk)
+Related video guide: [![Modifying a Span Using Hooks](https://img.youtube.com/vi/wtt5Zz7aZhk/hqdefault.jpg)](https://youtu.be/wtt5Zz7aZhk)
 
 Right now this functionality is limited to Web frameworks.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -397,6 +397,24 @@ const tracer = require('dd-trace').init({
 })
 ```
 
+<h3 id="span-tag">Span Tags</h3>
+The Datadog UI uses tags to set span level metadata. Custom tags may be set by grabbing the active span from the global tracer and setting a tag with `setTag` method.
+
+For example:
+```javascript
+app.get('/shopping_cart/:customer_id', (req, res) => {
+  // Get the active span
+  const span = tracer.scope().active()
+  if (span !== null) {
+    // customer_id -> 254889
+    span.setTag('customer.id', req.params.customer_id)
+  }
+})
+```
+[Video guide](https://youtu.be/pguPbIDN6hY)
+
+[This](https://youtu.be/gA68coge3Ro) shows some of the other ways to add span tags.
+
 <h3 id="span-hooks">Span Hooks</h3>
 
 In some cases, it's necessary to update the metadata of a span created by one of the built-in integrations. This is possible using span hooks registered by integration. Each hook provides the span as the first argument and other contextual objects as additional arguments.
@@ -414,6 +432,7 @@ tracer.use('express', {
   }
 })
 ```
+[Video guide](https://youtu.be/wtt5Zz7aZhk)
 
 Right now this functionality is limited to Web frameworks.
 


### PR DESCRIPTION
### What does this PR do?
Added some video guides and a code snippet from [here](https://docs.datadoghq.com/tracing/guide/add_span_md_and_graph_it/) to the API doc.

### Motivation
When I manually instrumented postgres.js, I found these resources very useful, so I thought it might be a good idea to include them in the documentation.
