### PR TITLE
IAST opt out activation

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/index.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/index.js
@@ -17,7 +17,18 @@ function disableAllAnalyzers () {
   }
 }
 
+function enableOptOutAnalyzers (tracerConfig) {
+  analyzers.HSTS_HEADER_MISSING_ANALYZER.configure({ enabled: true, tracerConfig })
+  analyzers.XCONTENTTYPE_HEADER_MISSING_ANALYZER.configure({ enabled: true, tracerConfig })
+
+  setCookiesHeaderInterceptor.configure({ enabled: true, tracerConfig })
+  analyzers.NO_HTTPONLY_COOKIE_ANALYZER.configure({ enabled: true, tracerConfig })
+  analyzers.INSECURE_COOKIE_ANALYZER.configure({ enabled: true, tracerConfig })
+  analyzers.NO_SAMESITE_COOKIE_ANALYZER.configure({ enabled: true, tracerConfig })
+}
+
 module.exports = {
   enableAllAnalyzers,
+  enableOptOutAnalyzers,
   disableAllAnalyzers
 }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -59,6 +59,8 @@ class Tracer extends NoopProxy {
 
         if (config.iast.enabled) {
           require('./appsec/iast').enable(config, this._tracer)
+        } else {
+          require('./appsec/iast').enableOptOut(config, this._tracer)
         }
 
         this._pluginManager.configure(config)


### PR DESCRIPTION
### What does this PR do?
Provides the feature to IAST to be active by default in the tracer without customer interaction, meaning no need to manually configure the different flags.

### Motivation
Provide vulnerability detection for a subset of vulnerabilities that require neither taint tracking nor propagation by default.

### Plugin Checklist
- [ ] Unit tests.

### Additional Notes
Vulnerabilities to detect:
| Vulnerability | Remarks |
|---------------|----------|
| INSECURE_COOKIE NO_HTTPONLY_COOKIE NO_SAMESITE_COOKIE | Checking for header attributes can be done with APM instrumentations and does not require propagation |
| XCONTENTTYPE_HEADER_MISSING HSTS_HEADER_MISSING | Checking for the absence of headers can be don with APM instrumentations and does not require propagation |


