### PR TITLE
Add more scenarios to system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: ./build.sh
 
       - name: Run
-        run: ./run.sh
+        run: ./run.sh TRACER_ESSENTIAL_SCENARIOS
 
       - name: Compress artifact
         if: ${{ always() }}


### PR DESCRIPTION
### What does this PR do?
This adds more scenarios to the system-tests CI job, which makes it run more tests in different situations.

### Motivation
Not all scenarios were run in PRs which obfuscated some failures.