### PR TITLE
add runtime.node.event_loop.utilization metric

### DIFF
--- a/packages/dd-trace/test/metrics.spec.js
+++ b/packages/dd-trace/test/metrics.spec.js
@@ -115,6 +115,8 @@ describe('metrics', () => {
       expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.95percentile')
       expect(client.increment).to.have.been.calledWith('runtime.node.event_loop.delay.count')
 
+      expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.utilization')
+
       expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.max')
       expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.min')
       expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.sum')


### PR DESCRIPTION
### What does this PR do?
- adds a new metric based on [event loop utilization](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2)
- this value is between 0 (idle) and 1 (busy)
- tracks the overall utilization for a given 10 second period
- available as `runtime.node.event_loop.utilization`

### Motivation
- the metric is a straightforward way to tell how busy a Node.js process is

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
- this originated as a customer request