### PR TITLE
[data streams] Return remaining bytes when decoding

### DIFF
--- a/packages/dd-trace/test/datastreams/encoding.spec.js
+++ b/packages/dd-trace/test/datastreams/encoding.spec.js
@@ -11,8 +11,9 @@ describe('encoding', () => {
       const encoded = encodeVarint(n)
       expect(encoded.length).to.equal(expectedEncoded.length)
       expect(encoded.every((val, i) => val === expectedEncoded[i])).to.true
-      const decoded = decodeVarint(encoded)
+      const [decoded, bytes] = decodeVarint(encoded)
       expect(decoded).to.equal(n)
+      expect(bytes).to.length(0)
     })
     it('encoding then decoding should be a no op for bigger than int32 numbers', () => {
       const n = 1679711644352
@@ -22,8 +23,13 @@ describe('encoding', () => {
       const encoded = encodeVarint(n)
       expect(encoded.length).to.equal(expectedEncoded.length)
       expect(encoded.every((val, i) => val === expectedEncoded[i])).to.true
-      const decoded = decodeVarint(encoded)
+      const toDecode = [...encoded, ...encoded]
+      const [decoded, bytes] = decodeVarint(toDecode)
       expect(decoded).to.equal(n)
+      expect(bytes.every((val, i) => val === expectedEncoded[i])).to.true
+      const [decoded2, bytes2] = decodeVarint(bytes)
+      expect(decoded2).to.equal(n)
+      expect(bytes2).to.length(0)
     })
     it('encoding a number bigger than Max safe int fails.', () => {
       const n = Number.MAX_SAFE_INTEGER + 10


### PR DESCRIPTION
### What does this PR do?
When decoding a varlength, we don't know how many bytes we decoded. So I updated the function to return the remaining bytes. So that the decoding can continue after the call to the decode function.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
