### PR TITLE
[ci-visibility] Split cypress integration tests

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -28,11 +28,43 @@ jobs:
       - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
       - run: yarn test:integration
 
+  integration-cypress:
+    strategy:
+      matrix:
+        version: [14, latest]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/node/setup
+      - run: yarn install
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - name: Install dependencies for cypress@6.7.0
+        id: install-dependencies
+        run: echo "folder=$(node integration-tests/scripts/sandbox.js cypress@6.7.0)" >> $GITHUB_OUTPUT
+      - run: yarn test:integration:cypress
+        env:
+          TEST_TMP_FOLDER: ${{ steps.install-dependencies.outputs.folder }}
+          CYPRESS_VERSION: "6.7.0"
+      - name: Remove temporary folder
+        run: rm -rf $TEST_TMP_FOLDER
+      # change latest to 11.2.0 for v2.x
+      - name: Install dependencies for cypress@latest
+        id: install-dependencies-latest
+        run: echo "folder=$(node integration-tests/scripts/sandbox.js cypress@latest)" >> $GITHUB_OUTPUT
+      - run: yarn test:integration:cypress
+        env:
+          TEST_TMP_FOLDER: ${{ steps.install-dependencies-latest.outputs.folder }}
+          CYPRESS_VERSION: "latest"
+      - name: Remove temporary folder
+        run: rm -rf $TEST_TMP_FOLDER
+
   integration-ci:
     strategy:
       matrix:
         version: [14, latest]
