### PR TITLE
Tedious - service naming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,10 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
   mssql:
-    image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+  # A working MSSQL server is not available on ARM.
+  # This image provides _most_ of sqlserver functionalities, but
+  # does not support stored procedures (corresponding tests will fail)
+    image: mcr.microsoft.com/mssql/azure-sql-edge
     environment:
       - "ACCEPT_EULA=Y"
       - "SA_PASSWORD=DD_HUNTER2"

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -9,8 +9,8 @@ class TediousPlugin extends DatabasePlugin {
   static get system () { return 'mssql' }
 
   start ({ queryOrProcedure, connectionConfig }) {
-    this.startSpan('tedious.request', {
-      service: this.config.service,
+    this.startSpan(this.operationName(), {
+      service: this.serviceName(this.config, this.system),
       resource: queryOrProcedure,
       type: 'sql',
       kind: 'client',

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const namingSchema = require('./naming')
 
 const MSSQL_USERNAME = 'sa'
 const MSSQL_PASSWORD = 'DD_HUNTER2'
@@ -70,6 +71,18 @@ describe('Plugin', () => {
           connection.close()
         }
       })
+
+      withNamingSchema(
+        done => {
+          const query = 'SELECT 1 + 1 AS solution'
+          const request = new tds.Request(query, (err) => {
+            if (err) return done(err)
+          })
+          connection.execSql(request)
+        },
+        () => namingSchema.client.opName,
+        () => namingSchema.client.serviceName
+      )
 
       describe('with tedious disabled', () => {
         beforeEach(() => {

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -123,8 +123,8 @@ describe('Plugin', () => {
 
         const promise = agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'tedious.request')
-            expect(traces[0][0]).to.have.property('service', 'test-mssql')
+            expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
+            expect(traces[0][0]).to.have.property('service', namingSchema.client.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
             expect(traces[0][0]).to.have.property('type', 'sql')
             expect(traces[0][0].meta).to.have.property('component', 'tedious')
@@ -148,8 +148,8 @@ describe('Plugin', () => {
 
         const promise = agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'tedious.request')
-            expect(traces[0][0]).to.have.property('service', 'test-mssql')
+            expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
+            expect(traces[0][0]).to.have.property('service', namingSchema.client.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
           })
 
@@ -167,8 +167,8 @@ describe('Plugin', () => {
 
         const promise = agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'tedious.request')
-            expect(traces[0][0]).to.have.property('service', 'test-mssql')
+            expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
+            expect(traces[0][0]).to.have.property('service', namingSchema.client.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
           })
 
@@ -184,8 +184,8 @@ describe('Plugin', () => {
 
         agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'tedious.request')
-            expect(traces[0][0]).to.have.property('service', 'test-mssql')
+            expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
+            expect(traces[0][0]).to.have.property('service', namingSchema.client.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
           })
           .then(done)
@@ -202,8 +202,8 @@ describe('Plugin', () => {
 
         const promise = agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'tedious.request')
-            expect(traces[0][0]).to.have.property('service', 'test-mssql')
+            expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
+            expect(traces[0][0]).to.have.property('service', namingSchema.client.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
           })
 
@@ -223,8 +223,8 @@ describe('Plugin', () => {
 
         const promise = agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'tedious.request')
-            expect(traces[0][0]).to.have.property('service', 'test-mssql')
+            expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
+            expect(traces[0][0]).to.have.property('service', namingSchema.client.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
           })
 
@@ -244,8 +244,8 @@ describe('Plugin', () => {
 
         const promise = agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'tedious.request')
-            expect(traces[0][0]).to.have.property('service', 'test-mssql')
+            expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
+            expect(traces[0][0]).to.have.property('service', namingSchema.client.serviceName)
             expect(traces[0][0]).to.have.property('resource', procedure)
           })
 
@@ -335,7 +335,7 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('name', 'tedious.request')
+                expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
                 expect(traces[0][0]).to.have.property('resource', bulkLoad.getBulkInsertSql())
               })
               .then(done)
@@ -351,7 +351,7 @@ describe('Plugin', () => {
 
               const promise = agent
                 .use(traces => {
-                  expect(traces[0][0]).to.have.property('name', 'tedious.request')
+                  expect(traces[0][0]).to.have.property('name', namingSchema.client.opName)
                   expect(traces[0][0]).to.have.property('resource', bulkLoad.getBulkInsertSql())
                 })
 

--- a/packages/datadog-plugin-tedious/test/naming.js
+++ b/packages/datadog-plugin-tedious/test/naming.js
@@ -1,14 +1,10 @@
-const { namingResolver } = require('../../dd-trace/test/plugins/helpers')
+const { resolveNaming } = require('../../dd-trace/test/plugins/helpers')
 
-module.exports = namingResolver({
-  outbound: {
+module.exports = resolveNaming({
+  client: {
     v0: {
       opName: 'tedious.request',
       serviceName: 'test-mssql'
-    },
-    v1: {
-      opName: 'sqlserver.query',
-      serviceName: 'test'
     }
   }
 })

--- a/packages/datadog-plugin-tedious/test/naming.js
+++ b/packages/datadog-plugin-tedious/test/naming.js
@@ -5,6 +5,10 @@ module.exports = resolveNaming({
     v0: {
       opName: 'tedious.request',
       serviceName: 'test-mssql'
+    },
+    v1: {
+      opName: 'mssql.query',
+      serviceName: 'test'
     }
   }
 })

--- a/packages/dd-trace/src/service-naming/schemas/v0/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/storage.js
@@ -26,7 +26,11 @@ const storage = {
       opName: () => 'memcached.command',
       serviceName: (service, config, system) => config.service || fromSystem(service, system)
     },
-    redis: redisConfig
+    redis: redisConfig,
+    tedious: {
+      opName: () => 'tedious.request',
+      serviceName: (service, config, system) => config.service || fromSystem(service, system)
+    }
   }
 }
 

--- a/packages/dd-trace/src/service-naming/schemas/v1/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v1/storage.js
@@ -14,7 +14,11 @@ const storage = {
       opName: () => 'memcached.command',
       serviceName: configWithFallback
     },
-    redis: redisNaming
+    redis: redisNaming,
+    tedious: {
+      opName: () => 'mssql.query',
+      serviceName: configWithFallback
+    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This applies the service naming schema logic (see #2941) to `tedious`.

This PR relies on #3056 for the split into different files according to general area (messaging, storage) and a few optimizations to the service naming computation.

### Motivation
<!-- What inspired you to submit this pull request? -->
Keep trucking on naming schema adoption.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
