### PR TITLE
Peer service mapping

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -319,6 +319,12 @@ class Config {
     const DD_TRACE_SPAN_ATTRIBUTE_SCHEMA = validateNamingVersion(
       process.env.DD_TRACE_SPAN_ATTRIBUTE_SCHEMA
     )
+    const DD_TRACE_PEER_SERVICE_MAPPING = coalesce(
+      options.peerServiceMapping,
+      process.env.DD_TRACE_PEER_SERVICE_MAPPING ? fromEntries(
+        process.env.DD_TRACE_PEER_SERVICE_MAPPING.split(',').map(x => x.trim().split(':'))
+      ) : {}
+    )
     const DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED = process.env.DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED
 
     const DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED = coalesce(
@@ -554,6 +560,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       : true
     )
     this.traceRemoveIntegrationServiceNamesEnabled = DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
+    this.peerServiceMapping = DD_TRACE_PEER_SERVICE_MAPPING
     this.lookup = options.lookup
     this.startupLogs = isTrue(DD_TRACE_STARTUP_LOGS)
     // Disabled for CI Visibility's agentless

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -28,6 +28,7 @@ module.exports = {
   CLIENT_PORT_KEY: 'network.destination.port',
   PEER_SERVICE_KEY: 'peer.service',
   PEER_SERVICE_SOURCE_KEY: '_dd.peer.service.source',
+  PEER_SERVICE_REMAP_KEY: '_dd.peer.service.remapped_from',
   SCI_REPOSITORY_URL: '_dd.git.repository_url',
   SCI_COMMIT_SHA: '_dd.git.commit.sha'
 }

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -27,6 +27,7 @@ class DatadogTracer {
     this._env = config.env
     this._tags = config.tags
     this._computePeerService = config.spanComputePeerService
+    this._peerServiceMapping = config.peerServiceMapping
     this._logInjection = config.logInjection
     this._debug = config.debug
     this._prioritySampler = new PrioritySampler(config.env, config.sampler)

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -3,7 +3,8 @@
 const {
   CLIENT_PORT_KEY,
   PEER_SERVICE_KEY,
-  PEER_SERVICE_SOURCE_KEY
+  PEER_SERVICE_SOURCE_KEY,
+  PEER_SERVICE_REMAP_KEY
 } = require('../constants')
 const TracingPlugin = require('./tracing')
 
@@ -34,9 +35,11 @@ class OutboundPlugin extends TracingPlugin {
      * - If `peer.service` was defined _before_ we compute it (for example in custom instrumentation),
      *   `_dd.peer.service.source`'s value is `peer.service`
      */
-
-    if (tags['peer.service'] !== undefined) {
-      return { [PEER_SERVICE_SOURCE_KEY]: 'peer.service' }
+    if (tags[PEER_SERVICE_KEY] !== undefined) {
+      return {
+        [PEER_SERVICE_KEY]: tags[PEER_SERVICE_KEY],
+        [PEER_SERVICE_SOURCE_KEY]: PEER_SERVICE_KEY
+      }
     }
 
     const sourceTags = [
@@ -52,25 +55,35 @@ class OutboundPlugin extends TracingPlugin {
         }
       }
     }
-    return {}
+    return undefined
   }
 
-  startSpan (name, options) {
-    const span = super.startSpan(name, options)
-    return span
+  getPeerServiceRemap (peerData) {
+    /**
+     * If DD_TRACE_PEER_SERVICE_MAPPING is matched, we need to override the existing
+     * peer service and add the value we overrode.
+     */
+    const peerService = peerData[PEER_SERVICE_KEY]
+    if (peerService && this.tracer._peerServiceMapping[peerService]) {
+      return {
+        ...peerData,
+        [PEER_SERVICE_KEY]: this.tracer._peerServiceMapping[peerService],
+        [PEER_SERVICE_REMAP_KEY]: peerService
+      }
+    }
+    return peerData
   }
 
   finish () {
-    const span = this.activeSpan
-    this.tagPeerService(span)
+    this.tagPeerService(this.activeSpan)
     super.finish(...arguments)
   }
 
   tagPeerService (span) {
     if (this.tracer._computePeerService) {
       const peerData = this.getPeerService(span.context()._tags)
-      if (peerData) {
-        span.addTags(peerData)
+      if (peerData !== undefined) {
+        span.addTags(this.getPeerServiceRemap(peerData))
       }
     }
   }

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -164,6 +164,7 @@ describe('Config', () => {
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.5'
     process.env.DD_SERVICE = 'service'
     process.env.DD_SERVICE_MAPPING = 'a:aa, b:bb'
+    process.env.DD_TRACE_PEER_SERVICE_MAPPING = 'c:cc, d:dd'
     process.env.DD_VERSION = '1.0.0'
     process.env.DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP = '.*'
     process.env.DD_TRACE_CLIENT_IP_ENABLED = 'true'
@@ -255,6 +256,10 @@ describe('Config', () => {
     expect(config).to.have.deep.property('serviceMapping', {
       a: 'aa',
       b: 'bb'
+    })
+    expect(config).to.have.deep.property('peerServiceMapping', {
+      c: 'cc',
+      d: 'dd'
     })
     expect(config).to.have.nested.deep.property('tracePropagationStyle.inject', ['b3', 'tracecontext'])
     expect(config).to.have.nested.deep.property('tracePropagationStyle.extract', ['b3', 'tracecontext'])
@@ -555,6 +560,7 @@ describe('Config', () => {
     process.env.DD_TRACE_PARTIAL_FLUSH_MIN_SPANS = 2000
     process.env.DD_SERVICE = 'service'
     process.env.DD_SERVICE_MAPPING = 'a:aa'
+    process.env.DD_TRACE_PEER_SERVICE_MAPPING = 'c:cc'
     process.env.DD_VERSION = '0.0.0'
     process.env.DD_RUNTIME_METRICS_ENABLED = 'true'
     process.env.DD_TRACE_REPORT_HOSTNAME = 'true'
@@ -608,6 +614,9 @@ describe('Config', () => {
       },
       serviceMapping: {
         b: 'bb'
+      },
+      peerServiceMapping: {
+        d: 'dd'
       },
       tracePropagationStyle: {
         inject: [],
@@ -663,6 +672,7 @@ describe('Config', () => {
     expect(config.tags).to.include({ foo: 'foo', baz: 'qux' })
     expect(config.tags).to.include({ service: 'test', version: '1.0.0', env: 'development' })
     expect(config).to.have.deep.property('serviceMapping', { b: 'bb' })
+    expect(config).to.have.deep.property('peerServiceMapping', { d: 'dd' })
     expect(config).to.have.nested.deep.property('tracePropagationStyle.inject', [])
     expect(config).to.have.nested.deep.property('tracePropagationStyle.extract', [])
     expect(config).to.have.nested.property('experimental.runtimeId', false)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Expose `DD_TRACE_PEER_SERVICE_MAPPING`, which behaves like `DD_SERVICE_MAPPING`, but for the `peer.service` tag.

If the mapping is matched, the original value is reported in `_dd.peer.service.remapped_from`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
