### PR TITLE
Opensearch: pin server version in CI

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -800,7 +800,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       opensearch:
-        image: opensearchproject/opensearch:2
+        image: opensearchproject/opensearch:2.8.0
         env:
           plugins.security.disabled: 'true'
           discovery.type: single-node


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Pin opensearch server version running in plugin tests to `2.8.0` - latest version does not work with tests.

