### PR TITLE
increase timeout for slow command injection analyzer test

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
@@ -5,7 +5,9 @@ const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
-describe('command injection analyzer', () => {
+describe('command injection analyzer', function () {
+  this.timeout(10000)
+
   prepareTestServerForIast('command injection analyzer',
     (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       testThatRequestHasVulnerability(() => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase timeout for slow command injection analyzer test.

### Motivation
<!-- What inspired you to submit this pull request? -->

This test fails often because it can take more than 2 seconds to run.