### PR TITLE
remove unnecessary macOS & Windos tests for lambda

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -12,15 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/node/setup
-      - run: yarn install
-      - run: yarn test:lambda:ci
-      - uses: codecov/codecov-action@v2
-
   ubuntu:
     runs-on: ubuntu-latest
     steps:
@@ -34,14 +25,5 @@ jobs:
       - uses: ./.github/actions/node/18
       - run: yarn test:lambda:ci
       - uses: ./.github/actions/node/latest
-      - run: yarn test:lambda:ci
-      - uses: codecov/codecov-action@v2
-
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/node/setup
-      - run: yarn install
       - run: yarn test:lambda:ci
       - uses: codecov/codecov-action@v2


### PR DESCRIPTION
### What does this PR do?
Remove the unnecessary macOS & Windos tests for lambda patches.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
