### PR TITLE
Taint request URI

### DIFF
--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -54,7 +54,7 @@ function onIncomingHttpRequestStart (data) {
           createTransaction(rootSpan.context().toSpanId(), iastContext)
           overheadController.initializeRequestContext(iastContext)
           iastTelemetry.onRequestStart(iastContext)
-          taintTrackingPlugin.taintHeaders(data.req.headers, iastContext)
+          taintTrackingPlugin.taintRequest(data.req, iastContext)
         }
         if (rootSpan.addTags) {
           rootSpan.addTags({

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -3,7 +3,7 @@
 const { SourceIastPlugin } = require('../iast-plugin')
 const { getIastContext } = require('../iast-context')
 const { storage } = require('../../../../../datadog-core')
-const { taintObject } = require('./operations')
+const { taintObject, newTaintedString } = require('./operations')
 const {
   HTTP_REQUEST_BODY,
   HTTP_REQUEST_COOKIE_VALUE,
@@ -11,6 +11,7 @@ const {
   HTTP_REQUEST_HEADER_VALUE,
   HTTP_REQUEST_HEADER_NAME,
   HTTP_REQUEST_PARAMETER,
+  HTTP_REQUEST_PATH,
   HTTP_REQUEST_PATH_PARAM
 } = require('./source-types')
 
@@ -87,6 +88,11 @@ class TaintTrackingPlugin extends SourceIastPlugin {
       tag: [HTTP_REQUEST_HEADER_VALUE, HTTP_REQUEST_HEADER_NAME],
       iastContext
     })
+  }
+
+  taintRequest (req, iastContext) {
+    taintObject(iastContext, req.headers, HTTP_REQUEST_HEADER_VALUE, true, HTTP_REQUEST_HEADER_NAME)
+    req.url = newTaintedString(iastContext, req.url, 'req.url', HTTP_REQUEST_PATH)
   }
 
   enable () {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -90,9 +90,19 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     })
   }
 
