### PR TITLE
Auto-instrument @opentelemetry/sdk-trace-node

### DIFF
--- a/integration-tests/opentelemetry/env-var.js
+++ b/integration-tests/opentelemetry/env-var.js
@@ -1,0 +1,24 @@
+'use strict'
+
+process.env.DD_TRACE_OTEL_ENABLED = '1'
+
+require('dd-trace').init()
+
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { JaegerExporter } = require('@opentelemetry/exporter-jaeger')
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new JaegerExporter()
+})
+
+sdk.start()
+
+const otelTracer = opentelemetry.api.trace.getTracer(
+  'my-service-tracer'
+)
+
+otelTracer.startActiveSpan('otel-sub', otelSpan => {
+  setImmediate(() => {
+    otelSpan.end()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@datadog/pprof": "^2.2.1",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/core": "<1.4.0",
+    "@opentelemetry/core": "^1.14.0",
     "crypto-randomuuid": "^1.0.0",
     "diagnostics_channel": "^1.1.0",
     "ignore": "^5.2.0",

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -14,6 +14,7 @@ module.exports = {
   '@koa/router': () => require('../koa'),
   '@node-redis/client': () => require('../redis'),
   '@opensearch-project/opensearch': () => require('../opensearch'),
+  '@opentelemetry/sdk-trace-node': () => require('../otel-sdk-trace'),
   '@redis/client': () => require('../redis'),
   'amqp10': () => require('../amqp10'),
   'amqplib': () => require('../amqplib'),

--- a/packages/datadog-instrumentations/src/otel-sdk-trace.js
+++ b/packages/datadog-instrumentations/src/otel-sdk-trace.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { addHook } = require('./helpers/instrument')
+const shimmer = require('../../datadog-shimmer')
+const tracer = require('../../dd-trace')
+
+if (process.env.DD_TRACE_OTEL_ENABLED) {
+  addHook({
+    name: '@opentelemetry/sdk-trace-node',
+    file: 'build/src/NodeTracerProvider.js',
+    versions: ['*']
+  }, (mod) => {
+    shimmer.wrap(mod, 'NodeTracerProvider', () => {
+      return tracer.TracerProvider
+    })
+    return mod
+  })
+}

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -75,6 +75,10 @@ class Tracer {
     this.appsec.setUser(user)
     return this
   }
+
+  get TracerProvider () {
+    return require('../opentelemetry/tracer_provider')
+  }
 }
 
 module.exports = Tracer

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -62,7 +62,7 @@ class ContextManager {
   bind (context, target) {
     const self = this
     return function (...args) {
-      return self.with(context, target, this, args)
+      return self.with(context, target, this, ...args)
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,17 +681,17 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.1.tgz#ff22eb2e5d476fbc2450a196e40dd243cc20c28f"
   integrity sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==
 
-"@opentelemetry/core@<1.4.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.3.1.tgz#6eef5c5efca9a4cd7daa0cd4c7ff28ca2317c8d7"
-  integrity sha512-k7lOC86N7WIyUZsUuSKZfFIrUtINtlauMGQsC1r7jNmcr0vVJGqK1ROBvt7WWMxLbpMnt1q2pXJO8tKu0b9auA==
+"@opentelemetry/core@^1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.14.0.tgz#64e876b29cb736c984d54164cd47433f513eafd3"
+  integrity sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==
   dependencies:
-    "@opentelemetry/semantic-conventions" "1.3.1"
+    "@opentelemetry/semantic-conventions" "1.14.0"
 
-"@opentelemetry/semantic-conventions@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz#ba07b864a3c955f061aa30ea3ef7f4ae4449794a"
-  integrity sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==
+"@opentelemetry/semantic-conventions@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz#6a729b7f372ce30f77a3f217c09bc216f863fccb"
+  integrity sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
### What does this PR do?

Auto-instrument `@opentelemetry/sdk-trace-node` when `DD_TRACE_OTEL_ENABLED` is set

### Motivation

We want to be able to enable our SDK with zero code changes.

Fixes #3240