### PR TITLE
[lambda] Modify how `DD_APM_FLUSH_DEADLINE_MILLISECONDS` is handled

### DIFF
--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -26,7 +26,7 @@ function checkTimeout (context) {
 
   let apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS)
   if (!apmFlushDeadline) {
-    apmFlushDeadline = 50
+    apmFlushDeadline = 100
   }
 
   __lambdaTimeout = setTimeout(() => {

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -22,7 +22,7 @@ let __lambdaTimeout
  * @param {*} context AWS Lambda context object.
  */
 function checkTimeout (context) {
-  let remainingTimeInMillis = context.getRemainingTimeInMillis()
+  const remainingTimeInMillis = context.getRemainingTimeInMillis()
 
   let apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS)
   if (!apmFlushDeadline) {

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -23,7 +23,7 @@ let __lambdaTimeout
  */
 function checkTimeout (context) {
   let remainingTimeInMillis = context.getRemainingTimeInMillis()
-  const apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE)
+  const apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS)
   if (apmFlushDeadline && apmFlushDeadline <= remainingTimeInMillis) {
     remainingTimeInMillis = apmFlushDeadline
   }

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -24,10 +24,8 @@ let __lambdaTimeout
 function checkTimeout (context) {
   const remainingTimeInMillis = context.getRemainingTimeInMillis()
 
-  let apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS)
-  if (!apmFlushDeadline || apmFlushDeadline < 0) {
-    apmFlushDeadline = 100
-  }
+  let apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS) || 100
+  apmFlushDeadline = apmFlushDeadline < 0 ? 100 : apmFlushDeadline
 
   __lambdaTimeout = setTimeout(() => {
     timeoutChannel.publish(undefined)

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -25,7 +25,7 @@ function checkTimeout (context) {
   const remainingTimeInMillis = context.getRemainingTimeInMillis()
 
   let apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS)
-  if (!apmFlushDeadline) {
+  if (!apmFlushDeadline || apmFlushDeadline < 0) {
     apmFlushDeadline = 100
   }
 

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -25,7 +25,7 @@ function checkTimeout (context) {
   let remainingTimeInMillis = context.getRemainingTimeInMillis()
 
   let apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS
-  if (!apmFlushDeadline) { 
+  if (!apmFlushDeadline) {
     apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE
   }
   apmFlushDeadline = parseInt(apmFlushDeadline)

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -24,21 +24,14 @@ let __lambdaTimeout
 function checkTimeout (context) {
   let remainingTimeInMillis = context.getRemainingTimeInMillis()
 
-  let apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS
-  // TODO: Remove this condition and parse int above
-  // once `datadog-lambda-js` updates tracer to v3
+  let apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS)
   if (!apmFlushDeadline) {
-    apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE
-  }
-  apmFlushDeadline = parseInt(apmFlushDeadline)
-
-  if (apmFlushDeadline && apmFlushDeadline <= remainingTimeInMillis) {
-    remainingTimeInMillis = apmFlushDeadline
+    apmFlushDeadline = 50
   }
 
   __lambdaTimeout = setTimeout(() => {
     timeoutChannel.publish(undefined)
-  }, remainingTimeInMillis - 50)
+  }, remainingTimeInMillis - apmFlushDeadline)
 }
 
 /**

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -23,7 +23,13 @@ let __lambdaTimeout
  */
 function checkTimeout (context) {
   let remainingTimeInMillis = context.getRemainingTimeInMillis()
-  const apmFlushDeadline = parseInt(process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS)
+
+  let apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS
+  if (!apmFlushDeadline) { 
+    apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE
+  }
+  apmFlushDeadline = parseInt(apmFlushDeadline)
+
   if (apmFlushDeadline && apmFlushDeadline <= remainingTimeInMillis) {
     remainingTimeInMillis = apmFlushDeadline
   }

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -25,6 +25,8 @@ function checkTimeout (context) {
   let remainingTimeInMillis = context.getRemainingTimeInMillis()
 
   let apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE_MILLISECONDS
+  // TODO: Remove this condition and parse int above
+  // once `datadog-lambda-js` updates tracer to v3
   if (!apmFlushDeadline) {
     apmFlushDeadline = process.env.DD_APM_FLUSH_DEADLINE
   }

--- a/packages/dd-trace/test/lambda/fixtures/handler.js
+++ b/packages/dd-trace/test/lambda/fixtures/handler.js
@@ -4,8 +4,7 @@ const _tracer = require('../../../../dd-trace')
 exports.handler = async (...args) => {
   const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-  await _tracer.trace('self.sleepy', () => sleep(200))
-
+  await _tracer.trace('self.sleepy', () => sleep(50))
   const response = {
     statusCode: 200,
     body: JSON.stringify(

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -60,20 +60,20 @@ describe('lambda', () => {
         },
         {
           envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',
-          value: 100
+          value: '-100'
         },
         {
-          envVar: 'DD_APM_FLUSH_DEADLINE',
-          value: 100
+          envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',
+          value: '50'
         }
       ]
 
       deadlines.forEach(deadline => {
         const flushDeadlineEnvVar = deadline.envVar
-        const customDeadline = deadline.value
+        const customDeadline = deadline.value ? deadline.value : ''
         const isDefault = flushDeadlineEnvVar === 'default'
 
-        it(`traces error on impending timeout using ${flushDeadlineEnvVar} deadline`, () => {
+        it(`traces error on impending timeout using ${flushDeadlineEnvVar} ${customDeadline} deadline`, () => {
           process.env[flushDeadlineEnvVar] = customDeadline
 
           const _context = {

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -78,7 +78,7 @@ describe('lambda', () => {
 
           const _context = {
             // If using default, we set the value to 150, since the
-            // fixture function we're using sleeps for 200ms
+            // fixture function we're sleeping for 200ms
             getRemainingTimeInMillis: () => isDefault ? 150 : 400
           }
           const _event = {}
@@ -91,10 +91,10 @@ describe('lambda', () => {
 
           // If default, then we don't wait for value from deadline, we just use
           // AWS Lambda remaining time in millis
-          const timeoutDeadline = isDefault ? _context.getRemainingTimeInMillis() : customDeadline - 50
+          const timeoutDeadline = isDefault ? _context.getRemainingTimeInMillis() : customDeadline
           setTimeout(() => {
             expect(result).to.equal(undefined)
-          }, timeoutDeadline)
+          }, timeoutDeadline - 50)
 
           const checkTraces = agent.use((_traces) => {
             // First trace, since errors are tagged at root span level.


### PR DESCRIPTION
### What does this PR do?

Update the environment variable `DD_APM_FLUSH_DEADLINE` to `DD_APM_FLUSH_DEADLINE_MILLISECONDS`.
Updated how `DD_APM_FLUSH_DEADLINE_MILLISECONDS` is handled. 
Previously, we would set the deadline as the environment variable value, if set. Now, we take the deadline as the remaining time in an AWS Lambda, and the value in the environment variable is used to subtract from the deadline. The default is now 100ms.

This is not a breaking change, since the release was not GA for Lambda. 

### Motivation

Updated how `DD_APM_FLUSH_DEADLINE_MILLISECONDS` is handled. 
Have units on the environment variable. 
Updating to match the environment variable in `dd-trace-py`. Doing it before we have GA on our instrumentation tools for AWS Lambda.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
