### PR TITLE
Fix log error message when intake request fails

### DIFF
--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -98,9 +98,16 @@ function request (data, options, callback) {
       if (res.statusCode >= 200 && res.statusCode <= 299) {
         callback(null, responseData, res.statusCode)
       } else {
-        const fullUrl = `${options.url || options.hostname || `localhost:${options.port}`}${options.path}`
-        // eslint-disable-next-line
-        let errorMessage = `Error from ${fullUrl}: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}.`
+        let errorMessage = ''
+        try {
+          const fullUrl = new URL(
+            options.path,
+            options.url || options.hostname || `http://localhost:${options.port}`
+          ).href
+          errorMessage = `Error from ${fullUrl}: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}.`
+        } catch (e) {
+          // ignore error
+        }
         if (responseData) {
           errorMessage += ` Response from the endpoint: "${responseData}"`
         }

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -91,7 +91,7 @@ describe('git_metadata', () => {
 
     gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, (err) => {
       // eslint-disable-next-line
-      expect(err.message).to.contain('Error fetching commits to exclude: Error from https://api.test.com//api/v2/git/repository/search_commits: 404 Not Found. Response from the endpoint: "Not found SHA"')
+      expect(err.message).to.contain('Error fetching commits to exclude: Error from https://api.test.com/api/v2/git/repository/search_commits: 404 Not Found. Response from the endpoint: "Not found SHA"')
       // to check that it is not called
       expect(scope.isDone()).to.be.false
       expect(scope.pendingMocks()).to.contain('POST https://api.test.com:443/api/v2/git/repository/packfile')

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -79,17 +79,33 @@ describe('request', function () {
   })
 
   it('should handle an http error', done => {
-    nock('http://localhost:80')
+    nock('http://localhost:8080')
       .put('/path')
       .reply(400)
 
     request(Buffer.from(''), {
       path: '/path',
       method: 'PUT',
-      port: 80
+      port: 8080
     }, err => {
       expect(err).to.be.instanceof(Error)
-      expect(err.message).to.equal('Error from localhost:80/path: 400 Bad Request.')
+      expect(err.message).to.equal('Error from http://localhost:8080/path: 400 Bad Request.')
+      done()
+    })
+  })
+
+  it('should handle an http error when url is specified', done => {
+    nock('http://api.datadog.com')
+      .put('/path')
+      .reply(400)
+
+    request(Buffer.from(''), {
+      path: '/path',
+      method: 'PUT',
+      url: new URL('http://api.datadog.com/')
+    }, err => {
+      expect(err).to.be.instanceof(Error)
+      expect(err.message).to.equal('Error from http://api.datadog.com/path: 400 Bad Request.')
       done()
     })
   })


### PR DESCRIPTION
### What does this PR do?
Due to a bad string concatenation, we were sometimes showing `//` instead of `/` in the boundary between a url's hostname and its path. This PR fixes it by using `new URL`

### Motivation
Fix log error message when a request to a given intake fails. 

