### PR TITLE
Fix span sampling

### DIFF
--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -12,7 +12,7 @@ class DatadogSpanContext {
     this._name = props.name
     this._isFinished = props.isFinished || false
     this._tags = props.tags || {}
-    this._sampling = props.sampling || {}
+    this._sampling = Object.assign({}, props.sampling)
     this._baggageItems = props.baggageItems || {}
     this._noop = props.noop || null
     this._trace = props.trace || {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -17,7 +17,7 @@ class SpanProcessor {
     this._killAll = false
 
     this._stats = new SpanStatsProcessor(config)
-    this._spanSampler = new SpanSampler(config)
+    this._spanSampler = new SpanSampler(config.sampler)
   }
 
   process (span) {

--- a/packages/dd-trace/src/span_sampler.js
+++ b/packages/dd-trace/src/span_sampler.js
@@ -2,11 +2,69 @@
 const { globMatch } = require('../src/util')
 const { USER_KEEP, AUTO_KEEP } = require('../../../ext').priority
 const RateLimiter = require('./rate_limiter')
+const Sampler = require('./sampler')
+
+class SpanSamplingRule {
+  constructor ({ service, name, sampleRate = 1.0, maxPerSecond } = {}) {
+    this.service = service
+    this.name = name
+
+    this._sampler = new Sampler(sampleRate)
+    this._limiter = undefined
+
+    if (Number.isFinite(maxPerSecond)) {
+      this._limiter = new RateLimiter(maxPerSecond)
+    }
+  }
+
+  get sampleRate () {
+    return this._sampler.rate()
+  }
+
+  get maxPerSecond () {
+    return this._limiter && this._limiter._rateLimit
+  }
+
+  static from (config) {
+    return new SpanSamplingRule(config)
+  }
+
+  match (service, name) {
+    if (this.service && !globMatch(this.service, service)) {
+      return false
+    }
+
+    if (this.name && !globMatch(this.name, name)) {
+      return false
+    }
+
+    return true
+  }
+
+  sample () {
+    if (!this._sampler.isSampled()) {
+      return false
+    }
+
+    if (this._limiter) {
+      return this._limiter.isAllowed()
+    }
+
+    return true
+  }
+}
 
 class SpanSampler {
-  constructor ({ spanSamplingRules = [] }) {
-    this._rules = spanSamplingRules
-    this._limiters = {}
+  constructor ({ spanSamplingRules = [] } = {}) {
+    this._rules = spanSamplingRules.map(SpanSamplingRule.from)
+  }
+
+  findRule (service, name) {
+    for (const rule of this._rules) {
+      if (rule.match(service, name)) {
+        return rule
+      }
+    }
   }
 
   sample (spanContext) {
@@ -15,63 +73,21 @@ class SpanSampler {
 
     const { started } = spanContext._trace
     for (const span of started) {
-      const service = span.tracer()._service
+      const tags = span.context()._tags || {}
       const name = span._name
-      const rule = findRule(this._rules, service, name)
-      if (!rule) continue
+      const service = tags.service ||
+        tags['service.name'] ||
+        span.tracer()._service
 
-      const sampleRate = getSampleRate(rule.sampleRate)
-      const maxPerSecond = getMaxPerSecond(rule.maxPerSecond)
-      const sampled = sample(sampleRate)
-      if (!sampled) continue
-
-      const key = `${service}:${name}`
-      const limiter = getLimiter(this._limiters, key, maxPerSecond)
-      if (limiter.isAllowed()) {
+      const rule = this.findRule(service, name)
+      if (rule && rule.sample()) {
         span.context()._sampling.spanSampling = {
-          sampleRate,
-          maxPerSecond
+          sampleRate: rule.sampleRate,
+          maxPerSecond: rule.maxPerSecond
         }
       }
     }
   }
-}
-
-function findRule (rules, service, name) {
-  for (const rule of rules) {
-    const servicePattern = getService(rule.service)
-    const namePattern = getName(rule.name)
-    if (globMatch(servicePattern, service) && globMatch(namePattern, name)) {
-      return rule
-    }
-  }
-}
-
-function getLimiter (list, key, maxPerSecond) {
-  if (typeof list[key] === 'undefined') {
-    list[key] = new RateLimiter(maxPerSecond)
-  }
-  return list[key]
-}
-
-function sample (sampleRate) {
-  return Math.random() < sampleRate
-}
-
-function getService (service) {
-  return service || '*'
-}
-
-function getName (name) {
-  return name || '*'
-}
-
-function getSampleRate (sampleRate) {
-  return sampleRate || 1.0
-}
-
-function getMaxPerSecond (maxPerSecond) {
-  return maxPerSecond || Infinity
 }
 
 module.exports = SpanSampler

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -72,6 +72,18 @@ describe('SpanContext', () => {
     })
   })
 
+  it('should clone sampling object', () => {
+    const first = new SpanContext({
+      sampling: { priority: 1 }
+    })
+    const second = new SpanContext({
+      sampling: first.sampling
+    })
+    second._sampling.priority = 2
+
+    expect(first._sampling).to.have.property('priority', 1)
+  })
+
   describe('toTraceId()', () => {
     it('should return the trace ID as string', () => {
       const spanContext = new SpanContext({

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -11,6 +11,8 @@ describe('SpanProcessor', () => {
   let tracer
   let format
   let config
+  let SpanSampler
+  let sample
 
   beforeEach(() => {
     tracer = {}
@@ -45,8 +47,14 @@ describe('SpanProcessor', () => {
     }
     format = sinon.stub().returns({ formatted: true })
 
+    sample = sinon.stub()
+    SpanSampler = sinon.stub().returns({
+      sample
+    })
+
     SpanProcessor = proxyquire('../src/span_processor', {
-      './format': format
+      './format': format,
+      './span_sampler': SpanSampler
     })
     processor = new SpanProcessor(exporter, prioritySampler, config)
   })
@@ -98,5 +106,27 @@ describe('SpanProcessor', () => {
 
     expect(trace).to.have.deep.property('started', [activeSpan])
     expect(trace).to.have.deep.property('finished', [])
+  })
+
+  it('should configure span sampler conrrectly', () => {
+    const config = {
+      stats: { enabled: false },
+      sampler: {
+        sampleRate: 0,
+        spanSamplingRules: [
+          {
+            service: 'foo',
+            name: 'bar',
+            sampleRate: 123,
+            maxPerSecond: 456
+          }
+        ]
+      }
+    }
+
+    const processor = new SpanProcessor(exporter, prioritySampler, config)
+    processor.process(finishedSpan)
+
+    expect(SpanSampler).to.have.been.calledWith(config.sampler)
   })
 })

--- a/packages/dd-trace/test/span_sampler.spec.js
+++ b/packages/dd-trace/test/span_sampler.spec.js
@@ -10,7 +10,9 @@ function createDummySpans () {
     'second_operation',
     'sub_second_operation_1',
     'sub_second_operation_2',
-    'sub_sub_second_operation_2'
+    'sub_sub_second_operation_2',
+    'custom_service_span_1',
+    'custom_service_span_2'
   ]
 
   const ids = [
@@ -19,13 +21,15 @@ function createDummySpans () {
     id('0234567812345673'),
     id('0234567812345674'),
     id('0234567812345675'),
-    id('0234567812345676')
+    id('0234567812345676'),
+    id('0234567812345677')
   ]
 
   const spans = []
   const spanContexts = []
 
-  operations.forEach((operation, idx) => {
+  for (let idx = 0; idx < operations.length; idx++) {
+    const operation = operations[idx]
     const id = ids[idx]
     const spanContext = {
       _spanId: id,
@@ -33,7 +37,13 @@ function createDummySpans () {
       _trace: {
         started: []
       },
-      _name: operation
+      _name: operation,
+      _tags: {}
+    }
+
+    // Give first span a custom service name
+    if ([6, 7].includes(idx)) {
+      spanContext._tags['service.name'] = 'span-service'
     }
 
     const span = {
@@ -46,7 +56,7 @@ function createDummySpans () {
 
     spanContexts.push(spanContext)
     spans.push(span)
-  })
+  }
 
   return { spans, spanContexts }
 }
@@ -104,6 +114,123 @@ describe('span sampler', () => {
         sampleRate: 1.0,
         maxPerSecond: 5
       })
+      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+    })
+
+    it('should consider missing service as match-all for service name', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            name: 'sub_second_operation_*',
+            sampleRate: 1.0,
+            maxPerSecond: 5
+          }
+        ]
+      })
+
+      const spanSampling = {
+        sampleRate: 1.0,
+        maxPerSecond: 5
+      }
+      sampler.sample(spanContexts[0])
+      expect(spans[0].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
+      // Only 3 and 4 should match because of the name pattern
+      expect(spans[3].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+    })
+
+    it('should consider missing name as match-all for span name', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            service: 'test',
+            sampleRate: 1.0,
+            maxPerSecond: 10
+          }
+        ]
+      })
+
+      const spanSampling = {
+        sampleRate: 1.0,
+        maxPerSecond: 10
+      }
+      sampler.sample(spanContexts[0])
+      expect(spans[0].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[1].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[2].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[3].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[5].context()._sampling.spanSampling).to.eql(spanSampling)
+      // Should not match because of different service name
+      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+    })
+
+    it('should stop at first rule match', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            service: 'test',
+            name: 'operation',
+            sampleRate: 1.0,
+            maxPerSecond: 5
+          },
+          {
+            service: 'test',
+            name: 'operation',
+            sampleRate: 1.0,
+            maxPerSecond: 10
+          }
+        ]
+      })
+
+      sampler.sample(spanContexts[0])
+      expect(spans[0].context()._sampling.spanSampling).to.eql({
+        sampleRate: 1.0,
+        maxPerSecond: 5
+      })
+      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+    })
+
+    it('should use span service name tags where present', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            service: 'span-service',
+            sampleRate: 1.0,
+            maxPerSecond: 5
+          }
+        ]
+      })
+
+      const spanSampling = {
+        sampleRate: 1.0,
+        maxPerSecond: 5
+      }
+      sampler.sample(spanContexts[0])
+      expect(spans[0].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[6].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[7].context()._sampling.spanSampling).to.eql(spanSampling)
     })
 
     it('should properly sample multiple single spans with one rule', () => {
@@ -118,15 +245,18 @@ describe('span sampler', () => {
         ]
       })
 
+      const spanSampling = {
+        sampleRate: 1.0,
+        maxPerSecond: 5
+      }
       sampler.sample(spanContexts[0])
-      expect(spans[4].context()._sampling.spanSampling, {
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      })
-      expect(spans[5].context()._sampling.spanSampling, {
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      })
+      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[5].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
     })
 
     it('should properly sample mutiple single spans with multiple rules', () => {
@@ -238,6 +368,39 @@ describe('span sampler', () => {
   })
 
   describe('maxPerSecond', () => {
+    it('should not create limiter without finite maxPerSecond', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            service: 'test',
+            name: 'operation',
+            sampleRate: 1.0
+          }
+        ]
+      })
+
+      const rule = sampler._rules[0]
+      expect(rule._limiter).to.equal(undefined)
+      expect(rule.maxPerSecond).to.equal(undefined)
+    })
+
+    it('should create limiter with finite maxPerSecond', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            service: 'test',
+            name: 'operation',
+            sampleRate: 1.0,
+            maxPerSecond: 123
+          }
+        ]
+      })
+
+      const rule = sampler._rules[0]
+      expect(rule._limiter).to.not.equal(undefined)
+      expect(rule).to.have.property('maxPerSecond', 123)
+    })
+
     it('should not sample spans past the rate limit', () => {
       sampler = new SpanSampler({
         spanSamplingRules: [
@@ -289,6 +452,31 @@ describe('span sampler', () => {
       sampler.sample(spanContexts[0])
       expect(spans[0].context()._sampling).to.not.haveOwnProperty('spanSampling')
       expect(spans[1].context()._sampling).to.haveOwnProperty('spanSampling')
+    })
+
+    it('should map limit by all spans matching pattern', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            service: 'test',
+            name: 'sub_second_operation_*',
+            sampleRate: 1.0,
+            maxPerSecond: 3
+          }
+        ]
+      })
+
+      // First time around both should have spanSampling to prove match
+      sampler.sample(spanContexts[0])
+      expect(spans[3].context()._sampling).to.haveOwnProperty('spanSampling')
+      expect(spans[4].context()._sampling).to.haveOwnProperty('spanSampling')
+      delete spans[3].context()._sampling.spanSampling
+      delete spans[4].context()._sampling.spanSampling
+
+      // Second time around only first should have spanSampling to prove limits
+      sampler.sample(spanContexts[0])
+      expect(spans[3].context()._sampling).to.haveOwnProperty('spanSampling')
+      expect(spans[4].context()._sampling).to.not.haveOwnProperty('spanSampling')
     })
 
     it('should allow unlimited rate limits', async () => {


### PR DESCRIPTION
Fix several bugs in the single span ingestion implementation

Bugs fixed:
- `SpanSampler` was not receiving `config.sampler`
- `SpanContext` sampling object was being reference-copied which made descending span contexts mutate their parents
- `Limiter` should should only be used it the `max_per_second` input is present and a valid finite number
- The `Limiter` should be associated with the matched rule, not with the `service:name` pair of the input context
- The `service` to match against should be pulled from span tags, if present
- An absent `service` or `name` on the rule should auto-match without running the glob matcher