### PR TITLE
plugin manager: allow plugin reconfiguration

### DIFF
--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -107,6 +107,7 @@ module.exports = class PluginManager {
 
     for (const name in pluginClasses) {
       this.loadPlugin(name)
+      this._pluginsByName[name]._tracerConfig = config
     }
   }
 

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -22,9 +22,10 @@ describe('Plugin Manager', () => {
     tracer = {}
     instantiated = []
     class FakePlugin {
-      constructor (aTracer) {
+      constructor (aTracer, tracerConfig) {
         expect(aTracer).to.equal(tracer)
         instantiated.push(this.constructor.id)
+        this._tracerConfig = tracerConfig
       }
     }
 
@@ -95,6 +96,16 @@ describe('Plugin Manager', () => {
         loadChannel.publish({ name: 'two' })
         expect(Two.prototype.configure).to.have.been.calledWithMatch({
           enabled: true,
+          foo: 'bar'
+        })
+      })
+      it('should update _tracerConfig in plugins upon calling configure()', () => {
+        expect(pm._tracerConfig).to.eql(null)
+        pm.configurePlugin('two', { foo: 'bar' })
+        loadChannel.publish({ name: 'two' })
+        expect(pm._pluginsByName['two']._tracerConfig).to.eql(null)
+        pm.configure({ foo: 'bar' })
+        expect(pm._pluginsByName['two']._tracerConfig).to.deep.equal({
           foo: 'bar'
         })
       })


### PR DESCRIPTION
### What does this PR do?
- allows each plugin to have it's `._tracerConfig` be reconfigured when `update()` is called in `PluginManager`
  - currently `._tracerConfig` is passed in when each Plugin is initialized
  - however, the tracer config can change in the future when `update()` is called
  - I think this is what Roch was trying to say in https://github.com/DataDog/dd-trace-js/pull/3235#discussion_r1228669515

### Motivation
- should fix #3296