### PR TITLE
Fix a phrase in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ $ yarn leak:plugins
 
 ### Linting
 
-We use [ESLint](https://eslint.org) to make sure that new code is
-conform to our coding standards.
+We use [ESLint](https://eslint.org) to make sure that new code
+conforms to our coding standards.
 
 To run the linter, use:
 


### PR DESCRIPTION
### What does this PR do?
Fixes a phrase in README: "conforms" instead of "is conform". Some participles of the verb "conform" could be used as adjectives here (so: "is conformant", "is conforming"), but not the verb itself; the verb itself will do nicely though although not in an adjective role.

### Motivation
Tripped me up mentally while reading the readme :-)
