### PR TITLE
extract cassandra contact points and use for peer.service

### DIFF
--- a/packages/datadog-instrumentations/src/cassandra-driver.js
+++ b/packages/datadog-instrumentations/src/cassandra-driver.js
@@ -28,7 +28,7 @@ addHook({ name: 'cassandra-driver', versions: ['>=3.0.0'] }, cassandra => {
     }
 
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ keyspace: this.keyspace, query: queries })
+      startCh.publish({ keyspace: this.keyspace, query: queries, contactPoints: this.options?.contactPoints })
       try {
         const res = batch.apply(this, arguments)
         if (typeof res === 'function' || !res) {
@@ -56,7 +56,7 @@ addHook({ name: 'cassandra-driver', versions: ['>=4.4'] }, cassandra => {
     }
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ keyspace: this.keyspace, query })
+      startCh.publish({ keyspace: this.keyspace, query, contactPoints: this.options?.contactPoints })
       const promise = _execute.apply(this, arguments)
 
       const promiseAsyncResource = new AsyncResource('bound-anonymous-fn')
@@ -88,7 +88,7 @@ addHook({ name: 'cassandra-driver', versions: ['3 - 4.3'] }, cassandra => {
       }
 
       return asyncResource.runInAsyncScope(() => {
-        startCh.publish({ keyspace: this.keyspace, query })
+        startCh.publish({ keyspace: this.keyspace, query, contactPoints: this.options?.contactPoints })
 
         const lastIndex = arguments.length - 1
         let cb = arguments[lastIndex]

--- a/packages/datadog-plugin-cassandra-driver/src/index.js
+++ b/packages/datadog-plugin-cassandra-driver/src/index.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
+const CASSANDRA_CONTACT_POINTS_KEY = 'db.cassandra.contact.points'
 
 class CassandraDriverPlugin extends DatabasePlugin {
   static get id () { return 'cassandra-driver' }
   static get system () { return 'cassandra' }
+  static get peerServicePrecursors () { return [CASSANDRA_CONTACT_POINTS_KEY] }
 
-  start ({ keyspace, query, connectionOptions = {} }) {
+  start ({ keyspace, query, contactPoints = {} }) {
     if (Array.isArray(query)) {
       query = combine(query)
     }
@@ -21,8 +22,7 @@ class CassandraDriverPlugin extends DatabasePlugin {
         'db.type': 'cassandra',
         'cassandra.query': query,
         'cassandra.keyspace': keyspace,
-        'out.host': connectionOptions.host,
-        [CLIENT_PORT_KEY]: connectionOptions.port
+        [CASSANDRA_CONTACT_POINTS_KEY]: contactPoints.join(',') || null
       }
     })
   }

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -43,6 +43,12 @@ describe('Plugin', () => {
           client.shutdown(done)
         })
 
+        withPeerService(
+          () => tracer,
+          (done) => client.execute('SELECT now() FROM local;', err => err && done(err)),
+          '127.0.0.1', 'db.cassandra.contact.points'
+        )
+
         it('should do automatic instrumentation', done => {
           const query = 'SELECT now() FROM local;'
           agent
@@ -58,6 +64,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('cassandra.keyspace', 'system')
               expect(traces[0][0].meta).to.have.property('component', 'cassandra-driver')
               expect(traces[0][0].meta).to.have.property('network.destination.port', '9042')
+              expect(traces[0][0].meta).to.have.property('db.cassandra.contact.points', '127.0.0.1')
             })
             .then(done)
             .catch(done)


### PR DESCRIPTION
### What does this PR do?

Leveraging #3177 it adds the precursor to have `peer.service` automatically calculated for cassandra

It adds the following tags:
* `db.cassandra.contact.points`: comma separated list of  contact points provided when creating the client

The `peer.service` tag is hence sourced from `db.cassandra.contact.points`


### Motivation

`peer.service` automatic calculation feature

### Plugin Checklist

- [x] Unit tests.

### Additional Notes