+  taintUrl (req, iastContext) {
+    this.execSource({
+      handler: function () {
+        req.url = newTaintedString(iastContext, req.url, 'req.url', HTTP_REQUEST_PATH)
+      },
+      tag: [HTTP_REQUEST_PATH],
+      iastContext
+    })
+  }
+
   taintRequest (req, iastContext) {
-    taintObject(iastContext, req.headers, HTTP_REQUEST_HEADER_VALUE, true, HTTP_REQUEST_HEADER_NAME)
-    req.url = newTaintedString(iastContext, req.url, 'req.url', HTTP_REQUEST_PATH)
+    this.taintHeaders(req.headers, iastContext)
+    this.taintUrl(req, iastContext)
   }
 
   enable () {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/source-types.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/source-types.js
@@ -7,5 +7,6 @@ module.exports = {
   HTTP_REQUEST_HEADER_NAME: 'http.request.header.name',
   HTTP_REQUEST_HEADER_VALUE: 'http.request.header',
   HTTP_REQUEST_PARAMETER: 'http.request.parameter',
+  HTTP_REQUEST_PATH: 'http.request.path',
   HTTP_REQUEST_PATH_PARAM: 'http.request.path.parameter'
 }

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
@@ -3,7 +3,12 @@
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 const overheadController = require('../../../../src/appsec/iast/overhead-controller')
-const { HTTP_REQUEST_HEADER_VALUE, HTTP_REQUEST_PARAMETER } =
+const {
+  HTTP_REQUEST_HEADER_VALUE,
+  HTTP_REQUEST_PARAMETER,
+  HTTP_REQUEST_PATH,
+  HTTP_REQUEST_PATH_PARAM
+} =
   require('../../../../src/appsec/iast/taint-tracking/source-types')
 
 describe('unvalidated-redirect-analyzer', () => {
@@ -11,7 +16,10 @@ describe('unvalidated-redirect-analyzer', () => {
   const TAINTED_LOCATION = 'evil.com'
 
   const TAINTED_HEADER_REFERER_ONLY = 'TAINTED_HEADER_REFERER_ONLY'
-  const TAINTED_HEADER_REFERER_AMONG_OTHERS = 'TAINTED_HEADER_REFERER_ONLY_AMONG_OTHERS'
+  const TAINTED_PATH_PARAMS_ONLY = 'TAINTED_PATH_PARAMS_ONLY'
+  const TAINTED_URL_ONLY = 'TAINTED_URL_ONLY'
+  const TAINTED_SAFE_RANGES = 'TAINTED_SAFE_RANGES'
+  const TAINTED_SAFE_RANGES_AMONG_OTHERS = 'TAINTED_SAFE_RANGES_AMONG_OTHERS'
 
   const REFERER_RANGE = {
     iinfo: {
@@ -31,6 +39,18 @@ describe('unvalidated-redirect-analyzer', () => {
       parameterName: 'param2'
     }
   }
+  const PATH_PARAM_RANGE = {
+    iinfo: {
+      type: HTTP_REQUEST_PATH_PARAM,
+      parameterName: 'path_param'
+    }
+  }
+  const URL_RANGE = {
+    iinfo: {
+      type: HTTP_REQUEST_PATH,
+      parameterName: 'path'
+    }
+  }
 
   const TaintTrackingMock = {
     isTainted: (iastContext, string) => {
@@ -38,14 +58,21 @@ describe('unvalidated-redirect-analyzer', () => {
     },
 
     getRanges: (iastContext, value) => {
-      if (value === NOT_TAINTED_LOCATION) return null
-
-      if (value === TAINTED_HEADER_REFERER_ONLY) {
-        return [REFERER_RANGE]
-      } else if (value === TAINTED_HEADER_REFERER_AMONG_OTHERS) {
-        return [REFERER_RANGE, PARAMETER1_RANGE]
-      } else {
-        return [PARAMETER1_RANGE, PARAMETER2_RANGE]
+      switch (value) {
+        case NOT_TAINTED_LOCATION:
+          return null
+        case TAINTED_HEADER_REFERER_ONLY:
+          return [REFERER_RANGE]
+        case TAINTED_PATH_PARAMS_ONLY:
+          return [PATH_PARAM_RANGE]
+        case TAINTED_URL_ONLY:
+          return [URL_RANGE]
+        case TAINTED_SAFE_RANGES:
+          return [REFERER_RANGE, PATH_PARAM_RANGE, URL_RANGE]
+        case TAINTED_SAFE_RANGES_AMONG_OTHERS:
+          return [REFERER_RANGE, PATH_PARAM_RANGE, URL_RANGE, PARAMETER1_RANGE]
+        default:
+          return [PARAMETER1_RANGE, PARAMETER2_RANGE]
       }
     }
   }
@@ -105,8 +132,26 @@ describe('unvalidated-redirect-analyzer', () => {
     expect(report).to.not.be.called
   })
 
+  it('should not report if tainted origin is path param exclusively', () => {
+    unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_PATH_PARAMS_ONLY)
+
+    expect(report).to.not.be.called
+  })
+
+  it('should not report if tainted origin is url exclusively', () => {
+    unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_URL_ONLY)
+
+    expect(report).to.not.be.called
+  })
+
+  it('should not report if all tainted origin are safe', () => {
+    unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_SAFE_RANGES)
+
+    expect(report).to.not.be.called
+  })
+
   it('should report if tainted origin contains referer header among others', () => {
-    unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_HEADER_REFERER_AMONG_OTHERS)
+    unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_SAFE_RANGES_AMONG_OTHERS)
 
     expect(report).to.be.called
   })

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
@@ -8,8 +8,7 @@ const {
   HTTP_REQUEST_PARAMETER,
   HTTP_REQUEST_PATH,
   HTTP_REQUEST_PATH_PARAM
-} =
-  require('../../../../src/appsec/iast/taint-tracking/source-types')
+} = require('../../../../src/appsec/iast/taint-tracking/source-types')
 
 describe('unvalidated-redirect-analyzer', () => {
   const NOT_TAINTED_LOCATION = 'url.com'

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
@@ -105,19 +105,19 @@ describe('unvalidated-redirect-analyzer', () => {
   it('should not report headers other than Location', () => {
     unvalidatedRedirectAnalyzer.analyze('X-test', NOT_TAINTED_LOCATION)
 
-    expect(report).to.not.have.been.called
+    expect(report).not.to.be.called
   })
 
   it('should not report Location header with non string values', () => {
     unvalidatedRedirectAnalyzer.analyze('X-test', [TAINTED_LOCATION])
 
-    expect(report).to.not.have.been.called
+    expect(report).not.to.be.called
   })
 
   it('should not report Location header with not tainted string value', () => {
     unvalidatedRedirectAnalyzer.analyze('Location', NOT_TAINTED_LOCATION)
 
-    expect(report).to.not.have.been.called
+    expect(report).not.to.be.called
   })
 
   it('should report Location header with tainted string value', () => {
@@ -129,25 +129,25 @@ describe('unvalidated-redirect-analyzer', () => {
   it('should not report if tainted origin is referer header exclusively', () => {
     unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_HEADER_REFERER_ONLY)
 
-    expect(report).to.not.be.called
+    expect(report).not.to.be.called
   })
 
   it('should not report if tainted origin is path param exclusively', () => {
     unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_PATH_PARAMS_ONLY)
 
-    expect(report).to.not.be.called
+    expect(report).not.to.be.called
   })
 
   it('should not report if tainted origin is url exclusively', () => {
     unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_URL_ONLY)
 
-    expect(report).to.not.be.called
+    expect(report).not.to.be.called
   })
 
   it('should not report if all tainted origin are safe', () => {
     unvalidatedRedirectAnalyzer.analyze('Location', TAINTED_SAFE_RANGES)
 
-    expect(report).to.not.be.called
+    expect(report).not.to.be.called
   })
 
   it('should report if tainted origin contains referer header among others', () => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
@@ -7,6 +7,9 @@ const dc = require('../../../../../diagnostics_channel')
 const {
   HTTP_REQUEST_COOKIE_VALUE,
   HTTP_REQUEST_COOKIE_NAME,
+  HTTP_REQUEST_HEADER_NAME,
+  HTTP_REQUEST_HEADER_VALUE,
+  HTTP_REQUEST_PATH,
   HTTP_REQUEST_PATH_PARAM
 } = require('../../../../src/appsec/iast/taint-tracking/source-types')
 
@@ -226,6 +229,31 @@ describe('IAST Taint tracking plugin', () => {
 
       processParamsStartCh.publish({ req })
       expect(taintTrackingOperations.taintObject).to.not.be.called
+    })
+
+    it('Should taint headers and uri from request', () => {
+      const req = {
+        headers: {
+          'x-iast-header': 'header-value'
+        },
+        url: 'https://testurl'
+      }
+      taintTrackingPlugin.taintRequest(req, iastContext)
+
+      expect(taintTrackingOperations.taintObject).to.be.calledOnceWith(
+        iastContext,
+        req.headers,
+        HTTP_REQUEST_HEADER_VALUE,
+        true,
+        HTTP_REQUEST_HEADER_NAME
+      )
+
+      expect(taintTrackingOperations.newTaintedString).to.be.calledOnceWith(
+        iastContext,
+        req.url,
+        'req.url',
+        HTTP_REQUEST_PATH
+      )
     })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
@@ -216,6 +216,16 @@ describe('Telemetry', () => {
           }
         }).catch(done)
       })
+
+      it('should have url source execution metric', (done) => {
+        agent
+          .use(traces => {
+            expect(traces[0][0].metrics['_dd.iast.telemetry.executed.source.http_request_path']).to.be.equal(1)
+          })
+          .then(done)
+          .catch(done)
+        axios.get(`http://localhost:${config.port}/`).catch(done)
+      })
     }
     testInRequest(app, tests)
   })


### PR DESCRIPTION
### What does this PR do?
Provides a new function in taint tracking to taint all relevant information from request:

- Request headers (already tainted from previous feature)
- Request url

Once IAST receives a message from a new request start, these information is tainted.

This PR also adds a check in `Unvalidated redirect analyzer` in order to not report vulnerability when tainted origins are URL or path parameters.

### Motivation
Taint more sources to improve custom code vulnerability detection.
Avoid false positives for Unvalidated redirect vulnerability.

- [x] Unit tests.