### PR TITLE
Peer service computation

### DIFF
--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -11,7 +11,8 @@
     "proxyquire": true,
     "withNamingSchema": true,
     "withVersions": true,
-    "withExports": true
+    "withExports": true,
+    "withPeerService": true
   },
   "rules": {
     "no-unused-expressions": 0,

--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -60,6 +60,13 @@ describe('Plugin', () => {
         })
 
         describe('when sending messages', () => {
+          withPeerService(
+            () => tracer,
+            () => sender.send({ key: 'value' }),
+            'localhost',
+            'out.host'
+          )
+
           it('should do automatic instrumentation', done => {
             agent
               .use(traces => {

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -53,6 +53,13 @@ describe('Plugin', () => {
           })
 
           describe('when sending commands', () => {
+            withPeerService(
+              () => tracer,
+              () => channel.assertQueue('test', {}, () => {}),
+              'localhost',
+              'out.host'
+            )
+
             it('should do automatic instrumentation for immediate commands', done => {
               agent
                 .use(traces => {
@@ -124,6 +131,13 @@ describe('Plugin', () => {
           })
 
           describe('when publishing messages', () => {
+            withPeerService(
+              () => tracer,
+              () => channel.assertQueue('test', {}, () => {}),
+              'localhost',
+              'out.host'
+            )
+
             it('should do automatic instrumentation', done => {
               agent
                 .use(traces => {

--- a/packages/datadog-plugin-dns/src/lookup.js
+++ b/packages/datadog-plugin-dns/src/lookup.js
@@ -33,7 +33,7 @@ class DNSLookupPlugin extends ClientPlugin {
       span.setTag('dns.address', result)
     }
 
-    span.finish()
+    super.finish()
   }
 }
 

--- a/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
@@ -32,7 +32,7 @@ class GoogleCloudPubsubConsumerPlugin extends ConsumerPlugin {
       span.setTag('pubsub.ack', 1)
     }
 
-    span.finish()
+    super.finish()
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -32,7 +32,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
   finish ({ res, args }) {
     const span = this.activeSpan
     this.config.hooks.execute(span, args, res)
-    span.finish()
+    super.finish()
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/parse.js
+++ b/packages/datadog-plugin-graphql/src/parse.js
@@ -25,7 +25,7 @@ class GraphQLParsePlugin extends TracingPlugin {
 
     this.config.hooks.parse(span, source, document)
 
-    span.finish()
+    super.finish()
   }
 }
 

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -56,11 +56,6 @@ class GraphQLResolvePlugin extends TracingPlugin {
     }
   }
 
-  finish (finishTime) {
-    const span = this.activeSpan
-    span.finish(finishTime)
-  }
-
   constructor (...args) {
     super(...args)
 

--- a/packages/datadog-plugin-graphql/src/validate.js
+++ b/packages/datadog-plugin-graphql/src/validate.js
@@ -21,7 +21,7 @@ class GraphQLValidatePlugin extends TracingPlugin {
   finish ({ document, errors }) {
     const span = this.activeSpan
     this.config.hooks.validate(span, document, errors)
-    span.finish()
+    super.finish()
   }
 }
 

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -57,7 +57,7 @@ class GrpcClientPlugin extends ClientPlugin {
       addMetadataTags(span, metadata, metadataFilter, 'response')
     }
 
-    span.finish()
+    super.finish()
   }
 
   configure (config) {

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -68,7 +68,7 @@ class GrpcServerPlugin extends ServerPlugin {
       addMetadataTags(span, trailer, metadataFilter, 'response')
     }
 
-    span.finish()
+    super.finish()
   }
 
   configure (config) {

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -83,7 +83,7 @@ class HttpClientPlugin extends ClientPlugin {
     addRequestHeaders(req, span, this.config)
 
     this.config.hooks.request(span, req, res)
-    span.finish()
+    super.finish()
   }
 
   error (err) {

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -56,6 +56,26 @@ describe('Plugin', () => {
             })
         })
 
+        withPeerService(
+          () => tracer,
+          () => {
+            const app = express()
+            app.get('/user', (req, res) => {
+              res.status(200).send()
+            })
+            getPort().then(port => {
+              appListener = server(app, port, () => {
+                const req = http.request(`${protocol}://localhost:${port}/user`, res => {
+                  res.on('data', () => {})
+                })
+                req.end()
+              })
+            })
+          },
+          'localhost',
+          'out.host'
+        )
+
         it('should do automatic instrumentation', done => {
           const app = express()
           app.get('/user', (req, res) => {

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -93,11 +93,6 @@ class Http2ClientPlugin extends ClientPlugin {
     this.enter(span, store)
   }
 
-  finish () {
-    const span = storage.getStore().span
-    span.finish()
-  }
-
   configure (config) {
     return super.configure(normalizeConfig(config))
   }

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -52,6 +52,31 @@ describe('Plugin', () => {
             })
         })
 
+        withPeerService(
+          () => tracer,
+          done => {
+            getPort().then(port => {
+              const app = (stream, headers) => {
+                stream.respond({
+                  ':status': 200
+                })
+                stream.end()
+              }
+              appListener = server(app, port, () => {
+                const client = http2
+                  .connect(`${protocol}://localhost:${port}`)
+                  .on('error', done)
+
+                const req = client.request({ ':path': '/user', ':method': 'GET' })
+                req.on('error', done)
+
+                req.end()
+              })
+            })
+          },
+          'localhost', 'out.host'
+        )
+
         it('should do automatic instrumentation', done => {
           const app = (stream, headers) => {
             stream.respond({

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -25,6 +25,12 @@ describe('Plugin', () => {
           Memcached = proxyquire(`../../../versions/memcached@${version}/node_modules/memcached`, {})
         })
 
+        withPeerService(
+          () => tracer,
+          done => memcached.get('test', err => err && done(err)),
+          'localhost',
+          'out.host'
+        )
         it('should do automatic instrumentation when using callbacks', done => {
           memcached = new Memcached('localhost:11211', { retries: 0 })
 

--- a/packages/datadog-plugin-moleculer/src/client.js
+++ b/packages/datadog-plugin-moleculer/src/client.js
@@ -29,7 +29,7 @@ class MoleculerClientPlugin extends ClientPlugin {
       span.addTags(moleculerTags(broker, ctx, this.config))
     }
 
-    span.finish()
+    super.finish()
   }
 }
 

--- a/packages/datadog-plugin-moleculer/test/index.spec.js
+++ b/packages/datadog-plugin-moleculer/test/index.spec.js
@@ -108,10 +108,28 @@ describe('Plugin', () => {
 
       describe('client', () => {
         describe('without configuration', () => {
-          before(() => agent.load('moleculer', { server: false }))
-          before(() => startBroker())
-          after(() => broker.stop())
-          after(() => agent.close({ ritmReset: false }))
+          const hostname = os.hostname()
+          let tracer
+
+          beforeEach(() => startBroker())
+          afterEach(() => broker.stop())
+
+          beforeEach(done => {
+            agent.load('moleculer', { server: false })
+              .then(() => { tracer = require('../../dd-trace') })
+              .then(done)
+              .catch(done)
+          })
+          afterEach(() => agent.close({ ritmReset: false }))
+
+          withPeerService(
+            () => tracer,
+            done => {
+              broker.call('math.add', { a: 5, b: 3 }).catch(done)
+            },
+            hostname,
+            'out.host'
+          )
 
           it('should do automatic instrumentation', done => {
             agent.use(traces => {
@@ -121,7 +139,7 @@ describe('Plugin', () => {
               expect(spans[0]).to.have.property('service', 'test')
               expect(spans[0]).to.have.property('resource', 'math.add')
               expect(spans[0].meta).to.have.property('span.kind', 'client')
-              expect(spans[0].meta).to.have.property('out.host', os.hostname())
+              expect(spans[0].meta).to.have.property('out.host', hostname)
               expect(spans[0].meta).to.have.property('moleculer.context.action', 'math.add')
               expect(spans[0].meta).to.have.property('moleculer.context.node_id', `server-${process.pid}`)
               expect(spans[0].meta).to.have.property('moleculer.context.request_id')

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -75,6 +75,16 @@ describe('Plugin', () => {
       })
     })
 
+    withPeerService(
+      () => tracer,
+      () => {
+        const socket = new net.Socket()
+        socket.connect(port, 'localhost')
+      },
+      'localhost',
+      'out.host'
+    )
+
     it('should instrument connect with a port', done => {
       const socket = new net.Socket()
       tracer.scope().activate(parent, () => {

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -40,6 +40,13 @@ describe('Legacy Plugin', () => {
           sub = redis.createClient()
         })
 
+        withPeerService(
+          () => tracer,
+          () => client.get('foo'),
+          '127.0.0.1',
+          'out.host'
+        )
+
         it('should do automatic instrumentation when using callbacks', done => {
           client.on('error', done)
           agent

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -47,6 +47,13 @@ describe('Plugin', () => {
           })
 
           describe('sending a message', () => {
+            withPeerService(
+              () => tracer,
+              () => context.sender.send({ body: 'Hello World!' }),
+              'localhost',
+              'out.host'
+            )
+
             it('should automatically instrument', (done) => {
               agent.use(traces => {
                 const span = traces[0][0]

--- a/packages/datadog-plugin-sharedb/src/index.js
+++ b/packages/datadog-plugin-sharedb/src/index.js
@@ -25,7 +25,7 @@ class SharedbPlugin extends ServerPlugin {
     if (this.config.hooks && this.config.hooks.reply) {
       this.config.hooks.reply(span, request, res)
     }
-    span.finish()
+    super.finish()
   }
 }
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -306,6 +306,8 @@ class Config {
     const DD_TRACE_SPAN_ATTRIBUTE_SCHEMA = validateNamingVersion(
       process.env.DD_TRACE_SPAN_ATTRIBUTE_SCHEMA
     )
+    const DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED = process.env.DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED
+
     const DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH = coalesce(
       process.env.DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH,
       '512'
@@ -524,6 +526,10 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       exporters: DD_PROFILING_EXPORTERS
     }
     this.spanAttributeSchema = DD_TRACE_SPAN_ATTRIBUTE_SCHEMA
+    this.spanComputePeerService = (this.spanAttributeSchema === 'v0'
+      ? isTrue(DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED)
+      : true
+    )
     this.lookup = options.lookup
     this.startupLogs = isTrue(DD_TRACE_STARTUP_LOGS)
     // Disabled for CI Visibility's agentless

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -26,6 +26,8 @@ module.exports = {
   ERROR_STACK: 'error.stack',
   COMPONENT: 'component',
   CLIENT_PORT_KEY: 'network.destination.port',
+  PEER_SERVICE_KEY: 'peer.service',
+  PEER_SERVICE_SOURCE_KEY: '_dd.peer.service.source',
   SCI_REPOSITORY_URL: '_dd.git.repository_url',
   SCI_COMMIT_SHA: '_dd.git.commit.sha'
 }

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -26,6 +26,7 @@ class DatadogTracer {
     this._version = config.version
     this._env = config.env
     this._tags = config.tags
+    this._computePeerService = config.spanComputePeerService
     this._logInjection = config.logInjection
     this._debug = config.debug
     this._prioritySampler = new PrioritySampler(config.env, config.sampler)

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -56,13 +56,18 @@ class OutboundPlugin extends TracingPlugin {
 
   startSpan (name, options) {
     const span = super.startSpan(name, options)
+    return span
+  }
+
+  finish () {
+    const span = this.activeSpan
     if (this.tracer._computePeerService) {
       const peerData = this.getPeerService(span.context()._tags)
       if (peerData) {
         span.addTags(peerData)
       }
     }
-    return span
+    super.finish(...arguments)
   }
 
   connect (url) {

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -1,16 +1,68 @@
 'use strict'
 
-const { CLIENT_PORT_KEY } = require('../constants')
+const {
+  CLIENT_PORT_KEY,
+  PEER_SERVICE_KEY,
+  PEER_SERVICE_SOURCE_KEY
+} = require('../constants')
 const TracingPlugin = require('./tracing')
+
+const COMMON_PEER_SVC_SOURCE_TAGS = [
+  'net.peer.name',
+  'out.host'
+]
 
 // TODO: Exit span on finish when AsyncResource instances are removed.
 class OutboundPlugin extends TracingPlugin {
+  static get peerServicePrecursors () { return [] }
+
   constructor (...args) {
     super(...args)
 
     this.addTraceSub('connect', message => {
       this.connect(message)
     })
+  }
+
+  getPeerService (tags) {
+    /**
+     * Compute `peer.service` and associated metadata from available tags, based
+     * on defined precursor tags names.
+     *
+     * - The `peer.service` tag is set from the first precursor available (based on list ordering)
+     * - The `_dd.peer.service.source` tag is set from the precursor's name
+     * - If `peer.service` was defined _before_ we compute it (for example in custom instrumentation),
+     *   `_dd.peer.service.source`'s value is `peer.service`
+     */
+
+    if (tags['peer.service']) {
+      return { [PEER_SERVICE_SOURCE_KEY]: 'peer.service' }
+    }
+
+    const sourceTags = [
+      ...this.constructor.peerServicePrecursors,
+      ...COMMON_PEER_SVC_SOURCE_TAGS
+    ]
+    for (const sourceTag of sourceTags) {
+      if (tags[sourceTag]) {
+        return {
+          [PEER_SERVICE_KEY]: tags[sourceTag],
+          [PEER_SERVICE_SOURCE_KEY]: sourceTag
+        }
+      }
+    }
+    return {}
+  }
+
+  startSpan (name, options) {
+    const span = super.startSpan(name, options)
+    if (this.tracer._computePeerService) {
+      const peerData = this.getPeerService(span.context()._tags)
+      if (peerData) {
+        span.addTags(peerData)
+      }
+    }
+    return span
   }
 
   connect (url) {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -92,6 +92,7 @@ describe('Config', () => {
     expect(config).to.have.property('traceId128BitGenerationEnabled', false)
     expect(config).to.have.property('traceId128BitLoggingEnabled', false)
     expect(config).to.have.property('spanAttributeSchema', 'v0')
+    expect(config).to.have.property('spanComputePeerService', false)
     expect(config).to.have.deep.property('serviceMapping', {})
     expect(config).to.have.nested.deep.property('tracePropagationStyle.inject', ['tracecontext', 'datadog'])
     expect(config).to.have.nested.deep.property('tracePropagationStyle.extract', ['tracecontext', 'datadog'])

--- a/packages/dd-trace/test/plugins/outbound.spec.js
+++ b/packages/dd-trace/test/plugins/outbound.spec.js
@@ -1,0 +1,59 @@
+'use strict'
+
+require('../setup/tap')
+
+const OutboundPlugin = require('../../src/plugins/outbound')
+
+describe('OuboundPlugin', () => {
+  describe('peer.service computation', () => {
+    let instance = null
+
+    before(() => {
+      instance = new OutboundPlugin()
+    })
+
+    it('should not set tags if no precursor tags are available', () => {
+      const res = instance.getPeerService({
+        fooIsNotAPrecursor: 'bar'
+      })
+      expect(res).to.deep.equal({})
+    })
+
+    it('should grab from remote host in datadog format', () => {
+      const res = instance.getPeerService({
+        fooIsNotAPrecursor: 'bar',
+        'out.host': 'mypeerservice'
+      })
+      expect(res).to.deep.equal({
+        'peer.service': 'mypeerservice',
+        '_dd.peer.service.source': 'out.host'
+      })
+    })
+
+    it('should grab from remote host in OTel format', () => {
+      const res = instance.getPeerService({
+        fooIsNotAPrecursor: 'bar',
+        'net.peer.name': 'mypeerservice'
+      })
+      expect(res).to.deep.equal({
+        'peer.service': 'mypeerservice',
+        '_dd.peer.service.source': 'net.peer.name'
+      })
+    })
+
+    it('should use specific tags in order of precedence if they are available', () => {
+      class WithPrecursors extends OutboundPlugin {
+        static get peerServicePrecursors () { return [ 'foo', 'bar' ] }
+      }
+      const res = new WithPrecursors().getPeerService({
+        fooIsNotAPrecursor: 'bar',
+        bar: 'barPeerService',
+        foo: 'fooPeerService'
+      })
+      expect(res).to.deep.equal({
+        'peer.service': 'fooPeerService',
+        '_dd.peer.service.source': 'foo'
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -9,7 +9,7 @@ const externals = require('../plugins/externals.json')
 const slackReport = require('./slack-report')
 const metrics = require('../../src/metrics')
 const agent = require('../plugins/agent')
-const Nomenclature = require('../../../dd-trace/src/service-naming')
+const Nomenclature = require('../../src/service-naming')
 const { storage } = require('../../../datadog-core')
 const { schemaDefinitions } = require('../../src/service-naming/schemas')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add peer service API for all spans of outgoing types, i.e. all `client` and `producer` spans.

### Motivation
<!-- What inspired you to submit this pull request? -->
Introducing tags to provide the data necessary for a better service map with less fake services.

* `peer.service`: the new source of truth for the service map, computed from precursor tags
* `_dd.peer.service.source`: the name of the tag use to get the value of peer service

These tags are added:
* in service naming version `v0` if the environment variable `DD_TRACE_SPAN_PEER_SERVICE` is set to a truthy value
* in all other service naming versions by default

Computing these uses the existing plugin hierarchy, with an optional `peerServicePrecursors` getter on classes which have more precursors than the default OTel/DDog `out.host`/`net.peer.host` tag.

This PR enables the computation of peer service for *all* `ClientPlugin` children, but not all of them have tests for peer service. This is because they (mostly databases) do not all have the correct precursors _yet_, or precursor sources need to be added - currently, only common tags are present, although the mechanism to add more tags is available.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
