### PR TITLE
Add APM FI team to codeowners for plugins

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,11 @@
 /packages/dd-trace/src/appsec/ @DataDog/appsec-js
 /packages/dd-trace/test/appsec/ @DataDog/appsec-js
 
+/packages/datadog-plugin-*/ @Datadog/dd-trace-js @Datadog/apm-framework-integrations-reviewers-js
+/packages/datadog-instrumentations/ @Datadog/dd-trace-js @Datadog/apm-framework-integrations-reviewers-js
+/packages/ddtrace/src/plugins/ @DataDog/dd-trace-js @Datadog/apm-framework-integrations-reviewers-js
+/packages/ddtrace/test/plugins/ @DataDog/dd-trace-js @Datadog/apm-framework-integrations-reviewers-js
+
 /packages/dd-trace/src/ci-visibility/ @DataDog/ci-app-libraries
 /packages/datadog-plugin-jest/ @DataDog/ci-app-libraries
 /packages/datadog-plugin-mocha/ @DataDog/ci-app-libraries
@@ -21,3 +26,6 @@
 /integration-tests/playwright/ @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-spec.js @DataDog/ci-app-libraries
 /integration-tests/test-api-manual.spec.js @DataDog/ci-app-libraries
+
+/packages/dd-trace/src/service-naming/ @Datadog/apm-framework-integrations-reviewers-js
+/packages/dd-trace/test/service-naming/ @Datadog/apm-framework-integrations-reviewers-js


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
