### PR TITLE
[ci-visibility] Undo `jest` flush interval change

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -3,15 +3,13 @@ const tracer = require('../packages/dd-trace')
 const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
 const { isTrue } = require('../packages/dd-trace/src/util')
 
-const isJestWorker = () => !!process.env.JEST_WORKER_ID
-
 const options = {
   startupLogs: false,
   tags: {
     [ORIGIN_KEY]: 'ciapp-test'
   },
   isCiVisibility: true,
-  flushInterval: isJestWorker() ? 120000 : 5000
+  flushInterval: 5000
 }
 
 let shouldInit = true


### PR DESCRIPTION
### What does this PR do?
When `workerIdleMemoryLimit` option is set in `jest` (which is recommended for some cases), the main process will forcefully kill workers. If `flushInterval` is big, the damage of losing a payload is bigger. 

### Motivation
Partially revert https://github.com/DataDog/dd-trace-js/pull/2839
