### PR TITLE
Fix COMMAND_INJECTION flaky test

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const childProcess = require('child_process')
 const { prepareTestServerForIast } = require('../utils')
 const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
@@ -12,12 +13,10 @@ describe('command injection analyzer', () => {
         const store = storage.getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const command = newTaintedString(iastContext, 'ls -la', 'param', 'Request')
-        const childProcess = require('child_process')
         childProcess.execSync(command)
       }, 'COMMAND_INJECTION')
 
       testThatRequestHasNoVulnerability(() => {
-        const childProcess = require('child_process')
         childProcess.execSync('ls -la')
       }, 'COMMAND_INJECTION')
     })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const childProcess = require('child_process')
 
 const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
 const { storage } = require('../../../../../datadog-core')
@@ -72,7 +73,6 @@ describe('TaintTracking', () => {
               expect(commandResult).eq(commandResultOrig)
 
               try {
-                const childProcess = require('child_process')
                 childProcess.execSync(commandResult, { stdio: 'ignore' })
               } catch (e) {
                 // do nothing


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
