### PR TITLE
esbuild: honor the .external build setting

### DIFF
--- a/integration-tests/esbuild.spec.js
+++ b/integration-tests/esbuild.spec.js
@@ -32,4 +32,24 @@ describe('esbuild', () => {
       process.chdir(CWD)
     }
   })
+
+  it('does not bundle modules listed in .external', () => {
+    // eslint-disable-next-line no-console
+    console.log(`cd ${TEST_DIR}`)
+    process.chdir(TEST_DIR)
+
+    try {
+      // eslint-disable-next-line no-console
+      console.log('node ./build-and-test-skip-external.js')
+      chproc.execSync('node ./build-and-test-skip-external.js', {
+        timeout: 1000 * 30
+      })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err)
+      process.exit(1)
+    } finally {
+      process.chdir(CWD)
+    }
+  })
 })

--- a/integration-tests/esbuild/.gitignore
+++ b/integration-tests/esbuild/.gitignore
@@ -1,1 +1,1 @@
-out.js
+*out.js

--- a/integration-tests/esbuild/build-and-test-skip-external.js
+++ b/integration-tests/esbuild/build-and-test-skip-external.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const assert = require('assert')
+
+const ddPlugin = require('../../esbuild') // dd-trace/esbuild
+const esbuild = require('esbuild')
+
+esbuild.build({
+  entryPoints: ['skip-external.js'],
+  bundle: true,
+  outfile: 'skip-external-out.js',
+  plugins: [ddPlugin],
+  platform: 'node',
+  target: ['node16'],
+  external: [
+    'knex'
+  ]
+}).then(() => {
+  const output = fs.readFileSync('./skip-external-out.js').toString()
+  // Note that esbuild converts 'foo' into "foo"
+  assert(output.includes('require("knex")'), 'bundle should contain a require call to non-bundled knex')
+  assert(!output.includes('require("axios")'), 'bundle should not contain a require call to bundled axios')
+  console.log('ok') // eslint-disable-line no-console
+  fs.rmSync('./skip-external-out.js')
+}).catch((err) => {
+  console.error(err) // eslint-disable-line no-console
+  process.exit(1)
+})

--- a/integration-tests/esbuild/package.json
+++ b/integration-tests/esbuild/package.json
@@ -18,6 +18,7 @@
   "author": "Thomas Hunter II <tlhunter@datadog.com>",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.21.2",
     "esbuild": "0.16.12",
     "express": "^4.16.2",
     "knex": "^2.4.2"

--- a/integration-tests/esbuild/skip-external.js
+++ b/integration-tests/esbuild/skip-external.js
@@ -1,0 +1,7 @@
+require('../../').init() // dd-trace
+
+// this should be bundled
+require('axios')
+
+// this is in the external list and should not be bundled
+require('knex')


### PR DESCRIPTION
### What does this PR do?
- skips translating the `require()` function upon encountering a package listed in the `external` list
- the module is still instrumented as it will fallback to using Node.js's `require()` function
  - in other words it still goes through require-in-the-middle at runtime

#### Output when packages are external

```js
// app.js
require_dd_trace_js();
var aws = require("aws-sdk");
var redis = require("redis");
console.log(aws.util);
console.log(redis);
```

#### Output when packages are not external (what happens today)

```js
// app.js
require_dd_trace_js();
var aws = require_aws2();
var redis = require_dist12();
console.log(aws.util);
console.log(redis);
```

### Motivation
- while debugging a ticket I noticed that external packages are included in build
  - https://github.com/DataDog/dd-trace-js/issues/3479 
- this is particularly annoying for lambda builds which include the entire aws-sdk even though it's already on disk
