### PR TITLE
[lambda] Fix potential crash when no active span exists on impending timeout

### DIFF
--- a/packages/dd-trace/test/lambda/fixtures/handler.js
+++ b/packages/dd-trace/test/lambda/fixtures/handler.js
@@ -1,20 +1,49 @@
 'use strict'
 const _tracer = require('../../../../dd-trace')
 
-exports.handler = async (...args) => {
-  const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-  await _tracer.trace('self.sleepy', () => sleep(50))
-  const response = {
-    statusCode: 200,
-    body: JSON.stringify(
-      {
-        message: 'hello!'
-      },
-      null,
-      2
-    )
-  }
+const sampleResponse = {
+  statusCode: 200,
+  body: JSON.stringify(
+    {
+      message: 'hello!'
+    },
+    null,
+    2
+  )
+}
+
+const handler = async (_event, _context) => {
+  const response = sampleResponse
 
   return response
+}
+
+const timeoutHandler = async (...args) => {
+  await _tracer.trace('self.sleepy', () => {
+    return sleep(50)
+  })
+  const response = sampleResponse
+
+  return response
+}
+
+const finishSpansEarlyTimeoutHandler = async (...args) => {
+  const response = sampleResponse
+
+  // mimick closing spans early
+  const currentSpan = _tracer.scope().active()
+  currentSpan.finish()
+
+  // timeout
+  await sleep(50)
+
+  return response
+}
+
+module.exports = {
+  finishSpansEarlyTimeoutHandler,
+  handler,
+  timeoutHandler
 }

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -1,104 +1,185 @@
 'use strict'
 
 const path = require('path')
+
+const ritm = require('../../src/lambda/runtime/ritm')
 const agent = require('../plugins/agent')
+
+const oldEnv = process.env
+/**
+ * Sets up the minimum environment variables to make sure
+ * the tracer works as expected for an AWS Lambda function.
+ */
+const setup = () => {
+  const newEnv = {
+    LAMBDA_TASK_ROOT: './packages/dd-trace/test/lambda/fixtures',
+    AWS_LAMBDA_FUNCTION_NAME: 'mock-function-name',
+    DD_TRACE_ENABLED: 'true',
+    DD_LOG_LEVEL: 'debug'
+  }
+  process.env = { ...oldEnv, ...newEnv }
+}
+
+const restoreEnv = () => {
+  process.env = oldEnv
+}
+
+/**
+ * Loads the test agent and makes sure the hook for the
+ * AWS Lambda function patch is re-registered.
+ *
+ * @param {*} exporter defines the type of exporter for the test agent.
+ * @returns a promise of the agent to load.
+ */
+const loadAgent = ({ exporter = 'agent' } = {}) => {
+  // Make sure the hook is re-registered
+  ritm.registerLambdaHook()
+  return agent.load(null, [], {
+    experimental: {
+      exporter
+    }
+  })
+}
+
+/**
+ * Closes the test agent, resets the ritm modules and ensures
+ * the cache for the AWS Lambda function patch is deleted so the hook
+ * is re-registered once the ritm calls it.
+ */
+const closeAgent = () => {
+  // In testing, the patch needs to be deleted from the require cache,
+  // in order to allow multiple handlers being patched properly.
+  delete require.cache[require.resolve('../../src/lambda/runtime/patch.js')]
+  agent.close({ ritmReset: true })
+}
 
 describe('lambda', () => {
   let datadog
-  const oldEnv = process.env
 
-  describe('with lambda extension - agent exporter', () => {
-    beforeEach(() => {
-      const newEnv = {
-        LAMBDA_TASK_ROOT: './packages/dd-trace/test/lambda/fixtures',
-        DD_LAMBDA_HANDLER: 'handler.handler',
-        AWS_LAMBDA_FUNCTION_NAME: 'my-function-name',
-        DD_TRACE_ENABLED: 'true',
-        DD_LOG_LEVEL: 'debug'
-      }
-      process.env = { ...oldEnv, ...newEnv }
-      return agent.load(null, [], {
-        // add experimental exporter to mock lambda extension
-        experimental: {
-          exporter: 'agent'
-        }
-      })
-    })
+  describe('patch', () => {
+    beforeEach(setup)
 
     afterEach(() => {
-      process.env = oldEnv
-      return agent.close({ ritmReset: false })
+      restoreEnv()
+      return closeAgent()
     })
 
     it('patches lambda function correctly', async () => {
+      // Set the desired handler to patch
+      process.env.DD_LAMBDA_HANDLER = 'handler.handler'
+      // Load the agent and re-register hook for patching.
+      await loadAgent()
+
       const _context = {
         getRemainingTimeInMillis: () => 150
       }
       const _event = {}
+
+      // Mock `datadog-lambda` handler resolve and import.
       const _handlerPath = path.resolve(__dirname, './fixtures/handler.js')
       const app = require(_handlerPath)
       datadog = require('./fixtures/datadog-lambda')
+
+      // Run the function.
       const result = await datadog(app.handler)(_event, _context)
 
       expect(result).to.not.equal(undefined)
       const body = JSON.parse(result.body)
       expect(body.message).to.equal('hello!')
+
+      // Expect traces to be correct.
       const checkTraces = agent.use((_traces) => {
         const traces = _traces[0]
-        expect(traces).lengthOf(2)
+        expect(traces).lengthOf(1)
         traces.forEach((trace) => {
           expect(trace.error).to.equal(0)
         })
       })
       await checkTraces
     })
+  })
 
-    describe('timeout spans', () => {
-      const deadlines = [
-        {
-          envVar: 'default'
-          // will use default remaining time
-        },
-        {
-          envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',
-          value: '-100' // will default to 0
-        },
-        {
-          envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',
-          value: '10' // subtract 10 from the remaining time
+  describe('timeout spans', () => {
+    beforeEach(setup)
+
+    afterEach(() => {
+      restoreEnv()
+      return closeAgent()
+    })
+
+    it(`doesnt crash when spans are finished early and reached impending timeout`, async () => {
+      process.env.DD_LAMBDA_HANDLER = 'handler.finishSpansEarlyTimeoutHandler'
+      await loadAgent()
+
+      const _context = {
+        getRemainingTimeInMillis: () => 25
+      }
+      const _event = {}
+
+      const _handlerPath = path.resolve(__dirname, './fixtures/handler.js')
+      const app = require(_handlerPath)
+      datadog = require('./fixtures/datadog-lambda')
+      const result = datadog(app.finishSpansEarlyTimeoutHandler)(_event, _context)
+
+      const checkTraces = agent.use((_traces) => {
+        const traces = _traces[0]
+        traces.forEach((trace) => {
+          expect(trace.error).to.equal(0)
+        })
+      })
+
+      return result.then(_ => {}).then(() => checkTraces)
+    })
+
+    const deadlines = [
+      {
+        envVar: 'default'
+        // will use default remaining time
+      },
+      {
+        envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',
+        value: '-100' // will default to 0
+      },
+      {
+        envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',
+        value: '10' // subtract 10 from the remaining time
+      }
+    ]
+
+    deadlines.forEach(deadline => {
+      const flushDeadlineEnvVar = deadline.envVar
+      const customDeadline = deadline.value ? deadline.value : ''
+
+      it(`traces error on impending timeout using ${flushDeadlineEnvVar} ${customDeadline} deadline`, () => {
+        process.env[flushDeadlineEnvVar] = customDeadline
+        process.env.DD_LAMBDA_HANDLER = 'handler.timeoutHandler'
+
+        const _context = {
+          getRemainingTimeInMillis: () => 25
         }
-      ]
+        const _event = {}
 
-      deadlines.forEach(deadline => {
-        const flushDeadlineEnvVar = deadline.envVar
-        const customDeadline = deadline.value ? deadline.value : ''
+        const _handlerPath = path.resolve(__dirname, './fixtures/handler.js')
 
-        it(`traces error on impending timeout using ${flushDeadlineEnvVar} ${customDeadline} deadline`, (done) => {
-          process.env[flushDeadlineEnvVar] = customDeadline
-
-          const _context = {
-            getRemainingTimeInMillis: () => 25
-          }
-          const _event = {}
-
-          const _handlerPath = path.resolve(__dirname, './fixtures/handler.js')
+        // Load agent and patch handler.
+        return loadAgent().then(_ => {
           const app = require(_handlerPath)
           datadog = require('./fixtures/datadog-lambda')
 
-          let error = false
-          agent.use((_traces) => {
+          const result = datadog(app.timeoutHandler)(_event, _context)
+
+          const checkTraces = agent.use(_traces => {
             // First trace, since errors are tagged at root span level.
             const trace = _traces[0][0]
             expect(trace.error).to.equal(1)
-            error = true
             expect(trace.meta['error.type']).to.equal('Impending Timeout')
             // Ensure that once this finish, an error was tagged.
-          }).then(() => expect(error).to.equal(true))
+          })
 
           // Since these are expected to timeout and one can't kill the
           // environment, one has to wait for the result to come in so
           // the traces are verified above.
-          datadog(app.handler)(_event, _context).then(_ => done(), done)
+          return result.then(_ => {}).then(() => checkTraces)
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
This adds a conditional to not tag and finish a non-existing active span.

--
Since this added a specific scenario for a handler, I had to do changes to the unit tests. Refactoring them for better testing and developer experience. This wasn't done before because of yagni.

### Motivation
We never handle the use case where there is no active span when going through an impending timeout.
First discovered in `dd-trace-py`: https://github.com/DataDog/dd-trace-py/pull/5224

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
