### PR TITLE
split next testing by version range

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -651,8 +651,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
-          with:
-            node-version: ${{ matrix.node-version }}
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: yarn install
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -642,6 +642,7 @@ jobs:
   next:
     strategy:
       matrix:
+        node-version: [14, 16, 18]
         range: ['>=9.5 <11.1', '>=11.1 <13.2', '>=13.2']
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -650,7 +650,9 @@ jobs:
       RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/node/${{ matrix.node-version }}
+      - uses: actions/setup-node@v3
+          with:
+            node-version: ${{ matrix.node-version }}
       - run: yarn install
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -640,9 +640,13 @@ jobs:
 
   # TODO: fix performance issues and test more Node versions
   next:
+    strategy:
+      matrix:
+        range: ['>=9.5 <11.1', '>=11.1 <13.2', '>=13.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: next
+      RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -19,7 +19,7 @@ env:
 # TODO: upstream jobs
 
 jobs:
-  amqp10:
+  amqp10: # TODO: move rhea to its own job
     runs-on: ubuntu-latest
     services:
       qpid:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -642,7 +642,7 @@ jobs:
   next:
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [14, 16]
         range: ['>=9.5 <11.1', '>=11.1 <13.2', '>=13.2']
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -30,7 +30,7 @@ jobs:
         ports:
           - 5673:5672
     env:
-      PLUGINS: amqp10|rhea # TODO: move rhea to its own job
+      PLUGINS: amqp10|rhea
       SERVICES: qpid
     steps:
       - uses: actions/checkout@v2
@@ -650,11 +650,8 @@ jobs:
       RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/${{ matrix.node-version }}
       - run: yarn install
-      - uses: ./.github/actions/node/14
-      - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "path-to-regexp": "^0.1.2",
     "protobufjs": "^7.1.2",
     "retry": "^0.10.1",
-    "semver": "^5.5.0"
+    "semver": "^7.3.8"
   },
   "devDependencies": {
     "@types/node": ">=14",

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -53,13 +53,14 @@ describe('Plugin', function () {
         this.timeout(120 * 1000) // Webpack is very slow and builds on every test run
 
         const cwd = __dirname
+        const nodules = `${__dirname}/../../../versions/next@${version}/node_modules`
         const pkg = require(`${__dirname}/../../../versions/next@${version}/package.json`)
 
         delete pkg.workspaces
 
-        writeFileSync(`${__dirname}/package.json`, JSON.stringify(pkg, null, 2))
+        execSync(`cp -R '${nodules}' ./`, { cwd })
 
-        execSync('npm --loglevel=error install', { cwd })
+        writeFileSync(`${__dirname}/package.json`, JSON.stringify(pkg, null, 2))
 
         // building in-process makes tests fail for an unknown reason
         execSync('npx next build', {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -63,7 +63,7 @@ describe('Plugin', function () {
         writeFileSync(`${__dirname}/package.json`, JSON.stringify(pkg, null, 2))
 
         // building in-process makes tests fail for an unknown reason
-        execSync('npx next build', {
+        execSync('yarn exec next build', {
           cwd,
           env: {
             ...process.env,
@@ -77,7 +77,6 @@ describe('Plugin', function () {
         this.timeout(5000)
         const files = [
           'package.json',
-          'package-lock.json',
           'node_modules',
           '.next'
         ]

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -63,10 +63,6 @@ function withVersions (plugin, modules, range, cb) {
     range = null
   }
 
-  if (process.env.RANGE) {
-    range = process.env.RANGE
-  }
-
   modules.forEach(moduleName => {
     const testVersions = new Map()
 
@@ -74,6 +70,7 @@ function withVersions (plugin, modules, range, cb) {
       .filter(instrumentation => instrumentation.name === moduleName)
       .forEach(instrumentation => {
         instrumentation.versions
+          .filter(version => !process.env.RANGE || semver.subset(version, process.env.RANGE))
           .forEach(version => {
             const min = semver.coerce(version).version
             const max = require(`../../../../versions/${moduleName}@${version}`).version()

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -63,6 +63,10 @@ function withVersions (plugin, modules, range, cb) {
     range = null
   }
 
+  if (process.env.RANGE) {
+    range = process.env.RANGE
+  }
+
   modules.forEach(moduleName => {
     const testVersions = new Map()
 

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -89,6 +89,8 @@ async function assertInstrumentation (instrumentation, external) {
 }
 
 async function assertModules (name, version, external) {
+  const range = process.env.RANGE
+  if (range && !semver.subset(version, range)) return
   addFolder(name)
   addFolder(name, version)
   assertFolder(name)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,6 +2857,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 lru-cache@^7.14.0:
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
@@ -3731,15 +3738,17 @@ semver@5.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
   integrity sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw==
 
-semver@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.18.0:
   version "0.18.0"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split `next` testing by version range.

### Motivation
<!-- What inspired you to submit this pull request? -->

Next tests are extremely slow because it forces users to use Webpack. Splitting them brings the total time of the job to ~2min from ~8-10min. Since this was the longest job of the workflow, it also bring the entire workflow down from 8-10min to ~2-3min. Further improvements could be made to get it closer to 1min mark, but for now this is sufficient.