### PR TITLE
Run tracing tests with node v16.13.1 version

### DIFF
--- a/.github/actions/node/16.13.1/action.yml
+++ b/.github/actions/node/16.13.1/action.yml
@@ -1,0 +1,8 @@
+name: Node 16.13.1
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      # channel.unsubscribe bug
+      with:
+        node-version: '16.13.1'

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -42,6 +42,8 @@ jobs:
       - run: MOCHA_FILE=test-results/tracing/linux-18.xml yarn test:trace:core:ci
       - uses: ./.github/actions/node/latest
       - run: MOCHA_FILE=test-results/tracing/linux-latest.xml yarn test:trace:core:ci
+      - uses: ./.github/actions/node/16.13.1
+      - run: MOCHA_FILE=test-results/tracing/linux-16.13.1.xml yarn test:trace:core:ci
       - uses: ./.github/actions/datadog-ci
       - run: |
           datadog-ci junit upload --service dd-trace-js-tests --tags os.platform:linux --tags runtime.version:14 test-results/tracing/linux-14.xml

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -278,4 +278,18 @@ describe('log', () => {
       expect(console.error).to.have.been.calledOnce
     })
   })
+
+  describe('unsubscribe', () => {
+    it('should fail when invoking unsubscribe with 16.13.1 node version', () => {
+      const dc = require('diagnostics_channel')
+      const ddTestChannel = dc.channel('dd:test:unsubscribe')
+
+      const version = process.version
+      if (version === 'v16.13.1') {
+        expect(() => ddTestChannel.unsubscribe(() => {})).to.throw
+      } else {
+        expect(() => ddTestChannel.unsubscribe(() => {})).to.not.throw
+      }
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Runs tracing tests with node `v16.13.1` version.
It could be run with `v17.1.0` or on each major versions with the bug too.

### Motivation
Some node versions (ie: >=`14.17.0/15.1.0 <14.19.0/16.14.0/17.1.0`) throws a `TypeError: channel.unsubscribe is not a function` when `unsubscribe` method is invoked on a channel without subscribers.
This is an attempt to detect possible runtime errors on these outdated node versions.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
