### PR TITLE
redis: extract host and port

### DIFF
--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -41,9 +41,9 @@ function wrapCommandQueueClass (cls) {
   const ret = class RedisCommandQueue extends cls {
     constructor () {
       super(arguments)
-      if (state['url']) {
+      if (state.url) {
         try {
-          const parsed = new URL(state['url'])
+          const parsed = new URL(state.url)
           if (parsed) {
             this._url = { host: parsed.hostname, port: +parsed.port || 6379 }
           }

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -59,9 +59,9 @@ function wrapCommandQueueClass (cls) {
 
 function wrapCreateClient (request) {
   return function (opts) {
-    state['url'] = opts?.url
+    state.url = opts && opts.url
     const ret = request.apply(this, arguments)
-    delete state['url']
+    delete state.url
     return ret
   }
 }

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -24,7 +24,7 @@ function wrapAddCommand (addCommand) {
 
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     return asyncResource.runInAsyncScope(() => {
-      start(this, name, args, this.__url)
+      start(this, name, args, this._url)
 
       const res = addCommand.apply(this, arguments)
       const onResolve = asyncResource.bind(() => finish(finishCh, errorCh))
@@ -45,13 +45,13 @@ function wrapCommandQueueClass (cls) {
         try {
           const parsed = new URL(state['url'])
           if (parsed) {
-            this.__url = { host: parsed.hostname, port: +parsed.port || 6379 }
+            this._url = { host: parsed.hostname, port: +parsed.port || 6379 }
           }
         } catch (error) {
           // ignore
         }
       }
-      this.__url = this.__url || { host: 'localhost', port: 6379 }
+      this._url = this._url || { host: 'localhost', port: 6379 }
     }
   }
   return ret

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -11,7 +11,7 @@ const startCh = channel('apm:redis:command:start')
 const finishCh = channel('apm:redis:command:finish')
 const errorCh = channel('apm:redis:command:error')
 
-const state = []
+let createClientUrl
 
 function wrapAddCommand (addCommand) {
   return function (command) {
@@ -41,9 +41,9 @@ function wrapCommandQueueClass (cls) {
   const ret = class RedisCommandQueue extends cls {
     constructor () {
       super(arguments)
-      if (state.url) {
+      if (createClientUrl) {
         try {
-          const parsed = new URL(state.url)
+          const parsed = new URL(createClientUrl)
           if (parsed) {
             this._url = { host: parsed.hostname, port: +parsed.port || 6379 }
           }
@@ -59,9 +59,9 @@ function wrapCommandQueueClass (cls) {
 
 function wrapCreateClient (request) {
   return function (opts) {
-    state.url = opts && opts.url
+    createClientUrl = opts && opts.url
     const ret = request.apply(this, arguments)
-    delete state.url
+    delete createClientUrl
     return ret
   }
 }

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -61,7 +61,7 @@ function wrapCreateClient (request) {
   return function (opts) {
     createClientUrl = opts && opts.url
     const ret = request.apply(this, arguments)
-    delete createClientUrl
+    createClientUrl = undefined
     return ret
   }
 }

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -14,6 +14,7 @@ const modules = semver.satisfies(process.versions.node, '>=14')
 describe('Plugin', () => {
   let redis
   let client
+  let tracer
 
   describe('redis', () => {
     withVersions('redis', modules, (version, moduleName) => {
@@ -27,8 +28,9 @@ describe('Plugin', () => {
         })
 
         beforeEach(async () => {
+          tracer = require('../../dd-trace')
           redis = require(`../../../versions/${moduleName}@${version}`).get()
-          client = redis.createClient()
+          client = redis.createClient({ url: 'redis://127.0.0.1:6379' })
 
           await client.connect()
         })
@@ -50,11 +52,18 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
               expect(traces[0][0].meta).to.have.property('redis.raw_command', 'GET foo')
               expect(traces[0][0].meta).to.have.property('component', 'redis')
+              expect(traces[0][0].meta).to.have.property('out.host', '127.0.0.1')
+              expect(traces[0][0].metrics).to.have.property('network.destination.port', 6379)
             })
 
           await client.get('foo')
           await promise
         })
+
+        withPeerService(
+          () => tracer,
+          (done) => client.get('bar').catch(done),
+          '127.0.0.1', 'out.host')
 
         it('should handle errors', async () => {
           let error
@@ -129,11 +138,18 @@ describe('Plugin', () => {
         it('should be configured with the correct values', async () => {
           const promise = agent.use(traces => {
             expect(traces[0][0]).to.have.property('service', 'custom')
+            expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
+            expect(traces[0][0].metrics).to.have.property('network.destination.port', 6379)
           })
 
           await client.get('foo')
           await promise
         })
+
+        withPeerService(
+          () => tracer,
+          (done) => client.get('bar').catch(done),
+          'localhost', 'out.host')
 
         it('should be able to filter commands', async () => {
           const promise = agent.use(traces => {


### PR DESCRIPTION
### What does this PR do?
enrich span created by `@node-redis/client` and `@redis/client` with `out.host` and `network.destination.port` .

Those tags were only available when using legacy redis client

### Motivation
Provide peer service precursors for all supported redis libraries

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [X ] Unit tests.

### Additional Notes
