### PR TITLE
Refactor passport instrumentation.

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -58,7 +58,7 @@ jobs:
   parametric:
     runs-on: ubuntu-latest
     env:
-      CLIENTS_ENABLED: nodejs
+      TEST_LIBRARY: nodejs
       NODEJS_DDTRACE_MODULE: datadog/dd-trace-js#${{ github.sha }}
     steps:
       - name: Checkout system tests
@@ -68,9 +68,17 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+      - name: Build
+        run: ./build.sh -i runner
       - name: Run
-        run: |
-          cd parametric
-          pip install wheel
-          pip install -r requirements.txt
-          ./run.sh
+        run: ./run.sh PARAMETRIC
+        
+      - name: Compress artifact
+        if: ${{ always() }}  
+        run: tar -czvf artifact.tar.gz $(ls | grep logs)
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: logs_parametric
+          path: artifact.tar.gz

--- a/packages/dd-trace/test/appsec/passport.spec.js
+++ b/packages/dd-trace/test/appsec/passport.spec.js
@@ -65,7 +65,8 @@ describe('Passport', () => {
       expect(setUser.setUserTags).not.to.have.been.called
       expect(events.trackEvent).to.have.been.calledOnceWithExactly(
         'users.login.failure',
-        { 'usr.id': ' ' },
+        null,
+        { user: { id: 'test' } },
         'passportTrackEvent',
         undefined,
         'safe'
@@ -75,27 +76,9 @@ describe('Passport', () => {
     it('should report login success when passportUser is present', () => {
       passportModule.passportTrackEvent(loginLocal, userUuid, rootSpan, 'safe')
 
-      expect(setUser.setUserTags).to.have.been.calledOnceWithExactly({ id: userUuid.id }, rootSpan)
       expect(events.trackEvent).to.have.been.calledOnceWithExactly(
         'users.login.success',
-        null,
-        'passportTrackEvent',
-        rootSpan,
-        'safe'
-      )
-    })
-
-    it('should report login success and blank id in safe mode when id is not a uuid', () => {
-      const user = {
-        id: 'publicName',
-        email: 'testUser@test.com',
-        username: 'Test User'
-      }
-      passportModule.passportTrackEvent(loginLocal, user, rootSpan, 'safe')
-
-      expect(setUser.setUserTags).to.have.been.calledOnceWithExactly({ id: ' ' }, rootSpan)
-      expect(events.trackEvent).to.have.been.calledOnceWithExactly(
-        'users.login.success',
+        { id: '591dc126-8431-4d0f-9509-b23318d3dce4' },
         null,
         'passportTrackEvent',
         rootSpan,
@@ -111,83 +94,20 @@ describe('Passport', () => {
       }
 
       passportModule.passportTrackEvent(loginLocal, user, rootSpan, 'extended')
-      expect(setUser.setUserTags).to.have.been.calledOnceWithExactly(
+
+      expect(events.trackEvent).to.have.been.calledOnceWithExactly(
+        'users.login.success',
         {
           id: 'publicName',
-          login: 'test',
           email: 'testUser@test.com',
-          username: 'Test User'
+          username: 'Test User',
+          login: 'test'
         },
-        rootSpan
-      )
-      expect(events.trackEvent).to.have.been.calledOnceWithExactly(
-        'users.login.success',
         null,
         'passportTrackEvent',
         rootSpan,
         'extended'
       )
-    })
-
-    it('should not call trackEvent in safe mode if sdk user event functions are already called', () => {
-      rootSpan.context = () => {
-        return {
-          _tags: {
-            '_dd.appsec.events.users.login.success.sdk': 'true'
-          }
-        }
-      }
-
-      passportModule.passportTrackEvent(loginLocal, userUuid, rootSpan, 'safe')
-      expect(setUser.setUserTags).not.to.have.been.called
-      expect(events.trackEvent).not.to.have.been.called
-    })
-
-    it('should not call trackEvent in extended mode if trackUserLoginSuccessEvent is already called', () => {
-      rootSpan.context = () => {
-        return {
-          _tags: {
-            '_dd.appsec.events.users.login.success.sdk': 'true'
-          }
-        }
-      }
-
-      passportModule.passportTrackEvent(loginLocal, userUuid, rootSpan, 'extended')
-      expect(setUser.setUserTags).not.to.have.been.called
-      expect(events.trackEvent).not.to.have.been.called
-    })
-
-    it('should call trackEvent in extended mode if trackCustomEvent function is already called', () => {
-      rootSpan.context = () => {
-        return {
-          _tags: {
-            '_dd.appsec.events.custom.event.sdk': 'true'
-          }
-        }
-      }
-
-      passportModule.passportTrackEvent(loginLocal, userUuid, rootSpan, 'extended')
-      expect(events.trackEvent).to.have.been.calledOnceWithExactly(
-        'users.login.success',
-        null,
-        'passportTrackEvent',
-        rootSpan,
-        'extended'
-      )
-    })
-
-    it('should not call trackEvent in extended mode if trackUserLoginFailureEvent is already called', () => {
-      rootSpan.context = () => {
-        return {
-          _tags: {
-            '_dd.appsec.events.users.login.failure.sdk': 'true'
-          }
-        }
-      }
-
-      passportModule.passportTrackEvent(loginLocal, userUuid, rootSpan, 'extended')
-      expect(setUser.setUserTags).not.to.have.been.called
-      expect(events.trackEvent).not.to.have.been.called
     })
 
     it('should report login success with the _id field', () => {
@@ -198,17 +118,14 @@ describe('Passport', () => {
       }
 
       passportModule.passportTrackEvent(loginLocal, user, rootSpan, 'extended')
-      expect(setUser.setUserTags).to.have.been.calledOnceWithExactly(
-        {
-          id: '591dc126-8431-4d0f-9509-b23318d3dce4',
-          login: 'test',
-          email: 'testUser@test.com',
-          username: 'Test User'
-        },
-        rootSpan
-      )
       expect(events.trackEvent).to.have.been.calledOnceWithExactly(
         'users.login.success',
+        {
+          id: '591dc126-8431-4d0f-9509-b23318d3dce4',
+          email: 'testUser@test.com',
+          username: 'Test User',
+          login: 'test'
+        },
         null,
         'passportTrackEvent',
         rootSpan,
@@ -225,15 +142,14 @@ describe('Passport', () => {
       rootSpan.context = () => { return {} }
 
       passportModule.passportTrackEvent(loginLocal, user, rootSpan, 'extended')
-      expect(setUser.setUserTags).to.have.been.calledOnceWithExactly(
+      expect(events.trackEvent).to.have.been.calledOnceWithExactly(
+        'users.login.success',
         {
           id: 'test',
           login: 'test',
           email: 'testUser@test.com',
           username: 'Test User'
-        }, rootSpan)
-      expect(events.trackEvent).to.have.been.calledOnceWithExactly(
-        'users.login.success',
+        },
         null,
         'passportTrackEvent',
         rootSpan,

--- a/packages/dd-trace/test/appsec/sdk/track_event.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event.spec.js
@@ -256,7 +256,7 @@ describe('track_event', () => {
         })
       })
 
-      it('should report login success and no id in safe mode when id is not a uuid', () => {
+      it('should report login success and no id in safe mode when id is a PII', () => {
         const user = {
           id: 'publicName',
           email: 'testUser@test.com',
@@ -271,6 +271,25 @@ describe('track_event', () => {
             'appsec.events.users.login.success.track': 'true',
             'manual.keep': 'true',
             '_dd.appsec.events.users.login.success.auto.mode': 'safe'
+          }
+        )
+      })
+
+      it('should report login failure and no id in safe mode when id is a PII', () => {
+        const metadata = {
+          user: {
+            id: 'publicName'
+          }
+        }
+
+        trackEvent('users.login.failure', null, metadata, 'login', rootSpan, 'safe')
+
+        expect(setUserTags).not.to.have.been.called
+        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly(
+          {
+            'appsec.events.users.login.failure.track': 'true',
+            'manual.keep': 'true',
+            '_dd.appsec.events.users.login.failure.auto.mode': 'safe'
           }
         )
       })


### PR DESCRIPTION
### What does this PR do?
* Stop sending empty 'usr.id' tag in safe mode where the id is a PII.
* Move PII handling code to track_event. This way that code is centralized in a common module which has several advantages like:
  * Several authentication frameworks instrumentation can use it.
  * Avoid tinkering with the user and metadata objects on each instrumentation. 


### Additional Notes
<!-- Anything else we should know when reviewing? -->
