### PR TITLE
feat: add the lib/core file which each client lib imports directly, s…

### DIFF
--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -176,8 +176,7 @@ addHook({ name: '@aws-sdk/smithy-client', versions: ['>=3'] }, smithy => {
   return smithy
 })
 
-addHook({ name: 'aws-sdk', file: 'lib/core.js', versions: ['>=2.3.0'] }, AWS => {
-  shimmer.wrap(AWS.Request.prototype, 'promise', wrapRequest)
+addHook({ name: 'aws-sdk', versions: ['>=2.3.0'] }, AWS => {
   shimmer.wrap(AWS.config, 'setPromisesDependency', setPromisesDependency => {
     return function wrappedSetPromisesDependency (dep) {
       const result = setPromisesDependency.apply(this, arguments)
@@ -185,6 +184,11 @@ addHook({ name: 'aws-sdk', file: 'lib/core.js', versions: ['>=2.3.0'] }, AWS => 
       return result
     }
   })
+  return AWS
+})
+
+addHook({ name: 'aws-sdk', file: 'lib/core.js', versions: ['>=2.3.0'] }, AWS => {
+  shimmer.wrap(AWS.Request.prototype, 'promise', wrapRequest)
   return AWS
 })
 

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -176,7 +176,7 @@ addHook({ name: '@aws-sdk/smithy-client', versions: ['>=3'] }, smithy => {
   return smithy
 })
 
-addHook({ name: 'aws-sdk', versions: ['>=2.3.0'] }, AWS => {
+addHook({ name: 'aws-sdk', file: 'lib/core.js', versions: ['>=2.3.0'] }, AWS => {
   shimmer.wrap(AWS.Request.prototype, 'promise', wrapRequest)
   shimmer.wrap(AWS.config, 'setPromisesDependency', setPromisesDependency => {
     return function wrappedSetPromisesDependency (dep) {
@@ -190,7 +190,7 @@ addHook({ name: 'aws-sdk', versions: ['>=2.3.0'] }, AWS => {
 
 // <2.1.35 has breaking changes for instrumentation
 // https://github.com/aws/aws-sdk-js/pull/629
-addHook({ name: 'aws-sdk', versions: ['>=2.1.35'] }, AWS => {
+addHook({ name: 'aws-sdk', file: 'lib/core.js', versions: ['>=2.1.35'] }, AWS => {
   shimmer.wrap(AWS.Request.prototype, 'send', wrapRequest)
   return AWS
 })


### PR DESCRIPTION
…o that users importing only one client still have instrumentation

### What does this PR do?
Fixes a bug where individually-imported clients weren't patched. This only applies to aws-sdk v2, which is quite stable but being replaced (however the majority of our users do use v2).

```js
const SNS = require('aws-sdk/clients/sns')
```

This now works:
<img width="828" alt="image" src="https://github.com/DataDog/dd-trace-js/assets/1598537/99a47783-e09c-4b0a-a34d-c890cf45bbd2">


Previously trace context was broken.

With fix: https://ddserverless.datadoghq.com/apm/trace/1119204871756489430?colorBy=service&env=dev&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=160341049083086681&spanViewType=metadata&timeHint=1689877451755

without:
https://ddserverless.datadoghq.com/apm/trace/152506109133381864?colorBy=service&env=dev&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=7098099035308270062&spanViewType=metadata&timeHint=1689868585843

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
