### PR TITLE
Check if channel has subscribers before call unsubscribe

### DIFF
--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -23,10 +23,18 @@ function withNoop (fn) {
 }
 
 function unsubscribeAll () {
-  debugChannel.unsubscribe(onDebug)
-  infoChannel.unsubscribe(onInfo)
-  warnChannel.unsubscribe(onWarn)
-  errorChannel.unsubscribe(onError)
+  if (debugChannel.hasSubscribers) {
+    debugChannel.unsubscribe(onDebug)
+  }
+  if (infoChannel.hasSubscribers) {
+    infoChannel.unsubscribe(onInfo)
+  }
+  if (warnChannel.hasSubscribers) {
+    warnChannel.unsubscribe(onWarn)
+  }
+  if (errorChannel.hasSubscribers) {
+    errorChannel.unsubscribe(onError)
+  }
 }
 
 function toggleSubscription (enable) {


### PR DESCRIPTION
### What does this PR do?
Check if channel has subscribers before unsubscribe

### Motivation
Unsubscribe is failing when channel has no subscribers for some node versions

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
