### PR TITLE
[ci-visibility] Increase timeout for `/skippable` call 

### DIFF
--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -19,7 +19,7 @@ function getSkippableSuites ({
     headers: {
       'Content-Type': 'application/json'
     },
-    timeout: 15000,
+    timeout: 20000,
     url
   }
 


### PR DESCRIPTION
### What does this PR do?
Increase timeout for `/skippable` request to 20 seconds.

### Motivation
Analysis of the queries to `/skippable` for big repositories show that some requests take slightly longer than 15 seconds. This PR increases the timeout to 20s to give room for these queries. 

