### PR TITLE
[ci-visibility] Fix random cypress integration tests timeouts 

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn test:integration:cypress
         env:
-          CYPRESS_VERSION: ${{ matrix.framework-version }}
+          CYPRESS_VERSION: ${{ matrix.cypress-version }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [master]
   schedule:
-    - cron: '0 4 * * *'
+    - cron: "0 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         version: [16, latest]
-        framework: [cucumber, cypress, playwright]
+        framework: [cucumber, playwright]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +45,24 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
       - run: yarn test:integration:${{ matrix.framework }}
+
+  integration-cypress:
+    strategy:
+      matrix:
+        version: [16, latest]
+        # 6.7.0 is the minimum version we support
+        cypress-version: [6.7.0, latest]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/node/setup
+      - run: yarn install
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - run: yarn test:integration:cypress
+        env:
+          CYPRESS_VERSION: ${{ matrix.framework-version }}
 
   lint:
     runs-on: ubuntu-latest

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -26,241 +26,325 @@ const {
 const { NODE_MAJOR } = require('../../version')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
-// TODO: remove when 2.x support is removed.
-// This is done because from cypress@>11.2.0 node 12 is not supported
-const versions = ['6.7.0', NODE_MAJOR <= 12 ? '11.2.0' : 'latest']
+function getCypressVersion () {
+  const version = process.env.CYPRESS_VERSION
+  // TODO: remove when 2.x support is removed.
+  // This is done because from cypress@>11.2.0 node 12 is not supported
+  if (version === 'latest' && NODE_MAJOR <= 12) {
+    return '11.2.0'
+  }
+  return version
+}
 
-versions.forEach((version) => {
-  describe(`cypress@${version}`, function () {
-    this.retries(2)
-    this.timeout(60000)
-    let sandbox, cwd, receiver, childProcess, webAppPort
-    const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json' : ''
-    before(async () => {
-      sandbox = await createSandbox([`cypress@${version}`], true)
-      cwd = sandbox.folder
-      webAppPort = await getPort()
-      webAppServer.listen(webAppPort)
+const version = getCypressVersion()
+
+describe(`cypress@${version}`, function () {
+  this.retries(2)
+  this.timeout(60000)
+  let sandbox, cwd, receiver, childProcess, webAppPort
+  const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json' : ''
+  before(async () => {
+    sandbox = await createSandbox([`cypress@${version}`], true)
+    cwd = sandbox.folder
+    webAppPort = await getPort()
+    webAppServer.listen(webAppPort)
+  })
+
+  after(async () => {
+    await sandbox.remove()
+    await new Promise(resolve => webAppServer.close(resolve))
+  })
+
+  beforeEach(async function () {
+    const port = await getPort()
+    receiver = await new FakeCiVisIntake(port).start()
+  })
+
+  afterEach(async () => {
+    childProcess.kill()
+    await receiver.stop()
+  })
+
+  it('catches errors in hooks', (done) => {
+    const receiverPromise = receiver
+      .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+
+        // test level hooks
+        const testHookSuite = events.find(
+          event => event.content.resource === 'test_suite.cypress/e2e/hook-test-error.cy.js'
+        )
+        const passedTest = events.find(
+          event => event.content.resource === 'cypress/e2e/hook-test-error.cy.js.hook-test-error tests passes'
+        )
+        const failedTest = events.find(
+          event => event.content.resource ===
+            'cypress/e2e/hook-test-error.cy.js.hook-test-error tests will fail because afterEach fails'
+        )
+        const skippedTest = events.find(
+          event => event.content.resource ===
+            'cypress/e2e/hook-test-error.cy.js.hook-test-error tests does not run because earlier afterEach fails'
+        )
+        assert.equal(passedTest.content.meta[TEST_STATUS], 'pass')
+        assert.equal(failedTest.content.meta[TEST_STATUS], 'fail')
+        assert.include(failedTest.content.meta[ERROR_MESSAGE], 'error in after each hook')
+        assert.equal(skippedTest.content.meta[TEST_STATUS], 'skip')
+        assert.equal(testHookSuite.content.meta[TEST_STATUS], 'fail')
+        assert.include(testHookSuite.content.meta[ERROR_MESSAGE], 'error in after each hook')
+
+        // describe level hooks
+        const describeHookSuite = events.find(
+          event => event.content.resource === 'test_suite.cypress/e2e/hook-describe-error.cy.js'
+        )
+        const passedTestDescribe = events.find(
+          event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after passes'
+        )
+        const failedTestDescribe = events.find(
+          event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after will be marked as failed'
+        )
+        const skippedTestDescribe = events.find(
+          event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.before will be skipped'
+        )
+        assert.equal(passedTestDescribe.content.meta[TEST_STATUS], 'pass')
+        assert.equal(failedTestDescribe.content.meta[TEST_STATUS], 'fail')
+        assert.include(failedTestDescribe.content.meta[ERROR_MESSAGE], 'error in after hook')
+        assert.equal(skippedTestDescribe.content.meta[TEST_STATUS], 'skip')
+        assert.equal(describeHookSuite.content.meta[TEST_STATUS], 'fail')
+        assert.include(describeHookSuite.content.meta[ERROR_MESSAGE], 'error in after hook')
+      }, 25000)
+
+    const {
+      NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+      ...restEnvVars
+    } = getCiVisEvpProxyConfig(receiver.port)
+
+    childProcess = exec(
+      `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+      {
+        cwd,
+        env: {
+          ...restEnvVars,
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+        },
+        stdio: 'pipe'
+      }
+    )
+    childProcess.on('exit', () => {
+      receiverPromise.then(() => {
+        done()
+      }).catch(done)
     })
+  })
 
-    after(async () => {
-      await sandbox.remove()
-      await new Promise(resolve => webAppServer.close(resolve))
+  it('can run and report tests', (done) => {
+    const receiverPromise = receiver
+      .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+
+        const testSessionEvent = events.find(event => event.type === 'test_session_end')
+        const testModuleEvent = events.find(event => event.type === 'test_module_end')
+        const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
+        const testEvents = events.filter(event => event.type === 'test')
+
+        const { content: testSessionEventContent } = testSessionEvent
+        const { content: testModuleEventContent } = testModuleEvent
+
+        assert.exists(testSessionEventContent.test_session_id)
+        assert.exists(testSessionEventContent.meta[TEST_COMMAND])
+        assert.exists(testSessionEventContent.meta[TEST_TOOLCHAIN])
+        assert.equal(testSessionEventContent.resource.startsWith('test_session.'), true)
+        assert.equal(testSessionEventContent.meta[TEST_STATUS], 'fail')
+
+        assert.exists(testModuleEventContent.test_session_id)
+        assert.exists(testModuleEventContent.test_module_id)
+        assert.exists(testModuleEventContent.meta[TEST_COMMAND])
+        assert.exists(testModuleEventContent.meta[TEST_MODULE])
+        assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
+        assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
+        assert.equal(
+          testModuleEventContent.test_session_id.toString(10),
+          testSessionEventContent.test_session_id.toString(10)
+        )
+        assert.exists(testModuleEventContent.meta[TEST_FRAMEWORK_VERSION])
+
+        assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
+          'test_suite.cypress/e2e/other.cy.js',
+          'test_suite.cypress/e2e/spec.cy.js'
+        ])
+
+        assert.includeMembers(testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]), [
+          'pass',
+          'fail'
+        ])
+
+        testSuiteEvents.forEach(({
+          content: {
+            meta,
+            test_suite_id: testSuiteId,
+            test_module_id: testModuleId,
+            test_session_id: testSessionId
+          }
+        }) => {
+          assert.exists(meta[TEST_COMMAND])
+          assert.exists(meta[TEST_MODULE])
+          assert.exists(testSuiteId)
+          assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+          assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+        })
+
+        assert.includeMembers(testEvents.map(test => test.content.resource), [
+          'cypress/e2e/other.cy.js.context passes',
+          'cypress/e2e/spec.cy.js.context passes',
+          'cypress/e2e/spec.cy.js.other context fails'
+        ])
+
+        assert.includeMembers(testEvents.map(test => test.content.meta[TEST_STATUS]), [
+          'pass',
+          'pass',
+          'fail'
+        ])
+
+        testEvents.forEach(({
+          content: {
+            meta,
+            test_suite_id: testSuiteId,
+            test_module_id: testModuleId,
+            test_session_id: testSessionId
+          }
+        }) => {
+          assert.exists(meta[TEST_COMMAND])
+          assert.exists(meta[TEST_MODULE])
+          assert.exists(testSuiteId)
+          assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+          assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+        })
+      }, 25000)
+
+    const {
+      NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+      ...restEnvVars
+    } = getCiVisEvpProxyConfig(receiver.port)
+
+    childProcess = exec(
+      `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+      {
+        cwd,
+        env: {
+          ...restEnvVars,
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+        },
+        stdio: 'pipe'
+      }
+    )
+
+    childProcess.on('exit', () => {
+      receiverPromise.then(() => {
+        done()
+      }).catch(done)
     })
+  })
 
-    beforeEach(async function () {
-      const port = await getPort()
-      receiver = await new FakeCiVisIntake(port).start()
-    })
+  it('can report code coverage if it is available', (done) => {
+    const {
+      NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+      ...restEnvVars
+    } = getCiVisAgentlessConfig(receiver.port)
 
-    afterEach(async () => {
-      childProcess.kill()
-      await receiver.stop()
-    })
+    const receiverPromise = receiver.gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcov', payloads => {
+      const [{ payload: coveragePayloads }] = payloads
+      const coverages = coveragePayloads.map(coverage => coverage.content)
+        .flatMap(content => content.coverages)
 
-    it('catches errors in hooks', (done) => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          // test level hooks
-          const testHookSuite = events.find(
-            event => event.content.resource === 'test_suite.cypress/e2e/hook-test-error.cy.js'
-          )
-          const passedTest = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-test-error.cy.js.hook-test-error tests passes'
-          )
-          const failedTest = events.find(
-            event => event.content.resource ===
-              'cypress/e2e/hook-test-error.cy.js.hook-test-error tests will fail because afterEach fails'
-          )
-          const skippedTest = events.find(
-            event => event.content.resource ===
-              'cypress/e2e/hook-test-error.cy.js.hook-test-error tests does not run because earlier afterEach fails'
-          )
-          assert.equal(passedTest.content.meta[TEST_STATUS], 'pass')
-          assert.equal(failedTest.content.meta[TEST_STATUS], 'fail')
-          assert.include(failedTest.content.meta[ERROR_MESSAGE], 'error in after each hook')
-          assert.equal(skippedTest.content.meta[TEST_STATUS], 'skip')
-          assert.equal(testHookSuite.content.meta[TEST_STATUS], 'fail')
-          assert.include(testHookSuite.content.meta[ERROR_MESSAGE], 'error in after each hook')
-
-          // describe level hooks
-          const describeHookSuite = events.find(
-            event => event.content.resource === 'test_suite.cypress/e2e/hook-describe-error.cy.js'
-          )
-          const passedTestDescribe = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after passes'
-          )
-          const failedTestDescribe = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after will be marked as failed'
-          )
-          const skippedTestDescribe = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.before will be skipped'
-          )
-          assert.equal(passedTestDescribe.content.meta[TEST_STATUS], 'pass')
-          assert.equal(failedTestDescribe.content.meta[TEST_STATUS], 'fail')
-          assert.include(failedTestDescribe.content.meta[ERROR_MESSAGE], 'error in after hook')
-          assert.equal(skippedTestDescribe.content.meta[TEST_STATUS], 'skip')
-          assert.equal(describeHookSuite.content.meta[TEST_STATUS], 'fail')
-          assert.include(describeHookSuite.content.meta[ERROR_MESSAGE], 'error in after hook')
-        }, 25000)
-
-      const {
-        NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
-        ...restEnvVars
-      } = getCiVisEvpProxyConfig(receiver.port)
-
-      childProcess = exec(
-        `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
-        {
-          cwd,
-          env: {
-            ...restEnvVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
-          },
-          stdio: 'pipe'
-        }
-      )
-      childProcess.on('exit', () => {
-        receiverPromise.then(() => {
-          done()
-        }).catch(done)
+      coverages.forEach(coverage => {
+        assert.property(coverage, 'test_session_id')
+        assert.property(coverage, 'test_suite_id')
+        assert.property(coverage, 'span_id')
+        assert.property(coverage, 'files')
       })
+
+      const fileNames = coverages
+        .flatMap(coverageAttachment => coverageAttachment.files)
+        .map(file => file.filename)
+
+      assert.includeMembers(fileNames, Object.keys(coverageFixture))
+    }, 20000)
+
+    childProcess = exec(
+      `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+      {
+        cwd,
+        env: {
+          ...restEnvVars,
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+        },
+        stdio: 'pipe'
+      }
+    )
+
+    childProcess.on('exit', () => {
+      receiverPromise.then(() => {
+        done()
+      }).catch(done)
     })
+  })
 
-    it('can run and report tests', (done) => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const testSessionEvent = events.find(event => event.type === 'test_session_end')
-          const testModuleEvent = events.find(event => event.type === 'test_module_end')
-          const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
-          const testEvents = events.filter(event => event.type === 'test')
-
-          const { content: testSessionEventContent } = testSessionEvent
-          const { content: testModuleEventContent } = testModuleEvent
-
-          assert.exists(testSessionEventContent.test_session_id)
-          assert.exists(testSessionEventContent.meta[TEST_COMMAND])
-          assert.exists(testSessionEventContent.meta[TEST_TOOLCHAIN])
-          assert.equal(testSessionEventContent.resource.startsWith('test_session.'), true)
-          assert.equal(testSessionEventContent.meta[TEST_STATUS], 'fail')
-
-          assert.exists(testModuleEventContent.test_session_id)
-          assert.exists(testModuleEventContent.test_module_id)
-          assert.exists(testModuleEventContent.meta[TEST_COMMAND])
-          assert.exists(testModuleEventContent.meta[TEST_MODULE])
-          assert.equal(testModuleEventContent.resource.startsWith('test_module.'), true)
-          assert.equal(testModuleEventContent.meta[TEST_STATUS], 'fail')
-          assert.equal(
-            testModuleEventContent.test_session_id.toString(10),
-            testSessionEventContent.test_session_id.toString(10)
-          )
-          assert.exists(testModuleEventContent.meta[TEST_FRAMEWORK_VERSION])
-
-          assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
-            'test_suite.cypress/e2e/other.cy.js',
-            'test_suite.cypress/e2e/spec.cy.js'
-          ])
-
-          assert.includeMembers(testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]), [
-            'pass',
-            'fail'
-          ])
-
-          testSuiteEvents.forEach(({
-            content: {
-              meta,
-              test_suite_id: testSuiteId,
-              test_module_id: testModuleId,
-              test_session_id: testSessionId
-            }
-          }) => {
-            assert.exists(meta[TEST_COMMAND])
-            assert.exists(meta[TEST_MODULE])
-            assert.exists(testSuiteId)
-            assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
-            assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-          })
-
-          assert.includeMembers(testEvents.map(test => test.content.resource), [
-            'cypress/e2e/other.cy.js.context passes',
-            'cypress/e2e/spec.cy.js.context passes',
-            'cypress/e2e/spec.cy.js.other context fails'
-          ])
-
-          assert.includeMembers(testEvents.map(test => test.content.meta[TEST_STATUS]), [
-            'pass',
-            'pass',
-            'fail'
-          ])
-
-          testEvents.forEach(({
-            content: {
-              meta,
-              test_suite_id: testSuiteId,
-              test_module_id: testModuleId,
-              test_session_id: testSessionId
-            }
-          }) => {
-            assert.exists(meta[TEST_COMMAND])
-            assert.exists(meta[TEST_MODULE])
-            assert.exists(testSuiteId)
-            assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
-            assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-          })
-        }, 25000)
-
-      const {
-        NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
-        ...restEnvVars
-      } = getCiVisEvpProxyConfig(receiver.port)
-
-      childProcess = exec(
-        `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
-        {
-          cwd,
-          env: {
-            ...restEnvVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
-          },
-          stdio: 'pipe'
-        }
+  context('intelligent test runner', () => {
+    it('can report git metadata', (done) => {
+      const searchCommitsRequestPromise = receiver.payloadReceived(
+        ({ url }) => url.endsWith('/api/v2/git/repository/search_commits')
       )
+      const packfileRequestPromise = receiver
+        .payloadReceived(({ url }) => url.endsWith('/api/v2/git/repository/packfile'))
 
-      childProcess.on('exit', () => {
-        receiverPromise.then(() => {
-          done()
-        }).catch(done)
-      })
-    })
-
-    it('can report code coverage if it is available', (done) => {
       const {
         NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
         ...restEnvVars
       } = getCiVisAgentlessConfig(receiver.port)
 
-      const receiverPromise = receiver.gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcov', payloads => {
-        const [{ payload: coveragePayloads }] = payloads
-        const coverages = coveragePayloads.map(coverage => coverage.content)
-          .flatMap(content => content.coverages)
+      childProcess = exec(
+        `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+        {
+          cwd,
+          env: {
+            ...restEnvVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+          },
+          stdio: 'pipe'
+        }
+      )
+      childProcess.on('exit', () => {
+        Promise.all([
+          searchCommitsRequestPromise,
+          packfileRequestPromise
+        ]).then(([searchCommitRequest, packfileRequest]) => {
+          assert.propertyVal(searchCommitRequest.headers, 'dd-api-key', '1')
+          assert.propertyVal(packfileRequest.headers, 'dd-api-key', '1')
+          done()
+        }).catch(done)
+      })
+    })
+    it('does not report code coverage if disabled by the API', (done) => {
+      receiver.setSettings({
+        code_coverage: false,
+        tests_skipping: false
+      })
 
-        coverages.forEach(coverage => {
-          assert.property(coverage, 'test_session_id')
-          assert.property(coverage, 'test_suite_id')
-          assert.property(coverage, 'span_id')
-          assert.property(coverage, 'files')
-        })
+      receiver.assertPayloadReceived(() => {
+        const error = new Error('it should not report code coverage')
+        done(error)
+      }, ({ url }) => url.endsWith('/api/v2/citestcov')).catch(() => {})
 
-        const fileNames = coverages
-          .flatMap(coverageAttachment => coverageAttachment.files)
-          .map(file => file.filename)
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const eventTypes = events.map(event => event.type)
+          assert.includeMembers(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+        }, 25000)
 
-        assert.includeMembers(fileNames, Object.keys(coverageFixture))
-      }, 20000)
+      const {
+        NODE_OPTIONS,
+        ...restEnvVars
+      } = getCiVisAgentlessConfig(receiver.port)
 
       childProcess = exec(
         `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
@@ -280,191 +364,113 @@ versions.forEach((version) => {
         }).catch(done)
       })
     })
+    it('can skip suites received by the intelligent test runner API and still reports code coverage', (done) => {
+      receiver.setSuitesToSkip([{
+        type: 'test',
+        attributes: {
+          name: 'context passes',
+          suite: 'cypress/e2e/other.cy.js'
+        }
+      }])
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const eventTypes = events.map(event => event.type)
 
-    context('intelligent test runner', () => {
-      it('can report git metadata', (done) => {
-        const searchCommitsRequestPromise = receiver.payloadReceived(
-          ({ url }) => url.endsWith('/api/v2/git/repository/search_commits')
-        )
-        const packfileRequestPromise = receiver
-          .payloadReceived(({ url }) => url.endsWith('/api/v2/git/repository/packfile'))
+          const skippedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/other.cy.js.context passes'
+          )
+          assert.notExists(skippedTest)
+          assert.includeMembers(eventTypes, ['test', 'test_suite_end', 'test_module_end', 'test_session_end'])
 
-        const {
-          NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
-          ...restEnvVars
-        } = getCiVisAgentlessConfig(receiver.port)
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'true')
+          assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
+          const testModule = events.find(event => event.type === 'test_module_end').content
+          assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'true')
+          assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
+          assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
+        }, 25000)
 
-        childProcess = exec(
-          `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
-          {
-            cwd,
-            env: {
-              ...restEnvVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
-        childProcess.on('exit', () => {
-          Promise.all([
-            searchCommitsRequestPromise,
-            packfileRequestPromise
-          ]).then(([searchCommitRequest, packfileRequest]) => {
-            assert.propertyVal(searchCommitRequest.headers, 'dd-api-key', '1')
-            assert.propertyVal(packfileRequest.headers, 'dd-api-key', '1')
-            done()
-          }).catch(done)
+      const skippableRequestPromise = receiver
+        .payloadReceived(({ url }) => url.endsWith('/api/v2/ci/tests/skippable'))
+        .then(skippableRequest => {
+          assert.propertyVal(skippableRequest.headers, 'dd-api-key', '1')
+          assert.propertyVal(skippableRequest.headers, 'dd-application-key', '1')
         })
+
+      const {
+        NODE_OPTIONS,
+        ...restEnvVars
+      } = getCiVisAgentlessConfig(receiver.port)
+
+      childProcess = exec(
+        `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+        {
+          cwd,
+          env: {
+            ...restEnvVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+          },
+          stdio: 'pipe'
+        }
+      )
+      childProcess.on('exit', () => {
+        Promise.all([eventsPromise, skippableRequestPromise]).then(() => {
+          done()
+        }).catch(done)
       })
-      it('does not report code coverage if disabled by the API', (done) => {
-        receiver.setSettings({
-          code_coverage: false,
-          tests_skipping: false
-        })
-
-        receiver.assertPayloadReceived(() => {
-          const error = new Error('it should not report code coverage')
-          done(error)
-        }, ({ url }) => url.endsWith('/api/v2/citestcov')).catch(() => {})
-
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const eventTypes = events.map(event => event.type)
-            assert.includeMembers(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
-          }, 25000)
-
-        const {
-          NODE_OPTIONS,
-          ...restEnvVars
-        } = getCiVisAgentlessConfig(receiver.port)
-
-        childProcess = exec(
-          `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
-          {
-            cwd,
-            env: {
-              ...restEnvVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => {
-            done()
-          }).catch(done)
-        })
+    })
+    it('does not skip tests if test skipping is disabled by the API', (done) => {
+      receiver.setSettings({
+        code_coverage: true,
+        tests_skipping: false
       })
-      it('can skip suites received by the intelligent test runner API and still reports code coverage', (done) => {
-        receiver.setSuitesToSkip([{
-          type: 'test',
-          attributes: {
-            name: 'context passes',
-            suite: 'cypress/e2e/other.cy.js'
-          }
-        }])
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const eventTypes = events.map(event => event.type)
 
-            const skippedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/other.cy.js.context passes'
-            )
-            assert.notExists(skippedTest)
-            assert.includeMembers(eventTypes, ['test', 'test_suite_end', 'test_module_end', 'test_session_end'])
+      receiver.setSuitesToSkip([{
+        type: 'test',
+        attributes: {
+          name: 'context passes',
+          suite: 'cypress/e2e/other.cy.js'
+        }
+      }])
 
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'true')
-            assert.propertyVal(testSession.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
-            assert.propertyVal(testSession.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
-            const testModule = events.find(event => event.type === 'test_module_end').content
-            assert.propertyVal(testModule.meta, TEST_ITR_TESTS_SKIPPED, 'true')
-            assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
-            assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
-          }, 25000)
+      receiver.assertPayloadReceived(() => {
+        const error = new Error('should not request skippable')
+        done(error)
+      }, ({ url }) => url.endsWith('/api/v2/ci/tests/skippable')).catch(() => {})
 
-        const skippableRequestPromise = receiver
-          .payloadReceived(({ url }) => url.endsWith('/api/v2/ci/tests/skippable'))
-          .then(skippableRequest => {
-            assert.propertyVal(skippableRequest.headers, 'dd-api-key', '1')
-            assert.propertyVal(skippableRequest.headers, 'dd-application-key', '1')
-          })
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const notSkippedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/other.cy.js.context passes'
+          )
+          assert.exists(notSkippedTest)
+        }, 25000)
 
-        const {
-          NODE_OPTIONS,
-          ...restEnvVars
-        } = getCiVisAgentlessConfig(receiver.port)
+      const {
+        NODE_OPTIONS,
+        ...restEnvVars
+      } = getCiVisAgentlessConfig(receiver.port)
 
-        childProcess = exec(
-          `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
-          {
-            cwd,
-            env: {
-              ...restEnvVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
-        childProcess.on('exit', () => {
-          Promise.all([eventsPromise, skippableRequestPromise]).then(() => {
-            done()
-          }).catch(done)
-        })
-      })
-      it('does not skip tests if test skipping is disabled by the API', (done) => {
-        receiver.setSettings({
-          code_coverage: true,
-          tests_skipping: false
-        })
+      childProcess = exec(
+        `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
+        {
+          cwd,
+          env: {
+            ...restEnvVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+          },
+          stdio: 'pipe'
+        }
+      )
 
-        receiver.setSuitesToSkip([{
-          type: 'test',
-          attributes: {
-            name: 'context passes',
-            suite: 'cypress/e2e/other.cy.js'
-          }
-        }])
-
-        receiver.assertPayloadReceived(() => {
-          const error = new Error('should not request skippable')
-          done(error)
-        }, ({ url }) => url.endsWith('/api/v2/ci/tests/skippable')).catch(() => {})
-
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const notSkippedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/other.cy.js.context passes'
-            )
-            assert.exists(notSkippedTest)
-          }, 25000)
-
-        const {
-          NODE_OPTIONS,
-          ...restEnvVars
-        } = getCiVisAgentlessConfig(receiver.port)
-
-        childProcess = exec(
-          `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,
-          {
-            cwd,
-            env: {
-              ...restEnvVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => {
-            done()
-          }).catch(done)
-        })
+      childProcess.on('exit', () => {
+        receiverPromise.then(() => {
+          done()
+        }).catch(done)
       })
     })
   })

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -260,7 +260,7 @@ versions.forEach((version) => {
           .map(file => file.filename)
 
         assert.includeMembers(fileNames, Object.keys(coverageFixture))
-      }, 20000).then(() => done()).catch(done)
+      }, 20000)
 
       childProcess = exec(
         `./node_modules/.bin/cypress run --quiet ${commandSuffix}`,


### PR DESCRIPTION
### What does this PR do?
There are occasional timeouts for cypress tests. This PR: 

* For cypress integration tests: handles `childProcess.on('exit')` and adds `done` in there. I'm not sure why, but not handling the exit of the process seems to leave node hanging. 
* Parallises cypress tests for different cypress versions: cypress tests are by nature slow because they need to spin a browser. This should keep duration reasonable. 

### Motivation
Keep CI fast and green. I've run the integration tests job 10 times and it seems flakiness is gone (at least potentially): https://github.com/DataDog/dd-trace-js/actions/runs/5313741276 

