### PR TITLE
Fix stringifying mongodb queries that are self referencing but provide toJSON methods

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -57,7 +57,7 @@ function truncate (input) {
 }
 
 function shouldSimplify (input) {
-  return !isObject(input)
+  return !isObject(input) || typeof input.toJSON === 'function'
 }
 
 function shouldHide (input) {

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -233,6 +233,26 @@ describe('Plugin', () => {
             }).toArray()
           })
 
+          it('should use the toJSON method of objects if it exists', done => {
+            const id = '123456781234567812345678'
+
+            agent
+              .use(traces => {
+                const span = traces[0][0]
+                const resource = `find test.${collectionName}`
+                const query = `{"_id":"${id}"}`
+
+                expect(span).to.have.property('resource', resource)
+                expect(span.meta).to.have.property('mongodb.query', query)
+              })
+              .then(done)
+              .catch(done)
+
+            collection.find({
+              _id: { toJSON: () => id }
+            }).toArray()
+          })
+
           it('should run the callback in the parent context', done => {
             const insertPromise = collection.insertOne({ a: 1 }, {}, () => {
               expect(tracer.scope().active()).to.be.null


### PR DESCRIPTION
### What does this PR do?
With this PR, when stringifying mongodb queries, `toJSON` methods of the objects are used, instead of manually iterating over all properties of the object.

### Motivation
There are certain situations where mongoose creates (filter) queries that have circular references in properties in their prototype (see https://github.com/DataDog/dd-trace-js/issues/3247, https://github.com/Automattic/mongoose/issues/13512). With the current implementation, this causes an error when trying to stringify the query. The idea of this PR is to use the `toJSON` methods of the objects provided by mongoose instead, because they are much better suited to convert the objects into a displayable format than manually iterating over all properties of the object (including the properties from the prototype). And since there are no circular references in the objects returned by `toJSON`, it also neatly solves https://github.com/DataDog/dd-trace-js/issues/3247.
