### PR TITLE
sirun: allow early termination in runall.sh

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Temporary until merged to master
 wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-musl.tar.gz \
 	&& tar -xzf sirun.tar.gz \

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -71,7 +71,9 @@ for D in *; do
   if [ -d "${D}" ]; then
     if [[ ${BENCH_INDEX} -ge ${BENCH_START} && ${BENCH_INDEX} -lt ${BENCH_END} ]]; then
       cd "${D}"
+      set +e
       run_all_variants $D
+      set -e
       cd ..
     fi
 


### PR DESCRIPTION
### What does this PR do?
- allows runall.sh to exit when encountering an error

### Motivation
- if something like `nvm use` fails it leaves things in a confusing state