### PR TITLE
plugin manager: init tracer config to empty object

### DIFF
--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -53,7 +53,7 @@ function maybeEnable (Plugin) {
 module.exports = class PluginManager {
   constructor (tracer) {
     this._tracer = tracer
-    this._tracerConfig = null
+    this._tracerConfig = {}
     this._pluginsByName = {}
     this._configsByName = {}
 


### PR DESCRIPTION
### What does this PR do?
- initializes `._tracerConfig` to an empty object instead of null

### Motivation
- should fix #3296