### PR TITLE
debugging the slack reporter, fixing slack link

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SLACK_REPORT_ENABLE: ${{ github.event.schedule }} # should be empty for non-nightly jobs
+  SLACK_REPORT_ENABLE: ${{ github.event.schedule }} # value is empty for non-nightly jobs
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  SLACK_MOREINFO: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  SLACK_MOREINFO: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 # TODO: upstream jobs
 

--- a/packages/dd-trace/test/setup/slack-report.js
+++ b/packages/dd-trace/test/setup/slack-report.js
@@ -5,6 +5,8 @@
  * This should help an on-call engineer quickly diagnose when an incompatibility was introduced.
  */
 
+/* eslint-disable no-console */
+
 const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK
 const SLACK_REPORT_ENABLE = process.env.SLACK_REPORT_ENABLE
 const SLACK_MOREINFO = process.env.SLACK_MOREINFO
@@ -28,14 +30,22 @@ const TIME_THRESHOLDS = [
  */
 module.exports = async (failures) => {
   if (!SLACK_REPORT_ENABLE) {
+    console.log('Slack Reporter is disabled')
     return
   }
+
+  console.log('Slack Reporter is enabled')
 
   if (!SLACK_WEBHOOK) {
     throw new Error('package reporting via slack webhook is enabled but misconfigured')
   }
 
   const packageNames = Object.keys(failures)
+
+  if (!packageNames.length) {
+    console.log('Slack Reporter has nothing to report')
+    return
+  }
 
   const descriptions = []
 


### PR DESCRIPTION
### What does this PR do?
- fixes the link to the failing report that is sent to slack. org name is contained in repo name
- adds some console statements to output

### Motivation
- nightly slack reporting isn't working as tedious is currently failing in master
- might be from a recent test refactor?