### PR TITLE
Remove string type check in `trackUserLoginFailureEvent()` to be consistent with the other methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -638,13 +638,13 @@ export declare interface Appsec {
 
   /**
    * Links a failed login event to the current trace.
-   * @param {string} userId The user id of the attemped login.
+   * @param {any} userId The user id of the attempted login.
    * @param {boolean} exists If the user id exists.
    * @param {[key: string]: string} metadata Custom fields to link to the login failure event.
    *
    * @beta This method is in beta and could change in future versions.
    */
-  trackUserLoginFailureEvent(userId: string, exists: boolean, metadata?: { [key: string]: string }): void
+  trackUserLoginFailureEvent(userId: any, exists: boolean, metadata?: { [key: string]: string }): void
 
   /**
    * Links a custom event to the current trace.

--- a/packages/dd-trace/src/appsec/sdk/track_event.js
+++ b/packages/dd-trace/src/appsec/sdk/track_event.js
@@ -24,7 +24,7 @@ function trackUserLoginSuccessEvent (tracer, user, metadata) {
 }
 
 function trackUserLoginFailureEvent (tracer, userId, exists, metadata) {
-  if (!user || !user.id) {
+  if (!userId || !userId) {
     log.warn('Invalid userId provided to trackUserLoginFailureEvent')
     return
   }

--- a/packages/dd-trace/src/appsec/sdk/track_event.js
+++ b/packages/dd-trace/src/appsec/sdk/track_event.js
@@ -24,7 +24,7 @@ function trackUserLoginSuccessEvent (tracer, user, metadata) {
 }
 
 function trackUserLoginFailureEvent (tracer, userId, exists, metadata) {
-  if (!userId || typeof userId !== 'string') {
+  if (!user || !user.id) {
     log.warn('Invalid userId provided to trackUserLoginFailureEvent')
     return
   }

--- a/packages/dd-trace/src/appsec/sdk/track_event.js
+++ b/packages/dd-trace/src/appsec/sdk/track_event.js
@@ -24,7 +24,7 @@ function trackUserLoginSuccessEvent (tracer, user, metadata) {
 }
 
 function trackUserLoginFailureEvent (tracer, userId, exists, metadata) {
-  if (!userId || !userId) {
+  if (!userId) {
     log.warn('Invalid userId provided to trackUserLoginFailureEvent')
     return
   }

--- a/packages/dd-trace/test/appsec/sdk/track_event.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event.spec.js
@@ -102,13 +102,8 @@ describe('track_event', () => {
     describe('trackUserLoginFailureEvent', () => {
       it('should log warning when passed invalid userId', () => {
         trackUserLoginFailureEvent(tracer, null, false)
-        trackUserLoginFailureEvent(tracer, [], false)
 
-        expect(log.warn).to.have.been.calledTwice
-        expect(log.warn.firstCall)
-          .to.have.been.calledWithExactly('Invalid userId provided to trackUserLoginFailureEvent')
-        expect(log.warn.secondCall)
-          .to.have.been.calledWithExactly('Invalid userId provided to trackUserLoginFailureEvent')
+        expect(log.warn).to.have.been.calledOnceWithExactly('Invalid userId provided to trackUserLoginFailureEvent')
         expect(setUserTags).to.not.have.been.called
         expect(rootSpan.addTags).to.not.have.been.called
       })


### PR DESCRIPTION
### What does this PR do?
We can send an integer to trackUserLoginSuccessEvent but not to trackUserLoginFailureEvent and if you don't activate the debugger you don't see any message.

### Motivation
We were not seeing our trackUserLoginFailureEvent in Datadog.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
