### PR TITLE
Vulnerability deduplication rework

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -115,7 +115,8 @@ tracer.init({
       enabled: true,
       requestSampling: 50,
       maxConcurrentRequests: 4,
-      maxContextOperations: 30
+      maxContextOperations: 30,
+      deduplicationEnabled: true
     }
   }
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -438,7 +438,11 @@ export declare interface TracerOptions {
        * Controls how many code vulnerabilities can be detected in the same request
        * @default 2
        */
-      maxContextOperations?: number
+      maxContextOperations?: number,
+      /**
+       * Whether to enable vulnerability deduplication
+       */
+      deduplicationEnabled?: boolean
     }
   };
 

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -4,8 +4,11 @@ const VULNERABILITIES_KEY = 'vulnerabilities'
 const IAST_JSON_TAG_KEY = '_dd.iast.json'
 const VULNERABILITY_HASHES_MAX_SIZE = 1000
 const VULNERABILITY_HASHES = new LRU({ max: VULNERABILITY_HASHES_MAX_SIZE })
+const RESET_VULNERABILITY_CACHE_INTERVAL = 60 * 60 * 1000 // 1 hour
 
 let tracer
+let resetVulnerabilityCacheTimer
+let deduplicationEnabled = true
 
 function createVulnerability (type, evidence, spanId, location) {
   if (type && evidence) {
@@ -164,7 +167,20 @@ function clearCache () { // only for test purposes
   VULNERABILITY_HASHES.clear()
 }
 
+function startClearCacheTimer () {
+  resetVulnerabilityCacheTimer = setInterval(clearCache, RESET_VULNERABILITY_CACHE_INTERVAL)
+  resetVulnerabilityCacheTimer.unref()
+}
+
+function stopClearCacheTimer () {
+  if (resetVulnerabilityCacheTimer) {
+    clearInterval(resetVulnerabilityCacheTimer)
+    resetVulnerabilityCacheTimer = null
+  }
+}
+
 function deduplicateVulnerabilities (vulnerabilities) {
+  if (!deduplicationEnabled) return vulnerabilities
   const deduplicated = vulnerabilities.filter((vulnerability) => {
     const key = `${vulnerability.type}${vulnerability.hash}`
     if (!VULNERABILITY_HASHES.get(key)) {
@@ -176,8 +192,16 @@ function deduplicateVulnerabilities (vulnerabilities) {
   return deduplicated
 }
 
-function setTracer (_tracer) {
+function start (config, _tracer) {
+  deduplicationEnabled = config.iast.deduplicationEnabled
+  if (deduplicationEnabled) {
+    startClearCacheTimer()
+  }
   tracer = _tracer
+}
+
+function stop () {
+  stopClearCacheTimer()
 }
 
 module.exports = {
@@ -185,5 +209,6 @@ module.exports = {
   addVulnerability,
   sendVulnerabilities,
   clearCache,
-  setTracer
+  start,
+  stop
 }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -382,6 +382,12 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       2
     )
 
+    const DD_IAST_DEDUPLICATION_ENABLED = coalesce(
+      iastOptions && iastOptions.deduplicationEnabled,
+      process.env.DD_IAST_DEDUPLICATION_ENABLED && isTrue(process.env.DD_IAST_DEDUPLICATION_ENABLED),
+      true
+    )
+
     const DD_CIVISIBILITY_GIT_UPLOAD_ENABLED = coalesce(
       process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED,
       true
@@ -489,7 +495,8 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       enabled: isTrue(DD_IAST_ENABLED),
       requestSampling: DD_IAST_REQUEST_SAMPLING,
       maxConcurrentRequests: DD_IAST_MAX_CONCURRENT_REQUESTS,
-      maxContextOperations: DD_IAST_MAX_CONTEXT_OPERATIONS
+      maxContextOperations: DD_IAST_MAX_CONTEXT_OPERATIONS,
+      deduplicationEnabled: DD_IAST_DEDUPLICATION_ENABLED
     }
 
     this.isCiVisibility = isTrue(DD_IS_CIVISIBILITY)

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -114,6 +114,8 @@ describe('IAST Index', () => {
 
     beforeEach(() => {
       mockVulnerabilityReporter = {
+        start: sinon.stub(),
+        stop: sinon.stub(),
         sendVulnerabilities: sinon.stub()
       }
       mockOverheadController = {
@@ -143,6 +145,19 @@ describe('IAST Index', () => {
       it('should finish global context refresher on iast disabled', () => {
         mockIast.disable()
         expect(mockOverheadController.finishGlobalContext).to.have.been.calledOnce
+      })
+    })
+
+    describe('managing vulnerability reporter', () => {
+      it('should start vulnerability reporter on iast enabled', () => {
+        const fakeTracer = {}
+        mockIast.enable(config, fakeTracer)
+        expect(mockVulnerabilityReporter.start).to.have.been.calledOnceWithExactly(config, fakeTracer)
+      })
+
+      it('should stop vulnerability reporter on iast disabled', () => {
+        mockIast.disable()
+        expect(mockVulnerabilityReporter.stop).to.have.been.calledOnce
       })
     })
 

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -1,4 +1,4 @@
-const { createVulnerability, addVulnerability, sendVulnerabilities, clearCache, setTracer } =
+const { createVulnerability, addVulnerability, sendVulnerabilities, clearCache, start, stop } =
   require('../../../src/appsec/iast/vulnerability-reporter')
 
 describe('vulnerability-reporter', () => {
@@ -138,11 +138,15 @@ describe('vulnerability-reporter', () => {
         fakeTracer = {
           startSpan: sinon.stub().returns(onTheFlySpan)
         }
-        setTracer(fakeTracer)
+        start({
+          iast: {
+            deduplicationEnabled: true
+          }
+        }, fakeTracer)
       })
       afterEach(() => {
         sinon.restore()
-        setTracer()
+        stop()
       })
       it('should create span on the fly', () => {
         const vulnerability = createVulnerability('INSECURE_HASHING', { value: 'sha1' }, undefined,
@@ -172,9 +176,15 @@ describe('vulnerability-reporter', () => {
       span = {
         addTags: sinon.stub()
       }
+      start({
+        iast: {
+          deduplicationEnabled: true
+        }
+      })
     })
     afterEach(() => {
       sinon.restore()
+      stop()
     })
 
     it('should not fail with invalid parameters', () => {
@@ -382,6 +392,55 @@ describe('vulnerability-reporter', () => {
       })
     })
 
+    it('should not deduplicate vulnerabilities if not enabled', () => {
+      start({
+        iast: {
+          deduplicationEnabled: false
+        }
+      })
+      const iastContext = { rootSpan: span }
+      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
+        { path: 'filename.js', line: 88 }))
+      addVulnerability(iastContext, createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
+        { path: 'filename.js', line: 88 }))
+      sendVulnerabilities(iastContext.vulnerabilities, span)
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
+        'manual.keep': 'true',
+        '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512691,' +
+          '"evidence":{"value":"sha1"},"location":{"spanId":888,"path":"filename.js","line":88}},' +
+          '{"type":"INSECURE_HASHING","hash":3410512691,"evidence":{"value":"sha1"},"location":' +
+          '{"spanId":888,"path":"filename.js","line":88}}]}'
+      })
+    })
+  })
+
+  describe('clearCache', () => {
+    let span
+    let originalSetInterval
+    let originalClearInterval
+
+    before(() => {
+      originalSetInterval = global.setInterval
+      originalClearInterval = global.clearInterval
+    })
+
+    beforeEach(() => {
+      global.setInterval = sinon.spy(global.setInterval)
+      global.clearInterval = sinon.spy(global.clearInterval)
+      span = {
+        addTags: sinon.stub()
+      }
+    })
+
+    after(() => {
+      global.setInterval = originalSetInterval
+      global.clearInterval = originalClearInterval
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
     it('should empty the cache with more than 1000 hashes', () => {
       const iastContext = { rootSpan: span }
       const MAX = 1000
@@ -399,6 +458,37 @@ describe('vulnerability-reporter', () => {
       addVulnerability(nextIastContext, vulnerabilityToRepeatInTheNext)
       sendVulnerabilities(nextIastContext.vulnerabilities, span)
       expect(span.addTags).to.have.been.calledTwice
+    })
+
+    it('should set timer to clear cache every hour if deduplication is enabled', () => {
+      const config = {
+        iast: {
+          deduplicationEnabled: true
+        }
+      }
+      start(config)
+      expect(global.setInterval).to.have.been.calledOnceWithExactly(clearCache, 60 * 60 * 1000)
+    })
+
+    it('should not set timer to clear cache every hour if deduplication is not enabled', () => {
+      const config = {
+        iast: {
+          deduplicationEnabled: false
+        }
+      }
+      start(config)
+      expect(global.setInterval).to.not.have.been.called
+    })
+
+    it('should unset timer to clear cache every hour', () => {
+      const config = {
+        iast: {
+          deduplicationEnabled: true
+        }
+      }
+      start(config)
+      stop()
+      expect(global.clearInterval).to.have.been.calledOnce
     })
   })
 })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -172,6 +172,7 @@ describe('Config', () => {
     process.env.DD_IAST_REQUEST_SAMPLING = '40'
     process.env.DD_IAST_MAX_CONCURRENT_REQUESTS = '3'
     process.env.DD_IAST_MAX_CONTEXT_OPERATIONS = '4'
+    process.env.DD_IAST_DEDUPLICATION_ENABLED = false
 
     const config = new Config()
 
@@ -229,6 +230,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.requestSampling', 40)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 3)
     expect(config).to.have.nested.property('iast.maxContextOperations', 4)
+    expect(config).to.have.nested.property('iast.deduplicationEnabled', false)
   })
 
   it('should read case-insensitive booleans from environment variables', () => {
@@ -339,7 +341,8 @@ describe('Config', () => {
           enabled: true,
           requestSampling: 50,
           maxConcurrentRequests: 4,
-          maxContextOperations: 5
+          maxContextOperations: 5,
+          deduplicationEnabled: false
         }
       },
       appsec: false,
@@ -386,6 +389,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.requestSampling', 50)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 4)
     expect(config).to.have.nested.property('iast.maxContextOperations', 5)
+    expect(config).to.have.nested.property('iast.deduplicationEnabled', false)
     expect(config).to.have.deep.nested.property('sampler', {
       sampleRate: 0.5,
       rateLimit: 1000,
@@ -600,6 +604,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.requestSampling', 30)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 2)
     expect(config).to.have.nested.property('iast.maxContextOperations', 2)
+    expect(config).to.have.nested.property('iast.deduplicationEnabled', true)
   })
 
   it('should give priority to non-experimental options', () => {


### PR DESCRIPTION
### What does this PR do?
Provides a configuration flag to disable vulnerability deduplication (enabled by default).
Sets a timer to clear vulnerability cache every hour.

### Motivation
Homogenize vulnerability reporting behavior across all libraries.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
