### PR TITLE
[ci-visibility] Add `gatherPayloadsMaxTimeout`, a faster version of `gatherPayloads`

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -192,6 +192,7 @@ class FakeCiVisIntake extends FakeAgent {
             onPayload(payloads)
             clearTimeout(timeoutId)
             this.off('message', messageHandler)
+            resolve()
           } catch (e) {
             // we'll try again when a new payload arrives
           }

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -158,7 +158,7 @@ versions.forEach((version) => {
                 ...restEnvVars,
                 CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
               },
-              stdio: 'on'
+              stdio: 'pipe'
             }
           )
         })

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -61,7 +61,7 @@ versions.forEach((version) => {
             ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
           const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
 
-          receiver.gatherPayloads(({ url }) => url === reportUrl, 25000).then((payloads) => {
+          receiver.gatherPayloadsMaxTimeout(({ url }) => url === reportUrl, payloads => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSessionEvent = events.find(event => event.type === 'test_session_end')
@@ -141,9 +141,7 @@ versions.forEach((version) => {
               assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
               assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
             })
-
-            done()
-          }).catch(done)
+          }, 25000).then(() => done()).catch(done)
 
           const {
             NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress


### PR DESCRIPTION
### What does this PR do?
Its API is a bit clumsier (callback vs promise) so I'm going to leave `gatherPayloads` for situations where timing is not that much of an issue. 

### Motivation
Make sure some browser test checks finish as soon as possible, not after the gathering time has passed. 

### Examples

#### Before
* [cypress tests](https://github.com/DataDog/dd-trace-js/actions/runs/4565478581/jobs/8056654326) (2m 36s)
* [playwright tests](https://github.com/DataDog/dd-trace-js/actions/runs/4565478581/jobs/8056654505) (2m 45s)

#### After
* [cypress tests](https://github.com/DataDog/dd-trace-js/actions/runs/4565498010/jobs/8056700268) (2m 18s)
* [playwright tests](https://github.com/DataDog/dd-trace-js/actions/runs/4565498010/jobs/8056700588) (1m 23s)


