### PR TITLE
Skip incompatible services on ARM64 `yarn services`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ $ docker-compose up -d -V --remove-orphans --force-recreate
 $ yarn services
 ```
 
+> **Note**
+> The `couchbase`, `grpc` and `oracledb` instrumentations rely on native modules
+> that do not compile on ARM64 devices (for example M1/M2 Mac) - their tests
+> cannot be run locally on these devices.
 
 ### Unit Tests
 

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fs = require('fs')
+const os = require('node:os')
 const path = require('path')
 const crypto = require('crypto')
 const semver = require('semver')
@@ -11,6 +12,7 @@ const externals = require('../packages/dd-trace/test/plugins/externals')
 
 const requirePackageJsonPath = require.resolve('../packages/dd-trace/src/require-package-json')
 
+const excludeList = os.arch() === 'arm64' ? ['couchbase', 'grpc', 'oracledb'] : []
 const workspaces = new Set()
 const versionLists = {}
 const deps = {}
@@ -42,6 +44,8 @@ async function run () {
   assertFolder()
   await assertVersions()
   assertWorkspace()
+  // Some native addon packages rely on libraries that are not supported on ARM64
+  excludeList.forEach(pkg => delete workspaces[pkg])
   install()
 }
 
@@ -197,7 +201,7 @@ function install () {
 
 function addFolder (name, version) {
   const basename = [name, version].filter(val => val).join('@')
-  workspaces.add(basename)
+  if (!excludeList.includes(name)) workspaces.add(basename)
 }
 
 function folder (name, version) {


### PR DESCRIPTION
### What does this PR do?
Some libraries relying on native modules will not compile on ARM64:

* `couchbase` is missing an ARM64 `config` directory [1]
* `oracledb` still does not support it because first party client libraries are not available [2]
* `grpc` is EoL and does not support ARM64 [3]

We skip these services such that `yarn services` still succeeds and installs all other dependencies.

[1] https://github.com/couchbase/couchnode/pull/106
[2] https://github.com/oracle/node-oracledb/issues/1349
[3] https://github.com/grpc/grpc-node/issues/1880#issuecomment-1273627039

<!-- A brief description of the change being made with this pull request. -->

### Motivation
This allows developers to confidently run tests unrelated to the 3 services above knowing that the script succeeded.
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests. N/A
- [x] TypeScript [definitions][1]. N/A
- [x] TypeScript [tests][2]. N/A
- [x] API [documentation][3]. N/A
- [x] CircleCI [jobs/workflows][4]. N/A
- [x] Plugin is [exported][5]. N/A

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
