### PR TITLE
sirun: decreasing log benchmark iterations 100x

### DIFF
--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -18,6 +18,6 @@ log.use({
   error () {}
 })
 
-for (let i = 0; i < 1000000000; i++) {
+for (let i = 0; i < 10000000; i++) {
   log[WITH_LEVEL](() => 'message')
 }


### PR DESCRIPTION
### What does this PR do?
- the previous PR #3359 increased iterations 1000x
- an individual run was 6 seconds
- however, I forgot that this all runs 40 times
- so the original PR passed, but future PRs started to exceed the 10m timeout

### Motivation
- was too aggressive