### PR TITLE
rdbms: add precursors and test for peer.service calculation

### DIFF
--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -50,6 +50,11 @@ describe('Plugin', () => {
           })
         })
 
+        withPeerService(
+          () => tracer,
+          (done) => connection.query('SELECT 1', (_) => { done() }),
+          'db', 'db.name')
+
         it('should propagate context to callbacks, with correct callback args', done => {
           const span = tracer.startSpan('test')
 

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -206,6 +206,11 @@ describe('Plugin', () => {
           })
         })
 
+        withPeerService(
+          () => tracer,
+          () => pool.query('SELECT 1', (_) => {}),
+          'db', 'db.name')
+
         it('should do automatic instrumentation', done => {
           agent.use(traces => {
             expect(traces[0][0]).to.have.property('name', namingSchema.outbound.opName)

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -38,6 +38,11 @@ describe('Plugin', () => {
           connection.connect()
         })
 
+        withPeerService(
+          () => tracer,
+          (done) => connection.query('SELECT 1', (_) => done()),
+          'db', 'db.name')
+
         it('should propagate context to callbacks, with correct callback args', done => {
           const span = tracer.startSpan('test')
 

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -7,6 +7,7 @@ const log = require('../../dd-trace/src/log')
 class OracledbPlugin extends DatabasePlugin {
   static get id () { return 'oracledb' }
   static get system () { return 'oracle' }
+  static get peerServicePrecursors () { return ['db.instance', 'db.hostname'] }
 
   start ({ query, connAttrs }) {
     const service = this.serviceName(this.config, connAttrs)

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -62,6 +62,12 @@ describe('Plugin', () => {
         })
 
         function connectionTests (url) {
+          if (url) {
+            withPeerService(
+              () => tracer,
+              () => connection.execute(dbQuery),
+              url.pathname.slice(1), 'db.instance')
+          }
           it('should be instrumented for promise API', done => {
             agent.use(traces => {
               expect(traces[0][0]).to.have.property('name', namingSchema.outbound.opName)

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -53,6 +53,16 @@ describe('Plugin', () => {
             client.connect(err => done(err))
           })
 
+          withPeerService(
+            () => tracer,
+            (done) => client.query('SELECT 1', (err, result) => {
+              if (err) {
+                done()
+              }
+            }),
+            'postgres', 'db.name'
+          )
+
           it('should do automatic instrumentation when using callbacks', done => {
             agent.use(traces => {
               expect(traces[0][0]).to.have.property('name', namingSchema.outbound.opName)

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -84,6 +84,13 @@ describe('Plugin', () => {
         () => namingSchema.client.serviceName
       )
 
+      withPeerService(
+        () => tracer,
+        (done) => connection.execSql(new tds.Request('SELECT 1', (err) => {
+          if (err) return done(err)
+        })), 'master', 'db.name'
+      )
+
       describe('with tedious disabled', () => {
         beforeEach(() => {
           tracer.use('tedious', false)

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -4,6 +4,7 @@ const StoragePlugin = require('./storage')
 
 class DatabasePlugin extends StoragePlugin {
   static get operation () { return 'query' }
+  static get peerServicePrecursors () { return ['db.name'] }
 
   constructor (...args) {
     super(...args)


### PR DESCRIPTION
### What does this PR do?

Leveraging #3177 it adds the precursor to have `peer.service` automatically calculated for rdbms clients:
* mssql
* postgres
* mysql/mariadb
* oracledb

Generally speaking the precursor priority is:
* db.name
* out.host 

For oracle, existing tags are different hence using:

* db.instance
* db.hostname


### Motivation

`peer.service` automatic calculation feature

### Plugin Checklist

- [x] Unit tests.

### Additional Notes
