### PR TITLE
[ci-visibility] Fix `cucumber` integration test version usage 

### DIFF
--- a/integration-tests/cucumber.spec.js
+++ b/integration-tests/cucumber.spec.js
@@ -21,7 +21,7 @@ versions.forEach(version => {
   describe(`cucumber@${version}`, () => {
     let sandbox, cwd, receiver, childProcess
     before(async () => {
-      sandbox = await createSandbox(['@cucumber/cucumber', 'assert'], true)
+      sandbox = await createSandbox([`@cucumber/cucumber@${version}`, 'assert'], true)
       cwd = sandbox.folder
     })
 


### PR DESCRIPTION
### What does this PR do?
Use `version` correctly.

### Motivation
We were not correctly installing versions in the version range. 

