### PR TITLE
core: emit warning on v2.x branch

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -21,6 +21,9 @@ class Tracer extends NoopProxy {
   init (options) {
     if (this._initialized) return this
 
+    process.emitWarning('The dd-trace@v2.x release line reached end of life on ' +
+      '2023-08-15 and will no longer receive updates. Please upgrade.')
+
     this._initialized = true
 
     try {


### PR DESCRIPTION
### What does this PR do?
- emits a warning about using the v2.x release
- don't land until August 15th
- PR made directly against v2.x since it should never land anywhere else

### Motivation
- v2.x will be EOL soon