### PR TITLE
Use 'process' as default strategy for oom export

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -91,8 +91,10 @@ class Config {
       Number(DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE), 0)
     const maxHeapExtensionCount = coalesce(options.oomMaxHeapExtensionCount,
       Number(DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT), 0)
-    const exportStrategies = ensureOOMExportStrategies(coalesce(options.oomExportStrategies,
-      DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES), this)
+    const exportStrategies = oomMonitoringEnabled
+      ? ensureOOMExportStrategies(coalesce(options.oomExportStrategies, DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES,
+        [oomExportStrategies.PROCESS]), this)
+      : []
     const exportCommand = oomMonitoringEnabled ? buildExportCommand(this) : undefined
     this.oomMonitoring = {
       enabled: oomMonitoringEnabled,

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -171,6 +171,27 @@ describe('config', () => {
     })
   })
 
+  it('should use process as default strategy for OOM heap profiler', () => {
+    process.env = {
+      DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED: 'true'
+    }
+    const config = new Config()
+
+    expect(config.oomMonitoring).to.deep.equal({
+      enabled: true,
+      heapLimitExtensionSize: 0,
+      maxHeapExtensionCount: 0,
+      exportStrategies: ['process'],
+      exportCommand: [
+        process.execPath,
+        path.normalize(path.join(__dirname, '../../src/profiling', 'exporter_cli.js')),
+        'http://localhost:8126/',
+        `host:${config.host},service:node,snapshot:on_oom`,
+        'space'
+      ]
+    })
+  })
+
   it('should support OOM heap profiler configuration', () => {
     process.env = {
       DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED: '1',


### PR DESCRIPTION
### What does this PR do?
Use `process` as default strategy for oom export.

### Motivation
`process` is the safer export strategy for heap profile export upon oom.
