### PR TITLE
Fix mongodb test in node12

### DIFF
--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -4,7 +4,9 @@ const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 
 const withTopologies = fn => {
-  withVersions('mongodb-core', 'mongodb', (version, moduleName) => {
+  const isOldNode = semver.satisfies(process.version, '<=12')
+  const range = isOldNode ? '>=2 <5' : '>=2' // TODO: remove when 2.x support is removed.
+  withVersions('mongodb-core', 'mongodb', range, (version, moduleName) => {
     describe('using the default topology', () => {
       fn(async () => {
         const { MongoClient } = require(`../../../versions/${moduleName}@${version}`).get()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix mongodb plugin test in node12
### Motivation
<!-- What inspired you to submit this pull request? -->
They released 5.0.0 version of mongodb, and they are not supporting node 12
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
