### PR TITLE
Use SpanContext name, not Span name, as Span name is not updated

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -32,6 +32,11 @@ class DatadogSpan {
     this._processor = processor
     this._prioritySampler = prioritySampler
     this._store = storage.getStore()
+    this._duration = undefined
+
+    // For internal use only. You probably want `context()._name`.
+    // This name property is not updated when the span name changes.
+    // This is necessary for span count metrics.
     this._name = operationName
 
     this._spanContext = this._createContext(parent)

--- a/packages/dd-trace/src/span_sampler.js
+++ b/packages/dd-trace/src/span_sampler.js
@@ -73,8 +73,9 @@ class SpanSampler {
 
     const { started } = spanContext._trace
     for (const span of started) {
-      const tags = span.context()._tags || {}
-      const name = span._name
+      const context = span.context()
+      const tags = context._tags || {}
+      const name = context._name
       const service = tags.service ||
         tags['service.name'] ||
         span.tracer()._service

--- a/packages/dd-trace/test/span_sampler.spec.js
+++ b/packages/dd-trace/test/span_sampler.spec.js
@@ -12,7 +12,8 @@ function createDummySpans () {
     'sub_second_operation_2',
     'sub_sub_second_operation_2',
     'custom_service_span_1',
-    'custom_service_span_2'
+    'custom_service_span_2',
+    'renamed_operation'
   ]
 
   const ids = [
@@ -44,6 +45,10 @@ function createDummySpans () {
     // Give first span a custom service name
     if ([6, 7].includes(idx)) {
       spanContext._tags['service.name'] = 'span-service'
+    }
+
+    if (idx === 8) {
+      spanContext._name = 'renamed'
     }
 
     const span = {
@@ -121,6 +126,7 @@ describe('span sampler', () => {
       expect(spans[5].context()._sampling.spanSampling).to.be.undefined
       expect(spans[6].context()._sampling.spanSampling).to.be.undefined
       expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
     })
 
     it('should consider missing service as match-all for service name', () => {
@@ -147,6 +153,8 @@ describe('span sampler', () => {
       expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
       expect(spans[5].context()._sampling.spanSampling).to.be.undefined
       expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
     })
 
     it('should consider missing name as match-all for span name', () => {
@@ -171,8 +179,10 @@ describe('span sampler', () => {
       expect(spans[3].context()._sampling.spanSampling).to.eql(spanSampling)
       expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
       expect(spans[5].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[8].context()._sampling.spanSampling).to.eql(spanSampling)
       // Should not match because of different service name
       expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
     })
 
     it('should stop at first rule match', () => {
@@ -205,6 +215,7 @@ describe('span sampler', () => {
       expect(spans[5].context()._sampling.spanSampling).to.be.undefined
       expect(spans[6].context()._sampling.spanSampling).to.be.undefined
       expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
     })
 
     it('should use span service name tags where present', () => {
@@ -231,6 +242,7 @@ describe('span sampler', () => {
       expect(spans[5].context()._sampling.spanSampling).to.be.undefined
       expect(spans[6].context()._sampling.spanSampling).to.eql(spanSampling)
       expect(spans[7].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
     })
 
     it('should properly sample multiple single spans with one rule', () => {
@@ -257,6 +269,7 @@ describe('span sampler', () => {
       expect(spans[5].context()._sampling.spanSampling).to.eql(spanSampling)
       expect(spans[6].context()._sampling.spanSampling).to.be.undefined
       expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
     })
 
     it('should properly sample mutiple single spans with multiple rules', () => {
@@ -293,6 +306,33 @@ describe('span sampler', () => {
       expect(spans[5].context()._sampling.spanSampling, {
         sampleRate: 1.0,
         maxPerSecond: 10
+      })
+    })
+
+    it('should properly sample renamed spans', () => {
+      sampler = new SpanSampler({
+        spanSamplingRules: [
+          {
+            service: 'test',
+            name: 'renamed',
+            sampleRate: 1.0,
+            maxPerSecond: 1
+          }
+        ]
+      })
+
+      sampler.sample(spanContexts[0])
+      expect(spans[0].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[8].context()._sampling.spanSampling).to.eql({
+        sampleRate: 1.0,
+        maxPerSecond: 1
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?

Use span context name for single span sampling rules rather than span name as span name is not changed when framework is set. Possibly the span name should actually be changed too, or maybe it should be a getter to retrieve it from the span context?

### Motivation

Single span ingestion is not matching web framework span names properly because they're only updated on the span context.