### PR TITLE
Fix vulnerability evidence redaction with empty sensitive ranges

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
@@ -76,7 +76,18 @@ class SensitiveHandler {
         while (nextSensitive != null && contains(nextTainted, nextSensitive)) {
           const redactionStart = nextSensitive.start - nextTainted.start
           const redactionEnd = nextSensitive.end - nextTainted.start
-          this.redactSource(sources, redactedSources, redactedSourcesContext, sourceIndex, redactionStart, redactionEnd)
+          if (redactionStart === redactionEnd) {
+            this.writeRedactedValuePart(valueParts, 0)
+          } else {
+            this.redactSource(
+              sources,
+              redactedSources,
+              redactedSourcesContext,
+              sourceIndex,
+              redactionStart,
+              redactionEnd
+            )
+          }
           nextSensitive = sensitive.shift()
         }
 

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
@@ -2679,6 +2679,60 @@
           }
         ]
       }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "SQLi exploited",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "SELECT * FROM Users WHERE email = '' OR TRUE --' AND password = '81dc9bdb52d04dc20036dbd8313ed055' AND deletedAt IS NULL",
+            "ranges": [
+              {
+                "start": 35,
+                "end": 47,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "email",
+                  "parameterValue": "' OR TRUE --"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "email",
+            "value": "' OR TRUE --"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "SELECT * FROM Users WHERE email = '"
+                },
+                {
+                  "redacted": true
+                },
+                {
+                  "source": 0,
+                  "value": "' OR TRUE --"
+                },
+                {
+                  "redacted": true
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?
Fixes issues with empty sensitive ranges that can be part of SQL queries (for instance empty string literals).

`SELECT * FROM Users WHERE email = '' OR TRUE --' AND password = 'password'`

### Motivation
Before the fix, evidence included empty and redacted value parts related to a source, which caused the source to be redacted when it shouldn't be.

### Plugin Checklist
- [x] Unit tests.