### PR TITLE
[ci-visibility] Fix `test.fixme` logic in playwright

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests/landing-page-test.js
+++ b/integration-tests/ci-visibility/playwright-tests/landing-page-test.js
@@ -15,4 +15,9 @@ test.describe('playwright', () => {
       'Hello World'
     ])
   })
+  test.fixme('should work with fixme', async ({ page }) => {
+    await expect(page.locator('.hello-world')).toHaveText([
+      'Hello Warld'
+    ])
+  })
 })

--- a/integration-tests/ci-visibility/playwright-tests/skipped-suite-test.js
+++ b/integration-tests/ci-visibility/playwright-tests/skipped-suite-test.js
@@ -4,14 +4,6 @@ test.beforeEach(async ({ page }) => {
   await page.goto(process.env.PW_BASE_URL)
 })
 
-test.describe('playwright', () => {
-  test('should work with failing tests', async ({ page }) => {
-    await expect(page.locator('.hello-world')).toHaveText([
-      'Hello Warld'
-    ])
-  })
-})
-
 test.fixme('should work with fixme root', async ({ page }) => {
   await expect(page.locator('.hello-world')).toHaveText([
     'Hello Warld'

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -75,18 +75,22 @@ versions.forEach((version) => {
 
             assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
               'test_suite.todo-list-page-test.js',
-              'test_suite.landing-page-test.js'
+              'test_suite.landing-page-test.js',
+              'test_suite.skipped-suite-test.js'
             ])
 
             assert.includeMembers(testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]), [
               'pass',
-              'fail'
+              'fail',
+              'skip'
             ])
 
             assert.includeMembers(testEvents.map(test => test.content.resource), [
               'landing-page-test.js.should work with passing tests',
               'landing-page-test.js.should work with skipped tests',
-              'todo-list-page-test.js.should work with failing tests'
+              'landing-page-test.js.should work with fixme',
+              'todo-list-page-test.js.should work with failing tests',
+              'todo-list-page-test.js.should work with fixme root'
             ])
 
             assert.includeMembers(testEvents.map(test => test.content.meta[TEST_STATUS]), [

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -214,10 +214,20 @@ function runnerHook (runnerExport, playwrightVersion) {
     })
 
     const runAllTestsReturn = await runAllTests.apply(this, arguments)
+
+    Object.values(remainingTestsByFile).forEach(tests => {
+      // `tests` should normally be empty, but if it isn't,
+      // there were tests that did not go through `testBegin` or `testEnd`,
+      // because they were skipped
+      tests.forEach(test => {
+        testBeginHandler(test)
+        testEndHandler(test, 'skip')
+      })
+    })
+
     const sessionStatus = runAllTestsReturn.status || runAllTestsReturn
 
     let onDone
-
     const flushWait = new Promise(resolve => {
       onDone = resolve
     })


### PR DESCRIPTION
### What does this PR do?
Tests marked as `fixme` do not always trigger `testBegin` and `testEnd` events. We now go through `remainingTestsByFile` at the end of the session to catch any remaining tests. 

### Motivation
Fixes #3097

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
