### PR TITLE
Add exclusions from weak hash vulnerabilities

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
@@ -1,4 +1,7 @@
 'use strict'
+
+const path = require('path')
+
 const Analyzer = require('./vulnerability-analyzer')
 const { WEAK_HASH } = require('../vulnerabilities')
 
@@ -8,6 +11,17 @@ const INSECURE_HASH_ALGORITHMS = new Set([
   'RSA-SHA1', 'RSA-SHA1-2', 'sha1', 'md5-sha1', 'sha1WithRSAEncryption', 'ssl3-sha1'
 ].map(algorithm => algorithm.toLowerCase()))
 
+const EXCLUDED_LOCATIONS = [
+  path.join('node_modules', 'etag', 'index.js'),
+  path.join('node_modules', 'redlock', 'dist', 'cjs'),
+  path.join('node_modules', 'ws', 'lib', 'websocket-server.js'),
+  path.join('node_modules', 'mysql2', 'lib', 'auth_41.js'),
+  path.join('node_modules', '@mikro-orm', 'core', 'utils', 'Utils.js')
+]
+
+const EXCLUDED_PATHS_FROM_STACK = [
+  path.join('node_modules', 'object-hash', path.sep)
+]
 class WeakHashAnalyzer extends Analyzer {
   constructor () {
     super(WEAK_HASH)
@@ -19,6 +33,16 @@ class WeakHashAnalyzer extends Analyzer {
       return INSECURE_HASH_ALGORITHMS.has(algorithm.toLowerCase())
     }
     return false
+  }
+
+  _isExcluded (location) {
+    return EXCLUDED_LOCATIONS.some(excludedLocation => {
+      return location.path.includes(excludedLocation)
+    })
+  }
+
+  _getExcludedPaths () {
+    return EXCLUDED_PATHS_FROM_STACK
   }
 }
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/weak-hash-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/weak-hash-analyzer.spec.js
@@ -3,6 +3,7 @@
 const weakHashAnalyzer = require('../../../../src/appsec/iast/analyzers/weak-hash-analyzer')
 const proxyquire = require('proxyquire')
 const { prepareTestServerForIast, testOutsideRequestHasVulnerability } = require('../utils')
+const path = require('path')
 
 describe('weak-hash-analyzer', () => {
   const VULNERABLE_ALGORITHM = 'sha1'
@@ -59,6 +60,57 @@ describe('weak-hash-analyzer', () => {
     proxiedWeakHashAnalyzer.analyze(VULNERABLE_ALGORITHM)
     expect(addVulnerability).to.have.been.calledOnce
     expect(addVulnerability).to.have.been.calledWithMatch({}, { type: 'WEAK_HASH' })
+  })
+
+  describe('some locations should be excluded', () => {
+    let locationPrefix
+    before(() => {
+      if (process.platform === 'win32') {
+        locationPrefix = 'C:\\path\\to\\project'
+      } else {
+        locationPrefix = '/path/to/project'
+      }
+    })
+
+    it('redlock', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', 'redlock', 'dist', 'cjs'),
+        line: 183
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
+
+    it('etag', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', 'etag', 'index.js'),
+        line: 47
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
+
+    it('websocket-server', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', 'ws', 'lib', 'websocket-server.js'),
+        line: 371
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
+
+    it('mysql 41 authentication mechanism', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', 'mysql2', 'lib', 'auth_41.js'),
+        line: 30
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
+
+    it('@micro-orm hash for keys', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', '@mikro-orm', 'core', 'utils', 'Utils.js'),
+        line: 30
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
   })
 
   describe('full feature', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Excludes vulnerabilities to be detected preventing some false positives.

### Motivation
<!-- What inspired you to submit this pull request? -->
We are detecting as vulnerability each time that vulnerable hashing algorithm as `sha1` is used in the customer application. Sometimes, the use of this kind of algorithms doesn't involve a risk, and we can't prevent the the noise in the UI just excluding it.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts

### Additional Notes
<!-- Anything else we should know when reviewing? -->
