### PR TITLE
dep: bump protobufjs to 7.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "node-abort-controller": "^3.0.1",
     "opentracing": ">=0.12.1",
     "path-to-regexp": "^0.1.2",
-    "protobufjs": "^7.1.2",
+    "protobufjs": "^7.2.4",
     "retry": "^0.10.1",
     "semver": "^7.3.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3666,10 +3666,10 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
-protobufjs@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.1.2.tgz#a0cf6aeaf82f5625bffcf5a38b7cd2a7de05890c"
-  integrity sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==
+protobufjs@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
+  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes https://github.com/DataDog/dd-trace-js/security/dependabot/23
Closes https://github.com/DataDog/dd-trace-js/issues/3355

### Motivation
<!-- What inspired you to submit this pull request? -->

Fixing the [same vulnerability in datadog-ci](https://github.com/DataDog/datadog-ci/security/dependabot/28).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Here is the comparison between the 2 versions:
https://github.com/protobufjs/protobuf.js/compare/protobufjs-v7.1.2...protobufjs-v7.2.4

Only fixes are included, except for 1 feature which made a minor bump: https://github.com/protobufjs/protobuf.js/pull/1840
