### PR TITLE
Improve integration tests for CI Visibility

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -63,7 +63,7 @@ versions.forEach(version => {
           envVars = isAgentless ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
         })
         it('can run and report tests', (done) => {
-          receiver.gatherPayloads(({ url }) => url.endsWith('/api/v2/citestcycle'), 5000).then((payloads) => {
+          receiver.gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSessionEvent = events.find(event => event.type === 'test_session_end')
@@ -151,9 +151,7 @@ versions.forEach(version => {
               assert.equal(stepEvent.content.name, 'cucumber.step')
               assert.property(stepEvent.content.meta, 'cucumber.step')
             })
-
-            done()
-          }).catch(done)
+          }, 5000).then(() => done()).catch(done)
 
           childProcess = exec(
             runTestsCommand,

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -29,7 +29,7 @@ const versions = ['6.7.0', isOldNode ? '11.2.0' : 'latest']
 versions.forEach((version) => {
   describe(`cypress@${version}`, function () {
     this.retries(2)
-    this.timeout(45000)
+    this.timeout(60000)
     let sandbox, cwd, receiver, childProcess, webAppPort
     before(async () => {
       sandbox = await createSandbox([`cypress@${version}`], true)


### PR DESCRIPTION
### What does this PR do?
* Reduce testing time for `cucumber` by using `gatherPayloadsMaxTimeout`
* Increase timeout for `cypress` tests

### Motivation
* Decrease overall testing time
* Improve flakiness for `cypress`

