### PR TITLE
benchmarks: add node 12, 14, 20, upgrade node 14, 16

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -82,5 +82,11 @@ benchmark:
         GROUP: 2
       - MAJOR_VERSION: 18
         GROUP: 3
+      - MAJOR_VERSION: 20
+        GROUP: 1
+      - MAJOR_VERSION: 20
+        GROUP: 2
+      - MAJOR_VERSION: 20
+        GROUP: 3
   variables:
     SPLITS: 3

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -82,11 +82,5 @@ benchmark:
         GROUP: 2
       - MAJOR_VERSION: 18
         GROUP: 3
-      - MAJOR_VERSION: 20
-        GROUP: 1
-      - MAJOR_VERSION: 20
-        GROUP: 2
-      - MAJOR_VERSION: 20
-        GROUP: 3
   variables:
     SPLITS: 3

--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -28,6 +28,7 @@ RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1
 RUN mkdir -p /usr/local/nvm \
 	&& wget -q -O - https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
 	&& . $NVM_DIR/nvm.sh \
+	&& nvm install --no-progress 14.21.3 \
 	&& nvm install --no-progress 16.20.1 \
 	&& nvm install --no-progress 18.16.1 \
 	&& nvm install --no-progress 20.4.0 \

--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -30,6 +30,7 @@ RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1
 RUN mkdir -p /usr/local/nvm \
 	&& wget -q -O - https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
 	&& . $NVM_DIR/nvm.sh \
+	&& nvm install --no-progress 12.22.12 \
 	&& nvm install --no-progress 14.21.3 \
 	&& nvm install --no-progress 16.20.1 \
 	&& nvm install --no-progress 18.16.1 \

--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -28,7 +28,8 @@ RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1
 RUN mkdir -p /usr/local/nvm \
 	&& wget -q -O - https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
 	&& . $NVM_DIR/nvm.sh \
-	&& nvm install --no-progress 16.17.1 \
-	&& nvm install --no-progress 18.10.0 \
+	&& nvm install --no-progress 16.20.1 \
+	&& nvm install --no-progress 18.16.1 \
+	&& nvm install --no-progress 20.4.0 \
 	&& nvm alias default 18 \
 	&& nvm use 18

--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -1,3 +1,4 @@
+# The version of this file in master is used across all PRs regardless of upstream branch
 FROM --platform=linux/amd64 ubuntu:22.04
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -25,6 +26,7 @@ RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1
 	&& rm sirun.tar.gz \
 	&& mv sirun /usr/bin/sirun
 
+# This list of installed Node.js versions should include all versions used by any active release line
 RUN mkdir -p /usr/local/nvm \
 	&& wget -q -O - https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
 	&& . $NVM_DIR/nvm.sh \


### PR DESCRIPTION
### What does this PR do?
- this modifies the Docker image used by sirun benchmarks
- specifically it adds and upgrades the versions of node available in the image
- this same image is used regardless of the upstream branch
  - aka these versions of node are available to a PR made against master
  - aka these versions of node are available to PRs made against release branches
- adds node v14 back
- adds node v20
- adds node v12
- upgrades v16 and v18 versions (which will skew results going forward)
- non customer facing, not worthy of release notes

### Motivation
- v2 / v3 tracer releases are currently failing due to not having node v14 available
- v3 should be testing against v20
- v2 should be testing against v12

When CI fails to find node v14 the following is logged:

```
N/A: version "14 -> N/A" is not yet installed.
You need to run "nvm install 14" to install it before using it.
using Node.js v18.10.0
```

This suggests the `nvm use 14` fails due to `nvm install 14` not having been previously run. We run the installs inside of the Docker container to make things quicker at test time.

### Additional Notes
- this PR should land everywhere
- will need separate commits to actually set the versions tested for each release
  - this is set in `.gitlab/benchmarks.yml`
