### PR TITLE
Implement remote configuration rules toggling with ASM product

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@datadog/native-appsec": "2.0.0",
+    "@datadog/native-appsec": "2.1.0",
     "@datadog/native-iast-rewriter": "1.1.2",
     "@datadog/native-iast-taint-tracking": "1.1.0",
     "@datadog/native-metrics": "^1.5.0",

--- a/packages/dd-trace/src/appsec/callbacks/ddwaf.js
+++ b/packages/dd-trace/src/appsec/callbacks/ddwaf.js
@@ -127,6 +127,10 @@ class WAFCallback {
     this.ddwaf.updateRuleData(ruleData)
   }
 
+  toggleRules (rulesTogglingData) {
+    this.ddwaf.toggleRules(rulesTogglingData)
+  }
+
   clear () {
     this.ddwaf.dispose()
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -44,6 +44,7 @@ async function enableAsync (_config) {
 function enableFromRules (_config, rules) {
   RuleManager.applyRules(rules, _config.appsec)
   remoteConfig.enableAsmData(_config.appsec)
+  remoteConfig.enableAsm()
 
   Reporter.setRateLimit(_config.appsec.rateLimit)
 
@@ -67,6 +68,7 @@ function abortEnable (err) {
   // abort AppSec start
   RuleManager.clearAllRules()
   remoteConfig.disableAsmData()
+  remoteConfig.disableAsm()
 }
 
 function incomingHttpStartTranslator ({ req, res, abortController }) {
@@ -161,6 +163,7 @@ function disable () {
 
   RuleManager.clearAllRules()
   remoteConfig.disableAsmData()
+  remoteConfig.disableAsm()
 
   // Channel#unsubscribe() is undefined for non active channels
   if (incomingHttpRequestStart.hasSubscribers) incomingHttpRequestStart.unsubscribe(incomingHttpStartTranslator)

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -44,7 +44,7 @@ async function enableAsync (_config) {
 function enableFromRules (_config, rules) {
   RuleManager.applyRules(rules, _config.appsec)
   remoteConfig.enableAsmData(_config.appsec)
-  remoteConfig.enableAsm()
+  remoteConfig.enableAsm(_config.appsec)
 
   Reporter.setRateLimit(_config.appsec.rateLimit)
 

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -32,14 +32,16 @@ function enable (config) {
   }
 }
 
-function enableAsm () {
-  if (rc) {
+function enableAsm (appsecConfig) {
+  if (rc && appsecConfig && appsecConfig.rules === undefined) {
+    rc.updateCapabilities(RemoteConfigCapabilities.ASM_DD_RULES, true)
     rc.on('ASM', RuleManager.toggleRules)
   }
 }
 
 function disableAsm () {
   if (rc) {
+    rc.updateCapabilities(RemoteConfigCapabilities.ASM_DD_RULES, false)
     rc.off('ASM', RuleManager.toggleRules)
   }
 }

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -32,6 +32,16 @@ function enable (config) {
   }
 }
 
+function enableAsm () {
+  rc.on('ASM', RuleManager.toggleRules)
+}
+
+function disableAsm () {
+  if (rc) {
+    rc.off('ASM', RuleManager.toggleRules)
+  }
+}
+
 function enableAsmData (appsecConfig) {
   if (rc && appsecConfig && appsecConfig.rules === undefined) {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_IP_BLOCKING, true)

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -33,7 +33,9 @@ function enable (config) {
 }
 
 function enableAsm () {
-  rc.on('ASM', RuleManager.toggleRules)
+  if (rc) {
+    rc.on('ASM', RuleManager.toggleRules)
+  }
 }
 
 function disableAsm () {
@@ -61,6 +63,8 @@ function _asmDataListener (action, ruleData, ruleId) {
 
 module.exports = {
   enable,
+  enableAsm,
+  disableAsm,
   enableAsmData,
   disableAsmData
 }

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -5,6 +5,7 @@ const Gateway = require('./gateway/engine')
 
 const appliedCallbacks = new Map()
 const appliedAsmData = new Map()
+let asmRulesToggling
 
 function applyRules (rules, config) {
   if (appliedCallbacks.has(rules)) return
@@ -69,6 +70,18 @@ function copyRulesData (rulesData) {
   }
   return copy
 }
+
+function toggleRules (action, _asmRulesToggling, _asmRulesTogglingId) {
+  if (action === 'unapply') {
+    asmRulesToggling = []
+  } else {
+    asmRulesToggling = _asmRulesToggling.rules_override
+  }
+  for (const callback of appliedCallbacks.values()) {
+    callback.toggleRules(asmRulesToggling)
+  }
+}
+
 function clearAllRules () {
   Gateway.manager.clear()
 

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -70,19 +70,19 @@ function copyRulesData (rulesData) {
   return copy
 }
 
-function getToggleRulesData (rulesOverrideData) {
-  if (!rulesOverrideData.rules_override || !rulesOverrideData.rules_override.filter) {
+function getRulesOverrideData (asmData) {
+  if (!asmData.rules_override || !asmData.rules_override.filter) {
     return
   }
 
-  return rulesOverrideData.rules_override.filter(ruleOverride => ruleOverride.hasOwnProperty('enabled'))
+  return asmData.rules_override.filter(ruleOverride => ruleOverride.hasOwnProperty('enabled'))
 }
 
-function toggleRules (action, asmRulesOverrideData, asmRulesOverrideId) {
-  const toggleRulesData = getToggleRulesData(asmRulesOverrideData)
-  if (action === 'apply' && toggleRulesData) {
+function toggleRules (action, asmData) {
+  const rulesOverrideData = getRulesOverrideData(asmData)
+  if (action !== 'unapply' && rulesOverrideData) {
     for (const callback of appliedCallbacks.values()) {
-      callback.toggleRules(toggleRulesData)
+      callback.toggleRules(rulesOverrideData)
     }
   }
 }

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -71,8 +71,10 @@ function copyRulesData (rulesData) {
 }
 
 function getRulesOverrideData (asmData) {
-  return asmData.rules_override && asmData.rules_override.filter &&
-    asmData.rules_override.filter(ruleOverride => ruleOverride.hasOwnProperty('enabled'))
+  return asmData.rules_override && Array.isArray(asmData.rules_override) &&
+    asmData.rules_override
+      .filter(ruleOverride => ruleOverride.hasOwnProperty('enabled'))
+      .map(ruleOverride => ({ id: ruleOverride.id, enabled: ruleOverride.enabled }))
 }
 
 function toggleRules (action, asmData) {

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -70,10 +70,19 @@ function copyRulesData (rulesData) {
   return copy
 }
 
-function toggleRules (action, _asmRulesToggling, _asmRulesTogglingId) {
-  if (action === 'apply' && _asmRulesToggling.rules_override) {
+function getToggleRulesData (rulesOverrideData) {
+  if (!rulesOverrideData.rules_override || !rulesOverrideData.rules_override.filter) {
+    return
+  }
+
+  return rulesOverrideData.rules_override.filter(ruleOverride => ruleOverride.hasOwnProperty('enabled'))
+}
+
+function toggleRules (action, asmRulesOverrideData, asmRulesOverrideId) {
+  const toggleRulesData = getToggleRulesData(asmRulesOverrideData)
+  if (action === 'apply' && toggleRulesData) {
     for (const callback of appliedCallbacks.values()) {
-      callback.toggleRules(_asmRulesToggling.rules_override)
+      callback.toggleRules(toggleRulesData)
     }
   }
 }

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -71,11 +71,8 @@ function copyRulesData (rulesData) {
 }
 
 function getRulesOverrideData (asmData) {
-  if (!asmData.rules_override || !asmData.rules_override.filter) {
-    return
-  }
-
-  return asmData.rules_override.filter(ruleOverride => ruleOverride.hasOwnProperty('enabled'))
+  return asmData.rules_override && asmData.rules_override.filter &&
+    asmData.rules_override.filter(ruleOverride => ruleOverride.hasOwnProperty('enabled'))
 }
 
 function toggleRules (action, asmData) {

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -96,5 +96,6 @@ function clearAllRules () {
 module.exports = {
   applyRules,
   clearAllRules,
-  updateAsmData
+  updateAsmData,
+  toggleRules
 }

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -5,7 +5,6 @@ const Gateway = require('./gateway/engine')
 
 const appliedCallbacks = new Map()
 const appliedAsmData = new Map()
-let asmRulesToggling
 
 function applyRules (rules, config) {
   if (appliedCallbacks.has(rules)) return
@@ -72,13 +71,10 @@ function copyRulesData (rulesData) {
 }
 
 function toggleRules (action, _asmRulesToggling, _asmRulesTogglingId) {
-  if (action === 'unapply') {
-    asmRulesToggling = []
-  } else {
-    asmRulesToggling = _asmRulesToggling.rules_override
-  }
-  for (const callback of appliedCallbacks.values()) {
-    callback.toggleRules(asmRulesToggling)
+  if (action === 'apply' && _asmRulesToggling.rules_override) {
+    for (const callback of appliedCallbacks.values()) {
+      callback.toggleRules(_asmRulesToggling.rules_override)
+    }
   }
 }
 

--- a/packages/dd-trace/test/appsec/callbacks/ddwaf.spec.js
+++ b/packages/dd-trace/test/appsec/callbacks/ddwaf.spec.js
@@ -170,6 +170,7 @@ describe('WAFCallback', () => {
           }
         })),
         updateRuleData: sinon.stub(),
+        toggleRules: sinon.stub(),
         dispose: sinon.stub()
       })
 
@@ -450,6 +451,22 @@ describe('WAFCallback', () => {
 
         expect(waf.ddwaf.updateRuleData).to.be.calledOnce
         expect(waf.ddwaf.updateRuleData).to.be.calledWithExactly(ruleData)
+      })
+    })
+
+    describe('toggleRules', () => {
+      it('should call ddwaf.toggleRules', () => {
+        const rulesTogglingData = [
+          {
+            id: 'blocked_users',
+            enabled: true
+          }
+        ]
+
+        waf.toggleRules(rulesTogglingData)
+
+        expect(waf.ddwaf.toggleRules).to.be.calledOnce
+        expect(waf.ddwaf.toggleRules).to.be.calledWithExactly(rulesTogglingData)
       })
     })
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -71,7 +71,7 @@ describe('AppSec Index', () => {
       expect(fs.readFileSync).to.have.been.calledWithExactly(config.appsec.blockedTemplateJson)
       expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] }, config.appsec)
       expect(remoteConfig.enableAsmData).to.have.been.calledOnce
-      expect(remoteConfig.enableAsm).to.have.been.calledOnce
+      expect(remoteConfig.enableAsm).to.have.been.calledOnceWithExactly(config.appsec)
       expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)
         .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
@@ -115,7 +115,7 @@ describe('AppSec Index', () => {
       expect(fs.promises.readFile).to.have.been.calledWithExactly(config.appsec.blockedTemplateJson)
       expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] }, config.appsec)
       expect(remoteConfig.enableAsmData).to.have.been.calledOnce
-      expect(remoteConfig.enableAsm).to.have.been.calledOnce
+      expect(remoteConfig.enableAsm).to.have.been.calledOnceWithExactly(config.appsec)
       expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)
         .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -48,6 +48,8 @@ describe('AppSec Index', () => {
     sinon.stub(RuleManager, 'applyRules')
     sinon.stub(remoteConfig, 'enableAsmData')
     sinon.stub(remoteConfig, 'disableAsmData')
+    sinon.stub(remoteConfig, 'enableAsm')
+    sinon.stub(remoteConfig, 'disableAsm')
     sinon.stub(Reporter, 'setRateLimit')
     sinon.stub(incomingHttpRequestStart, 'subscribe')
     sinon.stub(incomingHttpRequestEnd, 'subscribe')
@@ -69,6 +71,7 @@ describe('AppSec Index', () => {
       expect(fs.readFileSync).to.have.been.calledWithExactly(config.appsec.blockedTemplateJson)
       expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] }, config.appsec)
       expect(remoteConfig.enableAsmData).to.have.been.calledOnce
+      expect(remoteConfig.enableAsm).to.have.been.calledOnce
       expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)
         .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
@@ -112,6 +115,7 @@ describe('AppSec Index', () => {
       expect(fs.promises.readFile).to.have.been.calledWithExactly(config.appsec.blockedTemplateJson)
       expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] }, config.appsec)
       expect(remoteConfig.enableAsmData).to.have.been.calledOnce
+      expect(remoteConfig.enableAsm).to.have.been.calledOnce
       expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)
         .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
@@ -137,6 +141,7 @@ describe('AppSec Index', () => {
       expect(log.error.firstCall).to.have.been.calledWithExactly('Unable to start AppSec')
       expect(log.error.secondCall).to.have.been.calledWithExactly(err)
       expect(remoteConfig.disableAsmData).to.have.been.calledOnce
+      expect(remoteConfig.disableAsm).to.have.been.calledOnce
       expect(incomingHttpRequestStart.subscribe).to.not.have.been.called
       expect(incomingHttpRequestEnd.subscribe).to.not.have.been.called
       expect(Gateway.manager.addresses).to.be.empty
@@ -159,6 +164,7 @@ describe('AppSec Index', () => {
 
       expect(RuleManager.clearAllRules).to.have.been.calledOnce
       expect(remoteConfig.disableAsmData).to.have.been.calledOnce
+      expect(remoteConfig.disableAsm).to.have.been.calledOnce
       expect(incomingHttpRequestStart.unsubscribe)
         .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
       expect(incomingHttpRequestEnd.unsubscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpEndTranslator)

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { applyRules, clearAllRules, updateAsmData } = require('../../src/appsec/rule_manager')
+const { applyRules, clearAllRules, updateAsmData, toggleRules } = require('../../src/appsec/rule_manager')
 const callbacks = require('../../src/appsec/callbacks')
 const Gateway = require('../../src/appsec/gateway/engine')
 
@@ -14,6 +14,7 @@ describe('AppSec Rule Manager', () => {
 
     FakeDDWAF.prototype.clear = sinon.spy()
     FakeDDWAF.prototype.updateRuleData = sinon.spy()
+    FakeDDWAF.prototype.toggleRules = sinon.spy()
 
     sinon.stub(callbacks, 'DDWAF').get(() => FakeDDWAF)
   })
@@ -332,6 +333,50 @@ describe('AppSec Rule Manager', () => {
 
       expect(FakeDDWAF.prototype.updateRuleData).to.have.been.callCount(4)
       expect(FakeDDWAF.prototype.updateRuleData.lastCall).calledWithExactly(expectedMergedRulesData)
+    })
+  })
+
+  describe('toggleRules', () => {
+    it('should call toggleRules with rulesOverride data', () => {
+      const rulesOverride = {
+        rules_override: [
+          {
+            enabled: false,
+            id: 'crs-941-300'
+          },
+          {
+            enabled: false,
+            id: 'test-3'
+          }
+        ]
+      }
+
+      applyRules(rules)
+      toggleRules('apply', rulesOverride, '1')
+
+      expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(rulesOverride.rules_override)
+    })
+
+    it('should call toggleRules with empty data when unapply', () => {
+      const rulesOverride = {
+        rules_override: [
+          {
+            enabled: false,
+            id: 'crs-941-300'
+          },
+          {
+            enabled: false,
+            id: 'test-3'
+          }
+        ]
+      }
+
+      applyRules(rules)
+      toggleRules('apply', rulesOverride, '1')
+      toggleRules('unapply', rulesOverride, '2')
+
+      expect(FakeDDWAF.prototype.toggleRules).to.have.been.callCount(2)
+      expect(FakeDDWAF.prototype.toggleRules.lastCall).to.have.been.calledWithExactly([])
     })
   })
 })

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -441,5 +441,36 @@ describe('AppSec Rule Manager', () => {
       toggleRules('apply', asmPayload, '1')
       expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(expectedRulesOverride)
     })
+
+    it('should call WAF toggleRules with rules_override with extra fields', () => {
+      const asmPayload = {
+        rules_override: [
+          {
+            enabled: false,
+            id: 'crs-941-300',
+            extrafield: [ 'one', 'two', 'three' ]
+          },
+          {
+            enabled: false,
+            id: 'test-3'
+          }
+        ]
+      }
+
+      const expectedRulesOverride = [
+        {
+          enabled: false,
+          id: 'crs-941-300'
+        },
+        {
+          enabled: false,
+          id: 'test-3'
+        }
+      ]
+
+      applyRules(rules)
+      toggleRules('apply', asmPayload, '1')
+      expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(expectedRulesOverride)
+    })
   })
 })

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -337,7 +337,7 @@ describe('AppSec Rule Manager', () => {
   })
 
   describe('toggleRules', () => {
-    it('should call toggleRules with rulesOverride data', () => {
+    it('should call WAF toggleRules with rulesOverride data', () => {
       const rulesOverride = {
         rules_override: [
           {
@@ -357,7 +357,17 @@ describe('AppSec Rule Manager', () => {
       expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(rulesOverride.rules_override)
     })
 
-    it('should call toggleRules with empty data when unapply', () => {
+    it('should not call WAF toggleRules when rules_overrides is not present in data', () => {
+      const rulesOverride = {
+      }
+
+      applyRules(rules)
+      toggleRules('apply', rulesOverride, '1')
+
+      expect(FakeDDWAF.prototype.toggleRules).to.not.have.been.called
+    })
+
+    it('should not call WAF toggleRules when action is not apply', () => {
       const rulesOverride = {
         rules_override: [
           {
@@ -372,11 +382,10 @@ describe('AppSec Rule Manager', () => {
       }
 
       applyRules(rules)
-      toggleRules('apply', rulesOverride, '1')
+      toggleRules('modified', rulesOverride, '1')
       toggleRules('unapply', rulesOverride, '2')
 
-      expect(FakeDDWAF.prototype.toggleRules).to.have.been.callCount(2)
-      expect(FakeDDWAF.prototype.toggleRules.lastCall).to.have.been.calledWithExactly([])
+      expect(FakeDDWAF.prototype.toggleRules).to.not.have.been.called
     })
   })
 })

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -337,8 +337,8 @@ describe('AppSec Rule Manager', () => {
   })
 
   describe('toggleRules', () => {
-    it('should call WAF toggleRules with rulesOverride data', () => {
-      const rulesOverride = {
+    it('should call WAF toggleRules on apply action', () => {
+      const asmPayload = {
         rules_override: [
           {
             enabled: false,
@@ -352,44 +352,73 @@ describe('AppSec Rule Manager', () => {
       }
 
       applyRules(rules)
-      toggleRules('apply', rulesOverride, '1')
+      toggleRules('apply', asmPayload)
 
-      expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(rulesOverride.rules_override)
+      expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(asmPayload.rules_override)
     })
 
-    it('should not call WAF toggleRules when rules_overrides is not present in data', () => {
-      const rulesOverride = {
+    it('should call WAF toggleRules on modify action', () => {
+      const asmPayload = {
+        rules_override: [
+          {
+            enabled: false,
+            id: 'crs-941-300'
+          },
+          {
+            enabled: false,
+            id: 'test-3'
+          }
+        ]
       }
 
       applyRules(rules)
-      toggleRules('apply', rulesOverride, '1')
+      toggleRules('modify', asmPayload)
+
+      expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(asmPayload.rules_override)
+    })
+
+    it('should not call WAF toggleRules on unapply action', () => {
+      const asmPayload = {
+        rules_override: [
+          {
+            enabled: false,
+            id: 'crs-941-300'
+          },
+          {
+            enabled: false,
+            id: 'test-3'
+          }
+        ]
+      }
+
+      applyRules(rules)
+      toggleRules('unapply', asmPayload)
 
       expect(FakeDDWAF.prototype.toggleRules).to.not.have.been.called
     })
 
-    it('should not call WAF toggleRules when action is not apply', () => {
-      const rulesOverride = {
-        rules_override: [
-          {
-            enabled: false,
-            id: 'crs-941-300'
-          },
-          {
-            enabled: false,
-            id: 'test-3'
-          }
-        ]
+    it('should not call WAF toggleRules when rules_overrides is not present in ASM payload', () => {
+      const asmPayload = {}
+
+      applyRules(rules)
+      toggleRules('apply', asmPayload)
+
+      expect(FakeDDWAF.prototype.toggleRules).to.not.have.been.called
+    })
+
+    it('should not call WAF toggleRules when rules_override is empty', () => {
+      const asmPayload = {
+        rules_override: {}
       }
 
       applyRules(rules)
-      toggleRules('modified', rulesOverride, '1')
-      toggleRules('unapply', rulesOverride, '2')
+      toggleRules('apply', asmPayload)
 
       expect(FakeDDWAF.prototype.toggleRules).to.not.have.been.called
     })
 
     it('should call WAF toggleRules ignoring the empty overrides', () => {
-      const rulesOverride = {
+      const asmPayload = {
         rules_override: [
           {
             enabled: false,
@@ -409,7 +438,7 @@ describe('AppSec Rule Manager', () => {
       ]
 
       applyRules(rules)
-      toggleRules('apply', rulesOverride, '1')
+      toggleRules('apply', asmPayload, '1')
       expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(expectedRulesOverride)
     })
   })

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -387,5 +387,30 @@ describe('AppSec Rule Manager', () => {
 
       expect(FakeDDWAF.prototype.toggleRules).to.not.have.been.called
     })
+
+    it('should call WAF toggleRules ignoring the empty overrides', () => {
+      const rulesOverride = {
+        rules_override: [
+          {
+            enabled: false,
+            id: 'crs-941-300'
+          },
+          {
+            id: 'empty override'
+          }
+        ]
+      }
+
+      const expectedRulesOverride = [
+        {
+          enabled: false,
+          id: 'crs-941-300'
+        }
+      ]
+
+      applyRules(rules)
+      toggleRules('apply', rulesOverride, '1')
+      expect(FakeDDWAF.prototype.toggleRules).to.have.been.calledOnceWithExactly(expectedRulesOverride)
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,10 +189,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@datadog/native-appsec@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-2.0.0.tgz#ad65ba19bfd68e6b6c6cf64bb8ef55d099af8edc"
-  integrity sha512-XHARZ6MVgbnfOUO6/F3ZoZ7poXHJCNYFlgcyS2Xetuk9ITA5bfcooX2B2F7tReVB+RLJ+j8bsm0t55SyF04KDw==
+"@datadog/native-appsec@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-2.1.0.tgz#1dbd2138c0abb772f7a49f888efd8b081344e9e7"
+  integrity sha512-LE0Z635RVHLDbFqsXbBqZOWDrjlhwzQ0y005MRevTEkNbg4cCHepiRGsC7WFt1dSjDt3uKU8KvUIlGeqe8oKCw==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
Implement remote configuration rules toggling with ASM product

### Motivation
Remote configuration ASM product allows to toggle rules in ASM.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
