### PR TITLE
fix integration tests failing on node 12

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -45,7 +45,7 @@ const testFrameworks = [
   },
   {
     name: 'jest',
-    dependencies: [isOldNode ? 'jest@28' : 'jest', 'chai', 'jest-jasmine2'],
+    dependencies: [isOldNode ? 'jest@28' : 'jest', 'chai', isOldNode ? 'jest-jasmine2@28' : 'jest-jasmine2'],
     testFile: 'ci-visibility/run-jest.js',
     expectedStdout: 'Test Suites: 2 passed',
     expectedCoverageFiles: [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix integration tests failing on Node 12.

### Motivation
<!-- What inspired you to submit this pull request? -->

Similar to `jest`, `jest-jasmine2` also doesn't support Node 12 in recent versions.