### PR TITLE
ddTrace esbuild plugin /* @dd-bundle:  */ comment expressions PoC

### DIFF
--- a/packages/datadog-esbuild/dd-bundle.js
+++ b/packages/datadog-esbuild/dd-bundle.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+
+const DD_BUNDLE_COMMENT = /\/\*\s*@dd-bundle:(.*)\s*\*\//
+
+function readTemplate (resolveDir, tmplPath) {
+  const fileContent = fs.readFileSync(path.join(resolveDir, tmplPath), 'utf-8')
+  return `\`${fileContent}\``
+}
+
+function resolve (packageName, resolveDir) {
+  const packageToResolve = packageName === '..' ? `../index.js` : packageName
+  return require.resolve(packageToResolve, { paths: [ resolveDir ] })
+}
+
+function getDDBundleData (packageName, resolveDir, builtins) {
+  const validPackage = !resolveDir.includes('node_modules') &&
+  !builtins.has(packageName) &&
+  !packageName.endsWith('package.json') &&
+  resolveDir.includes('appsec')
+
+  if (validPackage) {
+    const packagePath = resolve(packageName, resolveDir)
+    let contents
+    if (fs.existsSync(packagePath)) {
+      contents = fs.readFileSync(packagePath, 'utf-8')
+      if (contents.match(DD_BUNDLE_COMMENT)) {
+        return {
+          resolveDir,
+          packagePath,
+          contents
+        }
+      }
+    }
+  }
+}
+
+function replaceDDBundle ({ contents, packagePath }) {
+  const resolveDir = path.dirname(packagePath)
+  const lines = contents.split('\n')
+  let modified = false
+  lines.forEach((line, index) => {
+    const m = line.match(DD_BUNDLE_COMMENT)
+    if (!m) return
+
+    const expr = m[1]
+
+    const exprEval = expr.match(/\${(.*)}/)
+    if (exprEval) {
+      // eslint-disable-next-line no-unused-vars
+      const template = ((base) => (path) => readTemplate(base, path))(resolveDir)
+      // eslint-disable-next-line no-eval
+      const resolved = eval(exprEval[1])
+      lines[index + 1] = expr.replace(exprEval[0], resolved)
+    } else {
+      lines[index + 1] = expr
+    }
+    modified = true
+  })
+
+  if (modified) {
+    contents = lines.join('\n')
+  }
+  return {
+    contents,
+    resolveDir
+  }
+}
+
+module.exports = {
+  getDDBundleData,
+  replaceDDBundle
+}

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -44,7 +44,10 @@ function block (req, res, rootSpan, abortController) {
 
 function loadTemplates (config) {
   if (!templateLoaded) {
+    /* @dd-bundle:templateHtml = ${template('./templates/blocked.html')} */
     templateHtml = fs.readFileSync(config.appsec.blockedTemplateHtml)
+
+    /* @dd-bundle:templateJson = ${template('./templates/blocked.json')} */
     templateJson = fs.readFileSync(config.appsec.blockedTemplateJson)
     templateLoaded = true
   }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -22,8 +22,9 @@ function enable (_config) {
 
   try {
     loadTemplates(_config)
-    const rules = fs.readFileSync(_config.appsec.rules || path.join(__dirname, 'recommended.json'))
-    enableFromRules(_config, JSON.parse(rules))
+    /* @dd-bundle:const rules = require('./recommended.json') */
+    const rules = JSON.parse(fs.readFileSync(_config.appsec.rules || path.join(__dirname, 'recommended.json')))
+    enableFromRules(_config, rules)
   } catch (err) {
     abortEnable(err)
   }


### PR DESCRIPTION
### What does this PR do?
It is only a PoC with a possible solution to embed template files when bundling the tracer.

Modifies ddTrace esbuild plugin to detect /* @dd-bundle:  */ comments and replace js code with the result of evaluating expressions contained in the comments (in a quick and simple way)

Example appsec/blocking.js 
Before bundler
``` 
/* @dd-bundle:templateHtml = ${template('./templates/blocked.html')} */
templateHtml = fs.readFileSync(config.appsec.blockedTemplateHtml)
```
After
```
templateHtml = `<!-- Sorry, you\u2019ve been blocked -->
<!DOCTYPE html>
<html lang="en">

<head>
...
`
```

### Motivation
appsec components are loading from disk some html or json files and when bundling dd-trace-js these files are not included in the final js causing errors (https://github.com/DataDog/dd-trace-js/pull/2841) 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
