### PR TITLE
[lambda] update context extraction

### DIFF
--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -60,13 +60,30 @@ function crashFlush () {
 }
 
 /**
+ * Extracts the context from the given Lambda handler arguments.
+ *
+ * @param {*} args any amount of arguments
+ * @returns the context, if extraction was succesful.
+ */
+function extractContext (args) {
+  let context = args.length > 1 ? args[1] : undefined
+  if (context === undefined || context.getRemainingTimeInMillis === undefined) {
+    context = args.length > 2 ? args[2] : undefined
+    if (context === undefined || context.getRemainingTimeInMillis === undefined) {
+      throw Error('Could not extract context')
+    }
+  }
+  return context
+}
+
+/**
  * Patches your AWS Lambda handler function to add some tracing support.
  *
  * @param {*} lambdaHandler a Lambda handler function.
  */
 exports.datadog = function datadog (lambdaHandler) {
   return (...args) => {
-    const context = args[1]
+    const context = extractContext(args)
     const patched = lambdaHandler.apply(this, args)
     checkTimeout(context)
 

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -83,14 +83,21 @@ function extractContext (args) {
  */
 exports.datadog = function datadog (lambdaHandler) {
   return (...args) => {
-    const context = extractContext(args)
     const patched = lambdaHandler.apply(this, args)
-    checkTimeout(context)
 
-    if (patched) {
-      // clear the timeout as soon as a result is returned
-      patched.then(_ => clearTimeout(__lambdaTimeout))
+    try {
+      const context = extractContext(args)
+
+      checkTimeout(context)
+
+      if (patched) {
+        // clear the timeout as soon as a result is returned
+        patched.then(_ => clearTimeout(__lambdaTimeout))
+      }
+    } catch (e) {
+      log.warn('Error patching AWS Lambda handler. Timeout spans will not be generated.')
     }
+
     return patched
   }
 }

--- a/packages/dd-trace/test/lambda/fixtures/handler.js
+++ b/packages/dd-trace/test/lambda/fixtures/handler.js
@@ -42,8 +42,15 @@ const finishSpansEarlyTimeoutHandler = async (...args) => {
   return response
 }
 
+const swappedArgsHandler = async (event, _, context) => {
+  const response = sampleResponse
+
+  return response
+}
+
 module.exports = {
   finishSpansEarlyTimeoutHandler,
   handler,
+  swappedArgsHandler,
   timeoutHandler
 }


### PR DESCRIPTION
### What does this PR do?

Updates how context extraction is done.

### Motivation
Context might not be the second, but the third argument. Which our patch might crash AWS Lambda function if this happens.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
