### PR TITLE
disable logs in exporting-pipeline benchmark

### DIFF
--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -8,6 +8,9 @@ const PrioritySampler = require('../../../packages/dd-trace/src/priority_sampler
 const id = require('../../../packages/dd-trace/src/id')
 const hostname = require('os').hostname()
 
+const log = require('../../../packages/dd-trace/src/log')
+log.toggle(true, 'info')
+
 const config = {
   url: 'http://localhost:8126',
   flushInterval: 1000,


### PR DESCRIPTION
### What does this PR do?
- disables printing logs to stdout in the exporting-pipeline benchmark
- this is an alternative to https://github.com/DataDog/dd-trace-js/pull/2850
- this doesn't really fix the underlying issue though
  - the diagnostics channel logging seems to not set a default log level for this particular benchmark
  - that said the underlying issue only affects tests and not apps

### Motivation
- get performance numbers green again