### PR TITLE
[ci-visibility] Change intelligent test runner default config

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -178,7 +178,6 @@ function getCiVisAgentlessConfig (port) {
     DD_APP_KEY: '1',
     DD_CIVISIBILITY_AGENTLESS_ENABLED: 1,
     DD_CIVISIBILITY_AGENTLESS_URL: `http://127.0.0.1:${port}`,
-    DD_CIVISIBILITY_ITR_ENABLED: 1,
     NODE_OPTIONS: '-r dd-trace/ci/init'
   }
 }
@@ -187,7 +186,6 @@ function getCiVisEvpProxyConfig (port) {
   return {
     ...process.env,
     DD_TRACE_AGENT_PORT: port,
-    DD_CIVISIBILITY_ITR_ENABLED: 1,
     NODE_OPTIONS: '-r dd-trace/ci/init'
   }
 }

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -36,9 +36,15 @@ function getItrConfiguration ({
       process.env.DATADOG_APPLICATION_KEY ||
       process.env.DD_APPLICATION_KEY
 
-    if (!apiKey || !appKey) {
-      return done(new Error('App key or API key undefined'))
+    const messagePrefix = "Configuration can't be fetched:"
+
+    if (!appKey) {
+      return done(new Error(`${messagePrefix} Application key is undefined.`))
     }
+    if (!apiKey) {
+      return done(new Error(`${messagePrefix} API key is undefined.`))
+    }
+
     options.headers['dd-api-key'] = apiKey
     options.headers['dd-application-key'] = appKey
   }

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -36,13 +36,13 @@ function getItrConfiguration ({
       process.env.DATADOG_APPLICATION_KEY ||
       process.env.DD_APPLICATION_KEY
 
-    const messagePrefix = "Configuration can't be fetched:"
+    const messagePrefix = 'Request to settings endpoint was not done because Datadog'
 
     if (!appKey) {
-      return done(new Error(`${messagePrefix} Application key is undefined.`))
+      return done(new Error(`${messagePrefix} application key is not defined.`))
     }
     if (!apiKey) {
-      return done(new Error(`${messagePrefix} API key is undefined.`))
+      return done(new Error(`${messagePrefix} API key is not defined.`))
     }
 
     options.headers['dd-api-key'] = apiKey

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -35,9 +35,15 @@ function getSkippableSuites ({
       process.env.DATADOG_APPLICATION_KEY ||
       process.env.DD_APPLICATION_KEY
 
-    if (!apiKey || !appKey) {
-      return done(new Error('App key or API key undefined'))
+    const messagePrefix = "Skippable suites can't be fetched:"
+
+    if (!appKey) {
+      return done(new Error(`${messagePrefix} Application key is undefined.`))
     }
+    if (!apiKey) {
+      return done(new Error(`${messagePrefix} API key is undefined.`))
+    }
+
     options.headers['dd-api-key'] = apiKey
     options.headers['dd-application-key'] = appKey
   }

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -35,13 +35,13 @@ function getSkippableSuites ({
       process.env.DATADOG_APPLICATION_KEY ||
       process.env.DD_APPLICATION_KEY
 
-    const messagePrefix = "Skippable suites can't be fetched:"
+    const messagePrefix = 'Skippable suites were not fetched because Datadog'
 
     if (!appKey) {
-      return done(new Error(`${messagePrefix} Application key is undefined.`))
+      return done(new Error(`${messagePrefix} application key is not defined.`))
     }
     if (!apiKey) {
-      return done(new Error(`${messagePrefix} API key is undefined.`))
+      return done(new Error(`${messagePrefix} API key is not defined.`))
     }
 
     options.headers['dd-api-key'] = apiKey

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -484,7 +484,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     this.isIntelligentTestRunnerEnabled = this.isCiVisibility && isTrue(DD_CIVISIBILITY_ITR_ENABLED)
     this.isGitUploadEnabled = this.isCiVisibility &&
-      (this.isIntelligentTestRunnerEnabled || isTrue(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED))
+      (this.isIntelligentTestRunnerEnabled && !isFalse(DD_CIVISIBILITY_GIT_UPLOAD_ENABLED))
 
     this.stats = {
       enabled: isTrue(DD_TRACE_STATS_COMPUTATION_ENABLED)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -161,7 +161,7 @@ class Config {
 
     const DD_CIVISIBILITY_ITR_ENABLED = coalesce(
       process.env.DD_CIVISIBILITY_ITR_ENABLED,
-      false
+      true
     )
 
     const DD_SERVICE = options.service ||

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -28,7 +28,7 @@ module.exports = class CiPlugin extends Plugin {
       }
       this.tracer._exporter.getItrConfiguration(this.testConfiguration, (err, itrConfig) => {
         if (err) {
-          log.error(`Error fetching intelligent test runner configuration: ${err.message}`)
+          log.error(`Intelligent Test Runner configuration could not be fetched. ${err.message}`)
         } else {
           this.itrConfig = itrConfig
         }
@@ -42,7 +42,7 @@ module.exports = class CiPlugin extends Plugin {
       }
       this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites) => {
         if (err) {
-          log.error(`Error fetching skippable suites: ${err.message}`)
+          log.error(`Skippable suites could not be fetched. ${err.message}`)
         }
         onDone({ err, skippableSuites })
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -152,7 +152,9 @@ describe('CI Visibility Agentless Exporter', () => {
       expect(agentlessExporter.shouldRequestItrConfiguration()).to.be.true
       agentlessExporter.getItrConfiguration({}, (err) => {
         expect(scope.isDone()).not.to.be.true
-        expect(err.message).to.contain("Configuration can't be fetched: Application key is undefined.")
+        expect(err.message).to.contain(
+          'Request to settings endpoint was not done because Datadog application key is not defined'
+        )
         expect(agentlessExporter.shouldRequestSkippableSuites()).to.be.false
         done()
       })

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -152,7 +152,7 @@ describe('CI Visibility Agentless Exporter', () => {
       expect(agentlessExporter.shouldRequestItrConfiguration()).to.be.true
       agentlessExporter.getItrConfiguration({}, (err) => {
         expect(scope.isDone()).not.to.be.true
-        expect(err.message).to.contain('App key or API key undefined')
+        expect(err.message).to.contain("Configuration can't be fetched: Application key is undefined.")
         expect(agentlessExporter.shouldRequestSkippableSuites()).to.be.false
         done()
       })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -875,18 +875,14 @@ describe('Config', () => {
         const config = new Config(options)
         expect(config).to.have.property('isGitUploadEnabled', false)
       })
-      context('DD_CIVISIBILITY_ITR_ENABLED is true', () => {
-        it('should enable intelligent test runner', () => {
-          process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
-          const config = new Config(options)
-          expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
-        })
-        it('should enable git upload, regardless of DD_CIVISIBILITY_GIT_UPLOAD_ENABLED', () => {
-          process.env.DD_CIVISIBILITY_ITR_ENABLED = 'true'
-          process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = 'false'
-          const config = new Config(options)
-          expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
-        })
+      it('should activate ITR by default', () => {
+        const config = new Config(options)
+        expect(config).to.have.property('isIntelligentTestRunnerEnabled', true)
+      })
+      it('should disable ITR if DD_CIVISIBILITY_ITR_ENABLED is set to false', () => {
+        process.env.DD_CIVISIBILITY_ITR_ENABLED = 'false'
+        const config = new Config(options)
+        expect(config).to.have.property('isIntelligentTestRunnerEnabled', false)
       })
     })
     context('ci visibility mode is not enabled', () => {


### PR DESCRIPTION
### What does this PR do?
Change CI Visibility's intelligent test runner default configuration: now, unless `DD_CIVISIBILITY_ITR_ENABLED` is explicitly set to `false`, a request to CI visibility will be fired to check the configuration of the service under test (`/api/v2/libraries/tests/services/setting` endpoint). 

### Motivation
Make it easier for customers to use ITR: after this change, the configuration is exclusively done at Datadog's UI. 

