### PR TITLE
Fix socketPath for Named Pipe UDS cases

### DIFF
--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -47,10 +47,11 @@ function fromUrlString (urlString) {
   ? urlToOptions(new URL(urlString))
   : urlParse(urlString)
 
-  // Add the leading characters back if we're using named pipes
-  if (url.protocol === 'unix:' && !urlString.endsWith('.sock')) {
-    url.path = '//.' + url.path
-    url.pathname = '//.' + url.pathname
+  // Add the 'hostname' back if we're using UDS
+  if (url.protocol === 'unix:') {
+    const udsPath = urlString.replace(/^unix:/, '')
+    url.path = udsPath
+    url.pathname = udsPath
   }
 
   return url

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -57,7 +57,7 @@ function request (data, options, callback) {
     const url = typeof options.url === 'object' ? urlToOptions(options.url) : fromUrlString(options.url)
     if (url.protocol === 'unix:') {
       if (typeof options.url === 'string') {
-        options.socketPath = options.url.replace(/^unix:/, '');
+        options.socketPath = options.url.replace(/^unix:/, '')
       } else {
         options.socketPath = url.pathname
       }

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -48,7 +48,7 @@ function fromUrlString (urlString) {
     : urlParse(urlString)
 
   // Add the 'hostname' back if we're using named pipes
-  if (url.protocol === 'unix:' && url.host == '.') {
+  if (url.protocol === 'unix:' && url.host === '.') {
     const udsPath = urlString.replace(/^unix:/, '')
     url.path = udsPath
     url.pathname = udsPath

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -44,11 +44,11 @@ function urlToOptions (url) {
 
 function fromUrlString (urlString) {
   const url = typeof urlToHttpOptions === 'function'
-  ? urlToOptions(new URL(urlString))
-  : urlParse(urlString)
+    ? urlToOptions(new URL(urlString))
+    : urlParse(urlString)
 
-  // Add the 'hostname' back if we're using UDS
-  if (url.protocol === 'unix:') {
+  // Add the 'hostname' back if we're using named pipes
+  if (url.protocol === 'unix:' && url.host == '.') {
     const udsPath = urlString.replace(/^unix:/, '')
     url.path = udsPath
     url.pathname = udsPath

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -56,7 +56,11 @@ function request (data, options, callback) {
   if (options.url) {
     const url = typeof options.url === 'object' ? urlToOptions(options.url) : fromUrlString(options.url)
     if (url.protocol === 'unix:') {
-      options.socketPath = url.pathname
+      if (typeof options.url === 'string') {
+        options.socketPath = options.url.replace(/^unix:/, '');
+      } else {
+        options.socketPath = url.pathname
+      }
     } else {
       if (!options.path) options.path = url.path
       options.protocol = url.protocol

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -278,6 +278,34 @@ describe('request', function () {
       })
   })
 
+  it('should parse unix domain sockets properly', (done) => {
+    const sock = '/tmp/unix_socket'
+  
+    request(
+      Buffer.from(''), {
+        url: 'unix:' + sock,
+        method: 'PUT'
+      },
+      (err, _) => {
+        expect(err.address).to.equal(sock)
+        done()
+      })
+  })
+
+  it('should parse windows named pipes properly', (done) => {
+    const pipe = '//./pipe/datadogtrace'
+  
+    request(
+      Buffer.from(''), {
+        url: 'unix:' + pipe,
+        method: 'PUT'
+      },
+      (err, _) => {
+        expect(err.address).to.equal(pipe)
+        done()
+      })
+  })
+
   describe('when intercepting http', () => {
     const sandbox = sinon.createSandbox()
 

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -280,7 +280,7 @@ describe('request', function () {
 
   it('should parse unix domain sockets properly', (done) => {
     const sock = '/tmp/unix_socket'
-  
+
     request(
       Buffer.from(''), {
         url: 'unix:' + sock,
@@ -294,7 +294,7 @@ describe('request', function () {
 
   it('should parse windows named pipes properly', (done) => {
     const pipe = '//./pipe/datadogtrace'
-  
+
     request(
       Buffer.from(''), {
         url: 'unix:' + pipe,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes how `options.socketPath` is parsed in cases where a UDS url comes in as a string. Currently, the behavior is the first case below. We want the second case where we keep the leading `//.`

```
> fromUrlString('unix://./pipe/datadogtrace').pathname
'/pipe/datadogtrace'

> fromUrlString('unix://./pipe/datadogtrace').pathname
'//./pipe/datadogtrace'
```

### Motivation
<!-- What inspired you to submit this pull request? -->
I was able to get runtime metrics working via the DogstatsD Http Proxy when using ports, but wasn’t able to get it running over pipes at first.

I pulled out the `options` going into `http.request` for the trace requests and the unsuccessful metrics requests:
* `socketPath: /pipe/datadogtrace`  bad metrics path
* `socketPath: \\\\.\\pipe\\datadogtrace`  good trace path (`//./pipe/datadogtrace` also works)

When I hardcoded this path, it ended up working!
 
This looks like it’s the case where `options.url` is a `string` and `fromUrlString()` is “incorrectly” parsing it, removing the leading `//.` Also happens when casting it with `new URL(url)`.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
