### PR TITLE
[ci-visibility] Add test suite level visibility to cypress

### DIFF
--- a/integration-tests/cypress-config.json
+++ b/integration-tests/cypress-config.json
@@ -1,0 +1,7 @@
+{
+  "video": false,
+  "screenshotOnRunFailure": false,
+  "pluginsFile": "cypress/plugins-old/index.js",
+  "supportFile": "cypress/support/e2e.js",
+  "integrationFolder": "cypress/e2e"
+}

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  e2e: {
+    setupNodeEvents (on, config) {
+      require('dd-trace/ci/cypress/plugin')(on, config)
+    }
+  },
+  video: false
+}

--- a/integration-tests/cypress.spec.js
+++ b/integration-tests/cypress.spec.js
@@ -1,0 +1,164 @@
+'use strict'
+
+const { exec } = require('child_process')
+
+const getPort = require('get-port')
+const { assert } = require('chai')
+
+const {
+  createSandbox,
+  getCiVisAgentlessConfig,
+  getCiVisEvpProxyConfig
+} = require('./helpers')
+const { FakeCiVisIntake } = require('./ci-visibility-intake')
+const webAppServer = require('./ci-visibility/web-app-server')
+const {
+  TEST_STATUS,
+  TEST_COMMAND,
+  TEST_BUNDLE,
+  TEST_FRAMEWORK_VERSION
+} = require('../packages/dd-trace/src/plugins/util/test')
+
+const versions = ['6.7.0', 'latest']
+
+versions.forEach((version) => {
+  describe(`cypress@${version}`, function () {
+    this.retries(2)
+    this.timeout(45000)
+    let sandbox, cwd, receiver, childProcess, webAppPort
+    before(async () => {
+      sandbox = await createSandbox([`cypress@${version}`], true)
+      cwd = sandbox.folder
+      webAppPort = await getPort()
+      webAppServer.listen(webAppPort)
+    })
+
+    after(async () => {
+      await sandbox.remove()
+      await new Promise(resolve => webAppServer.close(resolve))
+    })
+
+    beforeEach(async function () {
+      const port = await getPort()
+      receiver = await new FakeCiVisIntake(port).start()
+    })
+
+    afterEach(async () => {
+      childProcess.kill()
+      await receiver.stop()
+    })
+    const reportMethods = ['agentless', 'evp proxy']
+
+    reportMethods.forEach((reportMethod) => {
+      context(`reporting via ${reportMethod}`, () => {
+        it('can run and report tests', (done) => {
+          const envVars = reportMethod === 'agentless'
+            ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
+          const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
+
+          receiver.gatherPayloads(({ url }) => url === reportUrl, 25000).then((payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const testSessionEvent = events.find(event => event.type === 'test_session_end')
+            const testModuleEvent = events.find(event => event.type === 'test_module_end')
+            const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            const { content: testSessionEventContent } = testSessionEvent
+            const { content: testModuleEventContent } = testModuleEvent
+
+            assert.exists(testSessionEventContent.test_session_id)
+            assert.exists(testModuleEventContent.meta[TEST_COMMAND])
+            assert.equal(testSessionEventContent.resource.startsWith('test_session.'), true)
+            assert.equal(testSessionEventContent.meta[TEST_STATUS], 'fail')
+
+            assert.exists(testModuleEventContent.test_session_id)
+            assert.exists(testModuleEventContent.test_module_id)
+            assert.exists(testModuleEventContent.meta[TEST_COMMAND])
+            assert.exists(testModuleEventContent.meta[TEST_BUNDLE])
+            assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
+            assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
+            assert.equal(
+              testModuleEventContent.test_session_id.toString(10),
+              testSessionEventContent.test_session_id.toString(10)
+            )
+            assert.exists(testModuleEventContent.meta[TEST_FRAMEWORK_VERSION])
+
+            assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
+              'test_suite.cypress/e2e/other.cy.js',
+              'test_suite.cypress/e2e/spec.cy.js'
+            ])
+
+            assert.includeMembers(testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]), [
+              'pass',
+              'fail'
+            ])
+
+            testSuiteEvents.forEach(({
+              content: {
+                meta,
+                test_suite_id: testSuiteId,
+                test_module_id: testModuleId,
+                test_session_id: testSessionId
+              }
+            }) => {
+              assert.exists(meta[TEST_COMMAND])
+              assert.exists(meta[TEST_BUNDLE])
+              assert.exists(testSuiteId)
+              assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+              assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+            })
+
+            assert.includeMembers(testEvents.map(test => test.content.resource), [
+              'cypress/e2e/other.cy.js.context passes',
+              'cypress/e2e/spec.cy.js.context passes',
+              'cypress/e2e/spec.cy.js.other context fails'
+            ])
+
+            assert.includeMembers(testEvents.map(test => test.content.meta[TEST_STATUS]), [
+              'pass',
+              'pass',
+              'fail'
+            ])
+
+            testEvents.forEach(({
+              content: {
+                meta,
+                test_suite_id: testSuiteId,
+                test_module_id: testModuleId,
+                test_session_id: testSessionId
+              }
+            }) => {
+              assert.exists(meta[TEST_COMMAND])
+              assert.exists(meta[TEST_BUNDLE])
+              assert.exists(testSuiteId)
+              assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+              assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+            })
+
+            done()
+          }).catch(done)
+
+          const {
+            NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+            ...restEnvVars
+          } = envVars
+
+          const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json' : ''
+
+          childProcess = exec(
+            `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+            {
+              cwd,
+              env: {
+                ...restEnvVars,
+                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+              },
+              stdio: 'on'
+            }
+          )
+        })
+      })
+    })
+  })
+})

--- a/integration-tests/cypress/e2e/other.cy.js
+++ b/integration-tests/cypress/e2e/other.cy.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+describe('context', () => {
+  it('passes', () => {
+    cy.visit('/')
+      .get('.hello-world')
+      .should('have.text', 'Hello World')
+  })
+})

--- a/integration-tests/cypress/e2e/spec.cy.js
+++ b/integration-tests/cypress/e2e/spec.cy.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+describe('context', () => {
+  it('passes', () => {
+    cy.visit('/')
+      .get('.hello-world')
+      .should('have.text', 'Hello World')
+  })
+})
+
+describe('other context', () => {
+  it('fails', () => {
+    cy.visit('/')
+      .get('.hello-world')
+      .should('have.text', 'Hello Warld')
+  })
+})

--- a/integration-tests/cypress/plugins-old/index.js
+++ b/integration-tests/cypress/plugins-old/index.js
@@ -1,0 +1,3 @@
+module.exports = (on, config) => {
+  require('dd-trace/ci/cypress/plugin')(on, config)
+}

--- a/integration-tests/cypress/support/e2e.js
+++ b/integration-tests/cypress/support/e2e.js
@@ -1,0 +1,1 @@
+import 'dd-trace/ci/cypress/support'

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -8,7 +8,12 @@ beforeEach(() => {
   })
 })
 
+before(() => {
+  cy.task('dd:testSuiteStart', Cypress.mocha.getRootSuite().file)
+})
+
 after(() => {
+  cy.task('dd:testSuiteFinish', Cypress.mocha.getRunner().stats)
   cy.window().then(win => {
     win.dispatchEvent(new Event('beforeunload'))
   })


### PR DESCRIPTION
### What does this PR do?
Add support for test sessions, test module and test suites to `cypress` plugin. 

### Motivation
Have the same level of support as other testing frameworks. 

### Additional Notes
The new logic is all covered by integration tests, which more closely resembles how cucumber is going to be used by customers. 