### PR TITLE
graphql: Allow variables filter to access args/span/operation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1168,9 +1168,9 @@ declare namespace plugins {
           info: {
             span?: Span;
             args?: ExecutionArgs;
-            operation?: {
-              name: string;
-              operation: "query" | "mutation" | "subscription";
+            operation: {
+              name?: string;
+              type?: "query" | "mutation" | "subscription";
             };
           }
         ) => { [key: string]: any });

--- a/index.d.ts
+++ b/index.d.ts
@@ -1161,7 +1161,19 @@ declare namespace plugins {
      * the key/value pairs to record. For example, using
      * `variables => variables` would record all variables.
      */
-    variables?: string[] | ((variables: { [key: string]: any }) => { [key: string]: any });
+    variables?:
+      | string[]
+      | ((
+          variables: { [key: string]: any },
+          info: {
+            span?: Span;
+            args?: ExecutionArgs;
+            operation?: {
+              name: string;
+              operation: "query" | "mutation" | "subscription";
+            };
+          }
+        ) => { [key: string]: any });
 
     /**
      * Whether to collapse list items into a single element. (i.e. single

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -26,7 +26,7 @@ class GraphQLExecutePlugin extends TracingPlugin {
       }
     })
 
-    addVariableTags(this.config, span, args.variableValues)
+    addVariableTags(this.config, span, args, { type, name })
   }
 
   finish ({ res, args }) {
@@ -38,11 +38,11 @@ class GraphQLExecutePlugin extends TracingPlugin {
 
 // span-related
 
-function addVariableTags (config, span, variableValues) {
+function addVariableTags (config, span, args, operation) {
   const tags = {}
 
-  if (variableValues && config.variables) {
-    const variables = config.variables(variableValues)
+  if (args.variableValues && config.variables) {
+    const variables = config.variables(args.variableValues, { span, args, operation })
     for (const param in variables) {
       tags[`graphql.variables.${param}`] = variables[param]
     }


### PR DESCRIPTION
### What does this PR do?

graphql plugin: allow variables filter to access args/span/operation. 

### Motivation

So that you can e.g. only include variables for queries based on something in the context, or only for queries and not mutations, etc.

### Additional Notes

The operation could conceivably be the whole `OperationDefinitionNode` from graphql but I'm not convinced we would want to put that into dependencies. 
