### PR TITLE
make tracer config available to plugins

### DIFF
--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -68,7 +68,7 @@ module.exports = class PluginManager {
 
     if (!Plugin) return
     if (!this._pluginsByName[name]) {
-      this._pluginsByName[name] = new Plugin(this._tracer)
+      this._pluginsByName[name] = new Plugin(this._tracer, this._tracerConfig)
     }
     if (!this._tracerConfig) return // TODO: don't wait for tracer to be initialized
 
@@ -76,6 +76,7 @@ module.exports = class PluginManager {
       enabled: this._tracerConfig.plugins !== false
     }
 
+    // extracts predetermined configuration from tracer and combines it with plugin-specific config
     this._pluginsByName[name].configure({
       ...this._getSharedConfig(name),
       ...pluginConfig
@@ -127,8 +128,7 @@ module.exports = class PluginManager {
       serviceMapping,
       queryStringObfuscation,
       site,
-      url,
-      dbmPropagationMode
+      url
     } = this._tracerConfig
 
     const sharedConfig = {}
@@ -140,8 +140,6 @@ module.exports = class PluginManager {
     if (queryStringObfuscation !== undefined) {
       sharedConfig.queryStringObfuscation = queryStringObfuscation
     }
-
-    sharedConfig.dbmPropagationMode = dbmPropagationMode
 
     if (serviceMapping && serviceMapping[name]) {
       sharedConfig.service = serviceMapping[name]

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -38,13 +38,17 @@ class DatabasePlugin extends StoragePlugin {
   }
 
   injectDbmQuery (query, serviceName, isPreparedStatement = false) {
-    if (this.config.dbmPropagationMode === 'disabled') {
+    const mode = this.config.dbmPropagationMode || this._tracerConfig.dbmPropagationMode
+
+    if (mode === 'disabled') {
       return query
     }
+
     const servicePropagation = this.createDBMPropagationCommentService(serviceName)
-    if (isPreparedStatement || this.config.dbmPropagationMode === 'service') {
+
+    if (isPreparedStatement || mode === 'service') {
       return `/*${servicePropagation}*/ ${query}`
-    } else if (this.config.dbmPropagationMode === 'full') {
+    } else if (mode === 'full') {
       this.activeSpan.setTag('_dd.dbm_trace_injected', 'true')
       const traceparent = this.activeSpan._spanContext.toTraceparent()
       return `/*${servicePropagation},traceparent='${traceparent}'*/ ${query}`

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -26,10 +26,12 @@ class Subscription {
 }
 
 module.exports = class Plugin {
-  constructor (tracer) {
+  constructor (tracer, tracerConfig) {
     this._subscriptions = []
     this._enabled = false
     this._tracer = tracer
+    this.config = {} // plugin-specific configuration, unset until .configure() is called
+    this._tracerConfig = tracerConfig // global tracer configuration
   }
 
   get tracer () {


### PR DESCRIPTION
### What does this PR do?
- currently we need to shove a lot of random values into `_getSharedConfig` to pass from tracer config to plugin config
- with these changes we'll no longer need to edit that list
- there are plenty of situations where a plugin needs access to global tracer configuration

### Motivation
- it's annoying that global configuration settings can't be accessed within a plugin

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
