### PR TITLE
[ci-visibility] Dogfood CI Visibility with integration tests

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -37,7 +37,6 @@ jobs:
         framework: [cucumber, playwright]
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: '-r ./ci/init'
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
@@ -48,6 +47,8 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn install
       - run: yarn test:integration:${{ matrix.framework }}
+        env:
+          NODE_OPTIONS: '-r ./ci/init'
 
   integration-cypress:
     strategy:
@@ -57,7 +58,6 @@ jobs:
         cypress-version: [6.7.0, latest]
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: '-r ./ci/init'
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
@@ -71,6 +71,7 @@ jobs:
       - run: yarn test:integration:cypress
         env:
           CYPRESS_VERSION: ${{ matrix.cypress-version }}
+          NODE_OPTIONS: '-r ./ci/init'
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -36,6 +36,11 @@ jobs:
         version: [16, latest]
         framework: [cucumber, playwright]
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '-r ./ci/init'
+      DD_SERVICE: dd-trace-js-integration-tests
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
+      DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -51,6 +56,11 @@ jobs:
         # 6.7.0 is the minimum version we support
         cypress-version: [6.7.0, latest]
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '-r ./ci/init'
+      DD_SERVICE: dd-trace-js-integration-tests
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
+      DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/node/setup

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -124,15 +124,11 @@ describe(`cypress@${version}`, function () {
         cwd,
         env: {
           ...restEnvVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-          DD_TRACE_DEBUG: '1'
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
         },
         stdio: 'pipe'
       }
     )
