### PR TITLE
Disable `metrics.spec.js` tests (part of tracing tests) for windows

### DIFF
--- a/packages/dd-trace/test/metrics.spec.js
+++ b/packages/dd-trace/test/metrics.spec.js
@@ -2,7 +2,13 @@
 
 require('./setup/tap')
 
-describe('metrics', () => {
+const os = require('os')
+
+const isWindows = os.platform() === 'win32'
+
+const suiteDescribe = isWindows ? describe.skip : describe
+
+suiteDescribe('metrics', () => {
   let metrics
   let config
   let clock


### PR DESCRIPTION
### What does this PR do?
Disable tests in `metrics.spec.js` for windows. 

### Motivation
They are _very_ flaky and just noise at this point. 
