### PR TITLE
Remove interrupt callback strategy from OOM heap profiler

### DIFF
--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -128,20 +128,6 @@ describe('profiler', () => {
       return checkProfiles(agent, proc, timeout, ['space'], true)
     })
 
-    it('sends a heap profile on OOM with interrupt callback', async () => {
-      proc = fork(oomTestFile, {
-        cwd,
-        execArgv: oomExecArgv,
-        env: {
-          ...oomEnv,
-          DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 10000000,
-          DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 1,
-          DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'interrupt'
-        }
-      })
-      return checkProfiles(agent, proc, timeout, ['space'], true)
-    })
-
     it('sends heap profiles on OOM with multiple strategies', async () => {
       proc = fork(oomTestFile, {
         cwd,
@@ -150,10 +136,10 @@ describe('profiler', () => {
           ...oomEnv,
           DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 10000000,
           DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 1,
-          DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'async,interrupt,process'
+          DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'async,process'
         }
       })
-      return checkProfiles(agent, proc, timeout, ['space'], true, 4)
+      return checkProfiles(agent, proc, timeout, ['space'], true, 3)
     })
   })
 })

--- a/packages/dd-trace/src/profiling/constants.js
+++ b/packages/dd-trace/src/profiling/constants.js
@@ -9,7 +9,6 @@ const snapshotKinds = Object.freeze({
 const oomExportStrategies = Object.freeze({
   PROCESS: 'process',
   ASYNC_CALLBACK: 'async',
-  INTERRUPT_CALLBACK: 'interrupt',
   LOGS: 'logs'
 })
 

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -3,9 +3,7 @@
 const { oomExportStrategies } = require('../constants')
 
 function strategiesToCallbackMode (strategies, callbackMode) {
-  const hasInterrupt = strategies.includes(oomExportStrategies.INTERRUPT_CALLBACK) ? callbackMode.Interrupt : 0
-  const hasCallback = strategies.includes(oomExportStrategies.ASYNC_CALLBACK) ? callbackMode.Async : 0
-  return hasInterrupt | hasCallback
+  return strategies.includes(oomExportStrategies.ASYNC_CALLBACK) ? callbackMode.Async : 0
 }
 
 class NativeSpaceProfiler {

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -176,7 +176,7 @@ describe('config', () => {
       DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED: '1',
       DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: '1000000',
       DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: '2',
-      DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'process,interrupt,async,interrupt'
+      DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'process,async,process'
     }
 
     const config = new Config({})
@@ -185,7 +185,7 @@ describe('config', () => {
       enabled: true,
       heapLimitExtensionSize: 1000000,
       maxHeapExtensionCount: 2,
-      exportStrategies: ['process', 'interrupt', 'async'],
+      exportStrategies: ['process', 'async'],
       exportCommand: [
         process.execPath,
         path.normalize(path.join(__dirname, '../../src/profiling', 'exporter_cli.js')),


### PR DESCRIPTION
### What does this PR do?
Remove the interrupt callback strategy to export heap profile when OOM occurs.

### Motivation
Interrupt callback strategy is not safe and seems to causes crashes in node 14.
