### PR TITLE
remove resource truncation w/ agent, keep w/ agentless

### DIFF
--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -77,6 +77,22 @@ describe('Plugin', () => {
             })
           })
 
+          it('should send long queries to agent', done => {
+            agent.use(traces => {
+              expect(traces[0][0]).to.have.property('resource', `SELECT '${'x'.repeat(5000)}'::text as message`)
+
+              done()
+            })
+
+            client.query(`SELECT '${'x'.repeat(5000)}'::text as message`, (err, result) => {
+              if (err) throw err
+
+              client.end((err) => {
+                if (err) throw err
+              })
+            })
+          })
+
           if (semver.intersects(version, '>=5.1')) { // initial promise support
             it('should do automatic instrumentation when using promises', done => {
               agent.use(traces => {

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -14,7 +14,7 @@ float64Array[0] = -1
 const bigEndian = uInt8Float64Array[7] === 0
 
 function formatSpan (span) {
-  return normalizeSpan(truncateSpan(span))
+  return normalizeSpan(truncateSpan(span, false))
 }
 
 class AgentEncoder {

--- a/packages/dd-trace/src/encode/0.5.js
+++ b/packages/dd-trace/src/encode/0.5.js
@@ -7,7 +7,7 @@ const ARRAY_OF_TWO = 0x92
 const ARRAY_OF_TWELVE = 0x9c
 
 function formatSpan (span) {
-  return normalizeSpan(truncateSpan(span))
+  return normalizeSpan(truncateSpan(span, false))
 }
 
 class AgentEncoder extends BaseEncoder {

--- a/packages/dd-trace/src/encode/tags-processors.js
+++ b/packages/dd-trace/src/encode/tags-processors.js
@@ -38,11 +38,12 @@ function truncateToLength (value, maxLength) {
   return value
 }
 
-function truncateSpan (span) {
+// normally the agent truncates the resource and parses it in certain scenarios (e.g. SQL Queries)
+function truncateSpan (span, shouldTruncateResourceName = true) {
   return fromEntries(Object.entries(span).map(([key, value]) => {
     switch (key) {
       case 'resource':
-        return ['resource', truncateToLength(value, MAX_RESOURCE_NAME_LENGTH)]
+        return ['resource', shouldTruncateResourceName ? truncateToLength(value, MAX_RESOURCE_NAME_LENGTH) : value]
       case 'meta':
         return ['meta', fromEntries(Object.entries(value).map(([metaKey, metaValue]) =>
           [truncateToLength(metaKey, MAX_META_KEY_LENGTH), truncateToLength(metaValue, MAX_META_VALUE_LENGTH)]

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -81,23 +81,6 @@ describe('encode', () => {
     expect(trace[0].parent_id.toString(16)).to.equal('1234abcd1234abcd')
   })
 
-  it('should truncate long fields', function () {
-    this.timeout(5000)
-    const flushSize = 8 * 1024 * 1024
-    const tooLongString = randString(flushSize)
-
-    data[0].service = tooLongString
-    data[0].name = tooLongString
-    data[0].type = tooLongString
-    data[0].resource = tooLongString
-    data[0].meta.foo = tooLongString
-    data[0].metrics.foo = tooLongString
-
-    encoder.encode(data)
-
-    expect(writer.flush).to.not.have.been.called
-  })
-
   it('should report its count', () => {
     expect(encoder.count()).to.equal(0)
 

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -78,23 +78,6 @@ describe('encode 0.5', () => {
     expect(trace[0][5].toString(16)).to.equal('1234abcd1234abcd')
   })
 
-  it('should truncate long fields', function () {
-    this.timeout(5000)
-    const flushSize = 8 * 1024 * 1024
-    const tooLongString = randString(flushSize)
-
-    data[0].service = tooLongString
-    data[0].name = tooLongString
-    data[0].type = tooLongString
-    data[0].resource = tooLongString
-    data[0].meta.foo = tooLongString
-    data[0].metrics.foo = tooLongString
-
-    encoder.encode(data)
-
-    expect(writer.flush).to.not.have.been.called
-  })
-
   it('should report its count', () => {
     expect(encoder.count()).to.equal(0)
 


### PR DESCRIPTION
### What does this PR do?
- ensure the tracer is sending resource names greater than 5,000 characters

### Motivation
- the agent should be truncating these values not tracers
- the agent needs to parse values, such as SQL queries for obfuscation purposes
- [obfuscation must happen before truncation](https://github.com/DataDog/datadog-agent/blob/569d2facff27f10a39b0985770a2ec0e8ac97d1b/pkg/trace/agent/agent.go#L289-%23L290)
- behavior was added in #1880 but only for agentless situations
- behavior was later updated in #2361 for agentful situations

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [X] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
