### PR TITLE
Update blocking page and status from RC or rules file

### DIFF
--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -76,7 +76,8 @@ function block (req, res, rootSpan, abortController) {
     return
   }
 
-  if (blockingConfiguration && blockingConfiguration.type === 'redirect_request' && blockingConfiguration.parameters.location) {
+  if (blockingConfiguration && blockingConfiguration.type === 'redirect_request' &&
+      blockingConfiguration.parameters.location) {
     blockWithRedirect(res, rootSpan, abortController)
   } else {
     blockWithContent(req, res, rootSpan, abortController)

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -25,40 +25,38 @@ function block (req, res, rootSpan, abortController) {
     if (abortController) {
       abortController.abort()
     }
-
-    return
-  }
-
-  let type
-  let body
-
-  // parse the Accept header, ex: Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
-  const accept = req.headers.accept && req.headers.accept.split(',').map((str) => str.split(';', 1)[0].trim())
-
-  if (accept && accept.includes('text/html') && !accept.includes('application/json')) {
-    type = 'text/html; charset=utf-8'
-    body = templateHtml
   } else {
-    type = 'application/json'
-    body = templateJson
-  }
+    let type
+    let body
 
-  rootSpan.addTags({
-    'appsec.blocked': 'true'
-  })
+    // parse the Accept header, ex: Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
+    const accept = req.headers.accept && req.headers.accept.split(',').map((str) => str.split(';', 1)[0].trim())
 
-  if (blockingConfiguration && blockingConfiguration['type'] === 'block_request' &&
+    if (accept && accept.includes('text/html') && !accept.includes('application/json')) {
+      type = 'text/html; charset=utf-8'
+      body = templateHtml
+    } else {
+      type = 'application/json'
+      body = templateJson
+    }
+
+    rootSpan.addTags({
+      'appsec.blocked': 'true'
+    })
+
+    if (blockingConfiguration && blockingConfiguration['type'] === 'block_request' &&
       blockingConfiguration['parameters']['type'] === 'auto') {
-    res.statusCode = blockingConfiguration.parameters.status_code
-  } else {
-    res.statusCode = 403
-  }
-  res.setHeader('Content-Type', type)
-  res.setHeader('Content-Length', Buffer.byteLength(body))
-  res.end(body)
+      res.statusCode = blockingConfiguration.parameters.status_code
+    } else {
+      res.statusCode = 403
+    }
+    res.setHeader('Content-Type', type)
+    res.setHeader('Content-Length', Buffer.byteLength(body))
+    res.end(body)
 
-  if (abortController) {
-    abortController.abort()
+    if (abortController) {
+      abortController.abort()
+    }
   }
 }
 

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -44,8 +44,8 @@ function block (req, res, rootSpan, abortController) {
       'appsec.blocked': 'true'
     })
 
