### PR TITLE
[ci-visibility] Change git upload to opt out

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -169,7 +169,6 @@ function getCiVisAgentlessConfig (port) {
     DD_APP_KEY: '1',
     DD_CIVISIBILITY_AGENTLESS_ENABLED: 1,
     DD_CIVISIBILITY_AGENTLESS_URL: `http://127.0.0.1:${port}`,
-    DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: 1,
     DD_CIVISIBILITY_ITR_ENABLED: 1,
     NODE_OPTIONS: '-r dd-trace/ci/init'
   }
@@ -179,7 +178,6 @@ function getCiVisEvpProxyConfig (port) {
   return {
     ...process.env,
     DD_TRACE_AGENT_PORT: port,
-    DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: 1,
     DD_CIVISIBILITY_ITR_ENABLED: 1,
     NODE_OPTIONS: '-r dd-trace/ci/init'
   }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -376,7 +376,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     const DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = coalesce(
       process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED,
-      false
+      true
     )
 
     const ingestion = options.ingestion || {}

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -866,21 +866,27 @@ describe('Config', () => {
       beforeEach(() => {
         options = { isCiVisibility: true }
       })
-      it('should activate git upload if the env var is passed', () => {
-        process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'true'
+      it('should activate git upload by default', () => {
         const config = new Config(options)
         expect(config).to.have.property('isGitUploadEnabled', true)
       })
-      it('should activate intelligent test runner if the env var is passed', () => {
-        process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
+      it('should disable git upload if the DD_CIVISIBILITY_GIT_UPLOAD_ENABLED is set to false', () => {
+        process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'false'
         const config = new Config(options)
-        expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
+        expect(config).to.have.property('isGitUploadEnabled', false)
       })
-      it('should activate git upload automatically if intelligent test runner is activated', () => {
-        process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
-        const config = new Config(options)
-        expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
-        expect(config).to.have.property('isGitUploadEnabled', true)
+      context('DD_CIVISIBILITY_ITR_ENABLED is true', () => {
+        it('should enable intelligent test runner', () => {
+          process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
+          const config = new Config(options)
+          expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
+        })
+        it('should enable git upload, regardless of DD_CIVISIBILITY_GIT_UPLOAD_ENABLED', () => {
+          process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
+          process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'false'
+          const config = new Config(options)
+          expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
+        })
       })
     })
     context('ci visibility mode is not enabled', () => {


### PR DESCRIPTION
### What does this PR do?
Change `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED`'s default value to `true`, so that git upload becomes an opt out feature rather than opt in. 

### Motivation
Git tree information is necessary for intelligent test runner and will become necessary for other CI Visibility features. 

