### PR TITLE
force a stop before starting metrics

### DIFF
--- a/packages/dd-trace/test/metrics.spec.js
+++ b/packages/dd-trace/test/metrics.spec.js
@@ -51,6 +51,7 @@ describe('metrics', () => {
 
   describe('start', () => {
     it('it should initialize the Dogstatsd client with the correct options', function () {
+      metrics.stop()
       metrics.start(config)
 
       expect(Client).to.have.been.calledWithMatch({
@@ -66,6 +67,7 @@ describe('metrics', () => {
     it('it should initialize the Dogstatsd client with an IPv6 URL', function () {
       config.hostname = '::1'
 
+      metrics.stop()
       metrics.start(config)
 
       expect(Client).to.have.been.calledWithMatch({
@@ -79,6 +81,7 @@ describe('metrics', () => {
     })
 
     it('should start collecting metrics every 10 seconds', () => {
+      metrics.stop()
       metrics.start(config)
 
       global.gc()


### PR DESCRIPTION
### What does this PR do?
- attempting to fix flaky windows tests
- obsoletes #3163
- proposed solution by @Qard

### Motivation
- currently all PRs are failing
- no individual tests fail but the file itself seems to fail

### Additional Notes
- I bisected disabled tests until I narrowed it down to these three
- any of of the three tests seems to trigger the failure