### PR TITLE
set peer.service naming expectations based on tracer version

### DIFF
--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -7,6 +7,7 @@ const getService = require('./service')
 const loader = require('../../../versions/@grpc/proto-loader').get()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 
+const { DD_MAJOR } = require('../../../version')
 const nodeMajor = parseInt(process.versions.node.split('.')[0])
 const pkgs = nodeMajor > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
@@ -118,7 +119,7 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.client',
+                    name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
                     resource: '/test.TestService/getUnary',
                     type: 'http'
@@ -155,7 +156,7 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.client',
+                    name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
                     resource: '/test.TestService/getServerStream',
                     type: 'http'
@@ -190,7 +191,7 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.client',
+                    name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
                     resource: '/test.TestService/getClientStream',
                     type: 'http'
@@ -225,7 +226,7 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.client',
+                    name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
                     resource: '/test.TestService/getBidi',
                     type: 'http'
@@ -361,7 +362,7 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.client',
+                    name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
                     resource: '/test.TestService/getUnary'
                   })
@@ -393,7 +394,7 @@ describe('Plugin', () => {
               return agent
                 .use(traces => {
                   expect(traces[0][0]).to.deep.include({
-                    name: 'grpc.client',
+                    name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
                     resource: '/test.TestService/getUnary'
                   })

--- a/packages/datadog-plugin-grpc/test/naming.js
+++ b/packages/datadog-plugin-grpc/test/naming.js
@@ -1,9 +1,10 @@
 const { resolveNaming } = require('../../dd-trace/test/plugins/helpers')
+const { DD_MAJOR } = require('../../../version')
 
 module.exports = resolveNaming({
   client: {
     v0: {
-      opName: 'grpc.client',
+      opName: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
       serviceName: 'test'
     },
     v1: {
@@ -13,7 +14,7 @@ module.exports = resolveNaming({
   },
   server: {
     v0: {
-      opName: 'grpc.server',
+      opName: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.server',
       serviceName: 'test'
     },
     v1: {

--- a/packages/dd-trace/src/service-naming/schemas/v0/web.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/web.js
@@ -1,9 +1,10 @@
 const { identityService } = require('../util')
+const { DD_MAJOR } = require('../../../../../../version')
 
 const web = {
   client: {
     grpc: {
-      opName: () => 'grpc.client',
+      opName: () => DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
       serviceName: identityService
     },
     moleculer: {
@@ -13,7 +14,7 @@ const web = {
   },
   server: {
     grpc: {
-      opName: () => 'grpc.server',
+      opName: () => DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.server',
       serviceName: identityService
     },
     moleculer: {


### PR DESCRIPTION
### What does this PR do?
- v2 of the tracer had different naming expectations

### Motivation
- helps prevent conflicts, fixes v2 release