-        framework: [cucumber, cypress, playwright]
+        framework: [cucumber, playwright]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -63,7 +63,7 @@ versions.forEach(version => {
           envVars = isAgentless ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
         })
         it('can run and report tests', (done) => {
-          receiver.gatherPayloads(({ url }) => url.endsWith('/api/v2/citestcycle'), 5000).then((payloads) => {
+          receiver.gatherPayloads(({ url }) => url.endsWith('/api/v2/citestcycle'), 3000).then((payloads) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSessionEvent = events.find(event => event.type === 'test_session_end')

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -4,10 +4,8 @@ const { exec } = require('child_process')
 
 const getPort = require('get-port')
 const { assert } = require('chai')
-const semver = require('semver')
 
 const {
-  createSandbox,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig
 } = require('../helpers')
@@ -21,147 +19,140 @@ const {
   TEST_TOOLCHAIN
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
-// TODO: remove when 2.x support is removed.
-// This is done because from playwright@>=1.22.0 node 12 is not supported
-const isOldNode = semver.satisfies(process.version, '<=12')
-const versions = ['6.7.0', isOldNode ? '11.2.0' : 'latest']
+const version = process.env.CYPRESS_VERSION
 
-versions.forEach((version) => {
-  describe(`cypress@${version}`, function () {
-    this.retries(2)
-    this.timeout(45000)
-    let sandbox, cwd, receiver, childProcess, webAppPort
-    before(async () => {
-      sandbox = await createSandbox([`cypress@${version}`], true)
-      cwd = sandbox.folder
-      webAppPort = await getPort()
-      webAppServer.listen(webAppPort)
-    })
+describe(`cypress@${version}`, function () {
+  this.retries(2)
+  let cwd, receiver, childProcess, webAppPort
+  before(async () => {
+    cwd = process.env.TEST_TMP_FOLDER
+    webAppPort = await getPort()
+    webAppServer.listen(webAppPort)
+  })
 
-    after(async () => {
-      await sandbox.remove()
-      await new Promise(resolve => webAppServer.close(resolve))
-    })
+  after(() =>
+    new Promise(resolve => webAppServer.close(resolve))
+  )
 
-    beforeEach(async function () {
-      const port = await getPort()
-      receiver = await new FakeCiVisIntake(port).start()
-    })
+  beforeEach(async function () {
+    const port = await getPort()
+    receiver = await new FakeCiVisIntake(port).start()
+  })
 
-    afterEach(async () => {
-      childProcess.kill()
-      await receiver.stop()
-    })
-    const reportMethods = ['agentless', 'evp proxy']
+  afterEach(async () => {
+    childProcess.kill()
+    await receiver.stop()
+  })
 
-    reportMethods.forEach((reportMethod) => {
-      context(`reporting via ${reportMethod}`, () => {
-        it('can run and report tests', (done) => {
-          const envVars = reportMethod === 'agentless'
-            ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
-          const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
+  const reportMethods = ['agentless', 'evp proxy']
 
-          receiver.gatherPayloadsMaxTimeout(({ url }) => url === reportUrl, payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
+  reportMethods.forEach((reportMethod) => {
+    context(`reporting via ${reportMethod}`, () => {
+      it('can run and report tests', (done) => {
+        const envVars = reportMethod === 'agentless'
+          ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
+        const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
 
-            const testSessionEvent = events.find(event => event.type === 'test_session_end')
-            const testModuleEvent = events.find(event => event.type === 'test_module_end')
-            const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
-            const testEvents = events.filter(event => event.type === 'test')
+        receiver.gatherPayloadsMaxTimeout(({ url }) => url === reportUrl, payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
 
-            const { content: testSessionEventContent } = testSessionEvent
-            const { content: testModuleEventContent } = testModuleEvent
+          const testSessionEvent = events.find(event => event.type === 'test_session_end')
+          const testModuleEvent = events.find(event => event.type === 'test_module_end')
+          const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
+          const testEvents = events.filter(event => event.type === 'test')
 
-            assert.exists(testSessionEventContent.test_session_id)
-            assert.exists(testSessionEventContent.meta[TEST_COMMAND])
-            assert.exists(testSessionEventContent.meta[TEST_TOOLCHAIN])
-            assert.equal(testSessionEventContent.resource.startsWith('test_session.'), true)
-            assert.equal(testSessionEventContent.meta[TEST_STATUS], 'fail')
+          const { content: testSessionEventContent } = testSessionEvent
+          const { content: testModuleEventContent } = testModuleEvent
 
-            assert.exists(testModuleEventContent.test_session_id)
-            assert.exists(testModuleEventContent.test_module_id)
-            assert.exists(testModuleEventContent.meta[TEST_COMMAND])
-            assert.exists(testModuleEventContent.meta[TEST_MODULE])
-            assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
-            assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
-            assert.equal(
-              testModuleEventContent.test_session_id.toString(10),
-              testSessionEventContent.test_session_id.toString(10)
-            )
-            assert.exists(testModuleEventContent.meta[TEST_FRAMEWORK_VERSION])
+          assert.exists(testSessionEventContent.test_session_id)
+          assert.exists(testSessionEventContent.meta[TEST_COMMAND])
+          assert.exists(testSessionEventContent.meta[TEST_TOOLCHAIN])
+          assert.equal(testSessionEventContent.resource.startsWith('test_session.'), true)
+          assert.equal(testSessionEventContent.meta[TEST_STATUS], 'fail')
 
-            assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
-              'test_suite.cypress/e2e/other.cy.js',
-              'test_suite.cypress/e2e/spec.cy.js'
-            ])
-
-            assert.includeMembers(testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]), [
-              'pass',
-              'fail'
-            ])
-
-            testSuiteEvents.forEach(({
-              content: {
-                meta,
-                test_suite_id: testSuiteId,
-                test_module_id: testModuleId,
-                test_session_id: testSessionId
-              }
-            }) => {
-              assert.exists(meta[TEST_COMMAND])
-              assert.exists(meta[TEST_MODULE])
-              assert.exists(testSuiteId)
-              assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
-              assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-            })
-
-            assert.includeMembers(testEvents.map(test => test.content.resource), [
-              'cypress/e2e/other.cy.js.context passes',
-              'cypress/e2e/spec.cy.js.context passes',
-              'cypress/e2e/spec.cy.js.other context fails'
-            ])
-
-            assert.includeMembers(testEvents.map(test => test.content.meta[TEST_STATUS]), [
-              'pass',
-              'pass',
-              'fail'
-            ])
-
-            testEvents.forEach(({
-              content: {
-                meta,
-                test_suite_id: testSuiteId,
-                test_module_id: testModuleId,
-                test_session_id: testSessionId
-              }
-            }) => {
-              assert.exists(meta[TEST_COMMAND])
-              assert.exists(meta[TEST_MODULE])
-              assert.exists(testSuiteId)
-              assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
-              assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-            })
-          }, 25000).then(() => done()).catch(done)
-
-          const {
-            NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
-            ...restEnvVars
-          } = envVars
-
-          const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json' : ''
-
-          childProcess = exec(
-            `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
-            {
-              cwd,
-              env: {
-                ...restEnvVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
-              },
-              stdio: 'pipe'
-            }
+          assert.exists(testModuleEventContent.test_session_id)
+          assert.exists(testModuleEventContent.test_module_id)
+          assert.exists(testModuleEventContent.meta[TEST_COMMAND])
+          assert.exists(testModuleEventContent.meta[TEST_MODULE])
+          assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
+          assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
+          assert.equal(
+            testModuleEventContent.test_session_id.toString(10),
+            testSessionEventContent.test_session_id.toString(10)
           )
-        })
+          assert.exists(testModuleEventContent.meta[TEST_FRAMEWORK_VERSION])
+
+          assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
+            'test_suite.cypress/e2e/other.cy.js',
+            'test_suite.cypress/e2e/spec.cy.js'
+          ])
+
+          assert.includeMembers(testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]), [
+            'pass',
+            'fail'
+          ])
+
+          testSuiteEvents.forEach(({
+            content: {
+              meta,
+              test_suite_id: testSuiteId,
+              test_module_id: testModuleId,
+              test_session_id: testSessionId
+            }
+          }) => {
+            assert.exists(meta[TEST_COMMAND])
+            assert.exists(meta[TEST_MODULE])
+            assert.exists(testSuiteId)
+            assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+            assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+          })
+
+          assert.includeMembers(testEvents.map(test => test.content.resource), [
+            'cypress/e2e/other.cy.js.context passes',
+            'cypress/e2e/spec.cy.js.context passes',
+            'cypress/e2e/spec.cy.js.other context fails'
+          ])
+
+          assert.includeMembers(testEvents.map(test => test.content.meta[TEST_STATUS]), [
+            'pass',
+            'pass',
+            'fail'
+          ])
+
+          testEvents.forEach(({
+            content: {
+              meta,
+              test_suite_id: testSuiteId,
+              test_module_id: testModuleId,
+              test_session_id: testSessionId
+            }
+          }) => {
+            assert.exists(meta[TEST_COMMAND])
+            assert.exists(meta[TEST_MODULE])
+            assert.exists(testSuiteId)
+            assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+            assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+          })
+        }, 25000).then(() => done()).catch(done)
+
+        const {
+          NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+          ...restEnvVars
+        } = envVars
+
+        const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json' : ''
+
+        childProcess = exec(
+          `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+          {
+            cwd,
+            env: {
+              ...restEnvVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+            },
+            stdio: 'on'
+          }
+        )
       })
     })
   })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -17,7 +17,6 @@ const { TEST_STATUS } = require('../../packages/dd-trace/src/plugins/util/test')
 
 // TODO: remove when 2.x support is removed.
 // This is done because from playwright@>=1.22.0 node 12 is not supported
-// TODO: figure out why playwright 1.31.0 fails
 const isOldNode = semver.satisfies(process.version, '<=12')
 const versions = ['1.18.0', isOldNode ? '1.21.0' : 'latest']
 

--- a/integration-tests/scripts/sandbox.js
+++ b/integration-tests/scripts/sandbox.js
@@ -1,0 +1,11 @@
+// Script example usage: node sandbox.js cypress@10.1.0 assert@3.1.0 ...
+const { createSandbox } = require('../helpers')
+
+async function run () {
+  const dependencies = process.argv.slice(2)
+  const { folder } = await createSandbox(dependencies, true)
+  // eslint-disable-next-line
+  console.log(folder)
+}
+
+run()


### PR DESCRIPTION
### What does this PR do?
* Split cypress integration tests into its own job.
* Do browser dependency installation in the workflow file rather than programatically in the test. 

### Motivation
Cypress dependency installation is slow. Doing it at the test increases the risk of timing out. 

