### PR TITLE
Fix path traversal test in node 12

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -317,7 +317,7 @@ describe('integration test', () => {
       if (fd && fd.close) {
         fd.close()
       } else {
-        fs.close(fd)
+        fs.close(fd, () => {})
       }
     }, __filename, 'r')
   })
@@ -395,15 +395,16 @@ describe('integration test', () => {
 
     runFsMethodTestThreeWay('rmdir', 0, null, dirname)
   })
+  if (fs.rm) {
+    describe('test rm', () => {
+      const filename = path.join(os.tmpdir(), 'test-rmdir')
+      beforeEach(() => {
+        fs.writeFileSync(filename, '')
+      })
 
-  describe('test rm', () => {
-    const filename = path.join(os.tmpdir(), 'test-rmdir')
-    beforeEach(() => {
-      fs.writeFileSync(filename, '')
+      runFsMethodTestThreeWay('rm', 0, null, filename)
     })
-
-    runFsMethodTestThreeWay('rm', 0, null, filename)
-  })
+  }
 
   describe('test stat', () => {
     runFsMethodTestThreeWay('stat', 0, null, __filename)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix the path traversal test in node12
### Motivation
<!-- What inspired you to submit this pull request? -->
tracer v2.x should support node 12 and the test fails in release proposal
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
