### PR TITLE
Ldap plugin fixes

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -485,7 +485,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
+      - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -485,7 +485,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/16
+      - uses: ./.github/actions/node/oldest
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@datadog/native-appsec": "2.0.0",
     "@datadog/native-iast-rewriter": "1.1.2",
-    "@datadog/native-iast-taint-tracking": "1.1.0",
+    "@datadog/native-iast-taint-tracking": "1.1.1",
     "@datadog/native-metrics": "^1.5.0",
     "@datadog/pprof": "^1.1.1",
     "@datadog/sketches-js": "^2.1.0",

--- a/packages/datadog-instrumentations/src/ldapjs.js
+++ b/packages/datadog-instrumentations/src/ldapjs.js
@@ -87,5 +87,15 @@ addHook({ name: 'ldapjs', versions: ['>=2'] }, ldapjs => {
     return _send.apply(this, arguments)
   })
 
+  shimmer.wrap(ldapjs.Client.prototype, 'bind', bind => function (dn, password, controls, callback) {
+    if (typeof controls === 'function') {
+      arguments[2] = AsyncResource.bind(controls)
+    } else if (typeof callback === 'function') {
+      arguments[3] = AsyncResource.bind(callback)
+    }
+
+    return bind.apply(this, arguments)
+  })
+
   return ldapjs
 })

--- a/packages/datadog-instrumentations/src/ldapjs.js
+++ b/packages/datadog-instrumentations/src/ldapjs.js
@@ -53,7 +53,7 @@ function wrapEmitter (corkedEmitter) {
   shimmer.wrap(corkedEmitter, 'removeListener', removeListener)
 }
 
