### PR TITLE
fix client errors being flagged as errors for boom

### DIFF
--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -26,7 +26,11 @@ class HapiPlugin extends RouterPlugin {
       web.setRoute(req, route)
     })
 
-    this.addSub(`apm:hapi:request:error`, this.addError)
+    this.addSub('apm:hapi:request:error', error => {
+      if (!error || !error.isBoom || !this.config.validateStatus(error.output.statusCode)) {
+        this.addError(error)
+      }
+    })
 
     this.addSub('apm:hapi:extension:enter', ({ req }) => {
       this.enter(this._requestSpans.get(req))

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -315,6 +315,35 @@ describe('Plugin', () => {
           .get(`http://localhost:${port}/user/123`)
           .catch(() => {})
       })
+
+      it('should handle boom client errors', done => {
+        const Boom = require('../../../versions/@hapi/boom@9.1.4').get()
+        const error = Boom.badRequest()
+
+        server.route({
+          method: 'GET',
+          path: '/user/{id}',
+          handler: async (request, h) => {
+            if (typeof h === 'function') {
+              h(error)
+            } else {
+              throw error
+            }
+          }
+        })
+
+        agent
+          .use(traces => {
+            expect(traces[0][0]).to.have.property('error', 0)
+            expect(traces[0][0].meta).to.have.property('component', 'hapi')
+          })
+          .then(done)
+          .catch(done)
+
+        axios
+          .get(`http://localhost:${port}/user/123`)
+          .catch(() => {})
+      })
     })
   })
 })

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -69,6 +69,12 @@
       "versions": ["0.5.0"]
     }
   ],
+  "hapi": [
+    {
+      "name": "@hapi/boom",
+      "versions": ["9.1.4"]
+    }
+  ],
   "jest": [
     {
       "name": "jest",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix client errors being flagged as errors for `boom`.

### Motivation
<!-- What inspired you to submit this pull request? -->

`boom` throws actual exceptions that are then handled by `hapi`, even for client errors, so we have to validate the status code from these exceptions.

Fixes #2780