### PR TITLE
Stop attempting to instrument removed mongo functions

### DIFF
--- a/packages/datadog-instrumentations/src/mongodb-core.js
+++ b/packages/datadog-instrumentations/src/mongodb-core.js
@@ -25,10 +25,16 @@ addHook({ name: 'mongodb-core', versions: ['2 - 3.1.9'] }, Server => {
   return Server
 })
 
-addHook({ name: 'mongodb', versions: ['>=4'], file: 'lib/cmap/connection.js' }, Connection => {
+addHook({ name: 'mongodb', versions: ['>=4 <4.6.0'], file: 'lib/cmap/connection.js' }, Connection => {
   const proto = Connection.Connection.prototype
   shimmer.wrap(proto, 'command', command => wrapConnectionCommand(command, 'command'))
   shimmer.wrap(proto, 'query', query => wrapConnectionCommand(query, 'query'))
+  return Connection
+})
+
+addHook({ name: 'mongodb', versions: ['>=4.6.0'], file: 'lib/cmap/connection.js' }, Connection => {
+  const proto = Connection.Connection.prototype
+  shimmer.wrap(proto, 'command', command => wrapConnectionCommand(command, 'command'))
   return Connection
 })
 
@@ -46,7 +52,7 @@ addHook({ name: 'mongodb-core', versions: ['~3.1.10'], file: 'lib/wireprotocol/2
   return WireProtocol
 })
 
-addHook({ name: 'mongodb', versions: ['>=3.5.4'], file: 'lib/utils.js' }, util => {
+addHook({ name: 'mongodb', versions: ['>=3.5.4 <4.11.0'], file: 'lib/utils.js' }, util => {
   shimmer.wrap(util, 'maybePromise', maybePromise => function (parent, callback, fn) {
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     const callbackIndex = arguments.length - 2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The mongo driver has removed a couple of functions in recent driver versions. Functionally nothing seems to be broken, but it throws noisy log errors if you're running newer versions of the library.

Specifically, `maybePromise` was removed in a commit that ended up shipping in `4.11.0` https://github.com/mongodb/node-mongodb-native/commit/8c63447f8bcfb6a71d1838444fd87d9c251106b0

It was replaced with `maybeCallback`, but I'm not familiar enough with async hooks to currently feel comfortable adding that instrumentation myself. So for now I've only added a version guard on the `maybePromise` hook.

Secondly, `query` was removed in `4.6.0` https://github.com/mongodb/node-mongodb-native/commit/0ec03bfe84feed356630b2ed855e4c4da84b8385

I'm not sure what this drift is going to do to the accuracy of traces coming from mongo but it might be worth having someone take a pass through recent driver versions to add any necessary instrumentation for newer code.

### Motivation
<!-- What inspired you to submit this pull request? -->

Clean up the noisy log errors so developers stop thinking that something is broken in their development environments.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Closes https://github.com/DataDog/dd-trace-js/issues/2790