### PR TITLE
Embed AppSec rules and templates files to be compatible with bundlers

### DIFF
--- a/packages/dd-trace/src/appsec/blocked_templates.js
+++ b/packages/dd-trace/src/appsec/blocked_templates.js
@@ -1,4 +1,7 @@
-<!-- Sorry, you’ve been blocked -->
+/* eslint-disable max-len */
+'use strict'
+
+const html = `<!-- Sorry, you've been blocked -->
 <!DOCTYPE html>
 <html lang="en">
 
@@ -97,3 +100,18 @@
 </body>
 
 </html>
+`
+
+const json = `{
+  "errors": [
+    {
+      "title": "You've been blocked",
+      "detail": "Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog."
+    }
+  ]
+}`
+
+module.exports = {
+  html,
+  json
+}

--- a/packages/dd-trace/src/appsec/blocked_templates.js
+++ b/packages/dd-trace/src/appsec/blocked_templates.js
@@ -102,14 +102,14 @@ const html = `<!-- Sorry, you've been blocked -->
 </html>
 `
 
-const json = `{
-  "errors": [
+const json = JSON.stringify({
+  errors: [
     {
-      "title": "You've been blocked",
-      "detail": "Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog."
+      title: 'You\'ve been blocked',
+      detail: 'Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog.'
     }
   ]
-}`
+})
 
 module.exports = {
   html,

--- a/packages/dd-trace/src/appsec/blocked_templates.js
+++ b/packages/dd-trace/src/appsec/blocked_templates.js
@@ -102,14 +102,14 @@ const html = `<!-- Sorry, you've been blocked -->
 </html>
 `
 
-const json = JSON.stringify({
-  errors: [
+const json = `{
+  "errors": [
     {
-      title: 'You\'ve been blocked',
-      detail: 'Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog.'
+      "title": "You've been blocked",
+      "detail": "Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog."
     }
   ]
-})
+}`
 
 module.exports = {
   html,

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -1,12 +1,10 @@
 'use strict'
 
 const log = require('../log')
-const fs = require('fs')
+const blockedTemplates = require('./blocked_templates')
 
-// TODO: move template loading to a proper spot.
-let templateLoaded = false
-let templateHtml = '<html>blocked</html>'
-let templateJson = '{"error": "blocked"}'
+let templateHtml = blockedTemplates.html
+let templateJson = blockedTemplates.json
 
 function block (req, res, rootSpan, abortController) {
   if (res.headersSent) {
@@ -42,49 +40,16 @@ function block (req, res, rootSpan, abortController) {
   }
 }
 
-function loadTemplates (config) {
-  if (!templateLoaded) {
-    try {
-      templateHtml = fs.readFileSync(config.appsec.blockedTemplateHtml)
-    } catch (err) {
-      log.warn(`Unable to read ${config.appsec.blockedTemplateHtml} from disk.`)
-    }
-
-    try {
-      templateJson = fs.readFileSync(config.appsec.blockedTemplateJson)
-    } catch (err) {
-      log.warn(`Unable to read ${config.appsec.blockedTemplateJson} from disk.`)
-    }
-
-    templateLoaded = true
+function setTemplates (config) {
+  if (config.appsec.blockedTemplateHtml) {
+    templateHtml = config.appsec.blockedTemplateHtml
   }
-}
-
-async function loadTemplatesAsync (config) {
-  if (!templateLoaded) {
-    try {
-      templateHtml = await fs.promises.readFile(config.appsec.blockedTemplateHtml)
-    } catch (err) {
-      log.warn(`Unable to read ${config.appsec.blockedTemplateHtml} from disk.`)
-    }
-
-    try {
-      templateJson = await fs.promises.readFile(config.appsec.blockedTemplateJson)
-    } catch (err) {
-      log.warn(`Unable to read ${config.appsec.blockedTemplateJson} from disk.`)
-    }
-
-    templateLoaded = true
+  if (config.appsec.blockedTemplateJson) {
+    templateJson = config.appsec.blockedTemplateJson
   }
-}
-
-function resetTemplates () {
-  templateLoaded = false
 }
 
 module.exports = {
   block,
-  loadTemplates,
-  loadTemplatesAsync,
-  resetTemplates
+  setTemplates
 }

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -5,8 +5,8 @@ const fs = require('fs')
 
 // TODO: move template loading to a proper spot.
 let templateLoaded = false
-let templateHtml = ''
-let templateJson = ''
+let templateHtml = '<html>blocked</html>'
+let templateJson = '{"error": "blocked"}'
 
 function block (req, res, rootSpan, abortController) {
   if (res.headersSent) {
@@ -44,16 +44,36 @@ function block (req, res, rootSpan, abortController) {
 
 function loadTemplates (config) {
   if (!templateLoaded) {
-    templateHtml = fs.readFileSync(config.appsec.blockedTemplateHtml)
-    templateJson = fs.readFileSync(config.appsec.blockedTemplateJson)
+    try {
+      templateHtml = fs.readFileSync(config.appsec.blockedTemplateHtml)
+    } catch (err) {
+      log.warn(`Unable to read ${config.appsec.blockedTemplateHtml} from disk.`)
+    }
+
+    try {
+      templateJson = fs.readFileSync(config.appsec.blockedTemplateJson)
+    } catch (err) {
+      log.warn(`Unable to read ${config.appsec.blockedTemplateJson} from disk.`)
+    }
+
     templateLoaded = true
   }
 }
 
 async function loadTemplatesAsync (config) {
   if (!templateLoaded) {
-    templateHtml = await fs.promises.readFile(config.appsec.blockedTemplateHtml)
-    templateJson = await fs.promises.readFile(config.appsec.blockedTemplateJson)
+    try {
+      templateHtml = await fs.promises.readFile(config.appsec.blockedTemplateHtml)
+    } catch (err) {
+      log.warn(`Unable to read ${config.appsec.blockedTemplateHtml} from disk.`)
+    }
+
+    try {
+      templateJson = await fs.promises.readFile(config.appsec.blockedTemplateJson)
+    } catch (err) {
+      log.warn(`Unable to read ${config.appsec.blockedTemplateJson} from disk.`)
+    }
+
     templateLoaded = true
   }
 }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const log = require('../log')
 const RuleManager = require('./rule_manager')
 const remoteConfig = require('./remote_config')
@@ -12,7 +10,7 @@ const Reporter = require('./reporter')
 const web = require('../plugins/util/web')
 const { extractIp } = require('../plugins/util/ip_extractor')
 const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
-const { block, loadTemplates, loadTemplatesAsync } = require('./blocking')
+const { block, setTemplates } = require('./blocking')
 
 let isEnabled = false
 let config
@@ -21,21 +19,10 @@ function enable (_config) {
   if (isEnabled) return
 
   try {
-    loadTemplates(_config)
-    const rules = fs.readFileSync(_config.appsec.rules || path.join(__dirname, 'recommended.json'))
-    enableFromRules(_config, JSON.parse(rules))
-  } catch (err) {
-    abortEnable(err)
-  }
-}
+    setTemplates(_config)
 
-async function enableAsync (_config) {
-  if (isEnabled) return
-
-  try {
-    await loadTemplatesAsync(_config)
-    const rules = await fs.promises.readFile(_config.appsec.rules || path.join(__dirname, 'recommended.json'))
-    enableFromRules(_config, JSON.parse(rules))
+    const rules = _config.appsec.rules || require('./recommended.json')
+    enableFromRules(_config, rules)
   } catch (err) {
     abortEnable(err)
   }
@@ -169,7 +156,6 @@ function disable () {
 
 module.exports = {
   enable,
-  enableAsync,
   disable,
   incomingHttpStartTranslator,
   incomingHttpEndTranslator

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -23,7 +23,7 @@ function enable (config) {
         }
 
         if (shouldEnable) {
-          require('..').enableAsync(config).catch(() => {})
+          require('..').enable(config)
         } else {
           require('..').disable()
         }

--- a/packages/dd-trace/src/appsec/sdk/index.js
+++ b/packages/dd-trace/src/appsec/sdk/index.js
@@ -2,14 +2,14 @@
 
 const { trackUserLoginSuccessEvent, trackUserLoginFailureEvent, trackCustomEvent } = require('./track_event')
 const { checkUserAndSetUser, blockRequest } = require('./user_blocking')
-const { loadTemplates } = require('../blocking')
+const { setTemplates } = require('../blocking')
 const { setUser } = require('./set_user')
 
 class AppsecSdk {
   constructor (tracer, config) {
     this._tracer = tracer
     if (config) {
-      loadTemplates(config)
+      setTemplates(config)
     }
   }
 

--- a/packages/dd-trace/src/appsec/templates/blocked.json
+++ b/packages/dd-trace/src/appsec/templates/blocked.json
@@ -1,8 +1,0 @@
-{
-  "errors": [
-    {
-      "title": "You've been blocked",
-      "detail": "Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog."
-    }
-  ]
-}

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -16,12 +16,20 @@ const fromEntries = Object.fromEntries || (entries =>
 // eslint-disable-next-line max-len
 const qsRegex = '(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\\s|%20)+[a-z0-9\\._\\-]+|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+\\/=-]|%3D|%2F|%2B)+)?|[\\-]{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY[\\-]{5}[^\\-]+[\\-]{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY|ssh-rsa(?:\\s|%20)*(?:[a-z0-9\\/\\.+]|%2F|%5C|%2B){100,}'
 
-function maybeFile (filepath) {
+function isConfigPropCorrect (propOrEnv, isEnv) {
+  return `Is '${propOrEnv}' ${isEnv ? 'environment variable' : 'configuration property'} correct?`
+}
+
+function isEnvVarCorrect (envVar) {
+  return isConfigPropCorrect(envVar, true)
+}
+
+function maybeFile (filepath, errorMsg) {
   if (!filepath) return
   try {
     return fs.readFileSync(filepath, 'utf8')
   } catch (e) {
-    log.error(`Error reading file ${filepath}`)
+    log.error(`dd-trace: Error reading file ${filepath}.${errorMsg ? ' ' + errorMsg : ''}`)
     return undefined
   }
 }
@@ -288,8 +296,8 @@ class Config {
     )
 
     const DD_APPSEC_RULES = coalesce(
-      safeJsonParse(maybeFile(appsec.rules)),
-      safeJsonParse(maybeFile(process.env.DD_APPSEC_RULES))
+      safeJsonParse(maybeFile(appsec.rules, isConfigPropCorrect('appsec.rules'))),
+      safeJsonParse(maybeFile(process.env.DD_APPSEC_RULES, isEnvVarCorrect('DD_APPSEC_RULES')))
     )
     const DD_APPSEC_TRACE_RATE_LIMIT = coalesce(
       parseInt(appsec.rateLimit),
@@ -316,12 +324,14 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 |[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}[^\\-]+[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY|ssh-rsa\\s*[a-z0-9\\/\\.+]{100,}`
     )
     const DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = coalesce(
-      maybeFile(appsec.blockedTemplateHtml),
-      maybeFile(process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML)
+      maybeFile(appsec.blockedTemplateHtml, isConfigPropCorrect('appsec.blockedTemplateHtml')),
+      maybeFile(process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML,
+        isEnvVarCorrect('DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML'))
     )
     const DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = coalesce(
-      maybeFile(appsec.blockedTemplateJson),
-      maybeFile(process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON)
+      maybeFile(appsec.blockedTemplateJson, isConfigPropCorrect('appsec.blockedTemplateJson')),
+      maybeFile(process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON,
+        isEnvVarCorrect('DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON'))
     )
 
     const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
@@ -401,7 +411,8 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       }),
       spanSamplingRules: coalesce(
         options.spanSamplingRules,
-        safeJsonParse(maybeFile(process.env.DD_SPAN_SAMPLING_RULES_FILE)),
+        safeJsonParse(maybeFile(process.env.DD_SPAN_SAMPLING_RULES_FILE,
+          isEnvVarCorrect('DD_SPAN_SAMPLING_RULES_FILE'))),
         safeJsonParse(process.env.DD_SPAN_SAMPLING_RULES),
         []
       ).map(rule => {

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -1,17 +1,18 @@
 'use strict'
 
+const { expect } = require('chai')
 const { AbortController } = require('node-abort-controller')
 
 describe('blocking', () => {
   const config = {
     appsec: {
-      blockedTemplateHtml: 'htmlPath',
-      blockedTemplateJson: 'jsonPath'
+      blockedTemplateHtml: 'htmlBodyéé',
+      blockedTemplateJson: 'jsonBody'
     }
   }
 
-  let log, fs
-  let block, loadTemplates, loadTemplatesAsync, resetTemplates
+  let log
+  let block, setTemplates, blockedTemplate
   let req, res, rootSpan
 
   beforeEach(() => {
@@ -19,22 +20,17 @@ describe('blocking', () => {
       warn: sinon.stub()
     }
 
-    fs = {
-      readFileSync: sinon.stub().callsFake(getBody),
-      promises: {
-        readFile: sinon.stub()
-      }
+    blockedTemplate = {
+      html: 'block test',
+      json: '{ "block": true }'
     }
-
     const blocking = proxyquire('../src/appsec/blocking', {
       '../log': log,
-      fs
+      './blocked_templates': blockedTemplate
     })
 
     block = blocking.block
-    loadTemplates = blocking.loadTemplates
-    loadTemplatesAsync = blocking.loadTemplatesAsync
-    resetTemplates = blocking.resetTemplates
+    setTemplates = blocking.setTemplates
 
     req = {
       headers: {}
@@ -52,11 +48,10 @@ describe('blocking', () => {
 
   describe('block', () => {
     beforeEach(() => {
-      loadTemplates(config)
+      setTemplates(config)
     })
 
     afterEach(() => {
-      resetTemplates()
     })
 
     it('should log warn and not send blocking response when headers have already been sent', () => {
@@ -115,118 +110,28 @@ describe('blocking', () => {
     })
   })
 
-  describe('loadTemplates', () => {
-    afterEach(() => {
-      resetTemplates()
+  describe('block with default templates', () => {
+    const config = {
+      appsec: {
+        blockedTemplateHtml: undefined,
+        blockedTemplateJson: undefined
+      }
+    }
+    it('should require templates/blocked and use html property', () => {
+      req.headers.accept = 'text/html'
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.end).to.have.been.calledOnceWithExactly(blockedTemplate.html)
     })
 
-    describe('sync', () => {
-      it('should not read templates more than once if templates are already loaded', () => {
-        loadTemplates(config)
+    it('should require templates/blocked and use json property', () => {
+      setTemplates(config)
 
-        expect(fs.readFileSync).to.have.been.calledTwice
-        expect(fs.readFileSync.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.readFileSync.secondCall).to.have.been.calledWithExactly('jsonPath')
+      block(req, res, rootSpan)
 
-        fs.readFileSync.resetHistory()
-
-        loadTemplates(config)
-        loadTemplates(config)
-
-        expect(fs.readFileSync).to.not.have.been.called
-      })
-
-      it('should read templates twice if resetTemplates is called', () => {
-        loadTemplates(config)
-
-        expect(fs.readFileSync).to.have.been.calledTwice
-        expect(fs.readFileSync.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.readFileSync.secondCall).to.have.been.calledWithExactly('jsonPath')
-
-        fs.readFileSync.resetHistory()
-        resetTemplates()
-
-        loadTemplates(config)
-
-        expect(fs.readFileSync).to.have.been.calledTwice
-        expect(fs.readFileSync.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.readFileSync.secondCall).to.have.been.calledWithExactly('jsonPath')
-      })
-    })
-
-    describe('async', () => {
-      it('should not read templates more than once if templates are already loaded', async () => {
-        await loadTemplatesAsync(config)
-
-        expect(fs.promises.readFile).to.have.been.calledTwice
-        expect(fs.promises.readFile.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.promises.readFile.secondCall).to.have.been.calledWithExactly('jsonPath')
-
-        fs.promises.readFile.resetHistory()
-
-        await loadTemplatesAsync(config)
-        await loadTemplatesAsync(config)
-
-        expect(fs.promises.readFile).to.not.have.been.called
-      })
-
-      it('should read templates twice if resetTemplates is called', async () => {
-        await loadTemplatesAsync(config)
-
-        expect(fs.promises.readFile).to.have.been.calledTwice
-        expect(fs.promises.readFile.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.promises.readFile.secondCall).to.have.been.calledWithExactly('jsonPath')
-
-        fs.promises.readFile.resetHistory()
-        resetTemplates()
-
-        await loadTemplatesAsync(config)
-
-        expect(fs.promises.readFile).to.have.been.calledTwice
-        expect(fs.promises.readFile.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.promises.readFile.secondCall).to.have.been.calledWithExactly('jsonPath')
-      })
-    })
-
-    describe('mixed sync/async', () => {
-      it('should not read templates more than once if templates are already loaded', () => {
-        loadTemplates(config)
-
-        expect(fs.readFileSync).to.have.been.calledTwice
-        expect(fs.readFileSync.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.readFileSync.secondCall).to.have.been.calledWithExactly('jsonPath')
-
-        fs.readFileSync.resetHistory()
-
-        loadTemplatesAsync(config)
-        loadTemplatesAsync(config)
-
-        expect(fs.readFileSync).to.not.have.been.called
-        expect(fs.promises.readFile).to.not.have.been.called
-      })
-
-      it('should read templates twice if resetTemplates is called', async () => {
-        loadTemplates(config)
-
-        expect(fs.readFileSync).to.have.been.calledTwice
-        expect(fs.readFileSync.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.readFileSync.secondCall).to.have.been.calledWithExactly('jsonPath')
-
-        fs.readFileSync.resetHistory()
-        resetTemplates()
-
-        await loadTemplatesAsync(config)
-
-        expect(fs.readFileSync).to.not.have.been.called
-        expect(fs.promises.readFile).to.have.been.calledTwice
-        expect(fs.promises.readFile.firstCall).to.have.been.calledWithExactly('htmlPath')
-        expect(fs.promises.readFile.secondCall).to.have.been.calledWithExactly('jsonPath')
-      })
+      expect(res.end).to.have.been.calledOnceWithExactly(blockedTemplate.json)
     })
   })
 })
-
-function getBody (path) {
-  if (path === 'htmlPath') return 'htmlBodyéé'
-  if (path === 'jsonPath') return 'jsonBody'
-}

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { expect } = require('chai')
 const { AbortController } = require('node-abort-controller')
 
 describe('blocking', () => {

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -116,6 +116,7 @@ describe('blocking', () => {
         blockedTemplateJson: undefined
       }
     }
+
     it('should require templates/blocked and use html property', () => {
       req.headers.accept = 'text/html'
       setTemplates(config)

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -3,6 +3,11 @@
 const { AbortController } = require('node-abort-controller')
 
 describe('blocking', () => {
+  const defaultBlockedTemplate = {
+    html: 'block test',
+    json: '{ "block": true }'
+  }
+
   const config = {
     appsec: {
       blockedTemplateHtml: 'htmlBodyéé',
@@ -11,7 +16,7 @@ describe('blocking', () => {
   }
 
   let log
-  let block, setTemplates, blockedTemplate
+  let block, setTemplates
   let req, res, rootSpan
 
   beforeEach(() => {
@@ -19,13 +24,9 @@ describe('blocking', () => {
       warn: sinon.stub()
     }
 
-    blockedTemplate = {
-      html: 'block test',
-      json: '{ "block": true }'
-    }
     const blocking = proxyquire('../src/appsec/blocking', {
       '../log': log,
-      './blocked_templates': blockedTemplate
+      './blocked_templates': defaultBlockedTemplate
     })
 
     block = blocking.block
@@ -48,9 +49,6 @@ describe('blocking', () => {
   describe('block', () => {
     beforeEach(() => {
       setTemplates(config)
-    })
-
-    afterEach(() => {
     })
 
     it('should log warn and not send blocking response when headers have already been sent', () => {
@@ -117,21 +115,21 @@ describe('blocking', () => {
       }
     }
 
-    it('should require templates/blocked and use html property', () => {
+    it('should block with default html template', () => {
       req.headers.accept = 'text/html'
       setTemplates(config)
 
       block(req, res, rootSpan)
 
-      expect(res.end).to.have.been.calledOnceWithExactly(blockedTemplate.html)
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
     })
 
-    it('should require templates/blocked and use json property', () => {
+    it('should block with default json template', () => {
       setTemplates(config)
 
       block(req, res, rootSpan)
 
-      expect(res.end).to.have.been.calledOnceWithExactly(blockedTemplate.json)
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
     })
   })
 })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -70,8 +70,8 @@ describe('AppSec Index', () => {
       AppSec.enable(config)
       AppSec.enable(config)
 
-      expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly(RULES, config.appsec)
       expect(blocking.setTemplates).to.have.been.calledOnceWithExactly(config)
+      expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly(RULES, config.appsec)
       expect(remoteConfig.enableAsmData).to.have.been.calledOnce
       expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fs = require('fs')
 const path = require('path')
 const proxyquire = require('proxyquire')
 const log = require('../../src/log')
@@ -15,24 +14,27 @@ const agent = require('../plugins/agent')
 const Config = require('../../src/config')
 const axios = require('axios')
 const getPort = require('get-port')
-const { resetTemplates } = require('../../src/appsec/blocking')
+
+const blockedTemplate = require(path.join(__dirname, '..', '..', 'src', 'appsec', 'blocked_templates'))
 
 describe('AppSec Index', () => {
   let config
   let AppSec
   let web
 
+  const RULES = { rules: [{ a: 1 }] }
+
   beforeEach(() => {
     config = {
       appsec: {
         enabled: true,
-        rules: './path/rules.json',
+        rules: RULES,
         rateLimit: 42,
         wafTimeout: 42,
         obfuscatorKeyRegex: '.*',
         obfuscatorValueRegex: '.*',
-        blockedTemplateHtml: path.join(__dirname, '..', '..', 'src', 'appsec', 'templates', 'blocked.html'),
-        blockedTemplateJson: path.join(__dirname, '..', '..', 'src', 'appsec', 'templates', 'blocked.json')
+        blockedTemplateHtml: blockedTemplate.html,
+        blockedTemplateJson: blockedTemplate.json
       }
     }
 
@@ -44,10 +46,6 @@ describe('AppSec Index', () => {
       '../plugins/util/web': web
     })
 
-    resetTemplates()
-
-    sinon.stub(fs, 'readFileSync').returns('{"rules": [{"a": 1}]}')
-    sinon.stub(fs.promises, 'readFile').returns('{"rules": [{"a": 1}]}')
     sinon.stub(RuleManager, 'applyRules')
     sinon.stub(remoteConfig, 'enableAsmData')
     sinon.stub(remoteConfig, 'disableAsmData')
@@ -66,10 +64,7 @@ describe('AppSec Index', () => {
       AppSec.enable(config)
       AppSec.enable(config)
 
-      expect(fs.readFileSync).to.have.been.calledWithExactly('./path/rules.json')
-      expect(fs.readFileSync).to.have.been.calledWithExactly(config.appsec.blockedTemplateHtml)
-      expect(fs.readFileSync).to.have.been.calledWithExactly(config.appsec.blockedTemplateJson)
-      expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] }, config.appsec)
+      expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly(RULES, config.appsec)
       expect(remoteConfig.enableAsmData).to.have.been.calledOnce
       expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)
@@ -91,49 +86,6 @@ describe('AppSec Index', () => {
       sinon.stub(RuleManager, 'applyRules').throws(err)
 
       AppSec.enable(config)
-
-      expect(log.error).to.have.been.calledTwice
-      expect(log.error.firstCall).to.have.been.calledWithExactly('Unable to start AppSec')
-      expect(log.error.secondCall).to.have.been.calledWithExactly(err)
-      expect(remoteConfig.disableAsmData).to.have.been.calledOnce
-      expect(incomingHttpRequestStart.subscribe).to.not.have.been.called
-      expect(incomingHttpRequestEnd.subscribe).to.not.have.been.called
-      expect(Gateway.manager.addresses).to.be.empty
-    })
-  })
-
-  describe('enableAsync', () => {
-    it('should enable AppSec only once', async () => {
-      await AppSec.enableAsync(config)
-      await AppSec.enableAsync(config)
-
-      expect(fs.readFileSync).not.to.have.been.called
-      expect(fs.promises.readFile).to.have.been.calledThrice
-      expect(fs.promises.readFile).to.have.been.calledWithExactly('./path/rules.json')
-      expect(fs.promises.readFile).to.have.been.calledWithExactly(config.appsec.blockedTemplateHtml)
-      expect(fs.promises.readFile).to.have.been.calledWithExactly(config.appsec.blockedTemplateJson)
-      expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly({ rules: [{ a: 1 }] }, config.appsec)
-      expect(remoteConfig.enableAsmData).to.have.been.calledOnce
-      expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
-      expect(incomingHttpRequestStart.subscribe)
-        .to.have.been.calledOnceWithExactly(AppSec.incomingHttpStartTranslator)
-      expect(incomingHttpRequestEnd.subscribe).to.have.been.calledOnceWithExactly(AppSec.incomingHttpEndTranslator)
-      expect(Gateway.manager.addresses).to.have.all.keys(
-        addresses.HTTP_INCOMING_HEADERS,
-        addresses.HTTP_INCOMING_ENDPOINT,
-        addresses.HTTP_INCOMING_RESPONSE_HEADERS,
-        addresses.HTTP_INCOMING_REMOTE_IP
-      )
-    })
-
-    it('should log when enable fails', async () => {
-      sinon.stub(log, 'error')
-      RuleManager.applyRules.restore()
-
-      const err = new Error('Invalid Rules')
-      sinon.stub(RuleManager, 'applyRules').throws(err)
-
-      await AppSec.enableAsync(config)
 
       expect(log.error).to.have.been.calledTwice
       expect(log.error.firstCall).to.have.been.calledWithExactly('Unable to start AppSec')
@@ -481,7 +433,6 @@ describe('IP blocking', () => {
   })
   afterEach(() => {
     appsec.disable()
-    resetTemplates()
   })
 
   describe('do not block the request', () => {
@@ -521,11 +472,8 @@ describe('IP blocking', () => {
     })
 
     describe(`block - ip in header ${ipHeader}`, () => {
-      const templatesPath = path.join(__dirname, '..', '..', 'src', 'appsec', 'templates')
-      const htmlDefaultContent = fs.readFileSync(path.join(templatesPath, 'blocked.html'), 'utf8').toString()
-      const jsonDefaultContent = JSON.parse(
-        fs.readFileSync(path.join(templatesPath, 'blocked.json'), 'utf8').toString()
-      )
+      const htmlDefaultContent = blockedTemplate.html
+      const jsonDefaultContent = JSON.parse(blockedTemplate.json)
 
       it('should block the request with JSON content if no headers', async () => {
         await axios.get(`http://localhost:${port}/`, {

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const path = require('path')
 const proxyquire = require('proxyquire')
 const log = require('../../src/log')
 const RuleManager = require('../../src/appsec/rule_manager')
@@ -15,7 +14,8 @@ const Config = require('../../src/config')
 const axios = require('axios')
 const getPort = require('get-port')
 
-const blockedTemplate = require(path.join(__dirname, '..', '..', 'src', 'appsec', 'blocked_templates'))
+const blockedTemplate = require('../../src/appsec/blocked_templates')
+const recommendedJson = require('../../src/appsec/recommended.json')
 
 describe('AppSec Index', () => {
   let config
@@ -94,6 +94,13 @@ describe('AppSec Index', () => {
       expect(incomingHttpRequestStart.subscribe).to.not.have.been.called
       expect(incomingHttpRequestEnd.subscribe).to.not.have.been.called
       expect(Gateway.manager.addresses).to.be.empty
+    })
+
+    it('should load recommended.json rules if not provided by the user', () => {
+      config.appsec.rules = undefined
+      AppSec.enable(config)
+
+      expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly(recommendedJson, config.appsec)
     })
   })
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -21,6 +21,7 @@ describe('AppSec Index', () => {
   let config
   let AppSec
   let web
+  let blocking
 
   const RULES = { rules: [{ a: 1 }] }
 
@@ -42,8 +43,13 @@ describe('AppSec Index', () => {
       root: sinon.stub()
     }
 
+    blocking = {
+      setTemplates: sinon.stub()
+    }
+
     AppSec = proxyquire('../../src/appsec', {
-      '../plugins/util/web': web
+      '../plugins/util/web': web,
+      './blocking': blocking
     })
 
     sinon.stub(RuleManager, 'applyRules')
@@ -65,6 +71,7 @@ describe('AppSec Index', () => {
       AppSec.enable(config)
 
       expect(RuleManager.applyRules).to.have.been.calledOnceWithExactly(RULES, config.appsec)
+      expect(blocking.setTemplates).to.have.been.calledOnceWithExactly(config)
       expect(remoteConfig.enableAsmData).to.have.been.calledOnce
       expect(Reporter.setRateLimit).to.have.been.calledOnceWithExactly(42)
       expect(incomingHttpRequestStart.subscribe)

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -26,7 +26,6 @@ describe('Remote Config enable', () => {
 
     appsec = {
       enable: sinon.spy(),
-      enableAsync: sinon.spy(() => Promise.resolve()),
       disable: sinon.spy()
     }
 
@@ -76,15 +75,13 @@ describe('Remote Config enable', () => {
     it('should enable appsec when listener is called with apply and enabled', () => {
       listener('apply', { asm: { enabled: true } })
 
-      expect(appsec.enable).to.not.have.been.called
-      expect(appsec.enableAsync).to.have.been.calledOnceWithExactly(config)
+      expect(appsec.enable).to.have.been.calledOnceWithExactly(config)
     })
 
     it('should enable appsec when listener is called with modify and enabled', () => {
       listener('modify', { asm: { enabled: true } })
 
-      expect(appsec.enable).to.not.have.been.called
-      expect(appsec.enableAsync).to.have.been.calledOnceWithExactly(config)
+      expect(appsec.enable).to.have.been.calledOnceWithExactly(config)
     })
 
     it('should disable appsec when listener is called with unnaply and enabled', () => {
@@ -96,7 +93,6 @@ describe('Remote Config enable', () => {
     it('should not do anything when listener is called with apply and malformed data', () => {
       listener('apply', {})
 
-      expect(appsec.enableAsync).to.not.have.been.called
       expect(appsec.enable).to.not.have.been.called
       expect(appsec.disable).to.not.have.been.called
     })

--- a/packages/dd-trace/test/appsec/sdk/index.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/index.spec.js
@@ -28,7 +28,7 @@ describe('Appsec SDK', () => {
     appsecSdk = new AppsecSdk(tracer, config)
   })
 
-  it('should call loadTemplates when instanciated', () => {
+  it('should call setTemplates when instanciated', () => {
     expect(setTemplates).to.have.been.calledOnceWithExactly(config)
   })
 

--- a/packages/dd-trace/test/appsec/sdk/index.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/index.spec.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire')
 
 describe('Appsec SDK', () => {
   let trackUserLoginSuccessEvent, trackUserLoginFailureEvent, trackCustomEvent
-  let checkUserAndSetUser, blockRequest, setUser, loadTemplates
+  let checkUserAndSetUser, blockRequest, setUser, setTemplates
   let appsecSdk
   const tracer = {}
   const config = {}
@@ -15,13 +15,13 @@ describe('Appsec SDK', () => {
     trackCustomEvent = sinon.stub()
     checkUserAndSetUser = sinon.stub()
     blockRequest = sinon.stub()
-    loadTemplates = sinon.stub()
+    setTemplates = sinon.stub()
     setUser = sinon.stub()
 
     const AppsecSdk = proxyquire('../../../src/appsec/sdk', {
       './track_event': { trackUserLoginSuccessEvent, trackUserLoginFailureEvent, trackCustomEvent },
       './user_blocking': { checkUserAndSetUser, blockRequest },
-      '../blocking': { loadTemplates },
+      '../blocking': { setTemplates },
       './set_user': { setUser }
     })
 
@@ -29,7 +29,7 @@ describe('Appsec SDK', () => {
   })
 
   it('should call loadTemplates when instanciated', () => {
-    expect(loadTemplates).to.have.been.calledOnceWithExactly(config)
+    expect(setTemplates).to.have.been.calledOnceWithExactly(config)
   })
 
   it('trackUserLoginSuccessEvent should call internal function with proper params', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -4,7 +4,7 @@ require('./setup/tap')
 
 const { expect } = require('chai')
 const { EOL } = require('os')
-const path = require('path')
+
 describe('Config', () => {
   let Config
   let log
@@ -818,8 +818,8 @@ describe('Config', () => {
     const config = new Config({
       appsec: {
         enabled: true,
-        blockedTemplateHtml: path.join(__dirname, 'DOES_NOT_EXIST.html'),
-        blockedTemplateJson: path.join(__dirname, 'DOES_NOT_EXIST.json')
+        blockedTemplateHtml: 'DOES_NOT_EXIST.html',
+        blockedTemplateJson: 'DOES_NOT_EXIST.json'
       }
     })
     expect(config.appsec.blockedTemplateHtml).to.be.undefined

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -92,6 +92,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.wafTimeout', 5e3)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex').with.length(155)
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex').with.length(443)
+    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', undefined)
+    expect(config).to.have.nested.property('appsec.blockedTemplateJson', undefined)
     expect(config).to.have.nested.property('remoteConfig.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 5)
     expect(config).to.have.nested.property('iast.enabled', false)
@@ -169,6 +171,8 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = '42'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '.*'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '.*'
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = 'TODO'
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = 'TODO'
     process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = '42'
     process.env.DD_IAST_ENABLED = 'true'
@@ -227,6 +231,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
+    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', 'TODO')
+    expect(config).to.have.nested.property('appsec.blockedTemplateJson', 'TODO')
     expect(config).to.have.nested.property('remoteConfig.enabled', false)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
@@ -516,6 +522,8 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = 11
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '^$'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '^$'
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = 'TODO'
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = 'TODO'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
 
@@ -618,7 +626,9 @@ describe('Config', () => {
         rateLimit: 42,
         wafTimeout: 42,
         obfuscatorKeyRegex: '.*',
-        obfuscatorValueRegex: '.*'
+        obfuscatorValueRegex: '.*',
+        blockedTemplateHtml: 'TODO',
+        blockedTemplateJson: 'TODO'
       },
       experimental: {
         appsec: {
@@ -627,7 +637,9 @@ describe('Config', () => {
           rateLimit: 11,
           wafTimeout: 11,
           obfuscatorKeyRegex: '^$',
-          obfuscatorValueRegex: '^$'
+          obfuscatorValueRegex: '^$',
+          blockedTemplateHtml: 'TODO',
+          blockedTemplateJson: 'TODO'
         }
       }
     })
@@ -822,6 +834,8 @@ describe('Config', () => {
         blockedTemplateJson: 'DOES_NOT_EXIST.json'
       }
     })
+
+    expect(log.error).TODO
     expect(config.appsec.blockedTemplateHtml).to.be.undefined
     expect(config.appsec.blockedTemplateJson).to.be.undefined
   })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -528,8 +528,8 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = 11
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '^$'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '^$'
-    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = '/lower/priority/templates/blocked.html'
-    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = '/lower/priority/templates/blocked.json'
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = BLOCKED_TEMPLATE_JSON // note the inversion between json and html here
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = BLOCKED_TEMPLATE_HTML
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -19,9 +19,9 @@ describe('Config', () => {
   const RULES_JSON_PATH = require.resolve('./fixtures/config/appsec-rules.json')
   const RULES_JSON = require(RULES_JSON_PATH)
   const BLOCKED_TEMPLATE_HTML_PATH = require.resolve('./fixtures/config/appsec-blocked-template.html')
-  const BLOCKED_TEMPLATE_JSON_PATH = require.resolve('./fixtures/config/appsec-blocked-template.json')
   const BLOCKED_TEMPLATE_HTML = readFileSync(BLOCKED_TEMPLATE_HTML_PATH, { encoding: 'utf8' })
-  const BLOCKED_TEMPLATE_JSON = require(BLOCKED_TEMPLATE_JSON_PATH)
+  const BLOCKED_TEMPLATE_JSON_PATH = require.resolve('./fixtures/config/appsec-blocked-template.json')
+  const BLOCKED_TEMPLATE_JSON = readFileSync(BLOCKED_TEMPLATE_JSON_PATH, { encoding: 'utf8' })
 
   beforeEach(() => {
     pkg = {
@@ -832,7 +832,7 @@ describe('Config', () => {
     ])
   })
 
-  it('should ignore appsec.blockedTemplateHtml if it does not exist', () => {
+  it('should skip appsec config files if they do not exist', () => {
     const error = new Error('file not found')
     fs.readFileSync = () => { throw error }
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -3,6 +3,7 @@
 require('./setup/tap')
 
 const { expect } = require('chai')
+const { EOL } = require('os')
 const path = require('path')
 describe('Config', () => {
   let Config
@@ -14,6 +15,8 @@ describe('Config', () => {
   let existsSyncParam
   let existsSyncReturn
   let osType
+
+  const RULES_JSON_PATH = require.resolve('./fixtures/config/appsec-rules.json')
 
   beforeEach(() => {
     pkg = {
@@ -161,7 +164,7 @@ describe('Config', () => {
     process.env.DD_TRACE_EXPERIMENTAL_GET_RUM_DATA_ENABLED = 'true'
     process.env.DD_TRACE_EXPERIMENTAL_INTERNAL_ERRORS_ENABLED = 'true'
     process.env.DD_APPSEC_ENABLED = 'true'
-    process.env.DD_APPSEC_RULES = './path/rules.json'
+    process.env.DD_APPSEC_RULES = RULES_JSON_PATH
     process.env.DD_APPSEC_TRACE_RATE_LIMIT = '42'
     process.env.DD_APPSEC_WAF_TIMEOUT = '42'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '.*'
@@ -219,7 +222,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.exporter', 'log')
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
     expect(config).to.have.nested.property('appsec.enabled', true)
-    expect(config).to.have.nested.property('appsec.rules', './path/rules.json')
+    expect(config).to.have.nested.deep.property('appsec.rules', require(RULES_JSON_PATH))
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
@@ -555,13 +558,13 @@ describe('Config', () => {
       },
       appsec: {
         enabled: true,
-        rules: './path/rules.json',
+        rules: RULES_JSON_PATH,
         rateLimit: 42,
         wafTimeout: 42,
         obfuscatorKeyRegex: '.*',
         obfuscatorValueRegex: '.*',
-        blockedTemplateHtml: __filename,
-        blockedTemplateJson: __filename
+        blockedTemplateHtml: require.resolve('./fixtures/config/appsec-blocked-template.html'),
+        blockedTemplateJson: require.resolve('./fixtures/config/appsec-blocked-template.json')
       },
       remoteConfig: {
         pollInterval: 42
@@ -592,13 +595,13 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.exporter', 'agent')
     expect(config).to.have.nested.property('experimental.enableGetRumData', false)
     expect(config).to.have.nested.property('appsec.enabled', true)
-    expect(config).to.have.nested.property('appsec.rules', './path/rules.json')
+    expect(config).to.have.nested.deep.property('appsec.rules', require(RULES_JSON_PATH))
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
-    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', __filename)
-    expect(config).to.have.nested.property('appsec.blockedTemplateJson', __filename)
+    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', '<html>blocked</html>' + EOL)
+    expect(config).to.have.nested.property('appsec.blockedTemplateJson', '{"error": "blocked"}' + EOL)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 30)
@@ -611,7 +614,7 @@ describe('Config', () => {
     const config = new Config({
       appsec: {
         enabled: true,
-        rules: './path/rules.json',
+        rules: RULES_JSON_PATH,
         rateLimit: 42,
         wafTimeout: 42,
         obfuscatorKeyRegex: '.*',
@@ -631,15 +634,13 @@ describe('Config', () => {
 
     expect(config).to.have.deep.property('appsec', {
       enabled: true,
-      rules: './path/rules.json',
+      rules: require(RULES_JSON_PATH),
       rateLimit: 42,
       wafTimeout: 42,
       obfuscatorKeyRegex: '.*',
       obfuscatorValueRegex: '.*',
-      blockedTemplateHtml:
-        path.join(__dirname, '..', 'src', 'appsec', 'templates', 'blocked.html'),
-      blockedTemplateJson:
-        path.join(__dirname, '..', 'src', 'appsec', 'templates', 'blocked.json')
+      blockedTemplateHtml: undefined,
+      blockedTemplateJson: undefined
     })
   })
 
@@ -821,10 +822,8 @@ describe('Config', () => {
         blockedTemplateJson: path.join(__dirname, 'DOES_NOT_EXIST.json')
       }
     })
-    expect(config.appsec.blockedTemplateHtml).to.be
-      .equal(path.join(__dirname, '..', 'src', 'appsec', 'templates', 'blocked.html'))
-    expect(config.appsec.blockedTemplateJson).to.be
-      .equal(path.join(__dirname, '..', 'src', 'appsec', 'templates', 'blocked.json'))
+    expect(config.appsec.blockedTemplateHtml).to.be.undefined
+    expect(config.appsec.blockedTemplateJson).to.be.undefined
   })
 
   context('auto configuration w/ unix domain sockets', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -20,8 +20,8 @@ describe('Config', () => {
   const RULES_JSON = require(RULES_JSON_PATH)
   const BLOCKED_TEMPLATE_HTML_PATH = require.resolve('./fixtures/config/appsec-blocked-template.html')
   const BLOCKED_TEMPLATE_JSON_PATH = require.resolve('./fixtures/config/appsec-blocked-template.json')
-  const BLOCKED_TEMPLATE_HTML = '<html>blocked</html>' + EOL
-  const BLOCKED_TEMPLATE_JSON = '{"error": "blocked"}' + EOL
+  const BLOCKED_TEMPLATE_HTML = fs.readFileSync(BLOCKED_TEMPLATE_HTML_PATH, { encoding: 'utf8' })
+  const BLOCKED_TEMPLATE_JSON = require(BLOCKED_TEMPLATE_JSON_PATH)
 
   beforeEach(() => {
     pkg = {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -17,6 +17,11 @@ describe('Config', () => {
   let osType
 
   const RULES_JSON_PATH = require.resolve('./fixtures/config/appsec-rules.json')
+  const RULES_JSON = require(RULES_JSON_PATH)
+  const BLOCKED_TEMPLATE_HTML_PATH = require.resolve('./fixtures/config/appsec-blocked-template.html')
+  const BLOCKED_TEMPLATE_JSON_PATH = require.resolve('./fixtures/config/appsec-blocked-template.json')
+  const BLOCKED_TEMPLATE_HTML = '<html>blocked</html>' + EOL
+  const BLOCKED_TEMPLATE_JSON = '{"error": "blocked"}' + EOL
 
   beforeEach(() => {
     pkg = {
@@ -27,7 +32,8 @@ describe('Config', () => {
     log = {
       use: sinon.spy(),
       toggle: sinon.spy(),
-      warn: sinon.spy()
+      warn: sinon.spy(),
+      error: sinon.spy()
     }
 
     env = process.env
@@ -171,8 +177,8 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = '42'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '.*'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '.*'
-    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = 'TODO'
-    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = 'TODO'
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = BLOCKED_TEMPLATE_HTML_PATH
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = BLOCKED_TEMPLATE_JSON_PATH
     process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = '42'
     process.env.DD_IAST_ENABLED = 'true'
@@ -226,13 +232,13 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.exporter', 'log')
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
     expect(config).to.have.nested.property('appsec.enabled', true)
-    expect(config).to.have.nested.deep.property('appsec.rules', require(RULES_JSON_PATH))
+    expect(config).to.have.nested.deep.property('appsec.rules', RULES_JSON)
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
-    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', 'TODO')
-    expect(config).to.have.nested.property('appsec.blockedTemplateJson', 'TODO')
+    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', BLOCKED_TEMPLATE_HTML)
+    expect(config).to.have.nested.property('appsec.blockedTemplateJson', BLOCKED_TEMPLATE_JSON)
     expect(config).to.have.nested.property('remoteConfig.enabled', false)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
@@ -522,8 +528,8 @@ describe('Config', () => {
     process.env.DD_APPSEC_WAF_TIMEOUT = 11
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP = '^$'
     process.env.DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP = '^$'
-    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = 'TODO'
-    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = 'TODO'
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML = BLOCKED_TEMPLATE_HTML_PATH
+    process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = BLOCKED_TEMPLATE_JSON_PATH
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
 
@@ -571,8 +577,8 @@ describe('Config', () => {
         wafTimeout: 42,
         obfuscatorKeyRegex: '.*',
         obfuscatorValueRegex: '.*',
-        blockedTemplateHtml: require.resolve('./fixtures/config/appsec-blocked-template.html'),
-        blockedTemplateJson: require.resolve('./fixtures/config/appsec-blocked-template.json')
+        blockedTemplateHtml: BLOCKED_TEMPLATE_HTML_PATH,
+        blockedTemplateJson: BLOCKED_TEMPLATE_JSON_PATH
       },
       remoteConfig: {
         pollInterval: 42
@@ -603,13 +609,13 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.exporter', 'agent')
     expect(config).to.have.nested.property('experimental.enableGetRumData', false)
     expect(config).to.have.nested.property('appsec.enabled', true)
-    expect(config).to.have.nested.deep.property('appsec.rules', require(RULES_JSON_PATH))
+    expect(config).to.have.nested.deep.property('appsec.rules', RULES_JSON)
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
     expect(config).to.have.nested.property('appsec.obfuscatorValueRegex', '.*')
-    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', '<html>blocked</html>' + EOL)
-    expect(config).to.have.nested.property('appsec.blockedTemplateJson', '{"error": "blocked"}' + EOL)
+    expect(config).to.have.nested.property('appsec.blockedTemplateHtml', BLOCKED_TEMPLATE_HTML)
+    expect(config).to.have.nested.property('appsec.blockedTemplateJson', BLOCKED_TEMPLATE_JSON)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 30)
@@ -627,8 +633,8 @@ describe('Config', () => {
         wafTimeout: 42,
         obfuscatorKeyRegex: '.*',
         obfuscatorValueRegex: '.*',
-        blockedTemplateHtml: 'TODO',
-        blockedTemplateJson: 'TODO'
+        blockedTemplateHtml: undefined,
+        blockedTemplateJson: undefined
       },
       experimental: {
         appsec: {
@@ -638,15 +644,15 @@ describe('Config', () => {
           wafTimeout: 11,
           obfuscatorKeyRegex: '^$',
           obfuscatorValueRegex: '^$',
-          blockedTemplateHtml: 'TODO',
-          blockedTemplateJson: 'TODO'
+          blockedTemplateHtml: BLOCKED_TEMPLATE_HTML_PATH,
+          blockedTemplateJson: BLOCKED_TEMPLATE_JSON_PATH
         }
       }
     })
 
     expect(config).to.have.deep.property('appsec', {
       enabled: true,
-      rules: require(RULES_JSON_PATH),
+      rules: RULES_JSON,
       rateLimit: 42,
       wafTimeout: 42,
       obfuscatorKeyRegex: '.*',
@@ -835,7 +841,7 @@ describe('Config', () => {
       }
     })
 
-    expect(log.error).TODO
+    expect(log.error).to.be.called
     expect(config.appsec.blockedTemplateHtml).to.be.undefined
     expect(config.appsec.blockedTemplateJson).to.be.undefined
   })

--- a/packages/dd-trace/test/fixtures/config/appsec-blocked-template.html
+++ b/packages/dd-trace/test/fixtures/config/appsec-blocked-template.html
@@ -1,0 +1,1 @@
+<html>blocked</html>

--- a/packages/dd-trace/test/fixtures/config/appsec-blocked-template.json
+++ b/packages/dd-trace/test/fixtures/config/appsec-blocked-template.json
@@ -1,0 +1,1 @@
+{"error": "blocked"}

--- a/packages/dd-trace/test/fixtures/config/appsec-rules.json
+++ b/packages/dd-trace/test/fixtures/config/appsec-rules.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.5.2"
+  },
+  "rules": [{"a": 1}]
+}


### PR DESCRIPTION
### What does this PR do?

Move `templates/blocked.html` and `templates/blocked.json` file contents to `blocked_templates.js` file and require it in order to load the appsec templates.
Now is in `config.js` where the template and rules are loaded, establishing the corresponding values for `config.appsec.blockedTemplateHtml` and `config.appsec.blockedTemplateJson`.

Closes #2841
Closes #2899 


### Motivation
Avoid errors with esbuild bundles
