### PR TITLE
Fix job name

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -30,7 +30,7 @@ jobs:
 
   injection-image-publish:
     runs-on: ubuntu-latest
-    needs: ['publish']
+    needs: ['dev_release']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### What does this PR do?
Fix name of job dependency of `injection-image-publish`, currently workflow [fails](https://github.com/DataDog/dd-trace-js/actions/runs/5360146625).