### PR TITLE
pg: update error string comparison in test

### DIFF
--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -152,7 +152,12 @@ describe('Plugin', () => {
             agent.use(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
-              expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
+
+              // pg modifies stacktraces as of v8.11.1
+              const actualErrorNoStack = traces[0][0].meta[ERROR_STACK].split('\n')[0]
+              const expectedErrorNoStack = error.stack.split('\n')[0]
+              expect(actualErrorNoStack).to.eql(expectedErrorNoStack)
+
               expect(traces[0][0].meta).to.have.property('component', 'pg')
               expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
             })


### PR DESCRIPTION
### What does this PR do?
- the latest release of pg adds stack traces to errors
  - https://github.com/brianc/node-postgres/commit/d59cd15ed28f32271760e4ddf9d9018796fb8b8c
- this causes two tests to fail

```
AssertionError: expected { '_dd.p.dm': '-1', …(14) } to have property 'error.stack'
  of 'error: syntax error at or near "INVAL…', but got 'error: syntax error at or near "INVAL…'
```
