### PR TITLE
update grpc tests to work with node 16

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -339,7 +339,6 @@ jobs:
       - run: yarn test:plugins:upstream
       - uses: codecov/codecov-action@v2
 
-  # The grpc version ranges we support only support up to Node 14.
   grpc:
     runs-on: ubuntu-latest
     env:
@@ -349,6 +348,8 @@ jobs:
       - uses: ./.github/actions/node/setup
       - run: yarn install
       - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -4,6 +4,8 @@ const types = require('./types')
 const { addHook, channel, AsyncResource } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
+const nodeMajor = parseInt(process.versions.node.split('.')[0])
+
 const patched = new WeakSet()
 const instances = new WeakMap()
 
@@ -232,13 +234,15 @@ function patch (grpc) {
   return grpc
 }
 
-addHook({ name: 'grpc', versions: ['>=1.24.3'] }, patch)
+if (nodeMajor <= 14) {
+  addHook({ name: 'grpc', versions: ['>=1.24.3'] }, patch)
 
-addHook({ name: 'grpc', versions: ['>=1.24.3'], file: 'src/client.js' }, client => {
-  shimmer.wrap(client, 'makeClientConstructor', createWrapMakeClientConstructor())
+  addHook({ name: 'grpc', versions: ['>=1.24.3'], file: 'src/client.js' }, client => {
+    shimmer.wrap(client, 'makeClientConstructor', createWrapMakeClientConstructor())
 
-  return client
-})
+    return client
+  })
+}
 
 addHook({ name: '@grpc/grpc-js', versions: ['>=1.0.3'] }, patch)
 

--- a/packages/datadog-instrumentations/src/grpc/server.js
+++ b/packages/datadog-instrumentations/src/grpc/server.js
@@ -4,6 +4,8 @@ const types = require('./types')
 const { channel, addHook, AsyncResource } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
+const nodeMajor = parseInt(process.versions.node.split('.')[0])
+
 const startChannel = channel('apm:grpc:server:request:start')
 const errorChannel = channel('apm:grpc:server:request:error')
 const updateChannel = channel('apm:grpc:server:request:update')
@@ -139,11 +141,13 @@ function isEmitter (obj) {
   return typeof obj.emit === 'function' && typeof obj.once === 'function'
 }
 
-addHook({ name: 'grpc', versions: ['>=1.24.3'], file: 'src/server.js' }, server => {
-  shimmer.wrap(server.Server.prototype, 'register', wrapRegister)
+if (nodeMajor <= 14) {
+  addHook({ name: 'grpc', versions: ['>=1.24.3'], file: 'src/server.js' }, server => {
+    shimmer.wrap(server.Server.prototype, 'register', wrapRegister)
 
-  return server
-})
+    return server
+  })
+}
 
 addHook({ name: '@grpc/grpc-js', versions: ['>=1.0.3'], file: 'build/src/server.js' }, server => {
   shimmer.wrap(server.Server.prototype, 'register', wrapRegister)

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -319,7 +319,7 @@ describe('Plugin', () => {
                     'component': 'grpc'
                   })
                   expect(traces[0][0].meta).to.have.property(ERROR_STACK)
-                  expect(traces[0][0].meta[ERROR_MESSAGE]).to.match(/^13 INTERNAL:.+$/)
+                  expect(traces[0][0].meta[ERROR_MESSAGE]).to.match(/^13 INTERNAL:.+$/m)
                   expect(traces[0][0].metrics).to.have.property('grpc.status.code', 13)
                 })
             })

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -5,8 +5,10 @@ const getPort = require('get-port')
 const Readable = require('stream').Readable
 const getService = require('./service')
 const loader = require('../../../versions/@grpc/proto-loader').get()
-const pkgs = ['grpc', '@grpc/grpc-js']
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+
+const nodeMajor = parseInt(process.versions.node.split('.')[0])
+const pkgs = nodeMajor > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
 describe('Plugin', () => {
   let grpc

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -3,8 +3,10 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const getPort = require('get-port')
 const Readable = require('stream').Readable
-const pkgs = ['grpc', '@grpc/grpc-js']
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+
+const nodeMajor = parseInt(process.versions.node.split('.')[0])
+const pkgs = nodeMajor > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
 describe('Plugin', () => {
   let grpc


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update `grpc` tests to work with Node 16.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is needed as we're deprecating Node 14.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This was done in a way that can land in both 4.x and 3.x but not 2.x since it dropped versions of grpc.