### PR TITLE
database/dbm: no longer use _tracerConfig

### DIFF
--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -134,6 +134,7 @@ module.exports = class PluginManager {
       queryStringObfuscation,
       site,
       url,
+      dbmPropagationMode,
       dsmEnabled
     } = this._tracerConfig
 
@@ -147,6 +148,7 @@ module.exports = class PluginManager {
       sharedConfig.queryStringObfuscation = queryStringObfuscation
     }
 
+    sharedConfig.dbmPropagationMode = dbmPropagationMode
     sharedConfig.dsmEnabled = dsmEnabled
 
     if (serviceMapping && serviceMapping[name]) {

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -39,7 +39,7 @@ class DatabasePlugin extends StoragePlugin {
   }
 
   injectDbmQuery (query, serviceName, isPreparedStatement = false) {
-    const mode = this.config.dbmPropagationMode || this._tracerConfig.dbmPropagationMode
+    const mode = this.config.dbmPropagationMode
 
     if (mode === 'disabled') {
       return query


### PR DESCRIPTION
### What does this PR do?
- revert database dbm config lookup to use the 'plugin config tunnel' instead of _tracerConfig

### Motivation
- obsoletes https://github.com/DataDog/dd-trace-js/pull/3332
- should fix #3296