### PR TITLE
openai: remove String#replaceAll for Node.js <=14

### DIFF
--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -125,7 +125,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('openai.api_base', 'https://api.openai.com/v1')
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.model', 'text-davinci-002')
-              expect(traces[0][0].meta).to.have.property('openai.request.prompt', 'Hello, ')
+              expect(traces[0][0].meta).to.have.property('openai.request.prompt', 'Hello, \\n\\nFriend\\t\\tHi')
               expect(traces[0][0].meta).to.have.property('openai.request.stop', 'time')
               expect(traces[0][0].meta).to.have.property('openai.request.suffix', 'foo')
               expect(traces[0][0].meta).to.have.property('openai.request.user', 'hunter2')
@@ -151,7 +151,7 @@ describe('Plugin', () => {
 
           const result = await openai.createCompletion({
             model: 'text-davinci-002',
-            prompt: 'Hello, ',
+            prompt: 'Hello, \n\nFriend\t\tHi',
             suffix: 'foo',
             max_tokens: 7,
             temperature: 1.01,
@@ -194,7 +194,7 @@ describe('Plugin', () => {
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
             message: 'sampled createCompletion',
-            prompt: 'Hello, ',
+            prompt: 'Hello, \n\nFriend\t\tHi',
             choices: [
               {
                 text: 'FOO BAR BAZ',


### PR DESCRIPTION
### What does this PR do?
- remove calls to `String#replaceAll()`

### Motivation
- this causes build to fail for tracer version 2 (node v12) and 3 (node v14)
