### PR TITLE
fix kafka client trying to use ipv6 in tests

### DIFF
--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -25,7 +25,7 @@ describe('Plugin', () => {
           } = require(`../../../versions/kafkajs@${version}`).get()
           kafka = new Kafka({
             clientId: `kafkajs-test-${version}`,
-            brokers: ['localhost:9092']
+            brokers: ['127.0.0.1:9092']
           })
         })
         describe('producer', () => {

--- a/packages/dd-trace/test/setup/services/kafka.js
+++ b/packages/dd-trace/test/setup/services/kafka.js
@@ -5,7 +5,7 @@ const { Kafka } = require('../../../../../versions/kafkajs').get()
 
 const kafka = new Kafka({
   clientId: 'setup-client',
-  brokers: ['localhost:9092']
+  brokers: ['127.0.0.1:9092']
 })
 const producer = kafka.producer()
 const consumer = kafka.consumer({ groupId: 'test-group' })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix Kafka client trying to use IPv6 in tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests can otherwise fail in some environments like macOS.