### PR TITLE
[ci-visibility] Add test suite level visibility to cucumber

### DIFF
--- a/integration-tests/ci-visibility/features/farewell.feature
+++ b/integration-tests/ci-visibility/features/farewell.feature
@@ -1,0 +1,4 @@
+Feature: Farewell
+  Scenario: Say farewell
+    When the greeter says farewell
+    Then I should have heard "farewell"

--- a/integration-tests/ci-visibility/features/greetings.feature
+++ b/integration-tests/ci-visibility/features/greetings.feature
@@ -1,0 +1,17 @@
+Feature: Greetings
+  Scenario: Say greetings
+    When the greeter says greetings
+    Then I should have heard "greetings"
+
+  Scenario: Say yeah
+    When the greeter says yeah
+    Then I should have heard "yeah"
+
+  Scenario: Say yo
+    When the greeter says yo
+    Then I should have heard "yo"
+
+  @skip
+  Scenario: Say skip
+    When the greeter says yo
+    Then I should have heard "yo"

--- a/integration-tests/ci-visibility/features/support/steps.js
+++ b/integration-tests/ci-visibility/features/support/steps.js
@@ -1,0 +1,40 @@
+const assert = require('assert')
+const { When, Then, Before } = require('@cucumber/cucumber')
+class Greeter {
+  sayFarewell () {
+    return 'farewell'
+  }
+  sayGreetings () {
+    return 'greetings'
+  }
+  sayYo () {
+    return 'yo'
+  }
+  sayYeah () {
+    return 'yeah whatever'
+  }
+}
+
+Before('@skip', function () {
+  return 'skipped'
+})
+
+Then('I should have heard {string}', function (expectedResponse) {
+  assert.equal(this.whatIHeard, expectedResponse)
+})
+
+When('the greeter says farewell', function () {
+  this.whatIHeard = new Greeter().sayFarewell()
+})
+
+When('the greeter says yo', function () {
+  this.whatIHeard = new Greeter().sayYo()
+})
+
+When('the greeter says yeah', function () {
+  this.whatIHeard = new Greeter().sayYeah()
+})
+
+When('the greeter says greetings', function () {
+  this.whatIHeard = new Greeter().sayGreetings()
+})

