### PR TITLE
sleep ten minutes and retry k8s pull/push step

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,16 @@ deploy_to_reliability_env:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
 
+
+nap:
+  stage: deploy
+  script: "sleep 600" # sleep for ten minutes
+
+# this step pulls a docker image and then publishes it elsewhere
+# it previously started almost immediately
+# at the same time a GitHub action publishes the image to be pulled
+# this resulted in a race condition
+# therefore, we're sleeping before attempting the pull
 deploy_to_docker_registries:
   stage: deploy
   rules:
@@ -37,6 +47,9 @@ deploy_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-js-init:$CI_COMMIT_TAG
     IMG_SIGNING: "false"
+  retry: 2
+  needs:
+    - job: nap
 
 deploy_latest_to_docker_registries:
   stage: deploy


### PR DESCRIPTION
### What does this PR do?
- sleep 10 minutes before pulling docker image for k8s step
- also re-attempts the process two times ([the max that GitLab allows](https://docs.gitlab.com/ee/ci/yaml/#retry))
- should fix #2677

### Motivation
- currently k8s docker build step has a race condition
- the GitHub action to push to a registry usually isn't complete by the time GitLab pulls
- doesn't need to be super expedient hence the 10 minute retry
- prior art: [the Python tracer waits for 1 day](https://github.com/DataDog/dd-trace-py/pull/4931/files)

### Additional Notes
- not entirely sure if this will work
- this uses a timer and retries, which isn't exactly ideal
  - the perfect solution would be to not run the GitLab operations until the GitHub operations are complete
  - one way to do this would be a bash script in GL that polls the GH API asking for status
  - sadly, we can't easily know the ID of the GH workflow run, as GL only really has the git hash
  - we could add a step in GH to like make an HTTP request somewhere once it's complete
  - we could then build out a hosted locking mechanism complete with a database
  - of course, this is a lot of work we'll certainly end up with stuck locks