### PR TITLE
Only run release branches check on `master` PRs

### DIFF
--- a/.github/workflows/release-branches-check.yml
+++ b/.github/workflows/release-branches-check.yml
@@ -2,7 +2,7 @@ name: Release branches check
 
 on:
   pull_request:
-    types: [opened]
+    branches: [master]
 
 jobs:
   check-release-branch-v2:


### PR DESCRIPTION
### What does this PR do?
Only run `.github/workflows/release-branches-check.yml` on PRs to `master`

### Motivation
It's currently running in release branches PRs, which shouldn't happen.

