### PR TITLE
removed orphanable option for v4.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,9 +77,6 @@ export declare interface Tracer extends opentracing.Tracer {
    * span will finish when that callback is called.
    * * The function doesn't accept a callback and doesn't return a promise, in
    * which case the span will finish at the end of the function execution.
-   *
-   * If the `orphanable` option is set to false, the function will not be traced
-   * unless there is already an active span or `childOf` option.
    */
   trace<T> (name: string, fn: (span?: Span, fn?: (error?: Error) => any) => T): T;
   trace<T> (name: string, options: TraceOptions & SpanOptions, fn: (span?: Span, done?: (error?: Error) => string) => T): T;
@@ -487,12 +484,6 @@ export declare interface TracerOptions {
    * @default 'debug'
    */
   logLevel?: 'error' | 'debug'
-
-  /**
-   * If false, require a parent in order to trace.
-   * @default true
-   */
-  orphanable?: boolean
 
   /**
    * Enables DBM to APM link using tag injection.

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -26,10 +26,6 @@ class DatadogTracer extends Tracer {
       childOf: this.scope().active()
     }, options)
 
-    if (!options.childOf && options.orphanable === false) {
-      return fn(null, () => {})
-    }
-
     const span = this.startSpan(name, options)
 
     addTags(span, options)
@@ -79,10 +75,6 @@ class DatadogTracer extends Tracer {
       let optionsObj = options
       if (typeof optionsObj === 'function' && typeof fn === 'function') {
         optionsObj = optionsObj.apply(this, arguments)
-      }
-
-      if (optionsObj && optionsObj.orphanable === false && !tracer.scope().active()) {
-        return fn.apply(this, arguments)
       }
 
       const lastArgId = arguments.length - 1

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -245,60 +245,20 @@ describe('Tracer', () => {
     })
 
     describe('when there is no parent span', () => {
-      it('should not trace if `orphanable: false`', () => {
-        sinon.spy(tracer, 'startSpan')
+      sinon.spy(tracer, 'startSpan')
 
-        tracer.trace('name', { orphanable: false }, () => {})
+      tracer.trace('name', {}, () => {})
 
-        expect(tracer.startSpan).to.have.not.been.called
-      })
+      expect(tracer.startSpan).to.have.been.called
+    })
 
-      it('should trace if `orphanable: true`', () => {
-        sinon.spy(tracer, 'startSpan')
-
-        tracer.trace('name', { orhpanable: true }, () => {})
-
-        expect(tracer.startSpan).to.have.been.called
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        sinon.spy(tracer, 'startSpan')
+    describe('when there is a parent span', () => {
+      tracer.scope().activate(tracer.startSpan('parent'), () => {
+        // sinon.spy(tracer, 'startSpan')
 
         tracer.trace('name', {}, () => {})
 
         expect(tracer.startSpan).to.have.been.called
-      })
-    })
-
-    describe('when there is a parent span', () => {
-      it('should trace if `orphanable: false`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          sinon.spy(tracer, 'startSpan')
-
-          tracer.trace('name', { orhpanable: false }, () => {})
-
-          expect(tracer.startSpan).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: true`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          sinon.spy(tracer, 'startSpan')
-
-          tracer.trace('name', { orphanable: true }, () => {})
-
-          expect(tracer.startSpan).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          sinon.spy(tracer, 'startSpan')
-
-          tracer.trace('name', {}, () => {})
-
-          expect(tracer.startSpan).to.have.been.called
-        })
       })
     })
   })
@@ -444,72 +404,24 @@ describe('Tracer', () => {
     })
 
     describe('when there is no parent span', () => {
-      it('should not trace if `orphanable: false`', () => {
-        const fn = tracer.wrap('name', { orphanable: false }, () => {})
+      const fn = tracer.wrap('name', {}, () => {})
 
-        sinon.spy(tracer, 'trace')
+      // sinon.spy(tracer, 'trace')
 
-        fn()
+      fn()
 
-        expect(tracer.trace).to.have.not.been.called
-      })
-
-      it('should trace if `orphanable: true`', () => {
-        const fn = tracer.wrap('name', { orhpanable: true }, () => {})
-
-        sinon.spy(tracer, 'trace')
-
-        fn()
-
-        expect(tracer.trace).to.have.been.called
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        const fn = tracer.wrap('name', {}, () => {})
-
-        sinon.spy(tracer, 'trace')
-
-        fn()
-
-        expect(tracer.trace).to.have.been.called
-      })
+      expect(tracer.trace).to.have.been.called
     })
 
     describe('when there is a parent span', () => {
-      it('should trace if `orphanable: false`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          const fn = tracer.wrap('name', { orhpanable: false }, () => {})
+      tracer.scope().activate(tracer.startSpan('parent'), () => {
+        const fn = tracer.wrap('name', {}, () => {})
 
-          sinon.spy(tracer, 'trace')
+        // sinon.spy(tracer, 'trace')
 
-          fn()
+        fn()
 
-          expect(tracer.trace).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: true`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          const fn = tracer.wrap('name', { orphanable: true }, () => {})
-
-          sinon.spy(tracer, 'trace')
-
-          fn()
-
-          expect(tracer.trace).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          const fn = tracer.wrap('name', {}, () => {})
-
-          sinon.spy(tracer, 'trace')
-
-          fn()
-
-          expect(tracer.trace).to.have.been.called
-        })
+        expect(tracer.trace).to.have.been.called
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
Removes `orphanable` option

### Motivation
`orphanable` option is no longer needed since it is only used for `fs` which was removed

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
