### PR TITLE
Export heap profile on v8 heap OOM

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
+      # Disable core dumps since some integration tests intentionally abort and core dump generation takes around 5-10s
+      - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
       - run: yarn test:integration
 
   lint:

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -65,10 +65,11 @@ class FakeAgent extends EventEmitter {
     })
   }
 
-  assertMessageReceived (fn, timeout) {
+  assertMessageReceived (fn, timeout, expectedMessageCount = 1) {
     timeout = timeout || 5000
     let resultResolve
     let resultReject
+    let msgCount = 0
     const errors = []
 
     const timeoutObj = setTimeout(() => {
@@ -88,9 +89,12 @@ class FakeAgent extends EventEmitter {
 
     const messageHandler = msg => {
       try {
+        msgCount += 1
         fn(msg)
-        resultResolve()
-        this.removeListener('message', messageHandler)
+        if (msgCount === expectedMessageCount) {
+          resultResolve()
+          this.removeListener('message', messageHandler)
+        }
       } catch (e) {
         errors.push(e)
       }
@@ -119,6 +123,9 @@ function spawnProc (filename, options = {}) {
 }
 
 async function createSandbox (dependencies = [], isGitRepo = false) {
+  /* To execute integration tests without a sandbox uncomment the next line
+   * and do `yarn link && yarn link dd-trace` */
+  // return { folder: path.join(process.cwd(), 'integration-tests'), remove: async () => {} }
   const folder = path.join(os.tmpdir(), id().toString())
   const out = path.join(folder, 'dd-trace.tgz')
   const allDependencies = [`file:${out}`].concat(dependencies)

--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -2,36 +2,43 @@
 
 const {
   FakeAgent,
-  spawnProc,
   createSandbox
 } = require('./helpers')
+const childProcess = require('child_process')
+const { fork } = childProcess
 const path = require('path')
 const { assert } = require('chai')
 
-async function checkProfiles (agent, proc, timeout) {
+async function checkProfiles (agent, proc, timeout,
+  expectedProfileTypes = ['wall', 'space'], expectBadExit = false, multiplicity = 1) {
   const resultPromise = agent.assertMessageReceived(({ headers, payload, files }) => {
     assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
     assert.propertyVal(payload, 'format', 'pprof')
-    assert.deepPropertyVal(payload, 'types', ['wall', 'space'])
-    assert.propertyVal(files[0], 'originalname', 'wall.pb.gz')
-    assert.propertyVal(files[1], 'originalname', 'space.pb.gz')
-  }, timeout)
+    assert.deepPropertyVal(payload, 'types', expectedProfileTypes)
+    for (const [index, profileType] of expectedProfileTypes.entries()) {
+      assert.propertyVal(files[index], 'originalname', `${profileType}.pb.gz`)
+    }
+  }, timeout, multiplicity)
 
   await new Promise((resolve, reject) => {
     const timeoutObj = setTimeout(() => {
       reject(new Error('Process timed out'))
     }, timeout)
 
-    proc.on('exit', code => {
+    function checkExitCode (code) {
       clearTimeout(timeoutObj)
-      if (code !== 0) {
-        reject(new Error(`Process exited with status code ${code}.`))
+
+      if ((code !== 0) !== expectBadExit) {
+        reject(new Error(`Process exited with unexpected status code ${code}.`))
       } else {
         resolve()
       }
-    })
-  })
+    }
 
+    proc
+      .on('error', reject)
+      .on('exit', checkExitCode)
+  })
   return resultPromise
 }
 
@@ -41,11 +48,17 @@ describe('profiler', () => {
   let sandbox
   let cwd
   let profilerTestFile
+  let oomTestFile
+  let oomEnv
+  let oomExecArgv
+  const timeout = 5000
 
   before(async () => {
     sandbox = await createSandbox()
     cwd = sandbox.folder
     profilerTestFile = path.join(cwd, 'profiler/index.js')
+    oomTestFile = path.join(cwd, 'profiler/oom.js')
+    oomExecArgv = ['--max-old-space-size=50']
   })
 
   after(async () => {
@@ -55,6 +68,12 @@ describe('profiler', () => {
   context('shutdown', () => {
     beforeEach(async () => {
       agent = await new FakeAgent().start()
+      oomEnv = {
+        DD_TRACE_AGENT_PORT: agent.port,
+        DD_PROFILING_ENABLED: 1,
+        DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED: 1,
+        DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'process'
+      }
     })
 
     afterEach(async () => {
@@ -63,14 +82,78 @@ describe('profiler', () => {
     })
 
     it('records profile on process exit', async () => {
-      proc = await spawnProc(profilerTestFile, {
+      proc = fork(profilerTestFile, {
         cwd,
         env: {
           DD_TRACE_AGENT_PORT: agent.port,
           DD_PROFILING_ENABLED: 1
         }
       })
-      return checkProfiles(agent, proc, 5000)
+      return checkProfiles(agent, proc, timeout)
+    })
+
+    it('sends a heap profile on OOM with external process', async () => {
+      proc = fork(oomTestFile, {
+        cwd,
+        execArgv: oomExecArgv,
+        env: oomEnv
+      })
+      return checkProfiles(agent, proc, timeout, ['space'], true)
+    })
+
+    it('sends a heap profile on OOM with external process and ends successfully', async () => {
+      proc = fork(oomTestFile, {
+        cwd,
+        execArgv: oomExecArgv,
+        env: {
+          ...oomEnv,
+          DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 15000000,
+          DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 3
+        }
+      })
+      return checkProfiles(agent, proc, timeout, ['space'], false, 2)
+    })
+
+    it('sends a heap profile on OOM with async callback', async () => {
+      proc = fork(oomTestFile, {
+        cwd,
+        execArgv: oomExecArgv,
+        env: {
+          ...oomEnv,
+          DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 10000000,
+          DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 1,
+          DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'async'
+        }
+      })
+      return checkProfiles(agent, proc, timeout, ['space'], true)
+    })
+
+    it('sends a heap profile on OOM with interrupt callback', async () => {
+      proc = fork(oomTestFile, {
+        cwd,
+        execArgv: oomExecArgv,
+        env: {
+          ...oomEnv,
+          DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 10000000,
+          DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 1,
+          DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'interrupt'
+        }
+      })
+      return checkProfiles(agent, proc, timeout, ['space'], true)
+    })
+
+    it('sends heap profiles on OOM with multiple strategies', async () => {
+      proc = fork(oomTestFile, {
+        cwd,
+        execArgv: oomExecArgv,
+        env: {
+          ...oomEnv,
+          DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 10000000,
+          DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 1,
+          DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'async,interrupt,process'
+        }
+      })
+      return checkProfiles(agent, proc, timeout, ['space'], true, 4)
     })
   })
 })

--- a/integration-tests/profiler/index.js
+++ b/integration-tests/profiler/index.js
@@ -21,7 +21,4 @@ function busyWait (ms) {
   })
 }
 
-// Runner expects child process to send a port
-process.send({ port: 0 })
-
 setImmediate(async () => busyWait(500))

--- a/integration-tests/profiler/oom.js
+++ b/integration-tests/profiler/oom.js
@@ -1,0 +1,34 @@
+'use strict'
+
+require('dd-trace').init()
+
+const { Worker, isMainThread } = require('node:worker_threads')
+
+if (isMainThread) {
+  const nworkers = Number(process.argv[2])
+  const workers = []
+  if (nworkers) {
+    for (let i = 0; i < nworkers; i++) {
+      workers.push(new Worker(__filename))
+    }
+  }
+}
+
+const leak = []
+let count = 0
+
+function foo (size) {
+  count += 1
+  const n = size / 8
+  const x = []
+  x.length = n
+  for (let i = 0; i < n; i++) { x[i] = Math.random() }
+  leak.push(x)
+
+  if (count < maxCount) { setTimeout(() => foo(size), sleepMs) }
+}
+
+const maxCount = process.argv[3] || 12
+const sleepMs = process.argv[4] || 50
+
+setTimeout(() => foo(5 * 1024 * 1024), sleepMs)

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@datadog/native-iast-rewriter": "2.0.1",
     "@datadog/native-iast-taint-tracking": "1.1.1",
     "@datadog/native-metrics": "^1.5.0",
-    "@datadog/pprof": "^2.0.0",
+    "@datadog/pprof": "^2.1.0",
     "@datadog/sketches-js": "^2.1.0",
     "crypto-randomuuid": "^1.0.0",
     "diagnostics_channel": "^1.1.0",

--- a/packages/dd-trace/src/profiling/constants.js
+++ b/packages/dd-trace/src/profiling/constants.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const snapshotKinds = Object.freeze({
+  PERIODIC: 'periodic',
+  ON_SHUTDOWN: 'on_shutdown',
+  ON_OUT_OF_MEMORY: 'on_oom'
+})
+
+const oomExportStrategies = Object.freeze({
+  PROCESS: 'process',
+  ASYNC_CALLBACK: 'async',
+  INTERRUPT_CALLBACK: 'interrupt',
+  LOGS: 'logs'
+})
+
+module.exports = { snapshotKinds, oomExportStrategies }

--- a/packages/dd-trace/src/profiling/exporter_cli.js
+++ b/packages/dd-trace/src/profiling/exporter_cli.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { AgentExporter } = require('./exporters/agent')
+const { FileExporter } = require('./exporters/file')
+
+const { SourceMapper, heap, encode } = require('@datadog/pprof')
+const { ConsoleLogger } = require('./loggers/console')
+const { tagger } = require('./tagger')
+const fs = require('fs')
+const { fileURLToPath } = require('url')
+
+const logger = new ConsoleLogger()
+const timeoutMs = 10 * 1000
+
+function exporterFromURL (url) {
+  if (url.protocol === 'file:') {
+    return new FileExporter({ pprofPrefix: fileURLToPath(url) })
+  } else {
+    return new AgentExporter({
+      url,
+      logger,
+      uploadTimeout: timeoutMs
+    })
+  }
+}
+
+async function exportProfile (urls, tags, profileType, profile) {
+  let mapper
+  try {
+    mapper = await SourceMapper.create([process.cwd()])
+  } catch (err) {
+    logger.error(err)
+  }
+
+  const encodedProfile = await encode(heap.convertProfile(profile, undefined, mapper))
+  const start = new Date()
+  for (const url of urls) {
+    const exporter = exporterFromURL(url)
+
+    await exporter.export({
+      profiles: {
+        [profileType]: encodedProfile
+      },
+      start,
+      end: start,
+      tags
+    })
+  }
+}
+
+/** Expected command line arguments are:
+* - Comma separated list of URLs (eg. "http://127.0.0.1:8126/,file:///tmp/foo.pprof")
+* - Tags (eg. "service:nodejs_oom_test,version:1.0.0")
+* - Profiletype (eg. space,wall,cpu)
+* - JSON profile filepath
+**/
+const urls = process.argv[2].split(',').map(s => new URL(s))
+const tags = tagger.parse(process.argv[3])
+const profileType = process.argv[4]
+const profile = JSON.parse(fs.readFileSync(process.argv[5]))
+
+exportProfile(urls, tags, profileType, profile)

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -1,17 +1,37 @@
 'use strict'
 
+const { oomExportStrategies } = require('../constants')
+
+function strategiesToCallbackMode (strategies, callbackMode) {
+  const hasInterrupt = strategies.includes(oomExportStrategies.INTERRUPT_CALLBACK) ? callbackMode.Interrupt : 0
+  const hasCallback = strategies.includes(oomExportStrategies.ASYNC_CALLBACK) ? callbackMode.Async : 0
+  return hasInterrupt | hasCallback
+}
+
 class NativeSpaceProfiler {
   constructor (options = {}) {
     this.type = 'space'
     this._samplingInterval = options.samplingInterval || 512 * 1024
     this._stackDepth = options.stackDepth || 64
     this._pprof = undefined
+    this._oomMonitoring = options.oomMonitoring || {}
   }
 
-  start ({ mapper } = {}) {
+  start ({ mapper, nearOOMCallback } = {}) {
     this._mapper = mapper
     this._pprof = require('@datadog/pprof')
     this._pprof.heap.start(this._samplingInterval, this._stackDepth)
+    if (this._oomMonitoring.enabled) {
+      const strategies = this._oomMonitoring.exportStrategies
+      this._pprof.heap.monitorOutOfMemory(
+        this._oomMonitoring.heapLimitExtensionSize,
+        this._oomMonitoring.maxHeapExtensionCount,
+        strategies.includes(oomExportStrategies.LOGS),
+        strategies.includes(oomExportStrategies.PROCESS) ? this._oomMonitoring.exportCommand : [],
+        (profile) => nearOOMCallback(this.type, this._pprof.encodeSync(profile)),
+        strategiesToCallbackMode(strategies, this._pprof.heap.CallbackMode)
+      )
+    }
   }
 
   profile () {


### PR DESCRIPTION
What does this PR do?
Add an optional mode to export a heap profile when v8 runs out of heap memory.

Motivation
Heap profiles are sent every minute, and might not reflect the state of heap when OOM occurred.
