### PR TITLE
[data streams] Add encoding functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ typings/
 # Ignore all local history of files
 .history
 
+# IntelliJ
+.idea
+
 
 # End of https://www.gitignore.io/api/node,macos,visualstudiocode
 

--- a/packages/dd-trace/src/datastreams/encoding.js
+++ b/packages/dd-trace/src/datastreams/encoding.js
@@ -1,0 +1,76 @@
+// encodes positive and negative numbers, using zig zag encoding to reduce the size of the variable length encoding.
+// uses high and low part to ensure those parts are under the limit for byte operations in javascript (32 bits)
+function encodeVarint (v) {
+  const sign = v >= 0 ? 0 : 1;
+  // we leave the least significant bit for the sign.
+  const double = Math.abs(v) * 2;
+  const high = Math.floor(double / 0x100000000);
+  const low = (double & 0xffffffff) | sign;
+  return encodeUvarint64(low, high);
+}
+
+// decodes positive and negative numbers, using zig zag encoding to reduce the size of the variable length encoding.
+// uses high and low part to ensure those parts are under the limit for byte operations in javascript (32 bits)
+function decodeVarint(b) {
+  const [low, high] = decodeUvarint64(b);
+  if (low === undefined || high === undefined) {
+    return undefined;
+  }
+  const positive = (low & 1) === 0;
+  const abs = (low >>> 1) + high * 0x80000000;
+  return positive ? abs : -abs;
+}
+
+const maxVarLen64 = 9;
+
+function encodeUvarint64(low, high) {
+  const result = new Uint8Array(maxVarLen64);
+  let i = 0;
+  // if first byte is 1, the number is negative in javascript, but we want to interpret it as positive
+  while ((high !== 0 || low < 0 || low > 0x80) && i < maxVarLen64 - 1) {
+    result[i] = (low & 0x7f) | 0x80;
+    low >>>= 7;
+    low |= (high & 0x7f) << 25;
+    high >>>= 7;
+    i++;
+  }
+  result[i] = low & 0x7f;
+  return result.slice(0, i + 1);
+}
+
+function decodeUvarint64(
+  bytes
+) {
+  let low = 0;
+  let high = 0;
+  let s = 0;
+  for (let i = 0; ; i++) {
+    if (bytes.length <= i) {
+      return [undefined, undefined];
+    }
+    const n = bytes[i];
+    if (n < 0x80 || i === maxVarLen64 - 1) {
+      bytes = bytes.slice(i + 1);
+      if (s < 32) {
+        low |= n << s;
+      }
+      if (s > 0) {
+        high |= s - 32 > 0 ? n << (s - 32) : n >> (32 - s);
+      }
+      return [low, high];
+    }
+    if (s < 32) {
+      low |= (n & 0x7f) << s;
+    }
+    if (s > 0) {
+      high |=
+        s - 32 > 0 ? (n & 0x7f) << (s - 32) : (n & 0x7f) >> (32 - s);
+    }
+    s += 7;
+  }
+}
+
+module.exports = {
+  encodeVarint,
+  decodeVarint
+}

--- a/packages/dd-trace/src/datastreams/encoding.js
+++ b/packages/dd-trace/src/datastreams/encoding.js
@@ -1,9 +1,13 @@
 // encodes positive and negative numbers, using zig zag encoding to reduce the size of the variable length encoding.
 // uses high and low part to ensure those parts are under the limit for byte operations in javascript (32 bits)
