### PR TITLE
fix using pubsub internal api directly

### DIFF
--- a/packages/datadog-instrumentations/src/google-cloud-pubsub.js
+++ b/packages/datadog-instrumentations/src/google-cloud-pubsub.js
@@ -15,46 +15,106 @@ const receiveStartCh = channel(`apm:google-cloud-pubsub:receive:start`)
 const receiveFinishCh = channel('apm:google-cloud-pubsub:receive:finish')
 const receiveErrorCh = channel('apm:google-cloud-pubsub:receive:error')
 
-addHook({ name: '@google-cloud/pubsub', versions: ['>=1.2'] }, (obj) => {
-  const PubSub = obj.PubSub
-  const Subscription = obj.Subscription
+const publisherMethods = [
+  'createTopic',
+  'updateTopic',
+  'publish',
+  'getTopic',
+  'listTopics',
+  'listTopicSubscriptions',
+  'listTopicSnapshots',
+  'deleteTopic',
+  'detachSubscription'
+]
 
-  shimmer.wrap(PubSub.prototype, 'request', request => function (cfg = { reqOpts: {} }, cb) {
-    if (!requestStartCh.hasSubscribers) {
-      return request.apply(this, arguments)
-    }
+const schemaServiceMethods = [
+  'createSchema',
+  'getSchema',
+  'listSchemas',
+  'listSchemaRevisions',
+  'commitSchema',
+  'rollbackSchema',
+  'deleteSchemaRevision',
+  'deleteSchema',
+  'validateSchema',
+  'validateMessage'
+]
+
+const subscriberMethods = [
+  'createSubscription',
+  'getSubscription',
+  'updateSubscription',
+  'listSubscriptions',
+  'deleteSubscription',
+  'modifyAckDeadline',
+  'acknowledge',
+  'pull',
+  'streamingPull',
+  'modifyPushConfig',
+  'getSnapshot',
+  'listSnapshots',
+  'createSnapshot',
+  'updateSnapshot',
+  'deleteSnapshot',
+  'seek'
+]
+
+function wrapMethod (method) {
+  const api = method.name
+
+  return function (request) {
+    if (!requestStartCh.hasSubscribers) return request.apply(this, arguments)
 
     const innerAsyncResource = new AsyncResource('bound-anonymous-fn')
-    const outerAsyncResource = new AsyncResource('bound-anonymous-fn')
 
     return innerAsyncResource.runInAsyncScope(() => {
-      let messages = []
-      if (cfg.reqOpts && cfg.method === 'publish') {
-        messages = cfg.reqOpts.messages
-      }
+      const projectId = this.auth._cachedProjectId
+      const cb = arguments[arguments.length - 1]
 
-      requestStartCh.publish({ cfg, projectId: this.projectId, messages })
-      cb = outerAsyncResource.bind(cb)
+      requestStartCh.publish({ request, api, projectId })
 
-      const fn = () => {
-        arguments[1] = innerAsyncResource.bind(function (error) {
+      if (typeof cb === 'function') {
+        const outerAsyncResource = new AsyncResource('bound-anonymous-fn')
+
+        arguments[arguments.length - 1] = innerAsyncResource.bind(function (error) {
           if (error) {
             requestErrorCh.publish(error)
           }
-          requestFinishCh.publish(undefined)
-          return cb.apply(this, arguments)
-        })
-        return request.apply(this, arguments)
-      }
 
-      try {
-        return fn.apply(this, arguments)
-      } catch (e) {
-        requestErrorCh.publish(e)
-        throw e
+          requestFinishCh.publish()
+
+          return outerAsyncResource.runInAsyncScope(() => cb.apply(this, arguments))
+        })
+
+        return method.apply(this, arguments)
+      } else {
+        return method.apply(this, arguments)
+          .then(
+            response => {
+              requestFinishCh.publish()
+              return response
+            },
+            error => {
+              requestErrorCh.publish(error)
+              requestFinishCh.publish()
+              throw error
+            }
+          )
       }
     })
-  })
+  }
+}
+
+function massWrap (obj, methods, wrapper) {
+  for (const method of methods) {
+    if (typeof obj[method] === 'function') {
+      shimmer.wrap(obj, method, wrapper)
+    }
+  }
+}
+
+addHook({ name: '@google-cloud/pubsub', versions: ['>=1.2'] }, (obj) => {
+  const Subscription = obj.Subscription
 
   shimmer.wrap(Subscription.prototype, 'emit', emit => function (eventName, message) {
     if (eventName !== 'message' || !message) return emit.apply(this, arguments)
@@ -95,6 +155,19 @@ addHook({ name: '@google-cloud/pubsub', versions: ['>=1.2'], file: 'build/src/le
     }
     return clear.apply(this, arguments)
   })
+
+  return obj
+})
+
+addHook({ name: '@google-cloud/pubsub', versions: ['>=1.2'] }, (obj) => {
+  const { PublisherClient, SchemaServiceClient, SubscriberClient } = obj.v1
+
+  massWrap(PublisherClient.prototype, publisherMethods, wrapMethod)
+  massWrap(SubscriberClient.prototype, subscriberMethods, wrapMethod)
+
+  if (SchemaServiceClient) {
+    massWrap(SchemaServiceClient.prototype, schemaServiceMethods, wrapMethod)
+  }
 
   return obj
 })

--- a/packages/datadog-plugin-google-cloud-pubsub/src/client.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/client.js
@@ -6,15 +6,15 @@ class GoogleCloudPubsubClientPlugin extends ClientPlugin {
   static get name () { return 'google-cloud-pubsub' }
   static get operation () { return 'request' }
 
-  start ({ cfg, projectId }) {
-    if (cfg.method === 'publish') return
+  start ({ request, api, projectId }) {
+    if (api === 'publish') return
 
     this.startSpan('pubsub.request', {
       service: this.config.service || `${this.tracer._service}-pubsub`,
-      resource: [cfg.method, cfg.reqOpts.name].filter(x => x).join(' '),
+      resource: [api, request.name].filter(x => x).join(' '),
       kind: 'client',
       meta: {
-        'pubsub.method': cfg.method,
+        'pubsub.method': api,
         'gcloud.project_id': projectId
       }
     })

--- a/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
@@ -6,17 +6,18 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
   static get name () { return 'google-cloud-pubsub' }
   static get operation () { return 'request' }
 
-  start ({ cfg, projectId, messages }) {
-    if (cfg.method !== 'publish') return
+  start ({ request, api, projectId }) {
+    if (api !== 'publish') return
 
-    const topic = cfg.reqOpts.topic
+    const messages = request.messages || []
+    const topic = request.topic
     const span = this.startSpan('pubsub.request', { // TODO: rename
       service: this.config.service || `${this.tracer._service}-pubsub`,
-      resource: `${cfg.method} ${topic}`,
+      resource: `${api} ${topic}`,
       kind: 'producer',
       meta: {
         'gcloud.project_id': projectId,
-        'pubsub.method': cfg.method, // TODO: remove
+        'pubsub.method': api, // TODO: remove
         'pubsub.topic': topic
       }
     })

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -28,6 +28,8 @@ describe('Plugin', () => {
       let project
       let topicName
       let resource
+      let v1
+      let gax
 
       describe('without configuration', () => {
         beforeEach(() => {
@@ -35,11 +37,13 @@ describe('Plugin', () => {
         })
         beforeEach(() => {
           tracer = require('../../dd-trace')
-          const { PubSub } = require(`../../../versions/@google-cloud/pubsub@${version}`).get()
+          gax = require(`../../../versions/google-gax@3.5.7`).get()
+          const lib = require(`../../../versions/@google-cloud/pubsub@${version}`).get()
           project = getProjectId()
           topicName = getTopic()
           resource = `projects/${project}/topics/${topicName}`
-          pubsub = new PubSub({ projectId: project })
+          v1 = lib.v1
+          pubsub = new lib.PubSub({ projectId: project })
         })
         describe('createTopic', () => {
           it('should be instrumented', async () => {
@@ -54,24 +58,41 @@ describe('Plugin', () => {
             return expectedSpanPromise
           })
 
-          // TODO: Figure out how to cause an error at the client level.
-          it.skip('should be instrumented w/ error', async () => {
-            const error = new Error('bad')
+          it('should be instrumented when using the internal API', async () => {
+            const publisher = new v1.PublisherClient({
+              grpc: gax.grpc,
+              projectId: project,
+              servicePath: 'localhost',
+              port: 8081,
+              sslCreds: gax.grpc.credentials.createInsecure()
+            }, gax)
+
+            const expectedSpanPromise = expectSpanWithDefaults({
+              meta: {
+                'pubsub.method': 'createTopic',
+                'span.kind': 'client',
+                'component': 'google-cloud-pubsub'
+              }
+            })
+            const name = `projects/${project}/topics/${topicName}`
+            const promise = publisher.createTopic({ name })
+            await promise
+
+            return expectedSpanPromise
+          })
+
+          it('should be instrumented w/ error', async () => {
             const expectedSpanPromise = expectSpanWithDefaults({
               error: 1,
               meta: {
                 'pubsub.method': 'createTopic',
-                [ERROR_MESSAGE]: error.message,
-                [ERROR_TYPE]: error.name,
-                [ERROR_STACK]: error.stack,
                 'component': 'google-cloud-pubsub'
               }
             })
-            pubsub.getClient_ = function (config, callback) {
-              callback(error)
-            }
+            const publisher = new v1.PublisherClient({ projectId: project })
+            const name = `projects/${project}/topics/${topicName}`
             try {
-              await pubsub.createTopic(topicName)
+              await publisher.createTopic({ name })
             } catch (e) {
               // this is just to prevent mocha from crashing
             }
@@ -99,31 +120,6 @@ describe('Plugin', () => {
             })
             const [topic] = await pubsub.createTopic(topicName)
             await publish(topic, { data: Buffer.from('hello') })
-            return expectedSpanPromise
-          })
-
-          // TODO: Figure out how to cause an error at the client level.
-          it.skip('should be instrumented w/ error', async () => {
-            const error = new Error('bad')
-            const expectedSpanPromise = expectSpanWithDefaults({
-              error: 1,
-              meta: {
-                'pubsub.method': 'publish',
-                [ERROR_MESSAGE]: error.message,
-                [ERROR_TYPE]: error.name,
-                [ERROR_STACK]: error.stack,
-                'component': 'google-cloud-pubsub'
-              }
-            })
-            const [topic] = await pubsub.createTopic(topicName)
-            pubsub.getClient_ = function (config, callback) {
-              callback(error)
-            }
-            try {
-              await publish(topic, { data: Buffer.from('hello') })
-            } catch (e) {
-              // this is just to prevent mocha from crashing
-            }
             return expectedSpanPromise
           })
 

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -54,7 +54,8 @@ describe('Plugin', () => {
             return expectedSpanPromise
           })
 
-          it('should be instrumented w/ error', async () => {
+          // TODO: Figure out how to cause an error at the client level.
+          it.skip('should be instrumented w/ error', async () => {
             const error = new Error('bad')
             const expectedSpanPromise = expectSpanWithDefaults({
               error: 1,
@@ -101,7 +102,8 @@ describe('Plugin', () => {
             return expectedSpanPromise
           })
 
-          it('should be instrumented w/ error', async () => {
+          // TODO: Figure out how to cause an error at the client level.
+          it.skip('should be instrumented w/ error', async () => {
             const error = new Error('bad')
             const expectedSpanPromise = expectSpanWithDefaults({
               error: 1,

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -53,6 +53,12 @@
       "versions": [">=3"]
     }
   ],
+  "google-cloud-pubsub": [
+    {
+      "name": "google-gax",
+      "versions": ["3.5.7"]
+    }
+  ],
   "graphql": [
     {
       "name": "apollo-server-core",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix using Google Cloud PubSub client internal API directly.

### Motivation
<!-- What inspired you to submit this pull request? -->

Make it possible to use the internal API directly, for example:

```js
const { v1 } = require('@google-cloud/pubsub')
const publisher = new v1.PublisherClient({});
const response = await publisher.publish({ topic: 'abc', messages: [{ data: 'hello' }] })
```

The way this was implemented before was too high-level so traces were not generated when using the internal API directly.