### PR TITLE
change dns kind from client to internal

### DIFF
--- a/packages/datadog-plugin-dns/src/lookup.js
+++ b/packages/datadog-plugin-dns/src/lookup.js
@@ -10,7 +10,7 @@ class DNSLookupPlugin extends ClientPlugin {
     this.startSpan('dns.lookup', {
       service: this.config.service,
       resource: hostname,
-      kind: 'client',
+      kind: 'internal',
       meta: {
         'dns.hostname': hostname,
         'dns.address': '',

--- a/packages/datadog-plugin-dns/src/lookup_service.js
+++ b/packages/datadog-plugin-dns/src/lookup_service.js
@@ -10,7 +10,7 @@ class DNSLookupServicePlugin extends ClientPlugin {
     this.startSpan('dns.lookup_service', {
       service: this.config.service,
       resource: `${address}:${port}`,
-      kind: 'client',
+      kind: 'internal',
       meta: {
         'dns.address': address
       },

--- a/packages/datadog-plugin-dns/src/resolve.js
+++ b/packages/datadog-plugin-dns/src/resolve.js
@@ -12,7 +12,7 @@ class DNSResolvePlugin extends ClientPlugin {
     this.startSpan('dns.resolve', {
       service: this.config.service,
       resource: `${rrtype} ${hostname}`,
-      kind: 'client',
+      kind: 'internal',
       meta: {
         'dns.hostname': hostname,
         'dns.rrtype': rrtype

--- a/packages/datadog-plugin-dns/src/reverse.js
+++ b/packages/datadog-plugin-dns/src/reverse.js
@@ -10,7 +10,7 @@ class DNSReversePlugin extends ClientPlugin {
     this.startSpan('dns.reverse', {
       service: this.config.service,
       resource: ip,
-      kind: 'client',
+      kind: 'internal',
       meta: {
         'dns.ip': ip
       }

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -32,7 +32,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'component': 'dns',
-            'span.kind': 'client',
+            'span.kind': 'internal',
             'dns.hostname': 'localhost',
             'dns.address': '127.0.0.1'
           })
@@ -53,7 +53,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'component': 'dns',
-            'span.kind': 'client',
+            'span.kind': 'internal',
             'dns.hostname': 'localhost',
             'dns.address': '127.0.0.1',
             'dns.addresses': '127.0.0.1,::1'
@@ -76,7 +76,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'component': 'dns',
-            'span.kind': 'client',
+            'span.kind': 'internal',
             'dns.hostname': 'fakedomain.faketld',
             [ERROR_TYPE]: 'Error',
             [ERROR_MESSAGE]: 'getaddrinfo ENOTFOUND fakedomain.faketld'
@@ -100,7 +100,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'component': 'dns',
-            'span.kind': 'client',
+            'span.kind': 'internal',
             'dns.address': '127.0.0.1'
           })
           expect(traces[0][0].metrics).to.deep.include({
@@ -123,7 +123,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'component': 'dns',
-            'span.kind': 'client',
+            'span.kind': 'internal',
             'dns.hostname': 'lvh.me',
             'dns.rrtype': 'A'
           })
@@ -144,7 +144,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'component': 'dns',
-            'span.kind': 'client',
+            'span.kind': 'internal',
             'dns.hostname': 'lvh.me',
             'dns.rrtype': 'ANY'
           })
@@ -165,7 +165,7 @@ describe('Plugin', () => {
           })
           expect(traces[0][0].meta).to.deep.include({
             'component': 'dns',
-            'span.kind': 'client',
+            'span.kind': 'internal',
             'dns.ip': '127.0.0.1'
           })
         })


### PR DESCRIPTION
### What does this PR do?
- this replaces the span `.kind` of DNS operations from `client` to `internal`

### Motivation
- we've had many users find them distracting and request that they be hidden

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [X] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
