### PR TITLE
[ci-visibility] Fix potential issue when encoding `test_module_id`

### DIFF
--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -129,12 +129,17 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   _encodeEventContent (bytes, content) {
     const keysLength = Object.keys(content).length
 
+    let totalKeysLength = keysLength
     if (content.meta.test_session_id) {
-      this._encodeMapPrefix(bytes, keysLength + 3)
-    } else {
-      this._encodeMapPrefix(bytes, keysLength)
+      totalKeysLength = totalKeysLength + 1
     }
-
+    if (content.meta.test_module_id) {
+      totalKeysLength = totalKeysLength + 1
+    }
+    if (content.meta.test_suite_id) {
+      totalKeysLength = totalKeysLength + 1
+    }
+    this._encodeMapPrefix(bytes, totalKeysLength)
     if (content.type) {
       this._encodeString(bytes, 'type')
       this._encodeString(bytes, content.type)

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -170,15 +170,20 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       this._encodeString(bytes, 'test_session_id')
       this._encodeId(bytes, id(content.meta.test_session_id, 10))
       delete content.meta.test_session_id
+    }
 
+    if (content.meta.test_module_id) {
       this._encodeString(bytes, 'test_module_id')
       this._encodeId(bytes, id(content.meta.test_module_id, 10))
       delete content.meta.test_module_id
+    }
 
+    if (content.meta.test_suite_id) {
       this._encodeString(bytes, 'test_suite_id')
       this._encodeId(bytes, id(content.meta.test_suite_id, 10))
       delete content.meta.test_suite_id
     }
+
     this._encodeString(bytes, 'meta')
     this._encodeMap(bytes, content.meta)
     this._encodeString(bytes, 'metrics')

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -253,4 +253,29 @@ describe('agentless-ci-visibility-encode', () => {
     expect(decodedTrace.events[0].type).to.equal('test_session_end')
     expect(decodedTrace.events[0].content.type).to.eql('test_session_end')
   })
+
+  it('does not crash if test_session_id is in meta but not test_module_id', () => {
+    const traceToTruncate = [{
+      trace_id: id('1234abcd1234abcd'),
+      span_id: id('1234abcd1234abcd'),
+      parent_id: id('1234abcd1234abcd'),
+      error: 0,
+      meta: {
+        test_session_id: '1234abcd1234abcd'
+      },
+      metrics: {},
+      start: 123,
+      duration: 456,
+      type: 'foo',
+      name: '',
+      resource: '',
+      service: ''
+    }]
+    encoder.encode(traceToTruncate)
+    const buffer = encoder.makePayload()
+    const decodedTrace = msgpack.decode(buffer, { codec })
+    const spanEvent = decodedTrace.events[0]
+    expect(spanEvent.type).to.equal('span')
+    expect(spanEvent.version.toNumber()).to.equal(1)
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Do not attempt to `test_module_id` or `test_suite_id` if they're not part of `content.meta`. 

### Motivation
With https://github.com/DataDog/dd-trace-js/pull/2848 we fixed an issue where a bad init would make an test suite crash. 

This PR was done for a similar reason. If for whatever reason (like a bad init), one of the events we listen to to create module or session spans is _not_ triggered, some tags might be missing from a span meta. 

### Plugin Checklist
- [x] Unit tests.

### Additional Notes
I couldn't find a way to reproduce this with an integration test, so a unit test will have to do. 