### PR TITLE
[ci-visibility] Bump playwright's integration test `before` timeout

### DIFF
--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -24,7 +24,9 @@ const versions = ['1.18.0', isOldNode ? '1.21.0' : 'latest']
 versions.forEach((version) => {
   describe(`playwright@${version}`, () => {
     let sandbox, cwd, receiver, childProcess, webAppPort
-    before(async () => {
+    before(async function () {
+      // bump from 30 seconds because playwright dependencies are heavy
+      this.timeout(45000)
       sandbox = await createSandbox([`@playwright/test@${version}`], true)
       cwd = sandbox.folder
       // install necessary browser

--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -22,7 +22,7 @@ const isOldNode = semver.satisfies(process.version, '<=12')
 const versions = ['1.18.0', isOldNode ? '1.21.0' : 'latest']
 
 versions.forEach((version) => {
-  describe(`playwright@${version}`, () => {
+  describe.only(`playwright@${version}`, () => {
     let sandbox, cwd, receiver, childProcess, webAppPort
     before(async function () {
       // bump from 30 seconds because playwright dependencies are heavy

--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -22,11 +22,11 @@ const isOldNode = semver.satisfies(process.version, '<=12')
 const versions = ['1.18.0', isOldNode ? '1.21.0' : 'latest']
 
 versions.forEach((version) => {
-  describe.only(`playwright@${version}`, () => {
+  describe(`playwright@${version}`, () => {
     let sandbox, cwd, receiver, childProcess, webAppPort
     before(async function () {
-      // bump from 30 seconds because playwright dependencies are heavy
-      this.timeout(45000)
+      // bump from 30 to 60 seconds because playwright dependencies are heavy
+      this.timeout(60000)
       sandbox = await createSandbox([`@playwright/test@${version}`], true)
       cwd = sandbox.folder
       // install necessary browser


### PR DESCRIPTION
### What does this PR do?
Installing dependencies for `playwright` takes a while, so we're increasing the timeout. 

I retried the job 10 times and no flakiness: https://github.com/DataDog/dd-trace-js/actions/runs/4438679088. Let's hope this fixes it.

### Motivation
Fix flakiness of playwright tests.

