### PR TITLE
[ci-visibility] Fix jest worker shutdown

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -3,13 +3,16 @@ const tracer = require('../packages/dd-trace')
 const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
 const { isTrue } = require('../packages/dd-trace/src/util')
 
+const isJest = () =>
+  typeof jest !== 'undefined' || !!process.env.JEST_WORKER_ID
+
 const options = {
   startupLogs: false,
   tags: {
     [ORIGIN_KEY]: 'ciapp-test'
   },
   isCiVisibility: true,
-  flushInterval: 5000
+  flushInterval: isJest() ? 120000 : 5000
 }
 
 let shouldInit = true

--- a/ci/init.js
+++ b/ci/init.js
@@ -3,8 +3,7 @@ const tracer = require('../packages/dd-trace')
 const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
 const { isTrue } = require('../packages/dd-trace/src/util')
 
-const isJest = () =>
-  typeof jest !== 'undefined' || !!process.env.JEST_WORKER_ID
+const isJestWorker = () => !!process.env.JEST_WORKER_ID
 
 const options = {
   startupLogs: false,
@@ -12,7 +11,7 @@ const options = {
     [ORIGIN_KEY]: 'ciapp-test'
   },
   isCiVisibility: true,
-  flushInterval: isJest() ? 120000 : 5000
+  flushInterval: isJestWorker() ? 120000 : 5000
 }
 
 let shouldInit = true

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -47,6 +47,7 @@ module.exports = {
   'jest-environment-node': () => require('../jest'),
   'jest-environment-jsdom': () => require('../jest'),
   'jest-jasmine2': () => require('../jest'),
+  'jest-worker': () => require('../jest'),
   'koa': () => require('../koa'),
   'koa-router': () => require('../koa'),
   'kafkajs': () => require('../kafkajs'),

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -11,6 +11,7 @@ const testSessionConfigurationCh = channel('ci:jest:session:configuration')
 
 const testSuiteStartCh = channel('ci:jest:test-suite:start')
 const testSuiteFinishCh = channel('ci:jest:test-suite:finish')
+
 const testSuiteCodeCoverageCh = channel('ci:jest:test-suite:code-coverage')
 
 const testStartCh = channel('ci:jest:test:start')
@@ -475,3 +476,44 @@ addHook({
   versions: ['>=24.8.0'],
   file: 'build/jasmineAsyncInstall.js'
 }, jasmineAsyncInstallWraper)
+
+// Maximum time we allow the workers to shutdown
+const JEST_WORKER_SHUTDOWN_TIMEOUT = 20
+// https://github.com/facebook/jest/blob/d6ad15b0f88a05816c2fe034dd6900d28315d570/packages/jest-worker/src/types.ts#L38
+const CHILD_MESSAGE_END = 2
+
+addHook({
+  name: 'jest-worker',
+  versions: ['>=24.8.0'],
+  file: 'build/base/BaseWorkerPool.js'
+}, (baseWorkerPool) => {
+  const BaseWorkerPool = baseWorkerPool.default ? baseWorkerPool.default : baseWorkerPool
+  shimmer.wrap(BaseWorkerPool.prototype, 'end', end => async function () {
+    let timeoutId
+
+    try {
+      // End everything: we listen to this message and attempt to flush everything
+      this._workers.forEach(worker => {
+        worker.send([CHILD_MESSAGE_END], () => {}, () => {}, () => {})
+      })
+
+      const killPromise = new Promise((resolve) => {
+        timeoutId = setTimeout(() => {
+          resolve()
+        }, JEST_WORKER_SHUTDOWN_TIMEOUT * 1000)
+      })
+
+      const workersWaitForExitPromise = Promise.all(this._workers.map(worker =>
+        worker.waitForExit()
+      ))
+
+      // If the workers are able to shut down gracefully before the timeout, we proceed
+      await Promise.race([workersWaitForExitPromise, killPromise])
+      clearTimeout(timeoutId)
+    } catch (e) {
+      // ignore error
+    }
+    return end.apply(this, arguments)
+  })
+  return baseWorkerPool
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -482,9 +482,10 @@ const JEST_WORKER_SHUTDOWN_TIMEOUT = 20
 // https://github.com/facebook/jest/blob/d6ad15b0f88a05816c2fe034dd6900d28315d570/packages/jest-worker/src/types.ts#L38
 const CHILD_MESSAGE_END = 2
 
+// 25.1.0 is where waitForExit
 addHook({
   name: 'jest-worker',
-  versions: ['>=24.8.0'],
+  versions: ['>=24.9.0'],
   file: 'build/base/BaseWorkerPool.js'
 }, (baseWorkerPool) => {
   const BaseWorkerPool = baseWorkerPool.default ? baseWorkerPool.default : baseWorkerPool

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -29,6 +29,8 @@ class JestPlugin extends CiPlugin {
     // Used to handle the end of a jest worker to be able to flush
     const handler = ([message]) => {
       if (message === CHILD_MESSAGE_END) {
+        this.testSuiteSpan.finish()
+        finishAllTraceSpans(this.testSuiteSpan)
         this.tracer._exporter.flush(() => {
           // eslint-disable-next-line
           // https://github.com/facebook/jest/blob/24ed3b5ecb419c023ee6fdbc838f07cc028fc007/packages/jest-worker/src/workers/processChild.ts#L118-L133

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -39,6 +39,7 @@ module.exports = {
   get 'jest-environment-node' () { return require('../../../datadog-plugin-jest/src') },
   get 'jest-environment-jsdom' () { return require('../../../datadog-plugin-jest/src') },
   get 'jest-jasmine2' () { return require('../../../datadog-plugin-jest/src') },
+  get 'jest-worker' () { return require('../../../datadog-plugin-jest/src') },
   get 'koa' () { return require('../../../datadog-plugin-koa/src') },
   get 'koa-router' () { return require('../../../datadog-plugin-koa/src') },
   get 'kafkajs' () { return require('../../../datadog-plugin-kafkajs/src') },


### PR DESCRIPTION
### What does this PR do?

Add instrumentation to `build/base/BaseWorkerPool#end` to delay the sending of a kill signal to jest workers. 

### Motivation

Jest workers are forcefully shut down if they take longer than 500ms to exit (more context in https://github.com/facebook/jest/issues/13642). This is problematic when there are tests that have not been flushed yet, as they are lost. 

This PR adds instrumentation to delay the sending of the kill signal by a maximum of 20 seconds, though it's attempted to finish as soon as possible (via the usage of `worker.waitForExit`).

### Additional Notes

1. Testing this, even with e2e tests, is pretty much impossible, as in almost 100% of the cases the jest workers gracefully finish almost instantly. This code is for the edge cases where it does not happen. 

2. This is a short term solution. Medium term I want jest workers _not_ to report traces directly to the intake, but to the jest main process. The main process is not running tests so it's way freer and we can more easily control flushing. 

**Important**: don't land labels are added until we're sure this works in the `dev` release. 
