### PR TITLE
Exclude empty telemetry metrics

### DIFF
--- a/packages/dd-trace/src/telemetry/metrics.js
+++ b/packages/dd-trace/src/telemetry/metrics.js
@@ -25,6 +25,10 @@ function mapToJsonArray (map) {
   return Array.from(map.values()).map(v => v.toJSON())
 }
 
+function hasPoints (metric) {
+  return metric.points.length > 0
+}
+
 class Metric {
   constructor (namespace, metric, common, tags) {
     this.namespace = namespace.toString()
@@ -172,10 +176,16 @@ class MetricsCollection extends Map {
 
   toJSON () {
     if (!this.size) return
+
+    const series = mapToJsonArray(this)
+      .filter(hasPoints)
+
+    if (!series.length) return
+
     const { namespace } = this
     return {
       namespace,
-      series: mapToJsonArray(this)
+      series
     }
   }
 }

--- a/packages/dd-trace/test/telemetry/metrics.spec.js
+++ b/packages/dd-trace/test/telemetry/metrics.spec.js
@@ -157,6 +157,33 @@ describe('metrics', () => {
           ]
         })
     })
+
+    it('should not send empty metrics', () => {
+      const manager = new metrics.NamespaceManager()
+
+      const ns = manager.namespace('test')
+
+      const metric = ns.count('metric', { bar: 'baz' })
+      metric.inc()
+      metric.reset()
+
+      const config = {
+        hostname: 'localhost',
+        port: 12345,
+        tags: {
+          'runtime-id': 'abc123'
+        }
+      }
+      const application = {
+        language_name: 'nodejs',
+        tracer_version: '1.2.3'
+      }
+      const host = {}
+
+      manager.send(config, application, host)
+
+      expect(sendData).to.not.have.been.called
+    })
   })
 
   describe('Namespace', () => {
@@ -247,6 +274,18 @@ describe('metrics', () => {
             }
           ]
         }
+      })
+    })
+
+    it('should skip empty metrics', () => {
+      const ns = new metrics.Namespace('test')
+      const metric = ns.count('foo', { bar: 'baz' })
+      metric.inc()
+      metric.reset()
+
+      expect(ns.toJSON()).to.deep.equal({
+        distributions: undefined,
+        metrics: undefined
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?

Excludes empty telemetry metrics from being sent.

### Motivation

If a metric has not been updated since the last reporting interval it will contain an empty points list. The backend processor considers this an error so the metric should instead be omitted entirely.