### PR TITLE
Update ioredis type information documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1375,7 +1375,7 @@ declare namespace plugins {
    */
   interface ioredis extends Instrumentation {
     /**
-     * List of commands that should be instrumented.
+     * List of commands that should be instrumented. Commands must be in lowercase for example 'xread'.
      *
      * @default /^.*$/
      */
@@ -1391,7 +1391,7 @@ declare namespace plugins {
 
     /**
      * List of commands that should not be instrumented. Takes precedence over
-     * allowlist if a command matches an entry in both.
+     * allowlist if a command matches an entry in both. Commands must be in lowercase for example 'xread'.
      *
      * @default []
      */


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the type documentation to inform developers to use lowercase `ioredis` commands

### Motivation
<!-- What inspired you to submit this pull request? -->
The ioredis plugin is based on the redis plugin which formats the command to uppercase when starting the span. This can be confusing when trying to blocklist a command which is represented in uppercase in the Datadog APM UI

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [x] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
