### PR TITLE
modifying benchmarks to reduce non-determinism

### DIFF
--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -4,7 +4,6 @@ const log = require('../../../packages/dd-trace/src/log')
 
 const {
   DD_TRACE_DEBUG = 'true',
-  ITERATIONS = 5000,
   WITH_LEVEL = 'debug'
 } = process.env
 
@@ -19,6 +18,6 @@ log.use({
   error () {}
 })
 
-for (let i = 0; i < ITERATIONS; i++) {
+for (let i = 0; i < 5000; i++) {
   log[WITH_LEVEL](() => 'message')
 }

--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -18,6 +18,6 @@ log.use({
   error () {}
 })
 
-for (let i = 0; i < 1_000_000; i++) {
+for (let i = 0; i < 1000000; i++) {
   log[WITH_LEVEL](() => 'message')
 }

--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -18,6 +18,6 @@ log.use({
   error () {}
 })
 
-for (let i = 0; i < 5000; i++) {
+for (let i = 0; i < 1_000_000; i++) {
   log[WITH_LEVEL](() => 'message')
 }

--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -4,7 +4,7 @@ const log = require('../../../packages/dd-trace/src/log')
 
 const {
   DD_TRACE_DEBUG = 'true',
-  ITERATIONS = 1000,
+  ITERATIONS = 5000,
   WITH_LEVEL = 'debug'
 } = process.env
 

--- a/benchmark/sirun/log/meta.json
+++ b/benchmark/sirun/log/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 190,
+  "iterations": 40,
   "instructions": true,
   "variants": {
     "without-log": { "env": { "DD_TRACE_DEBUG": "false" } },


### PR DESCRIPTION
### What does this PR do?
- increases number of iterations per benchmark run for logs
- decreases benchmark runs for logs
- test run time goes from ~7s to ~30s
- note that the negative performance results is due to the test being updated in the PR but not in master

### Motivation
- a [forthcoming PR](https://github.com/DataDog/dd-trace-js/pull/3099) adds some weirdness to the benchmark results
- seems like we're hitting some sort of code file threshold