### PR TITLE
pg: retain prototype when injecting DBM comment

### DIFF
--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -27,7 +27,7 @@ class PGPlugin extends DatabasePlugin {
       }
     })
 
-    query.text = this.injectDbmQuery(query.text, service, !!query.name)
+    query.__ddInjectableQuery = this.injectDbmQuery(query.text, service, !!query.name)
   }
 }
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -6,6 +6,7 @@ const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const net = require('net')
 const namingSchema = require('./naming')
+const EventEmitter = require('events')
 
 const clients = {
   pg: pg => pg.Client
@@ -611,6 +612,40 @@ describe('Plugin', () => {
           }).then(done, done)
 
           client.query(query, ['Hello world!'], (err) => {
+            if (err) return done(err)
+
+            client.end((err) => {
+              if (err) return done(err)
+            })
+          })
+          queryText = client.queryQueue[0].text
+        })
+
+        it('should not fail when using query object that is an EventEmitter', done => {
+          let queryText = ''
+
+          class Query extends EventEmitter {
+            constructor (name, text) {
+              super()
+              this.name = name
+              this._internalText = text
+            }
+
+            get text () {
+              expect(typeof this.on).to.eql('function')
+              return this._internalText
+            }
+          }
+
+          const query = new Query('pgSelectQuery', 'SELECT $1::text as greeting')
+
+          agent.use(traces => {
+            expect(queryText).to.equal(
+              `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0'` +
+              `*/ SELECT $1::text as greeting`)
+          }).then(done, done)
+
+          client.query(query, ['Goodbye'], (err) => {
             if (err) return done(err)
 
             client.end((err) => {


### PR DESCRIPTION
### What does this PR do?
- at first we overwrite `query.text`, but when it was a getter it would crash
- then we made a shallow clone of `query`, but it lost important prototype methods
- now we're making a new object and using `query` as the prototype

### Motivation
- fixes #3239