### PR TITLE
Fix nextjs resource name

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -26,11 +26,13 @@ function wrapHandleApiRequest (handleApiRequest) {
       return promise.then(handled => {
         if (!handled) return handled
 
-        const page = getPageFromPath(pathname, this.dynamicRoutes)
+        return this.hasPage(pathname).then(pageFound => {
+          const page = pageFound ? pathname : getPageFromPath(pathname, this.dynamicRoutes)
 
-        pageLoadChannel.publish({ page })
+          pageLoadChannel.publish({ page })
 
-        return handled
+          return handled
+        })
       })
     })
   }

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -110,6 +110,28 @@ describe('Plugin', function () {
               .catch(done)
           })
 
+          const pathTests = [
+            ['/api/hello', '/api/hello'],
+            ['/api/hello/world', '/api/hello/[name]'],
+            ['/api/hello/other', '/api/hello/other']
+          ]
+          pathTests.forEach(([url, expectedPath]) => {
+            it(`should infer the corrrect resource path (${expectedPath})`, done => {
+              agent
+                .use(traces => {
+                  const spans = traces[0]
+
+                  expect(spans[0]).to.have.property('resource', `GET ${expectedPath}`)
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}${url}`)
+                .catch(done)
+            })
+          })
+
           it('should propagate context', done => {
             axios
               .get(`http://localhost:${port}/api/hello/world`)
@@ -185,6 +207,28 @@ describe('Plugin', function () {
             axios
               .get(`http://localhost:${port}/hello/world`)
               .catch(done)
+          })
+
+          const pathTests = [
+            ['/hello', '/hello'],
+            ['/hello/world', '/hello/[name]'],
+            ['/hello/other', '/hello/other']
+          ]
+          pathTests.forEach(([url, expectedPath]) => {
+            it(`should infer the corrrect resource (${expectedPath})`, done => {
+              agent
+                .use(traces => {
+                  const spans = traces[0]
+
+                  expect(spans[0]).to.have.property('resource', `GET ${expectedPath}`)
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}${url}`)
+                .catch(done)
+            })
           })
 
           it('should handle pages not found', done => {

--- a/packages/datadog-plugin-next/test/pages/api/hello/index.js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/index.js
@@ -1,0 +1,9 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+  const tracer = require('../../../../../dd-trace')
+  const span = tracer.scope().active()
+  const name = span && span.context()._name
+
+  res.status(200).json({ name })
+}

--- a/packages/datadog-plugin-next/test/pages/api/hello/other.js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/other.js
@@ -1,0 +1,9 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+  const tracer = require('../../../../../dd-trace')
+  const span = tracer.scope().active()
+  const name = span && span.context()._name
+
+  res.status(200).json({ name })
+}

--- a/packages/datadog-plugin-next/test/pages/hello/index.js
+++ b/packages/datadog-plugin-next/test/pages/hello/index.js
@@ -1,7 +1,7 @@
 export default function Home () {
   return (
     <div>
-      Hello [name]!
+      Hello index!
     </div>
   )
 }

--- a/packages/datadog-plugin-next/test/pages/hello/other.js
+++ b/packages/datadog-plugin-next/test/pages/hello/other.js
@@ -1,7 +1,7 @@
 export default function Home () {
   return (
     <div>
-      Hello [name]!
+      Hello other!
     </div>
   )
 }


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the `next` instrumentation where the resource name for the trace would be wrong when a dynamic route matches a path but isn't actually the one that will handle the page. For instance, given the following directory structure in `pages`:
```
api/
├─ hello/
│  ├─ index.js
│  ├─ [name].js
│  ├─ other.js
```
then a request to `/api/other` will result in a `next.request` span with `resource.name = GET /api/hello/[name]`, even though the `api/hello/other.js` route will be the one to handle the request. Thus, in this case I would expect `resource.name` to be `GET /api/hello/other`.

I can create an actual issue for this if you'd prefer.

The bug is shown as a failing test in this PR's first commit ([b82e242 - add failing test](https://github.com/DataDog/dd-trace-js/commit/b82e24238287e7baeabed5a891592d8da82ab713)). Specifically, the test that fails (on all versions) is: `for api routes -> should infer the corrrect resource path (/api/hello/other)`. Note that the new tests in `for pages` do not fail, but I thought they'd be valuable to have anyway.

The bug is fixed in the next commit ([f431c1e - fix test](https://github.com/DataDog/dd-trace-js/commit/f431c1e20afa373fef399ca65b6965957256c9a1)).

### Motivation
I wanted accurate resource names in the Trace view on Datadog.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
Heads-up: I believe the `next` instrumentation will break in `v13.1.7` due to [Server Router Improvements](https://github.com/vercel/next.js/commit/74ca99c866fdb0692917a6a179a7839c7440c1a6#diff-c49c4767e6ed8627e6e1b8f96b141ee13246153f5e9142e1da03450c8e81e96f). Specifically, while `handleApiRequest` will still exist, `this.dynamicRoutes` will no longer exist. 

However, it looks like `handleApiRequest` will have the page readily available in its parameters, so it's actually simpler.

When `v13.1.7` does get released, I'd be happy to help with updating the instrumentation :). Let me know.
