### PR TITLE
add smithy clients module hook

### DIFF
--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -83,7 +83,6 @@ function wrapSmithySend (send) {
             responseStartChannel.publish(message)
 
             cb.apply(this, arguments)
-
             if (message.needsFinish) {
               responseFinishChannel.publish(message.response.error)
             }
@@ -94,6 +93,7 @@ function wrapSmithySend (send) {
           .then(
             result => {
               const message = getMessage(request, null, result)
+
               completeChannel.publish(message)
               return result
             },
@@ -167,6 +167,11 @@ function getChannelSuffix (name) {
 }
 
 addHook({ name: '@aws-sdk/smithy-client', versions: ['>=3'] }, smithy => {
+  shimmer.wrap(smithy.Client.prototype, 'send', wrapSmithySend)
+  return smithy
+})
+
+addHook({ name: '@smithy/smithy-client', versions: ['>=1'] }, smithy => {
   shimmer.wrap(smithy.Client.prototype, 'send', wrapSmithySend)
   return smithy
 })

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -16,6 +16,7 @@ module.exports = {
   '@opensearch-project/opensearch': () => require('../opensearch'),
   '@opentelemetry/sdk-trace-node': () => require('../otel-sdk-trace'),
   '@redis/client': () => require('../redis'),
+  '@smithy/smithy-client': () => require('../aws-sdk'),
   'amqp10': () => require('../amqp10'),
   'amqplib': () => require('../amqplib'),
   'aws-sdk': () => require('../aws-sdk'),


### PR DESCRIPTION
### What does this PR do?

In 3.363.0 aws-sdk v3 moved `@aws-sdk/smithy-client` to `@smithy/smithy-client`

This add a hook for it.

### Motivation

### Plugin Checklist

- [ ] Unit tests.


### Additional Notes
