### PR TITLE
[ci-visibility] Use correct repository URL for git metadata upload 

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -120,7 +120,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
    * CI Visibility Protocol, hence the this._canUseCiVisProtocol promise.
    */
   getItrConfiguration (testConfiguration, callback) {
-    this.sendGitMetadata()
+    const { repositoryUrl } = testConfiguration
+    this.sendGitMetadata(repositoryUrl)
     if (!this.shouldRequestItrConfiguration()) {
       return callback(null, {})
     }
@@ -147,7 +148,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
     })
   }
 
-  sendGitMetadata () {
+  sendGitMetadata (repositoryUrl) {
     if (!this._config.isGitUploadEnabled) {
       return
     }
@@ -155,7 +156,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
       if (!canUseCiVisProtocol) {
         return
       }
-      sendGitMetadataRequest(this._getApiUrl(), !!this._isUsingEvpProxy, (err) => {
+      sendGitMetadataRequest(this._getApiUrl(), !!this._isUsingEvpProxy, repositoryUrl, (err) => {
         if (err) {
           log.error(`Error uploading git metadata: ${err.message}`)
         } else {

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -152,8 +152,11 @@ function uploadPackFile ({ url, isEvpProxy, packFileToUpload, repositoryUrl, hea
 /**
  * This function uploads git metadata to CI Visibility's backend.
 */
-function sendGitMetadata (url, isEvpProxy, callback) {
-  const repositoryUrl = getRepositoryUrl()
+function sendGitMetadata (url, isEvpProxy, configRepositoryUrl, callback) {
+  let repositoryUrl = configRepositoryUrl
+  if (!repositoryUrl) {
+    repositoryUrl = getRepositoryUrl()
+  }
 
   if (!repositoryUrl) {
     return callback(new Error('Repository URL is empty'))

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -59,6 +59,23 @@ describe('CI Visibility Exporter', () => {
       ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
       ciVisibilityExporter.sendGitMetadata()
     })
+    it('should use the input repository URL', (done) => {
+      nock(`http://localhost:${port}`)
+        .post('/api/v2/git/repository/search_commits')
+        .reply(200, function () {
+          const { meta: { repository_url: repositoryUrl } } = JSON.parse(this.req.requestBodyBuffers.toString())
+          expect(repositoryUrl).to.equal('https://custom-git@datadog.com')
+          done()
+        })
+        .post('/api/v2/git/repository/packfile')
+        .reply(202, '')
+
+      const url = new URL(`http://localhost:${port}`)
+      const ciVisibilityExporter = new CiVisibilityExporter({ url, isGitUploadEnabled: true })
+
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      ciVisibilityExporter.sendGitMetadata('https://custom-git@datadog.com')
+    })
   })
 
   describe('getItrConfiguration', () => {


### PR DESCRIPTION
### What does this PR do?
The logic to extract the repository URL to set as test span tags is the following: if it's extracted via CI provider's environment variables, it takes precedence over calling `git` binary. 

We should have the same logic for uploading git metadata: rather than relying on `git` binary as the source immediately, we should use the repository URL that was already calculated, if it's there. 

### Motivation
Consistency when uploading git metadata. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
