### PR TITLE
add option to truncate pg query

### DIFF
--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -10,7 +10,7 @@ class PGPlugin extends DatabasePlugin {
 
   start ({ params = {}, query, processId }) {
     const service = this.serviceName({ pluginConfig: this.config, params })
-    const originalStatement = query.text
+    const originalStatement = this.maybeTruncate(query.text)
 
     this.startSpan(this.operationName(), {
       service,

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -218,7 +218,7 @@ describe('Plugin', () => {
 
       describe('with configuration', () => {
         before(() => {
-          return agent.load('pg', { service: 'custom' })
+          return agent.load('pg', { service: 'custom', truncate: 12 })
         })
 
         after(() => {
@@ -242,6 +242,7 @@ describe('Plugin', () => {
           agent.use(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', 'custom')
+            expect(traces[0][0]).to.have.property('resource', 'SELECT $1...')
           })
             .then(done)
             .catch(done)

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -55,6 +55,18 @@ class DatabasePlugin extends StoragePlugin {
       return `/*${servicePropagation},traceparent='${traceparent}'*/ ${query}`
     }
   }
+
+  maybeTruncate (query) {
+    const maxLength = typeof this.config.truncate === 'number'
+      ? this.config.truncate
+      : 5000 // same as what the agent does
+
+    if (this.config.truncate && query && query.length > maxLength) {
+      query = `${query.slice(0, maxLength - 3)}...`
+    }
+
+    return query
+  }
 }
 
 module.exports = DatabasePlugin


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add option to truncate `pg` query.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, unique queries can be really large. When this happens, the agent gets out of memory and ends up crashing. Usually, such large queries couldn't really be properly analyzed anyway, and given their size, having just the first part of the query is good enough for most use cases.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This could eventually be done for all databases, but is currently an issue only for `pg`.