### PR TITLE
[ci-visibility] Remove unnecessary `test.bundle`

### DIFF
--- a/integration-tests/cucumber.spec.js
+++ b/integration-tests/cucumber.spec.js
@@ -15,7 +15,7 @@ const { FakeCiVisIntake } = require('./ci-visibility-intake')
 const {
   TEST_STATUS,
   TEST_COMMAND,
-  TEST_BUNDLE,
+  TEST_MODULE,
   TEST_TOOLCHAIN,
   TEST_SESSION_CODE_COVERAGE_ENABLED,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
@@ -85,7 +85,7 @@ versions.forEach(version => {
             assert.exists(testModuleEventContent.test_session_id)
             assert.exists(testModuleEventContent.test_module_id)
             assert.exists(testModuleEventContent.meta[TEST_COMMAND])
-            assert.exists(testModuleEventContent.meta[TEST_BUNDLE])
+            assert.exists(testModuleEventContent.meta[TEST_MODULE])
             assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
             assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
             assert.equal(
@@ -111,7 +111,7 @@ versions.forEach(version => {
               }
             }) => {
               assert.exists(meta[TEST_COMMAND])
-              assert.exists(meta[TEST_BUNDLE])
+              assert.exists(meta[TEST_MODULE])
               assert.exists(testSuiteId)
               assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
               assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
@@ -141,7 +141,7 @@ versions.forEach(version => {
               }
             }) => {
               assert.exists(meta[TEST_COMMAND])
-              assert.exists(meta[TEST_BUNDLE])
+              assert.exists(meta[TEST_MODULE])
               assert.exists(testSuiteId)
               assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
               assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))

--- a/integration-tests/cypress.spec.js
+++ b/integration-tests/cypress.spec.js
@@ -16,7 +16,7 @@ const webAppServer = require('./ci-visibility/web-app-server')
 const {
   TEST_STATUS,
   TEST_COMMAND,
-  TEST_BUNDLE,
+  TEST_MODULE,
   TEST_FRAMEWORK_VERSION,
   TEST_TOOLCHAIN
 } = require('../packages/dd-trace/src/plugins/util/test')
@@ -81,7 +81,7 @@ versions.forEach((version) => {
             assert.exists(testModuleEventContent.test_session_id)
             assert.exists(testModuleEventContent.test_module_id)
             assert.exists(testModuleEventContent.meta[TEST_COMMAND])
-            assert.exists(testModuleEventContent.meta[TEST_BUNDLE])
+            assert.exists(testModuleEventContent.meta[TEST_MODULE])
             assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
             assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
             assert.equal(
@@ -109,7 +109,7 @@ versions.forEach((version) => {
               }
             }) => {
               assert.exists(meta[TEST_COMMAND])
-              assert.exists(meta[TEST_BUNDLE])
+              assert.exists(meta[TEST_MODULE])
               assert.exists(testSuiteId)
               assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
               assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
@@ -136,7 +136,7 @@ versions.forEach((version) => {
               }
             }) => {
               assert.exists(meta[TEST_COMMAND])
-              assert.exists(meta[TEST_BUNDLE])
+              assert.exists(meta[TEST_MODULE])
               assert.exists(testSuiteId)
               assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
               assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -15,7 +15,6 @@ const {
   TEST_MODULE_ID,
   TEST_SESSION_ID,
   TEST_COMMAND,
-  TEST_BUNDLE,
   TEST_MODULE,
   finishAllTraceSpans
 } = require('../../dd-trace/src/plugins/util/test')
@@ -168,7 +167,6 @@ module.exports = (on, config) => {
       const testSuiteTags = {
         [TEST_COMMAND]: command,
         [TEST_COMMAND]: command,
-        [TEST_BUNDLE]: TEST_FRAMEWORK_NAME,
         [TEST_MODULE]: TEST_FRAMEWORK_NAME
       }
       if (testSuiteSpan) {

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -25,7 +25,7 @@ const {
   TEST_SUITE_ID,
   TEST_SESSION_ID,
   TEST_MODULE_ID,
-  TEST_BUNDLE
+  TEST_MODULE
 } = require('../../dd-trace/src/plugins/util/test')
 
 const { version: ddTraceVersion } = require('../../../package.json')
@@ -363,12 +363,12 @@ describe('Plugin', function () {
                   expect(testModuleSpan[TEST_SUITE_ID]).to.equal(undefined)
                   expect(testModuleSpan[TEST_MODULE_ID]).not.to.equal(undefined)
                   expect(testModuleSpan[TEST_SESSION_ID]).not.to.equal(undefined)
-                  expect(testModuleSpan.meta[TEST_BUNDLE]).not.to.equal(undefined)
+                  expect(testModuleSpan.meta[TEST_MODULE]).not.to.equal(undefined)
                 }
                 if (type === 'test_suite_end') {
                   expect(span.meta[TEST_SUITE]).to.equal(suite)
                   expect(span.meta[TEST_COMMAND]).not.to.equal(undefined)
-                  expect(span.meta[TEST_BUNDLE]).not.to.equal(undefined)
+                  expect(span.meta[TEST_MODULE]).not.to.equal(undefined)
                   expect(span[TEST_SUITE_ID]).not.to.equal(undefined)
                   expect(span[TEST_SESSION_ID]).not.to.equal(undefined)
                   expect(span[TEST_MODULE_ID]).not.to.equal(undefined)
@@ -377,7 +377,7 @@ describe('Plugin', function () {
                   expect(span.meta[TEST_SUITE]).to.equal(suite)
                   expect(span.meta[TEST_NAME]).to.equal(name)
                   expect(span.meta[TEST_COMMAND]).not.to.equal(undefined)
-                  expect(span.meta[TEST_BUNDLE]).not.to.equal(undefined)
+                  expect(span.meta[TEST_MODULE]).not.to.equal(undefined)
                   expect(span[TEST_SUITE_ID]).not.to.equal(undefined)
                   expect(span[TEST_SESSION_ID]).not.to.equal(undefined)
                   expect(span[TEST_MODULE_ID]).not.to.equal(undefined)

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -12,7 +12,6 @@ const {
   TEST_MODULE_ID,
   TEST_SESSION_ID,
   TEST_COMMAND,
-  TEST_BUNDLE,
   TEST_MODULE
 } = require('./util/test')
 const Plugin = require('./plugin')
@@ -130,7 +129,6 @@ module.exports = class CiPlugin extends Plugin {
         [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
         [TEST_SESSION_ID]: testSuiteSpan.context().toTraceId(),
         [TEST_COMMAND]: testSuiteSpan.context()._tags[TEST_COMMAND],
-        [TEST_BUNDLE]: this.constructor.name,
         [TEST_MODULE]: this.constructor.name
       }
       if (testSuiteSpan.context()._parentId) {

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -38,7 +38,6 @@ const TEST_CODE_OWNERS = 'test.codeowners'
 const TEST_SOURCE_FILE = 'test.source.file'
 const LIBRARY_VERSION = 'library_version'
 const TEST_COMMAND = 'test.command'
-const TEST_BUNDLE = 'test.bundle'
 const TEST_MODULE = 'test.module'
 const TEST_SESSION_ID = 'test_session_id'
 const TEST_MODULE_ID = 'test_module_id'
@@ -95,7 +94,6 @@ module.exports = {
   TEST_MODULE_ID,
   TEST_SUITE_ID,
   TEST_ITR_TESTS_SKIPPED,
-  TEST_BUNDLE,
   TEST_MODULE,
   TEST_SESSION_ITR_SKIPPING_ENABLED,
   TEST_SESSION_CODE_COVERAGE_ENABLED,
@@ -284,7 +282,6 @@ function getTestSessionCommonTags (command, testFrameworkVersion, testFramework)
   return {
     [SPAN_TYPE]: 'test_session_end',
     [RESOURCE_NAME]: `test_session.${command}`,
-    [TEST_BUNDLE]: testFramework,
     [TEST_MODULE]: testFramework,
     [TEST_TOOLCHAIN]: getPkgManager(),
     ...getTestLevelCommonTags(command, testFrameworkVersion)
@@ -295,7 +292,6 @@ function getTestModuleCommonTags (command, testFrameworkVersion, testFramework) 
   return {
     [SPAN_TYPE]: 'test_module_end',
     [RESOURCE_NAME]: `test_module.${command}`,
-    [TEST_BUNDLE]: testFramework,
     [TEST_MODULE]: testFramework,
     ...getTestLevelCommonTags(command, testFrameworkVersion)
   }
@@ -305,7 +301,6 @@ function getTestSuiteCommonTags (command, testFrameworkVersion, testSuite, testF
   return {
     [SPAN_TYPE]: 'test_suite_end',
     [RESOURCE_NAME]: `test_suite.${testSuite}`,
-    [TEST_BUNDLE]: testFramework,
     [TEST_MODULE]: testFramework,
     [TEST_SUITE]: testSuite,
     ...getTestLevelCommonTags(command, testFrameworkVersion)


### PR DESCRIPTION
### What does this PR do?
Remove `test.bundle` 

### Motivation
`test.bundle` is not meaningful in javascript and it's not longer a requirement in the backend. 

