### PR TITLE
Fix clientIpEnabled  feature&& and it to startup logs

### DIFF
--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -135,7 +135,8 @@ module.exports = class PluginManager {
       site,
       url,
       dbmPropagationMode,
-      dsmEnabled
+      dsmEnabled,
+      clientIpEnabled
     } = this._tracerConfig
 
     const sharedConfig = {}
@@ -155,6 +156,10 @@ module.exports = class PluginManager {
       sharedConfig.service = serviceMapping[name]
     }
 
+    if (clientIpEnabled !== undefined) {
+      sharedConfig.clientIpEnabled= clientIpEnabled
+    } 
+    
     sharedConfig.site = site
     sharedConfig.url = url
 

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -74,6 +74,7 @@ function startupLog ({ agentError } = {}) {
   out.profiling_enabled = !!(config.profiling || {}).enabled
   Object.assign(out, getIntegrationsAndAnalytics())
 
+  out.clientIpEnabled = !!config.clientIpEnabled
   out.appsec_enabled = !!config.appsec.enabled
 
   // // This next bunch is for features supported by other tracers, but not this


### PR DESCRIPTION
### What does this PR do?
clientIpEnabled  feature for non ASM spans was not working as the configuration provided to web.js didn't contain
clientIpEnabled value.

### Motivation
customer's request

### Additional Notes
<!-- Anything else we should know when reviewing? -->
