### PR TITLE
update sirun benchmark variants to run in parallel

### DIFF
--- a/benchmark/sirun/get-variants.js
+++ b/benchmark/sirun/get-variants.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const path = require('path')
+const metaJson = require(path.join(process.cwd(), 'meta.json'))
+const variants = Object.keys(metaJson.variants)
+
+process.stdout.write(variants.join(' '))

--- a/benchmark/sirun/run-one-variant.js
+++ b/benchmark/sirun/run-one-variant.js
@@ -3,8 +3,6 @@
 'use strict'
 
 const childProcess = require('child_process')
-const fs = require('fs')
-const path = require('path')
 const readline = require('readline')
 
 process.env.DD_TRACE_TELEMETRY_ENABLED = 'false'
@@ -24,9 +22,6 @@ function exec (...args) {
   })
 }
 
-require('./squash-affinity')
-
-const metaJson = require(path.join(process.cwd(), 'meta.json'))
 const env = Object.assign({}, process.env, { DD_TRACE_STARTUP_LOGS: 'false' })
 
 function streamAddVersion (input) {
@@ -50,21 +45,7 @@ function getStdio () {
 
 (async () => {
   try {
-    if (metaJson.variants) {
-      const variants = metaJson.variants
-      for (const variant in variants) {
-        const variantEnv = Object.assign({}, env, { SIRUN_VARIANT: variant })
-        await exec('sirun', ['meta-temp.json'], { env: variantEnv, stdio: getStdio() })
-      }
-    } else {
-      await exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })
-    }
-
-    try {
-      fs.unlinkSync(path.join(process.cwd(), 'meta-temp.json'))
-    } catch (e) {
-      // it's ok if we can't delete a temp file
-    }
+    await exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })
   } catch (e) {
     setImmediate(() => {
       throw e // Older Node versions don't fail on uncaught promise rejections.

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -33,21 +33,45 @@ export ENABLE_AFFINITY=true
 echo "using Node.js ${VERSION}"
 CPU_AFFINITY=24 # reset for each node.js version
 
-for D in *; do
-  if [ -d "${D}" ]; then
-    echo "running ${D} in background, pinned to core ${CPU_AFFINITY}..."
-    cd "${D}"
-    (time node ../run-all-variants.js >> ../results.ndjson && echo "${D} finished.") &
-    cd ..
+run_all_variants () {
+  local variants="$(node ../get-variants.js)"
+
+  node ../squash-affinity.js
+
+  for V in $variants; do
+    echo "running ${1}/${V} in background, pinned to core ${CPU_AFFINITY}..."
+
+    export SIRUN_VARIANT=$V
+
+    (time node ../run-one-variant.js >> ../results.ndjson && echo "${1}/${V} finished.") &
     ((CPU_AFFINITY=CPU_AFFINITY+1))
+  done
+}
+
+for D in *; do
+  if [ "${D}" == "encoding" ]; then
+    cd "${D}"
+
+    run_all_variants $D
+
+    cd ..
   fi
 done
 
 wait # waits until all tests are complete before continuing
 
+# TODO: cleanup even when something fails
+for D in *; do
+  if [ -d "${D}" ]; then
+    unlink "${D}/meta-temp.json" 2>/dev/null
+  fi
+done
+
 node ./strip-unwanted-results.js
 
-echo "Benchmark Results:"
-cat ./results.ndjson
+if [ "$DEBUG_RESULTS" == "true" ]; then
+  echo "Benchmark Results:"
+  cat ./results.ndjson
+fi
 
 echo "all tests for ${VERSION} have now completed."

--- a/benchmark/sirun/squash-affinity.js
+++ b/benchmark/sirun/squash-affinity.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const metaJson = require(path.join(process.cwd(), 'meta.json'))
+
+if (process.env.ENABLE_AFFINITY) {
+  squashAffinity(metaJson)
+
+  if (metaJson.variants) {
+    const variants = metaJson.variants
+
+    for (const variantName in variants) {
+      const variant = variants[variantName]
+      squashAffinity(variant)
+    }
+  }
+}
+
+function squashAffinity (obj) {
+  if (obj.run_with_affinity) {
+    obj.run = obj.run_with_affinity
+    delete obj.run_with_affinity
+  }
+
+  if (obj.setup_with_affinity) {
+    obj.setup = obj.setup_with_affinity
+    delete obj.setup_with_affinity
+  }
+}
+
+fs.writeFileSync(path.join(process.cwd(), `meta-temp.json`), JSON.stringify(metaJson, null, 2))

--- a/benchmark/sirun/strip-unwanted-results.js
+++ b/benchmark/sirun/strip-unwanted-results.js
@@ -36,4 +36,4 @@ for (const line of lines) {
   results.push(JSON.stringify(obj))
 }
 
-fs.writeFileSync('./results.ndjson', results.join('\n'))
+fs.writeFileSync('./results.ndjson', results.join('\n') + '\n')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update sirun benchmark variants to run in parallel.

### Motivation
<!-- What inspired you to submit this pull request? -->

Benchmarks can be slow, and running them in sequence takes a lot of time.