### PR TITLE
[ci-visibility] Fix cache issues with `jest` and CI Visibility

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -10,6 +10,7 @@ module.exports = {
   '@grpc/grpc-js': () => require('../grpc'),
   '@hapi/hapi': () => require('../hapi'),
   '@jest/core': () => require('../jest'),
+  '@jest/transform': () => require('../jest'),
   '@jest/reporters': () => require('../jest'),
   '@koa/router': () => require('../koa'),
   '@node-redis/client': () => require('../redis'),

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -419,7 +419,12 @@ addHook({
 
   transformPackage.createScriptTransformer = async function (config) {
     const { testEnvironmentOptions, ...restOfConfig } = config
-    const { _ddTestModuleId, _ddTestSessionId, _ddTestCommand, ...restOfTestEnvironmentOptions } = testEnvironmentOptions
+    const {
+      _ddTestModuleId,
+      _ddTestSessionId,
+      _ddTestCommand,
+      ...restOfTestEnvironmentOptions
+    } = testEnvironmentOptions
 
     restOfConfig.testEnvironmentOptions = restOfTestEnvironmentOptions
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -410,6 +410,27 @@ function jestConfigSyncWrapper (jestConfig) {
   return jestConfig
 }
 
+addHook({
+  name: '@jest/transform',
+  versions: ['>=24.8.0'],
+  file: 'build/ScriptTransformer.js'
+}, transformPackage => {
+  const originalCreateScriptTransformer = transformPackage.createScriptTransformer
+
+  transformPackage.createScriptTransformer = async function (config) {
+    const { testEnvironmentOptions, ...restOfConfig } = config
+    const { _ddTestModuleId, _ddTestSessionId, _ddTestCommand, ...restOfTestEnvironmentOptions } = testEnvironmentOptions
+
+    restOfConfig.testEnvironmentOptions = restOfTestEnvironmentOptions
+
+    arguments[0] = restOfConfig
+
+    return originalCreateScriptTransformer.apply(this, arguments)
+  }
+
+  return transformPackage
+})
+
 /**
  * Hook to remove the test paths (test suite) that are part of `skippableSuites`
  */

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -102,6 +102,7 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:worker-report:trace', traces => {
+      // we should be able to add test module and test session id here
       const formattedTraces = JSON.parse(traces).map(trace =>
         trace.map(span => ({
           ...span,

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -102,7 +102,6 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:worker-report:trace', traces => {
-      // we should be able to add test module and test session id here
       const formattedTraces = JSON.parse(traces).map(trace =>
         trace.map(span => ({
           ...span,

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -10,6 +10,7 @@ module.exports = {
   get '@grpc/grpc-js' () { return require('../../../datadog-plugin-grpc/src') },
   get '@hapi/hapi' () { return require('../../../datadog-plugin-hapi/src') },
   get '@jest/core' () { return require('../../../datadog-plugin-jest/src') },
+  get '@jest/transform' () { return require('../../../datadog-plugin-jest/src') },
   get '@koa/router' () { return require('../../../datadog-plugin-koa/src') },
   get '@node-redis/client' () { return require('../../../datadog-plugin-redis/src') },
   get '@opensearch-project/opensearch' () { return require('../../../datadog-plugin-opensearch/src') },


### PR DESCRIPTION
### What does this PR do?

`Jest` stores a cache of transpiled files to reduce the upfront computation that needs to happen before running an actual test. The key `jest` uses for this cache includes `testEnvironmentOptions`, which we leverage for passing information to the jest workers (namely, session and module id). Since those IDs change each run, the cache becomes unusable if CI Visibility is enabled. 

What this PR does is to make sure those IDs are ignored by `jest`, since those values changing should not invalidate the cache. 

At a future PR, I want to make the workers completely unaware of the session and module ids. This information can be attached to the spans before they are flushed in the jest's main process. This requires a bigger refactor though. 

### Motivation
Allow customers to correctly use the `jest` cache. 

Fixes #3389

### Additional Notes
Testing this change with our current setup would be really hard: we'd have to pull a big enough repository with enough tests and check that running a test suite is slightly faster the second time you do it. 

I've done it manually with `datadog-ci` (I run the experiment 10 times to make sure): 
https://github.com/DataDog/datadog-ci/actions/runs/5624386000/attempts/1

The second time a test suite is run for the released version takes roughly 90% of the time. 
The second time a test suite is run for this branch takes roughly 70% of the time, so there's a significant improvement, and this is thanks to the jest cache. 
