### PR TITLE
Fix distributed tracing issue caused by single span ingestion changes

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -107,7 +107,7 @@ function extractTags (trace, span) {
     }
   }
 
-  setSingleSpanIngestionTags(trace, context._sampling.spanSampling)
+  setSingleSpanIngestionTags(trace, context._spanSampling)
 
   addTag(trace.meta, trace.metrics, 'language', 'javascript')
   addTag(trace.meta, trace.metrics, PROCESS_ID, process.pid)

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -12,7 +12,8 @@ class DatadogSpanContext {
     this._name = props.name
     this._isFinished = props.isFinished || false
     this._tags = props.tags || {}
-    this._sampling = Object.assign({}, props.sampling)
+    this._sampling = props.sampling || {}
+    this._spanSampling = undefined
     this._baggageItems = props.baggageItems || {}
     this._traceparent = props.traceparent
     this._tracestate = props.tracestate

--- a/packages/dd-trace/src/span_sampler.js
+++ b/packages/dd-trace/src/span_sampler.js
@@ -82,7 +82,7 @@ class SpanSampler {
 
       const rule = this.findRule(service, name)
       if (rule && rule.sample()) {
-        span.context()._sampling.spanSampling = {
+        span.context()._spanSampling = {
           sampleRate: rule.sampleRate,
           maxPerSecond: rule.maxPerSecond
         }

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -129,7 +129,7 @@ describe('format', () => {
     })
 
     it('should always add single span ingestion tags from options if present', () => {
-      spanContext._sampling.spanSampling = {
+      spanContext._spanSampling = {
         maxPerSecond: 5,
         sampleRate: 1.0
       }

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -45,6 +45,7 @@ describe('SpanContext', () => {
       _isFinished: true,
       _tags: {},
       _sampling: { priority: 2 },
+      _spanSampling: undefined,
       _baggageItems: { foo: 'bar' },
       _noop: noop,
       _trace: {
@@ -71,6 +72,7 @@ describe('SpanContext', () => {
       _isFinished: false,
       _tags: {},
       _sampling: {},
+      _spanSampling: undefined,
       _baggageItems: {},
       _noop: null,
       _trace: {
@@ -83,16 +85,16 @@ describe('SpanContext', () => {
     })
   })
 
-  it('should clone sampling object', () => {
+  it('should share sampling object between contexts', () => {
     const first = new SpanContext({
       sampling: { priority: 1 }
     })
     const second = new SpanContext({
-      sampling: first.sampling
+      sampling: first._sampling
     })
     second._sampling.priority = 2
 
-    expect(first._sampling).to.have.property('priority', 1)
+    expect(first._sampling).to.have.property('priority', 2)
   })
 
   describe('toTraceId()', () => {

--- a/packages/dd-trace/test/span_sampler.spec.js
+++ b/packages/dd-trace/test/span_sampler.spec.js
@@ -117,18 +117,18 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling.spanSampling).to.eql({
+      expect(spans[0].context()._spanSampling).to.eql({
         sampleRate: 1.0,
         maxPerSecond: 5
       })
-      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[1].context()._spanSampling).to.be.undefined
+      expect(spans[2].context()._spanSampling).to.be.undefined
+      expect(spans[3].context()._spanSampling).to.be.undefined
+      expect(spans[4].context()._spanSampling).to.be.undefined
+      expect(spans[5].context()._spanSampling).to.be.undefined
+      expect(spans[6].context()._spanSampling).to.be.undefined
+      expect(spans[7].context()._spanSampling).to.be.undefined
+      expect(spans[8].context()._spanSampling).to.be.undefined
     })
 
     it('should consider missing service as match-all for service name', () => {
@@ -147,16 +147,16 @@ describe('span sampler', () => {
         maxPerSecond: 5
       }
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[0].context()._spanSampling).to.be.undefined
+      expect(spans[1].context()._spanSampling).to.be.undefined
+      expect(spans[2].context()._spanSampling).to.be.undefined
       // Only 3 and 4 should match because of the name pattern
-      expect(spans[3].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[3].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[4].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[5].context()._spanSampling).to.be.undefined
+      expect(spans[6].context()._spanSampling).to.be.undefined
+      expect(spans[7].context()._spanSampling).to.be.undefined
+      expect(spans[8].context()._spanSampling).to.be.undefined
     })
 
     it('should consider missing name as match-all for span name', () => {
@@ -175,16 +175,16 @@ describe('span sampler', () => {
         maxPerSecond: 10
       }
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[1].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[2].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[3].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[5].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[8].context()._sampling.spanSampling).to.eql(spanSampling)
+      expect(spans[0].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[1].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[2].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[3].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[4].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[5].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[8].context()._spanSampling).to.eql(spanSampling)
       // Should not match because of different service name
-      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[6].context()._spanSampling).to.be.undefined
+      expect(spans[7].context()._spanSampling).to.be.undefined
     })
 
     it('should stop at first rule match', () => {
@@ -206,18 +206,18 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling.spanSampling).to.eql({
+      expect(spans[0].context()._spanSampling).to.eql({
         sampleRate: 1.0,
         maxPerSecond: 5
       })
-      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[1].context()._spanSampling).to.be.undefined
+      expect(spans[2].context()._spanSampling).to.be.undefined
+      expect(spans[3].context()._spanSampling).to.be.undefined
+      expect(spans[4].context()._spanSampling).to.be.undefined
+      expect(spans[5].context()._spanSampling).to.be.undefined
+      expect(spans[6].context()._spanSampling).to.be.undefined
+      expect(spans[7].context()._spanSampling).to.be.undefined
+      expect(spans[8].context()._spanSampling).to.be.undefined
     })
 
     it('should use span service name tags where present', () => {
@@ -236,15 +236,15 @@ describe('span sampler', () => {
         maxPerSecond: 5
       }
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[6].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[7].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[0].context()._spanSampling).to.be.undefined
+      expect(spans[1].context()._spanSampling).to.be.undefined
+      expect(spans[2].context()._spanSampling).to.be.undefined
+      expect(spans[3].context()._spanSampling).to.be.undefined
+      expect(spans[4].context()._spanSampling).to.be.undefined
+      expect(spans[5].context()._spanSampling).to.be.undefined
+      expect(spans[6].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[7].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[8].context()._spanSampling).to.be.undefined
     })
 
     it('should properly sample multiple single spans with one rule', () => {
@@ -264,14 +264,14 @@ describe('span sampler', () => {
         maxPerSecond: 5
       }
       sampler.sample(spanContexts[0])
-      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[4].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[5].context()._sampling.spanSampling).to.eql(spanSampling)
-      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[8].context()._sampling.spanSampling).to.be.undefined
+      expect(spans[1].context()._spanSampling).to.be.undefined
+      expect(spans[2].context()._spanSampling).to.be.undefined
+      expect(spans[3].context()._spanSampling).to.be.undefined
+      expect(spans[4].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[5].context()._spanSampling).to.eql(spanSampling)
+      expect(spans[6].context()._spanSampling).to.be.undefined
+      expect(spans[7].context()._spanSampling).to.be.undefined
+      expect(spans[8].context()._spanSampling).to.be.undefined
     })
 
     it('should properly sample mutiple single spans with multiple rules', () => {
@@ -293,19 +293,19 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling.spanSampling, {
+      expect(spans[0].context()._spanSampling, {
         sampleRate: 1.0,
         maxPerSecond: 5
       })
-      expect(spans[3].context()._sampling.spanSampling, {
+      expect(spans[3].context()._spanSampling, {
         sampleRate: 1.0,
         maxPerSecond: 10
       })
-      expect(spans[4].context()._sampling.spanSampling, {
+      expect(spans[4].context()._spanSampling, {
         sampleRate: 1.0,
         maxPerSecond: 10
       })
-      expect(spans[5].context()._sampling.spanSampling, {
+      expect(spans[5].context()._spanSampling, {
         sampleRate: 1.0,
         maxPerSecond: 10
       })
@@ -324,15 +324,15 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[1].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[2].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[3].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[4].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[5].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[6].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[7].context()._sampling.spanSampling).to.be.undefined
-      expect(spans[8].context()._sampling.spanSampling).to.eql({
+      expect(spans[0].context()._spanSampling).to.be.undefined
+      expect(spans[1].context()._spanSampling).to.be.undefined
+      expect(spans[2].context()._spanSampling).to.be.undefined
+      expect(spans[3].context()._spanSampling).to.be.undefined
+      expect(spans[4].context()._spanSampling).to.be.undefined
+      expect(spans[5].context()._spanSampling).to.be.undefined
+      expect(spans[6].context()._spanSampling).to.be.undefined
+      expect(spans[7].context()._spanSampling).to.be.undefined
+      expect(spans[8].context()._spanSampling).to.eql({
         sampleRate: 1.0,
         maxPerSecond: 1
       })
@@ -362,7 +362,7 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling).to.haveOwnProperty('spanSampling')
+      expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
     })
 
     it('should not sample a matched span on non-allowed sample rate', () => {
@@ -380,7 +380,7 @@ describe('span sampler', () => {
 
       sampler.sample(spanContexts[0])
       for (const span of spans) {
-        expect(span.context()._sampling).to.not.haveOwnProperty('spanSampling')
+        expect(span.context()).to.not.haveOwnProperty('_spanSampling')
       }
     })
 
@@ -404,8 +404,8 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[2].context()._sampling).to.haveOwnProperty('spanSampling')
-      expect(spans[0].context()._sampling).to.not.haveOwnProperty('spanSampling')
+      expect(spans[2].context()).to.haveOwnProperty('_spanSampling')
+      expect(spans[0].context()).to.not.haveOwnProperty('_spanSampling')
     })
   })
 
@@ -456,13 +456,13 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling).to.haveOwnProperty('spanSampling')
-      delete spans[0].context()._sampling.spanSampling
+      expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
+      delete spans[0].context()._spanSampling
 
       // with how quickly these tests execute, the limiter should not allow the
       // next call to sample any spans
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling).to.not.haveOwnProperty('spanSampling')
+      expect(spans[0].context()).to.not.haveOwnProperty('_spanSampling')
     })
 
     it('should map different rules to different rate limiters', () => {
@@ -484,16 +484,16 @@ describe('span sampler', () => {
       })
 
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling).to.haveOwnProperty('spanSampling')
-      expect(spans[1].context()._sampling).to.haveOwnProperty('spanSampling')
-      delete spans[0].context()._sampling.spanSampling
-      delete spans[1].context()._sampling.spanSampling
+      expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
+      expect(spans[1].context()).to.haveOwnProperty('_spanSampling')
+      delete spans[0].context()._spanSampling
+      delete spans[1].context()._spanSampling
 
       // with how quickly these tests execute, the limiter should not allow the
       // next call to sample any spans
       sampler.sample(spanContexts[0])
-      expect(spans[0].context()._sampling).to.not.haveOwnProperty('spanSampling')
-      expect(spans[1].context()._sampling).to.haveOwnProperty('spanSampling')
+      expect(spans[0].context()).to.not.haveOwnProperty('_spanSampling')
+      expect(spans[1].context()).to.haveOwnProperty('_spanSampling')
     })
 
     it('should map limit by all spans matching pattern', () => {
@@ -510,15 +510,15 @@ describe('span sampler', () => {
 
       // First time around both should have spanSampling to prove match
       sampler.sample(spanContexts[0])
-      expect(spans[3].context()._sampling).to.haveOwnProperty('spanSampling')
-      expect(spans[4].context()._sampling).to.haveOwnProperty('spanSampling')
-      delete spans[3].context()._sampling.spanSampling
-      delete spans[4].context()._sampling.spanSampling
+      expect(spans[3].context()).to.haveOwnProperty('_spanSampling')
+      expect(spans[4].context()).to.haveOwnProperty('_spanSampling')
+      delete spans[3].context()._spanSampling
+      delete spans[4].context()._spanSampling
 
       // Second time around only first should have spanSampling to prove limits
       sampler.sample(spanContexts[0])
-      expect(spans[3].context()._sampling).to.haveOwnProperty('spanSampling')
-      expect(spans[4].context()._sampling).to.not.haveOwnProperty('spanSampling')
+      expect(spans[3].context()).to.haveOwnProperty('_spanSampling')
+      expect(spans[4].context()).to.not.haveOwnProperty('_spanSampling')
     })
 
     it('should allow unlimited rate limits', async () => {
@@ -534,8 +534,8 @@ describe('span sampler', () => {
 
       const interval = setInterval(() => {
         sampler.sample(spanContexts[0])
-        expect(spans[0].context()._sampling).to.haveOwnProperty('spanSampling')
-        delete spans[0].context()._sampling.spanSampling
+        expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
+        delete spans[0].context()._spanSampling
       }, 1)
 
       await new Promise(resolve => {
@@ -559,13 +559,13 @@ describe('span sampler', () => {
 
       await new Promise(resolve => {
         sampler.sample(spanContexts[0])
-        const before = spans[0].context()._sampling.spanSampling
-        delete spans[0].context()._sampling.spanSampling
+        const before = spans[0].context()._spanSampling
+        delete spans[0].context()._spanSampling
 
         setTimeout(() => {
           sampler.sample(spanContexts[0])
-          const after = spans[0].context()._sampling.spanSampling
-          delete spans[0].context()._sampling.spanSampling
+          const after = spans[0].context()._spanSampling
+          delete spans[0].context()._spanSampling
 
           expect(before).to.eql(after)
           resolve()


### PR DESCRIPTION
### What does this PR do?

Restores the shared sampling object design of span contexts.

### Motivation

Fixes #3244. The single span ingestion changes accidentally made the sampling object in span contexts copy on creation rather than sharing state. This resulted in sampling decisions applied on inner spans not becoming visible at the root span level.