### PR TITLE
[ci-visibility] Fix cucumber tests for node 12

### DIFF
--- a/integration-tests/cucumber.spec.js
+++ b/integration-tests/cucumber.spec.js
@@ -3,6 +3,7 @@
 const { exec } = require('child_process')
 
 const getPort = require('get-port')
+const semver = require('semver')
 const { assert } = require('chai')
 
 const {
@@ -13,7 +14,8 @@ const {
 const { FakeCiVisIntake } = require('./ci-visibility-intake')
 const { TEST_STATUS, TEST_COMMAND, TEST_BUNDLE } = require('../packages/dd-trace/src/plugins/util/test')
 
-const versions = ['7.0.0', 'latest']
+const isOldNode = semver.satisfies(process.version, '<=12')
+const versions = ['7.0.0', isOldNode ? '8' : 'latest']
 
 versions.forEach(version => {
   describe(`cucumber@${version}`, () => {


### PR DESCRIPTION
### What does this PR do?
Set maximum tested version for cucumber to `8` when node12 is being used.

### Motivation
Cucumber@9 does not support node@12 anymore: https://github.com/cucumber/cucumber-js/releases/tag/v9.0.0

