### PR TITLE
fix: Lambda handler must be awaited

### DIFF
--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -83,17 +83,11 @@ function extractContext (args) {
  */
 exports.datadog = function datadog(lambdaHandler) {
   return async (...args) => {
-    let patched
-
     const context = extractContext(args)
 
     checkTimeout(context)
-    patched = await lambdaHandler.apply(this, args)
-
-    if (patched) {
-      // clear the timeout as soon as a result is returned
-      patched.then(_ => clearTimeout(__lambdaTimeout))
-    }
+    const patched = await lambdaHandler.apply(this, args)
+    clearTimeout(__lambdaTimeout)
 
     return patched
   }

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -82,13 +82,10 @@ function extractContext (args) {
  * @param {*} lambdaHandler a Lambda handler function.
  */
 exports.datadog = function datadog (lambdaHandler) {
-  return async (...args) => {
+  return (...args) => {
     const context = extractContext(args)
 
     checkTimeout(context)
-    const patched = await lambdaHandler.apply(this, args)
-    clearTimeout(__lambdaTimeout)
-
-    return patched
+    return lambdaHandler.apply(this, args).then((res) => { clearTimeout(__lambdaTimeout); return res })
   }
 }

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -81,7 +81,7 @@ function extractContext (args) {
  *
  * @param {*} lambdaHandler a Lambda handler function.
  */
-exports.datadog = function datadog(lambdaHandler) {
+exports.datadog = function datadog (lambdaHandler) {
   return async (...args) => {
     const context = extractContext(args)
 

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -83,19 +83,16 @@ function extractContext (args) {
  */
 exports.datadog = function datadog(lambdaHandler) {
   return async (...args) => {
-    const patched = await lambdaHandler.apply(this, args)
+    let patched
 
-    try {
-      const context = extractContext(args)
+    const context = extractContext(args)
 
-      checkTimeout(context)
+    checkTimeout(context)
+    patched = await lambdaHandler.apply(this, args)
 
-      if (patched) {
-        // clear the timeout as soon as a result is returned
-        patched.then(_ => clearTimeout(__lambdaTimeout))
-      }
-    } catch (e) {
-      log.debug('Error patching AWS Lambda handler. Timeout spans will not be generated.')
+    if (patched) {
+      // clear the timeout as soon as a result is returned
+      patched.then(_ => clearTimeout(__lambdaTimeout))
     }
 
     return patched

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -81,9 +81,9 @@ function extractContext (args) {
  *
  * @param {*} lambdaHandler a Lambda handler function.
  */
-exports.datadog = function datadog (lambdaHandler) {
-  return (...args) => {
-    const patched = lambdaHandler.apply(this, args)
+exports.datadog = function datadog(lambdaHandler) {
+  return async (...args) => {
+    const patched = await lambdaHandler.apply(this, args)
 
     try {
       const context = extractContext(args)

--- a/packages/dd-trace/test/lambda/fixtures/handler.js
+++ b/packages/dd-trace/test/lambda/fixtures/handler.js
@@ -48,9 +48,20 @@ const swappedArgsHandler = async (event, _, context) => {
   return response
 }
 
+const errorHandler = async (_event, _context) => {
+  class CustomError extends Error {
+    constructor (message) {
+      super(message)
+      Object.defineProperty(this, 'name', { value: 'CustomError' })
+    }
+  }
+  throw new CustomError('my error')
+}
+
 module.exports = {
   finishSpansEarlyTimeoutHandler,
   handler,
   swappedArgsHandler,
-  timeoutHandler
+  timeoutHandler,
+  errorHandler
 }


### PR DESCRIPTION
### What does this PR do?
Fixes #2893 

### Motivation
With this change, errors are thrown and escalated properly:
<img width="1272" alt="image" src="https://github.com/DataDog/dd-trace-js/assets/1598537/3d9a6829-fc23-43bd-906f-22e21e8c8f6f">

without this change, handler errors become unhandled promise rejections:
<img width="1247" alt="image" src="https://github.com/DataDog/dd-trace-js/assets/1598537/c9bda0ff-5da0-4617-b369-a09670632d8f">

### Plugin Checklist
TODO - add units

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
