### PR TITLE
Fix path traversal vulnerability detection

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -37,7 +37,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
       if (obj.target) {
         pathArguments.push(obj.target)
       }
-      this.analyze(pathArguments)
+      pathArguments.length > 0 && this.analyze(pathArguments)
     })
 
     this.exclusionList = [ path.join('node_modules', 'send') + path.sep ]

--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -59,7 +59,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
 
     if (value && value.constructor === Array) {
       for (const val of value) {
-        if (this._isVulnerable(val, iastContext)) {
+        if (this._isVulnerable(val, iastContext) && this._checkOCE(iastContext)) {
           this._report(val, iastContext)
           // no support several evidences in the same vulnerability, just report the 1st one
           break

--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -9,6 +9,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
   constructor () {
     super('PATH_TRAVERSAL')
     this.addSub('apm:fs:operation:start', obj => {
+      if (obj.innerCall) return
       const pathArguments = []
       if (obj.dest) {
         pathArguments.push(obj.dest)

--- a/packages/dd-trace/src/appsec/iast/path-line.js
+++ b/packages/dd-trace/src/appsec/iast/path-line.js
@@ -19,7 +19,9 @@ const EXCLUDED_PATH_PREFIXES = [
   'node:child_process',
   'child_process',
   'node:async_hooks',
-  'async_hooks'
+  'async_hooks',
+  'fs',
+  'node:fs'
 ]
 
 function getCallSiteInfo () {

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -452,7 +452,7 @@ prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, t
   })
   if (fs.rm) {
     describe('test rm', () => {
-      const filename = path.join(os.tmpdir(), 'test-rmdir')
+      const filename = path.join(os.tmpdir(), 'test-rm')
       beforeEach(() => {
         fs.writeFileSync(filename, '')
       })


### PR DESCRIPTION
### What does this PR do?

- Fixes a bug to report path traversal vulnerability with correct location (exclude `node:fs` trace)
- Adds the `Overhead Controller` check when analyzing a path traversal vulnerability.
- Adds a flag in the message published by `fs` instrumentation to check if `fs` operation is an inner call or not in order to avoid analyzing subsequent calls from a `fs` operation.

### Motivation
Same path traversal vulnerability were reported multiple times, sometimes with the incorrect location.

