### PR TITLE
Don't redact ranges with only whitespaces in Command sensitive analyzer

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/command-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/command-sensitive-analyzer.js
@@ -2,7 +2,7 @@
 
 const iastLog = require('../../../iast-log')
 
-const COMMAND_PATTERN = '^(?:\\s*(?:sudo|doas)\\s+)?\\b\\S+\\b(.*)'
+const COMMAND_PATTERN = '^(?:\\s*(?:sudo|doas)\\s+)?\\b\\S+\\b\\s(.*)'
 
 class CommandSensitiveAnalyzer {
   constructor () {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
@@ -1517,7 +1517,7 @@
             "evidence": {
               "valueParts": [
                 {
-                  "value": "cat"
+                  "value": "cat "
                 },
                 {
                   "redacted": true
@@ -1574,7 +1574,7 @@
             "evidence": {
               "valueParts": [
                 {
-                  "value": "$1 cat"
+                  "value": "$1 cat "
                 },
                 {
                   "redacted": true
@@ -1583,6 +1583,70 @@
                   "source": 0,
                   "redacted": true
                 }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Command injection does not redact ranges with only whitespaces",
+      "parameters": {
+        "$1": [
+          "sudo",
+          "doas"
+        ]
+      },
+      "input": [
+        {
+          "type": "COMMAND_INJECTION",
+          "evidence": {
+            "value": "ls -lah",
+            "ranges": [
+              {
+                "start": 0,
+                "end": 2,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "command",
+                  "parameterValue": "ls"
+                }
+              },
+              {
+                "start": 3,
+                "end": 7,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "argument",
+                  "parameterValue": "-lha"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "command",
+            "value": "ls"
+          },
+          {
+            "origin": "http.request.parameter",
+            "name": "argument",
+            "redacted": true
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "COMMAND_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "source": 0, "value": "ls" },
+                { "value": " " },
+                { "source": 1, "redacted": true}
               ]
             }
           }


### PR DESCRIPTION
### What does this PR do?
Prevent to redact ranges with just whitespaces for command injection vulnerability

### Motivation
Get a clearer evidence value when reporting command injection vulnerability