### PR TITLE
update docker compose mssql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,10 @@ services:
   # A working MSSQL server is not available on ARM.
   # This image provides _most_ of sqlserver functionalities, but
   # does not support stored procedures (corresponding tests will fail)
-    image: mcr.microsoft.com/mssql/azure-sql-edge
+    image: mcr.microsoft.com/azure-sql-edge
     environment:
       - "ACCEPT_EULA=Y"
       - "SA_PASSWORD=DD_HUNTER2"
-      - "MSSQL_PID=Express"
     ports:
       - "127.0.0.1:1433:1433"
   mysql:


### PR DESCRIPTION
Use the up to date name for mssql image on docker compose in order to pull `latest`

Also, removing the PID=Express since outdated (the edition is now called Developer) and it's the default (otherwise is a licensed one)