### PR TITLE
update hapi tests to only test versions supported on current node

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -352,7 +352,6 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 
-  # The hapi version ranges we support only support up to Node 14.
   hapi:
     runs-on: ubuntu-latest
     env:
@@ -362,6 +361,8 @@ jobs:
       - uses: ./.github/actions/node/setup
       - run: yarn install
       - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -6,6 +6,10 @@ const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 
+const versionRange = parseInt(process.versions.node.split('.')[0]) > 14
+  ? '<17 || >18'
+  : ''
+
 describe('Plugin', () => {
   let tracer
   let Hapi
@@ -15,7 +19,7 @@ describe('Plugin', () => {
   let reply
 
   describe('hapi', () => {
-    withVersions('hapi', ['hapi', '@hapi/hapi'], (version, module) => {
+    withVersions('hapi', ['hapi', '@hapi/hapi'], versionRange, (version, module) => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
         handler = (request, h, body) => h.response ? h.response(body) : h(body)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update Hapi tests to only test versions supported on current Node.

### Motivation
<!-- What inspired you to submit this pull request? -->

This allows us to share the same code between 3.x and 4.x. This doesn't work for 2.x because older versions of Hapi were already removed.