### PR TITLE
extract peer service from aws sdk

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
-const Plugin = require('../../dd-trace/src/plugins/plugin')
+const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { storage } = require('../../datadog-core')
 const { isTrue } = require('../../dd-trace/src/util')
 
-class BaseAwsSdkPlugin extends Plugin {
+class BaseAwsSdkPlugin extends ClientPlugin {
   static get id () { return 'aws' }
 
   get serviceIdentifier () {
@@ -116,7 +116,7 @@ class BaseAwsSdkPlugin extends Plugin {
       this.config.hooks.request(span, response)
     }
 
-    span.finish()
+    super.finish()
   }
 
   configure (config) {

--- a/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
@@ -4,6 +4,7 @@ const BaseAwsSdkPlugin = require('../base')
 
 class DynamoDb extends BaseAwsSdkPlugin {
   static get id () { return 'dynamodb' }
+  static get peerServicePrecursors () { return ['tablename'] }
 
   generateTags (params, operation, response) {
     const tags = {}

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -3,6 +3,7 @@ const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 class Kinesis extends BaseAwsSdkPlugin {
   static get id () { return 'kinesis' }
+  static get peerServicePrecursors () { return ['streamname'] }
 
   generateTags (params, operation, response) {
     if (!params || !params.StreamName) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/s3.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/s3.js
@@ -4,6 +4,7 @@ const BaseAwsSdkPlugin = require('../base')
 
 class S3 extends BaseAwsSdkPlugin {
   static get id () { return 's3' }
+  static get peerServicePrecursors () { return ['bucketname'] }
 
   generateTags (params, operation, response) {
     const tags = {}

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -4,6 +4,7 @@ const BaseAwsSdkPlugin = require('../base')
 
 class Sns extends BaseAwsSdkPlugin {
   static get id () { return 'sns' }
+  static get peerServicePrecursors () { return ['topicname'] }
 
   generateTags (params, operation, response) {
     if (!params) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -6,6 +6,7 @@ const { storage } = require('../../../datadog-core')
 
 class Sqs extends BaseAwsSdkPlugin {
   static get id () { return 'sqs' }
+  static get peerServicePrecursors () { return ['queuename'] }
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -54,6 +54,15 @@ describe('Plugin', () => {
           return agent.close({ ritmReset: false })
         })
 
+        withPeerService(
+          () => tracer,
+          (done) => s3.putObject({
+            Bucket: bucketName,
+            Key: 'test-key',
+            Body: 'test body'
+          }, (err) => err && done()),
+          bucketName, 'bucketname')
+
         it('should allow disabling a specific span kind of a service', (done) => {
           let total = 0
 

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -50,6 +50,14 @@ describe('Plugin', () => {
           return agent.close({ ritmReset: false })
         })
 
+        withPeerService(
+          () => tracer,
+          (done) => sqs.sendMessage({
+            MessageBody: 'test body',
+            QueueUrl
+          }, (err) => err && done()),
+          'SQS_QUEUE_NAME', 'queuename')
+
         it('should propagate the tracing context from the producer to the consumer', (done) => {
           let parentId
           let traceId

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -43,6 +43,7 @@ class OutboundPlugin extends TracingPlugin {
       ...this.constructor.peerServicePrecursors,
       ...COMMON_PEER_SVC_SOURCE_TAGS
     ]
+
     for (const sourceTag of sourceTags) {
       if (tags[sourceTag]) {
         return {


### PR DESCRIPTION
### What does this PR do?

Leveraging #3177 it adds the precursor to have `peer.service` automatically calculated for aws-sdk

The mapping aws-service <-> precursor is:
* dynamodb: `streamname`
* s3: `bucketname`
* sqs: `queuename`
* sns: `topicname`
* kinesis: `streamname`


### Motivation

`peer.service` automatic calculation feature

### Plugin Checklist

- [x] Unit tests.

### Additional Notes