### PR TITLE
[ci-visibility] Better git commands 

### DIFF
--- a/packages/dd-trace/src/plugins/util/exec.js
+++ b/packages/dd-trace/src/plugins/util/exec.js
@@ -1,8 +1,8 @@
 const cp = require('child_process')
 
-const sanitizedExec = (cmd, options = {}) => {
+const sanitizedExec = (cmd, flags, options = { stdio: 'pipe' }) => {
   try {
-    return cp.execSync(cmd, options).toString().replace(/(\r\n|\n|\r)/gm, '')
+    return cp.execFileSync(cmd, flags, options).toString().replace(/(\r\n|\n|\r)/gm, '')
   } catch (e) {
     return ''
   }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -1,6 +1,7 @@
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 const os = require('os')
 const path = require('path')
+const fs = require('fs')
 
 const log = require('../../log')
 const { sanitizedExec } = require('./exec')
@@ -21,26 +22,35 @@ const {
 
 const GIT_REV_LIST_MAX_BUFFER = 8 * 1024 * 1024 // 8MB
 
+function isDirectory (path) {
+  try {
+    const stats = fs.statSync(path)
+    return stats.isDirectory()
+  } catch (e) {
+    return false
+  }
+}
+
 function isShallowRepository () {
-  return sanitizedExec('git rev-parse --is-shallow-repository', { stdio: 'pipe' }) === 'true'
+  return sanitizedExec('git', ['rev-parse', '--is-shallow-repository']) === 'true'
 }
 
 function unshallowRepository () {
   try {
-    execSync('git config remote.origin.partialclonefilter "blob:none"', { stdio: 'pipe' })
-    execSync('git fetch --shallow-since="1 month ago" --update-shallow --refetch', { stdio: 'pipe' })
+    sanitizedExec('git', ['config', 'remote.origin.partialclonefilter', '"blob:none"'])
+    sanitizedExec('git', ['fetch', '--shallow-since="1 month ago"', '--update-shallow', '--refetch'])
   } catch (err) {
     log.error(err)
   }
 }
 
 function getRepositoryUrl () {
-  return sanitizedExec('git config --get remote.origin.url', { stdio: 'pipe' })
+  return sanitizedExec('git', ['config', '--get', 'remote.origin.url'])
 }
 
 function getLatestCommits () {
   try {
-    return execSync('git log --format=%H -n 1000 --since="1 month ago"', { stdio: 'pipe' })
+    return execFileSync('git', ['log', '--format=%H', '-n 1000', '--since="1 month ago"'], { stdio: 'pipe' })
       .toString()
       .split('\n')
       .filter(commit => commit)
@@ -51,15 +61,21 @@ function getLatestCommits () {
 }
 
 function getCommitsToUpload (commitsToExclude) {
-  let gitCommandToGetCommitsToUpload =
-    'git rev-list --objects --no-object-names --filter=blob:none --since="1 month ago" HEAD'
-
-  commitsToExclude.forEach(commit => {
-    gitCommandToGetCommitsToUpload = `${gitCommandToGetCommitsToUpload} ^${commit}`
-  })
+  const commitsToExcludeString = commitsToExclude.map(commit => `^${commit}`)
 
   try {
-    return execSync(gitCommandToGetCommitsToUpload, { stdio: 'pipe', maxBuffer: GIT_REV_LIST_MAX_BUFFER })
+    return execFileSync(
+      'git',
+      [
+        'rev-list',
+        '--objects',
+        '--no-object-names',
+        '--filter=blob:none',
+        '--since="1 month ago"',
+        'HEAD',
+        ...commitsToExcludeString
+      ],
+      { stdio: 'pipe', maxBuffer: GIT_REV_LIST_MAX_BUFFER })
       .toString()
       .split('\n')
       .filter(commit => commit)
@@ -72,6 +88,11 @@ function getCommitsToUpload (commitsToExclude) {
 function generatePackFilesForCommits (commitsToUpload) {
   const tmpFolder = os.tmpdir()
 
+  if (!isDirectory(tmpFolder)) {
+    log.error(new Error('Provided path to generate packfiles is not a directory'))
+    return []
+  }
+
   const randomPrefix = String(Math.floor(Math.random() * 10000))
   const temporaryPath = path.join(tmpFolder, randomPrefix)
   const cwdPath = path.join(process.cwd(), randomPrefix)
@@ -79,14 +100,20 @@ function generatePackFilesForCommits (commitsToUpload) {
   // Generates pack files to upload and
   // returns the ordered list of packfiles' paths
   function execGitPackObjects (targetPath) {
-    return execSync(
-      `git pack-objects --compression=9 --max-pack-size=3m ${targetPath}`,
-      { input: commitsToUpload.join('\n') }
+    return execFileSync(
+      'git',
+      [
+        'pack-objects',
+        '--compression=9',
+        '--max-pack-size=3m',
+        targetPath
+      ],
+      { stdio: 'pipe', input: commitsToUpload.join('\n') }
     ).toString().split('\n').filter(commit => commit).map(commit => `${targetPath}-${commit}.pack`)
   }
 
   try {
-    return execGitPackObjects(temporaryPath, commitsToUpload)
+    return execGitPackObjects(temporaryPath)
   } catch (err) {
     log.error(err)
     /**
@@ -102,7 +129,7 @@ function generatePackFilesForCommits (commitsToUpload) {
      * TODO: fix issue and remove workaround.
      */
     try {
-      return execGitPackObjects(cwdPath, commitsToUpload)
+      return execGitPackObjects(cwdPath)
     } catch (err) {
       log.error(err)
     }
@@ -133,23 +160,23 @@ function getGitMetadata (ciMetadata) {
     committerName,
     committerEmail,
     committerDate
-  ] = sanitizedExec('git show -s --format=%an,%ae,%aI,%cn,%ce,%cI', { stdio: 'pipe' }).split(',')
+  ] = sanitizedExec('git', ['show', '-s', '--format=%an,%ae,%aI,%cn,%ce,%cI']).split(',')
 
   return {
     [GIT_REPOSITORY_URL]:
-      repositoryUrl || sanitizedExec('git ls-remote --get-url', { stdio: 'pipe' }),
+      repositoryUrl || sanitizedExec('git', ['ls-remote', '--get-url']),
     [GIT_COMMIT_MESSAGE]:
-      commitMessage || sanitizedExec('git show -s --format=%s', { stdio: 'pipe' }),
+      commitMessage || sanitizedExec('git', ['show', '-s', '--format=%s']),
     [GIT_COMMIT_AUTHOR_DATE]: authorDate,
     [GIT_COMMIT_AUTHOR_NAME]: ciAuthorName || authorName,
     [GIT_COMMIT_AUTHOR_EMAIL]: ciAuthorEmail || authorEmail,
     [GIT_COMMIT_COMMITTER_DATE]: committerDate,
     [GIT_COMMIT_COMMITTER_NAME]: committerName,
     [GIT_COMMIT_COMMITTER_EMAIL]: committerEmail,
-    [GIT_BRANCH]: branch || sanitizedExec('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' }),
-    [GIT_COMMIT_SHA]: commitSHA || sanitizedExec('git rev-parse HEAD', { stdio: 'pipe' }),
+    [GIT_BRANCH]: branch || sanitizedExec('git', ['rev-parse', '--abbrev-ref', 'HEAD']),
+    [GIT_COMMIT_SHA]: commitSHA || sanitizedExec('git', ['rev-parse', 'HEAD']),
     [GIT_TAG]: tag,
-    [CI_WORKSPACE_PATH]: ciWorkspacePath || sanitizedExec('git rev-parse --show-toplevel', { stdio: 'pipe' })
+    [CI_WORKSPACE_PATH]: ciWorkspacePath || sanitizedExec('git', ['rev-parse', '--show-toplevel'])
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Use `execFileSync` instead of `execSync` for extracting git metadata, which does not spawn a shell. Even though the input values are sanitized, this should be safer overall. 

### Motivation
Safer extraction of git metadata.

