### PR TITLE
[ci-visibility] Rename ITR and code cov tags

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -15,10 +15,8 @@ const {
 const { FakeCiVisIntake } = require('./ci-visibility-intake')
 
 const {
-  TEST_SESSION_CODE_COVERAGE_ENABLED,
-  TEST_SESSION_ITR_SKIPPING_ENABLED,
-  TEST_MODULE_CODE_COVERAGE_ENABLED,
-  TEST_MODULE_ITR_SKIPPING_ENABLED,
+  TEST_CODE_COVERAGE_ENABLED,
+  TEST_ITR_SKIPPING_ENABLED,
   TEST_ITR_TESTS_SKIPPED,
   TEST_CODE_COVERAGE_LINES_TOTAL
 } = require('../packages/dd-trace/src/plugins/util/test')
@@ -465,12 +463,12 @@ testFrameworks.forEach(({
           assert.includeMembers(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
           const testSession = payload.events.find(event => event.type === 'test_session_end').content
           assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-          assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'false')
-          assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'false')
+          assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'false')
+          assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'false')
           const testModule = payload.events.find(event => event.type === 'test_module_end').content
           assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-          assert.propertyVal(testModule.meta, TEST_MODULE_CODE_COVERAGE_ENABLED, 'false')
-          assert.propertyVal(testModule.meta, TEST_MODULE_ITR_SKIPPING_ENABLED, 'false')
+          assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'false')
+          assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'false')
         }, ({ url }) => url === '/api/v2/citestcycle').then(() => done()).catch(done)
 
         childProcess = exec(
@@ -520,12 +518,12 @@ testFrameworks.forEach(({
           assert.equal(numSuites, 1)
           const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
           assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'true')
-          assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'true')
-          assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
           const testModule = eventsRequest.payload.events.find(event => event.type === 'test_module_end').content
           assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'true')
-          assert.propertyVal(testModule.meta, TEST_MODULE_CODE_COVERAGE_ENABLED, 'true')
-          assert.propertyVal(testModule.meta, TEST_MODULE_ITR_SKIPPING_ENABLED, 'true')
+          assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
           done()
         }).catch(done)
 
