### PR TITLE
[ci-visibility] Add test start line

### DIFF
--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -13,7 +13,7 @@ const {
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const webAppServer = require('../ci-visibility/web-app-server')
-const { TEST_STATUS } = require('../../packages/dd-trace/src/plugins/util/test')
+const { TEST_STATUS, TEST_SOURCE_START } = require('../../packages/dd-trace/src/plugins/util/test')
 
 // TODO: remove when 2.x support is removed.
 // This is done because from playwright@>=1.22.0 node 12 is not supported
@@ -94,6 +94,10 @@ versions.forEach((version) => {
               'fail',
               'skip'
             ])
+
+            testEvents.forEach(testEvent => {
+              assert.exists(testEvent.content.metrics[TEST_SOURCE_START])
+            })
 
             stepEvents.forEach(stepEvent => {
               assert.equal(stepEvent.content.name, 'playwright.step')

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -90,12 +90,11 @@ function wrapRun (pl, isLatestVersion) {
       if (!pickleResultByFile[testSuiteFullPath]) { // first test in suite
         testSuiteStartCh.publish(testSuiteFullPath)
       }
-      let testSourceLine
-      try {
-        testSourceLine = this.gherkinDocument.feature.location.line
-      } catch (e) {
-        // ignore error
-      }
+
+      const testSourceLine = this.gherkinDocument &&
+        this.gherkinDocument.feature &&
+        this.gherkinDocument.feature.location &&
+        this.gherkinDocument.feature.location.line
 
       testStartCh.publish({
         testName: this.pickle.name,

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -90,7 +90,18 @@ function wrapRun (pl, isLatestVersion) {
       if (!pickleResultByFile[testSuiteFullPath]) { // first test in suite
         testSuiteStartCh.publish(testSuiteFullPath)
       }
-      testStartCh.publish({ testName: this.pickle.name, fullTestSuite: testSuiteFullPath })
+      let testSourceLine
+      try {
+        testSourceLine = this.gherkinDocument.feature.location.line
+      } catch (e) {
+        // ignore error
+      }
+
+      testStartCh.publish({
+        testName: this.pickle.name,
+        fullTestSuite: testSuiteFullPath,
+        testSourceLine
+      })
       try {
         const promise = run.apply(this, arguments)
         promise.finally(() => {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -5,7 +5,8 @@ const log = require('../../dd-trace/src/log')
 const {
   getCoveredFilenamesFromCoverage,
   JEST_WORKER_TRACE_PAYLOAD_CODE,
-  JEST_WORKER_COVERAGE_PAYLOAD_CODE
+  JEST_WORKER_COVERAGE_PAYLOAD_CODE,
+  getTestLineStart
 } = require('../../dd-trace/src/plugins/util/test')
 
 const testSessionStartCh = channel('ci:jest:session:start')
@@ -125,7 +126,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             suite: this.testSuite,
             runner: 'jest-circus',
             testParameters,
-            frameworkVersion: jestVersion
+            frameworkVersion: jestVersion,
+            testStartLine: getTestLineStart(event.test.asyncError, this.testSuite)
           })
           originalTestFns.set(event.test, event.test.fn)
           event.test.fn = asyncResource.bind(event.test.fn)
@@ -152,7 +154,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             name: getJestTestName(event.test),
             suite: this.testSuite,
             runner: 'jest-circus',
-            frameworkVersion: jestVersion
+            frameworkVersion: jestVersion,
+            testStartLine: getTestLineStart(event.test.asyncError, this.testSuite)
           })
         })
       }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -76,7 +76,7 @@ function getRootDir (playwrightRunner) {
 }
 
 function testBeginHandler (test) {
-  const { _requireFile: testSuiteAbsolutePath, title: testName, _type } = test
+  const { _requireFile: testSuiteAbsolutePath, title: testName, _type, location: { line: testSourceLine } } = test
 
   if (_type === 'beforeAll' || _type === 'afterAll') {
     return
@@ -96,7 +96,7 @@ function testBeginHandler (test) {
   const testAsyncResource = new AsyncResource('bound-anonymous-fn')
   testToAr.set(test, testAsyncResource)
   testAsyncResource.runInAsyncScope(() => {
-    testStartCh.publish({ testName, testSuiteAbsolutePath })
+    testStartCh.publish({ testName, testSuiteAbsolutePath, testSourceLine })
   })
 }
 

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -6,6 +6,7 @@ const { storage } = require('../../datadog-core')
 const {
   TEST_SKIP_REASON,
   TEST_STATUS,
+  TEST_SOURCE_START,
   finishAllTraceSpans,
   getTestSuitePath,
   getTestSuiteCommonTags,
@@ -80,10 +81,10 @@ class CucumberPlugin extends CiPlugin {
       this.tracer._exporter.exportCoverage(formattedCoverage)
     })
 
-    this.addSub('ci:cucumber:test:start', ({ testName, fullTestSuite }) => {
+    this.addSub('ci:cucumber:test:start', ({ testName, fullTestSuite, testSourceLine }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(fullTestSuite, this.sourceRoot)
-      const testSpan = this.startTestSpan(testName, testSuite)
+      const testSpan = this.startTestSpan(testName, testSuite, testSourceLine)
 
       this.enter(testSpan, store)
     })
@@ -130,11 +131,12 @@ class CucumberPlugin extends CiPlugin {
     })
   }
 
-  startTestSpan (testName, testSuite) {
+  startTestSpan (testName, testSuite, testSourceLine) {
     return super.startTestSpan(
       testName,
       testSuite,
-      this.testSuiteSpan
+      this.testSuiteSpan,
+      { [TEST_SOURCE_START]: testSourceLine }
     )
   }
 }

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -19,7 +19,8 @@ const {
   CI_APP_ORIGIN,
   TEST_SKIP_REASON,
   TEST_FRAMEWORK_VERSION,
-  LIBRARY_VERSION
+  LIBRARY_VERSION,
+  TEST_SOURCE_START
 } = require('../../dd-trace/src/plugins/util/test')
 
 const { version: ddTraceVersion } = require('../../../package.json')
@@ -98,6 +99,7 @@ describe('Plugin', function () {
             expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
             expect(testSpan.meta[TEST_SOURCE_FILE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('cucumber.test')
             expect(testSpan.resource.endsWith('simple.feature.pass scenario')).to.equal(true)
@@ -155,6 +157,7 @@ describe('Plugin', function () {
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
             expect(testSpan.meta[TEST_SOURCE_FILE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.type).to.equal('test')
             expect(testSpan.meta[COMPONENT]).to.equal('cucumber')
             expect(testSpan.name).to.equal('cucumber.test')
@@ -220,6 +223,7 @@ describe('Plugin', function () {
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
             expect(testSpan.meta[TEST_SOURCE_FILE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('cucumber.test')
             expect(testSpan.meta[COMPONENT]).to.equal('cucumber')
@@ -278,6 +282,7 @@ describe('Plugin', function () {
             })
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
             expect(testSpan.meta[TEST_SOURCE_FILE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('cucumber.test')
             expect(testSpan.meta[COMPONENT]).to.equal('cucumber')
@@ -377,6 +382,7 @@ describe('Plugin', function () {
             expect(testSpan.meta[COMPONENT]).to.equal('cucumber')
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
             expect(testSpan.meta[TEST_SOURCE_FILE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('cucumber.test')
             expect(testSpan.resource.endsWith('simple.feature.integration scenario')).to.equal(true)
@@ -440,6 +446,7 @@ describe('Plugin', function () {
             expect(testSpan.meta[COMPONENT]).to.equal('cucumber')
             expect(testSpan.meta[TEST_SUITE].endsWith('simple.feature')).to.equal(true)
             expect(testSpan.meta[TEST_SOURCE_FILE].endsWith('simple.feature')).to.equal(true)
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.type).to.equal('test')
             expect(testSpan.name).to.equal('cucumber.test')
             expect(testSpan.resource.endsWith('simple.feature.hooks fail')).to.equal(true)

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -16,6 +16,7 @@ const {
   TEST_SESSION_ID,
   TEST_COMMAND,
   TEST_MODULE,
+  TEST_SOURCE_START,
   finishAllTraceSpans
 } = require('../../dd-trace/src/plugins/util/test')
 
@@ -204,7 +205,7 @@ module.exports = (on, config) => {
       return activeSpan ? activeSpan.context().toTraceId() : null
     },
     'dd:afterEach': (test) => {
-      const { state, error, isRUMActive } = test
+      const { state, error, isRUMActive, testSourceLine } = test
       if (activeSpan) {
         activeSpan.setTag(TEST_STATUS, CYPRESS_STATUS_TO_TEST_STATUS[state])
         if (error) {
@@ -212,6 +213,9 @@ module.exports = (on, config) => {
         }
         if (isRUMActive) {
           activeSpan.setTag(TEST_IS_RUM_ACTIVE, 'true')
+        }
+        if (testSourceLine) {
+          activeSpan.setTag(TEST_SOURCE_START, testSourceLine)
         }
         activeSpan.finish()
       }

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -29,6 +29,10 @@ afterEach(() => {
       state: currentTest.state,
       error: currentTest.err,
     }
+    try {
+      testInfo.testSourceLine = Cypress.mocha.getRunner().currentRunnable.invocationDetails.line
+    } catch (e) {}
+
     if (win.DD_RUM) {
       testInfo.isRUMActive = true
     }

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -12,6 +12,7 @@ const {
   TEST_NAME,
   TEST_SUITE,
   TEST_SOURCE_FILE,
+  TEST_SOURCE_START,
   TEST_STATUS,
   TEST_IS_RUM_ACTIVE,
   CI_APP_ORIGIN,
@@ -84,6 +85,7 @@ describe('Plugin', function () {
             [COMPONENT]: 'cypress'
           })
           expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+          expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
         }, { timeoutMs: testTimeout })
         const failingTestPromise = agent.use(traces => {
           const testSpan = traces[0][0]
@@ -114,6 +116,7 @@ describe('Plugin', function () {
           expect(testSpan.meta[ERROR_MESSAGE]).to.contain(
             "expected '<div.hello-world>' to have text 'Bye World', but the text was 'Hello World'"
           )
+          expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
         }, { timeoutMs: testTimeout })
         Promise.all([passingTestPromise, failingTestPromise]).then(() => done()).catch(done)
       })

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -9,7 +9,8 @@ const {
   addIntelligentTestRunnerSpanTags,
   TEST_PARAMETERS,
   TEST_COMMAND,
-  TEST_FRAMEWORK_VERSION
+  TEST_FRAMEWORK_VERSION,
+  TEST_SOURCE_START
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -190,12 +191,13 @@ class JestPlugin extends CiPlugin {
   }
 
   startTestSpan (test) {
-    const { suite, name, runner, testParameters, frameworkVersion } = test
+    const { suite, name, runner, testParameters, frameworkVersion, testStartLine } = test
 
     const extraTags = {
       [JEST_TEST_RUNNER]: runner,
       [TEST_PARAMETERS]: testParameters,
-      [TEST_FRAMEWORK_VERSION]: frameworkVersion
+      [TEST_FRAMEWORK_VERSION]: frameworkVersion,
+      [TEST_SOURCE_START]: testStartLine
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -13,6 +13,7 @@ const {
   TEST_NAME,
   TEST_SUITE,
   TEST_SOURCE_FILE,
+  TEST_SOURCE_START,
   TEST_FRAMEWORK_VERSION,
   TEST_STATUS,
   CI_APP_ORIGIN,
@@ -170,6 +171,7 @@ describe('Plugin', function () {
               expect(testSpan.name).to.equal('jest.test')
               expect(testSpan.service).to.equal('test')
               expect(testSpan.resource).to.equal(`packages/datadog-plugin-jest/test/jest-test.js.${name}`)
+              expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
               expect(testSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
             }, {
               timeoutMs: assertionTimeout,

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -13,6 +13,7 @@ const {
   TEST_NAME,
   TEST_SUITE,
   TEST_SOURCE_FILE,
+  TEST_SOURCE_START,
   TEST_STATUS,
   TEST_PARAMETERS,
   CI_APP_ORIGIN,
@@ -164,6 +165,7 @@ describe('Plugin', () => {
               [ERROR_TYPE]: 'AssertionError',
               [ERROR_MESSAGE]: 'expected true to equal false'
             })
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
             expect(testSpan.parent_id.toString()).to.equal('0')
             expect(testSpan.meta[TEST_SUITE].endsWith('mocha-test-fail.js')).to.equal(true)
@@ -231,6 +233,7 @@ describe('Plugin', () => {
                 })
                 expect(testSpan.meta[ERROR_STACK]).not.to.be.undefined
               }
+              expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
               expect(testSpan.parent_id.toString()).to.equal('0')
               expect(testSpan.meta[TEST_SUITE].endsWith(test.fileName)).to.equal(true)
               expect(testSpan.type).to.equal('test')
@@ -264,6 +267,7 @@ describe('Plugin', () => {
               [TEST_SOURCE_FILE]: testSuite,
               [TEST_PARAMETERS]: JSON.stringify({ arguments: [1, 2, 3], metadata: {} })
             })
+            expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
             expect(testSpan.parent_id.toString()).to.equal('0')
             expect(testSpan.meta[TEST_SUITE].endsWith('mocha-test-parameterized.js')).to.equal(true)
             expect(testSpan.type).to.equal('test')
@@ -301,6 +305,7 @@ describe('Plugin', () => {
             [TEST_SUITE]: testSuite,
             [TEST_SOURCE_FILE]: testSuite
           })
+          expect(testSpan.metrics[TEST_SOURCE_START]).to.exist
         }).then(done, done)
 
         const mocha = new Mocha({

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -7,7 +7,8 @@ const {
   TEST_STATUS,
   finishAllTraceSpans,
   getTestSuitePath,
-  getTestSuiteCommonTags
+  getTestSuiteCommonTags,
+  TEST_SOURCE_START
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -64,10 +65,10 @@ class PlaywrightPlugin extends CiPlugin {
       span.finish()
     })
 
-    this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath }) => {
+    this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
-      const span = this.startTestSpan(testName, testSuite)
+      const span = this.startTestSpan(testName, testSuite, testSourceLine)
 
       this.enter(span, store)
     })
@@ -104,9 +105,9 @@ class PlaywrightPlugin extends CiPlugin {
     })
   }
 
-  startTestSpan (testName, testSuite) {
+  startTestSpan (testName, testSuite, testSourceLine) {
     const testSuiteSpan = this._testSuites.get(testSuite)
-    return super.startTestSpan(testName, testSuite, testSuiteSpan)
+    return super.startTestSpan(testName, testSuite, testSuiteSpan, { [TEST_SOURCE_START]: testSourceLine })
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
* Add `test.source.start`, the line at which a test is defined.

### Motivation
Allow users to see their test's source code in DataDog's UI, if they so desire. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