-    if (blockingConfiguration && blockingConfiguration['type'] === 'block_request' &&
-      blockingConfiguration['parameters']['type'] === 'auto') {
+    if (blockingConfiguration && blockingConfiguration.type === 'block_request' &&
+        blockingConfiguration.parameters.type === 'auto') {
       res.statusCode = blockingConfiguration.parameters.status_code
     } else {
       res.statusCode = 403

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -77,12 +77,8 @@ function setTemplates (config) {
   }
 }
 
-function updateBlockingConfiguration (newBlockingConfigurations) {
-  if (newBlockingConfigurations && newBlockingConfigurations.length) {
-    blockingConfiguration = newBlockingConfigurations[0]
-  } else {
-    blockingConfiguration = undefined
-  }
+function updateBlockingConfiguration (newBlockingConfiguration) {
+  blockingConfiguration = newBlockingConfiguration
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -7,7 +7,7 @@ let templateHtml = blockedTemplates.html
 let templateJson = blockedTemplates.json
 let blockingConfiguration
 
-function blockWithRedirect (rootSpan, res, abortController) {
+function blockWithRedirect (res, rootSpan, abortController) {
   rootSpan.addTags({
     'appsec.blocked': 'true'
   })
@@ -21,7 +21,7 @@ function blockWithRedirect (rootSpan, res, abortController) {
   }
 }
 
-function blockWithContent (req, rootSpan, res, abortController) {
+function blockWithContent (req, res, rootSpan, abortController) {
   let type
   let body
 
@@ -62,9 +62,9 @@ function block (req, res, rootSpan, abortController) {
   }
 
   if (blockingConfiguration && blockingConfiguration.type === 'redirect_request') {
-    blockWithRedirect(rootSpan, res, abortController)
+    blockWithRedirect(res, rootSpan, abortController)
   } else {
-    blockWithContent(req, rootSpan, res, abortController)
+    blockWithContent(req, res, rootSpan, abortController)
   }
 }
 

--- a/packages/dd-trace/src/appsec/remote_config/capabilities.js
+++ b/packages/dd-trace/src/appsec/remote_config/capabilities.js
@@ -7,5 +7,6 @@ module.exports = {
   ASM_EXCLUSIONS: 1n << 4n,
   ASM_REQUEST_BLOCKING: 1n << 5n,
   ASM_USER_BLOCKING: 1n << 7n,
-  ASM_CUSTOM_RULES: 1n << 8n
+  ASM_CUSTOM_RULES: 1n << 8n,
+  ASM_CUSTOM_BLOCKING_RESPONSE: 1n << 9n
 }

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -43,6 +43,7 @@ function enableWafUpdate (appsecConfig) {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_EXCLUSIONS, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
+    rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
 
     rc.on('ASM_DATA', noop)
     rc.on('ASM_DD', noop)

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -63,6 +63,7 @@ function disableWafUpdate () {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_EXCLUSIONS, false)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, false)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_RULES, false)
+    rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, false)
 
     rc.off('ASM_DATA', noop)
     rc.off('ASM_DD', noop)

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -247,6 +247,7 @@ function clearAllRules () {
   appliedRulesOverride.clear()
   appliedExclusions.clear()
   appliedCustomRules.clear()
+  appliedActions.clear()
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -239,6 +239,7 @@ function copyRulesData (rulesData) {
 
 function clearAllRules () {
   waf.destroy()
+  blocking.updateBlockingConfiguration(undefined)
 
   defaultRules = undefined
 

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -2,6 +2,7 @@
 
 const waf = require('./waf')
 const { ACKNOWLEDGED, ERROR } = require('./remote_config/apply_states')
+const blocking = require('./blocking')
 
 let defaultRules
 
@@ -10,11 +11,16 @@ let appliedRulesetId
 let appliedRulesOverride = new Map()
 let appliedExclusions = new Map()
 let appliedCustomRules = new Map()
+let appliedActions = new Map()
 
 function applyRules (rules, config) {
   defaultRules = rules
 
   waf.init(rules, config)
+
+  if (rules.actions) {
+    blocking.updateBlockingConfiguration(rules.actions.filter(action => action.id === 'block'))
+  }
 }
 
 function updateWafFromRC ({ toUnapply, toApply, toModify }) {
@@ -26,6 +32,7 @@ function updateWafFromRC ({ toUnapply, toApply, toModify }) {
   const newRulesOverride = new SpyMap(appliedRulesOverride)
   const newExclusions = new SpyMap(appliedExclusions)
   const newCustomRules = new SpyMap(appliedCustomRules)
+  const newActions = new SpyMap(appliedActions)
 
   for (const item of toUnapply) {
     const { product, id } = item
@@ -40,6 +47,7 @@ function updateWafFromRC ({ toUnapply, toApply, toModify }) {
       newRulesOverride.delete(id)
       newExclusions.delete(id)
       newCustomRules.delete(id)
+      newActions.delete(id)
     }
   }
 
@@ -67,19 +75,30 @@ function updateWafFromRC ({ toUnapply, toApply, toModify }) {
         batch.add(item)
       }
     } else if (product === 'ASM') {
+      let batchConfiguration = false
       if (file && file.rules_override && file.rules_override.length) {
+        batchConfiguration = true
         newRulesOverride.set(id, file.rules_override)
       }
 
       if (file && file.exclusions && file.exclusions.length) {
+        batchConfiguration = true
         newExclusions.set(id, file.exclusions)
       }
 
       if (file && file.custom_rules && file.custom_rules.length) {
+        batchConfiguration = true
         newCustomRules.set(id, file.custom_rules)
       }
 
-      batch.add(item)
+      if (file && file.actions && file.actions.length) {
+        newActions.set(id, file.actions)
+      }
+
+      // "actions" data is managed by tracer and not by waf
+      if (batchConfiguration) {
+        batch.add(item)
+      }
     }
   }
 
@@ -133,6 +152,11 @@ function updateWafFromRC ({ toUnapply, toApply, toModify }) {
   for (const config of batch) {
     config.apply_state = newApplyState
     if (newApplyError) config.apply_error = newApplyError
+  }
+
+  if (newActions.modified) {
+    blocking.updateBlockingConfiguration(concatArrays(newActions).filter(action => action.id === 'block'))
+    appliedActions = newActions
   }
 }
 

--- a/packages/dd-trace/src/appsec/rule_manager.js
+++ b/packages/dd-trace/src/appsec/rule_manager.js
@@ -19,7 +19,7 @@ function applyRules (rules, config) {
   waf.init(rules, config)
 
   if (rules.actions) {
-    blocking.updateBlockingConfiguration(rules.actions.filter(action => action.id === 'block'))
+    blocking.updateBlockingConfiguration(rules.actions.find(action => action.id === 'block'))
   }
 }
 
@@ -155,7 +155,7 @@ function updateWafFromRC ({ toUnapply, toApply, toModify }) {
   }
 
   if (newActions.modified) {
-    blocking.updateBlockingConfiguration(concatArrays(newActions).filter(action => action.id === 'block'))
+    blocking.updateBlockingConfiguration(concatArrays(newActions).find(action => action.id === 'block'))
     appliedActions = newActions
   }
 }

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -162,6 +162,42 @@ describe('blocking', () => {
       expect(res.statusCode).to.be.equal(401)
     })
 
+    it('should block with default json template and custom status when type is forced to json and accept is html', () => {
+      updateBlockingConfiguration({
+        id: 'block',
+        type: 'block_request',
+        parameters: {
+          status_code: 401,
+          type: 'json'
+        }
+      })
+      req.headers.accept = 'text/html'
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.statusCode).to.be.equal(401)
+    })
+
+    it('should block with default html template and custom status when type is forced to html and accept is html', () => {
+      updateBlockingConfiguration({
+        id: 'block',
+        type: 'block_request',
+        parameters: {
+          status_code: 401,
+          type: 'html'
+        }
+      })
+      req.headers.accept = 'text/html'
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
+      expect(res.statusCode).to.be.equal(401)
+    })
+
     it('should block with default json template and custom status', () => {
       updateBlockingConfiguration({
         id: 'block',
@@ -176,6 +212,40 @@ describe('blocking', () => {
       block(req, res, rootSpan)
 
       expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.statusCode).to.be.equal(401)
+    })
+
+    it('should block with default json template and custom status when type is forced to json and accept is not defined', () => {
+      updateBlockingConfiguration({
+        id: 'block',
+        type: 'block_request',
+        parameters: {
+          status_code: 401,
+          type: 'json'
+        }
+      })
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.statusCode).to.be.equal(401)
+    })
+
+    it('should block with default html template and custom status when type is forced to html and accept is not defined', () => {
+      updateBlockingConfiguration({
+        id: 'block',
+        type: 'block_request',
+        parameters: {
+          status_code: 401,
+          type: 'html'
+        }
+      })
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
       expect(res.statusCode).to.be.equal(401)
     })
 

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -145,14 +145,14 @@ describe('blocking', () => {
     }
 
     it('should block with default html template and custom status', () => {
-      updateBlockingConfiguration([{
+      updateBlockingConfiguration({
         id: 'block',
         type: 'block_request',
         parameters: {
           status_code: 401,
           type: 'auto'
         }
-      }])
+      })
       req.headers.accept = 'text/html'
       setTemplates(config)
 
@@ -163,14 +163,14 @@ describe('blocking', () => {
     })
 
     it('should block with default json template and custom status', () => {
-      updateBlockingConfiguration([{
+      updateBlockingConfiguration({
         id: 'block',
         type: 'block_request',
         parameters: {
           status_code: 401,
           type: 'auto'
         }
-      }])
+      })
       setTemplates(config)
 
       block(req, res, rootSpan)
@@ -180,14 +180,14 @@ describe('blocking', () => {
     })
 
     it('should block with custom redirect', () => {
-      updateBlockingConfiguration([{
+      updateBlockingConfiguration({
         id: 'block',
         type: 'redirect_request',
         parameters: {
           status_code: 301,
           location: '/you-have-been-blocked'
         }
-      }])
+      })
       setTemplates(config)
 
       block(req, res, rootSpan)

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -162,7 +162,8 @@ describe('blocking', () => {
       expect(res.statusCode).to.be.equal(401)
     })
 
-    it('should block with default json template and custom status when type is forced to json and accept is html', () => {
+    it('should block with default json template and custom status ' +
+        'when type is forced to json and accept is html', () => {
       updateBlockingConfiguration({
         id: 'block',
         type: 'block_request',
@@ -180,7 +181,8 @@ describe('blocking', () => {
       expect(res.statusCode).to.be.equal(401)
     })
 
-    it('should block with default html template and custom status when type is forced to html and accept is html', () => {
+    it('should block with default html template and custom status ' +
+        'when type is forced to html and accept is html', () => {
       updateBlockingConfiguration({
         id: 'block',
         type: 'block_request',
@@ -215,7 +217,8 @@ describe('blocking', () => {
       expect(res.statusCode).to.be.equal(401)
     })
 
-    it('should block with default json template and custom status when type is forced to json and accept is not defined', () => {
+    it('should block with default json template and custom status ' +
+        'when type is forced to json and accept is not defined', () => {
       updateBlockingConfiguration({
         id: 'block',
         type: 'block_request',
@@ -232,7 +235,8 @@ describe('blocking', () => {
       expect(res.statusCode).to.be.equal(401)
     })
 
-    it('should block with default html template and custom status when type is forced to html and accept is not defined', () => {
+    it('should block with default html template and custom status ' +
+        'when type is forced to html and accept is not defined', () => {
       updateBlockingConfiguration({
         id: 'block',
         type: 'block_request',

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -16,7 +16,7 @@ describe('blocking', () => {
   }
 
   let log
-  let block, setTemplates
+  let block, setTemplates, updateBlockingConfiguration
   let req, res, rootSpan
 
   beforeEach(() => {
@@ -31,6 +31,7 @@ describe('blocking', () => {
 
     block = blocking.block
     setTemplates = blocking.setTemplates
+    updateBlockingConfiguration = blocking.updateBlockingConfiguration
 
     req = {
       headers: {}
@@ -38,8 +39,10 @@ describe('blocking', () => {
 
     res = {
       setHeader: sinon.stub(),
+      writeHead: sinon.stub(),
       end: sinon.stub()
     }
+    res.writeHead.returns(res)
 
     rootSpan = {
       addTags: sinon.stub()
@@ -130,6 +133,69 @@ describe('blocking', () => {
       block(req, res, rootSpan)
 
       expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+    })
+  })
+
+  describe('block with custom actions', () => {
+    const config = {
+      appsec: {
+        blockedTemplateHtml: undefined,
+        blockedTemplateJson: undefined
+      }
+    }
+
+    it('should block with default html template and custom status', () => {
+      updateBlockingConfiguration([{
+        id: 'block',
+        type: 'block_request',
+        parameters: {
+          status_code: 401,
+          type: 'auto'
+        }
+      }])
+      req.headers.accept = 'text/html'
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
+      expect(res.statusCode).to.be.equal(401)
+    })
+
+    it('should block with default json template and custom status', () => {
+      updateBlockingConfiguration([{
+        id: 'block',
+        type: 'block_request',
+        parameters: {
+          status_code: 401,
+          type: 'auto'
+        }
+      }])
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.statusCode).to.be.equal(401)
+    })
+
+    it('should block with custom redirect', () => {
+      updateBlockingConfiguration([{
+        id: 'block',
+        type: 'redirect_request',
+        parameters: {
+          status_code: 301,
+          location: '/you-have-been-blocked'
+        }
+      }])
+      setTemplates(config)
+
+      block(req, res, rootSpan)
+
+      expect(res.writeHead).to.have.been.calledOnceWithExactly(301, {
+        'Location': '/you-have-been-blocked'
+      })
+      expect(res.end).to.have.been.calledOnce
     })
   })
 })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -469,6 +469,8 @@ describe('IP blocking', () => {
     id: '1',
     file: ruleData
   }]
+  const htmlDefaultContent = blockedTemplate.html
+  const jsonDefaultContent = JSON.parse(blockedTemplate.json)
 
   let http, appListener, port
   before(() => {
@@ -542,9 +544,6 @@ describe('IP blocking', () => {
     })
 
     describe(`block - ip in header ${ipHeader}`, () => {
-      const htmlDefaultContent = blockedTemplate.html
-      const jsonDefaultContent = JSON.parse(blockedTemplate.json)
-
       it('should block the request with JSON content if no headers', async () => {
         await axios.get(`http://localhost:${port}/`, {
           headers: {
@@ -577,6 +576,103 @@ describe('IP blocking', () => {
         }).catch((err) => {
           expect(err.response.status).to.be.equal(403)
           expect(err.response.data).to.be.equal(htmlDefaultContent)
+        })
+      })
+    })
+  })
+
+  describe('Custom actions', () => {
+    describe('Default content with custom status', () => {
+      const toModifyCustomActions = [{
+        product: 'ASM',
+        id: 'custom-actions',
+        file: {
+          actions: [
+            {
+              id: 'block',
+              type: 'block_request',
+              parameters: {
+                status_code: 500,
+                type: 'auto'
+              }
+            }
+          ]
+        }
+      }]
+
+      beforeEach(() => {
+        RuleManager.updateWafFromRC({
+          toUnapply: [],
+          toApply: [],
+          toModify: [...toModify, ...toModifyCustomActions]
+        })
+      })
+
+      it('Should block with custom status code and JSON content', () => {
+        return axios.get(`http://localhost:${port}/`, {
+          headers: {
+            'x-forwarded-for': invalidIp
+          }
+        }).then(() => {
+          throw new Error('Not expected')
+        }).catch((err) => {
+          expect(err.response.status).to.be.equal(500)
+          expect(err.response.data).to.deep.equal(jsonDefaultContent)
+        })
+      })
+
+      it('Should block with custom status code and HTML content', () => {
+        return axios.get(`http://localhost:${port}/`, {
+          headers: {
+            'x-forwarded-for': invalidIp,
+            'Accept': 'text/html'
+          }
+        }).then(() => {
+          throw new Error('Not expected')
+        }).catch((err) => {
+          expect(err.response.status).to.be.equal(500)
+          expect(err.response.data).to.deep.equal(htmlDefaultContent)
+        })
+      })
+    })
+
+    describe('Redirect on error', () => {
+      const toModifyCustomActions = [{
+        product: 'ASM',
+        id: 'custom-actions',
+        file: {
+          actions: [
+            {
+              id: 'block',
+              type: 'redirect_request',
+              parameters: {
+                status_code: 301,
+                location: '/error'
+              }
+            }
+          ]
+        }
+      }]
+
+      beforeEach(() => {
+        RuleManager.updateWafFromRC({
+          toUnapply: [],
+          toApply: [],
+          toModify: [...toModify, ...toModifyCustomActions]
+        })
+      })
+
+      it('Should block with redirect', () => {
+        return axios.get(`http://localhost:${port}/`, {
+          headers: {
+            'x-forwarded-for': invalidIp
+          },
+          maxRedirects: 0
+        }).then(() => {
+          throw new Error('Not resolve expected')
+        }).catch((err) => {
+          expect(err.response.status).to.be.equal(301)
+          expect(err.response.headers.location).to.be.equal('/error')
         })
       })
     })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -609,11 +609,7 @@ describe('IP blocking', () => {
       })
 
       afterEach(() => {
-        RuleManager.updateWafFromRC({
-          toApply: [],
-          toModify: [],
-          toUnapply: [...toModify, ...toModifyCustomActions]
-        })
+        RuleManager.clearAllRules()
       })
 
       it('Should block with custom status code and JSON content', () => {
@@ -668,6 +664,10 @@ describe('IP blocking', () => {
           toApply: [],
           toModify: [...toModify, ...toModifyCustomActions]
         })
+      })
+
+      afterEach(() => {
+        RuleManager.clearAllRules()
       })
 
       it('Should block with redirect', () => {

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -608,6 +608,14 @@ describe('IP blocking', () => {
         })
       })
 
+      afterEach(() => {
+        RuleManager.updateWafFromRC({
+          toApply: [],
+          toModify: [],
+          toUnapply: [...toModify, ...toModifyCustomActions]
+        })
+      })
+
       it('Should block with custom status code and JSON content', () => {
         return axios.get(`http://localhost:${port}/`, {
           headers: {

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -126,7 +126,7 @@ describe('Remote Config index', () => {
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(6)
+        expect(rc.updateCapabilities.callCount).to.be.equal(7)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, true)
         expect(rc.updateCapabilities.getCall(1))
@@ -139,6 +139,8 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, true)
         expect(rc.updateCapabilities.getCall(5))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
+        expect(rc.updateCapabilities.getCall(6))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
 
         expect(rc.on.callCount).to.be.equal(4)
         expect(rc.on.getCall(0)).to.have.been.calledWith('ASM_DATA')
@@ -152,7 +154,7 @@ describe('Remote Config index', () => {
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(6)
+        expect(rc.updateCapabilities.callCount).to.be.equal(7)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, true)
         expect(rc.updateCapabilities.getCall(1))
@@ -165,6 +167,8 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, true)
         expect(rc.updateCapabilities.getCall(5))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
+        expect(rc.updateCapabilities.getCall(6))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
 
         expect(rc.on.callCount).to.be.equal(4)
         expect(rc.on.getCall(0)).to.have.been.calledWith('ASM_DATA')
@@ -178,7 +182,7 @@ describe('Remote Config index', () => {
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(7)
+        expect(rc.updateCapabilities.callCount).to.be.equal(8)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_ACTIVATION, true)
         expect(rc.updateCapabilities.getCall(1))
@@ -193,6 +197,8 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, true)
         expect(rc.updateCapabilities.getCall(6))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
+        expect(rc.updateCapabilities.getCall(7))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
       })
     })
 
@@ -202,7 +208,7 @@ describe('Remote Config index', () => {
         rc.updateCapabilities.resetHistory()
         remoteConfig.disableWafUpdate()
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(6)
+        expect(rc.updateCapabilities.callCount).to.be.equal(7)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, false)
         expect(rc.updateCapabilities.getCall(1))
@@ -215,6 +221,8 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, false)
         expect(rc.updateCapabilities.getCall(5))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_RULES, false)
+        expect(rc.updateCapabilities.getCall(6))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, false)
 
         expect(rc.off.callCount).to.be.equal(4)
         expect(rc.off.getCall(0)).to.have.been.calledWith('ASM_DATA')

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -73,6 +73,7 @@ describe('AppSec Rule Manager', () => {
 
       clearAllRules()
       expect(waf.destroy).to.have.been.calledOnce
+      expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly(undefined)
     })
   })
 

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -6,6 +6,7 @@ const { ACKNOWLEDGED } = require('../../src/appsec/remote_config/apply_states')
 
 const rules = require('../../src/appsec/recommended.json')
 const waf = require('../../src/appsec/waf')
+const blocking = require('../../src/appsec/blocking')
 
 describe('AppSec Rule Manager', () => {
   let config
@@ -17,6 +18,8 @@ describe('AppSec Rule Manager', () => {
     sinon.stub(waf, 'init').callThrough()
     sinon.stub(waf, 'destroy').callThrough()
     sinon.stub(waf, 'update').callThrough()
+
+    sinon.stub(blocking, 'updateBlockingConfiguration').callThrough()
   })
 
   afterEach(() => {
@@ -29,6 +32,31 @@ describe('AppSec Rule Manager', () => {
       applyRules(rules, config.appsec)
 
       expect(waf.init).to.have.been.calledOnceWithExactly(rules, config.appsec)
+      expect(blocking.updateBlockingConfiguration).not.to.have.been.called
+    })
+
+    it('should call updateBlockingConfiguration with proper params', () => {
+      const testRules = {
+        ...rules,
+        actions: [
+          {
+            id: 'block',
+            otherParam: 'other'
+          },
+          {
+            id: 'otherId',
+            moreParams: 'more'
+          }
+        ]
+      }
+
+      applyRules(testRules, config.appsec)
+
+      expect(waf.init).to.have.been.calledOnceWithExactly(testRules, config.appsec)
+      expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly([{
+        id: 'block',
+        otherParam: 'other'
+      }])
     })
 
     it('should throw if null/undefined are passed', () => {
@@ -256,6 +284,7 @@ describe('AppSec Rule Manager', () => {
         expect(waf.update).calledWithExactly(expectedPayload)
       })
     })
+
     describe('ASM_DD', () => {
       beforeEach(() => {
         applyRules(rules, config.appsec)
@@ -402,6 +431,75 @@ describe('AppSec Rule Manager', () => {
         updateWafFromRC({ toUnapply: [], toApply, toModify: [] })
 
         expect(waf.update).to.have.been.calledOnceWithExactly(asm)
+      })
+
+      it('should apply blocking actions', () => {
+        const asm = {
+          actions: [
+            {
+              id: 'block',
+              otherParam: 'other'
+            },
+            {
+              id: 'otherId',
+              moreParams: 'more'
+            }
+          ]
+        }
+
+        const toApply = [
+          {
+            product: 'ASM',
+            id: '1',
+            file: asm
+          }
+        ]
+
+        updateWafFromRC({ toUnapply: [], toApply, toModify: [] })
+
+        expect(waf.update).not.to.have.been.called
+        expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly([
+          {
+            id: 'block',
+            otherParam: 'other'
+          }])
+      })
+
+      it('should unapply blocking actions', () => {
+        const asm = {
+          actions: [
+            {
+              id: 'block',
+              otherParam: 'other'
+            },
+            {
+              id: 'otherId',
+              moreParams: 'more'
+            }
+          ]
+        }
+        const toApply = [
+          {
+            product: 'ASM',
+            id: '1',
+            file: asm
+          }
+        ]
+        updateWafFromRC({ toUnapply: [], toApply, toModify: [] })
+        // reset counters
+        blocking.updateBlockingConfiguration.reset()
+
+        const toUnapply = [
+          {
+            product: 'ASM',
+            id: '1'
+          }
+        ]
+
+        updateWafFromRC({ toUnapply, toApply: [], toModify: [] })
+
+        expect(waf.update).not.to.have.been.called
+        expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly([])
       })
 
       it('should ignore other properties', () => {

--- a/packages/dd-trace/test/appsec/rule_manager.spec.js
+++ b/packages/dd-trace/test/appsec/rule_manager.spec.js
@@ -53,10 +53,10 @@ describe('AppSec Rule Manager', () => {
       applyRules(testRules, config.appsec)
 
       expect(waf.init).to.have.been.calledOnceWithExactly(testRules, config.appsec)
-      expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly([{
+      expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly({
         id: 'block',
         otherParam: 'other'
-      }])
+      })
     })
 
     it('should throw if null/undefined are passed', () => {
@@ -458,11 +458,11 @@ describe('AppSec Rule Manager', () => {
         updateWafFromRC({ toUnapply: [], toApply, toModify: [] })
 
         expect(waf.update).not.to.have.been.called
-        expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly([
+        expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly(
           {
             id: 'block',
             otherParam: 'other'
-          }])
+          })
       })
 
       it('should unapply blocking actions', () => {
@@ -499,7 +499,7 @@ describe('AppSec Rule Manager', () => {
         updateWafFromRC({ toUnapply, toApply: [], toModify: [] })
 
         expect(waf.update).not.to.have.been.called
-        expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly([])
+        expect(blocking.updateBlockingConfiguration).to.have.been.calledOnceWithExactly(undefined)
       })
 
       it('should ignore other properties', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Make it possible for the customers to define the status code or the redirect url for the blocking page. 

If they are defined in the custom rules file, the tracer will start to take the action defined there.


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
