### PR TITLE
openai: make services entirely optional when initializing

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -778,6 +778,23 @@ jobs:
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v2
 
+  openai:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: openai
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
+      - run: yarn install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:plugins:ci
+      - if: always()
+        uses: ./.github/actions/testagent/logs
+      - uses: codecov/codecov-action@v2
+
   opensearch:
     runs-on: ubuntu-latest
     services:

--- a/packages/datadog-plugin-openai/src/index.js
+++ b/packages/datadog-plugin-openai/src/index.js
@@ -26,7 +26,9 @@ class OpenApiPlugin extends TracingPlugin {
     this.sampler = new Sampler(0.1) // default 10% log sampling
 
     // hoist the max length env var to avoid making all of these functions a class method
-    MAX_TEXT_LEN = this._tracerConfig.openaiSpanCharLimit
+    if (this._tracerConfig) {
+      MAX_TEXT_LEN = this._tracerConfig.openaiSpanCharLimit
+    }
   }
 
   configure (config) {
@@ -547,7 +549,7 @@ function usageExtraction (tags, body) {
 }
 
 function truncateApiKey (apiKey) {
-  return `sk-...${apiKey.substr(apiKey.length - 4)}`
+  return apiKey && `sk-...${apiKey.substr(apiKey.length - 4)}`
 }
 
 /**

--- a/packages/datadog-plugin-openai/test/no-init.js
+++ b/packages/datadog-plugin-openai/test/no-init.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+/**
+ * Due to the complexity of the service initialization required by openai
+ * there was a bug where when requiring dd-trace followed by openai
+ * would result in an error if dd-trace wasn't first initialized.
+ *
+ * @see https://github.com/DataDog/dd-trace-js/issues/3357
+ */
+require(process.env.PATH_TO_DDTRACE)
+require(process.env.PATH_TO_OPENAI).get()

--- a/packages/datadog-plugin-openai/test/services.spec.js
+++ b/packages/datadog-plugin-openai/test/services.spec.js
@@ -9,7 +9,7 @@ describe('Plugin', () => {
         services.shutdown()
       })
 
-      it('dogstatsd does not throw', () => {
+      it('dogstatsd does not throw when missing .dogstatsd', () => {
         const service = services.init({
           hostname: 'foo',
           service: 'bar',
@@ -28,6 +28,13 @@ describe('Plugin', () => {
           interval: 1000
         })
 
+        service.logger.log('hello')
+      })
+
+      it('logger does not throw when passing in null', () => {
+        const service = services.init(null)
+
+        service.metrics.increment('mykey')
         service.logger.log('hello')
       })
     })

--- a/packages/dd-trace/src/external-logger/src/index.js
+++ b/packages/dd-trace/src/external-logger/src/index.js
@@ -127,4 +127,12 @@ class ExternalLogger {
   }
 }
 
-module.exports = ExternalLogger
+class NoopExternalLogger {
+  log () { }
+  enqueue () { }
+  shutdown () { }
+  flush () { }
+}
+
+module.exports.ExternalLogger = ExternalLogger
+module.exports.NoopExternalLogger = NoopExternalLogger

--- a/packages/dd-trace/src/external-logger/test/index.spec.js
+++ b/packages/dd-trace/src/external-logger/test/index.spec.js
@@ -15,7 +15,7 @@ describe('External Logger', () => {
   beforeEach(() => {
     errorLog = sinon.spy(tracerLogger, 'error')
 
-    const ExternalLogger = proxyquire('../src', {
+    const { ExternalLogger } = proxyquire('../src', {
       '../../log': {
         error: errorLog
       }


### PR DESCRIPTION
### What does this PR do?
- makes service configuration entirely optional when initializing openai
- both logger and metrics now have a noop version with method stubs
- adds a test that loads dd-trace, doesn't inintialize, then loads openai
- also enables running the tests in CI... whoops...

At a high level an application would require dd-trace but not initialize it, and then would require openai. When this happens all of the tracer configuration is missing and an error would be thrown when accessing a deeply-nested config value. So now there are a few checks to see if things are initialized. If so, continue as usual. If not, load noop classes since tracing won't work right without initialization anyway.

### Motivation
- fixes #3357, was able to exactly reproduce