### PR TITLE
[ci-visibility] Automatically unshallow repo

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -158,7 +158,7 @@ function sendGitMetadata (url, isEvpProxy, callback) {
   if (!repositoryUrl) {
     return callback(new Error('Repository URL is empty'))
   }
-
+  console.log('isShallowRepository', isShallowRepository())
   if (isShallowRepository()) {
     unshallowRepository()
   }

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -158,7 +158,7 @@ function sendGitMetadata (url, isEvpProxy, callback) {
   if (!repositoryUrl) {
     return callback(new Error('Repository URL is empty'))
   }
-  console.log('isShallowRepository', isShallowRepository())
+
   if (isShallowRepository()) {
     unshallowRepository()
   }

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -10,7 +10,9 @@ const {
   getLatestCommits,
   getRepositoryUrl,
   generatePackFilesForCommits,
-  getCommitsToUpload
+  getCommitsToUpload,
+  isShallowRepository,
+  unshallowRepository
 } = require('../../../plugins/util/git')
 
 const isValidSha = (sha) => /[0-9a-f]{40}/.test(sha)
@@ -155,6 +157,10 @@ function sendGitMetadata (url, isEvpProxy, callback) {
 
   if (!repositoryUrl) {
     return callback(new Error('Repository URL is empty'))
+  }
+
+  if (isShallowRepository()) {
+    unshallowRepository()
   }
 
   getCommitsToExclude({ url, repositoryUrl, isEvpProxy }, (err, commitsToExclude, headCommit) => {

--- a/packages/dd-trace/src/plugins/util/exec.js
+++ b/packages/dd-trace/src/plugins/util/exec.js
@@ -1,8 +1,8 @@
-const { execSync } = require('child_process')
+const cp = require('child_process')
 
 const sanitizedExec = (cmd, options = {}) => {
   try {
-    return execSync(cmd, options).toString().replace(/(\r\n|\n|\r)/gm, '')
+    return cp.execSync(cmd, options).toString().replace(/(\r\n|\n|\r)/gm, '')
   } catch (e) {
     return ''
   }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -30,12 +30,13 @@ function isShallowRepository () {
 function unshallowRepository () {
   let output
   try {
-    output = sanitizedExec('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' })
+    output = execSync('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' }).toString()
     console.log('config change: ', output)
-    output = sanitizedExec('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })
+    output = execSync('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })
+      .toString()
     console.log('unshallow: ', output)
-  } catch (e) {
-    log.error(e)
+  } catch (err) {
+    console.log('error unshallowRepository:', err)
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -26,6 +26,7 @@ function isShallowRepository () {
 }
 
 function unshallowRepository () {
+  console.log('calling unshallow!')
   try {
     execSync('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' })
     execSync('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -22,21 +22,15 @@ const {
 const GIT_REV_LIST_MAX_BUFFER = 8 * 1024 * 1024 // 8MB
 
 function isShallowRepository () {
-  const output = sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' })
-  console.log('output', output)
-  return output === 'true'
+  return sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' }) === 'true'
 }
 
 function unshallowRepository () {
-  let output
   try {
-    output = execSync('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' }).toString()
-    console.log('config change: ', output)
-    output = execSync('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })
-      .toString()
-    console.log('unshallow: ', output)
+    execSync('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' })
+    execSync('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })
   } catch (err) {
-    console.log('error unshallowRepository:', err)
+    log.error(err)
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -21,6 +21,24 @@ const {
 
 const GIT_REV_LIST_MAX_BUFFER = 8 * 1024 * 1024 // 8MB
 
+function isShallowRepository () {
+  const output = sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' })
+  console.log('output', output)
+  return output === 'true'
+}
+
+function unshallowRepository () {
+  let output
+  try {
+    output = sanitizedExec('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' })
+    console.log('config change: ', output)
+    output = sanitizedExec('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })
+    console.log('unshallow: ', output)
+  } catch (e) {
+    log.error(e)
+  }
+}
+
 function getRepositoryUrl () {
   return sanitizedExec('git config --get remote.origin.url', { stdio: 'pipe' })
 }
@@ -146,5 +164,7 @@ module.exports = {
   getRepositoryUrl,
   generatePackFilesForCommits,
   getCommitsToUpload,
-  GIT_REV_LIST_MAX_BUFFER
+  GIT_REV_LIST_MAX_BUFFER,
+  isShallowRepository,
+  unshallowRepository
 }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -22,7 +22,9 @@ const {
 const GIT_REV_LIST_MAX_BUFFER = 8 * 1024 * 1024 // 8MB
 
 function isShallowRepository () {
-  return sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' }) === 'true'
+  const res = sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' })
+  console.log('isShallowRepository:', res)
+  return res === 'true'
 }
 
 function unshallowRepository () {

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -22,13 +22,10 @@ const {
 const GIT_REV_LIST_MAX_BUFFER = 8 * 1024 * 1024 // 8MB
 
 function isShallowRepository () {
-  const res = sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' })
-  console.log('isShallowRepository:', res)
-  return res === 'true'
+  return sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' }) === 'true'
 }
 
 function unshallowRepository () {
-  console.log('calling unshallow!')
   try {
     execSync('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' })
     execSync('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -1,4 +1,6 @@
 'use strict'
+const cp = require('child_process')
+
 const { expect } = require('chai')
 const nock = require('nock')
 
@@ -8,7 +10,11 @@ describe.only('CI Visibility Agentless Exporter', () => {
   const url = new URL('http://www.example.com')
 
   beforeEach(() => {
+    sinon.stub(cp, 'execSync').returns('falsssse')
     nock.cleanAll()
+  })
+  afterEach(() => {
+    sinon.restore()
   })
 
   before(() => {

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -6,7 +6,7 @@ const nock = require('nock')
 
 const AgentlessCiVisibilityExporter = require('../../../../src/ci-visibility/exporters/agentless')
 
-describe.only('CI Visibility Agentless Exporter', () => {
+describe('CI Visibility Agentless Exporter', () => {
   const url = new URL('http://www.example.com')
 
   beforeEach(() => {
@@ -33,7 +33,7 @@ describe.only('CI Visibility Agentless Exporter', () => {
   })
 
   describe('when ITR is enabled', () => {
-    it.only('will request configuration to api.site by default', (done) => {
+    it('will request configuration to api.site by default', (done) => {
       const scope = nock('https://api.datadoge.c0m')
         .post('/api/v2/libraries/tests/services/setting')
         .reply(200, JSON.stringify({

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -10,7 +10,8 @@ describe('CI Visibility Agentless Exporter', () => {
   const url = new URL('http://www.example.com')
 
   beforeEach(() => {
-    sinon.stub(cp, 'execSync').returns('falsssse')
+    // to make sure `isShallowRepository` in `git.js` returns false
+    sinon.stub(cp, 'execSync').returns('false')
     nock.cleanAll()
   })
   afterEach(() => {

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -4,7 +4,7 @@ const nock = require('nock')
 
 const AgentlessCiVisibilityExporter = require('../../../../src/ci-visibility/exporters/agentless')
 
-describe('CI Visibility Agentless Exporter', () => {
+describe.only('CI Visibility Agentless Exporter', () => {
   const url = new URL('http://www.example.com')
 
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe('CI Visibility Agentless Exporter', () => {
   })
 
   describe('when ITR is enabled', () => {
-    it('will request configuration to api.site by default', (done) => {
+    it.only('will request configuration to api.site by default', (done) => {
       const scope = nock('https://api.datadoge.c0m')
         .post('/api/v2/libraries/tests/services/setting')
         .reply(200, JSON.stringify({

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -1,4 +1,5 @@
 'use strict'
+const cp = require('child_process')
 
 const CiVisibilityExporter = require('../../../src/ci-visibility/exporters/ci-visibility-exporter')
 const nock = require('nock')
@@ -7,9 +8,15 @@ describe('CI Visibility Exporter', () => {
   const port = 8126
 
   beforeEach(() => {
+    // to make sure `isShallowRepository` in `git.js` returns false
+    sinon.stub(cp, 'execSync').returns('false')
     process.env.DD_API_KEY = '1'
     process.env.DD_APP_KEY = '1'
     nock.cleanAll()
+  })
+
+  afterEach(() => {
+    sinon.restore()
   })
 
   describe('sendGitMetadata', () => {


### PR DESCRIPTION
### What does this PR do?
* If we detect we're in a shallow clone of a repository, we attempt to "unshallow it".

### Motivation
Some CI providers, such as github actions (see `fetch-depth` in https://github.com/actions/checkout), do shallow clones of the repositories they're going to run tests for. This is a problem for intelligent test runner and other CI Visibility features, that depend on knowing the git history to properly function.

This PR attempts to unshallow the repository by fetching it through these commands:
```
git config remote.origin.partialclonefilter "blob:none"
git fetch --shallow-since="1 month ago" --update-shallow --refetch
```

ℹ️ `blob:none` means that no actual file content is fetched but only git tree metadata (such as file names).
