### PR TITLE
Add job to check if PR has merge conflicts with release branches

### DIFF
--- a/.github/actions/check-release-branch/action.yml
+++ b/.github/actions/check-release-branch/action.yml
@@ -1,0 +1,25 @@
+name: Check release branch
+inputs:
+  release-branch:
+    description: 'Release branch to check'
+    required: true
+    default: '3.x'
+runs:
+  using: composite
+  steps:
+    - name: Squash current branch commits
+      id: get-commit-to-cherry-pick
+      shell: bash
+      run: |
+        git checkout -b ${{github.head_ref}}-squashed
+        git reset --soft refs/remotes/origin/master
+        git add -A
+        git config user.email "dummy@commit.com"
+        git config user.name "Dummy commit"
+        git commit -m "squashed commit"
+        echo "commit-to-cherry-pick=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+    - name: Attempt merge current branch to ${{ inputs.release-branch }}
+      shell: bash
+      run: |
+        git checkout ${{ inputs.release-branch }}
+        git cherry-pick ${{ steps.get-commit-to-cherry-pick.outputs.commit-to-cherry-pick}}

--- a/.github/workflows/release-branches-check.yml
+++ b/.github/workflows/release-branches-check.yml
@@ -1,0 +1,28 @@
+name: Release branches check
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  check-release-branch-v2:
+    if: "!contains(github.event.pull_request.labels.*.name, 'dont-land-on-v2.x')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/check-release-branch
+        with:
+          release-branch: v2.x
+
+  check-release-branch-v3:
+    if: "!contains(github.event.pull_request.labels.*.name, 'dont-land-on-v3.x')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/check-release-branch
+        with:
+          release-branch: v3.x


### PR DESCRIPTION
### What does this PR do?
Add a job that runs in PRs that attempts to squash commits in the PR branch and cherry-pick them at the release branches. 

### Motivation
Hopefully catch merge conflicts before the release process. 

ℹ️ While this _won't_ catch test failures, it hopefully improves the process a bit. 

