### PR TITLE
[ci-visibility] Move common functionality to `CiPlugin`

### DIFF
--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -6,16 +6,8 @@ const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const {
   TEST_STATUS,
   finishAllTraceSpans,
-  getTestParentSpan,
-  getTestSessionCommonTags,
   getTestSuitePath,
-  TEST_SESSION_ID,
-  TEST_COMMAND,
-  TEST_SUITE_ID,
-  getTestSuiteCommonTags,
-  getTestModuleCommonTags,
-  TEST_MODULE_ID,
-  TEST_BUNDLE
+  getTestSuiteCommonTags
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -29,32 +21,6 @@ class PlaywrightPlugin extends CiPlugin {
     super(...args)
 
     this._testSuites = new Map()
-
-    this.addSub('ci:playwright:session:start', ({ command, frameworkVersion, rootDir }) => {
-      const childOf = getTestParentSpan(this.tracer)
-      this.command = command
-      this.frameworkVersion = frameworkVersion
-      this.rootDir = rootDir
-
-      const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion)
-      this.testSessionSpan = this.tracer.startSpan('playwright.test_session', {
-        childOf,
-        tags: {
-          [COMPONENT]: this.constructor.name,
-          ...this.testEnvironmentMetadata,
-          ...testSessionSpanMetadata
-        }
-      })
-      const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion)
-      this.testModuleSpan = this.tracer.startSpan('playwright.test_module', {
-        childOf: this.testSessionSpan,
-        tags: {
-          [COMPONENT]: this.constructor.name,
-          ...this.testEnvironmentMetadata,
-          ...testModuleSpanMetadata
-        }
-      })
-    })
 
     this.addSub('ci:playwright:session:finish', ({ status, onDone }) => {
       this.testModuleSpan.setTag(TEST_STATUS, status)
@@ -138,34 +104,8 @@ class PlaywrightPlugin extends CiPlugin {
   }
 
   startTestSpan (testName, testSuite) {
-    const childOf = getTestParentSpan(this.tracer)
-    // TODO: move this logic to CiPlugin once every framework supports test suite level visibility
-    // This is a hack to get good time resolution on test events, while keeping
-    // the test event as the root span of its trace.
-    childOf._trace.startTime = this.testSessionSpan.context()._trace.startTime
-    childOf._trace.ticks = this.testSessionSpan.context()._trace.ticks
-
-    const testSuiteTags = {}
     const testSuiteSpan = this._testSuites.get(testSuite)
-    if (testSuiteSpan) {
-      const testSuiteId = testSuiteSpan.context().toSpanId()
-      testSuiteTags[TEST_SUITE_ID] = testSuiteId
-    }
-
-    if (this.testSessionSpan) {
-      const testSessionId = this.testSessionSpan.context().toTraceId()
-      testSuiteTags[TEST_SESSION_ID] = testSessionId
-      testSuiteTags[TEST_COMMAND] = this.command
-    }
-
-    if (this.testModuleSpan) {
-      const testModuleId = this.testModuleSpan.context().toSpanId()
-      testSuiteTags[TEST_MODULE_ID] = testModuleId
-      testSuiteTags[TEST_COMMAND] = this.command
-      testSuiteTags[TEST_BUNDLE] = this.command
-    }
-
-    return super.startTestSpan(testName, testSuite, childOf, this.frameworkVersion, testSuiteTags)
+    return super.startTestSpan(testName, testSuite, testSuiteSpan)
   }
 }
 

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -243,8 +243,9 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       event => event.type === 'test_session_end' || event.type === 'test_suite_end' || event.type === 'test_module_end'
     )
 
-    const isTestSessionTrace = !!testSessionEvents.length
-    const events = isTestSessionTrace ? testSessionEvents : rawEvents
+    const isTestTrace = rawEvents.find(event => event.type === 'test')
+
+    const events = isTestTrace ? rawEvents : testSessionEvents
 
     this._eventCount += events.length
 

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -243,9 +243,8 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       event => event.type === 'test_session_end' || event.type === 'test_suite_end' || event.type === 'test_module_end'
     )
 
-    const isTestTrace = rawEvents.find(event => event.type === 'test')
-
-    const events = isTestTrace ? rawEvents : testSessionEvents
+    const isTestSessionTrace = !!testSessionEvents.length
+    const events = isTestSessionTrace ? testSessionEvents : rawEvents
 
     this._eventCount += events.length
 


### PR DESCRIPTION
### What does this PR do?
* Move `:session:start` logic to `CiPlugin`.
* Change `CiPlugin#startTestSpan` to include test suite level tags.
* Add some safeguards when accessing `store.span`. 

### Motivation
Now that every CI plugin has test suite level visibility, it makes sense to move common functionality to `CiPlugin`.

