### PR TITLE
Associate tracing span IDs with samples in the wall profiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@datadog/native-iast-rewriter": "2.0.1",
     "@datadog/native-iast-taint-tracking": "^1.5.0",
     "@datadog/native-metrics": "^2.0.0",
-    "@datadog/pprof": "2.2.3",
+    "@datadog/pprof": "3.0.0",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^1.14.0",

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -37,7 +37,8 @@ class Config {
       DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED,
       DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE,
       DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT,
-      DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES
+      DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES,
+      DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED
     } = process.env
 
     const enabled = isTrue(coalesce(options.enabled, DD_PROFILING_ENABLED, true))
@@ -107,6 +108,9 @@ class Config {
       exportStrategies,
       exportCommand
     }
+
+    this.hotspots = isTrue(coalesce(options.hotspots,
+      DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED, false))
 
     const profilers = options.profilers
       ? options.profilers

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -18,8 +18,10 @@ function getActiveSpan () {
 class NativeWallProfiler {
   constructor (options = {}) {
     this.type = 'wall'
+    // input as micros, passed on as micros
     this._samplingInterval = options.samplingInterval || 1e6 / 99 // 99hz
-    this._flushInterval = options.flushInterval || 60 * 1000 // 60 seconds
+    // input as millis, passed on as micros
+    this._flushInterval = options.flushInterval * 1000 || 60 * 1e6 // 60 seconds
     this._hotspots = options.hotspots
     this._mapper = undefined
     this._pprof = undefined

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -27,6 +27,7 @@ class NativeWallProfiler {
     // Bind to this so the same value can be used to unsubscribe later
     this._enter = this._enter.bind(this)
     this._exit = this._exit.bind(this)
+    this._logger = options.logger
   }
 
   resetStack () {
@@ -37,6 +38,11 @@ class NativeWallProfiler {
   }
 
   start ({ mapper } = {}) {
+    if (this._hotspots && !this._emittedFFMessage && this._logger) {
+      this._logger.debug(`Wall profiler: Enable config_trace_show_breakdown_profiling_for_node feature flag to see code hotspots.`)
+      this._emittedFFMessage = true
+    }
+
     this._mapper = mapper
     this._pprof = require('@datadog/pprof')
 

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -106,7 +106,6 @@ class NativeWallProfiler {
     this._stop()
     this._stop = undefined
     this._setLabels = undefined
-    this._labelsCaptured = undefined
     if (this._hotspots) {
       beforeCh.unsubscribe(this._enter)
       afterCh.unsubscribe(this._exit)
@@ -118,16 +117,14 @@ class NativeWallProfiler {
 
   _record () {
     if (this._hotspots) {
-      const { stop, setLabels, labelsCaptured } = this._pprof.time.startWithLabels(
+      const { stop, setLabels } = this._pprof.time.startWithLabels(
         this._samplingInterval, this._flushInterval, null, this._mapper, false)
       this._stop = stop
       this._setLabels = setLabels
-      this._labelsCaptured = labelsCaptured
     } else {
       this._stop = this._pprof.time.start(
         this._samplingInterval, null, this._mapper, false)
       this._setLabels = undefined
-      this._labelsCaptured = undefined
     }
   }
 }

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -31,9 +31,7 @@ class NativeWallProfiler {
   }
 
   resetStack () {
-    this._currentSpan = undefined
     this._currentLabels = undefined
-    this._spanStack = []
     this._labelStack = []
   }
 
@@ -64,16 +62,6 @@ class NativeWallProfiler {
     }
   }
 
-  markAsSampled (span) {
-    // NOTE: there's no guarantee these tags will be applied to the span as it
-    // is possible it'll be sent to the agent by the time we get to execute
-    // this code.
-    if (span && this._labelsCaptured()) {
-      span.setTag('sampled', 'yes')
-      span.setTag('manual.keep', true)
-    }
-  }
-
   setLabels (labels) {
     this._currentLabels = labels
     this._setLabels(labels)
@@ -82,16 +70,7 @@ class NativeWallProfiler {
   _enter () {
     if (!this._setLabels) return
 
-    const lastSpan = this._currentSpan
-    this.markAsSampled(lastSpan)
-    // NOTE: We stack nulls/undefineds *except* at the bottom of the
-    // stack, since pop() on an empty stack "synthesizes" those anyway.
-    if (lastSpan || this._spanStack.length > 0) {
-      this._spanStack.push(lastSpan)
-    }
-
     const currentSpan = getActiveSpan() || null
-    this._currentSpan = currentSpan
 
     const activeCtx = currentSpan ? currentSpan.context() : null
 
@@ -108,8 +87,6 @@ class NativeWallProfiler {
   _exit () {
     if (!this._setLabels) return
 
-    this.markAsSampled(this._currentSpan)
-    this._currentSpan = this._spanStack.pop()
     this.setLabels(this._labelStack.pop())
   }
 

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -1,11 +1,38 @@
 'use strict'
 
+const { storage } = require('../../../../datadog-core')
+
+const dc = require('../../../../diagnostics_channel')
+
+const beforeCh = dc.channel('dd-trace:storage:before')
+const afterCh = dc.channel('dd-trace:storage:after')
+const incomingHttpRequestStart = dc.channel('dd-trace:incomingHttpRequestStart')
+const incomingHttpRequestEnd = dc.channel('dd-trace:incomingHttpRequestEnd')
+
+function getActiveSpan () {
+  const store = storage.getStore()
+  if (!store) return
+  return store.span
+}
+
 class NativeWallProfiler {
   constructor (options = {}) {
     this.type = 'wall'
     this._samplingInterval = options.samplingInterval || 1e6 / 99 // 99hz
+    this._flushInterval = options.flushInterval || 60 * 1000 // 60 seconds
     this._mapper = undefined
     this._pprof = undefined
+
+    // Bind to this so the same value can be used to unsubscribe later
+    this._enter = this._enter.bind(this)
+    this._exit = this._exit.bind(this)
+  }
+
+  resetStack () {
+    this._currentSpan = undefined
+    this._currentLabels = undefined
+    this._spanStack = []
+    this._labelStack = []
   }
 
   start ({ mapper } = {}) {
@@ -20,7 +47,62 @@ class NativeWallProfiler {
       process._stopProfilerIdleNotifier = () => {}
     }
 
+    this.resetStack()
     this._record()
+    this._enter()
+    beforeCh.subscribe(this._enter)
+    afterCh.subscribe(this._exit)
+    incomingHttpRequestStart.subscribe(this._enter)
+    incomingHttpRequestEnd.subscribe(this._exit)
+  }
+
+  markAsSampled (span) {
+    // NOTE: there's no guarantee these tags will be applied to the span as it
+    // is possible it'll be sent to the agent by the time we get to execute
+    // this code.
+    if (span && this._labelsCaptured()) {
+      span.setTag('sampled', 'yes')
+      span.setTag('manual.keep', true)
+    }
+  }
+
+  setLabels (labels) {
+    this._currentLabels = labels
+    this._setLabels(labels)
+  }
+
+  _enter () {
+    if (!this._stop) return
+
+    const lastSpan = this._currentSpan
+    this.markAsSampled(lastSpan)
+    // NOTE: We stack nulls/undefineds *except* at the bottom of the
+    // stack, since pop() on an empty stack "synthesizes" those anyway.
+    if (lastSpan || this._spanStack.length > 0) {
+      this._spanStack.push(lastSpan)
+    }
+
+    const currentSpan = getActiveSpan() || null
+    this._currentSpan = currentSpan
+
+    const activeCtx = currentSpan ? currentSpan.context() : null
+
+    const labels = activeCtx ? {
+      'span id': activeCtx.toSpanId()
+    } : null
+
+    if (this._currentLabels || this._labelStack.length > 0) {
+      this._labelStack.push(this._currentLabels)
+    }
+    this.setLabels(labels)
+  }
+
+  _exit () {
+    if (!this._stop) return
+
+    this.markAsSampled(this._currentSpan)
+    this._currentSpan = this._spanStack.pop()
+    this.setLabels(this._labelStack.pop())
   }
 
   profile () {
@@ -36,11 +118,20 @@ class NativeWallProfiler {
     if (!this._stop) return
     this._stop()
     this._stop = undefined
+    this._setLabels = undefined
+    beforeCh.unsubscribe(this._enter)
+    afterCh.unsubscribe(this._exit)
+    incomingHttpRequestStart.unsubscribe(this._enter)
+    incomingHttpRequestEnd.unsubscribe(this._exit)
+    this.resetStack()
   }
 
   _record () {
-    this._stop = this._pprof.time.start(this._samplingInterval, null,
-      this._mapper, false)
+    const { stop, setLabels, labelsCaptured } = this._pprof.time.start(
+      this._samplingInterval, this._flushInterval, null, this._mapper, false)
+    this._stop = stop
+    this._setLabels = setLabels
+    this._labelsCaptured = labelsCaptured
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Uses the new functionality of wall profiler in https://github.com/DataDog/pprof-nodejs/pull/98 to associate tracing span IDs with wall samples.

### Motivation
Adding the capabilities of the experimental CPU profiler to the wall profiler.

<!-- TO REVISIT LATER

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

-->

### Additional Notes

Things that do not seem to work properly yet:

* Without any changes, it only captures span IDs for work in asynchronous subtasks of the work that sets the span ID. For example, the `_enter` method in `wall.js` won't get invoked for `HTTPINCOMINGMESSAGE` handler, but it will be invoked for a `FSREQCALLBACK` if the request handler does async file IO. For this reason, the code specifically adds handlers for incoming HTTP requests. *Advice needed:* which other handlers need to be added?
* For some reason, the IDs of spans that end up marked with the `execution_traced` tag and the ones that show up in the captured profiles often don't match. *Help needed:* someone with tracing expertise to review the code with me.
