### PR TITLE
retry k8s docker image builds with delay

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,16 +20,6 @@ deploy_to_reliability_env:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
 
-
-nap:
-  stage: deploy
-  script: "sleep 600" # sleep for ten minutes
-
-# this step pulls a docker image and then publishes it elsewhere
-# it previously started almost immediately
-# at the same time a GitHub action publishes the image to be pulled
-# this resulted in a race condition
-# therefore, we're sleeping before attempting the pull
 deploy_to_docker_registries:
   stage: deploy
   rules:
@@ -47,9 +37,8 @@ deploy_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-js-init:$CI_COMMIT_TAG
     IMG_SIGNING: "false"
-  retry: 2
-  needs:
-    - job: nap
+    RETRY_COUNT: 5
+    RETRY_DELAY: 300
 
 deploy_latest_to_docker_registries:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,16 @@ deploy_to_reliability_env:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
     FORCE_TRIGGER: $FORCE_TRIGGER
 
+
+nap:
+  stage: deploy
+  script: "sleep 600" # sleep for ten minutes
+
+# this step pulls a docker image and then publishes it elsewhere
+# it previously started almost immediately
+# at the same time a GitHub action publishes the image to be pulled
+# this resulted in a race condition
+# therefore, we're sleeping before attempting the pull
 deploy_to_docker_registries:
   stage: deploy
   rules:
@@ -37,6 +47,9 @@ deploy_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-js-init:$CI_COMMIT_TAG
     IMG_SIGNING: "false"
+  retry: 2
+  needs:
+    - job: nap
 
 deploy_latest_to_docker_registries:
   stage: deploy


### PR DESCRIPTION
### What does this PR do?
- this should allow GitLab to retry the k8s build step with a five minute gap between retries
- apparently it's built in to the `DataDog/public-images` project

### Motivation
- this should fix a race condition between a GitHub job that builds a container and a GitLab job that pulls it

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
