### PR TITLE
esm now should be supported for node 20, so no need for esmTestSkipper

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -17,7 +17,6 @@ const path = require('path')
 const rimraf = promisify(require('rimraf'))
 const id = require('../packages/dd-trace/src/id')
 const upload = require('multer')()
-const version = require('../version.js')
 
 const hookFile = 'dd-trace/loader-hook.mjs'
 
@@ -269,13 +268,6 @@ function checkSpansForServiceName (spans, name) {
   return spans.some((span) => span.some((nestedSpan) => nestedSpan.name === name))
 }
 
-// TODO: add ESM support for Node 20 in import-in-the-middle
-function esmTestSkipper () {
-  return version.NODE_MAJOR >= 20
-    ? global.describe.skip
-    : global.describe
-}
-
 async function spawnPluginIntegrationTestProc (cwd, serverFile, agentPort, stdioHandler, additionalEnvArgs = {}) {
   let env = {
     NODE_OPTIONS: `--loader=${hookFile}`,
@@ -298,6 +290,5 @@ module.exports = {
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig,
   checkSpansForServiceName,
-  esmTestSkipper,
   spawnPluginIntegrationTestProc
 }

--- a/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-axios/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-axios/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-axios/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-axios/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -3,12 +3,9 @@
 const {
   FakeAgent,
   createSandbox,
-  spawnPluginIntegrationTestProc,
-  esmTestSkipper
+  spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { expect } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -5,7 +5,6 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -5,12 +5,10 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-dns/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-dns/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-dns/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-dns/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   curlAndAssertMessage,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   curlAndAssertMessage,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -5,7 +5,6 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -5,12 +5,10 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-fetch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fetch/test/integration-test/client.spec.js
@@ -3,12 +3,12 @@
 const {
   FakeAgent,
   createSandbox,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
 
-const describe = globalThis.fetch ? esmTestSkipper() : globalThis.describe.skip
+const describe = globalThis.fetch ? globalThis.describe : globalThis.describe.skip
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-fetch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fetch/test/integration-test/client.spec.js
@@ -3,7 +3,6 @@
 const {
   FakeAgent,
   createSandbox,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-http/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   curlAndAssertMessage,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-http/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   curlAndAssertMessage,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-http2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/integration-test/client.spec.js
@@ -3,13 +3,11 @@
 const {
   FakeAgent,
   createSandbox,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
 const http2 = require('http2')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-http2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/integration-test/client.spec.js
@@ -3,7 +3,6 @@
 const {
   FakeAgent,
   createSandbox,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-koa/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-koa/test/integration-test/client.spec.js
@@ -5,7 +5,6 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-koa/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-koa/test/integration-test/client.spec.js
@@ -5,12 +5,10 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -5,7 +5,6 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -5,12 +5,10 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-net/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-net/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-net/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-net/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-openai/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-openai/test/integration-test/server.mjs
@@ -1,5 +1,5 @@
 import 'dd-trace/init.js'
-import { Configuration, OpenAIApi } from 'openai'
+import openai from 'openai'
 import nock from 'nock'
 
 nock('https://api.openai.com:443')
@@ -22,11 +22,11 @@ nock('https://api.openai.com:443')
     'x-request-id', '7df89d8afe7bf24dc04e2c4dd4962d7f'
   ])
 
-const openai = new OpenAIApi(new Configuration({
+const openaiApp = new openai.OpenAIApi(new openai.Configuration({
   apiKey: 'sk-DATADOG-ACCEPTANCE-TESTS',
 }))
 
-await openai.createCompletion({
+await openaiApp.createCompletion({
   model: 'text-davinci-002',
   prompt: 'Hello, ',
   suffix: 'foo',

--- a/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -3,12 +3,10 @@
 const {
   FakeAgent,
   createSandbox,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { expect } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -3,7 +3,6 @@
 const {
   FakeAgent,
   createSandbox,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { expect } = require('chai')

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -5,7 +5,6 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -5,12 +5,10 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-router/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-router/test/integration-test/client.spec.js
@@ -5,7 +5,6 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-router/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-router/test/integration-test/client.spec.js
@@ -5,12 +5,10 @@ const {
   createSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -4,7 +4,6 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -7,6 +7,12 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const version = require('../../../../version.js')
+
+// tedious does not support node 20
+const describe = version.NODE_MAJOR >= 20
+  ? global.describe.skip
+  : global.describe
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -4,12 +4,10 @@ const {
   FakeAgent,
   createSandbox,
   checkSpansForServiceName,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -3,12 +3,10 @@
 const {
   FakeAgent,
   createSandbox,
-  esmTestSkipper,
+
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { expect } = require('chai')
-
-const describe = esmTestSkipper()
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -3,7 +3,6 @@
 const {
   FakeAgent,
   createSandbox,
-
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { expect } = require('chai')


### PR DESCRIPTION
### What does this PR do?
removes esmTestSkipper from esm integration tests

### Motivation
esm now should be supported for node 20, so no need for esmTestSkipper

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
