### PR TITLE
[ci-visibility] Make integration test for jest compatible with node 12

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -248,7 +248,7 @@ testFrameworks.forEach(({
           testOutput += chunk.toString()
         })
         childProcess.on('message', () => {
-          assert.include(testOutput, 'Exceeded timeout of 100 ms for a test while waiting for `done()` to be called.')
+          assert.include(testOutput, 'Exceeded timeout of 100 ms for a test')
           done()
         })
       })


### PR DESCRIPTION
### What does this PR do?
The error message changes slightly when using a different jest version (which we require when using node 12). This PR makes sure the error message is compatible with every version we use.

### Motivation
Fix 2.x release line
