### PR TITLE
Run NextJS plugin test on Node 14 and 16

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -667,6 +667,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 


### PR DESCRIPTION
### What does this PR do?
Run NextJS plugin test on Node 14 and 16, instead of just 14

### Motivation
NextJs supported versions are not compliant with OpenSSL 3 (NodeJS >= 17), throwing an ERR_OSSL_EVP_UNSUPPORTED error.
