### PR TITLE
[ci-visibility] Keep functionality with `.asyncResource`

### DIFF
--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -418,8 +418,13 @@ addHook({
 
         // we store the original function, not to lose it
         originalFns.set(newFn, this.fn)
-
         this.fn = newFn
+
+        // Temporarily keep functionality when .asyncResource is removed from node
+        // in https://github.com/nodejs/node/pull/46432
+        if (!this.fn.asyncResource) {
+          this.fn.asyncResource = asyncResource
+        }
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
Add `.asyncResource` if it's not there.

### Motivation
https://github.com/nodejs/node/pull/46432 is going to deprecate `.asyncResource` property from the returned value from `asyncResource.bind`. This PR is for keeping the current functionality in the `mocha` plugin.

