### PR TITLE
[ci-visibility] Fix calculation of test suites to skip based on ITR response

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -13,6 +13,11 @@ const {
   getTestSuitePath,
   getTestParametersString
 } = require('../../dd-trace/src/plugins/util/test')
+const {
+  getFormattedJestTestParameters,
+  getJestTestName,
+  getJestSuitesToRun
+} = require('../../datadog-plugin-jest/src/util')
 
 const testSessionStartCh = channel('ci:jest:session:start')
 const testSessionFinishCh = channel('ci:jest:session:finish')
@@ -38,8 +43,6 @@ const jestItrConfigurationCh = channel('ci:jest:itr-configuration')
 let skippableSuites = []
 let isCodeCoverageEnabled = false
 let isSuitesSkippingEnabled = false
-
-const { getFormattedJestTestParameters, getJestTestName } = require('../../datadog-plugin-jest/src/util')
 
 const sessionAsyncResource = new AsyncResource('bound-anonymous-fn')
 
@@ -426,10 +429,7 @@ addHook({
     const testPaths = await getTestPaths.apply(this, arguments)
     const { tests } = testPaths
 
-    const filteredTests = tests.filter(({ path: testPath }) => {
-      const relativePath = getTestSuitePath(testPath, rootDir)
-      return !skippableSuites.includes(relativePath)
-    })
+    const filteredTests = getJestSuitesToRun(skippableSuites, tests, rootDir)
 
     skippableSuites = []
 

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -1,3 +1,5 @@
+const { getTestSuitePath } = require('../../dd-trace/src/plugins/util/test')
+
 /**
  * There are two ways to call `test.each` in `jest`:
  * 1. With an array of arrays: https://jestjs.io/docs/api#1-testeachtablename-fn-timeout
@@ -45,4 +47,11 @@ function getJestTestName (test) {
   return titles.join(' ')
 }
 
-module.exports = { getFormattedJestTestParameters, getJestTestName }
+function getJestSuitesToRun (skippableSuites, originalTests, rootDir) {
+  return originalTests.filter(({ path: testPath }) => {
+    const relativePath = getTestSuitePath(testPath, rootDir)
+    return !skippableSuites.includes(relativePath)
+  })
+}
+
+module.exports = { getFormattedJestTestParameters, getJestTestName, getJestSuitesToRun }

--- a/packages/datadog-plugin-jest/test/util.spec.js
+++ b/packages/datadog-plugin-jest/test/util.spec.js
@@ -1,4 +1,5 @@
-const { getFormattedJestTestParameters } = require('../src/util')
+const path = require('path')
+const { getFormattedJestTestParameters, getJestSuitesToRun } = require('../src/util')
 
 describe('getFormattedJestTestParameters', () => {
   it('returns formatted parameters for arrays', () => {
@@ -16,5 +17,59 @@ describe('getFormattedJestTestParameters', () => {
     expect(resultEmptyArray).to.eql(undefined)
     expect(resultUndefined).to.eql(undefined)
     expect(resultObject).to.eql(undefined)
+  })
+})
+
+describe('getJestSuitesToRun', () => {
+  it('returns filtered suites', () => {
+    const skippableSuites = [
+      'src/unit.spec.js',
+      'src/integration.spec.js'
+    ]
+    const tests = [
+      { path: '/workspace/dd-trace-js/src/unit.spec.js' },
+      { path: '/workspace/dd-trace-js/src/integration.spec.js' },
+      { path: '/workspace/dd-trace-js/src/e2e.spec.js' }
+    ]
+    const rootDir = '/workspace/dd-trace-js'
+
+    const filteredSuites = getJestSuitesToRun(skippableSuites, tests, rootDir)
+    expect(filteredSuites).to.eql([{ path: '/workspace/dd-trace-js/src/e2e.spec.js' }])
+  })
+
+  it('returns filtered suites when paths are windows like', () => {
+    const skippableSuites = [
+      'src/unit.spec.js',
+      'src/integration.spec.js'
+    ]
+    const tests = [
+      { path: `C:${path.sep}temp${path.sep}dd-trace-js${path.sep}src${path.sep}unit.spec.js` },
+      { path: `C:${path.sep}temp${path.sep}dd-trace-js${path.sep}src${path.sep}integration.spec.js` },
+      { path: `C:${path.sep}temp${path.sep}dd-trace-js${path.sep}src${path.sep}e2e.spec.js` }
+    ]
+    const rootDir = `C:${path.sep}temp${path.sep}dd-trace-js`
+
+    const filteredSuites = getJestSuitesToRun(skippableSuites, tests, rootDir)
+    expect(filteredSuites).to.eql([
+      { path: `C:${path.sep}temp${path.sep}dd-trace-js${path.sep}src${path.sep}e2e.spec.js` }
+    ])
+  })
+
+  it('returns filtered suites when paths are relative', () => {
+    const skippableSuites = [
+      '../../src/unit.spec.js',
+      '../../src/integration.spec.js'
+    ]
+    const tests = [
+      { path: '/workspace/dd-trace-js/src/unit.spec.js' },
+      { path: '/workspace/dd-trace-js/src/integration.spec.js' },
+      { path: '/workspace/dd-trace-js/src/e2e.spec.js' }
+    ]
+    const rootDir = '/workspace/dd-trace-js/config/root-config'
+
+    const filteredSuites = getJestSuitesToRun(skippableSuites, tests, rootDir)
+    expect(filteredSuites).to.eql([
+      { path: '/workspace/dd-trace-js/src/e2e.spec.js' }
+    ])
   })
 })


### PR DESCRIPTION
### What does this PR do?
Fix calculation of the test suites to skip based on ITR for certain configurations of `jest`

### Motivation

This logic was wrong: 
```javascript
testPath.replace(`${rootDir}/`, '')
```
* it does not work for windows
* it's not the same logic that the one we use to calculate `test.suite`, therefore we couldn't find the suites that the backend was responding. 

### Additional Notes
This error only surfaces for uncommon `jest` configurations where the `rootDir` is different than the root of the repository, so it wasn't caught earlier. 
