### PR TITLE
update postgres tests to also run on latest node

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -733,7 +733,6 @@ jobs:
       # - run: yarn test:plugins:upstream
       - uses: codecov/codecov-action@v2
 
-  # The pg version range we support doesn't work beyond Node 14.
   postgres:
     runs-on: ubuntu-latest
     services:
@@ -752,6 +751,8 @@ jobs:
       - uses: ./.github/actions/node/setup
       - run: yarn install
       - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update `postgres` tests to run on also latest Node.

### Motivation
<!-- What inspired you to submit this pull request? -->

It makes it more difficult to bump the minimum version for 4.x otherwise. It's also tech debt we've had for a while as everything should be tested on latest Node.