### PR TITLE
[ci-visibility] Fix error in test fingerprint calculation due to `test.bundle`

### DIFF
--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -36,7 +36,8 @@ class CucumberPlugin extends CiPlugin {
       const testSuiteMetadata = getTestSuiteCommonTags(
         this.command,
         this.frameworkVersion,
-        getTestSuitePath(testSuiteFullPath, this.sourceRoot)
+        getTestSuitePath(testSuiteFullPath, this.sourceRoot),
+        'cucumber'
       )
       this.testSuiteSpan = this.tracer.startSpan('cucumber.test_suite', {
         childOf: this.testModuleSpan,

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -95,8 +95,8 @@ module.exports = (on, config) => {
     command = getCypressCommand(details)
     frameworkVersion = getCypressVersion(details)
 
-    const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion)
-    const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion)
+    const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion, 'cypress')
+    const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion, 'cypress')
 
     testSessionSpan = tracer.startSpan('cypress.test_session', {
       childOf,
@@ -137,7 +137,7 @@ module.exports = (on, config) => {
       if (testSuiteSpan) {
         return null
       }
-      const testSuiteSpanMetadata = getTestSuiteCommonTags(command, frameworkVersion, suite)
+      const testSuiteSpanMetadata = getTestSuiteCommonTags(command, frameworkVersion, suite, 'cypress')
       testSuiteSpan = tracer.startSpan('cypress.test_suite', {
         childOf: testModuleSpan,
         tags: {
@@ -167,7 +167,7 @@ module.exports = (on, config) => {
         [TEST_COMMAND]: command,
         [TEST_MODULE_ID]: testModuleId,
         [TEST_COMMAND]: command,
-        [TEST_BUNDLE]: command
+        [TEST_BUNDLE]: 'cypress'
       }
 
       const {

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -16,6 +16,7 @@ const {
   TEST_SESSION_ID,
   TEST_COMMAND,
   TEST_BUNDLE,
+  TEST_MODULE,
   finishAllTraceSpans
 } = require('../../dd-trace/src/plugins/util/test')
 
@@ -167,7 +168,8 @@ module.exports = (on, config) => {
         [TEST_COMMAND]: command,
         [TEST_MODULE_ID]: testModuleId,
         [TEST_COMMAND]: command,
-        [TEST_BUNDLE]: 'cypress'
+        [TEST_BUNDLE]: 'cypress',
+        [TEST_MODULE]: 'cypress'
       }
 
       const {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -90,7 +90,7 @@ class JestPlugin extends CiPlugin {
         'x-datadog-parent-id': testModuleId
       })
 
-      const testSuiteMetadata = getTestSuiteCommonTags(testCommand, frameworkVersion, testSuite)
+      const testSuiteMetadata = getTestSuiteCommonTags(testCommand, frameworkVersion, testSuite, 'jest')
 
       this.testSuiteSpan = this.tracer.startSpan('jest.test_suite', {
         childOf: testSessionSpanContext,

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -46,7 +46,8 @@ class MochaPlugin extends CiPlugin {
       const testSuiteMetadata = getTestSuiteCommonTags(
         this.command,
         this.frameworkVersion,
-        getTestSuitePath(suite.file, this.sourceRoot)
+        getTestSuitePath(suite.file, this.sourceRoot),
+        'mocha'
       )
       const testSuiteSpan = this.tracer.startSpan('mocha.test_suite', {
         childOf: this.testModuleSpan,

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -39,7 +39,8 @@ class PlaywrightPlugin extends CiPlugin {
       const testSuiteMetadata = getTestSuiteCommonTags(
         this.command,
         this.frameworkVersion,
-        testSuite
+        testSuite,
+        'playwright'
       )
 
       const testSuiteSpan = this.tracer.startSpan('playwright.test_suite', {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -12,7 +12,8 @@ const {
   TEST_MODULE_ID,
   TEST_SESSION_ID,
   TEST_COMMAND,
-  TEST_BUNDLE
+  TEST_BUNDLE,
+  TEST_MODULE
 } = require('./util/test')
 const Plugin = require('./plugin')
 const { COMPONENT } = require('../constants')
@@ -129,7 +130,8 @@ module.exports = class CiPlugin extends Plugin {
         [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
         [TEST_SESSION_ID]: testSuiteSpan.context().toTraceId(),
         [TEST_COMMAND]: testSuiteSpan.context()._tags[TEST_COMMAND],
-        [TEST_BUNDLE]: this.constructor.name
+        [TEST_BUNDLE]: this.constructor.name,
+        [TEST_MODULE]: this.constructor.name
       }
       if (testSuiteSpan.context()._parentId) {
         suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -50,8 +50,8 @@ module.exports = class CiPlugin extends Plugin {
 
     this.addSub(`ci:${this.constructor.name}:session:start`, ({ command, frameworkVersion, rootDir }) => {
       const childOf = getTestParentSpan(this.tracer)
-      const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion)
-      const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion)
+      const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion, this.constructor.name)
+      const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion, this.constructor.name)
 
       this.command = command
       this.frameworkVersion = frameworkVersion
@@ -129,7 +129,7 @@ module.exports = class CiPlugin extends Plugin {
         [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
         [TEST_SESSION_ID]: testSuiteSpan.context().toTraceId(),
         [TEST_COMMAND]: testSuiteSpan.context()._tags[TEST_COMMAND],
-        [TEST_BUNDLE]: testSuiteSpan.context()._tags[TEST_COMMAND]
+        [TEST_BUNDLE]: this.constructor.name
       }
       if (testSuiteSpan.context()._parentId) {
         suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -39,6 +39,7 @@ const TEST_SOURCE_FILE = 'test.source.file'
 const LIBRARY_VERSION = 'library_version'
 const TEST_COMMAND = 'test.command'
 const TEST_BUNDLE = 'test.bundle'
+const TEST_MODULE = 'test.module'
 const TEST_SESSION_ID = 'test_session_id'
 const TEST_MODULE_ID = 'test_module_id'
 const TEST_SUITE_ID = 'test_suite_id'
@@ -87,6 +88,7 @@ module.exports = {
   TEST_SUITE_ID,
   TEST_ITR_TESTS_SKIPPED,
   TEST_BUNDLE,
+  TEST_MODULE,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
   TEST_SESSION_CODE_COVERAGE_ENABLED,
   TEST_MODULE_ITR_SKIPPING_ENABLED,
@@ -266,6 +268,7 @@ function getTestSessionCommonTags (command, testFrameworkVersion, testFramework)
     [SPAN_TYPE]: 'test_session_end',
     [RESOURCE_NAME]: `test_session.${command}`,
     [TEST_BUNDLE]: testFramework,
+    [TEST_MODULE]: testFramework,
     ...getTestLevelCommonTags(command, testFrameworkVersion)
   }
 }
@@ -275,6 +278,7 @@ function getTestModuleCommonTags (command, testFrameworkVersion, testFramework) 
     [SPAN_TYPE]: 'test_module_end',
     [RESOURCE_NAME]: `test_module.${command}`,
     [TEST_BUNDLE]: testFramework,
+    [TEST_MODULE]: testFramework,
     ...getTestLevelCommonTags(command, testFrameworkVersion)
   }
 }
@@ -284,6 +288,7 @@ function getTestSuiteCommonTags (command, testFrameworkVersion, testSuite, testF
     [SPAN_TYPE]: 'test_suite_end',
     [RESOURCE_NAME]: `test_suite.${testSuite}`,
     [TEST_BUNDLE]: testFramework,
+    [TEST_MODULE]: testFramework,
     [TEST_SUITE]: testSuite,
     ...getTestLevelCommonTags(command, testFrameworkVersion)
   }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -261,28 +261,29 @@ function getTestLevelCommonTags (command, testFrameworkVersion) {
   }
 }
 
-function getTestSessionCommonTags (command, testFrameworkVersion) {
+function getTestSessionCommonTags (command, testFrameworkVersion, testFramework) {
   return {
     [SPAN_TYPE]: 'test_session_end',
     [RESOURCE_NAME]: `test_session.${command}`,
+    [TEST_BUNDLE]: testFramework,
     ...getTestLevelCommonTags(command, testFrameworkVersion)
   }
 }
 
-function getTestModuleCommonTags (command, testFrameworkVersion) {
+function getTestModuleCommonTags (command, testFrameworkVersion, testFramework) {
   return {
     [SPAN_TYPE]: 'test_module_end',
     [RESOURCE_NAME]: `test_module.${command}`,
-    [TEST_BUNDLE]: command,
+    [TEST_BUNDLE]: testFramework,
     ...getTestLevelCommonTags(command, testFrameworkVersion)
   }
 }
 
-function getTestSuiteCommonTags (command, testFrameworkVersion, testSuite) {
+function getTestSuiteCommonTags (command, testFrameworkVersion, testSuite, testFramework) {
   return {
     [SPAN_TYPE]: 'test_suite_end',
     [RESOURCE_NAME]: `test_suite.${testSuite}`,
-    [TEST_BUNDLE]: command,
+    [TEST_BUNDLE]: testFramework,
     [TEST_SUITE]: testSuite,
     ...getTestLevelCommonTags(command, testFrameworkVersion)
   }


### PR DESCRIPTION
### What does this PR do?

* Change `test.bundle` so that it does _not_ follow `test.command`. Since there is no concept of bundle in js, it will be set to the test framework, which can be considered constant for a given project. If the framework ever changes in a project, it's a good idea that fingerprints are different.

### Motivation

When adding test modules to CI Visibility I missed that `test.bundle` is used as part of the test fingerprint (which is used for distinguishing flaky tests, among other usages). Since there is no concept of module in javascript, I set it to copy `test.command`, which is *wrong*, as the same test can run under different test commands. 

Fixes #2874 

