### PR TITLE
restore orphanable only on older versions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,10 @@ export declare interface Tracer extends opentracing.Tracer {
    * span will finish when that callback is called.
    * * The function doesn't accept a callback and doesn't return a promise, in
    * which case the span will finish at the end of the function execution.
+   *
+   * If the `orphanable` option is set to false, the function will not be traced
+   * unless there is already an active span or `childOf` option. Note that this
+   * option is deprecated and has been removed in version 4.0.
    */
   trace<T> (name: string, fn: (span?: Span, fn?: (error?: Error) => any) => T): T;
   trace<T> (name: string, options: TraceOptions & SpanOptions, fn: (span?: Span, done?: (error?: Error) => string) => T): T;
@@ -489,6 +493,13 @@ export declare interface TracerOptions {
    * @default 'debug'
    */
   logLevel?: 'error' | 'debug'
+
+  /**
+   * If false, require a parent in order to trace.
+   * @default true
+   * @deprecated since version 4.0
+   */
+  orphanable?: boolean
 
   /**
    * Enables DBM to APM link using tag injection.

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -8,10 +8,13 @@ const Config = require('../src/config')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { MAJOR } = require('../../../version')
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
+
+const describeOrphanable = MAJOR < 4 ? describe : describe.skip
 
 describe('Tracer', () => {
   let Tracer
@@ -244,21 +247,61 @@ describe('Tracer', () => {
       })
     })
 
-    describe('when there is no parent span', () => {
-      sinon.spy(tracer, 'startSpan')
+    describeOrphanable('when there is no parent span', () => {
+      it('should not trace if `orphanable: false`', () => {
+        sinon.spy(tracer, 'startSpan')
 
-      tracer.trace('name', {}, () => {})
+        tracer.trace('name', { orphanable: false }, () => {})
 
-      expect(tracer.startSpan).to.have.been.called
-    })
+        expect(tracer.startSpan).to.have.not.been.called
+      })
 
-    describe('when there is a parent span', () => {
-      tracer.scope().activate(tracer.startSpan('parent'), () => {
-        // sinon.spy(tracer, 'startSpan')
+      it('should trace if `orphanable: true`', () => {
+        sinon.spy(tracer, 'startSpan')
+
+        tracer.trace('name', { orhpanable: true }, () => {})
+
+        expect(tracer.startSpan).to.have.been.called
+      })
+
+      it('should trace if `orphanable: undefined`', () => {
+        sinon.spy(tracer, 'startSpan')
 
         tracer.trace('name', {}, () => {})
 
         expect(tracer.startSpan).to.have.been.called
+      })
+    })
+
+    describeOrphanable('when there is a parent span', () => {
+      it('should trace if `orphanable: false`', () => {
+        tracer.scope().activate(tracer.startSpan('parent'), () => {
+          sinon.spy(tracer, 'startSpan')
+
+          tracer.trace('name', { orhpanable: false }, () => {})
+
+          expect(tracer.startSpan).to.have.been.called
+        })
+      })
+
+      it('should trace if `orphanable: true`', () => {
+        tracer.scope().activate(tracer.startSpan('parent'), () => {
+          sinon.spy(tracer, 'startSpan')
+
+          tracer.trace('name', { orphanable: true }, () => {})
+
+          expect(tracer.startSpan).to.have.been.called
+        })
+      })
+
+      it('should trace if `orphanable: undefined`', () => {
+        tracer.scope().activate(tracer.startSpan('parent'), () => {
+          sinon.spy(tracer, 'startSpan')
+
+          tracer.trace('name', {}, () => {})
+
+          expect(tracer.startSpan).to.have.been.called
+        })
       })
     })
   })
@@ -403,21 +446,31 @@ describe('Tracer', () => {
       expect(tracer.trace).to.have.not.been.called
     })
 
-    describe('when there is no parent span', () => {
-      const fn = tracer.wrap('name', {}, () => {})
+    describeOrphanable('when there is no parent span', () => {
+      it('should not trace if `orphanable: false`', () => {
+        const fn = tracer.wrap('name', { orphanable: false }, () => {})
 
-      // sinon.spy(tracer, 'trace')
+        sinon.spy(tracer, 'trace')
 
-      fn()
+        fn()
 
-      expect(tracer.trace).to.have.been.called
-    })
+        expect(tracer.trace).to.have.not.been.called
+      })
 
-    describe('when there is a parent span', () => {
-      tracer.scope().activate(tracer.startSpan('parent'), () => {
+      it('should trace if `orphanable: true`', () => {
+        const fn = tracer.wrap('name', { orhpanable: true }, () => {})
+
+        sinon.spy(tracer, 'trace')
+
+        fn()
+
+        expect(tracer.trace).to.have.been.called
+      })
+
+      it('should trace if `orphanable: undefined`', () => {
         const fn = tracer.wrap('name', {}, () => {})
 
-        // sinon.spy(tracer, 'trace')
+        sinon.spy(tracer, 'trace')
 
         fn()
 
@@ -425,17 +478,41 @@ describe('Tracer', () => {
       })
     })
 
-    describe('when the options object is a function returning a falsy value', () => {
-      it('should trace', () => {
-        const fn = tracer.wrap('name', () => false, () => {})
+    describeOrphanable('when there is a parent span', () => {
+      it('should trace if `orphanable: false`', () => {
+        tracer.scope().activate(tracer.startSpan('parent'), () => {
+          const fn = tracer.wrap('name', { orhpanable: false }, () => {})
 
-        sinon.stub(tracer, 'trace').callsFake((_, options) => {
-          expect(options).to.equal(false)
+          sinon.spy(tracer, 'trace')
+
+          fn()
+
+          expect(tracer.trace).to.have.been.called
         })
+      })
 
-        fn()
+      it('should trace if `orphanable: true`', () => {
+        tracer.scope().activate(tracer.startSpan('parent'), () => {
+          const fn = tracer.wrap('name', { orphanable: true }, () => {})
 
-        expect(tracer.trace).to.have.been.called
+          sinon.spy(tracer, 'trace')
+
+          fn()
+
+          expect(tracer.trace).to.have.been.called
+        })
+      })
+
+      it('should trace if `orphanable: undefined`', () => {
+        tracer.scope().activate(tracer.startSpan('parent'), () => {
+          const fn = tracer.wrap('name', {}, () => {})
+
+          sinon.spy(tracer, 'trace')
+
+          fn()
+
+          expect(tracer.trace).to.have.been.called
+        })
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Restore `orphanable` option only on older versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was removed in #3077 but keeping the code and only disabling it instead makes merge conflicts easier between release lines.