+// maximum number possible to encode is MAX_SAFE_INTEGER/2 (using zig zag shifts the bits by 1 to the left)
 function encodeVarint (v) {
   const sign = v >= 0 ? 0 : 1
   // we leave the least significant bit for the sign.
   const double = Math.abs(v) * 2
+  if (double > Number.MAX_SAFE_INTEGER) {
+    return undefined
+  }
   const high = Math.floor(double / 0x100000000)
   const low = (double & 0xffffffff) | sign
   return encodeUvarint64(low, high)

--- a/packages/dd-trace/src/datastreams/encoding.js
+++ b/packages/dd-trace/src/datastreams/encoding.js
@@ -1,72 +1,72 @@
 // encodes positive and negative numbers, using zig zag encoding to reduce the size of the variable length encoding.
 // uses high and low part to ensure those parts are under the limit for byte operations in javascript (32 bits)
 function encodeVarint (v) {
-  const sign = v >= 0 ? 0 : 1;
+  const sign = v >= 0 ? 0 : 1
   // we leave the least significant bit for the sign.
-  const double = Math.abs(v) * 2;
-  const high = Math.floor(double / 0x100000000);
-  const low = (double & 0xffffffff) | sign;
-  return encodeUvarint64(low, high);
+  const double = Math.abs(v) * 2
+  const high = Math.floor(double / 0x100000000)
+  const low = (double & 0xffffffff) | sign
+  return encodeUvarint64(low, high)
 }
 
 // decodes positive and negative numbers, using zig zag encoding to reduce the size of the variable length encoding.
 // uses high and low part to ensure those parts are under the limit for byte operations in javascript (32 bits)
-function decodeVarint(b) {
-  const [low, high] = decodeUvarint64(b);
+function decodeVarint (b) {
+  const [low, high] = decodeUvarint64(b)
   if (low === undefined || high === undefined) {
-    return undefined;
+    return undefined
   }
-  const positive = (low & 1) === 0;
-  const abs = (low >>> 1) + high * 0x80000000;
-  return positive ? abs : -abs;
+  const positive = (low & 1) === 0
+  const abs = (low >>> 1) + high * 0x80000000
+  return positive ? abs : -abs
 }
 
-const maxVarLen64 = 9;
+const maxVarLen64 = 9
 
-function encodeUvarint64(low, high) {
-  const result = new Uint8Array(maxVarLen64);
-  let i = 0;
+function encodeUvarint64 (low, high) {
+  const result = new Uint8Array(maxVarLen64)
+  let i = 0
   // if first byte is 1, the number is negative in javascript, but we want to interpret it as positive
   while ((high !== 0 || low < 0 || low > 0x80) && i < maxVarLen64 - 1) {
-    result[i] = (low & 0x7f) | 0x80;
-    low >>>= 7;
-    low |= (high & 0x7f) << 25;
-    high >>>= 7;
-    i++;
+    result[i] = (low & 0x7f) | 0x80
+    low >>>= 7
+    low |= (high & 0x7f) << 25
+    high >>>= 7
+    i++
   }
-  result[i] = low & 0x7f;
-  return result.slice(0, i + 1);
+  result[i] = low & 0x7f
+  return result.slice(0, i + 1)
 }
 
-function decodeUvarint64(
+function decodeUvarint64 (
   bytes
 ) {
-  let low = 0;
-  let high = 0;
-  let s = 0;
+  let low = 0
+  let high = 0
+  let s = 0
   for (let i = 0; ; i++) {
     if (bytes.length <= i) {
-      return [undefined, undefined];
+      return [undefined, undefined]
     }
-    const n = bytes[i];
+    const n = bytes[i]
     if (n < 0x80 || i === maxVarLen64 - 1) {
-      bytes = bytes.slice(i + 1);
+      bytes = bytes.slice(i + 1)
       if (s < 32) {
-        low |= n << s;
+        low |= n << s
       }
       if (s > 0) {
-        high |= s - 32 > 0 ? n << (s - 32) : n >> (32 - s);
+        high |= s - 32 > 0 ? n << (s - 32) : n >> (32 - s)
       }
-      return [low, high];
+      return [low, high]
     }
     if (s < 32) {
-      low |= (n & 0x7f) << s;
+      low |= (n & 0x7f) << s
     }
     if (s > 0) {
       high |=
-        s - 32 > 0 ? (n & 0x7f) << (s - 32) : (n & 0x7f) >> (32 - s);
+        s - 32 > 0 ? (n & 0x7f) << (s - 32) : (n & 0x7f) >> (32 - s)
     }
-    s += 7;
+    s += 7
   }
 }
 

--- a/packages/dd-trace/test/datastreams/encoding.spec.js
+++ b/packages/dd-trace/test/datastreams/encoding.spec.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const { encodeVarint, decodeVarint } = require('../../src/datastreams/encoding')
+const { expect } = require('chai')
+
+describe('encoding', () => {
+  describe('encodeVarInt', () => {
+    it('encoding then decoding should be a no op for int32 numbers', () => {
+      const n = 1679672748
+      const expectedEncoded = new Uint8Array([216, 150, 238, 193, 12])
+      const encoded = encodeVarint(n)
+      expect(encoded.length).to.equal(expectedEncoded.length)
+      expect(encoded.every((val, i) => val === expectedEncoded[i])).to.true
+      const decoded = decodeVarint(encoded)
+      expect(decoded).to.equal(n)
+    })
+    it('encoding then decoding should be a no op for bigger than int32 numbers', () => {
+      const n = 1679711644352
+      const expectedEncoded = new Uint8Array([
+        128, 171, 237, 233, 226, 97
+      ])
+      const encoded = encodeVarint(n)
+      expect(encoded.length).to.equal(expectedEncoded.length)
+      expect(encoded.every((val, i) => val === expectedEncoded[i])).to.true
+      const decoded = decodeVarint(encoded)
+      expect(decoded).to.equal(n)
+    })
+  })
+})

--- a/packages/dd-trace/test/datastreams/encoding.spec.js
+++ b/packages/dd-trace/test/datastreams/encoding.spec.js
@@ -25,5 +25,10 @@ describe('encoding', () => {
       const decoded = decodeVarint(encoded)
       expect(decoded).to.equal(n)
     })
+    it('encoding a number bigger than Max safe int fails.', () => {
+      const n = Number.MAX_SAFE_INTEGER + 10
+      const encoded = encodeVarint(n)
+      expect(encoded).to.undefined
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Add encoding functions used for encoding data streams headers.
Note that some complexity has been added by the fact that I'm using 2 numbers, because int operations are only supported up to 32 bits.

### Motivation
Pre-requisite for adding data streams support in Node.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
