### PR TITLE
[profiling] Enable OOM monitoring by default

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -53,7 +53,7 @@ class Config {
     const endpointCollection = coalesce(options.endpointCollection,
       DD_PROFILING_ENDPOINT_COLLECTION_ENABLED, false)
     const pprofPrefix = coalesce(options.pprofPrefix,
-      DD_PROFILING_PPROF_PREFIX)
+      DD_PROFILING_PPROF_PREFIX, '')
 
     this.enabled = enabled
     this.service = service
@@ -88,7 +88,7 @@ class Config {
     ], this)
 
     const oomMonitoringEnabled = isTrue(coalesce(options.oomMonitoring,
-      DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED, false))
+      DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED, true))
     const heapLimitExtensionSize = coalesce(options.oomHeapLimitExtensionSize,
       Number(DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE), 0)
     const maxHeapExtensionCount = coalesce(options.oomMaxHeapExtensionCount,

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -145,17 +145,6 @@ describe('config', () => {
     expect(exporterUrl).to.equal(expectedUrl)
   })
 
-  it('should disable OOM heap profiler by default', () => {
-    const config = new Config()
-    expect(config.oomMonitoring).to.deep.equal({
-      enabled: false,
-      heapLimitExtensionSize: 0,
-      maxHeapExtensionCount: 0,
-      exportStrategies: [],
-      exportCommand: undefined
-    })
-  })
-
   it('should support OOM heap profiler configuration', () => {
     process.env = {
       DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED: 'false'
@@ -171,10 +160,7 @@ describe('config', () => {
     })
   })
 
-  it('should use process as default strategy for OOM heap profiler', () => {
-    process.env = {
-      DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED: 'true'
-    }
+  it('should enable OOM heap profiler by default and use process as default strategy', () => {
     const config = new Config()
 
     expect(config.oomMonitoring).to.deep.equal({


### PR DESCRIPTION
### What does this PR do?
Enable send of heap profile upon out-of-memory by default.

### Motivation
This feature will allow users to determine what was consuming memory when OOM occurred.
