### PR TITLE
[ci-visibility] Fix `playwright` integration tests

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -72,6 +72,9 @@ function getRootDir (playwrightRunner) {
   if (playwrightRunner._configDir) {
     return playwrightRunner._configDir
   }
+  if (playwrightRunner._config && playwrightRunner._config.config) {
+    return playwrightRunner._config.config.rootDir
+  }
   return process.cwd()
 }
 


### PR DESCRIPTION
### What does this PR do?
Correctly extract `rootDir`, the root directory for the tests, when the version of playwright is >=1.33.0. 

### Motivation
With [playwright@1.33.0](https://github.com/microsoft/playwright/releases/tag/v1.33.0) and internal class changed its shape so we were not extracting root directory correctly.
 
