### PR TITLE
fix fetch integration leaking its async context

### DIFF
--- a/packages/datadog-instrumentations/src/http2/client.js
+++ b/packages/datadog-instrumentations/src/http2/client.js
@@ -42,6 +42,7 @@ function createWrapRequest (authority, options) {
         } catch (e) {
           ctx.error = e
           errorChannel.publish(ctx)
+          throw e
         } finally {
           endChannel.publish(ctx)
         }

--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -1,35 +1,27 @@
 'use strict'
 
 const HttpClientPlugin = require('../../datadog-plugin-http/src/client')
-const { HTTP_HEADERS } = require('../../../ext/formats')
 
 class FetchPlugin extends HttpClientPlugin {
   static get id () { return 'fetch' }
+  static get prefix () { return `apm:fetch:request` }
 
   addTraceSub (eventName, handler) {
     this.addSub(`apm:${this.constructor.id}:${this.operation}:${eventName}`, handler)
   }
 
-  start (message) {
+  bindStart (message) {
     const req = message.req
     const options = new URL(req.url)
     const headers = options.headers = Object.fromEntries(req.headers.entries())
 
-    const args = { options }
+    message.args = { options }
 
-    super.start({ args })
+    const store = super.bindStart(message)
 
     message.req = new globalThis.Request(req, { headers })
-  }
 
-  _inject (span, headers) {
-    const carrier = {}
-
-    this.tracer.inject(span, HTTP_HEADERS, carrier)
-
-    for (const name in carrier) {
-      headers.append(name, carrier[name])
-    }
+    return store
   }
 }
 

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -16,15 +16,11 @@ const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 class HttpClientPlugin extends ClientPlugin {
-  static get id () {
-    return 'http'
-  }
+  static get id () { return 'http' }
+  static get prefix () { return `apm:http:client:request` }
 
-  addTraceSub (eventName, handler) {
-    this.addSub(`apm:${this.constructor.id}:client:${this.operation}:${eventName}`, handler)
-  }
-
-  start ({ args, http = {} }) {
+  bindStart (message) {
+    const { args, http = {} } = message
     const store = storage.getStore()
     const options = args.options
     const agent = options.agent || options._defaultAgent || http.globalAgent || {}
@@ -67,11 +63,19 @@ class HttpClientPlugin extends ClientPlugin {
     }
 
     analyticsSampler.sample(span, this.config.measured)
-    this.enter(span, store)
+
+    message.span = span
+    message.parentStore = store
+    message.currentStore = { ...store, span }
+
+    return message.currentStore
   }
 
-  finish ({ req, res }) {
-    const span = storage.getStore().span
+  bindAsyncStart ({ parentStore }) {
+    return parentStore
+  }
+
+  finish ({ req, res, span }) {
     if (res) {
       const status = res.status || res.statusCode
 
@@ -87,17 +91,18 @@ class HttpClientPlugin extends ClientPlugin {
     addRequestHeaders(req, span, this.config)
 
     this.config.hooks.request(span, req, res)
-    super.finish()
+
+    this.tagPeerService(span)
+
+    span.finish()
   }
 
-  error (err) {
-    const span = storage.getStore().span
-
-    if (err) {
+  error ({ span, error }) {
+    if (error) {
       span.addTags({
-        [ERROR_TYPE]: err.name,
-        [ERROR_MESSAGE]: err.message || err.code,
-        [ERROR_STACK]: err.stack
+        [ERROR_TYPE]: error.name,
+        [ERROR_MESSAGE]: error.message || error.code,
+        [ERROR_STACK]: error.stack
       })
     } else {
       span.setTag('error', 1)

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -51,7 +51,7 @@ class HttpClientPlugin extends ClientPlugin {
       metrics: {
         [CLIENT_PORT_KEY]: parseInt(options.port)
       }
-    })
+    }, false)
 
     // TODO: Figure out a better way to do this for any span.
     if (!allowed) {

--- a/packages/diagnostics_channel/src/index.js
+++ b/packages/diagnostics_channel/src/index.js
@@ -64,7 +64,7 @@ if (!Channel.prototype.runStores) {
     this._stores.set(store, transform)
   }
 
-  Channel.prototype.unbindStore = ActiveChannelPrototype.runStores = function (store) {
+  Channel.prototype.unbindStore = ActiveChannelPrototype.unbindStore = function (store) {
     if (!this._stores) return
     this._stores.delete(store)
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `fetch` integration leaking its async context.

Fixes #3387
Fixes #3397

### Motivation
<!-- What inspired you to submit this pull request? -->

The `fetch` integration uses the same plugin class as `http` which enters a new store. The `http` plugin however restores the parent store since its instrumentation creates a new `AsyncResource` to wrap the handler, which the `fetch` integration doesn't do. In order to fix this without introducing an `AsyncResource` to fetch, the `http` client plugin was refactored to use `runStores` and `bindStore` instead.