### PR TITLE
Add eslint rule for object-curly-newline

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     "mocha/no-global-tests": 0,
     "mocha/no-exports": 0,
     "mocha/no-skipped-tests": 0,
-    "n/no-restricted-require": [2, ["diagnostics_channel"]]
+    "n/no-restricted-require": [2, ["diagnostics_channel"]],
+    "object-curly-newline": ["error", {"multiline": true, "consistent": true }]
   }
 }

--- a/benchmark/sirun/get-results.js
+++ b/benchmark/sirun/get-results.js
@@ -22,10 +22,12 @@ const artifactsUrl = num =>
 
 function get (url, headers) {
   return new Promise((resolve, reject) => {
-    https.get(url, { headers: Object.assign({
-      'user-agent': 'dd-results-retriever',
-      accept: 'application/json'
-    }, headers) }, async res => {
+    https.get(url, {
+      headers: Object.assign({
+        'user-agent': 'dd-results-retriever',
+        accept: 'application/json'
+      }, headers)
+    }, async res => {
       if (res.statusCode >= 300 && res.statusCode < 400) {
         resolve(get(res.headers.location))
         return

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -319,9 +319,11 @@ describe('Plugin', () => {
         before(() => {
           return agent.load('elasticsearch', {
             service: 'custom',
-            hooks: { query: (span, params) => {
-              span.addTags({ 'elasticsearch.params': 'foo', 'elasticsearch.method': params.method })
-            } }
+            hooks: {
+              query: (span, params) => {
+                span.addTags({ 'elasticsearch.params': 'foo', 'elasticsearch.method': params.method })
+              }
+            }
           })
         })
 

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -298,7 +298,8 @@ describe('Plugin', () => {
             await consumer.run({
               eachMessage: async ({ topic, partition, message, heartbeat, pause }) => {
                 expect(setDataStreamsContextSpy.args[0][0].hash).to.equal(expectedConsumerHash)
-              } })
+              }
+            })
             setDataStreamsContextSpy.restore()
           })
         })

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -316,7 +316,8 @@ describe('Plugin', () => {
                   'root': 'babbage',
                   'parent': null
                 }
-              ] }, [
+              ]
+            }, [
               'Date', 'Mon, 15 May 2023 23:26:42 GMT',
               'Content-Type', 'application/json',
               'Content-Length', '63979',
@@ -1000,51 +1001,74 @@ describe('Plugin', () => {
               'status': 'succeeded',
               'fine_tuned_model': 'curie:ft-foo:deleteme-2023-05-18-20-44-56',
               'events': [
-                { 'object': 'fine-tune-event',
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Created fine-tune: ft-10RCfqSvgyEcauomw7VpiYco',
-                  'created_at': 1684442489 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442489
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune costs $0.00',
-                  'created_at': 1684442612 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442612
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune enqueued. Queue number: 0',
-                  'created_at': 1684442612 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442612
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune started',
-                  'created_at': 1684442614 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442614
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 1/4',
-                  'created_at': 1684442677 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442677
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 2/4',
-                  'created_at': 1684442677 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442677
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 3/4',
-                  'created_at': 1684442678 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442678
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 4/4',
-                  'created_at': 1684442679 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442679
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Uploaded model: curie:ft-foo:deleteme-2023-05-18-20-44-56',
-                  'created_at': 1684442696 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442696
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Uploaded result file: file-bJyf8TM0jeSZueBo4jpodZVQ',
-                  'created_at': 1684442697 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442697
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune succeeded',
-                  'created_at': 1684442697 }
-              ] }, [
+                  'created_at': 1684442697
+                }
+              ]
+            }, [
               'Date', 'Thu, 18 May 2023 22:11:53 GMT',
               'Content-Type', 'application/json',
               'Content-Length', '2727',
@@ -1177,51 +1201,74 @@ describe('Plugin', () => {
             .reply(200, {
               'object': 'list',
               'data': [
-                { 'object': 'fine-tune-event',
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Created fine-tune: ft-10RCfqSvgyEcauomw7VpiYco',
-                  'created_at': 1684442489 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442489
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune costs $0.00',
-                  'created_at': 1684442612 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442612
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune enqueued. Queue number: 0',
-                  'created_at': 1684442612 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442612
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune started',
-                  'created_at': 1684442614 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442614
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 1/4',
-                  'created_at': 1684442677 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442677
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 2/4',
-                  'created_at': 1684442677 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442677
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 3/4',
-                  'created_at': 1684442678 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442678
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Completed epoch 4/4',
-                  'created_at': 1684442679 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442679
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Uploaded model: curie:ft-foo:deleteme-2023-05-18-20-44-56',
-                  'created_at': 1684442696 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442696
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Uploaded result file: file-bJyf8TM0jeSZueBo4jpodZVQ',
-                  'created_at': 1684442697 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684442697
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune succeeded',
-                  'created_at': 1684442697 }
-              ] }, [
+                  'created_at': 1684442697
+                }
+              ]
+            }, [
               'Date', 'Thu, 18 May 2023 22:47:17 GMT',
               'Content-Type', 'application/json',
               'Content-Length', '1718',
@@ -1341,15 +1388,20 @@ describe('Plugin', () => {
               'status': 'cancelled',
               'fine_tuned_model': 'idk',
               'events': [
-                { 'object': 'fine-tune-event',
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Created fine-tune: ft-TVpNqwlvermMegfRVqSOyPyS',
-                  'created_at': 1684452102 },
-                { 'object': 'fine-tune-event',
+                  'created_at': 1684452102
+                },
+                {
+                  'object': 'fine-tune-event',
                   'level': 'info',
                   'message': 'Fine-tune cancelled',
-                  'created_at': 1684452103 }
-              ] }, [
+                  'created_at': 1684452103
+                }
+              ]
+            }, [
               'Date', 'Thu, 18 May 2023 23:21:43 GMT',
               'Content-Type', 'application/json',
               'Content-Length', '1042',
@@ -1985,7 +2037,8 @@ describe('Plugin', () => {
                   'avg_logprob': -0.7777707236153739,
                   'compression_ratio': 0.6363636363636364,
                   'no_speech_prob': 0.043891049921512604,
-                  'transient': false }],
+                  'transient': false
+                }],
                 'text': 'Hello, friend.'
               }, [
                 'Date', 'Fri, 19 May 2023 03:19:49 GMT',

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -225,9 +225,11 @@ describe('Plugin', () => {
         before(() => {
           return agent.load('opensearch', {
             service: 'custom',
-            hooks: { query: (span, params) => {
-              span.addTags({ 'opensearch.params': 'foo', 'opensearch.method': params.method })
-            } }
+            hooks: {
+              query: (span, params) => {
+                span.addTags({ 'opensearch.params': 'foo', 'opensearch.method': params.method })
+              }
+            }
           })
         })
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/index.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const { enableRewriter, disableRewriter } = require('./rewriter')
-const { createTransaction,
+const {
+  createTransaction,
   removeTransaction,
   setMaxTransactions,
   enableTaintOperations,
-  disableTaintOperations } = require('./operations')
+  disableTaintOperations
+} = require('./operations')
 
 const taintTrackingPlugin = require('./plugin')
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -103,7 +103,8 @@ describe('path-traversal-analyzer', () => {
 
   it('Should report 1st argument', () => {
     const proxyPathAnalyzer = proxyquire('../../../../src/appsec/iast/analyzers/path-traversal-analyzer',
-      { './injection-analyzer': InjectionAnalyzer,
+      {
+        './injection-analyzer': InjectionAnalyzer,
         '../iast-context': { getIastContext: () => iastContext }
       })
 

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -48,11 +48,13 @@ describe('profilers/native/wall', () => {
 
     sinon.assert.calledOnce(pprof.time.start)
     sinon.assert.calledWith(pprof.time.start,
-      { intervalMicros: 1e6 / 99,
+      {
+        intervalMicros: 1e6 / 99,
         durationMillis: 60000,
         sourceMapper: undefined,
         withContexts: false,
-        lineNumbers: false })
+        lineNumbers: false
+      })
   })
 
   it('should use the provided configuration options', () => {
@@ -63,11 +65,13 @@ describe('profilers/native/wall', () => {
     profiler.stop()
 
     sinon.assert.calledWith(pprof.time.start,
-      { intervalMicros: 500,
+      {
+        intervalMicros: 500,
         durationMillis: 60000,
         sourceMapper: undefined,
         withContexts: false,
-        lineNumbers: false })
+        lineNumbers: false
+      })
   })
 
   it('should not stop when not started', () => {
@@ -134,10 +138,12 @@ describe('profilers/native/wall', () => {
     profiler.stop()
 
     sinon.assert.calledWith(pprof.time.start,
-      { intervalMicros: 1e6 / 99,
+      {
+        intervalMicros: 1e6 / 99,
         durationMillis: 60000,
         sourceMapper: mapper,
         withContexts: false,
-        lineNumbers: false })
+        lineNumbers: false
+      })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Add a new [eslint rule](https://eslint.org/docs/latest/rules/object-curly-newline) requiring that:
* curly braces around objects are consistent: either both curly braces, or neither, directly enclose newlines.
* if there are line breaks inside properties or between properties, then there should be line breaks line breaks after opening and before closing braces.

### Motivation
https://github.com/DataDog/dd-trace-js/pull/3371#discussion_r1256480648
