### PR TITLE
[ci-visibility] Fix agent proxy test

### DIFF
--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -218,11 +218,17 @@ describe('AgentProxyCiVisibilityExporter', () => {
       const agentProxyCiVisibilityExporter = new AgentProxyCiVisibilityExporter({ port, tags })
       agentProxyCiVisibilityExporter._writer = mockWriter
       agentProxyCiVisibilityExporter._coverageWriter = mockCoverageWriter
-      agentProxyCiVisibilityExporter.setUrl('http://example2.com')
-      const url = new URL('http://example2.com')
+
+      const newUrl = 'http://example2.com'
+      const newCoverageUrl = 'http://example3.com'
+      agentProxyCiVisibilityExporter.setUrl(newUrl, newCoverageUrl)
+      const url = new URL(newUrl)
+      const coverageUrl = new URL(newCoverageUrl)
+
       expect(agentProxyCiVisibilityExporter._url).to.deep.equal(url)
+      expect(agentProxyCiVisibilityExporter._coverageUrl).to.deep.equal(coverageUrl)
       expect(mockWriter.setUrl).to.have.been.calledWith(url)
-      expect(mockCoverageWriter.setUrl).to.have.been.calledWith(url)
+      expect(mockCoverageWriter.setUrl).to.have.been.calledWith(coverageUrl)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Fix agent proxy test.

### Motivation
The [19.8.0 nodejs release](https://nodejs.org/download/release/latest-v19.x/) (released today) seems to have changed something that makes one of the agent proxy tests fail: https://github.com/DataDog/dd-trace-js/actions/runs/4420601006/jobs/7750687083.

The changes in this PR makes the test better and immune to this nodejs change. 

