### PR TITLE
[ci-visibility] Fix cypress integration test for older node versions

### DIFF
--- a/integration-tests/cypress.spec.js
+++ b/integration-tests/cypress.spec.js
@@ -4,6 +4,7 @@ const { exec } = require('child_process')
 
 const getPort = require('get-port')
 const { assert } = require('chai')
+const semver = require('semver')
 
 const {
   createSandbox,
@@ -19,7 +20,10 @@ const {
   TEST_FRAMEWORK_VERSION
 } = require('../packages/dd-trace/src/plugins/util/test')
 
-const versions = ['6.7.0', 'latest']
+// TODO: remove when 2.x support is removed.
+// This is done because from playwright@>=1.22.0 node 12 is not supported
+const isOldNode = semver.satisfies(process.version, '<=12')
+const versions = ['6.7.0', isOldNode ? '11.2.0' : 'latest']
 
 versions.forEach((version) => {
   describe(`cypress@${version}`, function () {


### PR DESCRIPTION
### What does this PR do?
Use an older version of `cypress` for integration tests in `2.x`

### Motivation
Fix tests in 2.x branch

