### PR TITLE
Include send-data missing headers and organize telemetry config variables

### DIFF
--- a/packages/dd-trace/src/appsec/iast/telemetry/logs.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/logs.js
@@ -28,7 +28,7 @@ function sendLogs () {
 }
 
 function isLevelEnabled (level) {
-  return isLogCollectionEnabled(config) && (level !== 'DEBUG' || config.telemetry.debug)
+  return isLogCollectionEnabled(config) && (level !== 'DEBUG' || config.telemetry.diagnosticLogCollector)
 }
 
 function isLogCollectionEnabled (config) {

--- a/packages/dd-trace/src/appsec/iast/telemetry/logs.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/logs.js
@@ -28,7 +28,7 @@ function sendLogs () {
 }
 
 function isLevelEnabled (level) {
-  return isLogCollectionEnabled(config) && (level !== 'DEBUG' || config.telemetry.diagnosticLogCollection)
+  return isLogCollectionEnabled(config) && level !== 'DEBUG'
 }
 
 function isLogCollectionEnabled (config) {

--- a/packages/dd-trace/src/appsec/iast/telemetry/logs.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/logs.js
@@ -28,7 +28,7 @@ function sendLogs () {
 }
 
 function isLevelEnabled (level) {
-  return isLogCollectionEnabled(config) && (level !== 'DEBUG' || config.telemetry.diagnosticLogCollector)
+  return isLogCollectionEnabled(config) && (level !== 'DEBUG' || config.telemetry.diagnosticLogCollection)
 }
 
 function isLogCollectionEnabled (config) {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -200,8 +200,8 @@ class Config {
       process.env.DD_TRACE_TELEMETRY_ENABLED,
       !process.env.AWS_LAMBDA_FUNCTION_NAME
     )
-    const DD_TELEMETRY_DEBUG_ENABLED = coalesce(
-      process.env.DD_TELEMETRY_DEBUG_ENABLED,
+    const DD_TELEMETRY_DEBUG = coalesce(
+      process.env.DD_TELEMETRY_DEBUG,
       false
     )
     const DD_TRACE_AGENT_PROTOCOL_VERSION = coalesce(
@@ -375,6 +375,10 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       process.env.DD_TELEMETRY_LOG_COLLECTION_ENABLED,
       DD_IAST_ENABLED
     )
+    const DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = coalesce(
+      process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED,
+      false
+    )
 
     const defaultIastRequestSampling = 30
     const iastRequestSampling = coalesce(
@@ -489,7 +493,8 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.telemetry = {
       enabled: DD_TRACE_EXPORTER !== 'datadog' && isTrue(DD_TRACE_TELEMETRY_ENABLED),
       logCollection: isTrue(DD_TELEMETRY_LOG_COLLECTION_ENABLED),
-      debug: isTrue(DD_TELEMETRY_DEBUG_ENABLED)
+      diagnosticLogCollection: isTrue(DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED),
+      debug: isTrue(DD_TELEMETRY_DEBUG)
     }
     this.protocolVersion = DD_TRACE_AGENT_PROTOCOL_VERSION
     this.tagsHeaderMaxLength = parseInt(DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -378,10 +378,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       process.env.DD_TELEMETRY_LOG_COLLECTION_ENABLED,
       DD_IAST_ENABLED
     )
-    const DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = coalesce(
-      process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED,
-      false
-    )
 
     const defaultIastRequestSampling = 30
     const iastRequestSampling = coalesce(
@@ -497,7 +493,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       enabled: DD_TRACE_EXPORTER !== 'datadog' && isTrue(DD_TRACE_TELEMETRY_ENABLED),
       heartbeatInterval: DD_TELEMETRY_HEARTBEAT_INTERVAL,
       logCollection: isTrue(DD_TELEMETRY_LOG_COLLECTION_ENABLED),
-      diagnosticLogCollection: isTrue(DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED),
       debug: isTrue(DD_TELEMETRY_DEBUG)
     }
     this.protocolVersion = DD_TRACE_AGENT_PROTOCOL_VERSION

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -200,6 +200,9 @@ class Config {
       process.env.DD_TRACE_TELEMETRY_ENABLED,
       !process.env.AWS_LAMBDA_FUNCTION_NAME
     )
+    const DD_TELEMETRY_HEARTBEAT_INTERVAL = process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL
+      ? parseInt(process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL) * 1000
+      : 60000
     const DD_TELEMETRY_DEBUG = coalesce(
       process.env.DD_TELEMETRY_DEBUG,
       false
@@ -492,6 +495,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     // Disabled for CI Visibility's agentless
     this.telemetry = {
       enabled: DD_TRACE_EXPORTER !== 'datadog' && isTrue(DD_TRACE_TELEMETRY_ENABLED),
+      heartbeatInterval: DD_TELEMETRY_HEARTBEAT_INTERVAL,
       logCollection: isTrue(DD_TELEMETRY_LOG_COLLECTION_ENABLED),
       diagnosticLogCollection: isTrue(DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED),
       debug: isTrue(DD_TELEMETRY_DEBUG)

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -116,7 +116,7 @@ function start (aConfig, thePluginManager) {
   pluginManager = thePluginManager
   application = createAppObject()
   host = createHostObject()
-  heartbeatInterval = config.telemetry.heartbeatInterval || 60000
+  heartbeatInterval = config.telemetry.heartbeatInterval
 
   dependencies.start(config, application, host)
   sendData(config, application, host, 'app-started', appStarted())

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -6,10 +6,6 @@ const os = require('os')
 const dependencies = require('./dependencies')
 const { sendData } = require('./send-data')
 
-const HEARTBEAT_INTERVAL = process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL
-  ? Number(process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL) * 1000
-  : 60000
-
 const telemetryStartChannel = dc.channel('datadog:telemetry:start')
 const telemetryStopChannel = dc.channel('datadog:telemetry:stop')
 
@@ -19,6 +15,7 @@ let pluginManager
 let application
 let host
 let interval
+let heartbeatInterval
 const sentIntegrations = new Set()
 
 function getIntegrations () {
@@ -108,7 +105,7 @@ function createHostObject () {
 }
 
 function getTelemetryData () {
-  return { config, application, host, heartbeatInterval: HEARTBEAT_INTERVAL }
+  return { config, application, host, heartbeatInterval }
 }
 
 function start (aConfig, thePluginManager) {
@@ -119,11 +116,13 @@ function start (aConfig, thePluginManager) {
   pluginManager = thePluginManager
   application = createAppObject()
   host = createHostObject()
+  heartbeatInterval = config.telemetry.heartbeatInterval || 60000
+
   dependencies.start(config, application, host)
   sendData(config, application, host, 'app-started', appStarted())
   interval = setInterval(() => {
     sendData(config, application, host, 'app-heartbeat')
-  }, HEARTBEAT_INTERVAL)
+  }, heartbeatInterval)
   interval.unref()
   process.on('beforeExit', onBeforeExit)
 

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -1,9 +1,4 @@
 const request = require('../exporters/common/request')
-const { isTrue } = require('../util')
-
-const debug = process.env.DD_TELEMETRY_DEBUG
-  ? isTrue(process.env.DD_TELEMETRY_DEBUG)
-  : false
 
 function getHeaders (reqType, debug, application) {
   const headers = {
@@ -41,6 +36,7 @@ function sendData (config, application, host, reqType, payload = {}) {
     url
   } = config
 
+  const debug = config.telemetry && config.telemetry.debug
   const options = {
     url,
     hostname,

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -1,11 +1,12 @@
 const request = require('../exporters/common/request')
 
-function getHeaders (reqType, debug, application) {
+function getHeaders (config, application, reqType) {
   const headers = {
     'content-type': 'application/json',
     'dd-telemetry-api-version': 'v1',
     'dd-telemetry-request-type': reqType
   }
+  const debug = config.telemetry && config.telemetry.debug
   if (debug) {
     headers['dd-telemetry-debug-enabled'] = 'true'
   }
@@ -36,14 +37,13 @@ function sendData (config, application, host, reqType, payload = {}) {
     url
   } = config
 
-  const debug = config.telemetry && config.telemetry.debug
   const options = {
     url,
     hostname,
     port,
     method: 'POST',
     path: '/telemetry/proxy/api/v2/apmtelemetry',
-    headers: getHeaders(reqType, debug, application)
+    headers: getHeaders(config, application, reqType)
   }
   const data = JSON.stringify({
     api_version: 'v1',

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -2,16 +2,16 @@ const request = require('../exporters/common/request')
 
 function getHeaders (reqType, debug, application) {
   const headers = {
-    'Content-Type': 'application/json',
-    'DD-Telemetry-API-Version': 'v1',
-    'DD-Telemetry-Request-Type': reqType
+    'content-type': 'application/json',
+    'dd-telemetry-api-version': 'v1',
+    'dd-telemetry-request-type': reqType
   }
   if (debug) {
-    headers['DD-Telemetry-Debug-Enabled'] = 'true'
+    headers['dd-telemetry-debug-enabled'] = 'true'
   }
   if (application) {
-    headers['DD-Client-Library-Language'] = application.language_name
-    headers['DD-Client-Library-Version'] = application.tracer_version
+    headers['dd-client-library-language'] = application.language_name
+    headers['dd-client-library-version'] = application.tracer_version
   }
   return headers
 }

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -4,15 +4,13 @@ function getHeaders (config, application, reqType) {
   const headers = {
     'content-type': 'application/json',
     'dd-telemetry-api-version': 'v1',
-    'dd-telemetry-request-type': reqType
+    'dd-telemetry-request-type': reqType,
+    'dd-client-library-language': application.language_name,
+    'dd-client-library-version': application.tracer_version
   }
   const debug = config.telemetry && config.telemetry.debug
   if (debug) {
     headers['dd-telemetry-debug-enabled'] = 'true'
-  }
-  if (application) {
-    headers['dd-client-library-language'] = application.language_name
-    headers['dd-client-library-version'] = application.tracer_version
   }
   return headers
 }

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -1,4 +1,26 @@
 const request = require('../exporters/common/request')
+const { isTrue } = require('../util')
+
+const debug = process.env.DD_TELEMETRY_DEBUG
+  ? isTrue(process.env.DD_TELEMETRY_DEBUG)
+  : false
+
+function getHeaders (reqType, debug, application) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'DD-Telemetry-API-Version': 'v1',
+    'DD-Telemetry-Request-Type': reqType
+  }
+  if (debug) {
+    headers['DD-Telemetry-Debug-Enabled'] = 'true'
+  }
+  if (application) {
+    headers['DD-Client-Library-Language'] = application.language_name
+    headers['DD-Client-Library-Version'] = application.tracer_version
+  }
+  return headers
+}
+
 let seqId = 0
 
 function getPayload (payload) {
@@ -25,11 +47,7 @@ function sendData (config, application, host, reqType, payload = {}) {
     port,
     method: 'POST',
     path: '/telemetry/proxy/api/v2/apmtelemetry',
-    headers: {
-      'content-type': 'application/json',
-      'dd-telemetry-api-version': 'v1',
-      'dd-telemetry-request-type': reqType
-    }
+    headers: getHeaders(reqType, debug, application)
   }
   const data = JSON.stringify({
     api_version: 'v1',

--- a/packages/dd-trace/test/appsec/iast/iast-log.spec.js
+++ b/packages/dd-trace/test/appsec/iast/iast-log.spec.js
@@ -10,7 +10,7 @@ describe('IAST log', () => {
     config: {
       telemetry: {
         logCollection: true,
-        debug: true
+        diagnosticLogCollector: true
       }
     }
   }
@@ -19,7 +19,7 @@ describe('IAST log', () => {
     config: {
       telemetry: {
         logCollection: true,
-        debug: false
+        diagnosticLogCollector: false
       }
     }
   }

--- a/packages/dd-trace/test/appsec/iast/iast-log.spec.js
+++ b/packages/dd-trace/test/appsec/iast/iast-log.spec.js
@@ -6,20 +6,10 @@ const ddBasePath = calculateDDBasePath(__dirname)
 const EOL = '\n'
 
 describe('IAST log', () => {
-  const telemetryDebugConfig = {
-    config: {
-      telemetry: {
-        logCollection: true,
-        diagnosticLogCollection: true
-      }
-    }
-  }
-
   const telemetryDefaultConfig = {
     config: {
       telemetry: {
-        logCollection: true,
-        diagnosticLogCollection: false
+        logCollection: true
       }
     }
   }
@@ -75,81 +65,6 @@ describe('IAST log', () => {
   afterEach(() => {
     sinon.reset()
     telemetryLogs.stop()
-  })
-
-  describe('debug', () => {
-    it('should call log.debug', () => {
-      iastLog.debug('debug')
-
-      expect(log.debug).to.be.calledOnceWith('debug')
-    })
-
-    it('should call log.debug and not publish msg via telemetry', () => {
-      iastLog.debugAndPublish('debug')
-
-      expect(log.debug).to.be.calledOnceWith('debug')
-      expect(telemetryLogs.publish).to.not.be.called
-    })
-
-    it('should call log.debug and publish msg via telemetry', () => {
-      onTelemetryStart(telemetryDebugConfig)
-
-      iastLog.debugAndPublish('debug')
-
-      expect(log.debug).to.be.calledOnceWith('debug')
-      expect(telemetryLogs.publish).to.be.calledOnceWith({ message: 'debug', level: 'DEBUG' })
-    })
-
-    it('should chain multiple debug calls', () => {
-      onTelemetryStart(telemetryDebugConfig)
-
-      iastLog.debug('debug').debugAndPublish('debugAndPublish').debug('debug2')
-
-      expect(log.debug).to.be.calledThrice
-      expect(log.debug.getCall(0).args[0]).to.be.eq('debug')
-      expect(log.debug.getCall(1).args[0]).to.be.eq('debugAndPublish')
-      expect(log.debug.getCall(2).args[0]).to.be.eq('debug2')
-      expect(telemetryLogs.publish).to.be.calledOnceWith({ message: 'debugAndPublish', level: 'DEBUG' })
-    })
-
-    it('should chain multiple debug calls', () => {
-      onTelemetryStart(telemetryDebugConfig)
-
-      iastLog.debug('debug')
-
-      telemetryLogs.stop()
-
-      iastLog.debugAndPublish('debugAndPublish').debug('debug2')
-    })
-  })
-
-  describe('info', () => {
-    it('should call log.info', () => {
-      iastLog.info('info')
-
-      expect(log.info).to.be.calledOnceWith('info')
-    })
-
-    it('should call log.info and publish msg via telemetry', () => {
-      onTelemetryStart(telemetryDebugConfig)
-
-      iastLog.infoAndPublish('info')
-
-      expect(log.info).to.be.calledOnceWith('info')
-      expect(telemetryLogs.publish).to.be.calledOnceWith({ message: 'info', level: 'DEBUG' })
-    })
-
-    it('should chain multiple info calls', () => {
-      onTelemetryStart(telemetryDebugConfig)
-
-      iastLog.info('info').infoAndPublish('infoAndPublish').info('info2')
-
-      expect(log.info).to.be.calledThrice
-      expect(log.info.getCall(0).args[0]).to.be.eq('info')
-      expect(log.info.getCall(1).args[0]).to.be.eq('infoAndPublish')
-      expect(log.info.getCall(2).args[0]).to.be.eq('info2')
-      expect(telemetryLogs.publish).to.be.calledOnceWith({ message: 'infoAndPublish', level: 'DEBUG' })
-    })
   })
 
   describe('warn', () => {

--- a/packages/dd-trace/test/appsec/iast/iast-log.spec.js
+++ b/packages/dd-trace/test/appsec/iast/iast-log.spec.js
@@ -10,7 +10,7 @@ describe('IAST log', () => {
     config: {
       telemetry: {
         logCollection: true,
-        diagnosticLogCollector: true
+        diagnosticLogCollection: true
       }
     }
   }
@@ -19,7 +19,7 @@ describe('IAST log', () => {
     config: {
       telemetry: {
         logCollection: true,
-        diagnosticLogCollector: false
+        diagnosticLogCollection: false
       }
     }
   }

--- a/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
@@ -134,7 +134,7 @@ describe('telemetry logs', () => {
     const app = {}
     const host = {}
 
-    it('should be called with DEBUG level and error if config.telemetry.diagnosticLogCollector = true', () => {
+    it('should be called with DEBUG level and error if config.telemetry.diagnosticLogCollection = true', () => {
       const logCollectorAdd = sinon.stub()
       const logs = proxyquire('../../../../src/appsec/iast/telemetry/logs', {
         '../../../../../diagnostics_channel': dc,
@@ -144,7 +144,7 @@ describe('telemetry logs', () => {
       })
       logs.start()
 
-      onTelemetryStartMsg.config.telemetry.diagnosticLogCollector = true
+      onTelemetryStartMsg.config.telemetry.diagnosticLogCollection = true
       onTelemetryStartMsg.application = app
       onTelemetryStartMsg.host = host
       onTelemetryStart()(onTelemetryStartMsg)
@@ -156,7 +156,7 @@ describe('telemetry logs', () => {
       expect(logCollectorAdd).to.be.calledOnceWith(match({ message: 'test', level: 'DEBUG', stack_trace: stack }))
     })
 
-    it('should be not called with DEBUG level if config.telemetry.diagnosticLogCollector = false', () => {
+    it('should be not called with DEBUG level if config.telemetry.diagnosticLogCollection = false', () => {
       const logCollectorAdd = sinon.stub()
       const logs = proxyquire('../../../../src/appsec/iast/telemetry/logs', {
         '../../../../../diagnostics_channel': dc,

--- a/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
@@ -134,7 +134,7 @@ describe('telemetry logs', () => {
     const app = {}
     const host = {}
 
-    it('should be called with DEBUG level and error if config.telemetry.debug = true', () => {
+    it('should be called with DEBUG level and error if config.telemetry.diagnosticLogCollector = true', () => {
       const logCollectorAdd = sinon.stub()
       const logs = proxyquire('../../../../src/appsec/iast/telemetry/logs', {
         '../../../../../diagnostics_channel': dc,
@@ -144,7 +144,7 @@ describe('telemetry logs', () => {
       })
       logs.start()
 
-      onTelemetryStartMsg.config.telemetry.debug = true
+      onTelemetryStartMsg.config.telemetry.diagnosticLogCollector = true
       onTelemetryStartMsg.application = app
       onTelemetryStartMsg.host = host
       onTelemetryStart()(onTelemetryStartMsg)
@@ -156,7 +156,7 @@ describe('telemetry logs', () => {
       expect(logCollectorAdd).to.be.calledOnceWith(match({ message: 'test', level: 'DEBUG', stack_trace: stack }))
     })
 
-    it('should be not called with DEBUG level if config.telemetry.debug = false', () => {
+    it('should be not called with DEBUG level if config.telemetry.diagnosticLogCollector = false', () => {
       const logCollectorAdd = sinon.stub()
       const logs = proxyquire('../../../../src/appsec/iast/telemetry/logs', {
         '../../../../../diagnostics_channel': dc,

--- a/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
@@ -131,32 +131,7 @@ describe('telemetry logs', () => {
   })
 
   describe('sendData', () => {
-    const app = {}
-    const host = {}
-
-    it('should be called with DEBUG level and error if config.telemetry.diagnosticLogCollection = true', () => {
-      const logCollectorAdd = sinon.stub()
-      const logs = proxyquire('../../../../src/appsec/iast/telemetry/logs', {
-        '../../../../../diagnostics_channel': dc,
-        './log_collector': {
-          add: logCollectorAdd
-        }
-      })
-      logs.start()
-
-      onTelemetryStartMsg.config.telemetry.diagnosticLogCollection = true
-      onTelemetryStartMsg.application = app
-      onTelemetryStartMsg.host = host
-      onTelemetryStart()(onTelemetryStartMsg)
-
-      const error = new Error('test')
-      const stack = error.stack
-      logs.publish({ message: error.message, stack_trace: stack, level: 'DEBUG' })
-
-      expect(logCollectorAdd).to.be.calledOnceWith(match({ message: 'test', level: 'DEBUG', stack_trace: stack }))
-    })
-
-    it('should be not called with DEBUG level if config.telemetry.diagnosticLogCollection = false', () => {
+    it('should be not called with DEBUG level', () => {
       const logCollectorAdd = sinon.stub()
       const logs = proxyquire('../../../../src/appsec/iast/telemetry/logs', {
         '../../../../../diagnostics_channel': dc,

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -787,6 +787,7 @@ describe('Config', () => {
     expect(config.telemetry).to.not.be.undefined
     expect(config.telemetry.enabled).to.be.true
     expect(config.telemetry.logCollection).to.be.false
+    expect(config.telemetry.diagnosticLogCollection).to.be.false
     expect(config.telemetry.debug).to.be.false
   })
 
@@ -823,15 +824,26 @@ describe('Config', () => {
     process.env.DD_IAST_ENABLED = origIastEnabledValue
   })
 
-  it('should set DD_TELEMETRY_DEBUG_ENABLED', () => {
-    const origTelemetryDebugValue = process.env.DD_TELEMETRY_DEBUG_ENABLED
-    process.env.DD_TELEMETRY_DEBUG_ENABLED = 'true'
+  it('should set DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = true', () => {
+    const origDiagnosticLogCollectionValue = process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED
+    process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = 'true'
+
+    const config = new Config()
+
+    expect(config.telemetry.diagnosticLogCollection).to.be.true
+
+    process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = origDiagnosticLogCollectionValue
+  })
+
+  it('should set DD_TELEMETRY_DEBUG', () => {
+    const origTelemetryDebugValue = process.env.DD_TELEMETRY_DEBUG
+    process.env.DD_TELEMETRY_DEBUG = 'true'
 
     const config = new Config()
 
     expect(config.telemetry.debug).to.be.true
 
-    process.env.DD_TELEMETRY_DEBUG_ENABLED = origTelemetryDebugValue
+    process.env.DD_TELEMETRY_DEBUG = origTelemetryDebugValue
   })
 
   it('should not set DD_REMOTE_CONFIGURATION_ENABLED if AWS_LAMBDA_FUNCTION_NAME is present', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -786,9 +786,21 @@ describe('Config', () => {
 
     expect(config.telemetry).to.not.be.undefined
     expect(config.telemetry.enabled).to.be.true
+    expect(config.telemetry.heartbeatInterval).to.be.eq(60000)
     expect(config.telemetry.logCollection).to.be.false
     expect(config.telemetry.diagnosticLogCollection).to.be.false
     expect(config.telemetry.debug).to.be.false
+  })
+
+  it('should not set DD_TELEMETRY_HEARTBEAT_INTERVAL', () => {
+    const origTelemetryHeartbeatIntervalValue = process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL
+    process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL = '42'
+
+    const config = new Config()
+
+    expect(config.telemetry.heartbeatInterval).to.be.eq(42000)
+
+    process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL = origTelemetryHeartbeatIntervalValue
   })
 
   it('should not set DD_TRACE_TELEMETRY_ENABLED', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -788,7 +788,6 @@ describe('Config', () => {
     expect(config.telemetry.enabled).to.be.true
     expect(config.telemetry.heartbeatInterval).to.eq(60000)
     expect(config.telemetry.logCollection).to.be.false
-    expect(config.telemetry.diagnosticLogCollection).to.be.false
     expect(config.telemetry.debug).to.be.false
   })
 
@@ -834,17 +833,6 @@ describe('Config', () => {
     expect(config.telemetry.logCollection).to.be.true
 
     process.env.DD_IAST_ENABLED = origIastEnabledValue
-  })
-
-  it('should set DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = true', () => {
-    const origDiagnosticLogCollectionValue = process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED
-    process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = 'true'
-
-    const config = new Config()
-
-    expect(config.telemetry.diagnosticLogCollection).to.be.true
-
-    process.env.DD_TELEMETRY_DIAGNOSTIC_LOG_COLLECTION_ENABLED = origDiagnosticLogCollectionValue
   })
 
   it('should set DD_TELEMETRY_DEBUG', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -786,19 +786,19 @@ describe('Config', () => {
 
     expect(config.telemetry).to.not.be.undefined
     expect(config.telemetry.enabled).to.be.true
-    expect(config.telemetry.heartbeatInterval).to.be.eq(60000)
+    expect(config.telemetry.heartbeatInterval).to.eq(60000)
     expect(config.telemetry.logCollection).to.be.false
     expect(config.telemetry.diagnosticLogCollection).to.be.false
     expect(config.telemetry.debug).to.be.false
   })
 
-  it('should not set DD_TELEMETRY_HEARTBEAT_INTERVAL', () => {
+  it('should set DD_TELEMETRY_HEARTBEAT_INTERVAL', () => {
     const origTelemetryHeartbeatIntervalValue = process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL
     process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL = '42'
 
     const config = new Config()
 
-    expect(config.telemetry.heartbeatInterval).to.be.eq(42000)
+    expect(config.telemetry.heartbeatInterval).to.eq(42000)
 
     process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL = origTelemetryHeartbeatIntervalValue
   })

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -64,7 +64,7 @@ describe('telemetry', () => {
     circularObject.child.parent = circularObject
 
     telemetry.start({
-      telemetry: { enabled: true },
+      telemetry: { enabled: true, heartbeatInterval: 60000 },
       hostname: 'localhost',
       port: traceAgent.address().port,
       service: 'test service',
@@ -154,7 +154,7 @@ describe('telemetry', () => {
       expect.fail('server should not be called')
     }).listen(0, () => {
       telemetry.start({
-        telemetry: { enabled: false },
+        telemetry: { enabled: false, heartbeatInterval: 60000 },
         hostname: 'localhost',
         port: server.address().port
       })
@@ -169,8 +169,6 @@ describe('telemetry', () => {
 
 describe('telemetry with interval change', () => {
   it('should set the interval correctly', (done) => {
-    process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL = 12345
-
     const telemetry = proxyquire('../../src/telemetry', {
       '../exporters/common/docker': {
         id () {
@@ -190,7 +188,7 @@ describe('telemetry with interval change', () => {
     }
 
     telemetry.start({
-      telemetry: { enabled: true },
+      telemetry: { enabled: true, heartbeatInterval: 12345000 },
       hostname: 'localhost',
       port: 8126,
       service: 'test service',
@@ -205,7 +203,6 @@ describe('telemetry with interval change', () => {
 
     process.nextTick(() => {
       expect(intervalSetCorrectly).to.be.true
-      delete process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL
       done()
     })
   })

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -19,8 +19,12 @@ describe('sendData', () => {
   })
 
   it('should call to request (TCP)', () => {
-    sendDataModule.sendData({ hostname: '', port: '12345', tags: { 'runtime-id': '123' } },
-      application, 'test', 'req-type')
+    sendDataModule.sendData({
+      hostname: '',
+      port: '12345',
+      tags: { 'runtime-id': '123' }
+    },
+    application, 'test', 'req-type')
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
 
@@ -41,8 +45,11 @@ describe('sendData', () => {
   })
 
   it('should call to request (UDP)', () => {
-    sendDataModule.sendData({ url: 'unix:/foo/bar/baz', tags: { 'runtime-id': '123' } },
-      application, 'test', 'req-type')
+    sendDataModule.sendData({
+      url: 'unix:/foo/bar/baz',
+      tags: { 'runtime-id': '123' }
+    },
+    application, 'test', 'req-type')
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
 
@@ -63,14 +70,12 @@ describe('sendData', () => {
   })
 
   it('should add debug header if DD_TELEMETRY_DEBUG is present', () => {
-    sendDataModule = proxyquire('../../src/telemetry/send-data', {
-      '../exporters/common/request': request
-    })
-
-    sendDataModule.sendData({ url: '/test',
+    sendDataModule.sendData({
+      url: '/test',
       tags: { 'runtime-id': '123' },
       telemetry: { debug: true }
-    }, application, 'test', 'req-type')
+    },
+    application, 'test', 'req-type')
 
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -23,8 +23,8 @@ describe('sendData', () => {
       hostname: '',
       port: '12345',
       tags: { 'runtime-id': '123' }
-    },
-    application, 'test', 'req-type')
+    }, application, 'test', 'req-type')
+
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
 
@@ -32,11 +32,11 @@ describe('sendData', () => {
       method: 'POST',
       path: '/telemetry/proxy/api/v2/apmtelemetry',
       headers: {
-        'Content-Type': 'application/json',
-        'DD-Telemetry-API-Version': 'v1',
-        'DD-Telemetry-Request-Type': 'req-type',
-        'DD-Client-Library-Language': application.language_name,
-        'DD-Client-Library-Version': application.tracer_version
+        'content-type': 'application/json',
+        'dd-telemetry-api-version': 'v1',
+        'dd-telemetry-request-type': 'req-type',
+        'dd-client-library-language': application.language_name,
+        'dd-client-library-version': application.tracer_version
       },
       url: undefined,
       hostname: '',
@@ -48,8 +48,8 @@ describe('sendData', () => {
     sendDataModule.sendData({
       url: 'unix:/foo/bar/baz',
       tags: { 'runtime-id': '123' }
-    },
-    application, 'test', 'req-type')
+    }, application, 'test', 'req-type')
+
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
 
@@ -57,11 +57,11 @@ describe('sendData', () => {
       method: 'POST',
       path: '/telemetry/proxy/api/v2/apmtelemetry',
       headers: {
-        'Content-Type': 'application/json',
-        'DD-Telemetry-API-Version': 'v1',
-        'DD-Telemetry-Request-Type': 'req-type',
-        'DD-Client-Library-Language': application.language_name,
-        'DD-Client-Library-Version': application.tracer_version
+        'content-type': 'application/json',
+        'dd-telemetry-api-version': 'v1',
+        'dd-telemetry-request-type': 'req-type',
+        'dd-client-library-language': application.language_name,
+        'dd-client-library-version': application.tracer_version
       },
       url: 'unix:/foo/bar/baz',
       hostname: undefined,
@@ -74,8 +74,7 @@ describe('sendData', () => {
       url: '/test',
       tags: { 'runtime-id': '123' },
       telemetry: { debug: true }
-    },
-    application, 'test', 'req-type')
+    }, application, 'test', 'req-type')
 
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
@@ -84,12 +83,12 @@ describe('sendData', () => {
       method: 'POST',
       path: '/telemetry/proxy/api/v2/apmtelemetry',
       headers: {
-        'Content-Type': 'application/json',
-        'DD-Telemetry-API-Version': 'v1',
-        'DD-Telemetry-Request-Type': 'req-type',
-        'DD-Telemetry-Debug-Enabled': 'true',
-        'DD-Client-Library-Language': application.language_name,
-        'DD-Client-Library-Version': application.tracer_version
+        'content-type': 'application/json',
+        'dd-telemetry-api-version': 'v1',
+        'dd-telemetry-request-type': 'req-type',
+        'dd-telemetry-debug-enabled': 'true',
+        'dd-client-library-language': application.language_name,
+        'dd-client-library-version': application.tracer_version
       },
       url: '/test',
       hostname: undefined,

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -4,6 +4,11 @@ require('../setup/tap')
 
 const proxyquire = require('proxyquire')
 describe('sendData', () => {
+  const application = {
+    language_name: 'nodejs',
+    tracer_version: 'version'
+  }
+
   let sendDataModule
   let request
   beforeEach(() => {
@@ -12,8 +17,10 @@ describe('sendData', () => {
       '../exporters/common/request': request
     })
   })
+
   it('should call to request (TCP)', () => {
-    sendDataModule.sendData({ hostname: '', port: '12345', tags: { 'runtime-id': '123' } }, 'test', 'test', 'req-type')
+    sendDataModule.sendData({ hostname: '', port: '12345', tags: { 'runtime-id': '123' } },
+      application, 'test', 'req-type')
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
 
@@ -21,17 +28,21 @@ describe('sendData', () => {
       method: 'POST',
       path: '/telemetry/proxy/api/v2/apmtelemetry',
       headers: {
-        'content-type': 'application/json',
-        'dd-telemetry-api-version': 'v1',
-        'dd-telemetry-request-type': 'req-type'
+        'Content-Type': 'application/json',
+        'DD-Telemetry-API-Version': 'v1',
+        'DD-Telemetry-Request-Type': 'req-type',
+        'DD-Client-Library-Language': application.language_name,
+        'DD-Client-Library-Version': application.tracer_version
       },
       url: undefined,
       hostname: '',
       port: '12345'
     })
   })
+
   it('should call to request (UDP)', () => {
-    sendDataModule.sendData({ url: 'unix:/foo/bar/baz', tags: { 'runtime-id': '123' } }, 'test', 'test', 'req-type')
+    sendDataModule.sendData({ url: 'unix:/foo/bar/baz', tags: { 'runtime-id': '123' } },
+      application, 'test', 'req-type')
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
 
@@ -39,14 +50,47 @@ describe('sendData', () => {
       method: 'POST',
       path: '/telemetry/proxy/api/v2/apmtelemetry',
       headers: {
-        'content-type': 'application/json',
-        'dd-telemetry-api-version': 'v1',
-        'dd-telemetry-request-type': 'req-type'
+        'Content-Type': 'application/json',
+        'DD-Telemetry-API-Version': 'v1',
+        'DD-Telemetry-Request-Type': 'req-type',
+        'DD-Client-Library-Language': application.language_name,
+        'DD-Client-Library-Version': application.tracer_version
       },
       url: 'unix:/foo/bar/baz',
       hostname: undefined,
       port: undefined
     })
+  })
+
+  it('should add debug header if DD_TELEMETRY_DEBUG is present', () => {
+    const orig = process.env.DD_TELEMETRY_DEBUG
+    process.env.DD_TELEMETRY_DEBUG = 'true'
+
+    sendDataModule = proxyquire('../../src/telemetry/send-data', {
+      '../exporters/common/request': request
+    })
+
+    sendDataModule.sendData({ url: '/test', tags: { 'runtime-id': '123' } }, application, 'test', 'req-type')
+    expect(request).to.have.been.calledOnce
+    const options = request.getCall(0).args[1]
+
+    expect(options).to.deep.equal({
+      method: 'POST',
+      path: '/telemetry/proxy/api/v2/apmtelemetry',
+      headers: {
+        'Content-Type': 'application/json',
+        'DD-Telemetry-API-Version': 'v1',
+        'DD-Telemetry-Request-Type': 'req-type',
+        'DD-Telemetry-Debug-Enabled': 'true',
+        'DD-Client-Library-Language': application.language_name,
+        'DD-Client-Library-Version': application.tracer_version
+      },
+      url: '/test',
+      hostname: undefined,
+      port: undefined
+    })
+
+    process.env.DD_TELEMETRY_DEBUG = orig
   })
 
   it('should remove not wanted properties from a payload with object type', () => {

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -63,14 +63,15 @@ describe('sendData', () => {
   })
 
   it('should add debug header if DD_TELEMETRY_DEBUG is present', () => {
-    const orig = process.env.DD_TELEMETRY_DEBUG
-    process.env.DD_TELEMETRY_DEBUG = 'true'
-
     sendDataModule = proxyquire('../../src/telemetry/send-data', {
       '../exporters/common/request': request
     })
 
-    sendDataModule.sendData({ url: '/test', tags: { 'runtime-id': '123' } }, application, 'test', 'req-type')
+    sendDataModule.sendData({ url: '/test',
+      tags: { 'runtime-id': '123' },
+      telemetry: { debug: true }
+    }, application, 'test', 'req-type')
+
     expect(request).to.have.been.calledOnce
     const options = request.getCall(0).args[1]
 
@@ -89,8 +90,6 @@ describe('sendData', () => {
       hostname: undefined,
       port: undefined
     })
-
-    process.env.DD_TELEMETRY_DEBUG = orig
   })
 
   it('should remove not wanted properties from a payload with object type', () => {


### PR DESCRIPTION
### What does this PR do?
- Include `dd-client-library-language` and `dd-client-library-version` headers
- Move `DD_TELEMETRY_HEARTBEAT_INTERVAL` to `config.js`


### Motivation
Some system-tests will check them

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
