### PR TITLE
[ci-visibility] Fix latest `playwright` release instrumentation

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -171,10 +171,14 @@ class FakeCiVisIntake extends FakeAgent {
 
   gatherPayloads (payloadMatch, gatheringTime = 15000) {
     const payloads = []
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       setTimeout(() => {
         this.off('message', messageHandler)
-        resolve(payloads)
+        if (payloads.length === 0) {
+          reject(new Error('No payloads were received'))
+        } else {
+          resolve(payloads)
+        }
       }, gatheringTime)
       const messageHandler = (message) => {
         if (!payloadMatch || payloadMatch(message)) {

--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -19,7 +19,7 @@ const { TEST_STATUS } = require('../packages/dd-trace/src/plugins/util/test')
 // This is done because from playwright@>=1.22.0 node 12 is not supported
 // TODO: figure out why playwright 1.31.0 fails
 const isOldNode = semver.satisfies(process.version, '<=12')
-const versions = ['1.18.0', isOldNode ? '1.21.0' : '1.30.0']
+const versions = ['1.18.0', isOldNode ? '1.21.0' : 'latest']
 
 versions.forEach((version) => {
   describe(`playwright@${version}`, () => {


### PR DESCRIPTION
### What does this PR do?
Fix `@playwright/test` plugin by adding instrumentation to the new file paths. 

### Motivation
Latest `@playwright/test` release broke our instrumentation: https://github.com/microsoft/playwright/releases/tag/v1.31.0 because they moved certain files to a different folder.

