### PR TITLE
remove unused config fields from telemetry

### DIFF
--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -6,6 +6,9 @@ function sendData (config, application, host, reqType, payload = {}) {
     port,
     url
   } = config
+
+  const { logger, tags, serviceMapping, ...trimmedPayload } = payload
+
   const options = {
     url,
     hostname,
@@ -24,7 +27,7 @@ function sendData (config, application, host, reqType, payload = {}) {
     tracer_time: Math.floor(Date.now() / 1000),
     runtime_id: config.tags['runtime-id'],
     seq_id: ++seqId,
-    payload,
+    payload: trimmedPayload,
     application,
     host
   })


### PR DESCRIPTION
### What does this PR do?
- deletes some of the configuration fields used for telemetry metrics

### Motivation
- apparently this data isn't used and just wastes bandwidth

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
