### PR TITLE
skip extraction of upper bits for 64-bit trace id

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -495,7 +495,11 @@ class TextMapPropagator {
 
     if (buffer.length !== 16) return
 
-    spanContext._trace.tags['_dd.p.tid'] = traceId.substring(0, 16)
+    const tid = traceId.substring(0, 16)
+
+    if (tid === '0000000000000000') return
+
+    spanContext._trace.tags['_dd.p.tid'] = tid
   }
 
   _validateTagKey (key) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Skip extraction of upper bits for 64-bit trace ID.

### Motivation
<!-- What inspired you to submit this pull request? -->

Zero is not a valid value for upper bits and shouldn't be propagated, which would otherwise be the case for 64bit instead of 128bit.