### PR TITLE
[ci-visibility] Use new endpoint for code coverage

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -817,7 +817,7 @@ testFrameworks.forEach(({
 
           const [coveragePayload] = coverageRequest.payload
           assert.notProperty(coverageRequest.headers, 'dd-api-key')
-          assert.propertyVal(coverageRequest.headers, 'x-datadog-evp-subdomain', 'event-platform-intake')
+          assert.propertyVal(coverageRequest.headers, 'x-datadog-evp-subdomain', 'citestcov-intake')
           assert.propertyVal(coveragePayload, 'name', 'coverage1')
           assert.propertyVal(coveragePayload, 'filename', 'coverage1.msgpack')
           assert.propertyVal(coveragePayload, 'type', 'application/msgpack')

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -34,7 +34,7 @@ class Writer extends BaseWriter {
     if (this._evpProxyPrefix) {
       options.path = `${this._evpProxyPrefix}/api/v2/citestcov`
       delete options.headers['dd-api-key']
-      options.headers['X-Datadog-EVP-Subdomain'] = 'event-platform-intake'
+      options.headers['X-Datadog-EVP-Subdomain'] = 'citestcov-intake'
     }
 
     log.debug(() => `Request to the intake: ${safeJSONStringify(options)}`)

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -17,7 +17,7 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     this._url = url || new URL(`https://citestcycle-intake.${site}`)
     this._writer = new Writer({ url: this._url, tags })
 
-    this._coverageUrl = url || new URL(`https://event-platform-intake.${site}`)
+    this._coverageUrl = url || new URL(`https://citestcov-intake.${site}`)
     this._coverageWriter = new CoverageWriter({ url: this._coverageUrl })
 
     this._apiUrl = url || new URL(`https://api.${site}`)

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/coverage-writer.spec.js
@@ -29,7 +29,7 @@ describe('CI Visibility Coverage Writer', () => {
 
     url = {
       protocol: 'https:',
-      hostname: 'event-platform-intake.datadog.com'
+      hostname: 'citestcov-intake.datadog.com'
     }
 
     log = {

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -169,7 +169,7 @@ describe('CI Visibility Agentless Exporter', () => {
       const site = 'd4tad0g.com'
       const agentlessExporter = new AgentlessCiVisibilityExporter({ site, tags: {} })
       expect(agentlessExporter._url.href).to.equal(`https://citestcycle-intake.${site}/`)
-      expect(agentlessExporter._coverageUrl.href).to.equal(`https://event-platform-intake.${site}/`)
+      expect(agentlessExporter._coverageUrl.href).to.equal(`https://citestcov-intake.${site}/`)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
* Change code coverage endpoint from `event-platform-intake.${DD_SITE}` to `citestcov-intake.${DD_SITE}`

### Motivation
Keep up with backend changes.

