### PR TITLE
[data streams] Add test case for decoding function

### DIFF
--- a/packages/dd-trace/test/datastreams/encoding.spec.js
+++ b/packages/dd-trace/test/datastreams/encoding.spec.js
@@ -31,6 +31,19 @@ describe('encoding', () => {
       expect(decoded2).to.equal(n)
       expect(bytes2).to.length(0)
     })
+    it('encoding can be used to encode multiple numbers in a row', () => {
+      const n1 = 1680535452135000
+      const n2 = 1680535452178000
+      const encodedN1 = encodeVarint(n1)
+      const encodedN2 = encodeVarint(n2)
+      const encoded = new Uint8Array(encodedN1.length + encodedN2.length)
+      encoded.set(encodedN1)
+      encoded.set(encodedN2, encodedN2.length)
+      const [decodedN1, rest] = decodeVarint(encoded)
+      const [decodedN2] = decodeVarint(rest)
+      expect(decodedN1).to.equal(n1)
+      expect(decodedN2).to.equal(n2)
+    })
     it('encoding a number bigger than Max safe int fails.', () => {
       const n = Number.MAX_SAFE_INTEGER + 10
       const encoded = encodeVarint(n)


### PR DESCRIPTION
### What does this PR do?
Test that decoding works with two numbers that are different.

### Motivation


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
