### PR TITLE
use `withVersions` data for pg version

### DIFF
--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -465,7 +465,7 @@ describe('Plugin', () => {
           return agent.load('pg')
         })
         beforeEach(done => {
-          pg = require('../../../versions/pg@>=8.0.3').get()
+          pg = require(`../../../versions/pg@${version}`).get()
 
           tracer.init()
           tracer.use('pg', {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In `2.x` the instrumentation range is different, so #3087 doesn't pass the cherrypick in the tests where `8.0.3` is a hardcoded require.

These tests work fine in both `2.x` and `3.x` if we just pick the relevant version provided by `withVersions` instead.

### Motivation
<!-- What inspired you to submit this pull request? -->
Pass CI in `2.x`.
