### PR TITLE
fix traceparent version and version propagation

### DIFF
--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -422,7 +422,7 @@ describe('Plugin', () => {
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
-              `traceparent='01-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
+              `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
           pool.query('SELECT 1 + 1 AS solution', () => {
             queryText = pool._allConnections[0]._protocol._queue[0].sql

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -345,7 +345,7 @@ describe('Plugin', () => {
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
-              `traceparent='01-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
+              `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
           connection.query('SELECT 1 + 1 AS solution', () => {
             queryText = connection._protocol._queue[0].sql

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -481,7 +481,7 @@ describe('Plugin', () => {
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
-            `traceparent='01-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
+            `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
           const queryPool = pool.query('SELECT 1 + 1 AS solution', () => {
             queryText = queryPool.sql

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -404,7 +404,7 @@ describe('Plugin', () => {
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
-            `traceparent='01-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
+            `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
           const connect = connection.query('SELECT 1 + 1 AS solution', () => {
             queryText = connect.sql

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -399,7 +399,7 @@ describe('Plugin', () => {
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
-              `traceparent='01-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
+              `traceparent='00-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
           }).then(done, done)
 
           client.query('SELECT $1::text as message', ['Hello World!'], (err, result) => {

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -302,6 +302,7 @@ class TextMapPropagator {
     const matches = headerValue.trim().match(traceparentExpr)
     if (matches.length) {
       const [ version, traceId, spanId, flags, tail ] = matches.slice(1)
+      const traceparent = { version }
       const tracestate = TraceState.fromString(carrier.tracestate)
       if (invalidSegment.test(traceId)) return null
       if (invalidSegment.test(spanId)) return null
@@ -316,6 +317,7 @@ class TextMapPropagator {
         traceId: id(traceId, 16),
         spanId: id(spanId, 16),
         sampling: { priority: parseInt(flags, 10) & 1 ? 1 : 0 },
+        traceparent,
         tracestate
       })
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -14,6 +14,7 @@ class DatadogSpanContext {
     this._tags = props.tags || {}
     this._sampling = props.sampling || {}
     this._baggageItems = props.baggageItems || {}
+    this._traceparent = props.traceparent
     this._tracestate = props.tracestate
     this._noop = props.noop || null
     this._trace = props.trace || {
@@ -32,10 +33,11 @@ class DatadogSpanContext {
   }
 
   toTraceparent () {
-    const sampling = this._sampling.priority >= AUTO_KEEP ? '01' : '00'
+    const flags = this._sampling.priority >= AUTO_KEEP ? '01' : '00'
     const traceId = this._traceId.toString(16).padStart(32, '0')
     const spanId = this._spanId.toString(16).padStart(16, '0')
-    return `01-${traceId}-${spanId}-${sampling}`
+    const version = (this._traceparent && this._traceparent.version) || '00'
+    return `${version}-${traceId}-${spanId}-${flags}`
   }
 }
 

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -228,7 +228,7 @@ describe('TextMapPropagator', () => {
 
       propagator.inject(spanContext, carrier)
 
-      expect(carrier).to.have.property('traceparent', '01-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01')
+      expect(carrier).to.have.property('traceparent', '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01')
       expect(carrier).to.have.property(
         'tracestate',
         'dd=t.foo_bar_baz_:abc_!@#$%^&*()_+`-~;s:2;o:foo_bar~;t.dm:4,other=bleh'
@@ -623,6 +623,19 @@ describe('TextMapPropagator', () => {
           '_dd.p.foo_bar_baz_',
           'abc_!@#$%^&*()_+`-='
         )
+      })
+
+      it('should propagate the version', () => {
+        textMap['traceparent'] = '01-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01'
+        textMap['tracestate'] = 'other=bleh,dd=t.foo_bar_baz_:abc_!@#$%^&*()_+`-~;s:2;o:foo;t.dm:-4'
+        config.tracePropagationStyle.extract = ['tracecontext']
+
+        const carrier = {}
+        const spanContext = propagator.extract(textMap)
+
+        propagator.inject(spanContext, carrier)
+
+        expect(carrier.traceparent).to.match(/^01/)
       })
     })
   })

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -30,6 +30,7 @@ describe('SpanContext', () => {
         finished: ['span1'],
         tags: { foo: 'bar' }
       },
+      traceparent: '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01',
       tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar')
     }
     const spanContext = new SpanContext(props)
@@ -49,6 +50,7 @@ describe('SpanContext', () => {
         finished: ['span1'],
         tags: { foo: 'bar' }
       },
+      _traceparent: '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01',
       _tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar')
     })
   })
@@ -74,6 +76,7 @@ describe('SpanContext', () => {
         finished: [],
         tags: {}
       },
+      _traceparent: undefined,
       _tracestate: undefined
     })
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

* Fix traceparent version so that it's `00` and not `01`.
* Fix support for propagating a higher version when received.

### Motivation
<!-- What inspired you to submit this pull request? -->

The only version available right now is `00` but future versions are planned.