### PR TITLE
Support Cloud Foundry container IDs

### DIFF
--- a/packages/dd-trace/src/exporters/common/docker.js
+++ b/packages/dd-trace/src/exporters/common/docker.js
@@ -2,7 +2,10 @@
 
 const fs = require('fs')
 
-const uuidSource = '[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}'
+// The second part is the PCF / Garden regexp. We currently assume no suffix($) to avoid matching pod UIDs
+// See https://github.com/DataDog/datadog-agent/blob/7.40.x/pkg/util/cgroups/reader.go#L50
+const uuidSource =
+'[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{8}(?:-[0-9a-f]{4}){4}$'
 const containerSource = '[0-9a-f]{64}'
 const taskSource = '[0-9a-f]{32}-\\d+'
 const entityReg = new RegExp(`.*(${uuidSource}|${containerSource}|${taskSource})(?:\\.scope)?$`, 'm')

--- a/packages/dd-trace/test/exporters/common/docker.spec.js
+++ b/packages/dd-trace/test/exporters/common/docker.spec.js
@@ -83,4 +83,15 @@ describe('docker', () => {
 
     expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376')
   })
+
+  it('should support Cloud Foundry', () => {
+    const cgroup = [
+      '1:name=systemd:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1'
+    ].join('\n')
+
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    docker = proxyquire('../src/exporters/common/docker', { fs })
+
+    expect(docker.id()).to.equal('6f265890-5165-7fab-6b52-18d1')
+  })
 })


### PR DESCRIPTION
### What does this PR do?

This aligns our support with our other libraries. See:

- https://github.com/DataDog/dd-trace-java/pull/4183
- https://github.com/DataDog/dd-trace-go/pull/1549
- https://github.com/DataDog/dd-trace-py/pull/4405

### Motivation

To support identifying Pivotal Cloud Foundry containers