### PR TITLE
Add ability to create and publish .deb and .rpm packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,34 @@
 stages:
+  - package
   - deploy
   - benchmarks
   - benchmarks-pr-comment
 
-include: ".gitlab/benchmarks.yml"
+include:
+  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
+  - local: ".gitlab/benchmarks.yml"
+
+variables:
+  JS_PACKAGE_VERSION:
+    description: "Version to build for .deb and .rpm. Must be already published in NPM"
 
 .common: &common
   tags: [ "runner:main", "size:large" ]
+
+package:
+  extends: .package
+  rules:
+  - if: $JS_PACKAGE_VERSION
+    when: on_success
+  - if: $CI_COMMIT_TAG
+    when: on_success
+  script:
+    - ../.gitlab/build-deb-rpm.sh
+
+.release-package:
+  stage: deploy
+  variables:
+    PRODUCT_NAME: auto_inject-node
 
 deploy_to_reliability_env:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ package:
   rules:
   - if: $JS_PACKAGE_VERSION
     when: on_success
-  - if: $CI_COMMIT_TAG
+  - if: '$CI_COMMIT_TAG =~ /^v.*/'
     when: on_success
   script:
     - ../.gitlab/build-deb-rpm.sh

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -13,6 +13,7 @@ fpm --input-type npm \
   --npm-package-name-prefix "" \
   --output-type dir --prefix "" \
   --version "$JS_PACKAGE_VERSION" \
+  --verbose \
   --name dd-trace dd-trace
 
 cp auto_inject-node.version dd-trace.dir/lib/version

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ -n "$CI_COMMIT_TAG" ] && [ -z "$JS_PACKAGE_VERSION" ]; then
+  JS_PACKAGE_VERSION=${CI_COMMIT_TAG##v}
+fi
+
+echo -n $JS_PACKAGE_VERSION > auto_inject-node.version
+
+source common_build_functions.sh
+
+# Extract package to a dir to make changes
+fpm --input-type npm \
+  --npm-package-name-prefix "" \
+  --output-type dir --prefix "" \
+  --version "$JS_PACKAGE_VERSION" \
+  --name dd-trace dd-trace
+
+cp auto_inject-node.version dd-trace.dir/lib/version
+
+# Build packages
+fpm_wrapper "datadog-apm-library-js" "$JS_PACKAGE_VERSION" \
+  --input-type dir \
+  --url "https://github.com/DataDog/dd-trace-js" \
+  --description "Datadog APM client library for Javascript" \
+  --license "BSD-3-Clause" \
+  --chdir=dd-trace.dir/lib \
+  --prefix "$LIBRARIES_INSTALL_BASE/nodejs" \
+  .=.


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to create and publish .deb and .rpm packages. The package is built when `$JS_PACKAGE_VERSION` is set on the gitlab pipeline or if there is a git version tag.

### Motivation
To support APM auto injection initiatives
