### PR TITLE
Fix: router and http2

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "express": "^4.16.2",
+    "fetch-h2": "^3.0.2",
     "get-port": "^3.2.0",
     "glob": "^7.1.6",
     "graphql": "0.13.2",

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -79,7 +79,7 @@ class RouterPlugin extends WebPlugin {
       this._serverRequestFinish(req)
     })
   }
-  
+
   _serverRequestFinish (req) {
     const context = this._contexts.get(req)
 

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -72,16 +72,24 @@ class RouterPlugin extends WebPlugin {
     })
 
     this.addSub(`apm:http:server:request:finish`, ({ req }) => {
-      const context = this._contexts.get(req)
-
-      if (!context) return
-
-      let span
-
-      while ((span = context.middleware.pop())) {
-        span.finish()
-      }
+      this._serverRequestFinish(req)
     })
+
+    this.addSub(`apm:http2:server:request:finish`, ({ req }) => {
+      this._serverRequestFinish(req)
+    })
+  }
+  
+  _serverRequestFinish (req) {
+    const context = this._contexts.get(req)
+
+    if (!context) return
+
+    let span
+
+    while ((span = context.middleware.pop())) {
+      span.finish()
+    }
   }
 
   _getActive (req) {

--- a/packages/datadog-plugin-router/test/http1.spec.js
+++ b/packages/datadog-plugin-router/test/http1.spec.js
@@ -11,7 +11,7 @@ const web = require('../../dd-trace/src/plugins/util/web')
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
-describe('Plugin', () => {
+describe('Plugin with http/1.1 server', () => {
   let tracer
   let Router
   let appListener

--- a/packages/datadog-plugin-router/test/http2.spec.js
+++ b/packages/datadog-plugin-router/test/http2.spec.js
@@ -11,7 +11,6 @@
  * so we create a h2c server using http2.createServer and use fetch-h2 instead
  */
 const fetchH2 = require('fetch-h2').fetch
-const http2 = require('http2')
 const { once } = require('events')
 const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -21,6 +20,7 @@ const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toStrin
 
 describe('Plugin with http2 (h2c) server', () => {
   let tracer
+  let http2
   let Router
   let appListener
 
@@ -61,12 +61,8 @@ describe('Plugin with http2 (h2c) server', () => {
         })
 
         beforeEach(() => {
-          /**
-           * KLUDGE: Force loading of the http2 server plugin
-           * Router internally uses methods, which internally requires http
-           * so the http2 plugin was not being loaded
-           */
-          require('http2')
+          // Require http2 after agent loads the http2 plugin, so that it's instrumented
+          http2 = require('http2')
           Router = require(`../../../versions/router@${version}`).get()
         })
 

--- a/packages/datadog-plugin-router/test/http2.spec.js
+++ b/packages/datadog-plugin-router/test/http2.spec.js
@@ -1,0 +1,171 @@
+'use strict'
+
+// TODO: move tests from express since it uses the router plugin now
+
+/**
+ * Axios doesn't support http2. It relies on the server supporting http1 fallback
+ * Node uses ALPN, which is a TLS extension, to handle fallback
+ * so fallback / allowHTTP1:true is only supported when doing http2.createSecureServer
+ *
+ * We explicitly want to test for http2 and not worry about keys and certs
+ * so we create a h2c server using http2.createServer and use fetch-h2 instead
+ */
+const fetchH2 = require('fetch-h2').fetch
+const http2 = require('http2')
+const { once } = require('events')
+const getPort = require('get-port')
+const agent = require('../../dd-trace/test/plugins/agent')
+const web = require('../../dd-trace/src/plugins/util/web')
+
+const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
+
+describe('Plugin with http2 server', () => {
+  let tracer
+  let Router
+  let appListener
+
+  function defaultErrorHandler (req, res) {
+    return err => {
+      res.writeHead(err ? 500 : 404)
+      res.end()
+    }
+  }
+
+  function server (router, errorHandler = defaultErrorHandler) {
+    return http2.createServer((req, res) => {
+      const config = web.normalizeConfig({})
+
+      web.instrument(tracer, config, req, res, 'web.request')
+
+      return router(req, res, errorHandler(req, res))
+    })
+  }
+
+  describe('router', () => {
+    withVersions('router', 'router', version => {
+      beforeEach(() => {
+        tracer = require('../../dd-trace')
+      })
+
+      afterEach(() => {
+        appListener && appListener.close()
+      })
+
+      describe('without configuration', () => {
+        before(() => {
+          return agent.load(['http2', 'router'])
+        })
+
+        after(() => {
+          return agent.close({ ritmReset: false })
+        })
+
+        beforeEach(() => {
+          /**
+           * KLUDGE: Force loading of the http2 server plugin
+           * Router internally uses methods, which internally requires http
+           * so the http2 plugin was not being loaded
+           */
+          require('http2')
+          Router = require(`../../../versions/router@${version}`).get()
+        })
+
+        it('should copy custom prototypes on routers', () => {
+          const router = Router()
+          class ChildRouter extends Router {
+            get foo () {
+              return 'bar'
+            }
+          }
+          const childRouter = new ChildRouter()
+          childRouter.hello = 'goodbye'
+
+          childRouter.use('/child/:id', (req, res) => {
+            res.writeHead(200)
+            res.end()
+          })
+
+          router.use('/parent', childRouter)
+          expect(router.stack[0].handle.hello).to.equal('goodbye')
+          expect(router.stack[0].handle.foo).to.equal('bar')
+        })
+
+        it('should add the route to the request span', done => {
+          const router = Router()
+          const childRouter = Router()
+
+          childRouter.use('/child/:id', (req, res) => {
+            res.writeHead(200)
+            res.end()
+          })
+
+          router.use('/parent', childRouter)
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /parent/child/:id')
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server(router).listen(port, 'localhost', () => {
+              fetchH2(`http2://localhost:${port}/parent/child/123`)
+                .catch(done)
+            })
+          })
+        })
+
+        it('should not error a span when using next("route") with a string', async () => {
+          const router = Router()
+
+          router.use((req, res, next) => {
+            return next('route')
+          })
+          router.get('/foo', (req, res) => {
+            res.end()
+          })
+
+          const port = await getPort()
+          const agentPromise = agent.use(traces => {
+            for (const span of traces[0]) {
+              expect(span.error).to.equal(0)
+            }
+          }, { rejectFirst: true })
+
+          const httpd = server(router).listen(port, 'localhost')
+          await once(httpd, 'listening')
+          const reqPromise = fetchH2(`http2://localhost:${port}/foo`)
+
+          return Promise.all([agentPromise, reqPromise])
+        })
+
+        it('should not error a span when using next("router") with a string', async () => {
+          const router = Router()
+
+          router.use((req, res, next) => {
+            return next('router')
+          })
+          router.get('/foo', (req, res) => {
+            res.end()
+          })
+
+          const port = await getPort()
+          const agentPromise = agent.use(traces => {
+            for (const span of traces[0]) {
+              expect(span.error).to.equal(0)
+            }
+          }, { rejectFirst: true })
+
+          const httpd = server(router, (req, res) => err => res.end()).listen(port, 'localhost')
+          await once(httpd, 'listening')
+          const reqPromise = fetchH2(`http2://localhost:${port}/foo`)
+
+          return Promise.all([agentPromise, reqPromise])
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-router/test/http2.spec.js
+++ b/packages/datadog-plugin-router/test/http2.spec.js
@@ -19,7 +19,7 @@ const web = require('../../dd-trace/src/plugins/util/web')
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
-describe('Plugin with http2 server', () => {
+describe('Plugin with http2 (h2c) server', () => {
   let tracer
   let Router
   let appListener

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,6 +826,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/tough-cookie@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
+  integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+
 "@types/yoga-layout@1.9.2":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@types/yoga-layout/-/yoga-layout-1.9.2.tgz#efaf9e991a7390dc081a0b679185979a83a9639a"
@@ -871,6 +876,11 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+already@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/already/-/already-2.2.1.tgz#98c257baa0d3fe62d85163ff288235ba11e3f188"
+  integrity sha512-qk6RIVMS/R1yTvBzfIL1T76PsIL7DIVCINoLuFw2YXKLpLtsTobqdChMs8m3OhuPS3CEE3+Ra5ibYiqdyogbsQ==
 
 ansi-colors@4.1.1:
   version "4.1.1"
@@ -1177,6 +1187,11 @@ caller-path@^3.0.1:
   integrity sha512-fhmztL4wURO/BzwJUJ4aVRdnKEFskPBbrJ8fNgl7XdUiD1ygzzlt+nhPgUBSRq2ciEVubo6x+W8vJQzm55QLLQ==
   dependencies:
     caller-callsite "^4.1.0"
+
+callguard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callguard/-/callguard-2.0.0.tgz#32f98348ff82cb1dfcf7d1b198108cf4f5b64c1f"
+  integrity sha512-I3nd+fuj20FK1qu00ImrbH+II+8ULS6ioYr9igqR1xyqySoqc3DiHEyUM0mkoAdKeLGg2CtGnO8R3VRQX5krpQ==
 
 callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
@@ -2053,6 +2068,19 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fetch-h2@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fetch-h2/-/fetch-h2-3.0.2.tgz#9ac61967ccb821f80bc084c0c7201152ef1c9573"
+  integrity sha512-Lo6UPdMKKc9Ond7yjG2vq0mnocspOLh1oV6+XZdtfdexacvMSz5xm3WoQhTAdoR2+UqPlyMNqcqfecipoD+l/A==
+  dependencies:
+    "@types/tough-cookie" "^4.0.0"
+    already "^2.2.1"
+    callguard "^2.0.0"
+    get-stream "^6.0.1"
+    through2 "^4.0.2"
+    to-arraybuffer "^1.0.1"
+    tough-cookie "^4.0.0"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -2253,6 +2281,11 @@ get-port@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
   integrity sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==
+
+get-stream@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -3668,7 +3701,12 @@ proxyquire@^1.8.0:
     module-not-found-error "^1.0.0"
     resolve "~1.1.7"
 
-punycode@^2.0.0:
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+
+punycode@^2.0.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
@@ -3684,6 +3722,11 @@ qs@6.10.3:
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
   dependencies:
     side-channel "^1.0.4"
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3741,6 +3784,15 @@ react@^17.0.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+readable-stream@3:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.7"
@@ -3811,6 +3863,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -3901,7 +3958,7 @@ rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.1.0:
+safe-buffer@5.2.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -4173,6 +4230,13 @@ string.prototype.trimstart@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -4339,6 +4403,13 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+through2@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
+
 through@2, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -4348,6 +4419,11 @@ timestring@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/timestring/-/timestring-6.0.0.tgz#b0c7c331981ecf2066ce88bcfb8ee3ae32e7a0f6"
   integrity sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==
+
+to-arraybuffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+  integrity sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -4365,6 +4441,16 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+tough-cookie@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
+  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
 
 treport@^3.0.4:
   version "3.0.4"
@@ -4469,6 +4555,11 @@ unicode-length@^2.0.2:
   dependencies:
     punycode "^2.0.0"
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -4489,7 +4580,15 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-util-deprecate@~1.0.1:
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
+
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

We recently experimented with switching our express server to http2, and noticed that we weren't seeing a breakdown of the express requests under APM > Services anymore.

Dug into the code, and it looks like it's simply because the router plugin wasn't listening for the http2 server's requests finishing?

This PR should hopefully fix that issue?

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
