### PR TITLE
[ci-visibility] Fix logic to validate commit SHAs

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -15,18 +15,18 @@ const {
   unshallowRepository
 } = require('../../../plugins/util/git')
 
-const isValidSha = (sha) => /[0-9a-f]{40}/.test(sha)
+const isValidSha1 = (sha) => /^[0-9a-f]{40}$/.test(sha)
+const isValidSha256 = (sha) => /^[0-9a-f]{64}$/.test(sha)
 
-function sanitizeCommits (commits) {
+function validateCommits (commits) {
   return commits.map(({ id: commitSha, type }) => {
     if (type !== 'commit') {
       throw new Error('Invalid commit type response')
     }
-    const sanitizedCommit = commitSha.replace(/[^0-9a-f]+/g, '')
-    if (sanitizedCommit !== commitSha || !isValidSha(sanitizedCommit)) {
+    if (!isValidSha1(commitSha) && !isValidSha256(commitSha)) {
       throw new Error('Invalid commit format')
     }
-    return sanitizedCommit
+    return commitSha
   })
 }
 
@@ -84,7 +84,7 @@ function getCommitsToExclude ({ url, isEvpProxy, repositoryUrl }, callback) {
     }
     let commitsToExclude
     try {
-      commitsToExclude = sanitizeCommits(JSON.parse(response).data)
+      commitsToExclude = validateCommits(JSON.parse(response).data)
     } catch (e) {
       return callback(new Error(`Can't parse commits to exclude response: ${e.message}`))
     }

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -23,10 +23,11 @@ function validateCommits (commits) {
     if (type !== 'commit') {
       throw new Error('Invalid commit type response')
     }
-    if (!isValidSha1(commitSha) && !isValidSha256(commitSha)) {
+    const sanitizedCommit = commitSha.replace(/[^0-9a-f]+/g, '')
+    if (!isValidSha1(sanitizedCommit) && !isValidSha256(sanitizedCommit)) {
       throw new Error('Invalid commit format')
     }
-    return commitSha
+    return sanitizedCommit
   })
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -23,11 +23,10 @@ function validateCommits (commits) {
     if (type !== 'commit') {
       throw new Error('Invalid commit type response')
     }
-    const sanitizedCommit = commitSha.replace(/[^0-9a-f]+/g, '')
-    if (!isValidSha1(sanitizedCommit) && !isValidSha256(sanitizedCommit)) {
-      throw new Error('Invalid commit format')
+    if (isValidSha1(commitSha) || isValidSha256(commitSha)) {
+      return commitSha.replace(/[^0-9a-f]+/g, '')
     }
-    return sanitizedCommit
+    throw new Error('Invalid commit format')
   })
 }
 


### PR DESCRIPTION
### What does this PR do?
* Fix logic to validate commit SHAs

### Motivation
The regex used to validate commit SHAs `/[0-9a-f]{40}/` was wrong, as it tested positive for strings longer than 40 characters. 

