### PR TITLE
remove optional chaining from cassandra, elasticsearch

### DIFF
--- a/packages/datadog-instrumentations/src/cassandra-driver.js
+++ b/packages/datadog-instrumentations/src/cassandra-driver.js
@@ -28,7 +28,8 @@ addHook({ name: 'cassandra-driver', versions: ['>=3.0.0'] }, cassandra => {
     }
 
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ keyspace: this.keyspace, query: queries, contactPoints: this.options?.contactPoints })
+      const contactPoints = this.options && this.options.contactPoints
+      startCh.publish({ keyspace: this.keyspace, query: queries, contactPoints })
       try {
         const res = batch.apply(this, arguments)
         if (typeof res === 'function' || !res) {
@@ -56,7 +57,8 @@ addHook({ name: 'cassandra-driver', versions: ['>=4.4'] }, cassandra => {
     }
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     return asyncResource.runInAsyncScope(() => {
-      startCh.publish({ keyspace: this.keyspace, query, contactPoints: this.options?.contactPoints })
+      const contactPoints = this.options && this.options.contactPoints
+      startCh.publish({ keyspace: this.keyspace, query, contactPoints })
       const promise = _execute.apply(this, arguments)
 
       const promiseAsyncResource = new AsyncResource('bound-anonymous-fn')
@@ -88,7 +90,8 @@ addHook({ name: 'cassandra-driver', versions: ['3 - 4.3'] }, cassandra => {
       }
 
       return asyncResource.runInAsyncScope(() => {
-        startCh.publish({ keyspace: this.keyspace, query, contactPoints: this.options?.contactPoints })
+        const contactPoints = this.options && this.options.contactPoints
+        startCh.publish({ keyspace: this.keyspace, query, contactPoints })
 
         const lastIndex = arguments.length - 1
         let cb = arguments[lastIndex]

--- a/packages/datadog-instrumentations/src/elasticsearch.js
+++ b/packages/datadog-instrumentations/src/elasticsearch.js
@@ -34,7 +34,7 @@ function createWrapGetConnection (name) {
   return function wrapRequest (request) {
     return function () {
       const connection = request.apply(this, arguments)
-      if (connectCh.hasSubscribers && connection?.url) {
+      if (connectCh.hasSubscribers && connection && connection.url) {
         connectCh.publish(connection.url)
       }
       return connection
@@ -49,7 +49,7 @@ function createWrapSelect () {
       if (arguments.length === 1) {
         const cb = arguments[0]
         arguments[0] = function (err, connection) {
-          if (connectCh.hasSubscribers && connection?.host) {
+          if (connectCh.hasSubscribers && connection && connection.host) {
             connectCh.publish({ hostname: connection.host.host, port: connection.host.port })
           }
           cb(err, connection)


### PR DESCRIPTION
### What does this PR do?
- removes the `?.` operator which fails on old versions of Node
- need to update the linter

### Motivation
- fixes releases on v2.x and v3.x branches
- needs to be cherry picked into the current releases