### PR TITLE
[ci-visibility] Fix cypress test suite level visibility for some cases

### DIFF
--- a/packages/datadog-instrumentations/src/cypress.js
+++ b/packages/datadog-instrumentations/src/cypress.js
@@ -5,4 +5,4 @@ const { addHook } = require('./helpers/instrument')
 addHook({
   name: 'cypress',
   versions: ['>=6.7.0']
-})
+}, lib => lib)


### PR DESCRIPTION
### What does this PR do?
Fix some edges cases found in e2e tests for cypress.

### Motivation
Some e2e tests are failing because some suites call `before` twice. 

