### PR TITLE
Publish "dev" injection image

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -25,7 +25,8 @@ jobs:
       - run: npm publish --tag dev
       - run: |
           git tag --force dev
-          git push --force origin dev
+          git push origin :refs/tags/dev
+          git push origin --tags
 
   injection-image-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -23,3 +23,25 @@ jobs:
           echo "::set-output name=json::$content"
       - run: npm version --no-git-tag-version ${{ fromJson(steps.pkg.outputs.json).version }}-$(git rev-parse --short HEAD)+${{ github.run_id }}.${{ github.run_attempt }}
       - run: npm publish --tag dev
+      - run: |
+          git tag --force dev
+          git push --force origin dev
+
+  injection-image-publish:
+    runs-on: ubuntu-latest
+    needs: ['publish']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: npm pack for injection image
+        run: |
+          npm pack dd-trace@dev
+      - uses: ./.github/actions/injection
+        with:
+          init-image-version: dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ deploy_to_reliability_env:
 deploy_to_docker_registries:
   stage: deploy
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+    - if: '$CI_COMMIT_TAG =~ /^v.*/ || $CI_COMMIT_TAG == "dev"'
       when: on_success
     - when: manual
       allow_failure: true
@@ -78,3 +78,5 @@ deploy_latest_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-js/dd-lib-js-init:$CI_COMMIT_TAG
     IMG_DESTINATIONS: dd-lib-js-init:latest
     IMG_SIGNING: "false"
+    RETRY_COUNT: 5
+    RETRY_DELAY: 300


### PR DESCRIPTION
### What does this PR do?
For each new push on master, publish a new injection image with tag "dev".
We need to tag master branch with `dev` tag to trigger the `deploy_to_docker_registries` job in gitlab CI.

