### PR TITLE
Control naming of profile filename for file exporter 

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -24,6 +24,7 @@ const {
   DD_TRACE_AGENT_PORT,
   DD_PROFILING_UPLOAD_TIMEOUT,
   DD_PROFILING_SOURCE_MAP,
+  DD_PROFILING_UPLOAD_PERIOD,
   DD_PROFILING_PPROF_PREFIX
 } = process.env
 
@@ -36,9 +37,9 @@ class Config {
     const version = coalesce(options.version, DD_VERSION)
     const functionname = process.env.AWS_LAMBDA_FUNCTION_NAME
     // Must be longer than one minute so pad with five seconds
-    const flushInterval = coalesce(options.interval, 65 * 1000)
+    const flushInterval = coalesce(options.interval, Number(DD_PROFILING_UPLOAD_PERIOD) * 1000, 65 * 1000)
     const uploadTimeout = coalesce(options.uploadTimeout,
-      DD_PROFILING_UPLOAD_TIMEOUT, 60 * 1000)
+      Number(DD_PROFILING_UPLOAD_TIMEOUT), 60 * 1000)
     const sourceMap = coalesce(options.sourceMap,
       DD_PROFILING_SOURCE_MAP, true)
     const endpointCollection = coalesce(options.endpointCollection,

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -23,7 +23,8 @@ const {
   DD_AGENT_HOST,
   DD_TRACE_AGENT_PORT,
   DD_PROFILING_UPLOAD_TIMEOUT,
-  DD_PROFILING_SOURCE_MAP
+  DD_PROFILING_SOURCE_MAP,
+  DD_PROFILING_PPROF_PREFIX
 } = process.env
 
 class Config {
@@ -42,6 +43,8 @@ class Config {
       DD_PROFILING_SOURCE_MAP, true)
     const endpointCollection = coalesce(options.endpointCollection,
       DD_PROFILING_ENDPOINT_COLLECTION_ENABLED, false)
+    const pprofPrefix = coalesce(options.pprofPrefix,
+      DD_PROFILING_PPROF_PREFIX)
 
     this.enabled = String(enabled) !== 'false'
     this.service = service
@@ -60,6 +63,7 @@ class Config {
     this.uploadTimeout = uploadTimeout
     this.sourceMap = sourceMap
     this.endpointCollection = endpointCollection
+    this.pprofPrefix = pprofPrefix
 
     const hostname = coalesce(options.hostname, DD_AGENT_HOST) || 'localhost'
     const port = coalesce(options.port, DD_TRACE_AGENT_PORT) || 8126

--- a/packages/dd-trace/src/profiling/exporters/file.js
+++ b/packages/dd-trace/src/profiling/exporters/file.js
@@ -4,11 +4,22 @@ const fs = require('fs')
 const { promisify } = require('util')
 const writeFile = promisify(fs.writeFile)
 
+function formatDateTime (t) {
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${t.getUTCFullYear()}${pad(t.getUTCMonth() + 1)}${pad(t.getUTCDate())}` +
+         `T${pad(t.getUTCHours())}${pad(t.getUTCMinutes())}${pad(t.getUTCSeconds())}Z`
+}
+
 class FileExporter {
-  export ({ profiles }) {
+  constructor ({ pprofPrefix } = {}) {
+    this._pprofPrefix = pprofPrefix || ''
+  }
+
+  export ({ profiles, end }) {
     const types = Object.keys(profiles)
+    const dateStr = formatDateTime(end)
     const tasks = types.map(type => {
-      return writeFile(`${type}.pb.gz`, profiles[type])
+      return writeFile(`${this._pprofPrefix}${type}_${dateStr}.pprof`, profiles[type])
     })
 
     return Promise.all(tasks)

--- a/packages/dd-trace/test/profiling/exporters/file.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/file.spec.js
@@ -23,10 +23,21 @@ describe('exporters/file', () => {
     const profiles = {
       test: buffer
     }
-
-    await exporter.export({ profiles })
+    await exporter.export({ profiles, end: new Date('2023-02-10T21:03:05Z') })
 
     sinon.assert.calledOnce(fs.writeFile)
-    sinon.assert.calledWith(fs.writeFile, 'test.pb.gz', buffer)
+    sinon.assert.calledWith(fs.writeFile, 'test_20230210T210305Z.pprof', buffer)
+  })
+
+  it('should export to a file per profile type with given prefix', async () => {
+    const exporter = new FileExporter({ pprofPrefix: 'myprefix_' })
+    const buffer = Buffer.from('profile')
+    const profiles = {
+      test: buffer
+    }
+    await exporter.export({ profiles, end: new Date('2023-02-10T21:03:05Z') })
+
+    sinon.assert.calledOnce(fs.writeFile)
+    sinon.assert.calledWith(fs.writeFile, 'myprefix_test_20230210T210305Z.pprof', buffer)
   })
 })


### PR DESCRIPTION
### What does this PR do?

* Control the prefix of the profile filename through `DD_PROFILING_PPROF_PREFIX` env variable.
* Add the date/time to profile filename 
* Change the file extension from `.pb.gz` to `.pprof`.
* Allow changing the profile flushing interval with `DD_PROFILING_UPLOAD_PERIOD` env variable.

### Motivation
These changes will make adding the Node profiler to the [profiler correctness tests](https://github.com/DataDog/prof-correctness) easier:
* `.pprof` is the standard extension for profiles
* adding a prefix and the date/time avoids overwriting previous profiles and makes finding profiles easier 
* reducing the profile flush interval allows for shorter tests