### PR TITLE
Fix path traversal vulnerability on close

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -6,10 +6,14 @@ const { storage } = require('../../../../../datadog-core')
 const InjectionAnalyzer = require('./injection-analyzer')
 const { PATH_TRAVERSAL } = require('../vulnerabilities')
 
+const ignoredOperations = ['dir.close', 'close']
+
 class PathTraversalAnalyzer extends InjectionAnalyzer {
   constructor () {
     super(PATH_TRAVERSAL)
     this.addSub('apm:fs:operation:start', obj => {
+      if (ignoredOperations.includes(obj.operation)) return
+
       const pathArguments = []
       if (obj.dest) {
         pathArguments.push(obj.dest)

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -186,24 +186,30 @@ prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, t
       desc += `with vulnerabile index ${vulnerableIndex}`
     }
     describe(desc, () => {
+      const fsSyncWayMethodPath = path.join(os.tmpdir(), 'fs-sync-way-method.js')
+      const fsAsyncWayMethodPath = path.join(os.tmpdir(), 'fs-async-way-method.js')
+      const fsPromiseWayMethodPath = path.join(os.tmpdir(), 'fs-promise-way-method.js')
+
+      before(() => {
+        fs.copyFileSync(path.join(__dirname, 'resources', 'fs-sync-way-method.js'), fsSyncWayMethodPath)
+        fs.copyFileSync(path.join(__dirname, 'resources', 'fs-async-way-method.js'), fsAsyncWayMethodPath)
+        fs.copyFileSync(path.join(__dirname, 'resources', 'fs-promise-way-method.js'), fsPromiseWayMethodPath)
+      })
+
+      after(() => {
+        fs.rmSync(fsSyncWayMethodPath, { force: true })
+        fs.rmSync(fsAsyncWayMethodPath, { force: true })
+        fs.rmSync(fsPromiseWayMethodPath, { force: true })
+      })
+
       runFsMethodTest(`test fs.${methodName}Sync method`, vulnerableIndex, (args) => {
-        const method = `${methodName}Sync`
-        try {
-          const res = fs[method](...args)
-          cb(res)
-        } catch (e) {
-          cb(null)
-        }
+        require(fsSyncWayMethodPath)(methodName, args, cb)
       }, ...args)
       runFsMethodTest(`test fs.${methodName} method`, vulnerableIndex, (args) => {
-        return new Promise((resolve, reject) => {
-          fs[methodName](...args, (err, res) => {
-            resolve(cb(res))
-          })
-        })
+        return require(fsAsyncWayMethodPath)(methodName, args, cb)
       }, ...args)
       runFsMethodTest(`test fs.promises.${methodName} method`, vulnerableIndex, (args) => {
-        return fs.promises[methodName](...args).then(cb).catch(cb)
+        return require(fsPromiseWayMethodPath)(methodName, args, cb)
       }, ...args)
     })
   }

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-async-way-method.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-async-way-method.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const fs = require('fs')
+
+module.exports = function (methodName, args, cb) {
+  return new Promise((resolve, reject) => {
+    fs[methodName](...args, (err, res) => {
+      resolve(cb(res))
+    })
+  })
+}

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-promise-way-method.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-promise-way-method.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const fs = require('fs')
+
+module.exports = function (methodName, args, cb) {
+  return fs.promises[methodName](...args).then(cb).catch(cb)
+}

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-sync-way-method.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/fs-sync-way-method.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const fs = require('fs')
+
+module.exports = function (methodName, args, cb) {
+  const method = `${methodName}Sync`
+  try {
+    const res = fs[method](...args)
+    cb(res)
+  } catch (e) {
+    cb(null)
+  }
+}

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -151,7 +151,9 @@ function prepareTestServerForIast (description, tests) {
         experimental: {
           iast: {
             enabled: true,
-            requestSampling: 100
+            requestSampling: 100,
+            maxConcurrentRequests: 100,
+            maxContextOperations: 100
           }
         }
       }))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We have detected that an extra vulnerability was reported on dir.close function when the open was already vulnerable point. This PR prevents this double detection.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
