### PR TITLE
Fix fs instrumentation test in node12

### DIFF
--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -1,11 +1,17 @@
 const agent = require('../../dd-trace/test/plugins/agent')
+const semver = require('semver')
 describe('fs instrumentation', () => {
-  it('require node:fs should work', () => {
-    return agent.load('node:fs', undefined, { flushInterval: 1 }).then(() => {
-      const fs = require('node:fs')
-      expect(fs).not.to.be.undefined
-    })
+  afterEach(() => {
+    return agent.close({ ritmReset: false })
   })
+  if (semver.satisfies(process.versions.node, '>12')) {
+    it('require node:fs should work', () => {
+      return agent.load('node:fs', undefined, { flushInterval: 1 }).then(() => {
+        const fs = require('node:fs')
+        expect(fs).not.to.be.undefined
+      })
+    })
+  }
   it('require fs should work', () => {
     return agent.load('fs', undefined, { flushInterval: 1 }).then(() => {
       const fs = require('fs')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix the test execution in node 12
### Motivation
<!-- What inspired you to submit this pull request? -->
v2.x release proposal fails trying to require `node:fs`
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
