### PR TITLE
Use `os` instead of `node:os`

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fs = require('fs')
-const os = require('node:os')
+const os = require('os')
 const path = require('path')
 const crypto = require('crypto')
 const semver = require('semver')


### PR DESCRIPTION
### What does this PR do?
Use `os` instead of `node:os`

### Motivation
`node:os` does not work for node12, so our 2.x release line is broken after https://github.com/DataDog/dd-trace-js/pull/2868
