### PR TITLE
Fix setup in integration tests

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [master]
   schedule:
-    - cron: '0 4 * * *'
+    - cron: "0 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -22,12 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/node/setup
-      - run: yarn install
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
       # Disable core dumps since some integration tests intentionally abort and core dump generation takes around 5-10s
+      - run: yarn install
       - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
       - run: yarn test:integration
 
@@ -39,11 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/node/setup
-      - run: yarn install
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
+      - run: yarn install
       - run: yarn test:integration:${{ matrix.framework }}
 
   lint:


### PR DESCRIPTION
### What does this PR do?
Only use a single `setup-node` for integration tests.

### Motivation
Using two node versions for the same CI job is confusing.

