### PR TITLE
improve express regex middleware path parsing

### DIFF
--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -708,9 +708,16 @@ describe('Plugin', () => {
         it('should not lose the current path when route handler preceeded by a longer middleware resource', done => {
           const app = express()
 
-          app.use(/\/foo\/(bar|baz|bez)/, (req, res, next) => {
-            next()
-          })
+          try {
+            app.use(/\/foo\/(bar|baz|bez)/, (req, res, next) => {
+              next()
+            })
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.log('This version of Express (>4.0 <4.6) has broken support for regex routing. Skipping this test.')
+            this.skip && this.skip() // mocha allows dynamic skipping, tap does not
+            return done()
+          }
 
           app.get('/foo/bar', (req, res) => {
             res.status(200).send('')

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -705,6 +705,36 @@ describe('Plugin', () => {
           })
         })
 
+        it('should not lose the current path when route handler preceeded by a longer middleware resource', done => {
+          const app = express()
+
+          app.use(/\/foo\/(bar|baz|bez)/, (req, res, next) => {
+            next()
+          })
+
+          app.get('/foo/bar', (req, res) => {
+            res.status(200).send('')
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                console.log(spans);
+                expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = app.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/foo/bar`)
+                .catch(done)
+            })
+          })
+        })
+
         it('should not lose the current path on next', done => {
           const app = express()
           const Router = express.Router

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -721,7 +721,6 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                console.log(spans);
                 expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
               })
               .then(done)

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -130,7 +130,7 @@ class RouterPlugin extends WebPlugin {
       route = context.stack.join('')
 
       // Longer route is more likely to be the actual route handler route.
-      if (route.length > context.route.length) {
+      if (isMoreSpecificThan(route, context.route)) {
         context.route = route
       }
     } else {
@@ -146,6 +146,17 @@ class RouterPlugin extends WebPlugin {
 
     return context
   }
+}
+
+function isMoreSpecificThan(routeA, routeB) {
+  if (!routeIsRegex(routeA) && routeIsRegex(routeB)) {
+    return true;
+  }
+  return routeA.length > routeB.length;
+}
+
+function routeIsRegex(route) {
+  return route.startsWith('(/') && route.endsWith('/)');
 }
 
 module.exports = RouterPlugin

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -148,15 +148,15 @@ class RouterPlugin extends WebPlugin {
   }
 }
 
-function isMoreSpecificThan(routeA, routeB) {
+function isMoreSpecificThan (routeA, routeB) {
   if (!routeIsRegex(routeA) && routeIsRegex(routeB)) {
-    return true;
+    return true
   }
-  return routeA.length > routeB.length;
+  return routeA.length > routeB.length
 }
 
-function routeIsRegex(route) {
-  return route.startsWith('(/') && route.endsWith('/)');
+function routeIsRegex (route) {
+  return route.startsWith('(/') && route.endsWith('/)')
 }
 
 module.exports = RouterPlugin

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -156,9 +156,7 @@ function isMoreSpecificThan (routeA, routeB) {
 }
 
 function routeIsRegex (route) {
-  // console.log('ROUTE', typeof route, route)
-  // return route instanceof RegExp
-  return route.startsWith('(/') && route.endsWith('/)')
+  return route.includes('(/') && route.includes('/)')
 }
 
 module.exports = RouterPlugin

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -156,6 +156,8 @@ function isMoreSpecificThan (routeA, routeB) {
 }
 
 function routeIsRegex (route) {
+  // console.log('ROUTE', typeof route, route)
+  // return route instanceof RegExp
   return route.startsWith('(/') && route.endsWith('/)')
 }
 


### PR DESCRIPTION
### What does this PR do?
- fixes #2065
  - this takes the commit from that PR and builds on it

### Motivation
- we don't want to use the string regex representation of a middleware when determining the path
