### PR TITLE
Replace rmSync by unlinkSync

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.express.plugin.spec.js
@@ -15,7 +15,7 @@ describe('Insecure cookie vulnerability', () => {
   })
 
   after(() => {
-    fs.rmSync(setCookieFunctionsPath)
+    fs.unlinkSync(setCookieFunctionsPath)
   })
 
   withVersions('express', 'express', version => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -197,9 +197,9 @@ prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, t
       })
 
       after(() => {
-        fs.rmSync(fsSyncWayMethodPath, { force: true })
-        fs.rmSync(fsAsyncWayMethodPath, { force: true })
-        fs.rmSync(fsPromiseWayMethodPath, { force: true })
+        fs.unlinkSync(fsSyncWayMethodPath)
+        fs.unlinkSync(fsAsyncWayMethodPath)
+        fs.unlinkSync(fsPromiseWayMethodPath)
       })
 
       runFsMethodTest(`test fs.${methodName}Sync method`, vulnerableIndex, (args) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use unlinkSync method instead of rmSync
### Motivation
<!-- What inspired you to submit this pull request? -->
rmSync does not exist in old nodejs versions, and build in v2.x fails

