### PR TITLE
redis command names in blocklist/allowlist now case insensitive

### DIFF
--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -9,17 +9,19 @@ class RedisPlugin extends CachePlugin {
   static get system () { return 'redis' }
 
   start ({ db, command, args, connectionOptions = {}, connectionName }) {
-    if (!this.config.filter(command.toUpperCase())) return this.skip()
+    const rawCommand = command
+    const normalizedCommand = command.toUpperCase()
+    if (!this.config.filter(normalizedCommand)) return this.skip()
 
     this.startSpan('redis.command', {
       service: getService(this.config, connectionName),
-      resource: command,
+      resource: rawCommand,
       type: 'redis',
       kind: 'client',
       meta: {
         'db.type': 'redis',
         'db.name': db || '0',
-        'redis.raw_command': formatCommand(command, args),
+        'redis.raw_command': formatCommand(normalizedCommand, args),
         'out.host': connectionOptions.host,
         [CLIENT_PORT_KEY]: connectionOptions.port
       }
@@ -42,8 +44,6 @@ function getService (config, connectionName) {
 }
 
 function formatCommand (command, args) {
-  command = command.toUpperCase()
-
   if (!args || command === 'AUTH') return command
 
   for (let i = 0, l = args.length; i < l; i++) {

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -9,7 +9,7 @@ class RedisPlugin extends CachePlugin {
   static get system () { return 'redis' }
 
   start ({ db, command, args, connectionOptions = {}, connectionName }) {
-    if (!this.config.filter(command)) return this.skip()
+    if (!this.config.filter(command.toUpperCase())) return this.skip()
 
     this.startSpan('redis.command', {
       service: getService(this.config, connectionName),
@@ -76,11 +76,22 @@ function trim (str, maxlen) {
 }
 
 function normalizeConfig (config) {
+  if (config.allowlist) uppercaseAllEntries(config.allowlist)
+  if (config.whitelist) uppercaseAllEntries(config.whitelist)
+  if (config.blocklist) uppercaseAllEntries(config.blocklist)
+  if (config.blacklist) uppercaseAllEntries(config.blacklist)
+
   const filter = urlFilter.getFilter(config)
 
   return Object.assign({}, config, {
     filter
   })
+}
+
+function uppercaseAllEntries (entries) {
+  for (let i = 0; i < entries.length; i++) {
+    entries[i] = String(entries[i]).toUpperCase()
+  }
 }
 
 module.exports = RedisPlugin

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -9,13 +9,13 @@ class RedisPlugin extends CachePlugin {
   static get system () { return 'redis' }
 
   start ({ db, command, args, connectionOptions = {}, connectionName }) {
-    const rawCommand = command
+    const resource = command
     const normalizedCommand = command.toUpperCase()
     if (!this.config.filter(normalizedCommand)) return this.skip()
 
     this.startSpan('redis.command', {
       service: getService(this.config, connectionName),
-      resource: rawCommand,
+      resource,
       type: 'redis',
       kind: 'client',
       meta: {

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -135,6 +135,42 @@ describe('Plugin', () => {
           await promise
         })
       })
+
+      describe('with blocklist', () => {
+        before(() => {
+          return agent.load('redis', {
+            blocklist: [
+              'Set', // this should block set and SET commands
+              'FOO'
+            ]
+          })
+        })
+
+        after(() => {
+          return agent.close({ ritmReset: false })
+        })
+
+        beforeEach(async () => {
+          redis = require(`../../../versions/${moduleName}@${version}`).get()
+          client = redis.createClient()
+
+          await client.connect()
+        })
+
+        afterEach(async () => {
+          await client.quit()
+        })
+
+        it('should be able to filter commands on a case-insensitive basis', async () => {
+          const promise = agent.use(traces => {
+            expect(traces[0][0]).to.have.property('resource', 'GET')
+          })
+
+          await client.set('turtle', 'like')
+          await client.get('turtle')
+          await promise
+        })
+      })
     })
   })
 })

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 
-describe('Plugin', () => {
+describe('Legacy Plugin', () => {
   let redis
   let tracer
   let client
@@ -99,6 +99,10 @@ describe('Plugin', () => {
           client.stream.destroy()
         })
 
+        // TODO: This test is flakey. I've seen it affect 2.6.0, 2.5.3, 3.1.2, 0.12.0
+        // Increasing the test timeout does not help.
+        // Error will be set but span will not.
+        // agent.use is called a dozen times per test in legacy.spec but once per test in client.spec
         it('should handle errors', done => {
           const assertError = () => {
             if (!error || !span) return


### PR DESCRIPTION
### What does this PR do?
- previously commands could be either `set` or `SET`
- now we normalize everything internally as `SET`
- `ioredis` uses lowecase and `redis` uses uppercase
- Redis itself is case-insensitive

### Motivation
- this will save developers debugging time
