### PR TITLE
add environment variable to disable instrumentations completely

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:appsec:ci": "nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" -- npm run test:appsec",
     "test:appsec:plugins": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/appsec/**/*.@($(echo $PLUGINS)).plugin.spec.js\"",
     "test:appsec:plugins:ci": "yarn services && nyc --no-clean --include \"packages/dd-trace/test/appsec/**/*.@($(echo $PLUGINS)).plugin.spec.js\" -- npm run test:appsec:plugins",
-    "test:trace:core": "tap packages/dd-trace/test/*.spec.js \"packages/dd-trace/test/{ci-visibility,encode,exporters,opentelemetry,opentracing,plugins,telemetry}/**/*.spec.js\"",
+    "test:trace:core": "tap packages/dd-trace/test/*.spec.js \"packages/dd-trace/test/{ci-visibility,config,encode,exporters,opentelemetry,opentracing,plugins,telemetry}/**/*.spec.js\"",
     "test:trace:core:ci": "npm run test:trace:core -- --coverage --nyc-arg=--include=\"packages/dd-trace/src/**/*.js\"",
     "test:instrumentations": "mocha --colors -r 'packages/dd-trace/test/setup/mocha.js' 'packages/datadog-instrumentations/test/**/*.spec.js'",
     "test:instrumentations:ci": "nyc --no-clean --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations",

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -7,16 +7,23 @@ const Hook = require('./hook')
 const requirePackageJson = require('../../../dd-trace/src/require-package-json')
 const log = require('../../../dd-trace/src/log')
 
+const { DD_TRACE_DISABLED_INSTRUMENTATIONS = '' } = process.env
+
 const hooks = require('./hooks')
 const instrumentations = require('./instrumentations')
 const names = Object.keys(hooks)
 const pathSepExpr = new RegExp(`\\${path.sep}`, 'g')
+const disabledInstrumentations = new Set(
+  DD_TRACE_DISABLED_INSTRUMENTATIONS ? DD_TRACE_DISABLED_INSTRUMENTATIONS.split(',') : []
+)
 
 const loadChannel = channel('dd-trace:instrumentation:load')
 
 // TODO: make this more efficient
 
 for (const packageName of names) {
+  if (disabledInstrumentations.has(packageName)) continue
+
   Hook([packageName], (moduleExports, moduleName, moduleBaseDir, moduleVersion) => {
     moduleName = moduleName.replace(pathSepExpr, '/')
 

--- a/packages/dd-trace/test/config/disabled_instrumentations.spec.js
+++ b/packages/dd-trace/test/config/disabled_instrumentations.spec.js
@@ -1,0 +1,18 @@
+'use strict'
+
+process.env.DD_TRACE_DISABLED_INSTRUMENTATIONS = 'express'
+
+require('../setup/tap')
+
+describe('config/disabled_instrumentations', () => {
+  it('should disable loading instrumentations completely', () => {
+    const handleBefore = require('express').application.handle
+    const tracer = require('../../../..')
+    const handleAfterImport = require('express').application.handle
+    tracer.init()
+    const handleAfterInit = require('express').application.handle
+
+    expect(handleBefore).to.equal(handleAfterImport)
+    expect(handleBefore).to.equal(handleAfterInit)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add environment variable to disable instrumentations completely.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, especially when debugging an issue, it can be useful to disable not only the plugin, but also the entire instrumentation, to ensure that the module is not patched at all.