### PR TITLE
Fix Next.js getServerSideProps error handling

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -68,6 +68,12 @@ class NextPlugin extends Plugin {
       const span = store.span
       const req = this._requests.get(span)
 
+      // Only use error page names if there's not already a name
+      const current = span.context()._tags['next.page']
+      if (current && (page === '/404' || page === '/500' || page === '/_error')) {
+        return
+      }
+
       span.addTags({
         [COMPONENT]: this.constructor.id,
         'resource.name': `${req.method} ${page}`.trim(),

--- a/packages/datadog-plugin-next/test/pages/error/get_server_side_props.js
+++ b/packages/datadog-plugin-next/test/pages/error/get_server_side_props.js
@@ -1,0 +1,11 @@
+export async function getServerSideProps (ctx) {
+  throw new Error('fail')
+}
+
+export default function GetServerSideProps () {
+  return (
+    <div>
+      Get Server Side Props!
+    </div>
+  )
+}

--- a/packages/datadog-plugin-next/test/pages/error/not_found.js
+++ b/packages/datadog-plugin-next/test/pages/error/not_found.js
@@ -1,0 +1,13 @@
+export async function getServerSideProps (ctx) {
+  return {
+    notFound: true
+  }
+}
+
+export default function NotFound () {
+  return (
+    <div>
+      Not found!
+    </div>
+  )
+}


### PR DESCRIPTION
### What does this PR do?

Fixes handling of errors thrown in `getServerSideProps` and graceful `notFound`.

### Motivation

These should use the original route path not the `/_error` or `/$code` paths.