### PR TITLE
core: standardize interface for getting dd/node version

### DIFF
--- a/integration-tests/esbuild/basic-test.js
+++ b/integration-tests/esbuild/basic-test.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
+const { NODE_MAJOR } = require('../../version')
+
 // TODO: add support for Node.js v14.17+ and v16.0+
-if (Number(process.versions.node.split('.')[0]) < 16) {
+if (NODE_MAJOR < 16) {
   console.error(`Skip esbuild test for node@${process.version}`) // eslint-disable-line no-console
   process.exit(0)
 }

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable no-console */
 
+const { NODE_MAJOR, NODE_MINOR, NODE_FULL } = require('../../version')
 const instrumentations = require('../datadog-instrumentations/src/helpers/instrumentations.js')
 const hooks = require('../datadog-instrumentations/src/helpers/hooks.js')
 
@@ -153,13 +154,12 @@ module.exports.setup = function (build) {
 // Of course, the most ideal would be to support all versions of Node that dd-trace supports.
 // Version constraints based on Node's diagnostics_channel support
 function warnIfUnsupported () {
-  const [major, minor] = process.versions.node.split('.').map(Number)
   if (
-    major < 16 ||
-    (major === 16 && minor < 17) ||
-    (major === 18 && minor < 7)) {
+    NODE_MAJOR < 16 ||
+    (NODE_MAJOR === 16 && NODE_MINOR < 17) ||
+    (NODE_MAJOR === 18 && NODE_MINOR < 7)) {
     console.error('WARNING: Esbuild support isn\'t available for older versions of Node.js.')
-    console.error(`Expected: Node.js >=v16.17 or >=v18.7. Actual: Node.js = ${process.version}.`)
+    console.error(`Expected: Node.js >=v16.17 or >=v18.7. Actual: Node.js = ${NODE_FULL}.`)
     console.error('This application may build properly with this version of Node.js, but unless a')
     console.error('more recent version is used at runtime, third party packages won\'t be instrumented.')
   }

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -4,7 +4,7 @@ const types = require('./types')
 const { addHook, channel } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
-const nodeMajor = parseInt(process.versions.node.split('.')[0])
+const { NODE_MAJOR } = require('../../../../version')
 
 const patched = new WeakSet()
 const instances = new WeakMap()
@@ -236,7 +236,7 @@ function patch (grpc) {
   return grpc
 }
 
-if (nodeMajor <= 14) {
+if (NODE_MAJOR <= 14) {
   addHook({ name: 'grpc', versions: ['>=1.24.3'] }, patch)
 
   addHook({ name: 'grpc', versions: ['>=1.24.3'], file: 'src/client.js' }, client => {

--- a/packages/datadog-instrumentations/src/grpc/server.js
+++ b/packages/datadog-instrumentations/src/grpc/server.js
@@ -4,7 +4,7 @@ const types = require('./types')
 const { channel, addHook } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
-const nodeMajor = parseInt(process.versions.node.split('.')[0])
+const { NODE_MAJOR } = require('../../../../version')
 
 const startChannel = channel('apm:grpc:server:request:start')
 const asyncStartChannel = channel('apm:grpc:server:request:asyncStart')
@@ -150,7 +150,7 @@ function isEmitter (obj) {
   return typeof obj.emit === 'function' && typeof obj.once === 'function'
 }
 
-if (nodeMajor <= 14) {
+if (NODE_MAJOR <= 14) {
   addHook({ name: 'grpc', versions: ['>=1.24.3'], file: 'src/server.js' }, server => {
     shimmer.wrap(server.Server.prototype, 'register', wrapRegister)
 

--- a/packages/datadog-instrumentations/src/paperplane.js
+++ b/packages/datadog-instrumentations/src/paperplane.js
@@ -7,9 +7,9 @@ const logChannel = channel('apm:paperplane:log')
 const handleChannel = channel('apm:paperplane:request:handle')
 const routeChannel = channel('apm:paperplane:request:route')
 
-const nodeMajor = Number(process.versions.node.split('.')[0])
+const { NODE_MAJOR } = require('../../../version')
 const name = 'paperplane'
-const versions = nodeMajor <= 12 ? ['>=2.3.2'] : nodeMajor <= 14 ? ['>=3.1.1'] : []
+const versions = NODE_MAJOR <= 12 ? ['>=2.3.2'] : NODE_MAJOR <= 14 ? ['>=3.1.1'] : []
 
 const wrapRoute = handler => req => {
   const { original, route } = req
@@ -67,7 +67,7 @@ addHook({ name, versions, file: 'lib/routes.js' }, exports => {
   return exports
 })
 
-if (nodeMajor <= 12) {
+if (NODE_MAJOR <= 12) {
   addHook({ name, versions: ['2.3.0 - 2.3.1'] }, paperplane => {
     shimmer.wrap(paperplane, 'mount', wrapMount)
     shimmer.wrap(paperplane, 'routes', wrapRoutes)

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -7,9 +7,8 @@ const getService = require('./service')
 const loader = require('../../../versions/@grpc/proto-loader').get()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 
-const { DD_MAJOR } = require('../../../version')
-const nodeMajor = parseInt(process.versions.node.split('.')[0])
-const pkgs = nodeMajor > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
+const { DD_MAJOR, NODE_MAJOR } = require('../../../version')
+const pkgs = NODE_MAJOR > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
 describe('Plugin', () => {
   let grpc

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -5,11 +5,9 @@ const getPort = require('get-port')
 const Readable = require('stream').Readable
 
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { DD_MAJOR, NODE_MAJOR } = require('../../../version')
 
-const nodeMajor = parseInt(process.versions.node.split('.')[0])
-const pkgs = nodeMajor > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
-
-const { DD_MAJOR } = require('../../../version')
+const pkgs = NODE_MAJOR > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
 describe('Plugin', () => {
   let grpc

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -5,8 +5,9 @@ const getPort = require('get-port')
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { NODE_MAJOR } = require('../../../version')
 
-const versionRange = parseInt(process.versions.node.split('.')[0]) > 14
+const versionRange = NODE_MAJOR > 14
   ? '<17 || >18'
   : ''
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -10,12 +10,11 @@ const { storage } = require('../../datadog-core')
 const key = fs.readFileSync(path.join(__dirname, './ssl/test.key'))
 const cert = fs.readFileSync(path.join(__dirname, './ssl/test.crt'))
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { DD_MAJOR } = require('../../../version')
+const { DD_MAJOR, NODE_MAJOR } = require('../../../version')
 const { rawExpectedSchema } = require('./naming')
 
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
-const NODE_MAJOR = parseInt(process.versions.node.split('.')[0])
 const SERVICE_NAME = DD_MAJOR < 3 ? 'test-http-client' : 'test'
 
 describe('Plugin', () => {

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -4,7 +4,7 @@ const request = require('../common/request')
 const { startupLog } = require('../../startup-log')
 const metrics = require('../../metrics')
 const log = require('../../log')
-const tracerVersion = require('../../../../../package.json').version
+const { DD_FULL, NODE_FULL } = require('../../../../../version')
 const BaseWriter = require('../common/writer')
 
 const METRIC_PREFIX = 'datadog.tracer.node.exporter.agent'
@@ -82,7 +82,7 @@ function makeRequest (version, data, count, url, headers, lookup, needsStartupLo
     headers: {
       ...headers,
       'Content-Type': 'application/msgpack',
-      'Datadog-Meta-Tracer-Version': tracerVersion,
+      'Datadog-Meta-Tracer-Version': DD_FULL,
       'X-Datadog-Trace-Count': String(count)
     },
     lookup,
@@ -90,7 +90,7 @@ function makeRequest (version, data, count, url, headers, lookup, needsStartupLo
   }
 
   setHeader(options.headers, 'Datadog-Meta-Lang', 'nodejs')
-  setHeader(options.headers, 'Datadog-Meta-Lang-Version', process.version)
+  setHeader(options.headers, 'Datadog-Meta-Lang-Version', `v${NODE_FULL}`)
   setHeader(options.headers, 'Datadog-Meta-Lang-Interpreter', process.jsEngine || 'v8')
 
   log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)

--- a/packages/dd-trace/src/plugins/util/env.js
+++ b/packages/dd-trace/src/plugins/util/env.js
@@ -1,5 +1,7 @@
 const os = require('os')
 
+const { NODE_FULL } = require('../../../../../version')
+
 const OS_PLATFORM = 'os.platform'
 const OS_VERSION = 'os.version'
 const OS_ARCHITECTURE = 'os.architecture'
@@ -8,7 +10,7 @@ const RUNTIME_VERSION = 'runtime.version'
 
 function getRuntimeAndOSMetadata () {
   return {
-    [RUNTIME_VERSION]: process.version,
+    [RUNTIME_VERSION]: `v${NODE_FULL}`,
     [OS_ARCHITECTURE]: process.arch,
     [OS_PLATFORM]: process.platform,
     [RUNTIME_NAME]: 'node',

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -8,7 +8,7 @@ const { request: httpsRequest } = require('https')
 const docker = require('../../exporters/common/docker')
 const FormData = require('../../exporters/common/form-data')
 const { storage } = require('../../../../datadog-core')
-const version = require('../../../../../package.json').version
+const { DD_FULL, NODE_FULL } = require('../../../../../version')
 
 const containerId = docker.id()
 
@@ -68,14 +68,14 @@ class AgentExporter {
       ['recording-end', end.toISOString()],
       ['language', 'javascript'],
       ['runtime', 'nodejs'],
-      ['runtime_version', process.version],
-      ['profiler_version', version],
+      ['runtime_version', `v${NODE_FULL}`],
+      ['profiler_version', DD_FULL],
       ['format', 'pprof'],
 
       ['tags[]', 'language:javascript'],
       ['tags[]', 'runtime:nodejs'],
-      ['tags[]', `runtime_version:${process.version}`],
-      ['tags[]', `profiler_version:${version}`],
+      ['tags[]', `runtime_version:v${NODE_FULL}`],
+      ['tags[]', `profiler_version:${DD_FULL}`],
       ['tags[]', 'format:pprof'],
       ...Object.entries(tags).map(([key, value]) => ['tags[]', `${key}:${value}`])
     ]

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -4,7 +4,7 @@ const { info, warn } = require('./log/writer')
 
 const os = require('os')
 const { inspect } = require('util')
-const tracerVersion = require('../../../package.json').version
+const { DD_FULL, NODE_FULL } = require('../../../version')
 
 let config
 let pluginManager
@@ -51,9 +51,9 @@ function startupLog ({ agentError } = {}) {
   out.os_name = os.type()
   out.os_version = os.release()
   out.architecture = os.arch()
-  out.version = tracerVersion
+  out.version = DD_FULL
   out.lang = 'nodejs'
-  out.lang_version = process.versions.node
+  out.lang_version = NODE_FULL
   out.env = config.env
   out.enabled = config.enabled
   out.service = config.service

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -1,10 +1,11 @@
 'use strict'
 
-const tracerVersion = require('../../../../package.json').version
 const dc = require('../../../diagnostics_channel')
 const os = require('os')
 const dependencies = require('./dependencies')
 const { sendData } = require('./send-data')
+
+const { DD_FULL, NODE_FULL } = require('../../../../version')
 
 const { manager: metricsManager } = require('./metrics')
 
@@ -71,9 +72,9 @@ function createAppObject (config) {
     service_name: config.service,
     env: config.env,
     service_version: config.version,
-    tracer_version: tracerVersion,
+    tracer_version: DD_FULL,
     language_name: 'nodejs',
-    language_version: process.versions.node
+    language_version: NODE_FULL
   }
 }
 

--- a/packages/dd-trace/src/telemetry/metrics.js
+++ b/packages/dd-trace/src/telemetry/metrics.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { version } = require('../../../../package.json')
+const { DD_FULL, NODE_FULL } = require('../../../../version')
 
 const { sendData } = require('./send-data')
 
@@ -36,9 +36,9 @@ class Metric {
     this.tags = tagArray(tags)
     if (common) {
       this.tags.push('lib_language:nodejs')
-      this.tags.push(`version:${process.version}`)
+      this.tags.push(`version:${NODE_FULL}`)
     } else {
-      this.tags.push(`lib_version:${version}`)
+      this.tags.push(`lib_version:${DD_FULL}`)
     }
     this.common = common
 

--- a/packages/diagnostics_channel/src/index.js
+++ b/packages/diagnostics_channel/src/index.js
@@ -5,7 +5,8 @@ const {
   channel
 } = require('diagnostics_channel') // eslint-disable-line n/no-restricted-require
 
-const [major, minor] = process.versions.node.split('.')
+const { NODE_MAJOR, NODE_MINOR } = require('../../../version')
+
 const channels = new WeakSet()
 
 // Our own DC with a limited subset of functionality stable across Node versions.
@@ -15,7 +16,7 @@ const dc = { channel }
 
 // Prevent going to 0 subscribers to avoid bug in Node.
 // See https://github.com/nodejs/node/pull/47520
-if (major === '19' && minor === '9') {
+if (NODE_MAJOR === '19' && NODE_MINOR === '9') {
   dc.channel = function () {
     const ch = channel.apply(this, arguments)
 

--- a/version.js
+++ b/version.js
@@ -1,13 +1,17 @@
 'use strict'
 
-const ddMatches = require('./package.json').version.match(/^(\d+)\.(\d+)\.(\d+)/)
-const nodeMatches = process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/)
+const ddVersion = require('./package.json').version
+const ddMatches = ddVersion.match(/^(\d+)\.(\d+)\.(\d+)/)
+const nodeVersion = process.versions.node
+const nodeMatches = nodeVersion.match(/^(\d+)\.(\d+)\.(\d+)/)
 
 module.exports = {
   DD_MAJOR: parseInt(ddMatches[1]),
   DD_MINOR: parseInt(ddMatches[2]),
   DD_PATCH: parseInt(ddMatches[3]),
+  DD_FULL: ddVersion,
   NODE_MAJOR: parseInt(nodeMatches[1]),
   NODE_MINOR: parseInt(nodeMatches[2]),
-  NODE_PATCH: parseInt(nodeMatches[3])
+  NODE_PATCH: parseInt(nodeMatches[3]),
+  NODE_FULL: nodeVersion
 }


### PR DESCRIPTION
### What does this PR do?
- start using version.js everywhere

### Motivation
- DRY the code

### TODO
- wrap up the remaining non-semver uses
- require semver, export functions to do semver lookups
- linter rule to complain about accessing process.version, process.versions