### PR TITLE
Removed amqp.delivery.state tag for v.4.0

### DIFF
--- a/packages/datadog-plugin-rhea/src/consumer.js
+++ b/packages/datadog-plugin-rhea/src/consumer.js
@@ -11,7 +11,6 @@ class RheaConsumerPlugin extends ConsumerPlugin {
 
     this.addTraceSub('dispatch', ({ state }) => {
       const span = storage.getStore().span
-      span.setTag('amqp.delivery.state', state)
     })
   }
 

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -60,7 +60,6 @@ describe('Plugin', () => {
                   'span.kind': 'producer',
                   'amqp.link.target.address': 'amq.topic',
                   'amqp.link.role': 'sender',
-                  'amqp.delivery.state': 'accepted',
                   'out.host': 'localhost',
                   'component': 'rhea'
                 })
@@ -558,9 +557,6 @@ function expectReceiving (agent, deliveryState, topic) {
       'amqp.link.role': 'receiver',
       'component': 'rhea'
     }
-    if (deliveryState) {
-      expectedMeta['amqp.delivery.state'] = deliveryState
-    }
     expect(span.meta).to.include(expectedMeta)
   }))
 }
@@ -582,9 +578,6 @@ function expectSending (agent, deliveryState, topic) {
       'amqp.link.target.address': topic,
       'amqp.link.role': 'sender',
       'component': 'rhea'
-    }
-    if (deliveryState) {
-      expectedMeta['amqp.delivery.state'] = deliveryState
     }
     expect(span.meta).to.include(expectedMeta)
   }))


### PR DESCRIPTION
### What does this PR do?
Removes the amqp.delivery.state tag for v4.0 release

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
