### PR TITLE
Fix mongodb 5.0 test

### DIFF
--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -225,10 +225,16 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
-            collection.insertOne({ a: 1 }, {}, () => {
+            const insertPromise = collection.insertOne({ a: 1 }, {}, () => {
               expect(tracer.scope().active()).to.be.null
               done()
             })
+            if (insertPromise && insertPromise.then) {
+              insertPromise.then(() => {
+                expect(tracer.scope().active()).to.be.null
+                done()
+              })
+            }
           })
         })
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Change mongodb test to work when the method `insertOne` returns a promise instead of execute a callbackc

### Motivation
<!-- What inspired you to submit this pull request? -->
Yesterday was released new mongodb version (5.0.0) and they changed the API, now `insertOne` method returns a promise instead of execute a callback.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
