### PR TITLE
[ci-visibility] Fix agentless exporter test 

### DIFF
--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -14,7 +14,7 @@ describe('CI Visibility Agentless Exporter', () => {
 
   beforeEach(() => {
     // to make sure `isShallowRepository` in `git.js` returns false
-    sinon.stub(cp, 'execSync').returns('false')
+    sinon.stub(cp, 'execFileSync').returns('false')
     nock.cleanAll()
   })
   afterEach(() => {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -12,7 +12,7 @@ describe('CI Visibility Exporter', () => {
 
   beforeEach(() => {
     // to make sure `isShallowRepository` in `git.js` returns false
-    sinon.stub(cp, 'execSync').returns('false')
+    sinon.stub(cp, 'execFileSync').returns('false')
     process.env.DD_API_KEY = '1'
     process.env.DD_APP_KEY = '1'
     nock.cleanAll()


### PR DESCRIPTION
### What does this PR do?
After merging https://github.com/DataDog/dd-trace-js/pull/3236 I saw tracing tests failing with timeout. I thought it was random flakiness but it turns out I had forgotten to update an exporter test that relies on git commands. Previously we were stubbing `execSync` but now `execFileSync` needs stubbing. 

### Motivation
Fix CI
