### PR TITLE
Ignore esbuild output from integration tests in esbuild

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ node_modules
 versions
 acmeair-nodejs
 vendor
+integration-tests/esbuild/out.js


### PR DESCRIPTION
### What does this PR do?

Makes eslint ignore the esbuild output generated at `integration-tests/esbuild/out.js`.

### Motivation

The integration test for esbuild doesn't clean up the build output after running, so if you run integration-tests and then run `yarn lint` it will fail with hundreds of thousands of errors. 😅 
