### PR TITLE
Change meaning of b3 propagation mode from multiple header to single to match OTel

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,4 @@
 !package.json
 !cypress/**/*
 !ci/**/*
+!version.js

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -128,9 +128,8 @@ class TextMapPropagator {
   }
 
   _injectB3MultipleHeaders (spanContext, carrier) {
-    const hasB3 = this._hasPropagationStyle('inject', 'b3')
     const hasB3multi = this._hasPropagationStyle('inject', 'b3multi')
-    if (!(hasB3 || hasB3multi)) return
+    if (!hasB3multi) return
 
     carrier[b3TraceKey] = this._getB3TraceId(spanContext)
     carrier[b3SpanKey] = spanContext._spanId.toString(16)
@@ -146,8 +145,9 @@ class TextMapPropagator {
   }
 
   _injectB3SingleHeader (spanContext, carrier) {
+    const hasB3 = this._hasPropagationStyle('inject', 'b3')
     const hasB3SingleHeader = this._hasPropagationStyle('inject', 'b3 single header')
-    if (!hasB3SingleHeader) return null
+    if (!(hasB3 || hasB3SingleHeader)) return null
 
     const traceId = this._getB3TraceId(spanContext)
     const spanId = spanContext._spanId.toString(16)
@@ -216,10 +216,10 @@ class TextMapPropagator {
         case 'tracecontext':
           spanContext = this._extractTraceparentContext(carrier)
           break
-        case 'b3': // TODO: should match "b3 single header" in next major
         case 'b3multi':
           spanContext = this._extractB3MultiContext(carrier)
           break
+        case 'b3':
         case 'b3 single header': // TODO: delete in major after singular "b3"
           spanContext = this._extractB3SingleContext(carrier)
           break

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -9,6 +9,7 @@ const TraceState = require('../../../src/opentracing/propagation/tracestate')
 
 const { AUTO_KEEP, AUTO_REJECT, USER_KEEP } = require('../../../../../ext/priority')
 const { SAMPLING_MECHANISM_MANUAL } = require('../../../src/constants')
+const { MAJOR } = require('../../../../../version')
 const { expect } = require('chai')
 
 describe('TextMapPropagator', () => {
@@ -200,7 +201,7 @@ describe('TextMapPropagator', () => {
         }
       })
 
-      config.tracePropagationStyle.inject = ['b3multi']
+      config.tracePropagationStyle.inject = MAJOR >= 4 ? ['b3multi'] : ['b3']
 
       propagator.inject(spanContext, carrier)
 
@@ -222,7 +223,7 @@ describe('TextMapPropagator', () => {
         }
       })
 
-      config.tracePropagationStyle.inject = ['b3multi']
+      config.tracePropagationStyle.inject = MAJOR >= 4 ? ['b3multi'] : ['b3']
 
       propagator.inject(spanContext, carrier)
 
@@ -240,7 +241,7 @@ describe('TextMapPropagator', () => {
         }
       })
 
-      config.tracePropagationStyle.inject = ['b3multi']
+      config.tracePropagationStyle.inject = MAJOR >= 4 ? ['b3multi'] : ['b3']
 
       propagator.inject(spanContext, carrier)
 

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -200,7 +200,7 @@ describe('TextMapPropagator', () => {
         }
       })
 
-      config.tracePropagationStyle.inject = ['b3']
+      config.tracePropagationStyle.inject = ['b3multi']
 
       propagator.inject(spanContext, carrier)
 
@@ -222,7 +222,7 @@ describe('TextMapPropagator', () => {
         }
       })
 
-      config.tracePropagationStyle.inject = ['b3']
+      config.tracePropagationStyle.inject = ['b3multi']
 
       propagator.inject(spanContext, carrier)
 
@@ -240,7 +240,7 @@ describe('TextMapPropagator', () => {
         }
       })
 
-      config.tracePropagationStyle.inject = ['b3']
+      config.tracePropagationStyle.inject = ['b3multi']
 
       propagator.inject(spanContext, carrier)
 


### PR DESCRIPTION
### What does this PR do?

Changes the meaning of the "b3" option of header propagation styles from multi-header mode to single-header mode to match its meaning in the equivalent OTel configs.

### Motivation

To align with OTel user expectations so we don't cause any unnecessary confusion.
