### PR TITLE
Support query config objects in PG with DBM propagation

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -30,9 +30,8 @@ function wrapQuery (query) {
     const callbackResource = new AsyncResource('bound-anonymous-fn')
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     const processId = this.processID
-    let pgQuery = {
-      text: arguments[0] && typeof arguments[0] === 'object' ? arguments[0].text : arguments[0]
-    }
+
+    let pgQuery = arguments[0] && typeof arguments[0] === 'object' ? arguments[0] : { text: arguments[0] }
 
     return asyncResource.runInAsyncScope(() => {
       startCh.publish({
@@ -41,7 +40,7 @@ function wrapQuery (query) {
         processId
       })
 
-      arguments[0] = pgQuery.text
+      arguments[0] = pgQuery
 
       const finish = asyncResource.bind(function (error) {
         if (error) {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -505,53 +505,6 @@ describe('Plugin', () => {
           queryText = client.queryQueue[0].text
         })
       })
-      describe('DBM propagation enabled with full should handle prepared statements', () => {
-        const tracer = require('../../dd-trace')
-
-        before(() => {
-          return agent.load('pg')
-        })
-        beforeEach(done => {
-          pg = require('../../../versions/pg@>=8.0.3').get()
-
-          tracer.init()
-          tracer.use('pg', {
-            dbmPropagationMode: 'full',
-            service: 'post'
-          })
-
-          client = new pg.Client({
-            host: '127.0.0.1',
-            user: 'postgres',
-            password: 'postgres',
-            database: 'postgres'
-          })
-          client.connect(err => done(err))
-        })
-
-        it('prepared statements should be handled', done => {
-          let queryText = ''
-          const query = {
-            text: 'SELECT $1::text as message'
-          }
-          agent.use(traces => {
-            const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
-            const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
-
-            expect(queryText).to.equal(
-              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
-              `traceparent='00-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
-          }).then(done, done)
-          client.query(query, ['Hello world!'], (err) => {
-            if (err) return done(err)
-
-            client.end((err) => {
-              if (err) return done(err)
-            })
-          })
-          queryText = client.queryQueue[0].text
-        })
-      })
     })
   })
 })

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -458,7 +458,7 @@ describe('Plugin', () => {
           })
         })
       })
-      describe('DBM propagation enabled with full should handle prepared statements', () => {
+      describe('DBM propagation enabled with full should handle query config objects', () => {
         const tracer = require('../../dd-trace')
 
         before(() => {
@@ -482,9 +482,10 @@ describe('Plugin', () => {
           client.connect(err => done(err))
         })
 
-        it('prepared statements should be handled', done => {
+        it('query config objects should be handled', done => {
           let queryText = ''
           const query = {
+            name: 'monkeyFoot',
             text: 'SELECT $1::text as message'
           }
           agent.use(traces => {
@@ -503,6 +504,23 @@ describe('Plugin', () => {
             })
           })
           queryText = client.queryQueue[0].text
+        })
+        it('query config object should persist when comment is injected', done => {
+          const query = {
+            name: 'pgSelectQuery',
+            text: 'SELECT $1::text as message'
+          }
+          client.query(query, ['Hello world!'], (err) => {
+            if (err) return done(err)
+
+            client.end((err) => {
+              if (err) return done(err)
+            })
+          })
+          agent.use(traces => {
+            expect(query).to.have.property(
+              'name', 'pgSelectQuery')
+          }).then(done, done)
         })
       })
     })

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -485,7 +485,7 @@ describe('Plugin', () => {
         it('query config objects should be handled', done => {
           let queryText = ''
           const query = {
-            name: 'monkeyFoot',
+            name: 'pgSelectQuery',
             text: 'SELECT $1::text as message'
           }
           agent.use(traces => {


### PR DESCRIPTION
### What does this PR do?

This PR is to ensure that the query config object is persisted after comment is added for DBM propagation. This also adds testing to ensure the full query object is persisted after the comment has been added. 

### Motivation
This is related to [this PR](https://github.com/DataDog/dd-trace-js/pull/3087)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
