### PR TITLE
Fix erroneous resetting of profiler state to undefined

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -127,7 +127,6 @@ class NativeWallProfiler {
       this._profilerState = this._pprof.time.getState()
       this._currentContext = {}
       this._pprof.time.setContext(this._currentContext)
-      this._profilerState = undefined
       this._lastSpan = undefined
       this._lastStartedSpans = undefined
       this._lastSampleCount = 0


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in #3371 where a property is accidentally reassigned to undefined just after being assigned a value

