### PR TITLE
Remove unhandled wrap() typescript method overload

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,7 @@ export declare interface Tracer extends opentracing.Tracer {
    * * The function doesn't accept a callback and doesn't return a promise, in
    * which case the span will finish at the end of the function execution.
    */
-  wrap<T = (...args: any[]) => any> (name: string, fn: T, requiresParent?: boolean): T;
+  wrap<T = (...args: any[]) => any> (name: string, fn: T): T;
   wrap<T = (...args: any[]) => any> (name: string, options: TraceOptions & SpanOptions, fn: T): T;
   wrap<T = (...args: any[]) => any> (name: string, options: (...args: any[]) => TraceOptions & SpanOptions, fn: T): T;
 


### PR DESCRIPTION
When using library, noticed that actual implementation of tracer.wrap does not seem to handle 'requiresParent' third boolean arg and just returns boolean as a result https://github.com/DataDog/dd-trace-js/blob/9f753ce63d6ec7528eb21cec82ac18943c7315c6/packages/dd-trace/src/tracer.js#L71-L105 