-addHook({ name: 'ldapjs', versions: ['>=2 <3'] }, ldapjs => {
+addHook({ name: 'ldapjs', versions: ['>=2'] }, ldapjs => {
   const ldapSearchCh = channel('datadog:ldapjs:client:search')
 
   shimmer.wrap(ldapjs.Client.prototype, 'search', search => function (base, options) {

--- a/packages/datadog-instrumentations/src/ldapjs.js
+++ b/packages/datadog-instrumentations/src/ldapjs.js
@@ -35,7 +35,7 @@ function wrapEmitter (corkedEmitter) {
       }
       arguments[1] = bindedFn
     }
-    on.apply(this, arguments)
+    return on.apply(this, arguments)
   }
   shimmer.wrap(corkedEmitter, 'on', addListener)
   shimmer.wrap(corkedEmitter, 'addListener', addListener)
@@ -47,7 +47,7 @@ function wrapEmitter (corkedEmitter) {
         arguments[1] = emitterOn
       }
     }
-    off.apply(this, arguments)
+    return off.apply(this, arguments)
   }
   shimmer.wrap(corkedEmitter, 'off', removeListener)
   shimmer.wrap(corkedEmitter, 'removeListener', removeListener)

--- a/packages/datadog-instrumentations/src/ldapjs.js
+++ b/packages/datadog-instrumentations/src/ldapjs.js
@@ -53,7 +53,7 @@ function wrapEmitter (corkedEmitter) {
   shimmer.wrap(corkedEmitter, 'removeListener', removeListener)
 }
 
-addHook({ name: 'ldapjs', versions: ['>=2'] }, ldapjs => {
+addHook({ name: 'ldapjs', versions: ['>=2 <3'] }, ldapjs => {
   const ldapSearchCh = channel('datadog:ldapjs:client:search')
 
   shimmer.wrap(ldapjs.Client.prototype, 'search', search => function (base, options) {

--- a/packages/dd-trace/src/appsec/iast/iast-context.js
+++ b/packages/dd-trace/src/appsec/iast/iast-context.js
@@ -1,8 +1,12 @@
 const IAST_CONTEXT_KEY = Symbol('_dd.iast.context')
 const IAST_TRANSACTION_ID = Symbol('_dd.iast.transactionId')
 
-function getIastContext (store) {
-  return store && store[IAST_CONTEXT_KEY]
+function getIastContext (store, topContext) {
+  let iastContext = store && store[IAST_CONTEXT_KEY]
+  if (!iastContext) {
+    iastContext = topContext && topContext[IAST_CONTEXT_KEY]
+  }
+  return iastContext
 }
 
 /* TODO Fix storage problem when the close event is called without

--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -58,7 +58,8 @@ function onIncomingHttpRequestStart (data) {
 function onIncomingHttpRequestEnd (data) {
   if (data && data.req) {
     const store = storage.getStore()
-    const iastContext = iastContextFunctions.getIastContext(storage.getStore())
+    const topContext = web.getContext(data.req)
+    const iastContext = iastContextFunctions.getIastContext(store, topContext)
     if (iastContext && iastContext.rootSpan) {
       const vulnerabilities = iastContext.vulnerabilities
       const rootSpan = iastContext.rootSpan
@@ -66,7 +67,7 @@ function onIncomingHttpRequestEnd (data) {
       removeTransaction(iastContext)
     }
     // TODO web.getContext(data.req) is required when the request is aborted
-    if (iastContextFunctions.cleanIastContext(store, web.getContext(data.req), iastContext)) {
+    if (iastContextFunctions.cleanIastContext(store, topContext, iastContext)) {
       overheadController.releaseRequest()
     }
   }

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
@@ -20,8 +20,14 @@ describe('ldap-injection-analyzer with ldapjs', () => {
         client = ldapjs.createClient({
           url: 'ldap://localhost:1389'
         })
-        return new Promise((resolve) => {
-          client.bind(`cn=admin,${base}`, 'adminpassword', resolve)
+        return new Promise((resolve, reject) => {
+          client.bind(`cn=admin,${base}`, 'adminpassword', (err) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve()
+            }
+          })
         })
       })
 
@@ -39,6 +45,9 @@ describe('ldap-injection-analyzer with ldapjs', () => {
             filter = newTaintedString(iastCtx, filter, 'param', 'Request')
 
             client.search(base, filter, (err, searchRes) => {
+              if (err) {
+                return reject(err)
+              }
               searchRes.on('end', resolve)
               searchRes.on('error', reject)
             })
@@ -51,6 +60,9 @@ describe('ldap-injection-analyzer with ldapjs', () => {
           return new Promise((resolve, reject) => {
             const filter = '(objectClass=*)'
             client.search(base, filter, (err, searchRes) => {
+              if (err) {
+                return reject(err)
+              }
               searchRes.on('end', resolve)
               searchRes.on('error', reject)
             })
@@ -68,6 +80,9 @@ describe('ldap-injection-analyzer with ldapjs', () => {
             filter = newTaintedString(iastCtx, filter, 'param', 'Request')
 
             client.search(base, filter, (err, searchRes) => {
+              if (err) {
+                return reject(err)
+              }
               searchRes.on('end', () => {
                 const storeEnd = storage.getStore()
                 const iastCtxEnd = iastContextFunctions.getIastContext(storeEnd)
@@ -92,6 +107,9 @@ describe('ldap-injection-analyzer with ldapjs', () => {
 
             let searchResOnEndInvocations = 0
             client.search(base, filter, (err, searchRes) => {
+              if (err) {
+                return reject(err)
+              }
               const onSearchEnd = () => {
                 searchResOnEndInvocations++
                 searchRes.off('end', onSearchEnd)

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
@@ -53,8 +53,9 @@ describe('ldap-injection-analyzer with ldapjs', () => {
               if (err) {
                 return reject(err)
               }
-              searchRes.on('end', resolve)
-              searchRes.on('error', reject)
+              searchRes
+                .on('end', resolve)
+                .on('error', reject)
             })
           })
         }, 'LDAP_INJECTION')
@@ -68,8 +69,9 @@ describe('ldap-injection-analyzer with ldapjs', () => {
               if (err) {
                 return reject(err)
               }
-              searchRes.on('end', resolve)
-              searchRes.on('error', reject)
+              searchRes
+                .on('end', resolve)
+                .on('error', reject)
             })
           })
         }, 'LDAP_INJECTION')
@@ -94,8 +96,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
                 expect(iastCtxEnd).to.not.be.undefined
 
                 resolve()
-              })
-              searchRes.on('error', reject)
+              }).on('error', reject)
             })
           })
         }, 'LDAP_INJECTION')
@@ -117,8 +118,9 @@ describe('ldap-injection-analyzer with ldapjs', () => {
               }
               const onSearchEnd = () => {
                 searchResOnEndInvocations++
-                searchRes.off('end', onSearchEnd)
-                searchRes.emit('end')
+                searchRes
+                  .off('end', onSearchEnd)
+                  .emit('end')
 
                 // if .off method wouldn't work the test will never reach this lines because it will loop forever :S
                 expect(searchResOnEndInvocations).to.be.eq(1)

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
@@ -6,12 +6,17 @@ const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
 const agent = require('../../../plugins/agent')
+const semver = require('semver')
 
 const base = 'dc=example,dc=org'
+
+const isOldNode = semver.satisfies(process.version, '<=14')
 
 describe('ldap-injection-analyzer with ldapjs', () => {
   let client
   withVersions('ldapjs', 'ldapjs', version => {
+    if (isOldNode && version !== '2.0.0') return
+
     prepareTestServerForIast('ldapjs', (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       beforeEach(async () => {
         await agent.load('ldapjs')

--- a/packages/dd-trace/test/appsec/iast/iast-context.spec.js
+++ b/packages/dd-trace/test/appsec/iast/iast-context.spec.js
@@ -18,6 +18,20 @@ describe('IAST context', () => {
     it('should return undefined when no store is provided', () => {
       expect(iastContextHandler.getIastContext()).to.be.undefined
     })
+
+    it('should obtain iast context from topContext if store does not provide one', () => {
+      const store = {}
+      const topContext = {
+        [iastContextHandler.IAST_CONTEXT_KEY]: iastContext
+      }
+      expect(iastContextHandler.getIastContext(store, topContext)).to.be.equal(iastContext)
+    })
+
+    it('should not fail if no topContext is provided', () => {
+      const store = {}
+      const topContext = undefined
+      expect(iastContextHandler.getIastContext(store, topContext)).to.be.undefined
+    })
   })
 
   describe('saveIastContext', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,10 +203,10 @@
   dependencies:
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.1.0.tgz#8f7d0016157b32dbf5c01b15b8afb1c4286b4a18"
-  integrity sha512-TOrngpt6Qh52zWFOz1CkFXw0g43rnuUziFBtIMUsOLGzSHr9wdnTnE6HAyuvKy3f3ecAoZESlMfilGRKP93hXQ==
+"@datadog/native-iast-taint-tracking@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.1.1.tgz#cbeace022b6c1f3a0a40dc0000cc40079c6d4895"
+  integrity sha512-VkESVYpVlLHqw38UHqqEYsJaJTp3+JpKIJhfB9nlQO13dYBc3Sgq/QJZNdPViU73SVsCJtuw4D0SXRyjTXP1IA==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
* Upgrades native-iast-taint-tracking version
* Ensures `removeTransaction` is called obtaining `iastContext` from `topContext` if `store` is not available
* Fixes https://github.com/DataDog/dd-trace-js/issues/2822
* Invokes reject method when ldapjs client fails to bind or search.

### Motivation


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
