### PR TITLE
Bump profiler version to 2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@datadog/native-iast-rewriter": "2.0.1",
     "@datadog/native-iast-taint-tracking": "^1.5.0",
     "@datadog/native-metrics": "^2.0.0",
-    "@datadog/pprof": "2.2.2",
+    "@datadog/pprof": "2.2.3",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^1.14.0",

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -27,6 +27,7 @@ class Config {
       DD_TRACE_AGENT_URL,
       DD_AGENT_HOST,
       DD_TRACE_AGENT_PORT,
+      DD_PROFILING_DEBUG_SOURCE_MAPS,
       DD_PROFILING_UPLOAD_TIMEOUT,
       DD_PROFILING_SOURCE_MAP,
       DD_PROFILING_UPLOAD_PERIOD,
@@ -70,6 +71,7 @@ class Config {
     this.flushInterval = flushInterval
     this.uploadTimeout = uploadTimeout
     this.sourceMap = sourceMap
+    this.debugSourceMaps = isTrue(coalesce(options.debugSourceMaps, DD_PROFILING_DEBUG_SOURCE_MAPS, false))
     this.endpointCollection = endpointCollection
     this.pprofPrefix = pprofPrefix
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,10 +409,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-2.2.2.tgz#5cc8aa2c198bb594bc8ecd85c94adbfac6e75563"
-  integrity sha512-6FVmgQoYvHVnpnAzfTHRIONJQprEJ6PdrfA3Kn4dfVEXZMH42PBRLSNWe4qoi5AKmr4SoIc6Ay7VAlHb/cDNjA==
+"@datadog/pprof@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-2.2.3.tgz#a22ca30e386f5aa8559f4b2e297b76c80551c26d"
+  integrity sha512-cZXvNBBzvTMUx2xOxp49cZJ7/HOF7geVxqeRbveeJUVKwi8ZxmU1rQGcWPFX4iEEtfQu1M3NqbhmNtYsMJdEsQ==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "^3.9.0"


### PR DESCRIPTION
### What does this PR do?
Bump profiler version to 2.2.3

### Motivation
Use new profiler version that allows injecting a logger, adds a new boolean argument to debug source maps and add a workaround for source maps with incorrect `file` property generated by webpack/nextjs.