### PR TITLE
Switch reliability env deploys to be scheduled

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,11 @@ include: ".gitlab/benchmarks.yml"
 
 deploy_to_reliability_env:
   stage: deploy
-  when: on_success
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
+      when: on_success
+    - when: manual
+      allow_failure: true
   trigger:
     project: DataDog/apm-reliability/datadog-reliability-env
   variables:
@@ -18,13 +22,10 @@ deploy_to_reliability_env:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
-    FORCE_TRIGGER: $FORCE_TRIGGER
 
 deploy_to_docker_registries:
   stage: deploy
   rules:
-    - if: '$POPULATE_CACHE'
-      when: never
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success
     - when: manual
@@ -43,8 +44,6 @@ deploy_to_docker_registries:
 deploy_latest_to_docker_registries:
   stage: deploy
   rules:
-    - if: '$POPULATE_CACHE'
-      when: never
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success
     - when: manual


### PR DESCRIPTION
### What does this PR do?
1) This PR changes reliability env deploys to only happen when scheduled or manually triggered.

2) `POPULATE_CACHE` is not used in this repo and was likely there from copy/pasting

### Motivation
Deploying on commits to the main branch are too noisy to see medium-term trends. Switching to a scheduled deploy should help.
