### PR TITLE
Ensure OTel span name is copied to resource.name

### DIFF
--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -10,6 +10,7 @@ const { timeInputToHrTime } = require('@opentelemetry/core')
 const tracer = require('../../')
 const DatadogSpan = require('../opentracing/span')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../constants')
+const { SERVICE_NAME, RESOURCE_NAME } = require('../../../../ext/tags')
 
 const SpanContext = require('./span_context')
 
@@ -40,7 +41,8 @@ class Span {
       hostname: _tracer._hostname,
       integrationName: 'otel',
       tags: {
-        'service.name': _tracer._service
+        [SERVICE_NAME]: _tracer._service,
+        [RESOURCE_NAME]: spanName
       }
     }, _tracer._debug)
 

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -11,6 +11,7 @@ const SpanContext = require('../../src/opentelemetry/span_context')
 const { NoopSpanProcessor } = require('../../src/opentelemetry/span_processor')
 
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../src/constants')
+const { SERVICE_NAME, RESOURCE_NAME } = require('../../../../ext/tags')
 
 function makeSpan (...args) {
   const tracerProvider = new TracerProvider()
@@ -24,15 +25,13 @@ describe('OTel Span', () => {
     const span = makeSpan('name')
 
     const context = span._ddSpan.context()
-    expect(context._tags['service.name']).to.equal(tracer._tracer._service)
+    expect(context._tags[SERVICE_NAME]).to.equal(tracer._tracer._service)
     expect(context._hostname).to.equal(tracer._hostname)
   })
 
   it('should expose parent span id', () => {
     tracer.trace('outer', (outer) => {
-      global.hax = true
       const span = makeSpan('name', {})
-      global.hax = false
 
       expect(span.parentSpanId).to.equal(outer.context()._spanId.toString(16))
     })
@@ -42,6 +41,13 @@ describe('OTel Span', () => {
     const span = makeSpan('name')
 
     expect(span.name).to.equal('name')
+  })
+
+  it('should copy span name to resource.name', () => {
+    const span = makeSpan('name')
+
+    const context = span._ddSpan.context()
+    expect(context._tags[RESOURCE_NAME]).to.equal('name')
   })
 
   it('should expose span context', () => {


### PR DESCRIPTION
### What does this PR do?

Copies the OTel span name input to the `resource.name` tag.

### Motivation

We plan to change the operation name of the span to better align with how OTel intends it to work. For now, we want to make sure we're capturing the existing value in the `resource.name` tag instead so we aren't losing data when the change to operation name happens.
