### PR TITLE
Mini Agent: inherit stdio from parent

### DIFF
--- a/integration-tests/serverless/test-project/.env.yaml
+++ b/integration-tests/serverless/test-project/.env.yaml
@@ -1,4 +1,4 @@
 NODE_OPTIONS: "-r dd-trace/init"
-DD_TRACE_DEBUG: "true"
+DD_LOG_LEVEL: "debug"
 DD_API_KEY: "_api_key_"
 DD_TRACE_STATS_COMPUTATION_ENABLED: "false"

--- a/integration-tests/serverless/test-project/.env.yaml
+++ b/integration-tests/serverless/test-project/.env.yaml
@@ -1,4 +1,3 @@
 NODE_OPTIONS: "-r dd-trace/init"
-DD_LOG_LEVEL: "debug"
 DD_API_KEY: "_api_key_"
 DD_TRACE_STATS_COMPUTATION_ENABLED: "false"

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -17,16 +17,7 @@ function maybeStartServerlessMiniAgent () {
   }
   try {
     const { spawn } = require('child_process')
-    const miniAgentProcess = spawn(rustBinaryPath)
-    miniAgentProcess.stdout.on('data', (data) => {
-      log.info(data.toString())
-    })
-    miniAgentProcess.on('close', (code) => {
-      log.error(`Mini Agent exited with code ${code}`)
-    })
-    miniAgentProcess.on('error', (err) => {
-      log.error(err.toString())
-    })
+    spawn(rustBinaryPath, { stdio: 'inherit' })
   } catch (err) {
     log.error(`Error spawning mini agent process: ${err}`)
   }

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -19,7 +19,7 @@ function maybeStartServerlessMiniAgent () {
     const { spawn } = require('child_process')
     const miniAgentProcess = spawn(rustBinaryPath)
     miniAgentProcess.stdout.on('data', (data) => {
-      log.debug(data.toString())
+      log.info(data.toString())
     })
     miniAgentProcess.on('close', (code) => {
       log.error(`Mini Agent exited with code ${code}`)

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -16,8 +16,7 @@ function maybeStartServerlessMiniAgent () {
     return
   }
   try {
-    const { spawn } = require('child_process')
-    spawn(rustBinaryPath, { stdio: 'inherit' })
+    require('child_process').spawn(rustBinaryPath, { stdio: 'inherit' })
   } catch (err) {
     log.error(`Error spawning mini agent process: ${err}`)
   }

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -8,7 +8,7 @@ const childProcess = require('child_process')
 require('./setup/tap')
 
 describe('Serverless', () => {
-  const spawnSpy = sinon.spy(childProcess, 'spawn')
+  const spawnStub = sinon.stub(childProcess, 'spawn').returns(null)
 
   // so maybeStartServerlessMiniAgent thinks the default mini agent binary path exists
   const existsSyncStub = sinon.stub(fs, 'existsSync').returns(true)
@@ -24,7 +24,7 @@ describe('Serverless', () => {
 
   afterEach(() => {
     process.env = env
-    spawnSpy.resetHistory()
+    spawnStub.resetHistory()
   })
 
   it('should not spawn mini agent if not in google cloud function', () => {
@@ -32,7 +32,7 @@ describe('Serverless', () => {
 
     proxy.init()
 
-    expect(spawnSpy).to.not.have.been.called
+    expect(spawnStub).to.not.have.been.called
     delete process.env.DD_MINI_AGENT_PATH
   })
 
@@ -42,7 +42,7 @@ describe('Serverless', () => {
 
     proxy.init()
 
-    expect(spawnSpy).to.have.been.calledOnce
+    expect(spawnStub).to.have.been.calledOnce
   })
 
   it('should spawn mini agent when K_SERVICE and FUNCTION_TARGET env vars are defined', () => {
@@ -51,7 +51,7 @@ describe('Serverless', () => {
 
     proxy.init()
 
-    expect(spawnSpy).to.have.been.calledOnce
+    expect(spawnStub).to.have.been.calledOnce
   })
 
   it('should log error if mini agent binary path is invalid', () => {


### PR DESCRIPTION
### What does this PR do?

When spawning the mini agent, inherit stdio from the parent.

Tested in google cloud functions with our mini agent.

### Motivation

Currently all stdout from the mini agent is only shown when the tracer is set to the debug log level. This PR enables all output from the mini agent regardless of the tracer log level, as the mini agent has it's own log level logic.

The mini agent defaults to logging at the `info` level, and looks for the `DD_LOG_LEVEL` env var

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
