### PR TITLE
fix tcp connections to the agent being traced

### DIFF
--- a/packages/dd-trace/src/exporters/common/agents.js
+++ b/packages/dd-trace/src/exporters/common/agents.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const http = require('http')
+const https = require('https')
+const { storage } = require('../../../../datadog-core')
+
+const keepAlive = true
+const maxSockets = 1
+
+function createAgentClass (BaseAgent) {
+  class CustomAgent extends BaseAgent {
+    constructor () {
+      super({ keepAlive, maxSockets })
+    }
+
+    createConnection (...args) {
+      return this._noop(() => super.createConnection(...args))
+    }
+
+    keepSocketAlive (...args) {
+      return this._noop(() => super.keepSocketAlive(...args))
+    }
+
+    reuseSocket (...args) {
+      return this._noop(() => super.reuseSocket(...args))
+    }
+
+    _noop (callback) {
+      return storage.run({ noop: true }, callback)
+    }
+  }
+
+  return CustomAgent
+}
+
+const HttpAgent = createAgentClass(http.Agent)
+const HttpsAgent = createAgentClass(https.Agent)
+
+module.exports = {
+  httpAgent: new HttpAgent(),
+  HttpsAgent: new HttpsAgent()
+}

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -8,14 +8,11 @@ const http = require('http')
 const https = require('https')
 const { parse: urlParse } = require('url')
 const docker = require('./docker')
+const { httpAgent, httpsAgent } = require('./agents')
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 
-const keepAlive = true
-const maxSockets = 1
 const maxActiveRequests = 8
-const httpAgent = new http.Agent({ keepAlive, maxSockets })
-const httpsAgent = new https.Agent({ keepAlive, maxSockets })
 const containerId = docker.id()
 
 let activeRequests = 0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix TCP connections to the agent being traced.

### Motivation
<!-- What inspired you to submit this pull request? -->

The tracer should not be tracing itself as this creates noise for users.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I wasn't able to test this as I was only able to make this happen when creating traces synchronously at the root of the process. However, since `http.Agent` uses a connection pool, it's to be expected that it could happen in other scenarios as well.