### PR TITLE
[ci-visibility] Fix jest bug when parent id is null

### DIFF
--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -128,10 +128,13 @@ module.exports = class CiPlugin extends Plugin {
       const suiteTags = {
         [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
         [TEST_SESSION_ID]: testSuiteSpan.context().toTraceId(),
-        [TEST_MODULE_ID]: testSuiteSpan.context()._parentId.toString(10),
         [TEST_COMMAND]: testSuiteSpan.context()._tags[TEST_COMMAND],
         [TEST_BUNDLE]: testSuiteSpan.context()._tags[TEST_COMMAND]
       }
+      if (testSuiteSpan.context()._parentId) {
+        suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)
+      }
+
       testTags = {
         ...testTags,
         ...suiteTags


### PR DESCRIPTION
### What does this PR do?
If the initialization for CI Visibility is not correctly, a `jest` test suite may be started without a parent module or session. Since we assumed that `_parentId` would not be null, we would throw an error. This PR adds a guard against this case.

### Motivation
Fixes #2847 

