### PR TITLE
move next plugin to ServerPlugin

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -1,84 +1,82 @@
 'use strict'
 
-const Plugin = require('../../dd-trace/src/plugins/plugin')
+const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
-class NextPlugin extends Plugin {
+class NextPlugin extends ServerPlugin {
   static get id () {
     return 'next'
   }
 
   constructor (...args) {
     super(...args)
-
     this._requests = new WeakMap()
+    this.addSub('apm:next:page:load', message => this.pageLoad(message))
+  }
 
-    this.addSub('apm:next:request:start', ({ req, res }) => {
-      const store = storage.getStore()
-      const childOf = store ? store.span : store
-      const span = this.tracer.startSpan('next.request', {
-        childOf,
-        tags: {
-          [COMPONENT]: this.constructor.id,
-          'service.name': this.config.service || this.tracer._service,
-          'resource.name': req.method,
-          'span.type': 'web',
-          'span.kind': 'server',
-          'http.method': req.method
-        }
-      })
-
-      analyticsSampler.sample(span, this.config.measured, true)
-
-      this.enter(span, store)
-
-      this._requests.set(span, req)
-    })
-
-    this.addSub('apm:next:request:error', this.addError)
-
-    this.addSub('apm:next:request:finish', ({ req, res }) => {
-      const store = storage.getStore()
-
-      if (!store) return
-
-      const span = store.span
-      const error = span.context()._tags['error']
-
-      if (!this.config.validateStatus(res.statusCode) && !error) {
-        span.setTag('error', true)
-      }
-
-      span.addTags({
-        'http.status_code': res.statusCode
-      })
-
-      this.config.hooks.request(span, req, res)
-
-      span.finish()
-    })
-
-    this.addSub('apm:next:page:load', ({ page }) => {
-      const store = storage.getStore()
-
-      if (!store) return
-
-      const span = store.span
-      const req = this._requests.get(span)
-
-      // Only use error page names if there's not already a name
-      const current = span.context()._tags['next.page']
-      if (current && (page === '/404' || page === '/500' || page === '/_error')) {
-        return
-      }
-
-      span.addTags({
+  start ({ req, res }) {
+    const store = storage.getStore()
+    const childOf = store ? store.span : store
+    const span = this.tracer.startSpan('next.request', {
+      childOf,
+      tags: {
         [COMPONENT]: this.constructor.id,
-        'resource.name': `${req.method} ${page}`.trim(),
-        'next.page': page
-      })
+        'service.name': this.config.service || this.tracer._service,
+        'resource.name': req.method,
+        'span.type': 'web',
+        'span.kind': 'server',
+        'http.method': req.method
+      }
+    })
+
+    analyticsSampler.sample(span, this.config.measured, true)
+
+    this.enter(span, store)
+
+    this._requests.set(span, req)
+  }
+
+  finish ({ req, res }) {
+    const store = storage.getStore()
+
+    if (!store) return
+
+    const span = store.span
+    const error = span.context()._tags['error']
+
+    if (!this.config.validateStatus(res.statusCode) && !error) {
+      span.setTag('error', true)
+    }
+
+    span.addTags({
+      'http.status_code': res.statusCode
+    })
+
+    this.config.hooks.request(span, req, res)
+
+    span.finish()
+  }
+
+  pageLoad ({ page }) {
+    const store = storage.getStore()
+
+    if (!store) return
+
+    const span = store.span
+    const req = this._requests.get(span)
+
+    // Only use error page names if there's not already a name
+    const current = span.context()._tags['next.page']
+    if (current && (page === '/404' || page === '/500' || page === '/_error')) {
+      return
+    }
+
+    span.addTags({
+      [COMPONENT]: this.constructor.id,
+      'resource.name': `${req.method} ${page}`.trim(),
+      'next.page': page
     })
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Move the `next` plugin to a `ServerPlugin`.

### Motivation
<!-- What inspired you to submit this pull request? -->
We're interested in having service naming capabilities for the `next` Plugin, which are only available to `TracingPlugin` children. It should be a `ServerPlugin` anyway, given that it has the `server` kind, so we move it there.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This is a prerequisite for using the service naming API for `next`.