@@ -564,12 +562,12 @@ testFrameworks.forEach(({
           assert.equal(numSuites, 2)
           const testSession = payload.events.find(event => event.type === 'test_session_end').content
           assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-          assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'true')
-          assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
           const testModule = payload.events.find(event => event.type === 'test_module_end').content
           assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-          assert.propertyVal(testModule.meta, TEST_MODULE_CODE_COVERAGE_ENABLED, 'true')
-          assert.propertyVal(testModule.meta, TEST_MODULE_ITR_SKIPPING_ENABLED, 'true')
+          assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
         }, ({ url }) => url === '/api/v2/citestcycle').then(() => done()).catch(done)
 
         childProcess = exec(

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -18,7 +18,7 @@ const {
   TEST_CODE_COVERAGE_ENABLED,
   TEST_ITR_SKIPPING_ENABLED,
   TEST_ITR_TESTS_SKIPPED,
-  TEST_CODE_COVERAGE_LINES_TOTAL
+  TEST_CODE_COVERAGE_LINES_PCT
 } = require('../packages/dd-trace/src/plugins/util/test')
 
 // TODO: remove when 2.x support is removed.
@@ -418,7 +418,7 @@ testFrameworks.forEach(({
           assert.exists(coveragePayload.content.coverages[0].test_suite_id)
 
           const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
-          assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_TOTAL])
+          assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
           const eventTypes = eventsRequest.payload.events.map(event => event.type)
           assert.includeMembers(eventTypes, ['test', 'test_suite_end', 'test_module_end', 'test_session_end'])
@@ -736,7 +736,7 @@ testFrameworks.forEach(({
           assert.exists(coveragePayload.content.coverages[0].test_suite_id)
 
           const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
-          assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_TOTAL])
+          assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
           const eventTypes = eventsRequest.payload.events.map(event => event.type)
           assert.includeMembers(eventTypes, ['test', 'test_suite_end', 'test_module_end', 'test_session_end'])

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -418,8 +418,6 @@ testFrameworks.forEach(({
           assert.exists(coveragePayload.content.coverages[0].test_suite_id)
 
           const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
-          console.log(testSession.meta)
-          console.log(testSession.metrics)
           assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
           const eventTypes = eventsRequest.payload.events.map(event => event.type)

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -418,6 +418,8 @@ testFrameworks.forEach(({
           assert.exists(coveragePayload.content.coverages[0].test_suite_id)
 
           const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
+          console.log(testSession.meta)
+          console.log(testSession.metrics)
           assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
           const eventTypes = eventsRequest.payload.events.map(event => event.type)

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -17,12 +17,10 @@ const {
   TEST_COMMAND,
   TEST_MODULE,
   TEST_TOOLCHAIN,
-  TEST_SESSION_CODE_COVERAGE_ENABLED,
-  TEST_SESSION_ITR_SKIPPING_ENABLED,
-  TEST_MODULE_CODE_COVERAGE_ENABLED,
-  TEST_MODULE_ITR_SKIPPING_ENABLED,
+  TEST_CODE_COVERAGE_ENABLED,
+  TEST_ITR_SKIPPING_ENABLED,
   TEST_ITR_TESTS_SKIPPED,
-  TEST_CODE_COVERAGE_LINES_TOTAL
+  TEST_CODE_COVERAGE_LINES_PCT
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
 const isOldNode = semver.satisfies(process.version, '<=12')
@@ -252,7 +250,10 @@ versions.forEach(version => {
               assert.exists(coveragePayload.content.coverages[0].test_suite_id)
 
               const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
-              assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_TOTAL])
+              console.log(testSession.meta)
+              console.log(testSession.metrics)
+
+              assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
               const eventTypes = eventsRequest.payload.events.map(event => event.type)
               assert.includeMembers(eventTypes, ['test', 'test_suite_end', 'test_module_end', 'test_session_end'])
@@ -298,12 +299,12 @@ versions.forEach(version => {
               assert.includeMembers(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
               const testSession = payload.events.find(event => event.type === 'test_session_end').content
               assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-              assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'false')
-              assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'false')
+              assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'false')
+              assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'false')
               const testModule = payload.events.find(event => event.type === 'test_module_end').content
               assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-              assert.propertyVal(testModule.meta, TEST_MODULE_CODE_COVERAGE_ENABLED, 'false')
-              assert.propertyVal(testModule.meta, TEST_MODULE_ITR_SKIPPING_ENABLED, 'false')
+              assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'false')
+              assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'false')
             }, ({ url }) => url.endsWith('/api/v2/citestcycle')).then(() => done()).catch(done)
 
             childProcess = exec(
@@ -362,12 +363,12 @@ versions.forEach(version => {
               assert.equal(numSuites, 1)
               const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
               assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'true')
-              assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'true')
-              assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'true')
+              assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+              assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
               const testModule = eventsRequest.payload.events.find(event => event.type === 'test_module_end').content
               assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'true')
-              assert.propertyVal(testModule.meta, TEST_MODULE_CODE_COVERAGE_ENABLED, 'true')
-              assert.propertyVal(testModule.meta, TEST_MODULE_ITR_SKIPPING_ENABLED, 'true')
+              assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+              assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
               done()
             }).catch(done)
 
@@ -405,12 +406,12 @@ versions.forEach(version => {
               assert.equal(numSuites, 2)
               const testSession = payload.events.find(event => event.type === 'test_session_end').content
               assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-              assert.propertyVal(testSession.meta, TEST_SESSION_CODE_COVERAGE_ENABLED, 'true')
-              assert.propertyVal(testSession.meta, TEST_SESSION_ITR_SKIPPING_ENABLED, 'true')
+              assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+              assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
               const testModule = payload.events.find(event => event.type === 'test_module_end').content
               assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'false')
-              assert.propertyVal(testModule.meta, TEST_MODULE_CODE_COVERAGE_ENABLED, 'true')
-              assert.propertyVal(testModule.meta, TEST_MODULE_ITR_SKIPPING_ENABLED, 'true')
+              assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+              assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
             }, ({ url }) => url.endsWith('/api/v2/citestcycle')).then(() => done()).catch(done)
 
             childProcess = exec(

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -250,9 +250,6 @@ versions.forEach(version => {
               assert.exists(coveragePayload.content.coverages[0].test_suite_id)
 
               const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
-              console.log(testSession.meta)
-              console.log(testSession.metrics)
-
               assert.exists(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
               const eventTypes = eventsRequest.payload.events.map(event => event.type)

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -50,12 +50,10 @@ const CI_APP_ORIGIN = 'ciapp-test'
 const JEST_TEST_RUNNER = 'test.jest.test_runner'
 
 const TEST_ITR_TESTS_SKIPPED = '_dd.ci.itr.tests_skipped'
-const TEST_SESSION_ITR_SKIPPING_ENABLED = 'test_session.itr.tests_skipping.enabled'
-const TEST_SESSION_CODE_COVERAGE_ENABLED = 'test_session.code_coverage.enabled'
-const TEST_MODULE_ITR_SKIPPING_ENABLED = 'test_module.itr.tests_skipping.enabled'
-const TEST_MODULE_CODE_COVERAGE_ENABLED = 'test_module.code_coverage.enabled'
+const TEST_ITR_SKIPPING_ENABLED = 'test.itr.tests_skipping.enabled'
+const TEST_CODE_COVERAGE_ENABLED = 'test.code_coverage.enabled'
 
-const TEST_CODE_COVERAGE_LINES_TOTAL = 'test.codecov_lines_total'
+const TEST_CODE_COVERAGE_LINES_PCT = 'test.code_coverage.lines_pct'
 
 // jest worker variables
 const JEST_WORKER_TRACE_PAYLOAD_CODE = 60
@@ -97,11 +95,9 @@ module.exports = {
   TEST_SUITE_ID,
   TEST_ITR_TESTS_SKIPPED,
   TEST_MODULE,
-  TEST_SESSION_ITR_SKIPPING_ENABLED,
-  TEST_SESSION_CODE_COVERAGE_ENABLED,
-  TEST_MODULE_ITR_SKIPPING_ENABLED,
-  TEST_MODULE_CODE_COVERAGE_ENABLED,
-  TEST_CODE_COVERAGE_LINES_TOTAL,
+  TEST_ITR_SKIPPING_ENABLED,
+  TEST_CODE_COVERAGE_ENABLED,
+  TEST_CODE_COVERAGE_LINES_PCT,
   addIntelligentTestRunnerSpanTags,
   getCoveredFilenamesFromCoverage,
   resetCoverage,
@@ -316,17 +312,17 @@ function addIntelligentTestRunnerSpanTags (
   { isSuitesSkipped, isSuitesSkippingEnabled, isCodeCoverageEnabled, testCodeCoverageLinesTotal }
 ) {
   testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
-  testSessionSpan.setTag(TEST_SESSION_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
-  testSessionSpan.setTag(TEST_SESSION_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
+  testSessionSpan.setTag(TEST_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
+  testSessionSpan.setTag(TEST_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
 
   testModuleSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
-  testModuleSpan.setTag(TEST_MODULE_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
-  testModuleSpan.setTag(TEST_MODULE_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
+  testModuleSpan.setTag(TEST_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
+  testModuleSpan.setTag(TEST_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
 
   // If suites have been skipped we don't want to report the total coverage, as it will be wrong
   if (testCodeCoverageLinesTotal !== undefined && !isSuitesSkipped) {
-    testSessionSpan.setTag(TEST_CODE_COVERAGE_LINES_TOTAL, testCodeCoverageLinesTotal)
-    testModuleSpan.setTag(TEST_CODE_COVERAGE_LINES_TOTAL, testCodeCoverageLinesTotal)
+    testSessionSpan.setTag(TEST_CODE_COVERAGE_LINES_PCT, testCodeCoverageLinesTotal)
+    testModuleSpan.setTag(TEST_CODE_COVERAGE_LINES_PCT, testCodeCoverageLinesTotal)
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
* Consolidate `test_session.itr.tests_skipping.enabled` and `test_module.itr.tests_skipping.enabled` into `test.itr.tests_skipping.enabled`
* Consolidate `test_session.code_coverage.enabled` and `test_module.code_coverage.enabled` into `test.code_coverage.enabled`
* Rename `test.codecov_lines_total` to `test.code_coverage.lines_pct`

### Motivation
Consolidate tags so that we don't have so many of them.

