### PR TITLE
[ci-visibility] Update framework version calculation in ci plugins

### DIFF
--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -180,7 +180,7 @@ addHook({
   name: '@cucumber/cucumber',
   versions: ['>=7.0.0'],
   file: 'lib/runtime/index.js'
-}, (runtimePackage, frameworkVersion) => {
+}, (runtimePackage, cucumberVersion) => {
   shimmer.wrap(runtimePackage.default.prototype, 'start', start => async function () {
     pickleByFile = getPickleByFile(this)
 
@@ -189,7 +189,7 @@ addHook({
 
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     asyncResource.runInAsyncScope(() => {
-      sessionStartCh.publish({ command, frameworkVersion })
+      sessionStartCh.publish({ command, frameworkVersion: cucumberVersion })
     })
     const success = await start.apply(this, arguments)
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -72,7 +72,7 @@ function getTestEnvironmentOptions (config) {
   return {}
 }
 
-function getWrappedEnvironment (BaseEnvironment) {
+function getWrappedEnvironment (BaseEnvironment, jestVersion) {
   return class DatadogEnvironment extends BaseEnvironment {
     constructor (config, context) {
       super(config, context)
@@ -116,7 +116,8 @@ function getWrappedEnvironment (BaseEnvironment) {
             name: getJestTestName(event.test),
             suite: this.testSuite,
             runner: 'jest-circus',
-            testParameters
+            testParameters,
+            frameworkVersion: jestVersion
           })
           originalTestFns.set(event.test, event.test.fn)
           event.test.fn = asyncResource.bind(event.test.fn)
@@ -142,7 +143,8 @@ function getWrappedEnvironment (BaseEnvironment) {
           testSkippedCh.publish({
             name: getJestTestName(event.test),
             suite: this.testSuite,
-            runner: 'jest-circus'
+            runner: 'jest-circus',
+            frameworkVersion: jestVersion
           })
         })
       }
@@ -150,14 +152,14 @@ function getWrappedEnvironment (BaseEnvironment) {
   }
 }
 
-function getTestEnvironment (pkg) {
+function getTestEnvironment (pkg, jestVersion) {
   if (pkg.default) {
-    const wrappedTestEnvironment = getWrappedEnvironment(pkg.default)
+    const wrappedTestEnvironment = getWrappedEnvironment(pkg.default, jestVersion)
     pkg.default = wrappedTestEnvironment
     pkg.TestEnvironment = wrappedTestEnvironment
     return pkg
   }
-  return getWrappedEnvironment(pkg)
+  return getWrappedEnvironment(pkg, jestVersion)
 }
 
 addHook({
@@ -438,7 +440,7 @@ addHook({
   versions: ['24.8.0 - 24.9.0']
 }, jestConfigSyncWrapper)
 
-function jasmineAsyncInstallWraper (jasmineAsyncInstallExport) {
+function jasmineAsyncInstallWraper (jasmineAsyncInstallExport, jestVersion) {
   return function (globalConfig, globalInput) {
     globalInput._ddtrace = global._ddtrace
     shimmer.wrap(globalInput.jasmine.Spec.prototype, 'execute', execute => function (onComplete) {
@@ -448,7 +450,8 @@ function jasmineAsyncInstallWraper (jasmineAsyncInstallExport) {
         testStartCh.publish({
           name: this.getFullName(),
           suite: testSuite,
-          runner: 'jest-jasmine2'
+          runner: 'jest-jasmine2',
+          frameworkVersion: jestVersion
         })
         const spec = this
         const callback = asyncResource.bind(function () {

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -38,7 +38,7 @@ const testFileToSuiteAr = new Map()
 const originalCoverageMap = createCoverageMap()
 
 let suitesToSkip = []
-let mochaVersion
+let frameworkVersion
 
 function getSuitesByTestFile (root) {
   const suitesByTestFile = {}
@@ -128,7 +128,7 @@ function mochaHook (Runner) {
     this.once('start', testRunAsyncResource.bind(function () {
       const processArgv = process.argv.slice(2).join(' ')
       const command = `mocha ${processArgv}`
-      testSessionStartCh.publish({ command, frameworkVersion: mochaVersion })
+      testSessionStartCh.publish({ command, frameworkVersion })
     }))
 
     this.on('suite', function (suite) {
@@ -313,14 +313,14 @@ addHook({
   name: 'mocha',
   versions: ['>=5.2.0'],
   file: 'lib/mocha.js'
-}, (Mocha) => {
+}, (Mocha, mochaVersion) => {
+  frameworkVersion = mochaVersion
   const mochaRunAsyncResource = new AsyncResource('bound-anonymous-fn')
   /**
    * Get ITR configuration and skippable suites
    * If ITR is disabled, `onDone` is called immediately on the subscriber
    */
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
-    mochaVersion = this.version
     if (!itrConfigurationCh.hasSubscribers) {
       return run.apply(this, arguments)
     }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -181,17 +181,15 @@ function dispatcherHookNew (dispatcherExport) {
   return dispatcherExport
 }
 
-function runnerHook (runnerExport) {
+function runnerHook (runnerExport, playwrightVersion) {
   shimmer.wrap(runnerExport.Runner.prototype, 'runAllTests', runAllTests => async function () {
     const testSessionAsyncResource = new AsyncResource('bound-anonymous-fn')
-    const { version: frameworkVersion } = getPlaywrightConfig(this)
-
     const rootDir = getRootDir(this)
 
     const processArgv = process.argv.slice(2).join(' ')
     const command = `playwright ${processArgv}`
     testSessionAsyncResource.runInAsyncScope(() => {
-      testSessionStartCh.publish({ command, frameworkVersion, rootDir })
+      testSessionStartCh.publish({ command, frameworkVersion: playwrightVersion, rootDir })
     })
 
     const res = await runAllTests.apply(this, arguments)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -158,7 +158,13 @@ class CucumberPlugin extends CiPlugin {
     testSuiteTags[TEST_COMMAND] = this.command
     testSuiteTags[TEST_BUNDLE] = this.command
 
-    return super.startTestSpan(testName, testSuite, testSuiteTags, childOf)
+    return super.startTestSpan(
+      testName,
+      testSuite,
+      childOf,
+      this.frameworkVersion,
+      testSuiteTags
+    )
   }
 }
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -17,8 +17,7 @@ const {
   TEST_MODULE_ID,
   TEST_SUITE_ID,
   TEST_COMMAND,
-  TEST_BUNDLE,
-  TEST_FRAMEWORK_VERSION
+  TEST_BUNDLE
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
@@ -106,7 +105,7 @@ class JestPlugin extends CiPlugin {
       })
     })
 
-    this.addSub('ci:jest:test-suite:start', ({ testSuite, testEnvironmentOptions, jestVersion }) => {
+    this.addSub('ci:jest:test-suite:start', ({ testSuite, testEnvironmentOptions, frameworkVersion }) => {
       const {
         _ddTestSessionId: testSessionId,
         _ddTestCommand: testCommand,
@@ -120,7 +119,7 @@ class JestPlugin extends CiPlugin {
         'x-datadog-parent-id': testModuleId
       })
 
-      const testSuiteMetadata = getTestSuiteCommonTags(testCommand, jestVersion, testSuite)
+      const testSuiteMetadata = getTestSuiteCommonTags(testCommand, frameworkVersion, testSuite)
 
       const testSuiteSpan = this.tracer.startSpan('jest.test_suite', {
         childOf: testSessionSpanContext,
@@ -185,7 +184,7 @@ class JestPlugin extends CiPlugin {
   }
 
   startTestSpan (test) {
-    let childOf, frameworkVersion
+    let childOf
     const suiteTags = {}
     const store = storage.getStore()
     const testSuiteSpan = store ? store.span : undefined
@@ -202,10 +201,9 @@ class JestPlugin extends CiPlugin {
       childOf = getTestParentSpan(this.tracer)
       childOf._trace.startTime = testSuiteSpan.context()._trace.startTime
       childOf._trace.ticks = testSuiteSpan.context()._trace.ticks
-      frameworkVersion = testSuiteSpan.context()._tags[TEST_FRAMEWORK_VERSION]
     }
 
-    const { suite, name, runner, testParameters } = test
+    const { suite, name, runner, testParameters, frameworkVersion } = test
 
     const extraTags = {
       [JEST_TEST_RUNNER]: runner,

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -54,6 +54,7 @@ class MochaPlugin extends CiPlugin {
       const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion)
 
       this.command = command
+      this.frameworkVersion = frameworkVersion
       this.testSessionSpan = this.tracer.startSpan('mocha.test_session', {
         childOf,
         tags: {
@@ -78,7 +79,7 @@ class MochaPlugin extends CiPlugin {
       const store = storage.getStore()
       const testSuiteMetadata = getTestSuiteCommonTags(
         this.command,
-        this.tracer._version,
+        this.frameworkVersion,
         getTestSuitePath(suite.file, this.sourceRoot)
       )
       const testSuiteSpan = this.tracer.startSpan('mocha.test_suite', {
@@ -212,7 +213,7 @@ class MochaPlugin extends CiPlugin {
       extraTags[TEST_PARAMETERS] = testParametersString
     }
 
-    return super.startTestSpan(fullTestName, testSuite, extraTags, childOf)
+    return super.startTestSpan(fullTestName, testSuite, childOf, this.frameworkVersion, extraTags)
   }
 }
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -165,7 +165,7 @@ class PlaywrightPlugin extends CiPlugin {
       testSuiteTags[TEST_BUNDLE] = this.command
     }
 
-    return super.startTestSpan(testName, testSuite, testSuiteTags, childOf)
+    return super.startTestSpan(testName, testSuite, childOf, this.frameworkVersion, testSuiteTags)
   }
 }
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -70,9 +70,9 @@ module.exports = class CiPlugin extends Plugin {
     }
   }
 
-  startTestSpan (name, suite, extraTags, childOf) {
+  startTestSpan (name, suite, childOf, frameworkVersion, extraTags) {
     const parent = childOf || getTestParentSpan(this.tracer)
-    const testCommonTags = getTestCommonTags(name, suite, this.tracer._version)
+    const testCommonTags = getTestCommonTags(name, suite, frameworkVersion)
 
     const testTags = {
       ...testCommonTags,


### PR DESCRIPTION
### What does this PR do?
Get framework version from ritm hook function in every CI Visibility plugin (but cypress, which does not use ritm). 

### Motivation
After https://github.com/DataDog/dd-trace-js/pull/2782/files#diff-0f4756798ec0b2564244375056c78d8ceca75a90a6b6dbc152d5468eb754c618R35 we're able to get the version of the library we're patching directly from the hook function. This allows us to have a single way to get this version, instead of a per framework solution.

