### PR TITLE
Fix trace stats duration

### DIFF
--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -28,7 +28,7 @@ class SpanAggStats {
   }
 
   record (span) {
-    const durationNs = span._duration * 1e6
+    const durationNs = span.duration
     this.hits++
     this.duration += durationNs
 

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -113,7 +113,7 @@ describe('SpanAggStats', () => {
 
     const okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
     const errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
-    okDistribution.accept(basicSpan._duration * 1e6)
+    okDistribution.accept(basicSpan.duration)
 
     expect(aggStats.toJSON()).to.deep.equal({
       Name: aggKey.name,
@@ -125,7 +125,7 @@ describe('SpanAggStats', () => {
       Hits: 1,
       TopLevelHits: 0,
       Errors: 0,
-      Duration: basicSpan._duration * 1e6,
+      Duration: basicSpan.duration,
       OkSummary: okDistribution.toProto(),
       ErrorSummary: errorDistribution.toProto()
     })
@@ -138,7 +138,7 @@ describe('SpanAggStats', () => {
 
     const okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
     const errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
-    okDistribution.accept(topLevelSpan._duration * 1e6)
+    okDistribution.accept(topLevelSpan.duration)
 
     expect(aggStats.toJSON()).to.deep.equal({
       Name: aggKey.name,
@@ -150,7 +150,7 @@ describe('SpanAggStats', () => {
       Hits: 1,
       TopLevelHits: 1,
       Errors: 0,
-      Duration: topLevelSpan._duration * 1e6,
+      Duration: topLevelSpan.duration,
       OkSummary: okDistribution.toProto(),
       ErrorSummary: errorDistribution.toProto()
     })
@@ -163,7 +163,7 @@ describe('SpanAggStats', () => {
 
     const okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
     const errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
-    errorDistribution.accept(errorSpan._duration * 1e6)
+    errorDistribution.accept(errorSpan.duration)
 
     expect(aggStats.toJSON()).to.deep.equal({
       Name: aggKey.name,
@@ -175,7 +175,7 @@ describe('SpanAggStats', () => {
       Hits: 1,
       TopLevelHits: 0,
       Errors: 1,
-      Duration: errorSpan._duration * 1e6,
+      Duration: errorSpan.duration,
       OkSummary: okDistribution.toProto(),
       ErrorSummary: errorDistribution.toProto()
     })
@@ -273,7 +273,7 @@ describe('SpanStatsProcessor', () => {
     okDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
     errorDistribution = new LogCollapsingLowestDenseDDSketch(0.00775)
     for (let i = 0; i < n; i++) {
-      okDistribution.accept(topLevelSpan._duration * 1e6)
+      okDistribution.accept(topLevelSpan.duration)
     }
 
     expect(spanBucket.toJSON()).to.deep.equal({
@@ -286,7 +286,7 @@ describe('SpanStatsProcessor', () => {
       Hits: n,
       TopLevelHits: n,
       Errors: 0,
-      Duration: (topLevelSpan._duration * 1e6) * n,
+      Duration: (topLevelSpan.duration) * n,
       OkSummary: okDistribution.toProto(),
       ErrorSummary: errorDistribution.toProto()
     })
@@ -312,7 +312,7 @@ describe('SpanStatsProcessor', () => {
           Hits: n,
           TopLevelHits: n,
           Errors: 0,
-          Duration: (topLevelSpan._duration * 1e6) * n,
+          Duration: (topLevelSpan.duration) * n,
           OkSummary: okDistribution.toProto(),
           ErrorSummary: errorDistribution.toProto()
         }]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

With `DD_TRACE_STATS_COMPUTATION_ENABLED=true`, I was getting duration of 0 in trace stats. This PR fixes this.

The code was using `span._duration` (note the underscore) instead of `span.duration`. The unit tests also compared output to `span._duration` so it didn't catch it.

### Motivation

serverless will use tracer computed trace stats for our rust mini agent

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
