### PR TITLE
Optimizations in tags-procesors.js

### DIFF
--- a/packages/dd-trace/src/encode/tags-processors.js
+++ b/packages/dd-trace/src/encode/tags-processors.js
@@ -9,8 +9,6 @@ const MAX_META_KEY_LENGTH = 200
 const MAX_META_VALUE_LENGTH = 25000
 // MAX_METRIC_KEY_LENGTH the maximum length of a metric name key
 const MAX_METRIC_KEY_LENGTH = MAX_META_KEY_LENGTH
-// MAX_METRIC_VALUE_LENGTH the maximum length of a metric name value
-const MAX_METRIC_VALUE_LENGTH = MAX_META_VALUE_LENGTH
 
 // From agent normalizer:
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/traceutil/normalize.go
@@ -39,6 +37,7 @@ function truncateSpan (span, shouldTruncateResourceName = true) {
     if (metaKey.length > MAX_META_KEY_LENGTH) {
       delete span.meta[metaKey]
       metaKey = `${metaKey.slice(0, MAX_META_KEY_LENGTH)}...`
+      span.metrics[metaKey] = val
     }
     if (val && val.length > MAX_META_VALUE_LENGTH) {
       span.meta[metaKey] = `${val.slice(0, MAX_META_VALUE_LENGTH)}...`
@@ -49,9 +48,7 @@ function truncateSpan (span, shouldTruncateResourceName = true) {
     if (metricsKey.length > MAX_METRIC_KEY_LENGTH) {
       delete span.metrics[metricsKey]
       metricsKey = `${metricsKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
-    }
-    if (val && val.length > MAX_METRIC_VALUE_LENGTH) {
-      span.metrics[metricsKey] = `${val.slice(0, MAX_METRIC_VALUE_LENGTH)}...`
+      span.metrics[metricsKey] = val
     }
   }
 
@@ -83,7 +80,6 @@ module.exports = {
   MAX_META_KEY_LENGTH,
   MAX_META_VALUE_LENGTH,
   MAX_METRIC_KEY_LENGTH,
-  MAX_METRIC_VALUE_LENGTH,
   MAX_NAME_LENGTH,
   MAX_SERVICE_LENGTH,
   MAX_TYPE_LENGTH,

--- a/packages/dd-trace/src/encode/tags-processors.js
+++ b/packages/dd-trace/src/encode/tags-processors.js
@@ -25,14 +25,7 @@ const MAX_SERVICE_LENGTH = 100
 // MAX_TYPE_LENGTH the maximum length a span type can have
 const MAX_TYPE_LENGTH = 100
 
-function truncateToLength (value, maxLength) {
-  if (value && value.length > maxLength) {
-    return `${value.slice(0, maxLength)}...`
-  }
-  return value
-}
-
-// TODO(bengl) Pretty much everything in this file should happen in
+// TODO (bengl) Pretty much everything in this file should happen in
 // `format.js`, so that we're not iterating over all the spans and modifying
 // them yet again.
 
@@ -47,7 +40,9 @@ function truncateSpan (span, shouldTruncateResourceName = true) {
       delete span.meta[metaKey]
       metaKey = `${metaKey.slice(0, MAX_META_KEY_LENGTH)}...`
     }
-    span.meta[metaKey] = truncateToLength(val, MAX_META_VALUE_LENGTH)
+    if (val && val.length > MAX_META_VALUE_LENGTH) {
+      span.meta[metaKey] = `${val.slice(0, MAX_META_VALUE_LENGTH)}...`
+    }
   }
   for (let metricsKey in span.metrics) {
     const val = span.metrics[metricsKey]
@@ -55,7 +50,9 @@ function truncateSpan (span, shouldTruncateResourceName = true) {
       delete span.metrics[metricsKey]
       metricsKey = `${metricsKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
     }
-    span.metrics[metricsKey] = truncateToLength(val, MAX_METRIC_VALUE_LENGTH)
+    if (val && val.length > MAX_METRIC_VALUE_LENGTH) {
+      span.metrics[metricsKey] = `${val.slice(0, MAX_METRIC_VALUE_LENGTH)}...`
+    }
   }
 
   return span

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -10,7 +10,6 @@ const {
   MAX_META_KEY_LENGTH,
   MAX_META_VALUE_LENGTH,
   MAX_METRIC_KEY_LENGTH,
-  MAX_METRIC_VALUE_LENGTH,
   MAX_NAME_LENGTH,
   MAX_SERVICE_LENGTH,
   MAX_RESOURCE_NAME_LENGTH,
@@ -180,7 +179,7 @@ describe('agentless-ci-visibility-encode', () => {
     expect(spanEvent.content.name).to.equal(DEFAULT_SPAN_NAME)
   })
 
-  it('should cut too long meta and metrics keys and values', () => {
+  it('should cut too long meta and metrics keys and meta values', () => {
     const tooLongKey = new Array(300).fill('a').join('')
     const tooLongValue = new Array(26000).fill('a').join('')
     const traceToTruncate = [{
@@ -192,7 +191,7 @@ describe('agentless-ci-visibility-encode', () => {
         [tooLongKey]: tooLongValue
       },
       metrics: {
-        [tooLongKey]: tooLongValue
+        [tooLongKey]: 15
       },
       start: 123,
       duration: 456,
@@ -210,7 +209,7 @@ describe('agentless-ci-visibility-encode', () => {
       [`${tooLongKey.slice(0, MAX_META_KEY_LENGTH)}...`]: `${tooLongValue.slice(0, MAX_META_VALUE_LENGTH)}...`
     })
     expect(spanEvent.content.metrics).to.eql({
-      [`${tooLongKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`]: `${tooLongValue.slice(0, MAX_METRIC_VALUE_LENGTH)}...`
+      [`${tooLongKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`]: 15
     })
   })
 


### PR DESCRIPTION
* Reduce looping. For the most part, we know which tags we're looking at, and don't need loops to find them.
* Reduce object creation. Rather than treating input objects as immutable, we can just modify them, since the original objects aren't referenced anymore in the code after these functions are called.