### PR TITLE
openai: do not crash when dogstatsd not configured

### DIFF
--- a/packages/datadog-plugin-openai/src/services.js
+++ b/packages/datadog-plugin-openai/src/services.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const DogStatsDClient = require('../../dd-trace/src/dogstatsd')
+const { DogStatsDClient, NoopDogStatsDClient } = require('../../dd-trace/src/dogstatsd')
 const ExternalLogger = require('../../dd-trace/src/external-logger/src')
 
 const FLUSH_INTERVAL = 10 * 1000
@@ -10,15 +10,19 @@ let logger = null
 let interval = null
 
 module.exports.init = function (tracerConfig) {
-  metrics = new DogStatsDClient({
-    host: tracerConfig.dogstatsd.hostname,
-    port: tracerConfig.dogstatsd.port,
-    tags: [
-      `service:${tracerConfig.tags.service}`,
-      `env:${tracerConfig.tags.env}`,
-      `version:${tracerConfig.tags.version}`
-    ]
-  })
+  if (tracerConfig.dogstatsd) {
+    metrics = new DogStatsDClient({
+      host: tracerConfig.dogstatsd.hostname,
+      port: tracerConfig.dogstatsd.port,
+      tags: [
+        `service:${tracerConfig.tags.service}`,
+        `env:${tracerConfig.tags.env}`,
+        `version:${tracerConfig.tags.version}`
+      ]
+    })
+  } else {
+    metrics = new NoopDogStatsDClient()
+  }
 
   logger = new ExternalLogger({
     ddsource: 'openai',

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -8,7 +8,7 @@ const nock = require('nock')
 const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const DogStatsDClient = require('../../dd-trace/src/dogstatsd')
+const { DogStatsDClient } = require('../../dd-trace/src/dogstatsd')
 const ExternalLogger = require('../../dd-trace/src/external-logger/src')
 const Sampler = require('../../dd-trace/src/sampler')
 

--- a/packages/datadog-plugin-openai/test/services.spec.js
+++ b/packages/datadog-plugin-openai/test/services.spec.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const services = require('../src/services')
+
+describe('Plugin', () => {
+  describe('openai services', () => {
+    describe('when unconfigured', () => {
+      afterEach(() => {
+        services.shutdown()
+      })
+
+      it('dogstatsd does not throw', () => {
+        const service = services.init({
+          hostname: 'foo',
+          service: 'bar',
+          apiKey: 'my api key',
+          interval: 1000
+        })
+
+        service.metrics.increment('mykey')
+        service.logger.log('hello')
+      })
+
+      it('logger does not throw', () => {
+        const service = services.init({
+          hostname: 'foo',
+          service: 'bar',
+          interval: 1000
+        })
+
+        service.logger.log('hello')
+      })
+    })
+  })
+})

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -143,4 +143,17 @@ class DogStatsDClient {
   }
 }
 
-module.exports = DogStatsDClient
+class NoopDogStatsDClient {
+  gauge () { }
+
+  increment () { }
+
+  distribution () { }
+
+  flush () { }
+}
+
+module.exports = {
+  DogStatsDClient,
+  NoopDogStatsDClient
+}

--- a/packages/dd-trace/src/metrics.js
+++ b/packages/dd-trace/src/metrics.js
@@ -5,7 +5,7 @@
 const { URL, format } = require('url')
 const v8 = require('v8')
 const os = require('os')
-const Client = require('./dogstatsd')
+const { DogStatsDClient } = require('./dogstatsd')
 const log = require('./log')
 const Histogram = require('./histogram')
 const { performance } = require('perf_hooks')
@@ -67,7 +67,7 @@ module.exports = {
       }))
     }
 
-    client = new Client(clientConfig)
+    client = new DogStatsDClient(clientConfig)
 
     time = process.hrtime()
 

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -64,7 +64,7 @@ describe('dogstatsd', () => {
     Client = proxyquire('../src/dogstatsd', {
       'dgram': dgram,
       'dns': dns
-    })
+    }).DogStatsDClient
 
     httpData = []
     statusCode = 200

--- a/packages/dd-trace/test/metrics.spec.js
+++ b/packages/dd-trace/test/metrics.spec.js
@@ -28,7 +28,9 @@ suiteDescribe('metrics', () => {
     }
 
     metrics = proxyquire('../src/metrics', {
-      './dogstatsd': Client
+      './dogstatsd': {
+        DogStatsDClient: Client
+      }
     })
 
     config = {


### PR DESCRIPTION
### What does this PR do?
- do not attempt to instantiate dogstatsd instance in openai when dogstatsd isn't configured

### Motivation
- should fix #3357