### PR TITLE
fix mariadb connection pool spans leaking across queries

### DIFF
--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -1,7 +1,5 @@
 'use strict'
 
-// TODO: Add tracing support for connection pool queries.
-
 const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 
 const shimmer = require('../../datadog-shimmer')

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -1,5 +1,7 @@
 'use strict'
 
+// TODO: Add tracing support for connection pool queries.
+
 const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 
 const shimmer = require('../../datadog-shimmer')
@@ -7,17 +9,17 @@ const shimmer = require('../../datadog-shimmer')
 const startCh = channel('apm:mariadb:query:start')
 const finishCh = channel('apm:mariadb:query:finish')
 const errorCh = channel('apm:mariadb:query:error')
+const skipCh = channel('apm:mariadb:pool:skip')
+const unskipCh = channel('apm:mariadb:pool:unskip')
 
-function wrapCommandStart (start) {
+function wrapCommandStart (start, callbackResource) {
   return function () {
     if (!startCh.hasSubscribers) return start.apply(this, arguments)
-
-    const callbackResource = new AsyncResource('bound-anonymous-fn')
 
     const resolve = callbackResource.bind(this.resolve)
     const reject = callbackResource.bind(this.reject)
 
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
+    const asyncResource = callbackResource.runInAsyncScope(() => new AsyncResource('bound-anonymous-fn'))
 
     shimmer.wrap(this, 'resolve', function wrapResolve () {
       return function () {
@@ -41,23 +43,139 @@ function wrapCommandStart (start) {
     })
 
     return asyncResource.runInAsyncScope(() => {
+      unskipCh.publish() // Escape the noop store when in connection pool.
       startCh.publish({ sql: this.sql, conf: this.opts })
       return start.apply(this, arguments)
     })
   }
 }
 
+function wrapCommand (Command) {
+  return class extends Command {
+    constructor (...args) {
+      super(...args)
+
+      const callbackResource = new AsyncResource('bound-anonymous-fn')
+
+      if (this.start) {
+        this.start = wrapCommandStart(this.start, callbackResource)
+      }
+    }
+  }
+}
+
+function createWrapQuery (options) {
+  return function wrapQuery (query) {
+    return function (sql) {
+      if (!startCh.hasSubscribers) return query.apply(this, arguments)
+
+      const asyncResource = new AsyncResource('bound-anonymous-fn')
+
+      return asyncResource.runInAsyncScope(() => {
+        startCh.publish({ sql, conf: options })
+
+        return query.apply(this, arguments)
+          .then(result => {
+            finishCh.publish()
+            return result
+          }, error => {
+            errorCh.publish(error)
+            finishCh.publish()
+            throw error
+          })
+      }, 'bound-anonymous-fn')
+    }
+  }
+}
+
+function createWrapQueryCallback (options) {
+  return function wrapQuery (query) {
+    return function (sql) {
+      if (!startCh.hasSubscribers) return query.apply(this, arguments)
+
+      const cb = arguments[arguments.length - 1]
+      const asyncResource = new AsyncResource('bound-anonymous-fn')
+      const callbackResource = new AsyncResource('bound-anonymous-fn')
+
+      if (typeof cb !== 'function') {
+        arguments.length = arguments.length + 1
+      }
+
+      arguments[arguments.length - 1] = asyncResource.bind(function (err) {
+        if (err) {
+          errorCh.publish(err)
+        }
+
+        finishCh.publish()
+
+        if (typeof cb === 'function') {
+          return callbackResource.runInAsyncScope(() => cb.apply(this, arguments))
+        }
+      })
+
+      return asyncResource.runInAsyncScope(() => {
+        startCh.publish({ sql, conf: options })
+
+        return query.apply(this, arguments)
+      }, 'bound-anonymous-fn')
+    }
+  }
+}
+
+function wrapConnection (Connection) {
+  return function (options) {
+    Connection.apply(this, arguments)
+
+    shimmer.wrap(this, '_queryPromise', createWrapQuery(options))
+    shimmer.wrap(this, '_queryCallback', createWrapQueryCallback(options))
+  }
+}
+
+function wrapPoolBase (PoolBase) {
+  return function (options, processTask, createConnectionPool, pingPromise) {
+    arguments[1] = wrapPoolMethod(processTask)
+    arguments[2] = wrapPoolMethod(createConnectionPool)
+
+    PoolBase.apply(this, arguments)
+
+    shimmer.wrap(this, 'query', createWrapQuery(options.connOptions))
+  }
+}
+
+// It's not possible to prevent connection pools from leaking across queries,
+// so instead we just skip instrumentation completely to avoid memory leaks
+// and/or orphan spans.
+function wrapPoolMethod (createConnection) {
+  return function () {
+    skipCh.publish()
+    try {
+      return createConnection.apply(this, arguments)
+    } finally {
+      unskipCh.publish()
+    }
+  }
+}
+
 const name = 'mariadb'
-const versions = ['>=2.0.3']
 
-addHook({ name, file: 'lib/cmd/query.js', versions }, (Query) => {
-  shimmer.wrap(Query.prototype, 'start', wrapCommandStart)
-
-  return Query
+addHook({ name, file: 'lib/cmd/query.js', versions: ['>=3'] }, (Query) => {
+  return wrapCommand(Query)
 })
 
-addHook({ name, file: 'lib/cmd/execute.js', versions }, (Query) => {
-  shimmer.wrap(Query.prototype, 'start', wrapCommandStart)
+addHook({ name, file: 'lib/cmd/execute.js', versions: ['>=3'] }, (Execute) => {
+  return wrapCommand(Execute)
+})
 
-  return Query
+addHook({ name, file: 'lib/pool.js', versions: ['>=3'] }, (Pool) => {
+  shimmer.wrap(Pool.prototype, '_createConnection', wrapPoolMethod)
+
+  return Pool
+})
+
+addHook({ name, file: 'lib/connection.js', versions: ['>=2.0.3 <3'] }, (Connection) => {
+  return shimmer.wrap(Connection, wrapConnection(Connection))
+})
+
+addHook({ name, file: 'lib/pool-base.js', versions: ['>=2.0.3 <3'] }, (PoolBase) => {
+  return shimmer.wrap(PoolBase, wrapPoolBase(PoolBase))
 })

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -1,10 +1,27 @@
 'use strict'
 
+const { storage } = require('../../datadog-core')
 const MySQLPlugin = require('../../datadog-plugin-mysql/src')
+
+let skippedStore
 
 class MariadbPlugin extends MySQLPlugin {
   static get name () { return 'mariadb' }
   static get system () { return 'mariadb' }
+
+  constructor (...args) {
+    super(...args)
+
+    this.addSub(`apm:${this.component}:pool:skip`, () => {
+      skippedStore = storage.getStore()
+      storage.enterWith({ noop: true })
+    })
+
+    this.addSub(`apm:${this.component}:pool:unskip`, () => {
+      storage.enterWith(skippedStore)
+      skippedStore = undefined
+    })
+  }
 }
 
 module.exports = MariadbPlugin


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `mariadb` connection pool spans leaking across queries by removing the connection spans completely.

### Motivation
<!-- What inspired you to submit this pull request? -->

TCP spans can end up as children of each other every time a reconnection happens since the connection pool uses an internal queue. The root TCP span can also end up in a random request or outside of any request.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This changes the behaviour slightly in `mariadb` 2.x because in order to be able to instrument the query outside of the connection it was necessary to start the span before the connection is established instead of after. This means that the duration of the `mariadb.query` spans will be longer in those versions. I didn't find another way to handle this since once the connection pool takes control of the async context there is nowhere that the correct context can be restored.

I also bumped the minimum version from 2.0.3 to 2.0.4 because 2.0.3 would require its own instrumentation as 2.x changed completely in 2.0.4 and it's unlikely anyone would still be using this version. Generally speaking, 2.0.x versions of `mariadb` were full of bugs to the point that some of them outright didn't work, hence the minimum version already not being 2.0.0.