--- a/integration-tests/cucumber.spec.js
+++ b/integration-tests/cucumber.spec.js
@@ -59,20 +59,16 @@ versions.forEach(version => {
             const { content: testModuleEventContent } = testModuleEvent
 
             assert.exists(testSessionEventContent.test_session_id)
-            assert.equal(testSessionEventContent.resource, 'test_session.cucumber-js')
-            assert.include(testSessionEventContent.meta, {
-              [TEST_STATUS]: 'fail',
-              [TEST_COMMAND]: 'cucumber-js'
-            })
+            assert.exists(testModuleEventContent.meta[TEST_COMMAND])
+            assert.equal(testSessionEventContent.resource.startsWith('test_session.'), true)
+            assert.equal(testSessionEventContent.meta[TEST_STATUS], 'fail')
 
             assert.exists(testModuleEventContent.test_session_id)
             assert.exists(testModuleEventContent.test_module_id)
-            assert.equal(testModuleEventContent.resource, 'test_module.cucumber-js')
-            assert.include(testModuleEventContent.meta, {
-              [TEST_STATUS]: 'fail',
-              [TEST_COMMAND]: 'cucumber-js',
-              [TEST_BUNDLE]: 'cucumber-js'
-            })
+            assert.exists(testModuleEventContent.meta[TEST_COMMAND])
+            assert.exists(testModuleEventContent.meta[TEST_BUNDLE])
+            assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
+            assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
             assert.equal(
               testModuleEventContent.test_session_id.toString(10),
               testSessionEventContent.test_session_id.toString(10)
@@ -89,11 +85,14 @@ versions.forEach(version => {
 
             testSuiteEvents.forEach(({
               content: {
+                meta,
                 test_suite_id: testSuiteId,
                 test_module_id: testModuleId,
                 test_session_id: testSessionId
               }
             }) => {
+              assert.exists(meta[TEST_COMMAND])
+              assert.exists(meta[TEST_BUNDLE])
               assert.exists(testSuiteId)
               assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
               assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
@@ -116,11 +115,14 @@ versions.forEach(version => {
 
             testEvents.forEach(({
               content: {
+                meta,
                 test_suite_id: testSuiteId,
                 test_module_id: testModuleId,
                 test_session_id: testSessionId
               }
             }) => {
+              assert.exists(meta[TEST_COMMAND])
+              assert.exists(meta[TEST_BUNDLE])
               assert.exists(testSuiteId)
               assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
               assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))

--- a/integration-tests/cucumber.spec.js
+++ b/integration-tests/cucumber.spec.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const { exec } = require('child_process')
+
+const getPort = require('get-port')
+const { assert } = require('chai')
+
+const {
+  createSandbox,
+  getCiVisAgentlessConfig,
+  getCiVisEvpProxyConfig
+} = require('./helpers')
+const { FakeCiVisIntake } = require('./ci-visibility-intake')
+const { TEST_STATUS } = require('../packages/dd-trace/src/plugins/util/test')
+
+describe('cucumber', () => {
+  let sandbox, cwd, receiver, childProcess
+  before(async () => {
+    sandbox = await createSandbox(['@cucumber/cucumber', 'assert'], true)
+    cwd = sandbox.folder
+  })
+
+  after(async () => {
+    await sandbox.remove()
+  })
+
+  beforeEach(async function () {
+    const port = await getPort()
+    receiver = await new FakeCiVisIntake(port).start()
+  })
+
+  afterEach(async () => {
+    childProcess.kill()
+    await receiver.stop()
+  })
+  const reportMethods = ['agentless', 'evp proxy']
+
+  reportMethods.forEach((reportMethod) => {
+    context(`reporting via ${reportMethod}`, () => {
+      it('can run and report tests', (done) => {
+        const envVars = reportMethod === 'agentless'
+          ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
+        const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
+
+        receiver.gatherPayloads(({ url }) => url === reportUrl, 5000).then((payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const testSessionEvent = events.find(event => event.type === 'test_session_end')
+          const testModuleEvent = events.find(event => event.type === 'test_module_end')
+          const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
+          const testEvents = events.filter(event => event.type === 'test')
+
+          const stepEvents = events.filter(event => event.type === 'span')
+
+          assert.equal(testSessionEvent.content.resource, 'test_session.cucumber-js')
+          assert.equal(testSessionEvent.content.meta[TEST_STATUS], 'fail')
+          assert.equal(testModuleEvent.content.resource, 'test_module.cucumber-js')
+          assert.equal(testModuleEvent.content.meta[TEST_STATUS], 'fail')
+
+          assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
+            'test_suite.ci-visibility/features/farewell.feature',
+            'test_suite.ci-visibility/features/greetings.feature'
+          ])
+
+          assert.includeMembers(testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]), [
+            'pass',
+            'fail'
+          ])
+
+          assert.includeMembers(testEvents.map(test => test.content.resource), [
+            'ci-visibility/features/farewell.feature.Say farewell',
+            'ci-visibility/features/greetings.feature.Say greetings',
+            'ci-visibility/features/greetings.feature.Say yeah',
+            'ci-visibility/features/greetings.feature.Say yo',
+            'ci-visibility/features/greetings.feature.Say skip'
+          ])
+
+          assert.includeMembers(testEvents.map(test => test.content.meta[TEST_STATUS]), [
+            'pass',
+            'pass',
+            'pass',
+            'fail',
+            'skip'
+          ])
+
+          stepEvents.forEach(stepEvent => {
+            assert.equal(stepEvent.content.name, 'cucumber.step')
+            assert.property(stepEvent.content.meta, 'cucumber.step')
+          })
+
+          done()
+        }).catch(done)
+
+        childProcess = exec(
+          './node_modules/.bin/cucumber-js ci-visibility/features/*.feature',
+          {
+            cwd,
+            env: envVars,
+            stdio: 'pipe'
+          }
+        )
+      })
+    })
+  })
+})

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -183,9 +183,13 @@ addHook({
 }, (runtimePackage, frameworkVersion) => {
   shimmer.wrap(runtimePackage.default.prototype, 'start', start => async function () {
     pickleByFile = getPickleByFile(this)
+
+    const processArgv = process.argv.slice(2).join(' ')
+    const command = process.env.npm_lifecycle_script || `cucumber-js ${processArgv}`
+
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     asyncResource.runInAsyncScope(() => {
-      sessionStartCh.publish({ command: 'cucumber-js', frameworkVersion })
+      sessionStartCh.publish({ command, frameworkVersion })
     })
     const success = await start.apply(this, arguments)
 

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -88,6 +88,7 @@ function wrapRun (pl, isLatestVersion) {
           } else {
             pickleResultByFile[testSuiteFullPath].push(status)
           }
+          // last test in suite
           if (pickleResultByFile[testSuiteFullPath].length === pickleByFile[testSuiteFullPath].length) {
             const testSuiteStatus = getSuiteStatusFromTestStatuses(pickleResultByFile[testSuiteFullPath])
             testSuiteFinishCh.publish(testSuiteStatus)

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -32,7 +32,7 @@ for (const packageName of names) {
           try {
             loadChannel.publish({ name, version, file })
 
-            moduleExports = hook(moduleExports)
+            moduleExports = hook(moduleExports, version)
           } catch (e) {
             log.error(e)
           }

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -139,6 +139,7 @@ class CucumberPlugin extends CiPlugin {
 
   startTestSpan (testName, testSuite) {
     const childOf = getTestParentSpan(this.tracer)
+    // TODO: move this logic to CiPlugin once every framework supports test suite level visibility
     // This is a hack to get good time resolution on test events, while keeping
     // the test event as the root span of its trace.
     childOf._trace.startTime = this.testSessionSpan.context()._trace.startTime

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -195,6 +195,7 @@ class JestPlugin extends CiPlugin {
       suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)
       suiteTags[TEST_COMMAND] = testSuiteSpan.context()._tags[TEST_COMMAND]
       suiteTags[TEST_BUNDLE] = testSuiteSpan.context()._tags[TEST_COMMAND]
+      // TODO: move this logic to CiPlugin once every framework supports test suite level visibility
       // This is a hack to get good time resolution on test events, while keeping
       // the test event as the root span of its trace.
       childOf = getTestParentSpan(this.tracer)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -173,6 +173,7 @@ class MochaPlugin extends CiPlugin {
 
   startTestSpan (test) {
     const childOf = getTestParentSpan(this.tracer)
+    // TODO: move this logic to CiPlugin once every framework supports test suite level visibility
     // This is a hack to get good time resolution on test events, while keeping
     // the test event as the root span of its trace.
     childOf._trace.startTime = this.testSessionSpan.context()._trace.startTime

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -139,6 +139,7 @@ class PlaywrightPlugin extends CiPlugin {
 
   startTestSpan (testName, testSuite) {
     const childOf = getTestParentSpan(this.tracer)
+    // TODO: move this logic to CiPlugin once every framework supports test suite level visibility
     // This is a hack to get good time resolution on test events, while keeping
     // the test event as the root span of its trace.
     childOf._trace.startTime = this.testSessionSpan.context()._trace.startTime


### PR DESCRIPTION
### What does this PR do?
Add support for test sessions, test module and test suites to `cucumber` plugin. 

### Motivation
Have the same level of support as other testing frameworks. 

### Additional Notes
The new logic is all covered by integration tests, which more closely resembles how cucumber is going to be used by customers. 