### PR TITLE
[ci-visibility] Fix cypress errors when using interactive mode

### DIFF
--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -20,6 +20,8 @@ const {
   finishAllTraceSpans
 } = require('../../dd-trace/src/plugins/util/test')
 
+const TEST_FRAMEWORK_NAME = 'cypress'
+
 const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
 
 const CYPRESS_STATUS_TO_TEST_STATUS = {
@@ -52,9 +54,9 @@ function getCypressVersion (details) {
 
 function getCypressCommand (details) {
   if (!details) {
-    return 'cypress'
+    return TEST_FRAMEWORK_NAME
   }
-  return `cypress ${details.specPattern || ''}`
+  return `${TEST_FRAMEWORK_NAME} ${details.specPattern || ''}`
 }
 
 function getSessionStatus (summary) {
@@ -79,7 +81,7 @@ function getSuiteStatus (suiteStats) {
 
 module.exports = (on, config) => {
   const tracer = require('../../dd-trace')
-  const testEnvironmentMetadata = getTestEnvironmentMetadata('cypress')
+  const testEnvironmentMetadata = getTestEnvironmentMetadata(TEST_FRAMEWORK_NAME)
 
   const codeOwnersEntries = getCodeOwnersFileEntries()
 
@@ -96,21 +98,21 @@ module.exports = (on, config) => {
     command = getCypressCommand(details)
     frameworkVersion = getCypressVersion(details)
 
-    const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion, 'cypress')
-    const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion, 'cypress')
+    const testSessionSpanMetadata = getTestSessionCommonTags(command, frameworkVersion, TEST_FRAMEWORK_NAME)
+    const testModuleSpanMetadata = getTestModuleCommonTags(command, frameworkVersion, TEST_FRAMEWORK_NAME)
 
-    testSessionSpan = tracer.startSpan('cypress.test_session', {
+    testSessionSpan = tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test_session`, {
       childOf,
       tags: {
-        [COMPONENT]: 'cypress',
+        [COMPONENT]: TEST_FRAMEWORK_NAME,
         ...testEnvironmentMetadata,
         ...testSessionSpanMetadata
       }
     })
-    testModuleSpan = tracer.startSpan('cypress.test_module', {
+    testModuleSpan = tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test_module`, {
       childOf: testSessionSpan,
       tags: {
-        [COMPONENT]: 'cypress',
+        [COMPONENT]: TEST_FRAMEWORK_NAME,
         ...testEnvironmentMetadata,
         ...testModuleSpanMetadata
       }
@@ -118,14 +120,16 @@ module.exports = (on, config) => {
   })
 
   on('after:run', (suiteStats) => {
-    const testStatus = getSessionStatus(suiteStats)
-    testModuleSpan.setTag(TEST_STATUS, testStatus)
-    testSessionSpan.setTag(TEST_STATUS, testStatus)
+    if (testSessionSpan && testModuleSpan) {
+      const testStatus = getSessionStatus(suiteStats)
+      testModuleSpan.setTag(TEST_STATUS, testStatus)
+      testSessionSpan.setTag(TEST_STATUS, testStatus)
 
-    testModuleSpan.finish()
-    testSessionSpan.finish()
+      testModuleSpan.finish()
+      testSessionSpan.finish()
 
-    finishAllTraceSpans(testSessionSpan)
+      finishAllTraceSpans(testSessionSpan)
+    }
 
     return new Promise(resolve => {
       tracer._tracer._exporter._writer.flush(() => {
@@ -138,11 +142,11 @@ module.exports = (on, config) => {
       if (testSuiteSpan) {
         return null
       }
-      const testSuiteSpanMetadata = getTestSuiteCommonTags(command, frameworkVersion, suite, 'cypress')
-      testSuiteSpan = tracer.startSpan('cypress.test_suite', {
+      const testSuiteSpanMetadata = getTestSuiteCommonTags(command, frameworkVersion, suite, TEST_FRAMEWORK_NAME)
+      testSuiteSpan = tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test_suite`, {
         childOf: testModuleSpan,
         tags: {
-          [COMPONENT]: 'cypress',
+          [COMPONENT]: TEST_FRAMEWORK_NAME,
           ...testEnvironmentMetadata,
           ...testSuiteSpanMetadata
         }
@@ -150,26 +154,29 @@ module.exports = (on, config) => {
       return null
     },
     'dd:testSuiteFinish': (suiteStats) => {
-      const status = getSuiteStatus(suiteStats)
-      testSuiteSpan.setTag(TEST_STATUS, status)
-      testSuiteSpan.finish()
-      testSuiteSpan = null
+      if (testSuiteSpan) {
+        const status = getSuiteStatus(suiteStats)
+        testSuiteSpan.setTag(TEST_STATUS, status)
+        testSuiteSpan.finish()
+        testSuiteSpan = null
+      }
       return null
     },
     'dd:beforeEach': (test) => {
       const { testName, testSuite } = test
-      const testSuiteId = testSuiteSpan.context().toSpanId()
-      const testSessionId = testSessionSpan.context().toTraceId()
-      const testModuleId = testModuleSpan.context().toSpanId()
 
       const testSuiteTags = {
-        [TEST_SUITE_ID]: testSuiteId,
-        [TEST_SESSION_ID]: testSessionId,
         [TEST_COMMAND]: command,
-        [TEST_MODULE_ID]: testModuleId,
         [TEST_COMMAND]: command,
-        [TEST_BUNDLE]: 'cypress',
-        [TEST_MODULE]: 'cypress'
+        [TEST_BUNDLE]: TEST_FRAMEWORK_NAME,
+        [TEST_MODULE]: TEST_FRAMEWORK_NAME
+      }
+      if (testSuiteSpan) {
+        testSuiteTags[TEST_SUITE_ID] = testSuiteSpan.context().toSpanId()
+      }
+      if (testSessionSpan && testModuleSpan) {
+        testSuiteTags[TEST_SESSION_ID] = testSessionSpan.context().toTraceId()
+        testSuiteTags[TEST_MODULE_ID] = testModuleSpan.context().toSpanId()
       }
 
       const {
@@ -185,10 +192,10 @@ module.exports = (on, config) => {
       }
 
       if (!activeSpan) {
-        activeSpan = tracer.startSpan('cypress.test', {
+        activeSpan = tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test`, {
           childOf,
           tags: {
-            [COMPONENT]: 'cypress',
+            [COMPONENT]: TEST_FRAMEWORK_NAME,
             [ORIGIN_KEY]: CI_APP_ORIGIN,
             ...testSpanMetadata,
             ...testEnvironmentMetadata,
@@ -196,7 +203,7 @@ module.exports = (on, config) => {
           }
         })
       }
-      return activeSpan ? activeSpan._spanContext._traceId.toString(10) : null
+      return activeSpan ? activeSpan.context().toTraceId() : null
     },
     'dd:afterEach': (test) => {
       const { state, error, isRUMActive } = test


### PR DESCRIPTION
### What does this PR do?
When using `cypress open`, that is, the interactive mode (used in local development), we can't rely on the `before:run` and `after:run` events in `cypress`. Example: https://docs.cypress.io/api/plugins/after-run-api 

> When running via cypress open, the after:run event only fires if the [experimentalInteractiveRunEvents flag](https://docs.cypress.io/guides/references/configuration#Experiments) is enabled.

This is why we need to make sure to check whether test session and test module are defined before continuing. 

### Motivation
Fixes #2890

### Additional Notes
This error only happens when using the interactive mode, that I don't think I can run in CI, so no tests possible here. 
