### PR TITLE
[fix: plugin-pg] Support Query config object again

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -30,9 +30,9 @@ function wrapQuery (query) {
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     const processId = this.processID
-    let pgQuery = {
-      text: arguments[0]
-    }
+    let pgQuery = typeof arguments[0] === 'object' ? {
+      ...arguments[0]
+    } : { text: arguments[0] }
 
     return asyncResource.runInAsyncScope(() => {
       startCh.publish({
@@ -41,7 +41,7 @@ function wrapQuery (query) {
         processId
       })
 
-      arguments[0] = pgQuery.text
+      arguments[0] = pgQuery
 
       const finish = asyncResource.bind(function (error) {
         if (error) {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -95,6 +95,26 @@ describe('Plugin', () => {
             })
           })
 
+          it('should send queries to agent when using query config of format', done => {
+            agent.use(traces => {
+              expect(traces[0][0]).to.have.property('resource', `SELECT $1::text as message`)
+              done()
+            })
+
+            const query = {
+              text: 'SELECT $1::text as message',
+              values: ['test']
+            }
+
+            client.query(query, (err, result) => {
+              if (err) throw err
+
+              client.end((err) => {
+                if (err) throw err
+              })
+            })
+          })
+
           if (semver.intersects(version, '>=5.1')) { // initial promise support
             it('should do automatic instrumentation when using promises', done => {
               agent.use(traces => {


### PR DESCRIPTION
Fixes #3007

### What does this PR do?
There are multiple formats for querying the pg client. Previously dd-trace supported all of them, but this broke in a recent refactor. The call signatures are:
(query, ...)
(query, values, ...)
(object: {}, ...)
https://node-postgres.com/features/queries

I don't totally understand what's going on with the `queryQueue` but it seems like since we set the query as a let we are anticipating the object might get shoved onto a queue. This means we need to copy the full arguments object to initially log it and then to later apply it (i.e. just copying the query text didn't seem like enough)

The bigger problem is that we have two formats for this from PG, but we are expecting one in the pg plugin itself. This could potentially be simpler if we just had that plugin check for .text on the object instead of doing it here. So feel free to take that approach too!

### Motivation
This broke in 3.17 from bad code in #2938.