### PR TITLE
[ci-visibility] Add warning about `jest-jasmine2` usage

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -454,6 +454,7 @@ addHook({
 }, jestConfigSyncWrapper)
 
 function jasmineAsyncInstallWraper (jasmineAsyncInstallExport, jestVersion) {
+  log.warn('jest-jasmine2 support is removed from dd-trace@v4. Consider changing to jest-circus as `testRunner`.')
   return function (globalConfig, globalInput) {
     globalInput._ddtrace = global._ddtrace
     shimmer.wrap(globalInput.jasmine.Spec.prototype, 'execute', execute => function (onComplete) {


### PR DESCRIPTION
### What does this PR do?
Add a warning log if `jest-jasmine2` is being used.

### Motivation
Let users know we're removing its support. 
