### PR TITLE
Azure App Services Extension Support

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -221,6 +221,8 @@ class Config {
     const isNewerGCPFunction = process.env.K_SERVICE !== undefined && process.env.FUNCTION_TARGET !== undefined
     const isGCPFunction = isDeprecatedGCPFunction || isNewerGCPFunction
 
+    const inWindowsAzureAppServices = process.env.WEBSITE_NODE_DEFAULT_VERSION !== undefined && process.env.IISNODE_VERSION !== undefined
+
     const inServerlessEnvironment = inAWSLambda || isGCPFunction
 
     const DD_TRACE_TELEMETRY_ENABLED = coalesce(
@@ -617,6 +619,8 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.traceId128BitLoggingEnabled = isTrue(DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED)
 
     this.isGCPFunction = isGCPFunction
+
+    this.inWindowsAzureAppServices = inWindowsAzureAppServices
 
     tagger.add(this.tags, {
       service: this.service,

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -34,6 +34,10 @@ class Tracer extends NoopProxy {
         require('./serverless').maybeStartServerlessMiniAgent()
       }
 
+      if (config.inWindowsAzureAppServices) {
+        require('./serverless').startAgents()
+      }
+
       if (config.profiling.enabled) {
         // do not stop tracer initialization if the profiler fails to be imported
         try {

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -22,4 +22,18 @@ function maybeStartServerlessMiniAgent () {
   }
 }
 
-module.exports = { maybeStartServerlessMiniAgent }
+function startAgents() {
+  const log = require('./log')
+
+  log.error('I would start the agents if I knew how...')
+
+  if (process.env.TRACE_AGENT_PATH !== undefined) {
+    
+  }
+
+  if (process.env.DOGSTATSD_PATH !== undefined) {
+    
+  }
+}
+
+module.exports = { maybeStartServerlessMiniAgent, startAgents }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds support for an Azure App Services Extension. During startup, if we detect that we're in a Windows AAS environment, we'll attempt to launch the trace agent and dogstatsd.

We will also use named pipes instead of ports in this use case. This is because the agents are brittle in Windows AAS and ports aren't freed when the agents die. Rather than trying to find an open port, we can use named pipes.

### Motivation
<!-- What inspired you to submit this pull request? -->
Goal is to add support for Windows Node in Azure App Services. Currently we only support .NET and Java in Windows AAS.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
