### PR TITLE
feat: allow DD_TRACE_AWSSDK_{SERVICE}_ENABLED configuration

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -3,6 +3,7 @@
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const Plugin = require('../../dd-trace/src/plugins/plugin')
 const { storage } = require('../../datadog-core')
+const { isTrue } = require('../../dd-trace/src/util')
 
 class BaseAwsSdkPlugin extends Plugin {
   get serviceIdentifier () {
@@ -74,7 +75,9 @@ class BaseAwsSdkPlugin extends Plugin {
   }
 
   isEnabled (request) {
-    return true
+    const serviceId = this.serviceIdentifier.toUpperCase()
+    const envVarValue = process.env[`DD_TRACE_AWSSDK_${serviceId}_ENABLED`]
+    return envVarValue ? isTrue(envVarValue) : true
   }
 
   addResponseTags (span, response) {

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -76,7 +76,7 @@ class BaseAwsSdkPlugin extends Plugin {
 
   isEnabled (request) {
     const serviceId = this.serviceIdentifier.toUpperCase()
-    const envVarValue = process.env[`DD_TRACE_AWSSDK_${serviceId}_ENABLED`]
+    const envVarValue = process.env[`DD_TRACE_AWS_SDK_${serviceId}_ENABLED`]
     return envVarValue ? isTrue(envVarValue) : true
   }
 

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -111,5 +111,29 @@ describe('Kinesis', () => {
 
       helpers.putTestRecord(kinesis, helpers.dataBuffer, e => e && done(e))
     })
+
+    describe('Disabled', () => {
+      before(() => {
+        process.env.DD_TRACE_AWSSDK_KINESIS_ENABLED = 'false'
+      })
+
+      after(() => {
+        delete process.env.DD_TRACE_AWSSDK_KINESIS_ENABLED
+      })
+
+      it('skip injects trace context to Kinesis putRecord when disabled', done => {
+        helpers.putTestRecord(kinesis, helpers.dataBuffer, (err, data) => {
+          if (err) return done(err)
+
+          helpers.getTestData(kinesis, data, (err, data) => {
+            if (err) return done(err)
+
+            expect(data).not.to.have.property('_datadog')
+
+            done()
+          })
+        })
+      })
+    })
   })
 })

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -114,11 +114,11 @@ describe('Kinesis', () => {
 
     describe('Disabled', () => {
       before(() => {
-        process.env.DD_TRACE_AWSSDK_KINESIS_ENABLED = 'false'
+        process.env.DD_TRACE_AWS_SDK_KINESIS_ENABLED = 'false'
       })
 
       after(() => {
-        delete process.env.DD_TRACE_AWSSDK_KINESIS_ENABLED
+        delete process.env.DD_TRACE_AWS_SDK_KINESIS_ENABLED
       })
 
       it('skip injects trace context to Kinesis putRecord when disabled', done => {


### PR DESCRIPTION
### What does this PR do?
allow DD_TRACE_AWS_SDK_{SERVICE}_ENABLED configuration.

For example: 
- `DD_TRACE_AWS_SDK_KINESIS_ENABLED`
- `DD_TRACE_AWS_SDK_CLOUDWATCHLOGS_ENABLED`
- `DD_TRACE_AWS_SDK_DYNAMODB_ENABLED`
- `DD_TRACE_AWS_SDK_EVENTBRIDGE_ENABLED`
- `DD_TRACE_AWS_SDK_LAMBDA_ENABLED`
- `DD_TRACE_AWS_SDK_REDSHIFT_ENABLED`
- `DD_TRACE_AWS_SDK_S3_ENABLED`
- `DD_TRACE_AWS_SDK_SNS_ENABLED`
- `DD_TRACE_AWS_SDK_SQS_ENABLED`

### Motivation
Be able to have dd_trace enabled on lambdas but disable for specific services, like Kinesis.

closes #2816 