-    childProcess.stdout.pipe(process.stdout)
-    childProcess.stderr.pipe(process.stderr)
-
     childProcess.on('exit', () => {
       receiverPromise.then(() => {
         done()
@@ -143,8 +139,6 @@ describe(`cypress@${version}`, function () {
   it('can run and report tests', (done) => {
     const receiverPromise = receiver
       .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-        console.log('payloads', payloads)
-        console.log('payloads json', JSON.stringify(payloads))
         const events = payloads.flatMap(({ payload }) => payload.events)
 
         const testSessionEvent = events.find(event => event.type === 'test_session_end')
@@ -237,14 +231,11 @@ describe(`cypress@${version}`, function () {
         cwd,
         env: {
           ...restEnvVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-          DD_TRACE_DEBUG: '1'
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
         },
         stdio: 'pipe'
       }
     )
-    childProcess.stdout.pipe(process.stdout)
-    childProcess.stderr.pipe(process.stderr)
 
     childProcess.on('exit', () => {
       receiverPromise.then(() => {
@@ -284,15 +275,11 @@ describe(`cypress@${version}`, function () {
         cwd,
         env: {
           ...restEnvVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-          DD_TRACE_DEBUG: '1'
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
         },
         stdio: 'pipe'
       }
     )
-
-    childProcess.stdout.pipe(process.stdout)
-    childProcess.stderr.pipe(process.stderr)
 
     childProcess.on('exit', () => {
       receiverPromise.then(() => {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -139,6 +139,8 @@ describe(`cypress@${version}`, function () {
   it('can run and report tests', (done) => {
     const receiverPromise = receiver
       .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+        console.log('payloads', payloads)
+        console.log('payloads json', JSON.stringify(payloads))
         const events = payloads.flatMap(({ payload }) => payload.events)
 
         const testSessionEvent = events.find(event => event.type === 'test_session_end')

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -124,11 +124,15 @@ describe(`cypress@${version}`, function () {
         cwd,
         env: {
           ...restEnvVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+          DD_TRACE_DEBUG: '1'
         },
         stdio: 'pipe'
       }
     )
+    childProcess.stdout.pipe(process.stdout)
+    childProcess.stderr.pipe(process.stderr)
+
     childProcess.on('exit', () => {
       receiverPromise.then(() => {
         done()
@@ -233,11 +237,14 @@ describe(`cypress@${version}`, function () {
         cwd,
         env: {
           ...restEnvVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+          DD_TRACE_DEBUG: '1'
         },
         stdio: 'pipe'
       }
     )
+    childProcess.stdout.pipe(process.stdout)
+    childProcess.stderr.pipe(process.stderr)
 
     childProcess.on('exit', () => {
       receiverPromise.then(() => {
@@ -277,11 +284,15 @@ describe(`cypress@${version}`, function () {
         cwd,
         env: {
           ...restEnvVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+          DD_TRACE_DEBUG: '1'
         },
         stdio: 'pipe'
       }
     )
+
+    childProcess.stdout.pipe(process.stdout)
+    childProcess.stderr.pipe(process.stderr)
 
     childProcess.on('exit', () => {
       receiverPromise.then(() => {

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -246,7 +246,8 @@ function getCiVisEvpProxyConfig (port) {
   return {
     ...process.env,
     DD_TRACE_AGENT_PORT: port,
-    NODE_OPTIONS: '-r dd-trace/ci/init'
+    NODE_OPTIONS: '-r dd-trace/ci/init',
+    DD_CIVISIBILITY_AGENTLESS_ENABLED: '0'
   }
 }
 

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -180,9 +180,12 @@ async function createSandbox (dependencies = [], isGitRepo = false) {
   const out = path.join(folder, 'dd-trace.tgz')
   const allDependencies = [`file:${out}`].concat(dependencies)
 
+  // We might use NODE_OPTIONS to init the tracer. We don't want this to affect this operations
+  const { NODE_OPTIONS, ...restOfEnv } = process.env
+
   await mkdir(folder)
   await exec(`yarn pack --filename ${out}`) // TODO: cache this
-  await exec(`yarn add ${allDependencies.join(' ')}`, { cwd: folder })
+  await exec(`yarn add ${allDependencies.join(' ')}`, { cwd: folder, env: restOfEnv })
   await exec(`cp -R ./integration-tests/* ${folder}`)
   if (isGitRepo) {
     await exec('git init', { cwd: folder })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -30,7 +30,8 @@ versions.forEach((version) => {
       sandbox = await createSandbox([`@playwright/test@${version}`, 'typescript'], true)
       cwd = sandbox.folder
       // install necessary browser
-      execSync('npx playwright install', { cwd })
+      const { NODE_OPTIONS, ...restOfEnv } = process.env
+      execSync('npx playwright install', { cwd, env: restOfEnv })
       webAppPort = await getPort()
       webAppServer.listen(webAppPort)
     })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -108,7 +108,7 @@ versions.forEach((version) => {
               assert.equal(stepEvent.content.name, 'playwright.step')
               assert.property(stepEvent.content.meta, 'playwright.step')
             })
-          }).then(() => done()).catch(done)
+          }, 20000).then(() => done()).catch(done)
 
           childProcess = exec(
             './node_modules/.bin/playwright test -c playwright.config.js',
@@ -137,7 +137,7 @@ versions.forEach((version) => {
         assert.include(testOutput, '1 passed')
         assert.include(testOutput, '1 skipped')
         assert.notInclude(testOutput, 'TypeError')
-      }).then(() => done()).catch(done)
+      }, 20000).then(() => done()).catch(done)
 
       childProcess = exec(
         'node ./node_modules/typescript/bin/tsc' +

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -116,11 +116,15 @@ versions.forEach((version) => {
               cwd,
               env: {
                 ...envVars,
-                PW_BASE_URL: `http://localhost:${webAppPort}`
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                DD_TRACE_DEBUG: '1'
               },
               stdio: 'pipe'
             }
           )
+
+          childProcess.stdout.pipe(process.stdout)
+          childProcess.stderr.pipe(process.stderr)
         })
       })
     })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -108,7 +108,7 @@ versions.forEach((version) => {
               assert.equal(stepEvent.content.name, 'playwright.step')
               assert.property(stepEvent.content.meta, 'playwright.step')
             })
-          }, 20000).then(() => done()).catch(done)
+          }).then(() => done()).catch(done)
 
           childProcess = exec(
             './node_modules/.bin/playwright test -c playwright.config.js',
@@ -116,15 +116,11 @@ versions.forEach((version) => {
               cwd,
               env: {
                 ...envVars,
-                PW_BASE_URL: `http://localhost:${webAppPort}`,
-                DD_TRACE_DEBUG: '1'
+                PW_BASE_URL: `http://localhost:${webAppPort}`
               },
               stdio: 'pipe'
             }
           )
-
-          childProcess.stdout.pipe(process.stdout)
-          childProcess.stderr.pipe(process.stderr)
         })
       })
     })
@@ -141,7 +137,7 @@ versions.forEach((version) => {
         assert.include(testOutput, '1 passed')
         assert.include(testOutput, '1 skipped')
         assert.notInclude(testOutput, 'TypeError')
-      }, 20000).then(() => done()).catch(done)
+      }).then(() => done()).catch(done)
 
       childProcess = exec(
         'node ./node_modules/typescript/bin/tsc' +


### PR DESCRIPTION
### What does this PR do?
Integration tests are spawning new processes to test stuff, so initializing the tracer in the main process should not interfere with any test.

### Motivation
Get more visibility over integration tests.

