### PR TITLE
Fix `Writer` flush error in `core` benchmark

### DIFF
--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -11,7 +11,7 @@ const Writer = proxyquire('../packages/dd-trace/src/exporters/agent/writer', {
   './request': () => Promise.resolve(),
   '../../encode/0.4': {
     AgentEncoder: function () {
-      return { 
+      return {
         encode () {},
         count () {}
       }

--- a/benchmark/core.js
+++ b/benchmark/core.js
@@ -11,7 +11,10 @@ const Writer = proxyquire('../packages/dd-trace/src/exporters/agent/writer', {
   './request': () => Promise.resolve(),
   '../../encode/0.4': {
     AgentEncoder: function () {
-      return { encode () {} }
+      return { 
+        encode () {},
+        count () {}
+      }
     }
   }
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add stubbed count function to mocked `AgentEncoder` to fix error when flushing `Writer` in core benchmark.

### Motivation
<!-- What inspired you to submit this pull request? -->

When trying to run the benchmarks, the following error would occur:
```
yarn bench
yarn run v1.22.19
$ node benchmark

=== core ===

DatadogTracer#startSpan x 2,882,289 ops/sec ±1.85% (5 runs sampled)
TextMapPropagator#inject x 337,006 ops/sec ±0.98% (5 runs sampled)
TextMapPropagator#extract x 1,386,504 ops/sec ±1.77% (5 runs sampled)
Writer#append x 130,979,968 ops/sec ±1.14% (5 runs sampled)
Sampler#isSampled x 95,301,885 ops/sec ±0.44% (5 runs sampled)
format x 912,952 ops/sec ±31.20% (5 runs sampled)
encode (0.4) x 934,657 ops/sec ±1.29% (5 runs sampled)
encode (0.5) x 2,904,707 ops/sec ±3.48% (5 runs sampled)
id x 45,633,102 ops/sec ±1.10% (5 runs sampled)
Histogram x 27,250,730 ops/sec ±0.88% (5 runs sampled)
metrics#boolean x 68,151,576 ops/sec ±0.34% (5 runs sampled)
metrics#histogram x 91,917,818 ops/sec ±0.20% (5 runs sampled)
metrics#gauge x 92,089,148 ops/sec ±0.29% (5 runs sampled)
metrics#increment x 150,998,832 ops/sec ±0.27% (5 runs sampled)
metrics#increment (monotonic) x 149,878,956 ops/sec ±0.66% (5 runs sampled)
metrics#decrement x 154,871,306 ops/sec ±2.27% (5 runs sampled)
log (debug) x 16,195,709 ops/sec ±1.29% (5 runs sampled)
log (error) x 187,289 ops/sec ±16.58% (5 runs sampled)
log (none) x 1,030,367,025 ops/sec ±0.94% (5 runs sampled)
/dd-trace-js/packages/dd-trace/src/exporters/common/writer.js:13
    const count = this._encoder.count()
                                ^

TypeError: this._encoder.count is not a function
    at Writer.flush (/dd-trace-js/packages/dd-trace/src/exporters/common/writer.js:13:33)
    at process.<anonymous> (/dd-trace-js/packages/dd-trace/src/exporters/agent/index.js:31:51)
    at Object.onceWrapper (node:events:628:26)
    at process.emit (node:events:513:28)
    at process.callbackTrampoline (node:internal/async_hooks:130:17)
node:child_process:935
    throw err;
    ^

Error: Command failed: node benchmark/core
    at checkExecSyncError (node:child_process:861:11)
    at execSync (node:child_process:932:15)
    at exec (/dd-trace-js/benchmark/index.js:4:21)
    at Object.<anonymous> (/dd-trace-js/benchmark/index.js:6:1)
    at Module._compile (node:internal/modules/cjs/loader:1191:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1245:10)
    at Module.load (node:internal/modules/cjs/loader:1069:32)
    at Function.Module._load (node:internal/modules/cjs/loader:904:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 1701,
  stdout: null,
  stderr: null
}
```
