### PR TITLE
Add `test:local` command 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "test:trace:core:ci": "npm run test:trace:core -- --coverage --nyc-arg=--include=\"packages/dd-trace/src/**/*.js\"",
     "test:instrumentations": "mocha --colors -r 'packages/dd-trace/test/setup/mocha.js' 'packages/datadog-instrumentations/test/**/*.spec.js'",
     "test:instrumentations:ci": "nyc --no-clean --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations",
+    "test:local": "DISABLE_TAP=1 mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/{ci-visibility,encode,exporters,opentracing,plugins,telemetry}/**/*.spec.js\"",
+    "test:local:debug": "yarn test:local --inspect-brk",
     "test:core": "tap \"packages/datadog-core/test/**/*.spec.js\"",
     "test:core:ci": "npm run test:core -- --coverage --nyc-arg=--include=\"packages/datadog-core/src/**/*.js\"",
     "test:lambda": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/lambda/**/*.spec.js\"",

--- a/packages/dd-trace/test/setup/tap.js
+++ b/packages/dd-trace/test/setup/tap.js
@@ -1,4 +1,6 @@
 'use strict'
 
-require('tap').mochaGlobals()
-require('./core')
+if (!process.env.DISABLE_TAP) {
+  require('tap').mochaGlobals()
+  require('./core')
+}


### PR DESCRIPTION
### What does this PR do?
Add `test:local` and `test:local:debug` commands, for easier local development. 

### Motivation
Tap does not seem to work well with running single tests or files and `--inspect-brk` can't be passed (at least I couldn't make it work). 
