### PR TITLE
add link to test failures when reporting via slack

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
   SLACK_REPORT_ENABLE: ${{ github.event.schedule }} # should be empty for non-nightly jobs
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  SLACK_MOREINFO: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 # TODO: upstream jobs
 

--- a/packages/dd-trace/test/setup/slack-report.js
+++ b/packages/dd-trace/test/setup/slack-report.js
@@ -7,6 +7,7 @@
 
 const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK
 const SLACK_REPORT_ENABLE = process.env.SLACK_REPORT_ENABLE
+const SLACK_MOREINFO = process.env.SLACK_MOREINFO
 
 const VERSION_EXTRACT = /^v?(\d+)\.(\d+)\.(\d+)$/
 
@@ -44,7 +45,14 @@ module.exports = async (failures) => {
     descriptions.push(description)
   }
 
-  const message = descriptions.join('\n\n')
+  let message = descriptions.join('\n\n')
+
+  if (SLACK_MOREINFO) {
+    // It's not easy to contextually link to individual job failures.
+    // @see https://github.com/community/community/discussions/8945
+    // Instead we add a single link at the end to the overall run.
+    message += `\n<${SLACK_MOREINFO}|View the failing test(s) here>.`
+  }
 
   reportToSlack(message)
 }


### PR DESCRIPTION
### What does this PR do?
- adds a link to the failing test run when reporting package failures via slack

### Motivation
- help an on call engineer diagnose a new package incompatibility even faster