### PR TITLE
force hyphen prefix for decision making header

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -343,10 +343,10 @@ class TextMapPropagator {
               spanContext._trace.origin = value
               break
             case 't.dm': {
-              const mechanism = parseInt(value, 10)
+              const mechanism = -Math.abs(parseInt(value, 10))
               if (Number.isInteger(mechanism)) {
                 spanContext._sampling.mechanism = mechanism
-                spanContext._trace.tags['_dd.p.dm'] = mechanism
+                spanContext._trace.tags['_dd.p.dm'] = String(mechanism)
               }
               break
             }


### PR DESCRIPTION
### What does this PR do?
- according to an internal RFC the numeric mechanism value should be prefixed with a hyphen

### Motivation
- the lack of a hyphen may break another tracer, for example Java