### PR TITLE
Add exclusions for weak hash vulnerabilities

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
@@ -16,7 +16,10 @@ const EXCLUDED_LOCATIONS = [
   path.join('node_modules', 'redlock', 'dist', 'cjs'),
   path.join('node_modules', 'ws', 'lib', 'websocket-server.js'),
   path.join('node_modules', 'mysql2', 'lib', 'auth_41.js'),
-  path.join('node_modules', '@mikro-orm', 'core', 'utils', 'Utils.js')
+  path.join('node_modules', '@mikro-orm', 'core', 'utils', 'Utils.js'),
+  path.join('node_modules', 'mongodb', 'lib', 'core', 'connection', 'connection.js'),
+  path.join('node_modules', 'sqreen', 'lib', 'package-reader', 'index.js'),
+  path.join('node_modules', 'pusher', 'lib', 'utils.js')
 ]
 
 const EXCLUDED_PATHS_FROM_STACK = [

--- a/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 
+const { getNodeModulesPaths } = require('../path-line')
 const Analyzer = require('./vulnerability-analyzer')
 const { WEAK_HASH } = require('../vulnerabilities')
 
@@ -11,16 +12,16 @@ const INSECURE_HASH_ALGORITHMS = new Set([
   'RSA-SHA1', 'RSA-SHA1-2', 'sha1', 'md5-sha1', 'sha1WithRSAEncryption', 'ssl3-sha1'
 ].map(algorithm => algorithm.toLowerCase()))
 
-const EXCLUDED_LOCATIONS = [
-  path.join('node_modules', 'etag', 'index.js'),
-  path.join('node_modules', 'redlock', 'dist', 'cjs'),
-  path.join('node_modules', 'ws', 'lib', 'websocket-server.js'),
-  path.join('node_modules', 'mysql2', 'lib', 'auth_41.js'),
-  path.join('node_modules', '@mikro-orm', 'core', 'utils', 'Utils.js'),
-  path.join('node_modules', 'mongodb', 'lib', 'core', 'connection', 'connection.js'),
-  path.join('node_modules', 'sqreen', 'lib', 'package-reader', 'index.js'),
-  path.join('node_modules', 'pusher', 'lib', 'utils.js')
-]
+const EXCLUDED_LOCATIONS = getNodeModulesPaths(
+  'etag/index.js',
+  '@mikro-orm/core/utils/Utils.js',
+  'mongodb/lib/core/connection/connection.js',
+  'mysql2/lib/auth_41.js',
+  'pusher/lib/utils.js',
+  'redlock/dist/cjs',
+  'sqreen/lib/package-reader/index.js',
+  'ws/lib/websocket-server.js'
+)
 
 const EXCLUDED_PATHS_FROM_STACK = [
   path.join('node_modules', 'object-hash', path.sep)

--- a/packages/dd-trace/test/appsec/iast/analyzers/weak-hash-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/weak-hash-analyzer.spec.js
@@ -113,6 +113,30 @@ describe('weak-hash-analyzer', () => {
       }
       expect(weakHashAnalyzer._isExcluded(location)).to.be.true
     })
+
+    it('mongodb host address hash', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', 'mongodb', 'lib', 'core', 'connection', 'connection.js'),
+        line: 137
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
+
+    it('sqreen package list fingerprint', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', 'sqreen', 'lib', 'package-reader', 'index.js'),
+        line: 135
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
+
+    it('pusher request body fingerprint', () => {
+      const location = {
+        path: path.join(locationPrefix, 'node_modules', 'pusher', 'lib', 'utils.js'),
+        line: 23
+      }
+      expect(weakHashAnalyzer._isExcluded(location)).to.be.true
+    })
   })
 
   describe('full feature', () => {


### PR DESCRIPTION
### What does this PR do?
Excludes Weak Hash vulnerability detection for legit use in `mongodb`, `sqreen` and `pusher` libraries.

### Motivation
We are detecting as vulnerability each time a vulnerable hashing algorithm is used in the customer application.
In some cases, the use of this kind of algorithms is legit and doesn't involve a risk, so they are excluded to prevent reporting false positives.

### Plugin Checklist
- [x] Unit tests.

### Additional Notes
#### mongodb
Uses `sha1` as algorithm to hash the host address. [Code](https://github.com/mongodb/node-mongodb-native/blob/v3.7.3/lib/core/connection/connection.js#L137)
#### sqreen
Uses `sha1` to compute the fingerprint the list of the packages.
#### pusher
Uses `md5` to compute the fingerprint of request’s body which is send to Pusher REST API. [Code](https://github.com/pusher/pusher-http-node/blob/master/lib/util.js#L23)