### PR TITLE
Length based evidence redaction

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
@@ -140,7 +140,7 @@ class SensitiveHandler {
         const _length = nextSensitive.end - nextSensitive.start
         this.writeRedactedValuePart(valueParts, _length)
 
-        start = i + (nextSensitive.end - nextSensitive.start)
+        start = i + _length
         i = start - 1
         nextSensitive = sensitive.shift()
       }
@@ -200,15 +200,18 @@ class SensitiveHandler {
       } else {
         let _value = partValue
         const dedupedSourceRedactionContexts = []
+
         sourceRedactionContext.forEach(_sourceRedactionContext => {
           const isPresentInDeduped = dedupedSourceRedactionContexts.some(_dedupedSourceRedactionContext =>
             _dedupedSourceRedactionContext.start === _sourceRedactionContext.start &&
             _dedupedSourceRedactionContext.end === _sourceRedactionContext.end
           )
+
           if (!isPresentInDeduped) {
             dedupedSourceRedactionContexts.push(_sourceRedactionContext)
           }
         })
+
         let offset = 0
         dedupedSourceRedactionContexts.forEach((_sourceRedactionContext) => {
           if (_sourceRedactionContext.start > 0) {
@@ -216,9 +219,11 @@ class SensitiveHandler {
               source: sourceIndex,
               value: _value.substring(0, _sourceRedactionContext.start - offset)
             })
+
             _value = _value.substring(_sourceRedactionContext.start - offset)
             offset = _sourceRedactionContext.start
           }
+
           const sensitive =
             _value.substring(_sourceRedactionContext.start - offset, _sourceRedactionContext.end - offset)
           const indexOfPartValueInPattern = source.value.indexOf(sensitive)
@@ -232,6 +237,7 @@ class SensitiveHandler {
             source: sourceIndex,
             pattern
           })
+
           _value = _value.substring(pattern.length)
           offset += pattern.length
         })

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
@@ -14,6 +14,8 @@ const DEFAULT_IAST_REDACTION_NAME_PATTERN = '(?:p(?:ass)?w(?:or)?d|pass(?:_?phra
 // eslint-disable-next-line max-len
 const DEFAULT_IAST_REDACTION_VALUE_PATTERN = '(?:bearer\\s+[a-z0-9\\._\\-]+|glpat-[\\w\\-]{20}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\\w=\\-]+\\.ey[I-L][\\w=\\-]+(?:\\.[\\w.+/=\\-]+)?|(?:[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}[^\\-]+[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY[\\-]{5}|ssh-rsa\\s*[a-z0-9/\\.+]{100,}))'
 
