### PR TITLE
bump minimum node version for tedious

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -874,7 +874,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/14
+      - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - run: yarn test:plugins:upstream
       - uses: ./.github/actions/node/latest


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump minimum node version for `tedious`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Latest version of `tedious` dropped support for Node 16, failing our tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Ideally we would be able to pick different Node versions depending on the library version range, but this is not possible today and can be done in a separate PR.