### PR TITLE
[docs] clarify disabling grahql signature caveat

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1166,8 +1166,8 @@ declare namespace plugins {
 
     /**
      * Whether to enable signature calculation for the resource name. This can
-     * be disabled if your GraphQL operations always have a name. Note that all
-     * queries will need to be named for this to work properly.
+     * be disabled if your GraphQL operations always have a name. Note that when
+     * disabled all queries will need to be named for this to work properly.
      *
      * @default true
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1166,7 +1166,8 @@ declare namespace plugins {
 
     /**
      * Whether to enable signature calculation for the resource name. This can
-     * be disabled if your GraphQL operations always have a name.
+     * be disabled if your GraphQL operations always have a name. Note that all
+     * queries will need to be named for this to work properly.
      *
      * @default true
      */


### PR DESCRIPTION
### What does this PR do?
- adds clarification to disabling graphql plugin signature

### Motivation
- internally saw a mention of this from an engineer for a customer