### PR TITLE
use default node version in ci for setup action

### DIFF
--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -2,13 +2,12 @@ name: Node Setup
 runs:
   using: composite
   steps:
+    # https://github.com/actions/cache/issues/752#issuecomment-1222415717)
+    - name: "Use GNU tar instead BSD tar"
+      if: ${{ runner.os == 'Windows' }}
+      shell: cmd
+      run: copy /y C:\Program Files\Git\usr\bin\tar.exe C:\Windows\System32\tar.exe
     - uses: actions/setup-node@v3
-      if: ${{ runner.os != 'Windows' }}
       with:
         cache: yarn
-        node-version: '14'
-    # https://github.com/actions/cache/issues/752)
-    - uses: actions/setup-node@v3
-      if: ${{ runner.os == 'Windows' }}
-      with:
         node-version: '14'

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -2,12 +2,13 @@ name: Node Setup
 runs:
   using: composite
   steps:
-    # https://github.com/actions/cache/issues/752#issuecomment-1222415717)
-    - name: "Use GNU tar instead BSD tar"
-      if: ${{ runner.os == 'Windows' }}
-      shell: cmd
-      run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
     - uses: actions/setup-node@v3
+      if: ${{ runner.os != 'Windows' }}
       with:
         cache: yarn
+        node-version: '14'
+    # https://github.com/actions/cache/issues/752)
+    - uses: actions/setup-node@v3
+      if: ${{ runner.os == 'Windows' }}
+      with:
         node-version: '14'

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -2,8 +2,12 @@ name: Node Setup
 runs:
   using: composite
   steps:
+    # https://github.com/actions/cache/issues/752#issuecomment-1222415717)
+    - name: "Use GNU tar instead BSD tar"
+      if: ${{ runner.os == 'Windows' }}
+      shell: cmd
+      run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
     - uses: actions/setup-node@v3
       with:
         cache: yarn
-        enableCrossOsArchive: 'true'
         node-version: '14'

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -5,3 +5,5 @@ runs:
     - uses: actions/setup-node@v3
       with:
         cache: yarn
+        enableCrossOsArchive: 'true'
+        node-version: '14'

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -5,4 +5,3 @@ runs:
     - uses: actions/setup-node@v3
       with:
         cache: yarn
-        node-version: '14'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use default Node version in CI for setup action.

### Motivation
<!-- What inspired you to submit this pull request? -->

According to the documentation, this uses the already present version from PATH instead of actually installing. This won't change much in cases where we install specific versions, but it should speed up cases where the version doesn't matter, and also tests on Windows.