### PR TITLE
Allow PR commenter failure instead of silencing

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -39,7 +39,8 @@ benchmarks-pr-comment:
     - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
     - git clone --branch dd-trace-js https://github.com/DataDog/relenv-microbenchmarking-platform /platform && cd /platform
-    - "./steps/post-pr-comment.sh || :"
+    - ./steps/post-pr-comment.sh
+  allow_failure: true
   variables:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID # The ID of the current project. This ID is unique across all projects on the GitLab instance.
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME # "dd-trace-js"


### PR DESCRIPTION
### What does this PR do?

Updates how PR commenter script is called.
Now errors won't be silenced and if PR commenter fails to post a comment - job will fail as well.
This won't break existing pipelines / behavior - it is rather a change for monitoring on APM R&P side so we can track errors in PR comments posting.

### Motivation

I want to add additional checks in Datadog UI to be aware when Github API has outage or we have a problem in our PR commenting code.

In order to do this in a good manner, I need to change a way how PR commenting job is executed.
