### PR TITLE
Fix to DBM propagation - comment is injected before query is sent

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -27,26 +27,20 @@ function wrapQuery (query) {
       return query.apply(this, arguments)
     }
 
-    const retval = query.apply(this, arguments)
-
-    const queryQueue = this.queryQueue || this._queryQueue
-    const activeQuery = this.activeQuery || this._activeQuery
-    const pgQuery = queryQueue[queryQueue.length - 1] || activeQuery
-
-    if (!pgQuery) {
-      return retval
-    }
-
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     const processId = this.processID
+    let pgQuery = {}
+    pgQuery.text = arguments[0]
+
     return asyncResource.runInAsyncScope(() => {
       startCh.publish({
         params: this.connectionParameters,
-        originalQuery: pgQuery.text,
         query: pgQuery,
         processId
       })
+
+      arguments[0] = pgQuery.text
 
       const finish = asyncResource.bind(function (error) {
         if (error) {
@@ -54,6 +48,16 @@ function wrapQuery (query) {
         }
         finishCh.publish()
       })
+
+      const retval = query.apply(this, arguments)
+      const queryQueue = this.queryQueue || this._queryQueue
+      const activeQuery = this.activeQuery || this._activeQuery
+
+      pgQuery = queryQueue[queryQueue.length - 1] || activeQuery
+
+      if (!pgQuery) {
+        return retval
+      }
 
       if (pgQuery.callback) {
         const originalCallback = callbackResource.bind(pgQuery.callback)

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -61,7 +61,6 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
               expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
               expect(traces[0][0].meta).to.have.property('component', 'pg')
-              expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
               if (implementation !== 'pg.native') {
                 expect(traces[0][0].metrics).to.have.property('db.pid')
@@ -106,7 +105,6 @@ describe('Plugin', () => {
                 expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
                 expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
                 expect(traces[0][0].meta).to.have.property('component', 'pg')
-                expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
                 if (implementation !== 'pg.native') {
                   expect(traces[0][0].metrics).to.have.property('db.pid')
@@ -129,7 +127,6 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
               expect(traces[0][0].meta).to.have.property('component', 'pg')
-              expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
               done()
             })
@@ -151,7 +148,6 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
               expect(traces[0][0].meta).to.have.property('component', 'pg')
-              expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
               done()
             })
@@ -410,7 +406,7 @@ describe('Plugin', () => {
             return originalWrite.apply(this, arguments)
           }
         })
-        after(() => {
+        afterEach(() => {
           // Ensure your environment changes are restored, even if the tests failed.
           net.Socket.prototype.write = originalWrite
         })
@@ -425,7 +421,6 @@ describe('Plugin', () => {
           client.query('SELECT $1::text as message', ['Hello World!'], (err, result) => {
             if (err) return done(err)
             expect(seenTraceParent).to.be.true
-            net.Socket.prototype.write = originalWrite
 
             client.end((err) => {
               if (err) return done(err)

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -4,6 +4,7 @@ const { expect } = require('chai')
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const net = require('net')
 
 const clients = {
   pg: pg => pg.Client
@@ -396,24 +397,37 @@ describe('Plugin', () => {
         })
 
         it('query text should contain traceparent', done => {
-          let queryText = ''
+          let seenTraceParent
+          let seenTraceId
+          let seenSpanId
+          const originalWrite = net.Socket.prototype.write
+          net.Socket.prototype.write = function (buffer) {
+            let strBuf = buffer.toString()
+            if (strBuf.includes('traceparent=\'')) {
+              strBuf = strBuf.split('-')
+              seenTraceParent = true
+              seenTraceId = strBuf[1]
+              seenSpanId = strBuf[2]
+            }
+            return originalWrite.apply(this, arguments)
+          }
+
           agent.use(traces => {
             const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
-
-            expect(queryText).to.equal(
-              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
-              `traceparent='00-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
+            expect(seenTraceId).to.equal(traceId)
+            expect(seenSpanId).to.equal(spanId)
           }).then(done, done)
 
           client.query('SELECT $1::text as message', ['Hello World!'], (err, result) => {
             if (err) return done(err)
+            expect(seenTraceParent).to.be.true
+            net.Socket.prototype.write = originalWrite
 
             client.end((err) => {
               if (err) return done(err)
             })
           })
-          queryText = client.queryQueue[0].text
         })
         it('query should inject _dd.dbm_trace_injected into span', done => {
           agent.use(traces => {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -407,7 +407,6 @@ describe('Plugin', () => {
           }
         })
         afterEach(() => {
-          // Ensure your environment changes are restored, even if the tests failed.
           net.Socket.prototype.write = originalWrite
         })
         it('query text should contain traceparent', done => {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -61,6 +61,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
               expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
               expect(traces[0][0].meta).to.have.property('component', 'pg')
+              expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
               if (implementation !== 'pg.native') {
                 expect(traces[0][0].metrics).to.have.property('db.pid')
@@ -105,6 +106,7 @@ describe('Plugin', () => {
                 expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
                 expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
                 expect(traces[0][0].meta).to.have.property('component', 'pg')
+                expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
                 if (implementation !== 'pg.native') {
                   expect(traces[0][0].metrics).to.have.property('db.pid')
@@ -127,6 +129,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
               expect(traces[0][0].meta).to.have.property('component', 'pg')
+              expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
               done()
             })
@@ -148,6 +151,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
               expect(traces[0][0].meta).to.have.property('component', 'pg')
+              expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
 
               done()
             })

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -420,7 +420,6 @@ describe('Plugin', () => {
           client.query('SELECT $1::text as message', ['Hello World!'], (err, result) => {
             if (err) return done(err)
             expect(seenTraceParent).to.be.true
-
             client.end((err) => {
               if (err) return done(err)
             })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
