### PR TITLE
[ci-visibility] Fix playwright require issue

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-ts/one-test.ts
+++ b/integration-tests/ci-visibility/playwright-tests-ts/one-test.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(process.env.PW_BASE_URL)
+})
+
+test.describe('playwright', () => {
+  test('should work with passing tests', async ({ page }) => {
+    await expect(page.locator('.hello-world')).toHaveText([
+      'Hello World'
+    ])
+  })
+  test.skip('should work with skipped tests', async ({ page }) => {
+    await expect(page.locator('.hello-world')).toHaveText([
+      'Hello World'
+    ])
+  })
+})

--- a/integration-tests/playwright.config.ts
+++ b/integration-tests/playwright.config.ts
@@ -1,0 +1,19 @@
+// Playwright typescript config file for integration tests
+// @ts-ignore
+import { devices } from '@playwright/test'
+
+export default {
+  baseURL: process.env.PW_BASE_URL,
+  testDir: './ci-visibility',
+  reporter: 'line',
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome']
+      }
+    }
+  ],
+  testMatch: '**/*-test.js'
+}

--- a/integration-tests/playwright.spec.js
+++ b/integration-tests/playwright.spec.js
@@ -27,7 +27,7 @@ versions.forEach((version) => {
     before(async function () {
       // bump from 30 to 60 seconds because playwright dependencies are heavy
       this.timeout(60000)
-      sandbox = await createSandbox([`@playwright/test@${version}`], true)
+      sandbox = await createSandbox([`@playwright/test@${version}`, 'typescript'], true)
       cwd = sandbox.folder
       // install necessary browser
       execSync('npx playwright install', { cwd })
@@ -68,9 +68,9 @@ versions.forEach((version) => {
 
             const stepEvents = events.filter(event => event.type === 'span')
 
-            assert.equal(testSessionEvent.content.resource, 'test_session.playwright test')
+            assert.include(testSessionEvent.content.resource, 'test_session.playwright test')
             assert.equal(testSessionEvent.content.meta[TEST_STATUS], 'fail')
-            assert.equal(testModuleEvent.content.resource, 'test_module.playwright test')
+            assert.include(testModuleEvent.content.resource, 'test_module.playwright test')
             assert.equal(testModuleEvent.content.meta[TEST_STATUS], 'fail')
 
             assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
@@ -104,7 +104,7 @@ versions.forEach((version) => {
           }).catch(done)
 
           childProcess = exec(
-            './node_modules/.bin/playwright test',
+            './node_modules/.bin/playwright test -c playwright.config.js',
             {
               cwd,
               env: {
@@ -115,6 +115,41 @@ versions.forEach((version) => {
             }
           )
         })
+      })
+    })
+    it('works when tests are compiled to a different location', (done) => {
+      let testOutput = ''
+      receiver.gatherPayloads(({ url }) => url === '/api/v2/citestcycle').then((payloads) => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testEvents = events.filter(event => event.type === 'test')
+        assert.includeMembers(testEvents.map(test => test.content.resource), [
+          'playwright-tests-ts/one-test.js.should work with passing tests',
+          'playwright-tests-ts/one-test.js.should work with skipped tests'
+        ])
+        assert.include(testOutput, '1 passed')
+        assert.include(testOutput, '1 skipped')
+        assert.notInclude(testOutput, 'TypeError')
+        done()
+      }).catch(done)
+
+      childProcess = exec(
+        'node ./node_modules/typescript/bin/tsc' +
+        '&& ./node_modules/.bin/playwright test -c ci-visibility/playwright-tests-ts-out',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            PW_RUNNER_DEBUG: '1'
+          },
+          stdio: 'inherit'
+        }
+      )
+      childProcess.stdout.on('data', chunk => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr.on('data', chunk => {
+        testOutput += chunk.toString()
       })
     })
   })

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "ci-visibility/playwright-tests-ts-out",
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["ci-visibility/playwright-tests-ts"],
+  "files": ["playwright.config.ts"]
+}

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -76,7 +76,7 @@ function getRootDir (playwrightRunner) {
 }
 
 function testBeginHandler (test) {
-  const { title: testName, location: { file: testSuiteAbsolutePath }, _type } = test
+  const { _requireFile: testSuiteAbsolutePath, title: testName, _type } = test
 
   if (_type === 'beforeAll' || _type === 'afterAll') {
     return
@@ -101,7 +101,7 @@ function testBeginHandler (test) {
 }
 
 function testEndHandler (test, testStatus, error) {
-  const { location: { file: testSuiteAbsolutePath }, results, _type } = test
+  const { _requireFile: testSuiteAbsolutePath, results, _type } = test
 
   if (_type === 'beforeAll' || _type === 'afterAll') {
     return


### PR DESCRIPTION
### What does this PR do?
For defining the test file > tests dictionary we were using `test._requireFile` but when accessing it we were using `test.location.file`. This seemed to work for most of the cases but not always. By always using `test._requireFile` we seem to be safer. 

### Motivation
Fixes #2924 

