### PR TITLE
Fix native-iast-taint-tracking version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@datadog/native-appsec": "^3.2.0",
     "@datadog/native-iast-rewriter": "2.0.1",
-    "@datadog/native-iast-taint-tracking": "^1.5.0",
+    "@datadog/native-iast-taint-tracking": "1.5.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "3.1.0",
     "@datadog/sketches-js": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,7 +394,7 @@
   dependencies:
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@^1.5.0":
+"@datadog/native-iast-taint-tracking@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz#1a55eca6692079ac6167696682acb972aa0b0181"
   integrity sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix @datadog/native-iast-taint-tracking module version to 1.5.0
### Motivation
<!-- What inspired you to submit this pull request? -->
1.6.0 version is generating problems on customers because it is not fixed in our package.json
