### PR TITLE
Update iast rewriter version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@datadog/native-appsec": "2.0.0",
-    "@datadog/native-iast-rewriter": "1.1.2",
+    "@datadog/native-iast-rewriter": "2.0.1",
     "@datadog/native-iast-taint-tracking": "1.1.1",
     "@datadog/native-metrics": "^1.5.0",
     "@datadog/pprof": "^2.0.0",

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -41,7 +41,9 @@ function getCompileMethodFn (compileMethod) {
     try {
       if (isPrivateModule(filename) && isNotLibraryFile(filename)) {
         const rewritten = rewriter.rewrite(content, filename)
-        return compileMethod.apply(this, [rewritten, filename])
+        if (rewritten && rewritten.content) {
+          return compileMethod.apply(this, [rewritten.content, filename])
+        }
       }
     } catch (e) {
       log.error(e)

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -40,10 +40,11 @@ function getCompileMethodFn (compileMethod) {
   return function (content, filename) {
     try {
       if (isPrivateModule(filename) && isNotLibraryFile(filename)) {
-        content = rewriter.rewrite(content, filename)
+        const rewritten = rewriter.rewrite(content, filename)
+        return compileMethod.apply(this, [rewritten, filename])
       }
     } catch (e) {
-      log.debug(e)
+      log.error(e)
     }
     return compileMethod.apply(this, [content, filename])
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,10 +196,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-1.1.2.tgz#793cbf92d218ec80d645be0830023656b81018ea"
-  integrity sha512-pigRfRtAjZjMjqIXyXb98S4aDnuHz/EmqpoxAajFZsNjBLM87YonwSY5zoBdCsOyA46ddKOJRoCQd5ZalpOFMQ==
+"@datadog/native-iast-rewriter@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz#dc4a23796870f2d840053ae879c61547eda6bb89"
+  integrity sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==
   dependencies:
     node-gyp-build "^4.5.0"
 


### PR DESCRIPTION
### What does this PR do?
* Updates `@datadog/native-iast-rewriter` version fixing one sourceMappingURL treatment issue.
* protects the compilation of the rewritten code and if it fails try again with the original code.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
