### PR TITLE
Next Plugin Next 13.2 updated handleAPIRequest support

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -45,8 +45,8 @@ function wrapHandleApiRequestWithMatch (handleApiRequest) {
       return promise.then(handled => {
         if (!handled) return handled
 
-        const page = (typeof match === 'object' && typeof match.definitions === 'object')
-          ? match.definitions.page
+        const page = (typeof match === 'object' && typeof match.definition === 'object')
+          ? match.definition.page
           : undefined
 
         pageLoadChannel.publish({ page })

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -42,19 +42,13 @@ function wrapHandleApiRequest (handleApiRequest) {
 function wrapHandleApiRequestWithMatch (handleApiRequest) {
   return function (req, res, query, match) {
     return instrument(req, res, () => {
-      const promise = handleApiRequest.apply(this, arguments)
+      const page = (typeof match === 'object' && typeof match.definition === 'object')
+        ? match.definition.pathname
+        : undefined
 
-      return promise.then(handled => {
-        if (!handled) return handled
+      pageLoadChannel.publish({ page })
 
-        const page = (typeof match === 'object' && typeof match.definition === 'object')
-          ? match.definition.page
-          : undefined
-
-        pageLoadChannel.publish({ page })
-
-        return handled
-      })
+      return handleApiRequest.apply(this, arguments)
     })
   }
 }

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -45,7 +45,9 @@ function wrapHandleApiRequestWithMatch (handleApiRequest) {
       return promise.then(handled => {
         if (!handled) return handled
 
-        const page = match?.definitions?.page
+        const page = (typeof match === 'object' && typeof match.definitions === 'object')
+          ? match.definitions.page
+          : undefined
 
         pageLoadChannel.publish({ page })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
The parameters of handleAPIRequest changed in next v13.2, adding a new wrapper to support using the new parameters.
Also leverages the new page definitions thats passed along the with the full information

link to new next api code
https://github.com/vercel/next.js/blob/dbdf47cf617b8d7213ffe1ff28318ea8eb88c623/packages/next/src/server/next-server.ts#L1329

link to match.definition interface
https://github.com/vercel/next.js/blob/canary/packages/next/src/server/future/route-definitions/route-definition.ts#L3

using this code via patch-package in the mean time until some solution gets merged in

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
