### PR TITLE
[ci-visibility][major][breaking-change] Remove support for `jest-jasmine2` 

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -22,6 +22,10 @@ for (const packageName of names) {
 
     hooks[packageName]()
 
+    if (!instrumentations[packageName]) {
+      return moduleExports
+    }
+
     for (const { name, file, versions, hook } of instrumentations[packageName]) {
       const fullFilename = filename(name, file)
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -1,7 +1,10 @@
 'use strict'
+const semver = require('semver')
+
 const { addHook, channel, AsyncResource } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 const log = require('../../dd-trace/src/log')
+const { version: ddTraceVersion } = require('../../../package.json')
 const {
   getCoveredFilenamesFromCoverage,
   JEST_WORKER_TRACE_PAYLOAD_CODE,
@@ -484,7 +487,12 @@ addHook({
   name: 'jest-jasmine2',
   versions: ['>=24.8.0'],
   file: 'build/jasmineAsyncInstall.js'
-}, jasmineAsyncInstallWraper)
+}, (jestJasmineAsyncInstallExport, jestVersion) => {
+  if (semver.gte(ddTraceVersion, '4')) {
+    return jestJasmineAsyncInstallExport
+  }
+  return jasmineAsyncInstallWraper(jestJasmineAsyncInstallExport, jestVersion)
+})
 
 addHook({
   name: 'jest-worker',

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -483,16 +483,13 @@ function jasmineAsyncInstallWraper (jasmineAsyncInstallExport, jestVersion) {
   }
 }
 
-addHook({
-  name: 'jest-jasmine2',
-  versions: ['>=24.8.0'],
-  file: 'build/jasmineAsyncInstall.js'
-}, (jestJasmineAsyncInstallExport, jestVersion) => {
-  if (semver.gte(ddTraceVersion, '4.0.0')) {
-    return jestJasmineAsyncInstallExport
-  }
-  return jasmineAsyncInstallWraper(jestJasmineAsyncInstallExport, jestVersion)
-})
+if (semver.lt(ddTraceVersion, '4.0.0')) {
+  addHook({
+    name: 'jest-jasmine2',
+    versions: ['>=24.8.0'],
+    file: 'build/jasmineAsyncInstall.js'
+  }, jasmineAsyncInstallWraper)
+}
 
 addHook({
   name: 'jest-worker',

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -488,7 +488,7 @@ addHook({
   versions: ['>=24.8.0'],
   file: 'build/jasmineAsyncInstall.js'
 }, (jestJasmineAsyncInstallExport, jestVersion) => {
-  if (semver.gte(ddTraceVersion, '4')) {
+  if (semver.gte(ddTraceVersion, '4.0.0')) {
     return jestJasmineAsyncInstallExport
   }
   return jasmineAsyncInstallWraper(jestJasmineAsyncInstallExport, jestVersion)

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -23,7 +23,7 @@ const {
 
 const { version: ddTraceVersion } = require('../../../package.json')
 
-const describeFunction = semver.gte(ddTraceVersion, '4.0.0') ? describe.skip : describe
+const describeFunction = semver.lt(ddTraceVersion, '4.0.0') ? describe : describe.skip
 
 describeFunction('Plugin', function () {
   this.retries(2)

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -23,7 +23,7 @@ const {
 
 const { version: ddTraceVersion } = require('../../../package.json')
 
-const describeFunction = semver.gte(ddTraceVersion, '4') ? describe.skip : describe
+const describeFunction = semver.gte(ddTraceVersion, '4.0.0') ? describe.skip : describe
 
 describeFunction('Plugin', function () {
   this.retries(2)

--- a/packages/datadog-plugin-jest/test/jasmine2.spec.js
+++ b/packages/datadog-plugin-jest/test/jasmine2.spec.js
@@ -2,6 +2,7 @@
 const fs = require('fs')
 const path = require('path')
 
+const semver = require('semver')
 const nock = require('nock')
 
 const { ORIGIN_KEY, COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -22,7 +23,9 @@ const {
 
 const { version: ddTraceVersion } = require('../../../package.json')
 
-describe('Plugin', function () {
+const describeFunction = semver.gte(ddTraceVersion, '4') ? describe.skip : describe
+
+describeFunction('Plugin', function () {
   this.retries(2)
   let jestExecutable
 


### PR DESCRIPTION
### What does this PR do?
Disable `jest-jasmine2` if `dd-trace` version is greater or equal than `4`.

### Motivation
* jest-jasmine2 is not going to get updates: jest-circus is the default test runner for jest since jest@27 (May 2021) and jest-jasmine2 was removed altogether from the jest bundle in jest@28 (Feb 2022). 
* Supporting test suite visibility in jest-jasmine2 has proven impossible, and future features are likely to have the same issue. 
* Maintaining two runners for the same framework increases complexity considerably. 


