### PR TITLE
Taint express route paramaters

### DIFF
--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -66,7 +66,7 @@ const wrapProcessParamsMethod = (requestPositionInArguments) => {
         processParamsStartCh.publish({ req: arguments[requestPositionInArguments] })
       }
 
-      original.apply(this, arguments)
+      return original.apply(this, arguments)
     }
   }
 }

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -58,12 +58,12 @@ addHook({
   })
 })
 
-const paramParserReadCh = channel('datadog:express:process_params:start')
+const processParamsStartCh = channel('datadog:express:process_params:start')
 const wrapProcessParamsMethod = (requestPositionInArguments) => {
   return (original) => {
     return function () {
-      if (paramParserReadCh.hasSubscribers) {
-        paramParserReadCh.publish({ req: arguments[requestPositionInArguments] })
+      if (processParamsStartCh.hasSubscribers) {
+        processParamsStartCh.publish({ req: arguments[requestPositionInArguments] })
       }
 
       original.apply(this, arguments)

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/origin-types.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/origin-types.js
@@ -2,9 +2,10 @@
 
 module.exports = {
   HTTP_REQUEST_BODY: 'http.request.body',
-  HTTP_REQUEST_PARAMETER: 'http.request.parameter',
   HTTP_REQUEST_COOKIE_VALUE: 'http.request.cookie.value',
   HTTP_REQUEST_COOKIE_NAME: 'http.request.cookie.name',
   HTTP_REQUEST_HEADER_NAME: 'http.request.header.name',
-  HTTP_REQUEST_HEADER_VALUE: 'http.request.header'
+  HTTP_REQUEST_HEADER_VALUE: 'http.request.header',
+  HTTP_REQUEST_PARAMETER: 'http.request.parameter',
+  HTTP_REQUEST_PATH_PARAM: 'http.request.path.parameter'
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -49,7 +49,9 @@ class TaintTrackingPlugin extends Plugin {
     this.addSub(
       'datadog:express:process_params:start',
       ({ req }) => {
-        this._taintTrackingHandler(HTTP_REQUEST_PATH_PARAM, req, 'params')
+        if (req && req.params && typeof req.params === 'object') {
+          this._taintTrackingHandler(HTTP_REQUEST_PATH_PARAM, req, 'params')
+        }
       }
     )
   }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -5,12 +5,14 @@ const { getIastContext } = require('../iast-context')
 const { storage } = require('../../../../../datadog-core')
 const { taintObject } = require('./operations')
 const {
-  HTTP_REQUEST_PARAMETER,
   HTTP_REQUEST_BODY,
   HTTP_REQUEST_COOKIE_VALUE,
   HTTP_REQUEST_COOKIE_NAME,
   HTTP_REQUEST_HEADER_VALUE,
-  HTTP_REQUEST_HEADER_NAME
+  HTTP_REQUEST_HEADER_NAME,
+  HTTP_REQUEST_PARAMETER,
+  HTTP_REQUEST_PATH_PARAM
+
 } = require('./origin-types')
 
 class TaintTrackingPlugin extends Plugin {
@@ -43,6 +45,12 @@ class TaintTrackingPlugin extends Plugin {
     this.addSub(
       'datadog:cookie:parse:finish',
       ({ cookies }) => this._cookiesTaintTrackingHandler(cookies)
+    )
+    this.addSub(
+      'datadog:express:process_params:start',
+      ({ req }) => {
+        this._taintTrackingHandler(HTTP_REQUEST_PATH_PARAM, req, 'params')
+      }
     )
   }
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
@@ -41,7 +41,7 @@ describe('IAST Taint tracking plugin', () => {
   })
 
   it('Should subscribe to body parser, qs, cookie and process_params channel', () => {
-    expect(taintTrackingPlugin._subscriptions).to.have.lengthOf(4)
+    expect(taintTrackingPlugin._subscriptions).to.have.lengthOf(5)
     expect(taintTrackingPlugin._subscriptions[0]._channel.name).to.equals('datadog:body-parser:read:finish')
     expect(taintTrackingPlugin._subscriptions[1]._channel.name).to.equals('datadog:qs:parse:finish')
     expect(taintTrackingPlugin._subscriptions[2]._channel.name).to.equals('apm:express:middleware:next')

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
@@ -38,12 +38,13 @@ describe('IAST Taint tracking plugin', () => {
     sinon.restore()
   })
 
-  it('Should subscribe to body parser, qs and cookie channel', () => {
+  it('Should subscribe to body parser, qs, cookie and process_params channel', () => {
     expect(taintTrackingPlugin._subscriptions).to.have.lengthOf(4)
     expect(taintTrackingPlugin._subscriptions[0]._channel.name).to.equals('datadog:body-parser:read:finish')
     expect(taintTrackingPlugin._subscriptions[1]._channel.name).to.equals('datadog:qs:parse:finish')
     expect(taintTrackingPlugin._subscriptions[2]._channel.name).to.equals('apm:express:middleware:next')
     expect(taintTrackingPlugin._subscriptions[3]._channel.name).to.equals('datadog:cookie:parse:finish')
+    expect(taintTrackingPlugin._subscriptions[4]._channel.name).to.equals('datadog:express:process_params:start')
   })
 
   describe('taint sources', () => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
@@ -1,0 +1,169 @@
+'use strict'
+
+const axios = require('axios')
+const getPort = require('get-port')
+const semver = require('semver')
+const agent = require('../../../../plugins/agent')
+const Config = require('../../../../../src/config')
+const { storage } = require('../../../../../../datadog-core')
+const iast = require('../../../../../src/appsec/iast')
+const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
+const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
+const { HTTP_REQUEST_PATH_PARAM } = require('../../../../../src/appsec/iast/taint-tracking/origin-types')
+
+describe('Path params sourcing with express', () => {
+  let express
+  let expressVersion
+  let appListener
+
+  withVersions('express', 'express', version => {
+    const checkParamIsTaintedAndNext = (req, res, next, param) => {
+      const store = storage.getStore()
+      const iastContext = iastContextFunctions.getIastContext(store)
+
+      const pathParamValue = param
+      const isParameterTainted = isTainted(iastContext, pathParamValue)
+      expect(isParameterTainted).to.be.true
+      const taintedParameterValueRanges = getRanges(iastContext, pathParamValue)
+      expect(taintedParameterValueRanges[0].iinfo.type).to.be.equal(HTTP_REQUEST_PATH_PARAM)
+
+      next()
+    }
+
+    before(() => {
+      return agent.load(['http', 'express'], { client: false })
+    })
+
+    after(() => {
+      return agent.close({ ritmReset: false })
+    })
+
+    beforeEach(() => {
+      iast.enable(new Config({
+        experimental: {
+          iast: {
+            enabled: true,
+            requestSampling: 100
+          }
+        }
+      }))
+
+      const expressRequire = require(`../../../../../../../versions/express@${version}`)
+      express = expressRequire.get()
+      expressVersion = expressRequire.version()
+    })
+
+    afterEach(() => {
+      appListener && appListener.close()
+      appListener = null
+
+      iast.disable()
+    })
+
+    it('should taint path params', function (done) {
+      const app = express()
+      app.get('/:parameter1/:parameter2', (req, res) => {
+        const store = storage.getStore()
+        const iastContext = iastContextFunctions.getIastContext(store)
+
+        for (const pathParamName of ['parameter1', 'parameter2']) {
+          const pathParamValue = req.params[pathParamName]
+          const isParameterTainted = isTainted(iastContext, pathParamValue)
+          expect(isParameterTainted).to.be.true
+          const taintedParameterValueRanges = getRanges(iastContext, pathParamValue)
+          expect(taintedParameterValueRanges[0].iinfo.type).to.be.equal(HTTP_REQUEST_PATH_PARAM)
+        }
+
+        res.status(200).send()
+      })
+
+      getPort().then(port => {
+        appListener = app.listen(port, 'localhost', () => {
+          axios
+            .get(`http://localhost:${port}/tainted1/tainted2`)
+            .then(() => done())
+            .catch(done)
+        })
+      })
+    })
+
+    it('should taint path params in nested routers with merged params', function (done) {
+      if (!semver.satisfies(expressVersion, '>4.5.0')) {
+        this.skip()
+      }
+
+      const app = express()
+      const nestedRouter = express.Router({ mergeParams: true })
+
+      nestedRouter.get('/:parameterChild', (req, res) => {
+        const store = storage.getStore()
+        const iastContext = iastContextFunctions.getIastContext(store)
+
+        for (const pathParamName of ['parameterParent', 'parameterChild']) {
+          const pathParamValue = req.params[pathParamName]
+          const isParameterTainted = isTainted(iastContext, pathParamValue)
+          expect(isParameterTainted).to.be.true
+          const taintedParameterValueRanges = getRanges(iastContext, pathParamValue)
+          expect(taintedParameterValueRanges[0].iinfo.type).to.be.equal(HTTP_REQUEST_PATH_PARAM)
+        }
+
+        res.status(200).send()
+      })
+
+      app.use('/:parameterParent', nestedRouter)
+
+      getPort().then(port => {
+        appListener = app.listen(port, 'localhost', () => {
+          axios
+            .get(`http://localhost:${port}/tainted1/tainted2`)
+            .then(() => done())
+            .catch(done)
+        })
+      })
+    })
+
+    it('should taint path param on router.params callback', function (done) {
+      const app = express()
+
+      app.use('/:parameter1/:parameter2', (req, res) => {
+        res.status(200).send()
+      })
+
+      app.param('parameter1', checkParamIsTaintedAndNext)
+      app.param('parameter2', checkParamIsTaintedAndNext)
+
+      getPort().then(port => {
+        appListener = app.listen(port, 'localhost', () => {
+          axios
+            .get(`http://localhost:${port}/tainted1/tainted2`)
+            .then(() => done())
+            .catch(done)
+        })
+      })
+    })
+
+    it('should taint path param on router.params callback with custom implementation', function (done) {
+      const app = express()
+
+      app.use('/:parameter1/:parameter2', (req, res) => {
+        res.status(200).send()
+      })
+
+      app.param((param, option) => {
+        return checkParamIsTaintedAndNext
+      })
+
+      app.param('parameter1')
+      app.param('parameter2')
+
+      getPort().then(port => {
+        appListener = app.listen(port, 'localhost', () => {
+          axios
+            .get(`http://localhost:${port}/tainted1/tainted2`)
+            .then(() => done())
+            .catch(done)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Provides a feature to taint express route parameters.

### Motivation
Taint more sources to improve vulnerability detection.

### Additional Notes
Wraps Express Router `process_param` and publish the request object to `datadog:express:process_params:start` channel.
Taint tracking plugin subscribes to channel and taint all `req.params` from message payload.
