### PR TITLE
adding a gatekeeper job to fail PRs

### DIFF
--- a/.github/workflows/pr-all-green.yml
+++ b/.github/workflows/pr-all-green.yml
@@ -1,0 +1,28 @@
+name: Alls Green
+
+on:
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  check:
+    if: always()
+
+    needs:
+    - system-tests
+    - parametric
+    - package-size-report
+    - amqp10
+    - mysql
+    # plus a ton more
+
+    runs-on: Ubuntu-latest
+
+    steps:
+    - name: Determine if everything is passing
+      uses: re-actors/alls-green@release/v1
+      with:
+        #allowed-failures: docs, linters
+        #allowed-skips: non-voting-flaky-job
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### What does this PR do?
- currently PRs can be merged even if jobs are failing
- this requires that all listed jobs pass first

### Motivation
- this should increase our confidence in product correctness
