### PR TITLE
pg: do not throw when query contains getter

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -31,16 +31,19 @@ function wrapQuery (query) {
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     const processId = this.processID
 
-    let pgQuery = arguments[0] && typeof arguments[0] === 'object' ? arguments[0] : { text: arguments[0] }
+    const pgQuery = arguments[0] && typeof arguments[0] === 'object' ? arguments[0] : { text: arguments[0] }
+
+    // shallow clone the existing query to swap out .text field
+    let newQuery = { ...pgQuery }
 
     return asyncResource.runInAsyncScope(() => {
       startCh.publish({
         params: this.connectionParameters,
-        query: pgQuery,
+        query: newQuery,
         processId
       })
 
-      arguments[0] = pgQuery
+      arguments[0] = newQuery
 
       const finish = asyncResource.bind(function (error) {
         if (error) {
@@ -53,24 +56,24 @@ function wrapQuery (query) {
       const queryQueue = this.queryQueue || this._queryQueue
       const activeQuery = this.activeQuery || this._activeQuery
 
-      pgQuery = queryQueue[queryQueue.length - 1] || activeQuery
+      newQuery = queryQueue[queryQueue.length - 1] || activeQuery
 
-      if (!pgQuery) {
+      if (!newQuery) {
         return retval
       }
 
-      if (pgQuery.callback) {
-        const originalCallback = callbackResource.bind(pgQuery.callback)
-        pgQuery.callback = function (err, res) {
+      if (newQuery.callback) {
+        const originalCallback = callbackResource.bind(newQuery.callback)
+        newQuery.callback = function (err, res) {
           finish(err)
           return originalCallback.apply(this, arguments)
         }
-      } else if (pgQuery.once) {
-        pgQuery
+      } else if (newQuery.once) {
+        newQuery
           .once('error', finish)
           .once('end', () => finish())
       } else {
-        pgQuery.then(() => finish(), finish)
+        newQuery.then(() => finish(), finish)
       }
 
       try {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -566,6 +566,30 @@ describe('Plugin', () => {
           })
           queryText = client.queryQueue[0].text
         })
+
+        it('should not fail when using query object with getters', done => {
+          let queryText = ''
+
+          const query = {
+            name: 'pgSelectQuery',
+            get text () { return 'SELECT $1::text as message' }
+          }
+
+          agent.use(traces => {
+            expect(queryText).to.equal(
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0'` +
+              `*/ SELECT $1::text as message`)
+          }).then(done, done)
+
+          client.query(query, ['Hello world!'], (err) => {
+            if (err) return done(err)
+
+            client.end((err) => {
+              if (err) return done(err)
+            })
+          })
+          queryText = client.queryQueue[0].text
+        })
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?
- The `sql-template-strings` library seems to generate a complex query object with the use of getters/setters:
  - https://github.com/felixfbecker/node-sql-template--strings/blob/7e6cad0c5cee072275ecd11340a01dc03f990582/index.js#L18-L21 
- Later, we modify the user’s query object by trying to replace the .text field:
  - https://github.com/DataDog/dd-trace-js/blob/dec9dd38b34fd9d10baef7b697bdc80b2f87fd4c/packages/datadog-plugin-pg/src/index.js#L30 

The failure then happens since one cannot write to a getter unless a setter is present.

### Motivation
- fixes https://github.com/DataDog/dd-trace-js/issues/3116
