### PR TITLE
Don't block request if headers have been sent

### DIFF
--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -3,6 +3,8 @@
 const fs = require('fs')
 let templateHtml, templateJson
 function block (req, res, topSpan, abortController) {
+  if (res.headersSent) return 
+
   let type
   let body
 

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const log = require('../log')
 const fs = require('fs')
 
 // TODO: move template loading to a proper spot.
@@ -8,7 +9,10 @@ let templateHtml = ''
 let templateJson = ''
 
 function block (req, res, rootSpan, abortController) {
-  if (res.headersSent) return
+  if (res.headersSent) {
+    log.warn('Cannot send blocking response when headers have already been sent')
+    return
+  }
 
   let type
   let body

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -239,6 +239,19 @@ describe('user_blocking', () => {
         }).then(done).catch(done)
         axios.get(`http://localhost:${port}/`)
       })
+
+      it('should not set the proper tags when response has already been sent', (done) => {
+        controller = (req, res) => {
+          res.end()
+          const ret = tracer.appsec.blockRequest()
+          expect(ret).to.be.true
+        }
+        agent.use(traces => {
+          expect(traces[0][0].meta).to.not.have.property('appsec.blocked', 'true')
+          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+        }).then(done).catch(done)
+        axios.get(`http://localhost:${port}/`)
+      })
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Checks if response headers have already been sent before blocking with AppSec.

### Motivation
The `blockRequest()` SDK method could throw when used after sending response headers.
