### PR TITLE
Fix typo --ignore-engine => --ignore-engines

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -816,7 +816,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
-      - run: yarn install --ignore-engine
+      - run: yarn install --ignore-engines
       - run: yarn services
       - run: yarn test:plugins
       - uses: codecov/codecov-action@v2


### PR DESCRIPTION
### What does this PR do?
Fix a typo in github worflow
