### PR TITLE
set minimum version for aws-sdk tests to node 14

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
+      - uses: ./.github/actions/node/14
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set minimum version for aws-sdk tests to node 14.

### Motivation
<!-- What inspired you to submit this pull request? -->

AWS SDK v3 no longer supports Node 12.