### PR TITLE
express: recognize regex with flags

### DIFF
--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -741,6 +741,42 @@ describe('Plugin', () => {
           })
         })
 
+        it('should work with regex having flags', done => {
+          const app = express()
+
+          try {
+            app.use(/\/foo\/(bar|baz|bez)/i, (req, res, next) => {
+              next()
+            })
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.log('This version of Express (>4.0 <4.6) has broken support for regex routing. Skipping this test.')
+            this.skip && this.skip() // mocha allows dynamic skipping, tap does not
+            return done()
+          }
+
+          app.get('/foo/bar', (req, res) => {
+            res.status(200).send('')
+          })
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = app.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/foo/bar`)
+                .catch(done)
+            })
+          })
+        })
+
         it('long regex child of string router should not steal path', done => {
           const app = express()
           const router = express.Router()

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -156,7 +156,7 @@ function isMoreSpecificThan (routeA, routeB) {
 }
 
 function routeIsRegex (route) {
-  return route.includes('(/') && route.includes('/)')
+  return route.includes('(/')
 }
 
 module.exports = RouterPlugin


### PR DESCRIPTION
### What does this PR do?
- when determining if an express route is a regex, ensure we work when modifier flags are set
- so now we're just looking for the start of a regex pattern anywhere in the path (and not looking for an end)

### Motivation
- fixes #3245