### PR TITLE
[ci-visibility] Wait for flush in `jest`

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -49,7 +49,8 @@ class JestPlugin extends CiPlugin {
       isSuitesSkipped,
       isSuitesSkippingEnabled,
       isCodeCoverageEnabled,
-      testCodeCoverageLinesTotal
+      testCodeCoverageLinesTotal,
+      onDone
     }) => {
       this.testSessionSpan.setTag(TEST_STATUS, status)
       this.testModuleSpan.setTag(TEST_STATUS, status)
@@ -63,7 +64,7 @@ class JestPlugin extends CiPlugin {
       this.testModuleSpan.finish()
       this.testSessionSpan.finish()
       finishAllTraceSpans(this.testSessionSpan)
-      this.tracer._exporter.flush()
+      this.tracer._exporter.flush(onDone)
     })
 
     // Test suites can be run in a different process from jest's main one.


### PR DESCRIPTION
### What does this PR do?
Wait for flush for `jest`. 

### Motivation
Jest forcefully shuts down the process running tests if it does not gracefully shut down in 1 second. This is sometimes not enough for us to finish every ongoing request. 

This PR adds a maximum 5 second delay to give time for us to finish any ongoing request. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
