### PR TITLE
Support array payloads in telemetry send-data

### DIFF
--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -1,13 +1,23 @@
 const request = require('../exporters/common/request')
 let seqId = 0
+
+function getPayload (payload) {
+  // Some telemetry endpoints payloads accept collections of elements such as the 'logs' endpoint.
+  // 'logs' request type payload is meant to send library logs to Datadog’s backend.
+  if (Array.isArray(payload)) {
+    return payload
+  } else {
+    const { logger, tags, serviceMapping, ...trimmedPayload } = payload
+    return trimmedPayload
+  }
+}
+
 function sendData (config, application, host, reqType, payload = {}) {
   const {
     hostname,
     port,
     url
   } = config
-
-  const { logger, tags, serviceMapping, ...trimmedPayload } = payload
 
   const options = {
     url,
@@ -27,7 +37,7 @@ function sendData (config, application, host, reqType, payload = {}) {
     tracer_time: Math.floor(Date.now() / 1000),
     runtime_id: config.tags['runtime-id'],
     seq_id: ++seqId,
-    payload: trimmedPayload,
+    payload: getPayload(payload),
     application,
     host
   })

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -48,4 +48,30 @@ describe('sendData', () => {
       port: undefined
     })
   })
+
+  it('should remove not wanted properties from a payload with object type', () => {
+    const payload = {
+      message: 'test',
+      logger: {},
+      tags: {},
+      serviceMapping: {}
+    }
+    sendDataModule.sendData({ tags: { 'runtime-id': '123' } }, 'test', 'test', 'req-type', payload)
+
+    expect(request).to.have.been.calledOnce
+    const data = JSON.parse(request.getCall(0).args[0])
+
+    const { logger, tags, serviceMapping, ...trimmedPayload } = payload
+    expect(data.payload).to.deep.equal(trimmedPayload)
+  })
+
+  it('should not destructure a payload with array type', () => {
+    const arrayPayload = [{ message: 'test' }, { message: 'test2' }]
+    sendDataModule.sendData({ tags: { 'runtime-id': '123' } }, 'test', 'test', 'req-type', arrayPayload)
+
+    expect(request).to.have.been.calledOnce
+    const data = JSON.parse(request.getCall(0).args[0])
+
+    expect(data.payload).to.deep.equal(arrayPayload)
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Adds support for sending telemetry payloads of the array type

### Motivation
The payload object destructuring performed in send-data to filter out unwanted properties was converting the array payloads to objects, and some telemetry endpoints like 'logs' specify a payload of the array type

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
