### PR TITLE
drop support for next.js v9.5, v10.0, v10.1

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -643,7 +643,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14, 16]
-        range: ['>=9.5 <11.1', '>=11.1 <13.2', '>=13.2']
+        range: ['10.2', '>=11.1 <13.2', '>=13.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: next

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -168,7 +168,7 @@ addHook({ name: 'next', versions: ['>=11.1 <13.2'], file: 'dist/server/next-serv
   return nextServer
 })
 
-addHook({ name: 'next', versions: ['>=9.5 <11.1'], file: 'dist/next-server/server/next-server.js' }, nextServer => {
+addHook({ name: 'next', versions: ['>=10.2 <11.1'], file: 'dist/next-server/server/next-server.js' }, nextServer => {
   const Server = nextServer.default
 
   shimmer.wrap(Server.prototype, 'handleRequest', wrapHandleRequest)


### PR DESCRIPTION
### What does this PR do?
- drops support for next.js v9.5, v10.0, v10.1

### Motivation
- supporting these versions comes with some webpack related issues
  - usage of these versions is pretty low anyway

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js