### PR TITLE
[ci-visibility] Support custom test configurations in ITR

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -8,6 +8,19 @@ const { getSkippableSuites: getSkippableSuitesRequest } = require('../intelligen
 const log = require('../../log')
 const AgentInfoExporter = require('../../exporters/common/agent-info-exporter')
 
+function getTestConfigurationTags (tags) {
+  if (!tags) {
+    return {}
+  }
+  return Object.keys(tags).reduce((acc, key) => {
+    if (key.startsWith('test.configuration.')) {
+      const [, configKey] = key.split('test.configuration.')
+      acc[configKey] = tags[key]
+    }
+    return acc
+  }, {})
+}
+
 function getIsTestSessionTrace (trace) {
   return trace.some(span =>
     span.type === 'test_session_end' || span.type === 'test_suite_end' || span.type === 'test_module_end'
@@ -119,6 +132,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,
+        custom: getTestConfigurationTags(this._config.tags),
         ...testConfiguration
       }
       getItrConfigurationRequest(configuration, (err, itrConfig) => {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -108,6 +108,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,
+        custom: getTestConfigurationTags(this._config.tags),
         ...testConfiguration
       }
       getSkippableSuitesRequest(configuration, callback)

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -13,7 +13,8 @@ function getItrConfiguration ({
   osArchitecture,
   runtimeName,
   runtimeVersion,
-  branch
+  branch,
+  custom
 }, done) {
   const options = {
     path: '/api/v2/libraries/tests/services/setting',
@@ -53,7 +54,8 @@ function getItrConfiguration ({
           'os.version': osVersion,
           'os.architecture': osArchitecture,
           'runtime.name': runtimeName,
-          'runtime.version': runtimeVersion
+          'runtime.version': runtimeVersion,
+          custom
         },
         service,
         env,

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -11,7 +11,8 @@ function getSkippableSuites ({
   osPlatform,
   osArchitecture,
   runtimeName,
-  runtimeVersion
+  runtimeVersion,
+  custom
 }, done) {
   const options = {
     path: '/api/v2/ci/tests/skippable',
@@ -51,7 +52,8 @@ function getSkippableSuites ({
           'os.version': osVersion,
           'os.architecture': osArchitecture,
           'runtime.name': runtimeName,
-          'runtime.version': runtimeVersion
+          'runtime.version': runtimeVersion,
+          custom
         },
         service,
         env,

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -201,6 +201,52 @@ describe('CI Visibility Exporter', () => {
       })
     })
     context('if ITR is enabled and the tracer can use CI Vis Protocol', () => {
+      it('should add custom configurations', (done) => {
+        let customConfig
+
+        nock(`http://localhost:${port}`)
+          .post('/api/v2/git/repository/search_commits')
+          .reply(200, JSON.stringify({
+            data: []
+          }))
+          .post('/api/v2/git/repository/packfile')
+          .reply(202, '')
+
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/tests/skippable', function (body) {
+            customConfig = body.data.attributes.configurations.custom
+            return true
+          })
+          .reply(200, JSON.stringify({
+            data: [{
+              type: 'suite',
+              attributes: {
+                suite: 'ci-visibility/test/ci-visibility-test.js'
+              }
+            }]
+          }))
+
+        const ciVisibilityExporter = new CiVisibilityExporter({
+          port,
+          isIntelligentTestRunnerEnabled: true,
+          isGitUploadEnabled: true,
+          tags: {
+            'test.configuration.my_custom_config_2': 'my_custom_config_value_2'
+          }
+        })
+
+        ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+
+        ciVisibilityExporter.getSkippableSuites({}, () => {
+          expect(scope.isDone()).to.be.true
+          expect(customConfig).to.eql({
+            'my_custom_config_2': 'my_custom_config_value_2'
+          })
+          done()
+        })
+        ciVisibilityExporter.sendGitMetadata()
+      })
       it('should request the API after git upload promise is resolved', (done) => {
         nock(`http://localhost:${port}`)
           .post('/api/v2/git/repository/search_commits')


### PR DESCRIPTION
### What does this PR do?
Add `test.configuration.` tags to the ITR requests.

### Motivation
Be able to distinguish suites that have a different custom configuration in the ITR request.