+const REDACTED_SOURCE_BUFFER = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+
 class SensitiveHandler {
   constructor () {
     this._namePattern = new RegExp(DEFAULT_IAST_REDACTION_NAME_PATTERN, 'gmi')
@@ -54,6 +56,7 @@ class SensitiveHandler {
   toRedactedJson (evidence, sensitive, sourcesIndexes, sources) {
     const valueParts = []
     const redactedSources = []
+    const redactedSourcesContext = []
 
     const { value, ranges } = evidence
 
@@ -71,21 +74,41 @@ class SensitiveHandler {
         sourceIndex = sourcesIndexes[nextTaintedIndex]
 
         while (nextSensitive != null && contains(nextTainted, nextSensitive)) {
-          sourceIndex != null && redactedSources.push(sourceIndex)
+          const redactionStart = nextSensitive.start - nextTainted.start
+          const redactionEnd = nextSensitive.end - nextTainted.start
+          this.redactSource(sources, redactedSources, redactedSourcesContext, sourceIndex, redactionStart, redactionEnd)
           nextSensitive = sensitive.shift()
         }
 
         if (nextSensitive != null && intersects(nextSensitive, nextTainted)) {
-          sourceIndex != null && redactedSources.push(sourceIndex)
+          const redactionStart = nextSensitive.start - nextTainted.start
+          const redactionEnd = nextSensitive.end - nextTainted.start
+          this.redactSource(sources, redactedSources, redactedSourcesContext, sourceIndex, redactionStart, redactionEnd)
 
           const entries = remove(nextSensitive, nextTainted)
           nextSensitive = entries.length > 0 ? entries[0] : null
         }
 
-        this.isSensibleSource(sources[sourceIndex]) && redactedSources.push(sourceIndex)
+        if (this.isSensibleSource(sources[sourceIndex])) {
+          if (!sources[sourceIndex].redacted) {
+            redactedSources.push(sourceIndex)
+            sources[sourceIndex].pattern = ''.padEnd(sources[sourceIndex].value.length, REDACTED_SOURCE_BUFFER)
+            sources[sourceIndex].redacted = true
+          }
+        }
 
         if (redactedSources.indexOf(sourceIndex) > -1) {
-          this.writeRedactedValuePart(valueParts, sourceIndex)
+          const partValue = value.substring(i, i + (nextTainted.end - nextTainted.start))
+          this.writeRedactedValuePart(
+            valueParts,
+            partValue.length,
+            sourceIndex,
+            partValue,
+            sources[sourceIndex],
+            redactedSourcesContext[sourceIndex],
+            this.isSensibleSource(sources[sourceIndex])
+          )
+          redactedSourcesContext[sourceIndex] = []
         } else {
           const substringEnd = Math.min(nextTainted.end, value.length)
           this.writeValuePart(valueParts, value.substring(nextTainted.start, substringEnd), sourceIndex)
@@ -100,7 +123,10 @@ class SensitiveHandler {
         this.writeValuePart(valueParts, value.substring(start, i), sourceIndex)
         if (nextTainted != null && intersects(nextSensitive, nextTainted)) {
           sourceIndex = sourcesIndexes[nextTaintedIndex]
-          sourceIndex != null && redactedSources.push(sourceIndex)
+
+          const redactionStart = nextSensitive.start - nextTainted.start
+          const redactionEnd = nextSensitive.end - nextTainted.start
+          this.redactSource(sources, redactedSources, redactedSourcesContext, sourceIndex, redactionStart, redactionEnd)
 
           for (const entry of remove(nextSensitive, nextTainted)) {
             if (entry.start === i) {
@@ -111,7 +137,8 @@ class SensitiveHandler {
           }
         }
 
-        this.writeRedactedValuePart(valueParts)
+        const _length = nextSensitive.end - nextSensitive.start
+        this.writeRedactedValuePart(valueParts, _length)
 
         start = i + (nextSensitive.end - nextSensitive.start)
         i = start - 1
@@ -126,6 +153,24 @@ class SensitiveHandler {
     return { redactedValueParts: valueParts, redactedSources }
   }
 
+  redactSource (sources, redactedSources, redactedSourcesContext, sourceIndex, start, end) {
+    if (sourceIndex != null) {
+      if (!sources[sourceIndex].redacted) {
+        redactedSources.push(sourceIndex)
+        sources[sourceIndex].pattern = ''.padEnd(sources[sourceIndex].value.length, REDACTED_SOURCE_BUFFER)
+        sources[sourceIndex].redacted = true
+      }
+
+      if (!redactedSourcesContext[sourceIndex]) {
+        redactedSourcesContext[sourceIndex] = []
+      }
+      redactedSourcesContext[sourceIndex].push({
+        start,
+        end
+      })
+    }
+  }
+
   writeValuePart (valueParts, value, source) {
     if (value.length > 0) {
       if (source != null) {
@@ -136,9 +181,68 @@ class SensitiveHandler {
     }
   }
 
-  writeRedactedValuePart (valueParts, source) {
-    if (source != null) {
-      valueParts.push({ redacted: true, source })
+  writeRedactedValuePart (
+    valueParts,
+    length,
+    sourceIndex,
+    partValue,
+    source,
+    sourceRedactionContext,
+    isSensibleSource
+  ) {
+    if (sourceIndex != null) {
+      const placeholder = source.value.includes(partValue)
+        ? source.pattern
+        : '*'.repeat(length)
+
+      if (isSensibleSource) {
+        valueParts.push({ redacted: true, source: sourceIndex, pattern: placeholder })
+      } else {
+        let _value = partValue
+        const dedupedSourceRedactionContexts = []
+        sourceRedactionContext.forEach(_sourceRedactionContext => {
+          const isPresentInDeduped = dedupedSourceRedactionContexts.some(_dedupedSourceRedactionContext =>
+            _dedupedSourceRedactionContext.start === _sourceRedactionContext.start &&
+            _dedupedSourceRedactionContext.end === _sourceRedactionContext.end
+          )
+          if (!isPresentInDeduped) {
+            dedupedSourceRedactionContexts.push(_sourceRedactionContext)
+          }
+        })
+        let offset = 0
+        dedupedSourceRedactionContexts.forEach((_sourceRedactionContext) => {
+          if (_sourceRedactionContext.start > 0) {
+            valueParts.push({
+              source: sourceIndex,
+              value: _value.substring(0, _sourceRedactionContext.start - offset)
+            })
+            _value = _value.substring(_sourceRedactionContext.start - offset)
+            offset = _sourceRedactionContext.start
+          }
+          const sensitive =
+            _value.substring(_sourceRedactionContext.start - offset, _sourceRedactionContext.end - offset)
+          const indexOfPartValueInPattern = source.value.indexOf(sensitive)
+
+          const pattern = indexOfPartValueInPattern > -1
+            ? placeholder.substring(indexOfPartValueInPattern, indexOfPartValueInPattern + sensitive.length)
+            : placeholder.substring(_sourceRedactionContext.start, _sourceRedactionContext.end)
+
+          valueParts.push({
+            redacted: true,
+            source: sourceIndex,
+            pattern
+          })
+          _value = _value.substring(pattern.length)
+          offset += pattern.length
+        })
+
+        if (_value.length) {
+          valueParts.push({
+            source: sourceIndex,
+            value: _value
+          })
+        }
+      }
     } else {
       valueParts.push({ redacted: true })
     }

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
@@ -28,7 +28,6 @@ class VulnerabilityFormatter {
       const { redactedValueParts, redactedSources } = scrubbingResult
       redactedSources.forEach(i => {
         delete sources[i].value
-        sources[i].redacted = true
       })
       return { valueParts: redactedValueParts }
     }

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 1.1,
   "suite": [
     {
       "type": "SOURCES",
@@ -207,7 +207,8 @@
           {
             "origin": "http.request.parameter",
             "name": "secret",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcde"
           }
         ],
         "vulnerabilities": [
@@ -220,7 +221,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcde"
                 }
               ]
             }
@@ -938,7 +940,8 @@
           {
             "origin": "http.request.parameter",
             "name": "username",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -951,7 +954,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "value": "'"
@@ -989,7 +993,8 @@
           {
             "origin": "http.request.parameter",
             "name": "user_id",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abc"
           }
         ],
         "vulnerabilities": [
@@ -1002,7 +1007,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abc"
                 }
               ]
             }
@@ -1037,7 +1043,8 @@
           {
             "origin": "http.request.parameter",
             "name": "password",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcde"
           }
         ],
         "vulnerabilities": [
@@ -1050,7 +1057,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcde"
                 },
                 {
                   "value": "'"
@@ -1088,7 +1096,8 @@
           {
             "origin": "http.request.parameter",
             "name": "password",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcde"
           }
         ],
         "vulnerabilities": [
@@ -1101,7 +1110,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcde"
                 },
                 {
                   "redacted": true
@@ -1142,7 +1152,8 @@
           {
             "origin": "http.request.parameter",
             "name": "first_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -1155,7 +1166,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "redacted": true
@@ -1196,7 +1208,8 @@
           {
             "origin": "http.request.parameter",
             "name": "last_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abc"
           }
         ],
         "vulnerabilities": [
@@ -1212,7 +1225,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abc"
                 },
                 {
                   "redacted": true
@@ -1253,7 +1267,8 @@
           {
             "origin": "http.request.parameter",
             "name": "clause",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijklmnopq"
           }
         ],
         "vulnerabilities": [
@@ -1266,7 +1281,16 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "mnop"
+                },
+                {
+                  "source": 0,
+                  "value": "'"
                 }
               ]
             }
@@ -1301,7 +1325,8 @@
           {
             "origin": "http.request.parameter",
             "name": "clause",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijklmnop"
           }
         ],
         "vulnerabilities": [
@@ -1314,7 +1339,12 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "mnop"
                 },
                 {
                   "redacted": true
@@ -1373,17 +1403,20 @@
           {
             "origin": "http.request.parameter",
             "name": "first_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           },
           {
             "origin": "http.request.parameter",
             "name": "last_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abc"
           },
           {
             "origin": "http.request.parameter",
             "name": "password",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijkl"
           }
         ],
         "vulnerabilities": [
@@ -1396,21 +1429,24 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "redacted": true
                 },
                 {
                   "source": 1,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abc"
                 },
                 {
                   "value": "' and password LIKE '"
                 },
                 {
                   "source": 2,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijkl"
                 },
                 {
                   "redacted": true
@@ -1463,7 +1499,8 @@
           {
             "origin": "http.request.parameter",
             "name": "query",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijk"
           }
         ],
         "vulnerabilities": [
@@ -1479,7 +1516,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "redacted": true
@@ -1492,12 +1530,77 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "redacted": true
                 },
                 {
+                  "value": "'"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Full query tainted",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from table where name LIKE '%searchparam%' OR description LIKE '%searchparam%'",
+            "ranges": [
+              {
+                "start": 0,
+                "end": 87,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "query",
+                  "parameterValue": "select * from table where name LIKE '%searchparam%' OR description LIKE '%searchparam%'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "query",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxy"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "source": 0,
+                  "value": "select * from table where name LIKE '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "LMNOPQRSTUVWX"
+                },
+                {
+                  "source": 0,
+                  "value": "' OR description LIKE '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "LMNOPQRSTUVWX"
+                },
+                {
+                  "source": 0,
                   "value": "'"
                 }
               ]
@@ -1673,7 +1776,8 @@
           {
             "origin": "http.request.parameter",
             "name": "cn",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijk"
           }
         ],
         "vulnerabilities": [
@@ -1686,7 +1790,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "value": ")\n(!(cn="
@@ -1705,14 +1810,16 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "fghijk"
                 },
                 {
                   "value": ")(cn="
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdef"
                 },
                 {
                   "redacted": true
@@ -1759,7 +1866,8 @@
           {
             "origin": "http.request.parameter",
             "name": "file",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijk"
           }
         ],
         "vulnerabilities": [
@@ -1784,7 +1892,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "value": ")\n(bin="
@@ -1888,7 +1997,8 @@
           {
             "origin": "http.request.parameter",
             "name": "file",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefgh"
           }
         ],
         "vulnerabilities": [
@@ -1904,7 +2014,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefgh"
                 }
               ]
             }
@@ -1945,7 +2056,8 @@
           {
             "origin": "http.request.parameter",
             "name": "file",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefgh"
           }
         ],
         "vulnerabilities": [
@@ -1961,7 +2073,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefgh"
                 }
               ]
             }
@@ -2010,7 +2123,8 @@
           {
             "origin": "http.request.parameter",
             "name": "argument",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -2027,7 +2141,8 @@
                 },
                 {
                   "source": 1,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 }
               ]
             }
@@ -2189,7 +2304,7 @@
                 "end": 36,
                 "iinfo": {
                   "type": "http.request.parameter",
-                  "parameterName": "fist_name",
+                  "parameterName": "first_name",
                   "parameterValue": "john"
                 }
               }
@@ -2206,8 +2321,9 @@
           },
           {
             "origin": "http.request.parameter",
-            "name": "fist_name",
-            "redacted": true
+            "name": "first_name",
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -2227,7 +2343,8 @@
                 },
                 {
                   "source": 1,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "value": "&last_name="
@@ -2342,6 +2459,222 @@
             "type": "WEAK_RANDOMNESS",
             "evidence": {
               "value": "java.util.Math"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive source should be redacted fully in the evidence (source matches)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'john'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 43,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "password",
+                  "parameterValue": "username = 'john'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "password",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopq"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "abcdefghijklmnopq"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive sources should be redacted fully in the evidence (source does not match)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'my user'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 46,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "password",
+                  "parameterValue": "username = 'my%20user'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "password",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopqrstuv"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "********************"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive tainted range (source matches)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'john'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 43,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "clause",
+                  "parameterValue": "username = 'john'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "clause",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopq"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "mnop"
+                },
+                {
+                  "source": 0,
+                  "value": "'"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive tainted range (source does not match)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'my user'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 46,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "clause",
+                  "parameterValue": "username = 'my%20user'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "clause",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopqrstuv"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "*******"
+                },
+                {
+                  "source": 0,
+                  "value": "'"
+                }
+              ]
             }
           }
         ]


### PR DESCRIPTION
### What does this PR do?
Updates the redaction system for IAST vulnerability evidences to be more lenient.

##### Source redaction
- Sources values will be redacted in the source entry using an alphanumeric placeholder string of the same length (a-zA-Z0-9) and added to a new attribute named `"pattern": ${REDACTED_VALUE}`.
- When a source is redacted, all of its occurrences will be marked as redacted in the vulnerability evidence section as well following the same approach as in the sources. The value will be formatted using the characters from the source generated placeholder (taking into account the ranges) and non tainted redacted ranges will drop the value.

##### Evidence redaction
The redaction of the tainted ranges in the evidence should follow the rules described next:

- Split the tainted range in its sensitive and non-sensitive parts
- For non-sensitive parts:
  - Append value part as by default
- For sensitive parts:
  - If the string is found in the source, the matching pattern of the sensitive range will be reused
  - If not, the pattern will use the asterisk character *  (e.g. if the source has been decoded or modified in any non traceable form).


### Motivation
Update the redaction system according to the final RFC.

### Plugin Checklist
- [x] Unit tests.
