### PR TITLE
sirun: increasing log benchmark iterations 1000x

### DIFF
--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -18,6 +18,6 @@ log.use({
   error () {}
 })
 
-for (let i = 0; i < 1000000; i++) {
+for (let i = 0; i < 1000000000; i++) {
   log[WITH_LEVEL](() => 'message')
 }


### PR DESCRIPTION
### What does this PR do?
- slows down the log benchmark 1,000 times
- on my machine a run takes ~2 seconds

### Motivation
- currently it's very fragile
- currently it isn't really measuring log time