### PR TITLE
[esbuild] add esbuild.js to npm package, change warning message

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@
 !README.md
 !index.d.ts
 !index.js
+!esbuild.js
 !init.js
 !loader-hook.mjs
 !package.json

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -93,11 +93,18 @@ module.exports.setup = function (build) {
   })
 }
 
+// Currently esbuild support requires Node.js >=v16.17 or >=v18.7
+// Better yet it would support Node >=v14.17 or >=v16
+// Of course, the most ideal would be to support all versions of Node that dd-trace supports.
+// Version constraints based on Node's diagnostics_channel support
 function warnIfUnsupported () {
   const [major, minor] = process.versions.node.split('.').map(Number)
-  if (major < 14 || (major === 14 && minor < 17)) {
+  if (
+    major < 16 ||
+    (major === 16 && minor < 17) ||
+    (major === 18 && minor < 7)) {
     console.error('WARNING: Esbuild support isn\'t available for older versions of Node.js.')
-    console.error(`Expected: Node.js >= v14.17. Actual: Node.js = ${process.version}.`)
+    console.error(`Expected: Node.js >=v16.17 or >=v18.7. Actual: Node.js = ${process.version}.`)
     console.error('This application may build properly with this version of Node.js, but unless a')
     console.error('more recent version is used at runtime, third party packages won\'t be instrumented.')
   }


### PR DESCRIPTION
### What does this PR do?
- change the node.js version range warnings when attempting to bundle via esbuild
- actually includes esbuild.js in npm package (a la `require('dd-trace/esbuild')`)
- fixes #2983

### Motivation
- otherwise it doesn't work
- also users won't get warnings for all incompatible scenarios
- make the warning range match the README