### PR TITLE
bump node version for ci integration tests

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -34,7 +34,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [14, latest]
+        version: [16, latest]
         framework: [cucumber, cypress, playwright]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump node version for CI integration tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

New version of Cucumber doesn't support Node 14.