### PR TITLE
[PROF-7353] Allow both number and bigint as parsed period types.

### DIFF
--- a/packages/dd-trace/test/asserts/profile.js
+++ b/packages/dd-trace/test/asserts/profile.js
@@ -9,13 +9,17 @@ module.exports = ({ Assertion, expect }, { expectTypes }) => {
     expect(obj.unit).to.be.a('number')
   })
 
+  Assertion.addProperty('numeric', function () {
+    expectTypes(this, ['number', 'bigint'])
+  })
+
   Assertion.addProperty('profile', function () {
     const obj = this._obj
 
     expect(obj).to.be.an('object')
 
     expect(obj.timeNanos).to.be.a('bigint')
-    expectTypes(expect(obj.period), ['number', 'bigint'])
+    expect(obj.period).to.be.numeric
     expect(obj.periodType).to.be.a.valueType
     expect(obj.sampleType).to.be.an('array').and.have.length(2)
     expect(obj.sample).to.be.an('array')

--- a/packages/dd-trace/test/asserts/profile.js
+++ b/packages/dd-trace/test/asserts/profile.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = ({ Assertion, expect }, utils) => {
+module.exports = ({ Assertion, expect }, { expectTypes }) => {
   Assertion.addProperty('valueType', function () {
     const obj = this._obj
 
@@ -15,7 +15,7 @@ module.exports = ({ Assertion, expect }, utils) => {
     expect(obj).to.be.an('object')
 
     expect(obj.timeNanos).to.be.a('bigint')
-    utils.expectTypes(expect(obj.period), ['number', 'bigint'])
+    expectTypes(expect(obj.period), ['number', 'bigint'])
     expect(obj.periodType).to.be.a.valueType
     expect(obj.sampleType).to.be.an('array').and.have.length(2)
     expect(obj.sample).to.be.an('array')

--- a/packages/dd-trace/test/asserts/profile.js
+++ b/packages/dd-trace/test/asserts/profile.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = ({ Assertion, expect }) => {
+module.exports = ({ Assertion, expect }, utils) => {
   Assertion.addProperty('valueType', function () {
     const obj = this._obj
 
@@ -15,7 +15,7 @@ module.exports = ({ Assertion, expect }) => {
     expect(obj).to.be.an('object')
 
     expect(obj.timeNanos).to.be.a('bigint')
-    expect(obj.period).to.be.a('number')
+    utils.expectTypes(expect(obj.period), ['number', 'bigint'])
     expect(obj.periodType).to.be.a.valueType
     expect(obj.sampleType).to.be.an('array').and.have.length(2)
     expect(obj.sample).to.be.an('array')


### PR DESCRIPTION
Allow both number and bigint as parsed period types.

### What does this PR do?
Fixes a flaky test as described by [PROF-7353](https://datadoghq.atlassian.net/browse/PROF-7353). 

### Motivation
Flaky tests are annoying.

### Additional Notes
The test is flaky because the library we use for decoding pprof will decode some numbers as JavaScript bigints, so we need to be more lenient with a type test. Since decoding is only used to verify the request information we're passing on to the profiler backend, we can live with this. (The backend uses its own decoding that doesn't suffer from this number/bigint duality.)



[PROF-7353]: https://datadoghq.atlassian.net/browse/PROF-7353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