### PR TITLE
Use log/writer as a logger

### DIFF
--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -78,39 +78,47 @@ function reset () {
 }
 
 function onError (err) {
-  if (enabled) {
-    if (typeof err !== 'object' || !err) {
-      err = String(err)
-    } else if (!err.stack) {
-      err = String(err.message || err)
-    }
-
-    if (typeof err === 'string') {
-      err = new Error(err)
-    }
-
-    withNoop(() => logger.error(err))
-  }
+  if (enabled) error(err)
 }
 
 function onWarn (message) {
-  if (!logger.warn) return onDebug(message)
-  if (enabled) {
-    withNoop(() => logger.warn(message))
-  }
+  if (enabled) warn(message)
 }
 
 function onInfo (message) {
-  if (!logger.info) return onDebug(message)
-  if (enabled) {
-    withNoop(() => logger.info(message))
-  }
+  if (enabled) info(message)
 }
 
 function onDebug (message) {
-  if (enabled) {
-    withNoop(() => logger.debug(message))
-  }
+  if (enabled) debug(message)
 }
 
-module.exports = { use, toggle, reset }
+function error (err) {
+  if (typeof err !== 'object' || !err) {
+    err = String(err)
+  } else if (!err.stack) {
+    err = String(err.message || err)
+  }
+
+  if (typeof err === 'string') {
+    err = new Error(err)
+  }
+
+  withNoop(() => logger.error(err))
+}
+
+function warn (message) {
+  if (!logger.warn) return debug(message)
+  withNoop(() => logger.warn(message))
+}
+
+function info (message) {
+  if (!logger.info) return debug(message)
+  withNoop(() => logger.info(message))
+}
+
+function debug (message) {
+  withNoop(() => logger.debug(message))
+}
+
+module.exports = { use, toggle, reset, error, warn, info, debug }

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const mainLogger = require('./log')
+const { info, warn } = require('./log/writer')
 
 const os = require('os')
 const { inspect } = require('util')
 const tracerVersion = require('../../../package.json').version
-
-const logger = Object.create(mainLogger)
-logger.toggle(true)
 
 let config
 let pluginManager
@@ -89,9 +86,9 @@ function startupLog ({ agentError } = {}) {
   // out.service_mapping
   // out.service_mapping_error
 
-  logger.info('DATADOG TRACER CONFIGURATION - ' + out)
+  info('DATADOG TRACER CONFIGURATION - ' + out)
   if (agentError) {
-    logger.warn('DATADOG TRACER DIAGNOSTIC - Agent Error: ' + agentError.message)
+    warn('DATADOG TRACER DIAGNOSTIC - Agent Error: ' + agentError.message)
   }
 
   config = undefined

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -278,4 +278,89 @@ describe('log', () => {
       expect(console.error).to.have.been.calledOnce
     })
   })
+
+  describe('logWriter', () => {
+    let logWriter
+    beforeEach(() => {
+      logWriter = require('../src/log/writer')
+    })
+
+    afterEach(() => {
+      logWriter.reset()
+    })
+
+    describe('error', () => {
+      it('should call logger error', () => {
+        logWriter.error(error)
+
+        expect(console.error).to.have.been.calledOnceWith(error)
+      })
+
+      it('should call console.error no matter enable flag value', () => {
+        logWriter.toggle(false)
+        logWriter.error(error)
+
+        expect(console.error).to.have.been.calledOnceWith(error)
+      })
+    })
+
+    describe('warn', () => {
+      it('should call logger warn', () => {
+        logWriter.warn('warn')
+
+        expect(console.warn).to.have.been.calledOnceWith('warn')
+      })
+
+      it('should call logger debug if warn is not provided', () => {
+        logWriter.use(logger)
+        logWriter.warn('warn')
+
+        expect(logger.debug).to.have.been.calledOnceWith('warn')
+      })
+
+      it('should call console.warn no matter enable flag value', () => {
+        logWriter.toggle(false)
+        logWriter.warn('warn')
+
+        expect(console.warn).to.have.been.calledOnceWith('warn')
+      })
+    })
+
+    describe('info', () => {
+      it('should call logger info', () => {
+        logWriter.info('info')
+
+        expect(console.info).to.have.been.calledOnceWith('info')
+      })
+
+      it('should call logger debug if info is not provided', () => {
+        logWriter.use(logger)
+        logWriter.info('info')
+
+        expect(logger.debug).to.have.been.calledOnceWith('info')
+      })
+
+      it('should call console.info no matter enable flag value', () => {
+        logWriter.toggle(false)
+        logWriter.info('info')
+
+        expect(console.info).to.have.been.calledOnceWith('info')
+      })
+    })
+
+    describe('debug', () => {
+      it('should call logger debug', () => {
+        logWriter.debug('debug')
+
+        expect(console.debug).to.have.been.calledOnceWith('debug')
+      })
+
+      it('should call console.debug no matter enable flag value', () => {
+        logWriter.toggle(false)
+        logWriter.debug('debug')
+
+        expect(console.debug).to.have.been.calledOnceWith('debug')
+      })
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Exposes `error`, `warn`, `info` and `debug` methods from `log/writer` module in order to use them directly.

### Motivation
In some situations we want to write to the logger regardless of whether `log` it is enabled or not like in `startup-log.js`

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
