### PR TITLE
[ci-visibility] Fix jest error when using `jest-jasmine2`

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -45,7 +45,7 @@ const testFrameworks = [
   },
   {
     name: 'jest',
-    dependencies: [isOldNode ? 'jest@28' : 'jest', 'chai'],
+    dependencies: [isOldNode ? 'jest@28' : 'jest', 'chai', 'jest-jasmine2'],
     testFile: 'ci-visibility/run-jest.js',
     expectedStdout: 'Test Suites: 2 passed',
     expectedCoverageFiles: [
@@ -144,6 +144,28 @@ testFrameworks.forEach(({
         childProcess.on('message', () => {
           assert.notInclude(testOutput, 'TypeError')
           assert.include(testOutput, expectedStdout)
+          done()
+        })
+      })
+      it('does not crash when jest uses jest-jasmine2', (done) => {
+        childProcess = fork('ci-visibility/run-jest.js', {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            OLD_RUNNER: 1,
+            NODE_OPTIONS: '-r dd-trace/ci/init',
+            RUN_IN_PARALLEL: true
+          },
+          stdio: 'pipe'
+        })
+        childProcess.stdout.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.on('message', () => {
+          assert.notInclude(testOutput, 'TypeError')
           done()
         })
       })

--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -14,6 +14,10 @@ if (process.env.RUN_IN_PARALLEL) {
   options.maxWorkers = 2
 }
 
+if (process.env.OLD_RUNNER) {
+  options.testRunner = 'jest-jasmine2'
+}
+
 jest.runCLI(
   options,
   options.projects

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -31,8 +31,11 @@ class JestPlugin extends CiPlugin {
       // Used to handle the end of a jest worker to be able to flush
       const handler = ([message]) => {
         if (message === CHILD_MESSAGE_END) {
-          this.testSuiteSpan.finish()
-          finishAllTraceSpans(this.testSuiteSpan)
+          // testSuiteSpan is not defined for older versions of jest, where jest-jasmine2 is still used
+          if (this.testSuiteSpan) {
+            this.testSuiteSpan.finish()
+            finishAllTraceSpans(this.testSuiteSpan)
+          }
           this.tracer._exporter.flush()
           process.removeListener('message', handler)
         }


### PR DESCRIPTION
### What does this PR do?
When using `jest-jasmine2`, the default test runner for older versions of `jest`, test suite spans are not defined, so we need to account for that.

### Motivation
Fixes #2989

