### PR TITLE
Add test in shimmer wrap to preserve function name

### DIFF
--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -137,7 +137,7 @@ describe('shimmer', () => {
 
       shimmer.wrap(obj, 'count', () => () => {})
 
-      expect(obj.count).to.have.property(name, 'count')
+      expect(obj.count).to.have.property('name', 'count')
     })
 
     it('should inherit from the original prototype', () => {
@@ -314,7 +314,7 @@ describe('shimmer', () => {
 
       const wrapped = shimmer.wrap(count, () => {})
 
-      expect(wrapped).to.have.property(name, 'count')
+      expect(wrapped).to.have.property('name', 'count')
     })
 
     it('should inherit from the original prototype', () => {

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -132,6 +132,14 @@ describe('shimmer', () => {
       expect(obj.count).to.have.length(3)
     })
 
+    it('should preserve the original function name', () => {
+      const obj = { count (a, b, c) {} }
+
+      shimmer.wrap(obj, 'count', () => () => {})
+
+      expect(obj.count).to.have.property(name, 'count')
+    })
+
     it('should inherit from the original prototype', () => {
       const obj = { count: () => {} }
 
@@ -299,6 +307,14 @@ describe('shimmer', () => {
       const wrapped = shimmer.wrap(count, () => {})
 
       expect(wrapped).to.have.length(3)
+    })
+
+    it('should preserve the original function name', () => {
+      const count = function count (a, b, c) {}
+
+      const wrapped = shimmer.wrap(count, () => {})
+
+      expect(wrapped).to.have.property(name, 'count')
     })
 
     it('should inherit from the original prototype', () => {


### PR DESCRIPTION
### What does this PR do?
Just add a small test to make sure function names are preserved in shimmer.js

