### PR TITLE
Fix flaky serverless integration test (part2)

### DIFF
--- a/integration-tests/serverless/test-gcloud-function.sh
+++ b/integration-tests/serverless/test-gcloud-function.sh
@@ -30,9 +30,6 @@ DEPLOY_OUTPUT=$(gcloud functions deploy dd-trace-js-sls-mini-agent-integration-t
 
 INVOKE_URL=$(echo "$DEPLOY_OUTPUT" | awk -F'uri: ' '{print $2}' | xargs)
 
-echo "Waiting 10 seconds before invoking cloud function"
-sleep 10
-
 echo "Calling deployed cloud function"
 
 curl -s "${INVOKE_URL}"

--- a/integration-tests/serverless/test-gcloud-function.sh
+++ b/integration-tests/serverless/test-gcloud-function.sh
@@ -28,7 +28,10 @@ DEPLOY_OUTPUT=$(gcloud functions deploy dd-trace-js-sls-mini-agent-integration-t
     --allow-unauthenticated \
     --env-vars-file "${SERVERLESS_INTEGRATION_DIR_PATH}/test-project/.env.yaml")
 
-INVOKE_URL=$(echo "$DEPLOY_OUTPUT" | awk 'END {print $NF}')
+INVOKE_URL=$(echo "$DEPLOY_OUTPUT" | awk -F'uri: ' '{print $2}' | xargs)
+
+echo "Waiting 10 seconds before invoking cloud function"
+sleep 10
 
 echo "Calling deployed cloud function"
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

[The previous fix](https://github.com/DataDog/dd-trace-js/pull/3418) didn't fully solve the issue, the URL outputted by the gcloud deploy command still intermittently will result in a 404. Switch over to using the URI outputted (associated with the underlying Cloud Run app powering the functon), which is reliable.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
