### PR TITLE
[ci-visibility] Do not modify how jest reports timeouts

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -230,6 +230,28 @@ testFrameworks.forEach(({
             }).catch(done)
         })
       })
+      it('reports timeout error message', (done) => {
+        childProcess = fork('ci-visibility/run-jest.js', {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '-r dd-trace/ci/init',
+            RUN_IN_PARALLEL: true,
+            TEST_REGEX: 'timeout-test/timeout-test.js'
+          },
+          stdio: 'pipe'
+        })
+        childProcess.stdout.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.on('message', () => {
+          assert.include(testOutput, 'Exceeded timeout of 100 ms for a test while waiting for `done()` to be called.')
+          done()
+        })
+      })
     }
 
     it('can run tests and report spans', (done) => {

--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -4,7 +4,7 @@ const options = {
   projects: [__dirname],
   testPathIgnorePatterns: ['/node_modules/'],
   cache: false,
-  testRegex: /test\/ci-visibility-test/,
+  testRegex: process.env.TEST_REGEX ? new RegExp(process.env.TEST_REGEX) : /test\/ci-visibility-test/,
   coverage: true,
   runInBand: true
 }

--- a/integration-tests/ci-visibility/timeout-test/timeout-test.js
+++ b/integration-tests/ci-visibility/timeout-test/timeout-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 jest.setTimeout(100)
 describe('ci visibility', () => {
   it('will timeout', (done) => {

--- a/integration-tests/ci-visibility/timeout-test/timeout-test.js
+++ b/integration-tests/ci-visibility/timeout-test/timeout-test.js
@@ -1,0 +1,8 @@
+jest.setTimeout(100)
+describe('ci visibility', () => {
+  it('will timeout', (done) => {
+    setTimeout(() => {
+      done()
+    }, 200)
+  })
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -129,7 +129,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             suite: this.testSuite,
             runner: 'jest-circus',
             testParameters,
-            frameworkVersion: jestVersion,
+            frameworkVersion: jestVersion
           })
           originalTestFns.set(event.test, event.test.fn)
           event.test.fn = asyncResource.bind(event.test.fn)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -473,7 +473,7 @@ function jasmineAsyncInstallWraper (jasmineAsyncInstallExport, jestVersion) {
             const formattedError = formatJestError(spec.result.failedExpectations[0].error)
             testErrCh.publish(formattedError)
           }
-          testRunFinishCh.publish(specStatusToTestStatus[spec.result.status])
+          testRunFinishCh.publish({ status: specStatusToTestStatus[spec.result.status] })
           onComplete.apply(this, arguments)
         })
         arguments[0] = callback

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -130,7 +130,6 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             runner: 'jest-circus',
             testParameters,
             frameworkVersion: jestVersion,
-            testStartLine: getTestLineStart(event.test.asyncError, this.testSuite)
           })
           originalTestFns.set(event.test, event.test.fn)
           event.test.fn = asyncResource.bind(event.test.fn)
@@ -145,7 +144,10 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             const formattedError = formatJestError(event.test.errors[0])
             testErrCh.publish(formattedError)
           }
-          testRunFinishCh.publish(status)
+          testRunFinishCh.publish({
+            status,
+            testStartLine: getTestLineStart(event.test.asyncError, this.testSuite)
+          })
           // restore in case it is retried
           event.test.fn = originalTestFns.get(event.test)
         })

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -166,7 +166,7 @@ class JestPlugin extends CiPlugin {
       this.enter(span, store)
     })
 
-    this.addSub('ci:jest:test:finish', ( {status, testStartLine }) => {
+    this.addSub('ci:jest:test:finish', ({ status, testStartLine }) => {
       const span = storage.getStore().span
       span.setTag(TEST_STATUS, status)
       span.setTag(TEST_SOURCE_START, testStartLine)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -200,7 +200,7 @@ class JestPlugin extends CiPlugin {
     const extraTags = {
       [JEST_TEST_RUNNER]: runner,
       [TEST_PARAMETERS]: testParameters,
-      [TEST_FRAMEWORK_VERSION]: frameworkVersion,
+      [TEST_FRAMEWORK_VERSION]: frameworkVersion
     }
     if (testStartLine) {
       extraTags[TEST_SOURCE_START] = testStartLine

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -166,9 +166,10 @@ class JestPlugin extends CiPlugin {
       this.enter(span, store)
     })
 
-    this.addSub('ci:jest:test:finish', (status) => {
+    this.addSub('ci:jest:test:finish', ( {status, testStartLine }) => {
       const span = storage.getStore().span
       span.setTag(TEST_STATUS, status)
+      span.setTag(TEST_SOURCE_START, testStartLine)
       span.finish()
       finishAllTraceSpans(span)
     })
@@ -192,13 +193,12 @@ class JestPlugin extends CiPlugin {
   }
 
   startTestSpan (test) {
-    const { suite, name, runner, testParameters, frameworkVersion, testStartLine } = test
+    const { suite, name, runner, testParameters, frameworkVersion } = test
 
     const extraTags = {
       [JEST_TEST_RUNNER]: runner,
       [TEST_PARAMETERS]: testParameters,
-      [TEST_FRAMEWORK_VERSION]: frameworkVersion,
-      [TEST_SOURCE_START]: testStartLine
+      [TEST_FRAMEWORK_VERSION]: frameworkVersion
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -169,7 +169,9 @@ class JestPlugin extends CiPlugin {
     this.addSub('ci:jest:test:finish', ({ status, testStartLine }) => {
       const span = storage.getStore().span
       span.setTag(TEST_STATUS, status)
-      span.setTag(TEST_SOURCE_START, testStartLine)
+      if (testStartLine) {
+        span.setTag(TEST_SOURCE_START, testStartLine)
+      }
       span.finish()
       finishAllTraceSpans(span)
     })
@@ -193,12 +195,15 @@ class JestPlugin extends CiPlugin {
   }
 
   startTestSpan (test) {
-    const { suite, name, runner, testParameters, frameworkVersion } = test
+    const { suite, name, runner, testParameters, frameworkVersion, testStartLine } = test
 
     const extraTags = {
       [JEST_TEST_RUNNER]: runner,
       [TEST_PARAMETERS]: testParameters,
-      [TEST_FRAMEWORK_VERSION]: frameworkVersion
+      [TEST_FRAMEWORK_VERSION]: frameworkVersion,
+    }
+    if (testStartLine) {
+      extraTags[TEST_SOURCE_START] = testStartLine
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)


### PR DESCRIPTION
### What does this PR do?
I'm not sure why, but accessing `event.test.asyncError` before the test starts can cause error messages from timeouts not to show up correctly. By accessing `event.test.asyncError` _after_ a test finishes, things work correctly.

### Motivation
Make sure we don't modify what `jest` reports. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
