### PR TITLE
Protect HttpClientPlugin.error method from undefined spans

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -98,6 +98,8 @@ class HttpClientPlugin extends ClientPlugin {
   }
 
   error ({ span, error }) {
+    if (!span) return
+
     if (error) {
       span.addTags({
         [ERROR_TYPE]: error.name,


### PR DESCRIPTION
### What does this PR do?
Check if span is `undefined` in `HttpClientPlugin.error` before using it.

### Motivation
I see app crashes after socket timeouts:

```
dd-trace-js/packages/datadog-plugin-http/src/client.js:102
      span.addTags({
           ^

TypeError: Cannot read properties of undefined (reading 'addTags')
    at HttpClientPlugin.error (dd-trace-js/packages/datadog-plugin-http/src/client.js:102:12)
    at dd-trace-js/packages/dd-trace/src/plugins/tracing.js:73:22
    at Subscription._handler (dd-trace-js/packages/dd-trace/src/plugins/plugin.js:14:9)
    at Channel.publish (node:diagnostics_channel:54:9)
    at ClientRequest.req.emit (dd-trace-js/packages/datadog-instrumentations/src/http/client.js:91:30)
    at Socket.socketCloseListener (node:_http_client:420:11)
    at Socket.emit (node:events:402:35)
    at Socket.emit (dd-trace-js/packages/datadog-instrumentations/src/net.js:61:25)
    at TCP.<anonymous> (node:net:687:12)
    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)   
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
