### PR TITLE
[ci-visibility] Fix jest parameters being modified

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -105,7 +105,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         await super.handleTestEvent(event, state)
       }
 
-      const setNameToParams = (name, params) => { this.nameToParams[name] = params }
+      const setNameToParams = (name, params) => { this.nameToParams[name] = [...params] }
 
       if (event.name === 'setup') {
         if (this.global.test) {

--- a/packages/datadog-plugin-jest/test/jest-test.js
+++ b/packages/datadog-plugin-jest/test/jest-test.js
@@ -42,8 +42,12 @@ describe('jest-test-suite', () => {
   // only run for jest-circus tests
   // eslint-disable-next-line
   if (jest.retryTimes) {
-    it.each([[1, 2, 3], [2, 3, 5]])('can do parameterized test', (a, b, expected) => {
+    const parameters = [[1, 2, 3], [2, 3, 5]]
+    it.each(parameters)('can do parameterized test', (a, b, expected) => {
       expect(a + b).toEqual(expected)
+      // They are not modified by dd-trace reading the parameters
+      expect(parameters[0]).toEqual([1, 2, 3])
+      expect(parameters[1]).toEqual([2, 3, 5])
     })
   }
   it('promise passes', () => {


### PR DESCRIPTION
### What does this PR do?
We were calling `.shift()` on the parameter input to `test.each`. This was causing undesired mutations on the array. 
Now we create a copy of the parameter array so we can `.shift` safely. 

### Motivation
Fixes #3504

### Plugin Checklist

- [x] Unit tests.
