### PR TITLE
postgres: DBM full service fallback w/ prepared statements

### DIFF
--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -27,7 +27,7 @@ class PGPlugin extends DatabasePlugin {
       }
     })
 
-    query.text = this.injectDbmQuery(query.text, service)
+    query.text = this.injectDbmQuery(query.text, service, !!query.name)
   }
 }
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -313,7 +313,7 @@ describe('Plugin', () => {
           if (client.queryQueue[0] !== undefined) {
             try {
               expect(client.queryQueue[0].text).to.equal(
-                `/*dddbs='serviced',dde='tester',ddps='test',ddpv='8.4.0'*/ SELECT $1::text as message`)
+                `/*dddbs='serviced',dde='tester',ddps='test',ddpv='10.2.0'*/ SELECT $1::text as message`)
             } catch (e) {
               done(e)
             }
@@ -371,7 +371,7 @@ describe('Plugin', () => {
             try {
               expect(clientDBM.queryQueue[0].text).to.equal(
                 `/*dddbs='~!%40%23%24%25%5E%26*()_%2B%7C%3F%3F%2F%3C%3E',dde='tester',` +
-                `ddps='test',ddpv='8.4.0'*/ SELECT $1::text as message`)
+                `ddps='test',ddpv='10.2.0'*/ SELECT $1::text as message`)
               done()
             } catch (e) {
               done(e)
@@ -501,7 +501,6 @@ describe('Plugin', () => {
           let queryText = ''
 
           const query = {
-            name: 'pgSelectQuery',
             text: 'SELECT $1::text as message'
           }
 
@@ -510,7 +509,7 @@ describe('Plugin', () => {
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
             expect(queryText).to.equal(
-              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='10.2.0',` +
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
           }).then(done, done)
 
@@ -549,13 +548,12 @@ describe('Plugin', () => {
 
           const query = {
             name: 'pgSelectQuery',
-            text: 'SELECT $1::text as message',
-            name: 'getText'
+            text: 'SELECT $1::text as message'
           }
 
           agent.use(traces => {
             expect(queryText).to.equal(
-              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0'` +
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='10.2.0'` +
               `*/ SELECT $1::text as message`)
           }).then(done, done)
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -313,7 +313,7 @@ describe('Plugin', () => {
           if (client.queryQueue[0] !== undefined) {
             try {
               expect(client.queryQueue[0].text).to.equal(
-                `/*dddbs='serviced',dde='tester',ddps='test',ddpv='10.2.0'*/ SELECT $1::text as message`)
+                `/*dddbs='serviced',dde='tester',ddps='test',ddpv='8.4.0'*/ SELECT $1::text as message`)
             } catch (e) {
               done(e)
             }
@@ -371,7 +371,7 @@ describe('Plugin', () => {
             try {
               expect(clientDBM.queryQueue[0].text).to.equal(
                 `/*dddbs='~!%40%23%24%25%5E%26*()_%2B%7C%3F%3F%2F%3C%3E',dde='tester',` +
-                `ddps='test',ddpv='10.2.0'*/ SELECT $1::text as message`)
+                `ddps='test',ddpv='8.4.0'*/ SELECT $1::text as message`)
               done()
             } catch (e) {
               done(e)
@@ -509,7 +509,7 @@ describe('Plugin', () => {
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
             expect(queryText).to.equal(
-              `/*dddbs='post',dde='tester',ddps='test',ddpv='10.2.0',` +
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
           }).then(done, done)
 
@@ -553,7 +553,7 @@ describe('Plugin', () => {
 
           agent.use(traces => {
             expect(queryText).to.equal(
-              `/*dddbs='post',dde='tester',ddps='test',ddpv='10.2.0'` +
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0'` +
               `*/ SELECT $1::text as message`)
           }).then(done, done)
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -271,6 +271,7 @@ describe('Plugin', () => {
           })
         })
       })
+
       describe('with DBM propagation enabled with service using plugin configurations', () => {
         before(() => {
           return agent.load('pg', [{ dbmPropagationMode: 'service', service: () => 'serviced' }])
@@ -318,6 +319,7 @@ describe('Plugin', () => {
             }
           }
         })
+
         it('trace query resource should not be changed when propagation is enabled', done => {
           agent.use(traces => {
             expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
@@ -331,8 +333,10 @@ describe('Plugin', () => {
           })
         })
       })
+
       describe('DBM propagation should handle special characters', () => {
         let clientDBM
+
         before(() => {
           return agent.load('pg', [{ dbmPropagationMode: 'service', service: '~!@#$%^&*()_+|??/<>' }])
         })
@@ -340,6 +344,7 @@ describe('Plugin', () => {
         after(() => {
           return agent.close({ ritmReset: false })
         })
+
         beforeEach(done => {
           pg = require(`../../../versions/pg@${version}`).get()
 
@@ -352,6 +357,7 @@ describe('Plugin', () => {
 
           clientDBM.connect(err => done(err))
         })
+
         it('DBM propagation should handle special characters', done => {
           clientDBM.query('SELECT $1::text as message', ['Hello world!'], (err, result) => {
             if (err) return done(err)
@@ -373,15 +379,18 @@ describe('Plugin', () => {
           }
         })
       })
+
       describe('with DBM propagation enabled with full using tracer configurations', () => {
         const tracer = require('../../dd-trace')
         let seenTraceParent
         let seenTraceId
         let seenSpanId
         let originalWrite
+
         before(() => {
           return agent.load('pg')
         })
+
         beforeEach(done => {
           pg = require(`../../../versions/pg@${version}`).get()
 
@@ -409,9 +418,11 @@ describe('Plugin', () => {
             return originalWrite.apply(this, arguments)
           }
         })
+
         afterEach(() => {
           net.Socket.prototype.write = originalWrite
         })
+
         it('query text should contain traceparent', done => {
           agent.use(traces => {
             const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
@@ -428,6 +439,7 @@ describe('Plugin', () => {
             })
           })
         })
+
         it('query should inject _dd.dbm_trace_injected into span', done => {
           agent.use(traces => {
             expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
@@ -442,6 +454,7 @@ describe('Plugin', () => {
             })
           })
         })
+
         it('service should default to tracer service name', done => {
           tracer
           agent.use(traces => {
@@ -458,12 +471,14 @@ describe('Plugin', () => {
           })
         })
       })
+
       describe('DBM propagation enabled with full should handle query config objects', () => {
         const tracer = require('../../dd-trace')
 
         before(() => {
           return agent.load('pg')
         })
+
         beforeEach(done => {
           pg = require(`../../../versions/pg@${version}`).get()
 
@@ -484,10 +499,12 @@ describe('Plugin', () => {
 
         it('query config objects should be handled', done => {
           let queryText = ''
+
           const query = {
             name: 'pgSelectQuery',
             text: 'SELECT $1::text as message'
           }
+
           agent.use(traces => {
             const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
@@ -496,6 +513,7 @@ describe('Plugin', () => {
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
           }).then(done, done)
+
           client.query(query, ['Hello world!'], (err) => {
             if (err) return done(err)
 
@@ -505,11 +523,13 @@ describe('Plugin', () => {
           })
           queryText = client.queryQueue[0].text
         })
+
         it('query config object should persist when comment is injected', done => {
           const query = {
             name: 'pgSelectQuery',
             text: 'SELECT $1::text as message'
           }
+
           client.query(query, ['Hello world!'], (err) => {
             if (err) return done(err)
 
@@ -517,10 +537,36 @@ describe('Plugin', () => {
               if (err) return done(err)
             })
           })
+
           agent.use(traces => {
             expect(query).to.have.property(
               'name', 'pgSelectQuery')
           }).then(done, done)
+        })
+
+        it('falls back to service with prepared statements', done => {
+          let queryText = ''
+
+          const query = {
+            name: 'pgSelectQuery',
+            text: 'SELECT $1::text as message',
+            name: 'getText'
+          }
+
+          agent.use(traces => {
+            expect(queryText).to.equal(
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0'` +
+              `*/ SELECT $1::text as message`)
+          }).then(done, done)
+
+          client.query(query, ['Hello world!'], (err) => {
+            if (err) return done(err)
+
+            client.end((err) => {
+              if (err) return done(err)
+            })
+          })
+          queryText = client.queryQueue[0].text
         })
       })
     })

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -37,12 +37,12 @@ class DatabasePlugin extends StoragePlugin {
     `ddps='${encodedDdps}',ddpv='${encodedDdpv}'`
   }
 
-  injectDbmQuery (query, serviceName) {
+  injectDbmQuery (query, serviceName, isPreparedStatement = false) {
     if (this.config.dbmPropagationMode === 'disabled') {
       return query
     }
     const servicePropagation = this.createDBMPropagationCommentService(serviceName)
-    if (this.config.dbmPropagationMode === 'service') {
+    if (isPreparedStatement || this.config.dbmPropagationMode === 'service') {
       return `/*${servicePropagation}*/ ${query}`
     } else if (this.config.dbmPropagationMode === 'full') {
       this.activeSpan.setTag('_dd.dbm_trace_injected', 'true')


### PR DESCRIPTION
### What does this PR do?
- when DBM is set to full service
  - the DBM comment falls back to service mode
  - but only when sending a prepared statement

### Motivation
- without this, each prepared statement query is technically different
  - this causes the pg library to fail as it does an exact string check of the query
  - ideally the pg library would somehow parse out and not consider comments
- at any rate this brings parity with other tracer implementations
- see https://github.com/brianc/node-postgres/issues/2735
- previously attempted in 0ff9465907228c81d258372818db42d151852d10

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js