### PR TITLE
Re-enable Couchbase testing

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -182,24 +182,25 @@ jobs:
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v2
 
-  # couchbase:
-  #   runs-on: ubuntu-latest
-  #   services:
-  #     couchbase:
-  #       image: sabrenner/couchbase-server-sandbox:latest
-  #       ports:
-  #         - 8091-8095:8091-8095
-  #         - 11210:11210
-  #   env:
-  #     PLUGINS: couchbase
-  #     SERVICES: couchbase
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./.github/actions/node/setup
-  #     - run: yarn install
-  #     - uses: ./.github/actions/node/oldest
-  #     - run: yarn test:plugins:ci
-  #     - uses: codecov/codecov-action@v2
+  couchbase:
+    runs-on: ubuntu-latest
+    services:
+      couchbase:
+        image: ghcr.io/datadog/couchbase-server-sandbox:latest
+        ports:
+          - 8091-8095:8091-8095
+          - 11210:11210
+    env:
+      PLUGINS: couchbase
+      SERVICES: couchbase
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
+      - run: yarn install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: codecov/codecov-action@v2
 
   connect:
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   couchbase:
-    image: sabrenner/couchbase-server-sandbox:latest
+    image: ghcr.io/datadog/couchbase-server-sandbox:latest
     ports:
       - "127.0.0.1:8091-8095:8091-8095"
       - "127.0.0.1:11210:11210"

--- a/packages/datadog-instrumentations/src/couchbase.js
+++ b/packages/datadog-instrumentations/src/couchbase.js
@@ -160,7 +160,7 @@ function wrapV3Query (query) {
 }
 
 // semver >=2 <3
-addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^2.6.5'] }, Bucket => {
+addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^2.6.12'] }, Bucket => {
   const startCh = channel('apm:couchbase:query:start')
   const finishCh = channel('apm:couchbase:query:finish')
   const errorCh = channel('apm:couchbase:query:error')
@@ -208,7 +208,7 @@ addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^2.6.5'] }, Buck
   return Bucket
 })
 
-addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^2.6.5'] }, Cluster => {
+addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^2.6.12'] }, Cluster => {
   Cluster.prototype._maybeInvoke = wrapMaybeInvoke(Cluster.prototype._maybeInvoke)
   Cluster.prototype.query = wrapQuery(Cluster.prototype.query)
 
@@ -217,7 +217,7 @@ addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^2.6.5'] }, Clu
 
 // semver >=3 <3.2.0
 
-addHook({ name: 'couchbase', file: 'lib/collection.js', versions: ['>=3.0.0 <3.2.0'] }, Collection => {
+addHook({ name: 'couchbase', file: 'lib/collection.js', versions: ['^3.0.7', '^3.1.3'] }, Collection => {
   wrapAllNames(['upsert', 'insert', 'replace'], name => {
     shimmer.wrap(Collection.prototype, name, wrapWithName(name))
   })
@@ -225,7 +225,7 @@ addHook({ name: 'couchbase', file: 'lib/collection.js', versions: ['>=3.0.0 <3.2
   return Collection
 })
 
-addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['>=3.0.0 <3.2.0'] }, Cluster => {
+addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^3.0.7', '^3.1.3'] }, Cluster => {
   shimmer.wrap(Cluster.prototype, 'query', wrapV3Query)
   return Cluster
 })

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -12,6 +12,7 @@ const externals = require('../packages/dd-trace/test/plugins/externals')
 
 const requirePackageJsonPath = require.resolve('../packages/dd-trace/src/require-package-json')
 
+// Can remove couchbase after removing support for couchbase <= 3.2.0
 const excludeList = os.arch() === 'arm64' ? ['couchbase', 'grpc', 'oracledb'] : []
 const workspaces = new Set()
 const versionLists = {}


### PR DESCRIPTION
### What does this PR do?
Re-enable couchbase testing

This change re-enables testing for the couchbase integration.  In order
to do so, there are a few changes which were made:

1. Use a new container repository for Couchbase (previously owned by sabrenner, now owned by DataDog).
2. Update the Couchbase server from 6.0.1 to 6.6.5 (invisible, as the container was updated in another repo).
    * Enables 3.2.x and 2.6.12 tests to succeed
3. Change tested versions of the Couchbase client from:
    * 2.6.5 -> 2.6.12 (due to compilation errors)
    * 3.0.0 -> 3.0.7 (due to flaky connections)
    * 3.1.0 -> 3.1.2 (due to flaky connections)
  
### Motivation
These changes are being made to re-enable Couchbase testing to (a) protect customers and (b) allow other projects (such as service naming) to make tested changes

### Plugin Checklist
Couchbase: re-enabling tests and dropping versions

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
This change does not add any new code, it only modified the container and tested versions of Couchbase.
