### PR TITLE
[ci-visibility] Add support for Team City CI provider

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -534,6 +534,18 @@ module.exports = {
       }
     }
 
+    if (env.TEAMCITY_VERSION) {
+      const { BUILD_URL, TEAMCITY_BUILDCONF_NAME, DATADOG_BUILD_ID } = env
+      tags = {
+        [CI_PROVIDER_NAME]: 'teamcity',
+        [CI_JOB_URL]: BUILD_URL,
+        [CI_JOB_NAME]: TEAMCITY_BUILDCONF_NAME,
+        [CI_ENV_VARS]: JSON.stringify({
+          DATADOG_BUILD_ID
+        })
+      }
+    }
+
     normalizeTag(tags, CI_WORKSPACE_PATH, resolveTilde)
     normalizeTag(tags, GIT_REPOSITORY_URL, filterSensitiveInfoFromRepository)
     normalizeTag(tags, GIT_BRANCH, normalizeRef)

--- a/packages/dd-trace/test/plugins/util/ci-env/teamcity.json
+++ b/packages/dd-trace/test/plugins/util/ci-env/teamcity.json
@@ -1,0 +1,78 @@
+[
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity"
+    }
+  ],
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity",
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "DD_GIT_TAG": "0.0.2",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git",
+      "git.tag": "0.0.2"
+    }
+  ]
+]


### PR DESCRIPTION
### What does this PR do?
Read team city's env vars.

### Motivation
Show information about the CI job run when tests are run in team city.

