### PR TITLE
Setup python 3.9 for system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -23,6 +23,11 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
     steps:
+      - name: Setup python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
       - name: Checkout system tests
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### What does this PR do?
This PR installs python 3.9 for system tests jobs.

### Motivation

System test executor will run on the host rather than inside a container (see https://github.com/DataDog/system-tests/pull/958). It will allow users to do step-by-step debugging, and will allow to unify architecture with parametric tests.

