### PR TITLE
[ci-visibility] Do not run `mocha` plugin if in parallel mode 

### DIFF
--- a/integration-tests/ci-visibility/run-mocha.js
+++ b/integration-tests/ci-visibility/run-mocha.js
@@ -1,6 +1,8 @@
 const Mocha = require('mocha')
 
-const mocha = new Mocha()
+const mocha = new Mocha({
+  parallel: !!process.env.RUN_IN_PARALLEL
+})
 mocha.addFile(require.resolve('./test/ci-visibility-test.js'))
 mocha.addFile(require.resolve('./test/ci-visibility-test-2.js'))
 mocha.run(() => {

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -2,6 +2,8 @@ const { createCoverageMap } = require('istanbul-lib-coverage')
 
 const { addHook, channel, AsyncResource } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
+const log = require('../../dd-trace/src/log')
+
 const {
   getCoveredFilenamesFromCoverage,
   resetCoverage,
@@ -33,6 +35,9 @@ const patched = new WeakSet()
 const testToAr = new WeakMap()
 const originalFns = new WeakMap()
 const testFileToSuiteAr = new Map()
+
+// `isWorker` is true if it's a Mocha worker
+let isWorker = false
 
 // We'll preserve the original coverage here
 const originalCoverageMap = createCoverageMap()
@@ -101,7 +106,7 @@ function mochaHook (Runner) {
   patched.add(Runner)
 
   shimmer.wrap(Runner.prototype, 'run', run => function () {
-    if (!testStartCh.hasSubscribers) {
+    if (!testStartCh.hasSubscribers || isWorker) {
       return run.apply(this, arguments)
     }
 
@@ -321,7 +326,15 @@ addHook({
    * If ITR is disabled, `onDone` is called immediately on the subscriber
    */
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
-    if (!itrConfigurationCh.hasSubscribers) {
+    if (this.options.parallel) {
+      log.warn(`Unable to initialize CI Visibility because Mocha is running in parallel mode.`)
+      return run.apply(this, arguments)
+    }
+
+    if (!itrConfigurationCh.hasSubscribers || this.isWorker) {
+      if (this.isWorker) {
+        isWorker = true
+      }
       return run.apply(this, arguments)
     }
     this.options.delay = true
@@ -379,7 +392,9 @@ addHook({
      * This attaches `run` to the global context, which we'll call after
      * our configuration and skippable suites requests
      */
-    mocha.options.delay = true
+    if (!mocha.options.parallel) {
+      mocha.options.delay = true
+    }
     return runMocha.apply(this, arguments)
   })
   return run


### PR DESCRIPTION
### What does this PR do?
Do not generate traces from the mocha plugin if mocha is configured in parallel mode. 

### Motivation
This just makes it explicit that we don't work with parallel mode. We eventually want to support it but in the meantime we need _not_ to break tests. 

Fixes #2886

Related to https://github.com/DataDog/dd-trace-js/pull/2888