### PR TITLE
[ci-visibility] One git upload per test session

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -8,7 +8,8 @@ const options = {
   tags: {
     [ORIGIN_KEY]: 'ciapp-test'
   },
-  isCiVisibility: true
+  isCiVisibility: true,
+  flushInterval: 5000
 }
 
 let shouldInit = true

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -186,13 +186,12 @@ function cliWrapper (cli) {
 
     try {
       const { err, itrConfig } = await configurationPromise
-      if (err) {
-        log.error(err)
+      if (!err) {
+        isCodeCoverageEnabled = itrConfig.isCodeCoverageEnabled
+        isSuitesSkippingEnabled = itrConfig.isSuitesSkippingEnabled
       }
-      isCodeCoverageEnabled = itrConfig.isCodeCoverageEnabled
-      isSuitesSkippingEnabled = itrConfig.isSuitesSkippingEnabled
-    } catch (e) {
-      log.error(e)
+    } catch (err) {
+      log.error(err)
     }
 
     if (isSuitesSkippingEnabled) {
@@ -206,13 +205,11 @@ function cliWrapper (cli) {
 
       try {
         const { err, skippableSuites: receivedSkippableSuites } = await skippableSuitesPromise
-        if (err) {
-          log.error(err)
-        } else {
+        if (!err) {
           skippableSuites = receivedSkippableSuites
         }
-      } catch (e) {
-        log.error(e)
+      } catch (err) {
+        log.error(err)
       }
     }
 

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -2,7 +2,6 @@ const { createCoverageMap } = require('istanbul-lib-coverage')
 
 const { addHook, channel, AsyncResource } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
-const log = require('../../dd-trace/src/log')
 const {
   getCoveredFilenamesFromCoverage,
   resetCoverage,
@@ -331,7 +330,6 @@ addHook({
 
     const onReceivedSkippableSuites = ({ err, skippableSuites }) => {
       if (err) {
-        log.error(err)
         suitesToSkip = []
       } else {
         suitesToSkip = skippableSuites
@@ -343,7 +341,6 @@ addHook({
 
     const onReceivedConfiguration = ({ err }) => {
       if (err) {
-        log.error(err)
         return global.run()
       }
       if (!skippableSuitesCh.hasSubscribers) {

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -20,8 +20,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       prioritySampler,
       lookup,
       protocolVersion,
-      headers,
-      isGitUploadEnabled
+      headers
     } = config
 
     this.getAgentInfo((err, agentInfo) => {
@@ -38,9 +37,6 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
           url: this._url,
           evpProxyPrefix: AGENT_EVP_PROXY_PATH
         })
-        if (isGitUploadEnabled) {
-          this.sendGitMetadata({ url: this._url, isEvpProxy: true })
-        }
       } else {
         this._writer = new AgentWriter({
           url: this._url,

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -9,7 +9,7 @@ const log = require('../../../log')
 class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
   constructor (config) {
     super(config)
-    const { tags, site, url, isGitUploadEnabled } = config
+    const { tags, site, url } = config
     // we don't need to request /info because we are using agentless by configuration
     this._isInitialized = true
     this._resolveCanUseCiVisProtocol(true)
@@ -21,10 +21,6 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     this._coverageWriter = new CoverageWriter({ url: this._coverageUrl })
 
     this._apiUrl = url || new URL(`https://api.${site}`)
-
-    if (isGitUploadEnabled) {
-      this.sendGitMetadata({ url: this._getApiUrl() })
-    }
   }
 
   setUrl (url, coverageUrl = url, apiUrl = url) {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -32,7 +32,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
     }, GIT_UPLOAD_TIMEOUT).unref()
 
     const canUseCiVisProtocolTimeoutId = setTimeout(() => {
-      this._resolveGit(new Error('Timeout while attempting to communicate with the agent'))
+      this._resolveCanUseCiVisProtocol(false)
     }, CAN_USE_CI_VIS_PROTOCOL_TIMEOUT).unref()
 
     this._gitUploadPromise = new Promise(resolve => {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -7,9 +7,9 @@ const {
   TEST_CODE_OWNERS,
   CI_APP_ORIGIN
 } = require('./util/test')
-const { COMPONENT } = require('../constants')
-
 const Plugin = require('./plugin')
+const { COMPONENT } = require('../constants')
+const log = require('../log')
 
 module.exports = class CiPlugin extends Plugin {
   constructor (...args) {
@@ -20,7 +20,9 @@ module.exports = class CiPlugin extends Plugin {
         return onDone({ err: new Error('CI Visibility was not initialized correctly') })
       }
       this.tracer._exporter.getItrConfiguration(this.testConfiguration, (err, itrConfig) => {
-        if (!err) {
+        if (err) {
+          log.error(`Error fetching intelligent test runner configuration: ${err.message}`)
+        } else {
           this.itrConfig = itrConfig
         }
         onDone({ err, itrConfig })
@@ -32,6 +34,9 @@ module.exports = class CiPlugin extends Plugin {
         return onDone({ err: new Error('CI Visibility was not initialized correctly') })
       }
       this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites) => {
+        if (err) {
+          log.error(`Error fetching skippable suites: ${err.message}`)
+        }
         onDone({ err, skippableSuites })
       })
     })

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -70,19 +70,6 @@ describe('AgentProxyCiVisibilityExporter', () => {
       expect(agentProxyCiVisibilityExporter._writer).to.be.instanceOf(AgentlessWriter)
       expect(agentProxyCiVisibilityExporter._coverageWriter).to.be.instanceOf(CoverageWriter)
     })
-    it('should upload git metadata if configured', async () => {
-      const scope = nock('http://localhost:8126')
-        .post('/evp_proxy/v2/api/v2/git/repository/search_commits')
-        .reply(200, JSON.stringify({ data: [] }))
-        .post('/evp_proxy/v2/api/v2/git/repository/packfile')
-        .reply(204)
-
-      const agentProxyCiVisibilityExporter = new AgentProxyCiVisibilityExporter({
-        port, tags, isGitUploadEnabled: true
-      })
-      await agentProxyCiVisibilityExporter._gitUploadPromise
-      expect(scope.isDone()).to.be.true
-    })
 
     it('should process test suite level visibility spans', async () => {
       const mockWriter = {

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -21,22 +21,6 @@ describe('CI Visibility Agentless Exporter', () => {
     delete process.env.DD_APP_KEY
   })
 
-  it('uploads git metadata if configured to do so', (done) => {
-    const scope = nock('http://www.example.com')
-      .post('/api/v2/git/repository/search_commits')
-      .reply(200, JSON.stringify({
-        data: []
-      }))
-      .post('/api/v2/git/repository/packfile')
-      .reply(202, '')
-
-    const agentlessExporter = new AgentlessCiVisibilityExporter({ url, isGitUploadEnabled: true, tags: {} })
-    agentlessExporter._gitUploadPromise.then(() => {
-      expect(scope.isDone()).to.be.true
-      done()
-    })
-  })
-
   it('can use CI Vis protocol right away', () => {
     const agentlessExporter = new AgentlessCiVisibilityExporter({ url, isGitUploadEnabled: true, tags: {} })
     expect(agentlessExporter.canReportSessionTraces()).to.be.true

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -22,32 +22,32 @@ describe('CI Visibility Exporter', () => {
         .post('/api/v2/git/repository/packfile')
         .reply(202, '')
 
-      const ciVisibilityExporter = new CiVisibilityExporter({ port })
+      const url = new URL(`http://localhost:${port}`)
+      const ciVisibilityExporter = new CiVisibilityExporter({ url, isGitUploadEnabled: true })
 
       ciVisibilityExporter._gitUploadPromise.then((err) => {
         expect(err).not.to.exist
         expect(scope.isDone()).to.be.true
         done()
       })
-
-      const url = new URL(`http://localhost:${port}`)
-      ciVisibilityExporter.sendGitMetadata({ url, isEvpProxy: false })
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      ciVisibilityExporter.sendGitMetadata()
     })
     it('should resolve _gitUploadPromise with an error when git metadata request fails', (done) => {
       const scope = nock(`http://localhost:${port}`)
         .post('/api/v2/git/repository/search_commits')
         .reply(404)
 
-      const ciVisibilityExporter = new CiVisibilityExporter({ port })
+      const url = new URL(`http://localhost:${port}`)
+      const ciVisibilityExporter = new CiVisibilityExporter({ url, isGitUploadEnabled: true })
 
       ciVisibilityExporter._gitUploadPromise.then((err) => {
         expect(err.message).to.include('Error fetching commits to exclude')
         expect(scope.isDone()).to.be.true
         done()
       })
-
-      const url = new URL(`http://localhost:${port}`)
-      ciVisibilityExporter.sendGitMetadata({ url, isEvpProxy: false })
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      ciVisibilityExporter.sendGitMetadata()
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
* Move `sendGitUpload` request from init path to `getItrConfiguration`, that only happens once every test session. 
* Improve error logging when ITR config or `skippable` requests fail. 
* Increase `flushInterval` for CI Visibility to 5000 ms: this is based on heuristics for long test sessions.

### Motivation
The disadvantage of using `NODE_OPTIONS` to inititialize `dd-trace` is that every spawned node process will initialize it. This is fine for most cases, but when `DD_TRACE_CIVISIBILITY_GIT_UPLOAD_ENABLED` is set to true, each of the initializations will perform a git upload. Some testing frameworks use subprocesses to run tests, so this means that up to 10 (or more) instances of `dd-trace` can be uploading git metadata in parallel. This PR fixes this issue by **moving the git upload operation from the init path to the generation of test sessions** (which should happen only once). 


