### PR TITLE
Convert grpc to use tracing channel

### DIFF
--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const types = require('./types')
-const { addHook, channel, AsyncResource } = require('../helpers/instrument')
+const { addHook, channel } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
 const nodeMajor = parseInt(process.versions.node.split('.')[0])
@@ -10,8 +10,10 @@ const patched = new WeakSet()
 const instances = new WeakMap()
 
 const startChannel = channel('apm:grpc:client:request:start')
+const asyncStartChannel = channel('apm:grpc:client:request:asyncStart')
 const errorChannel = channel('apm:grpc:client:request:error')
 const finishChannel = channel('apm:grpc:client:request:finish')
+const emitChannel = channel('apm:grpc:client:request:emit')
 
 function createWrapMakeRequest (type) {
   return function wrapMakeRequest (makeRequest) {
@@ -101,45 +103,39 @@ function wrapMethod (method, path, type) {
   return wrapped
 }
 
-function wrapCallback (requestResource, parentResource, callback) {
+function wrapCallback (ctx, callback = () => { }) {
   return function (err) {
     if (err) {
-      requestResource.runInAsyncScope(() => {
-        errorChannel.publish(err)
-      })
+      ctx.error = err
+      errorChannel.publish(ctx)
     }
 
-    if (callback) {
-      return parentResource.runInAsyncScope(() => {
-        return callback.apply(this, arguments)
-      })
-    }
+    return asyncStartChannel.runStores(ctx, () => {
+      return callback.apply(this, arguments)
+      // No async end channel needed
+    })
   }
 }
 
-function wrapStream (call, requestResource, parentResource) {
-  if (!call || typeof call.emit !== 'function') return
+function createWrapEmit (ctx) {
+  return function wrapEmit (emit) {
+    return function (event, arg1) {
+      switch (event) {
+        case 'error':
+          ctx.error = arg1
+          errorChannel.publish(ctx)
+          break
+        case 'status':
+          ctx.result = arg1
+          finishChannel.publish(ctx)
+          break
+      }
 
-  shimmer.wrap(call, 'emit', emit => {
-    return function (eventName, ...args) {
-      requestResource.runInAsyncScope(() => {
-        switch (eventName) {
-          case 'error':
-            errorChannel.publish(args[0])
-
-            break
-          case 'status':
-            finishChannel.publish(args[0])
-
-            break
-        }
-      })
-
-      return parentResource.runInAsyncScope(() => {
+      return emitChannel.runStores(ctx, () => {
         return emit.apply(this, arguments)
       })
     }
-  })
+  }
 }
 
 function callMethod (client, method, args, path, metadata, type) {
@@ -147,25 +143,31 @@ function callMethod (client, method, args, path, metadata, type) {
 
   const length = args.length
   const callback = args[length - 1]
-  const parentResource = new AsyncResource('bound-anonymous-fn')
-  const requestResource = new AsyncResource('bound-anonymous-fn')
 
-  return requestResource.runInAsyncScope(() => {
-    startChannel.publish({ metadata, path, type })
+  const ctx = { metadata, path, type }
 
-    if (type === types.unary || type === types.client_stream) {
-      if (typeof callback === 'function') {
-        args[length - 1] = wrapCallback(requestResource, parentResource, callback)
-      } else {
-        args[length] = wrapCallback(requestResource, parentResource)
+  return startChannel.runStores(ctx, () => {
+    try {
+      if (type === types.unary || type === types.client_stream) {
+        if (typeof callback === 'function') {
+          args[length - 1] = wrapCallback(ctx, callback)
+        } else {
+          args[length] = wrapCallback(ctx)
+        }
       }
+
+      const call = method.apply(client, args)
+
+      if (call && typeof call.emit === 'function') {
+        shimmer.wrap(call, 'emit', createWrapEmit(ctx))
+      }
+
+      return call
+    } catch (e) {
+      ctx.error = e
+      errorChannel.publish(ctx)
     }
-
-    const call = method.apply(client, args)
-
-    wrapStream(call, requestResource, parentResource)
-
-    return call
+    // No end channel needed
   })
 }
 

--- a/packages/datadog-instrumentations/src/grpc/server.js
+++ b/packages/datadog-instrumentations/src/grpc/server.js
@@ -1,15 +1,17 @@
 'use strict'
 
 const types = require('./types')
-const { channel, addHook, AsyncResource } = require('../helpers/instrument')
+const { channel, addHook } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
 const nodeMajor = parseInt(process.versions.node.split('.')[0])
 
 const startChannel = channel('apm:grpc:server:request:start')
+const asyncStartChannel = channel('apm:grpc:server:request:asyncStart')
 const errorChannel = channel('apm:grpc:server:request:error')
 const updateChannel = channel('apm:grpc:server:request:update')
 const finishChannel = channel('apm:grpc:server:request:finish')
+const emitChannel = channel('apm:grpc:server:request:emit')
 
 // https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 const OK = 0
@@ -33,28 +35,38 @@ function wrapHandler (func, name) {
     const type = types[this.type]
     const isStream = type !== 'unary'
 
-    const parentResource = new AsyncResource('bound-anonymous-fn')
-    const requestResource = new AsyncResource('bound-anonymous-fn')
+    const ctx = { name, metadata, type }
 
-    return requestResource.runInAsyncScope(() => {
-      startChannel.publish({ name, metadata, type })
+    return startChannel.runStores(ctx, () => {
+      try {
+        const onCancel = () => {
+          ctx.code = CANCELLED
+          finishChannel.publish(ctx)
+        }
 
-      const onCancel = requestResource.bind(() => {
-        finishChannel.publish({ code: CANCELLED })
-      })
+        // Finish the span if the call was cancelled.
+        call.once('cancelled', onCancel)
 
-      // Finish the span if the call was cancelled.
-      call.once('cancelled', onCancel)
+        if (isStream) {
+          wrapStream(call, ctx, onCancel)
+        } else {
+          arguments[1] = wrapCallback(callback, call, ctx, onCancel)
+        }
 
-      if (isStream) {
-        wrapStream(call, requestResource, onCancel)
-      } else {
-        arguments[1] = wrapCallback(callback, call, requestResource, parentResource, onCancel)
+        shimmer.wrap(call, 'emit', emit => {
+          return function () {
+            return emitChannel.runStores(ctx, () => {
+              return emit.apply(this, arguments)
+            })
+          }
+        })
+
+        return func.apply(this, arguments)
+      } catch (e) {
+        ctx.error = e
+        errorChannel.publish(ctx)
       }
-
-      shimmer.wrap(call, 'emit', emit => requestResource.bind(emit))
-
-      return func.apply(this, arguments)
+      // No end channel needed
     })
   }
 }
@@ -69,69 +81,66 @@ function wrapRegister (register) {
   }
 }
 
-function wrapStream (call, requestResource, onCancel) {
-  if (call.call && call.call.sendStatus) {
-    call.call.sendStatus = wrapSendStatus(call.call.sendStatus, requestResource)
-  }
-
-  shimmer.wrap(call, 'emit', emit => {
-    return function (eventName, ...args) {
-      switch (eventName) {
+function createWrapEmit (call, ctx, onCancel) {
+  return function wrapEmit (emit) {
+    return function (event, arg1) {
+      switch (event) {
         case 'error':
-          errorChannel.publish(args[0])
-          finishChannel.publish({ code: args[0].code })
-
+          ctx.error = arg1
+          errorChannel.publish(ctx)
+          ctx.code = arg1.code
+          finishChannel.publish(ctx)
           call.removeListener('cancelled', onCancel)
-
           break
-
-          // Finish the span of the response only if it was successful.
-          // Otherwise it'll be finished in the `error` listener.
         case 'finish':
           if (call.status) {
             updateChannel.publish(call.status)
           }
-
           if (!call.status || call.status.code === 0) {
-            finishChannel.publish()
+            finishChannel.publish(ctx)
           }
-
           call.removeListener('cancelled', onCancel)
-
           break
       }
 
       return emit.apply(this, arguments)
     }
-  })
-}
-
-function wrapCallback (callback, call, requestResource, parentResource, onCancel) {
-  return function (err, value, trailer, flags) {
-    requestResource.runInAsyncScope(() => {
-      if (err) {
-        errorChannel.publish(err)
-        finishChannel.publish(err)
-      } else {
-        finishChannel.publish({ code: OK, trailer })
-      }
-
-      call.removeListener('cancelled', onCancel)
-    })
-
-    if (callback) {
-      return parentResource.runInAsyncScope(() => {
-        return callback.apply(this, arguments)
-      })
-    }
   }
 }
 
-function wrapSendStatus (sendStatus, requestResource) {
-  return function (status) {
-    requestResource.runInAsyncScope(() => {
-      updateChannel.publish(status)
+function wrapStream (call, ctx, onCancel) {
+  if (call.call && call.call.sendStatus) {
+    call.call.sendStatus = wrapSendStatus(call.call.sendStatus, ctx)
+  }
+
+  shimmer.wrap(call, 'emit', createWrapEmit(call, ctx, onCancel))
+}
+
+function wrapCallback (callback = () => {}, call, ctx, onCancel) {
+  return function (err, value, trailer, flags) {
+    if (err) {
+      ctx.error = err
+      errorChannel.publish(ctx)
+    } else {
+      ctx.code = OK
+      ctx.trailer = trailer
+    }
+
+    finishChannel.publish(ctx)
+
+    call.removeListener('cancelled', onCancel)
+
+    return asyncStartChannel.runStores(ctx, () => {
+      return callback.apply(this, arguments)
+      // No async end channel needed
     })
+  }
+}
+
+function wrapSendStatus (sendStatus, ctx) {
+  return function (status) {
+    ctx.status = status
+    updateChannel.publish(ctx)
 
     return sendStatus.apply(this, arguments)
   }

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -63,13 +63,9 @@ class GrpcClientPlugin extends ClientPlugin {
     return parentStore
   }
 
-  error ({ error }) {
-    const span = this.activeSpan
-
-    if (!span) return
-
+  error ({ span, error }) {
     this.addCode(span, error.code)
-    this.addError(error)
+    this.addError(error, span)
   }
 
   finish ({ span, result }) {

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { storage } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -7,9 +8,20 @@ const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
 class GrpcClientPlugin extends ClientPlugin {
   static get id () { return 'grpc' }
   static get operation () { return 'client:request' }
+  static get prefix () { return `apm:grpc:client:request` }
   static get peerServicePrecursors () { return ['rpc.service'] }
 
-  start ({ metadata, path, type }) {
+  constructor (...args) {
+    super(...args)
+
+    this.addTraceBind('emit', ({ parentStore }) => {
+      return parentStore
+    })
+  }
+
+  bindStart (message) {
+    const store = storage.getStore()
+    const { metadata, path, type } = message
     const metadataFilter = this.config.metadataFilter
     const method = getMethodMetadata(path, type)
     const span = this.startSpan(this.operationName(), {
@@ -28,7 +40,7 @@ class GrpcClientPlugin extends ClientPlugin {
       metrics: {
         'grpc.status.code': 0
       }
-    })
+    }, false)
 
     // needed as precursor for peer.service
     if (method.service && method.package) {
@@ -39,9 +51,19 @@ class GrpcClientPlugin extends ClientPlugin {
       addMetadataTags(span, metadata, metadataFilter, 'request')
       inject(this.tracer, span, metadata)
     }
+
+    message.span = span
+    message.parentStore = store
+    message.currentStore = { ...store, span }
+
+    return message.currentStore
   }
 
-  error (error) {
+  bindAsyncStart ({ parentStore }) {
+    return parentStore
+  }
+
+  error ({ error }) {
     const span = this.activeSpan
 
     if (!span) return
@@ -50,11 +72,10 @@ class GrpcClientPlugin extends ClientPlugin {
     this.addError(error)
   }
 
-  finish ({ code, metadata }) {
-    const span = this.activeSpan
-
+  finish ({ span, result }) {
     if (!span) return
 
+    const { code, metadata } = result || {}
     const metadataFilter = this.config.metadataFilter
 
     this.addCode(span, code)
@@ -63,7 +84,8 @@ class GrpcClientPlugin extends ClientPlugin {
       addMetadataTags(span, metadata, metadataFilter, 'response')
     }
 
-    super.finish()
+    this.tagPeerService(span)
+    span.finish()
   }
 
   configure (config) {

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { storage } = require('../../datadog-core')
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -7,6 +8,7 @@ const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
 class GrpcServerPlugin extends ServerPlugin {
   static get id () { return 'grpc' }
   static get operation () { return 'server:request' }
+  static get prefix () { return `apm:grpc:server:request` }
 
   constructor (...args) {
     super(...args)
@@ -18,9 +20,15 @@ class GrpcServerPlugin extends ServerPlugin {
 
       this.addCode(span, code)
     })
+
+    this.addTraceBind('emit', ({ currentStore }) => {
+      return currentStore
+    })
   }
 
-  start ({ name, metadata, type }) {
+  bindStart (message) {
+    const store = storage.getStore()
+    const { name, metadata, type } = message
     const metadataFilter = this.config.metadataFilter
     const childOf = extract(this.tracer, metadata)
     const method = getMethodMetadata(name, type)
@@ -44,9 +52,19 @@ class GrpcServerPlugin extends ServerPlugin {
     })
 
     addMetadataTags(span, metadata, metadataFilter, 'request')
+
+    message.span = span
+    message.parentStore = store
+    message.currentStore = { ...store, span }
+
+    return message.currentStore
   }
 
-  error (error) {
+  bindAsyncStart ({ parentStore }) {
+    return parentStore
+  }
+
+  error ({ error }) {
     const span = this.activeSpan
 
     if (!span) return
@@ -55,9 +73,7 @@ class GrpcServerPlugin extends ServerPlugin {
     this.addError(error)
   }
 
-  finish ({ code, trailer } = {}) {
-    const span = this.activeSpan
-
+  finish ({ span, code, trailer }) {
     if (!span) return
 
     const metadataFilter = this.config.metadataFilter
@@ -68,7 +84,7 @@ class GrpcServerPlugin extends ServerPlugin {
       addMetadataTags(span, trailer, metadataFilter, 'response')
     }
 
-    super.finish()
+    span.finish()
   }
 
   configure (config) {

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -83,9 +83,7 @@ class TracingPlugin extends Plugin {
     this.addBind(`${prefix}:${eventName}`, transform)
   }
 
-  addError (error) {
-    const span = this.activeSpan
-
+  addError (error, span = this.activeSpan) {
     if (!span._spanContext._tags['error']) {
       // Errors may be wrapped in a context.
       error = (error && error.error) || error


### PR DESCRIPTION
### What does this PR do?

grpc client and server instrumentation has been converted to use the tracing channel pattern rather than `AsyncResource`.

### Motivation

This is an attempt to resolve an AsyncResource leak caused by the grpc instrumentation by eliminating its use.
