### PR TITLE
v2.46.0

### DIFF
--- a/integration-tests/esbuild.spec.js
+++ b/integration-tests/esbuild.spec.js
@@ -32,4 +32,24 @@ describe('esbuild', () => {
       process.chdir(CWD)
     }
   })
+
+  it('does not bundle modules listed in .external', () => {
+    // eslint-disable-next-line no-console
+    console.log(`cd ${TEST_DIR}`)
+    process.chdir(TEST_DIR)
+
+    try {
+      // eslint-disable-next-line no-console
+      console.log('node ./build-and-test-skip-external.js')
+      chproc.execSync('node ./build-and-test-skip-external.js', {
+        timeout: 1000 * 30
+      })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err)
+      process.exit(1)
+    } finally {
+      process.chdir(CWD)
+    }
+  })
 })

--- a/integration-tests/esbuild/.gitignore
+++ b/integration-tests/esbuild/.gitignore
@@ -1,1 +1,1 @@
-out.js
+*out.js

--- a/integration-tests/esbuild/build-and-test-skip-external.js
+++ b/integration-tests/esbuild/build-and-test-skip-external.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const assert = require('assert')
+
+const ddPlugin = require('../../esbuild') // dd-trace/esbuild
+const esbuild = require('esbuild')
+
+esbuild.build({
+  entryPoints: ['skip-external.js'],
+  bundle: true,
+  outfile: 'skip-external-out.js',
+  plugins: [ddPlugin],
+  platform: 'node',
+  target: ['node16'],
+  external: [
+    'knex'
+  ]
+}).then(() => {
+  const output = fs.readFileSync('./skip-external-out.js').toString()
+  // Note that esbuild converts 'foo' into "foo"
+  assert(output.includes('require("knex")'), 'bundle should contain a require call to non-bundled knex')
+  assert(!output.includes('require("axios")'), 'bundle should not contain a require call to bundled axios')
+  console.log('ok') // eslint-disable-line no-console
+  fs.unlinkSync('./skip-external-out.js')
+}).catch((err) => {
+  console.error(err) // eslint-disable-line no-console
+  process.exit(1)
+})

--- a/integration-tests/esbuild/package.json
+++ b/integration-tests/esbuild/package.json
@@ -18,6 +18,7 @@
   "author": "Thomas Hunter II <tlhunter@datadog.com>",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.21.2",
     "esbuild": "0.16.12",
     "express": "^4.16.2",
     "knex": "^2.4.2"

--- a/integration-tests/esbuild/skip-external.js
+++ b/integration-tests/esbuild/skip-external.js
@@ -1,0 +1,7 @@
+require('../../').init() // dd-trace
+
+// this should be bundled
+require('axios')
+
+// this is in the external list and should not be bundled
+require('knex')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "2.45.1",
+  "version": "2.46.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -105,7 +105,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         await super.handleTestEvent(event, state)
       }
 
-      const setNameToParams = (name, params) => { this.nameToParams[name] = params }
+      const setNameToParams = (name, params) => { this.nameToParams[name] = [...params] }
 
       if (event.name === 'setup') {
         if (this.global.test) {

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -30,6 +30,8 @@ const testSuiteFinishCh = channel('ci:mocha:test-suite:finish')
 const testSuiteErrorCh = channel('ci:mocha:test-suite:error')
 const testSuiteCodeCoverageCh = channel('ci:mocha:test-suite:code-coverage')
 
+const itrSkippedSuitesCh = channel('ci:mocha:itr:skipped-suites')
+
 // TODO: remove when root hooks and fixtures are implemented
 const patched = new WeakSet()
 
@@ -47,6 +49,7 @@ const originalCoverageMap = createCoverageMap()
 let suitesToSkip = []
 let frameworkVersion
 let isSuitesSkipped = false
+let skippedSuites = []
 
 function getSuitesByTestFile (root) {
   const suitesByTestFile = {}
@@ -97,10 +100,17 @@ function getTestAsyncResource (test) {
   return testToAr.get(originalFn)
 }
 
-function getSuitesToRun (originalSuites) {
-  return originalSuites.filter(suite =>
-    !suitesToSkip.includes(getTestSuitePath(suite.file, process.cwd()))
-  )
+function getFilteredSuites (originalSuites) {
+  return originalSuites.reduce((acc, suite) => {
+    const testPath = getTestSuitePath(suite.file, process.cwd())
+    const shouldSkip = suitesToSkip.includes(testPath)
+    if (shouldSkip) {
+      acc.skippedSuites.add(testPath)
+    } else {
+      acc.suitesToRun.push(suite)
+    }
+    return acc
+  }, { suitesToRun: [], skippedSuites: new Set() })
 }
 
 function mochaHook (Runner) {
@@ -137,13 +147,21 @@ function mochaHook (Runner) {
         global.__coverage__ = fromCoverageMapToCoverage(originalCoverageMap)
       }
 
-      testSessionFinishCh.publish({ status, isSuitesSkipped, testCodeCoverageLinesTotal })
+      testSessionFinishCh.publish({
+        status,
+        isSuitesSkipped,
+        testCodeCoverageLinesTotal,
+        numSkippedSuites: skippedSuites.length
+      })
     }))
 
     this.once('start', testRunAsyncResource.bind(function () {
       const processArgv = process.argv.slice(2).join(' ')
       const command = `mocha ${processArgv}`
       testSessionStartCh.publish({ command, frameworkVersion })
+      if (skippedSuites.length) {
+        itrSkippedSuitesCh.publish({ skippedSuites, frameworkVersion })
+      }
     }))
 
     this.on('suite', function (suite) {
@@ -359,9 +377,13 @@ addHook({
         suitesToSkip = skippableSuites
       }
       // We remove the suites that we skip through ITR
-      const newSuites = getSuitesToRun(runner.suite.suites)
-      isSuitesSkipped = newSuites.length !== runner.suite.suites.length
-      runner.suite.suites = newSuites
+      const filteredSuites = getFilteredSuites(runner.suite.suites)
+      const { suitesToRun } = filteredSuites
+
+      isSuitesSkipped = suitesToRun.length !== runner.suite.suites.length
+      runner.suite.suites = suitesToRun
+
+      skippedSuites = Array.from(filteredSuites.skippedSuites)
 
       global.run()
     }

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -25,12 +25,24 @@ class CucumberPlugin extends CiPlugin {
 
     this.sourceRoot = process.cwd()
 
-    this.addSub('ci:cucumber:session:finish', ({ status, isSuitesSkipped, testCodeCoverageLinesTotal }) => {
+    this.addSub('ci:cucumber:session:finish', ({
+      status,
+      isSuitesSkipped,
+      numSkippedSuites,
+      testCodeCoverageLinesTotal
+    }) => {
       const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig || {}
       addIntelligentTestRunnerSpanTags(
         this.testSessionSpan,
         this.testModuleSpan,
-        { isSuitesSkipped, isSuitesSkippingEnabled, isCodeCoverageEnabled, testCodeCoverageLinesTotal }
+        {
+          isSuitesSkipped,
+          isSuitesSkippingEnabled,
+          isCodeCoverageEnabled,
+          testCodeCoverageLinesTotal,
+          skippingCount: numSkippedSuites,
+          skippingType: 'suite'
+        }
       )
 
       this.testSessionSpan.setTag(TEST_STATUS, status)

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -20,7 +20,8 @@ const {
   finishAllTraceSpans,
   getCoveredFilenamesFromCoverage,
   getTestSuitePath,
-  addIntelligentTestRunnerSpanTags
+  addIntelligentTestRunnerSpanTags,
+  TEST_SKIPPED_BY_ITR
 } = require('../../dd-trace/src/plugins/util/test')
 const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
 const log = require('../../dd-trace/src/log')
@@ -120,6 +121,7 @@ function getSkippableTests (isSuitesSkippingEnabled, tracer, testConfiguration) 
 
 module.exports = (on, config) => {
   let isTestsSkipped = false
+  const skippedTests = []
   const tracer = require('../../dd-trace')
   const testEnvironmentMetadata = getTestEnvironmentMetadata(TEST_FRAMEWORK_NAME)
 
@@ -248,19 +250,23 @@ module.exports = (on, config) => {
     const cypressTests = tests || []
     const finishedTests = finishedTestsByFile[spec.relative] || []
 
-    // Get tests that didn't go through `dd:afterEach` and haven't been skipped by ITR
+    // Get tests that didn't go through `dd:afterEach`
     // and create a skipped test span for each of them
     cypressTests.filter(({ title }) => {
+      const cypressTestName = title.join(' ')
+      const isTestFinished = finishedTests.find(({ testName }) => cypressTestName === testName)
+
+      return !isTestFinished
+    }).forEach(({ title }) => {
       const cypressTestName = title.join(' ')
       const isSkippedByItr = testsToSkip.find(test =>
         cypressTestName === test.name && spec.relative === test.suite
       )
-      const isTestFinished = finishedTests.find(({ testName }) => cypressTestName === testName)
-
-      return !isSkippedByItr && !isTestFinished
-    }).forEach(({ title }) => {
-      const skippedTestSpan = getTestSpan(title.join(' '), spec.relative)
+      const skippedTestSpan = getTestSpan(cypressTestName, spec.relative)
       skippedTestSpan.setTag(TEST_STATUS, 'skip')
+      if (isSkippedByItr) {
+        skippedTestSpan.setTag(TEST_SKIPPED_BY_ITR, 'true')
+      }
       skippedTestSpan.finish()
     })
 
@@ -309,7 +315,9 @@ module.exports = (on, config) => {
         {
           isSuitesSkipped: isTestsSkipped,
           isSuitesSkippingEnabled,
-          isCodeCoverageEnabled
+          isCodeCoverageEnabled,
+          skippingType: 'test',
+          skippingCount: skippedTests.length
         }
       )
 
@@ -353,6 +361,7 @@ module.exports = (on, config) => {
       if (testsToSkip.find(test => {
         return testName === test.name && testSuite === test.suite
       })) {
+        skippedTests.push(test)
         isTestsSkipped = true
         return { shouldSkip: true }
       }

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -78,24 +78,30 @@ describe('Plugin', () => {
           return agent.close({ ritmReset: false })
         })
 
+        withNamingSchema(
+          async () => {
+            const client = await buildClient({
+              getUnary: (_, callback) => callback()
+            })
+
+            client.getUnary({ first: 'foobar' }, () => {})
+          },
+          {
+            v0: {
+              opName: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.server',
+              serviceName: 'test'
+            },
+            v1: {
+              opName: 'grpc.server.request',
+              serviceName: 'test'
+            }
+          }
+        )
+
         it('should handle `unary` calls', async () => {
           const client = await buildClient({
             getUnary: (_, callback) => callback()
           })
-
-          withNamingSchema(
-            (done) => client.getUnary({ first: 'foobar' }, () => done()),
-            {
-              v0: {
-                opName: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.server',
-                serviceName: 'test'
-              },
-              v1: {
-                opName: 'grpc.server.request',
-                serviceName: 'test'
-              }
-            }
-          )
 
           client.getUnary({ first: 'foobar' }, () => {})
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -49,7 +49,8 @@ class JestPlugin extends CiPlugin {
       isSuitesSkipped,
       isSuitesSkippingEnabled,
       isCodeCoverageEnabled,
-      testCodeCoverageLinesTotal
+      testCodeCoverageLinesTotal,
+      numSkippedSuites
     }) => {
       this.testSessionSpan.setTag(TEST_STATUS, status)
       this.testModuleSpan.setTag(TEST_STATUS, status)
@@ -57,7 +58,14 @@ class JestPlugin extends CiPlugin {
       addIntelligentTestRunnerSpanTags(
         this.testSessionSpan,
         this.testModuleSpan,
-        { isSuitesSkipped, isSuitesSkippingEnabled, isCodeCoverageEnabled, testCodeCoverageLinesTotal }
+        {
+          isSuitesSkipped,
+          isSuitesSkippingEnabled,
+          isCodeCoverageEnabled,
+          testCodeCoverageLinesTotal,
+          skippingType: 'suite',
+          skippingCount: numSkippedSuites
+        }
       )
 
       this.testModuleSpan.finish()

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -48,10 +48,16 @@ function getJestTestName (test) {
 }
 
 function getJestSuitesToRun (skippableSuites, originalTests, rootDir) {
-  return originalTests.filter(({ path: testPath }) => {
-    const relativePath = getTestSuitePath(testPath, rootDir)
-    return !skippableSuites.includes(relativePath)
-  })
+  return originalTests.reduce((acc, test) => {
+    const relativePath = getTestSuitePath(test.path, rootDir)
+    const shouldBeSkipped = skippableSuites.includes(relativePath)
+    if (shouldBeSkipped) {
+      acc.skippedSuites.push(relativePath)
+    } else {
+      acc.suitesToRun.push(test)
+    }
+    return acc
+  }, { skippedSuites: [], suitesToRun: [] })
 }
 
 module.exports = { getFormattedJestTestParameters, getJestTestName, getJestSuitesToRun }

--- a/packages/datadog-plugin-jest/test/jest-test.js
+++ b/packages/datadog-plugin-jest/test/jest-test.js
@@ -42,8 +42,12 @@ describe('jest-test-suite', () => {
   // only run for jest-circus tests
   // eslint-disable-next-line
   if (jest.retryTimes) {
-    it.each([[1, 2, 3], [2, 3, 5]])('can do parameterized test', (a, b, expected) => {
+    const parameters = [[1, 2, 3], [2, 3, 5]]
+    it.each(parameters)('can do parameterized test', (a, b, expected) => {
       expect(a + b).toEqual(expected)
+      // They are not modified by dd-trace reading the parameters
+      expect(parameters[0]).toEqual([1, 2, 3])
+      expect(parameters[1]).toEqual([2, 3, 5])
     })
   }
   it('promise passes', () => {

--- a/packages/datadog-plugin-jest/test/util.spec.js
+++ b/packages/datadog-plugin-jest/test/util.spec.js
@@ -33,8 +33,8 @@ describe('getJestSuitesToRun', () => {
     ]
     const rootDir = '/workspace/dd-trace-js'
 
-    const filteredSuites = getJestSuitesToRun(skippableSuites, tests, rootDir)
-    expect(filteredSuites).to.eql([{ path: '/workspace/dd-trace-js/src/e2e.spec.js' }])
+    const { suitesToRun } = getJestSuitesToRun(skippableSuites, tests, rootDir)
+    expect(suitesToRun).to.eql([{ path: '/workspace/dd-trace-js/src/e2e.spec.js' }])
   })
 
   it('returns filtered suites when paths are windows like', () => {
@@ -49,8 +49,8 @@ describe('getJestSuitesToRun', () => {
     ]
     const rootDir = `C:${path.sep}temp${path.sep}dd-trace-js`
 
-    const filteredSuites = getJestSuitesToRun(skippableSuites, tests, rootDir)
-    expect(filteredSuites).to.eql([
+    const { suitesToRun } = getJestSuitesToRun(skippableSuites, tests, rootDir)
+    expect(suitesToRun).to.eql([
       { path: `C:${path.sep}temp${path.sep}dd-trace-js${path.sep}src${path.sep}e2e.spec.js` }
     ])
   })
@@ -67,9 +67,29 @@ describe('getJestSuitesToRun', () => {
     ]
     const rootDir = '/workspace/dd-trace-js/config/root-config'
 
-    const filteredSuites = getJestSuitesToRun(skippableSuites, tests, rootDir)
-    expect(filteredSuites).to.eql([
+    const { suitesToRun } = getJestSuitesToRun(skippableSuites, tests, rootDir)
+    expect(suitesToRun).to.eql([
       { path: '/workspace/dd-trace-js/src/e2e.spec.js' }
+    ])
+  })
+
+  it('returns the list of skipped suites', () => {
+    const skippableSuites = [
+      'src/unit.spec.js',
+      'src/integration.spec.js',
+      'src/not-in-the-repo-so-will-not-show-up-in-skipped-suites.js'
+    ]
+    const tests = [
+      { path: '/workspace/dd-trace-js/src/unit.spec.js' },
+      { path: '/workspace/dd-trace-js/src/integration.spec.js' },
+      { path: '/workspace/dd-trace-js/src/e2e.spec.js' }
+    ]
+    const rootDir = '/workspace/dd-trace-js'
+
+    const { skippedSuites } = getJestSuitesToRun(skippableSuites, tests, rootDir)
+    expect(skippedSuites).to.eql([
+      'src/unit.spec.js',
+      'src/integration.spec.js'
     ])
   })
 })

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -135,7 +135,12 @@ class MochaPlugin extends CiPlugin {
       this._testNameToParams[name] = params
     })
 
-    this.addSub('ci:mocha:session:finish', ({ status, isSuitesSkipped, testCodeCoverageLinesTotal }) => {
+    this.addSub('ci:mocha:session:finish', ({
+      status,
+      isSuitesSkipped,
+      testCodeCoverageLinesTotal,
+      numSkippedSuites
+    }) => {
       if (this.testSessionSpan) {
         const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig || {}
         this.testSessionSpan.setTag(TEST_STATUS, status)
@@ -144,7 +149,14 @@ class MochaPlugin extends CiPlugin {
         addIntelligentTestRunnerSpanTags(
           this.testSessionSpan,
           this.testModuleSpan,
-          { isSuitesSkipped, isSuitesSkippingEnabled, isCodeCoverageEnabled, testCodeCoverageLinesTotal }
+          {
+            isSuitesSkipped,
+            isSuitesSkippingEnabled,
+            isCodeCoverageEnabled,
+            testCodeCoverageLinesTotal,
+            skippingCount: numSkippedSuites,
+            skippingType: 'suite'
+          }
         )
 
         this.testModuleSpan.finish()

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -4,6 +4,7 @@ const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT } = require('../../dd-trace/src/constants')
+const web = require('../../dd-trace/src/plugins/util/web')
 
 class NextPlugin extends ServerPlugin {
   static get id () {
@@ -49,6 +50,7 @@ class NextPlugin extends ServerPlugin {
 
     const span = store.span
     const error = span.context()._tags['error']
+    const page = span.context()._tags['next.page']
 
     if (!this.config.validateStatus(res.statusCode) && !error) {
       span.setTag('error', true)
@@ -57,6 +59,8 @@ class NextPlugin extends ServerPlugin {
     span.addTags({
       'http.status_code': res.statusCode
     })
+
+    if (page) web.setRoute(req, page)
 
     this.config.hooks.request(span, req, res)
 

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -16,7 +16,7 @@ class NextPlugin extends ServerPlugin {
     this.addSub('apm:next:page:load', message => this.pageLoad(message))
   }
 
-  start ({ req, res }) {
+  bindStart ({ req, res }) {
     const store = storage.getStore()
     const childOf = store ? store.span : store
     const span = this.tracer.startSpan(this.operationName(), {
@@ -33,9 +33,13 @@ class NextPlugin extends ServerPlugin {
 
     analyticsSampler.sample(span, this.config.measured, true)
 
-    this.enter(span, store)
-
     this._requests.set(span, req)
+
+    return { ...store, span }
+  }
+
+  error ({ span, error }) {
+    this.addError(error, span)
   }
 
   finish ({ req, res }) {

--- a/packages/datadog-plugin-next/test/datadog.js
+++ b/packages/datadog-plugin-next/test/datadog.js
@@ -10,4 +10,4 @@ module.exports = require('../../..').init({
       span.setTag('foo', 'bar')
     }
   }
-} : true)
+} : true).use('http', { client: false })

--- a/packages/datadog-plugin-next/test/datadog.js
+++ b/packages/datadog-plugin-next/test/datadog.js
@@ -1,0 +1,13 @@
+module.exports = require('../../..').init({
+  service: 'test',
+  flushInterval: 0,
+  plugins: false
+}).use('next', process.env.WITH_CONFIG ? {
+  validateStatus: code => false,
+  hooks: {
+    request: (span, req) => {
+      span.setTag('req', req.constructor.name)
+      span.setTag('foo', 'bar')
+    }
+  }
+} : true)

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -125,7 +125,8 @@ describe('Plugin', function () {
           hooks: (schemaVersion, defaultToGlobalService) => startServer({
             withConfig: false,
             standalone: false
-          }, schemaVersion, defaultToGlobalService)
+          }, schemaVersion, defaultToGlobalService),
+          selectSpan: traces => traces[0][1]
         }
       )
 
@@ -138,14 +139,14 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '200')
-                expect(spans[0].meta).to.have.property('component', 'next')
+                expect(spans[1]).to.have.property('name', 'next.request')
+                expect(spans[1]).to.have.property('service', 'test')
+                expect(spans[1]).to.have.property('type', 'web')
+                expect(spans[1]).to.have.property('resource', 'GET /api/hello/[name]')
+                expect(spans[1].meta).to.have.property('span.kind', 'server')
+                expect(spans[1].meta).to.have.property('http.method', 'GET')
+                expect(spans[1].meta).to.have.property('http.status_code', '200')
+                expect(spans[1].meta).to.have.property('component', 'next')
               })
               .then(done)
               .catch(done)
@@ -166,7 +167,7 @@ describe('Plugin', function () {
                 .use(traces => {
                   const spans = traces[0]
 
-                  expect(spans[0]).to.have.property('resource', `GET ${expectedPath}`)
+                  expect(spans[1]).to.have.property('resource', `GET ${expectedPath}`)
                 })
                 .then(done)
                 .catch(done)
@@ -192,13 +193,13 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '404')
-                expect(spans[0].meta).to.have.property('component', 'next')
+                expect(spans[1]).to.have.property('name', 'next.request')
+                expect(spans[1]).to.have.property('service', 'test')
+                expect(spans[1]).to.have.property('type', 'web')
+                expect(spans[1].meta).to.have.property('span.kind', 'server')
+                expect(spans[1].meta).to.have.property('http.method', 'GET')
+                expect(spans[1].meta).to.have.property('http.status_code', '404')
+                expect(spans[1].meta).to.have.property('component', 'next')
               })
               .then(done)
               .catch(done)
@@ -213,14 +214,14 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET /_error')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '400')
-                expect(spans[0].meta).to.have.property('component', 'next')
+                expect(spans[1]).to.have.property('name', 'next.request')
+                expect(spans[1]).to.have.property('service', 'test')
+                expect(spans[1]).to.have.property('type', 'web')
+                expect(spans[1]).to.have.property('resource', 'GET /_error')
+                expect(spans[1].meta).to.have.property('span.kind', 'server')
+                expect(spans[1].meta).to.have.property('http.method', 'GET')
+                expect(spans[1].meta).to.have.property('http.status_code', '400')
+                expect(spans[1].meta).to.have.property('component', 'next')
               })
               .then(done)
               .catch(done)
@@ -228,6 +229,22 @@ describe('Plugin', function () {
             axios
               .get(`http://localhost:${port}/api/invalid/%ff`)
               .catch(() => {})
+          })
+
+          it('should pass resource path to parent span', done => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[0]).to.have.property('name', 'web.request')
+                expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
+              })
+              .then(done)
+              .catch(done)
+
+            axios
+              .get(`http://localhost:${port}/api/hello/world`)
+              .catch(done)
           })
         })
 
@@ -237,14 +254,14 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET /hello/[name]')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '200')
-                expect(spans[0].meta).to.have.property('component', 'next')
+                expect(spans[1]).to.have.property('name', 'next.request')
+                expect(spans[1]).to.have.property('service', 'test')
+                expect(spans[1]).to.have.property('type', 'web')
+                expect(spans[1]).to.have.property('resource', 'GET /hello/[name]')
+                expect(spans[1].meta).to.have.property('span.kind', 'server')
+                expect(spans[1].meta).to.have.property('http.method', 'GET')
+                expect(spans[1].meta).to.have.property('http.status_code', '200')
+                expect(spans[1].meta).to.have.property('component', 'next')
               })
               .then(done)
               .catch(done)
@@ -267,8 +284,8 @@ describe('Plugin', function () {
                 .use(traces => {
                   const spans = traces[0]
 
-                  expect(spans[0]).to.have.property('resource', `GET ${expectedPath}`)
-                  expect(spans[0].meta).to.have.property('http.status_code', `${statusCode || 200}`)
+                  expect(spans[1]).to.have.property('resource', `GET ${expectedPath}`)
+                  expect(spans[1].meta).to.have.property('http.status_code', `${statusCode || 200}`)
                 })
                 .then(done)
                 .catch(done)
@@ -282,13 +299,13 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '404')
-                expect(spans[0].meta).to.have.property('component', 'next')
+                expect(spans[1]).to.have.property('name', 'next.request')
+                expect(spans[1]).to.have.property('service', 'test')
+                expect(spans[1]).to.have.property('type', 'web')
+                expect(spans[1].meta).to.have.property('span.kind', 'server')
+                expect(spans[1].meta).to.have.property('http.method', 'GET')
+                expect(spans[1].meta).to.have.property('http.status_code', '404')
+                expect(spans[1].meta).to.have.property('component', 'next')
               })
               .then(done)
               .catch(done)
@@ -296,6 +313,22 @@ describe('Plugin', function () {
             axios
               .get(`http://localhost:${port}/missing`)
               .catch(() => {})
+          })
+
+          it('should pass resource path to parent span', done => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[0]).to.have.property('name', 'web.request')
+                expect(spans[0]).to.have.property('resource', 'GET /hello/[name]')
+              })
+              .then(done)
+              .catch(done)
+
+            axios
+              .get(`http://localhost:${port}/hello/world`)
+              .catch(done)
           })
         })
 
@@ -305,14 +338,14 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'next.request')
-                expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'web')
-                expect(spans[0]).to.have.property('resource', 'GET')
-                expect(spans[0].meta).to.have.property('span.kind', 'server')
-                expect(spans[0].meta).to.have.property('http.method', 'GET')
-                expect(spans[0].meta).to.have.property('http.status_code', '200')
-                expect(spans[0].meta).to.have.property('component', 'next')
+                expect(spans[1]).to.have.property('name', 'next.request')
+                expect(spans[1]).to.have.property('service', 'test')
+                expect(spans[1]).to.have.property('type', 'web')
+                expect(spans[1]).to.have.property('resource', 'GET')
+                expect(spans[1].meta).to.have.property('span.kind', 'server')
+                expect(spans[1].meta).to.have.property('http.method', 'GET')
+                expect(spans[1].meta).to.have.property('http.status_code', '200')
+                expect(spans[1].meta).to.have.property('component', 'next')
               })
               .then(done)
               .catch(done)
@@ -347,17 +380,17 @@ describe('Plugin', function () {
             .use(traces => {
               const spans = traces[0]
 
-              expect(spans[0]).to.have.property('name', 'next.request')
-              expect(spans[0]).to.have.property('service', 'test')
-              expect(spans[0]).to.have.property('type', 'web')
-              expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
-              expect(spans[0]).to.have.property('error', 1)
-              expect(spans[0].meta).to.have.property('span.kind', 'server')
-              expect(spans[0].meta).to.have.property('http.method', 'GET')
-              expect(spans[0].meta).to.have.property('http.status_code', '200')
-              expect(spans[0].meta).to.have.property('foo', 'bar')
-              expect(spans[0].meta).to.have.property('req', 'IncomingMessage')
-              expect(spans[0].meta).to.have.property('component', 'next')
+              expect(spans[1]).to.have.property('name', 'next.request')
+              expect(spans[1]).to.have.property('service', 'test')
+              expect(spans[1]).to.have.property('type', 'web')
+              expect(spans[1]).to.have.property('resource', 'GET /api/hello/[name]')
+              expect(spans[1]).to.have.property('error', 1)
+              expect(spans[1].meta).to.have.property('span.kind', 'server')
+              expect(spans[1].meta).to.have.property('http.method', 'GET')
+              expect(spans[1].meta).to.have.property('http.status_code', '200')
+              expect(spans[1].meta).to.have.property('foo', 'bar')
+              expect(spans[1].meta).to.have.property('req', 'IncomingMessage')
+              expect(spans[1].meta).to.have.property('component', 'next')
             })
             .then(done)
             .catch(done)
@@ -385,14 +418,14 @@ describe('Plugin', function () {
                 .use(traces => {
                   const spans = traces[0]
 
-                  expect(spans[0]).to.have.property('name', 'next.request')
-                  expect(spans[0]).to.have.property('service', 'test')
-                  expect(spans[0]).to.have.property('type', 'web')
-                  expect(spans[0]).to.have.property('resource', expectedResource)
-                  expect(spans[0].meta).to.have.property('span.kind', 'server')
-                  expect(spans[0].meta).to.have.property('http.method', 'GET')
-                  expect(spans[0].meta).to.have.property('http.status_code', '200')
-                  expect(spans[0].meta).to.have.property('component', 'next')
+                  expect(spans[1]).to.have.property('name', 'next.request')
+                  expect(spans[1]).to.have.property('service', 'test')
+                  expect(spans[1]).to.have.property('type', 'web')
+                  expect(spans[1]).to.have.property('resource', expectedResource)
+                  expect(spans[1].meta).to.have.property('span.kind', 'server')
+                  expect(spans[1].meta).to.have.property('http.method', 'GET')
+                  expect(spans[1].meta).to.have.property('http.status_code', '200')
+                  expect(spans[1].meta).to.have.property('component', 'next')
                 })
                 .then(done)
                 .catch(done)

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -336,6 +336,7 @@ describe('Plugin', function () {
               expect(spans[0].meta).to.have.property('http.method', 'GET')
               expect(spans[0].meta).to.have.property('http.status_code', '200')
               expect(spans[0].meta).to.have.property('foo', 'bar')
+              expect(spans[0].meta).to.have.property('req', 'IncomingMessage')
               expect(spans[0].meta).to.have.property('component', 'next')
             })
             .then(done)

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -236,7 +236,7 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'web.request')
+                expect(spans[0]).to.have.property('name', 'http.request')
                 expect(spans[0]).to.have.property('resource', 'GET /api/hello/[name]')
               })
               .then(done)
@@ -320,7 +320,7 @@ describe('Plugin', function () {
               .use(traces => {
                 const spans = traces[0]
 
-                expect(spans[0]).to.have.property('name', 'web.request')
+                expect(spans[0]).to.have.property('name', 'http.request')
                 expect(spans[0]).to.have.property('resource', 'GET /hello/[name]')
               })
               .then(done)

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   eslint: {
     ignoreDuringBuilds: true
+  },
+  output: 'standalone',
+  experimental: {
+    outputStandalone: true
   }
 }

--- a/packages/datadog-plugin-next/test/server.js
+++ b/packages/datadog-plugin-next/test/server.js
@@ -9,7 +9,8 @@ require('../../..').init({
 }).use('next', WITH_CONFIG ? {
   validateStatus: code => false,
   hooks: {
-    request: (span) => {
+    request: (span, req) => {
+      span.setTag('req', req.constructor.name)
       span.setTag('foo', 'bar')
     }
   }

--- a/packages/datadog-plugin-next/test/server.js
+++ b/packages/datadog-plugin-next/test/server.js
@@ -1,20 +1,8 @@
 'use strict'
 
-const { PORT, WITH_CONFIG } = process.env
+const { PORT } = process.env
 
-require('../../..').init({
-  service: 'test',
-  flushInterval: 0,
-  plugins: false
-}).use('next', WITH_CONFIG ? {
-  validateStatus: code => false,
-  hooks: {
-    request: (span, req) => {
-      span.setTag('req', req.constructor.name)
-      span.setTag('foo', 'bar')
-    }
-  }
-} : true)
+require('./datadog')
 
 const { createServer } = require('http')
 const { parse } = require('url')

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -66,7 +66,7 @@ function taintObject (iastContext, object, type, keyTainting, keyType) {
               const taintedProperty = TaintedUtils.newTaintedString(transactionId, key, property, keyType)
               parent[taintedProperty] = tainted
             } else {
-              parent[property] = tainted
+              parent[key] = tainted
             }
           }
         } else if (typeof value === 'object' && !visited.has(value)) {

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
@@ -28,7 +28,6 @@ class VulnerabilityFormatter {
       const { redactedValueParts, redactedSources } = scrubbingResult
       redactedSources.forEach(i => {
         delete sources[i].value
-        sources[i].redacted = true
       })
       return { valueParts: redactedValueParts }
     }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -47,6 +47,7 @@ const TEST_SESSION_ID = 'test_session_id'
 const TEST_MODULE_ID = 'test_module_id'
 const TEST_SUITE_ID = 'test_suite_id'
 const TEST_TOOLCHAIN = 'test.toolchain'
+const TEST_SKIPPED_BY_ITR = 'test.skipped_by_itr'
 
 const CI_APP_ORIGIN = 'ciapp-test'
 
@@ -54,6 +55,8 @@ const JEST_TEST_RUNNER = 'test.jest.test_runner'
 
 const TEST_ITR_TESTS_SKIPPED = '_dd.ci.itr.tests_skipped'
 const TEST_ITR_SKIPPING_ENABLED = 'test.itr.tests_skipping.enabled'
+const TEST_ITR_SKIPPING_TYPE = 'test.itr.tests_skipping.type'
+const TEST_ITR_SKIPPING_COUNT = 'test.itr.tests_skipping.count'
 const TEST_CODE_COVERAGE_ENABLED = 'test.code_coverage.enabled'
 
 const TEST_CODE_COVERAGE_LINES_PCT = 'test.code_coverage.lines_pct'
@@ -80,6 +83,7 @@ module.exports = {
   JEST_WORKER_TRACE_PAYLOAD_CODE,
   JEST_WORKER_COVERAGE_PAYLOAD_CODE,
   TEST_SOURCE_START,
+  TEST_SKIPPED_BY_ITR,
   getTestEnvironmentMetadata,
   getTestParametersString,
   finishAllTraceSpans,
@@ -99,6 +103,8 @@ module.exports = {
   TEST_ITR_TESTS_SKIPPED,
   TEST_MODULE,
   TEST_ITR_SKIPPING_ENABLED,
+  TEST_ITR_SKIPPING_TYPE,
+  TEST_ITR_SKIPPING_COUNT,
   TEST_CODE_COVERAGE_ENABLED,
   TEST_CODE_COVERAGE_LINES_PCT,
   addIntelligentTestRunnerSpanTags,
@@ -354,14 +360,25 @@ function getTestSuiteCommonTags (command, testFrameworkVersion, testSuite, testF
 function addIntelligentTestRunnerSpanTags (
   testSessionSpan,
   testModuleSpan,
-  { isSuitesSkipped, isSuitesSkippingEnabled, isCodeCoverageEnabled, testCodeCoverageLinesTotal }
+  {
+    isSuitesSkipped,
+    isSuitesSkippingEnabled,
+    isCodeCoverageEnabled,
+    testCodeCoverageLinesTotal,
+    skippingCount,
+    skippingType = 'suite'
+  }
 ) {
   testSessionSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
   testSessionSpan.setTag(TEST_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
+  testSessionSpan.setTag(TEST_ITR_SKIPPING_TYPE, skippingType)
+  testSessionSpan.setTag(TEST_ITR_SKIPPING_COUNT, skippingCount)
   testSessionSpan.setTag(TEST_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
 
   testModuleSpan.setTag(TEST_ITR_TESTS_SKIPPED, isSuitesSkipped ? 'true' : 'false')
   testModuleSpan.setTag(TEST_ITR_SKIPPING_ENABLED, isSuitesSkippingEnabled ? 'true' : 'false')
+  testModuleSpan.setTag(TEST_ITR_SKIPPING_TYPE, skippingType)
+  testModuleSpan.setTag(TEST_ITR_SKIPPING_COUNT, skippingCount)
   testModuleSpan.setTag(TEST_CODE_COVERAGE_ENABLED, isCodeCoverageEnabled ? 'true' : 'false')
 
   // If suites have been skipped we don't want to report the total coverage, as it will be wrong

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -3,6 +3,8 @@
 const { storage } = require('../../../../datadog-core')
 
 const dc = require('../../../../diagnostics_channel')
+const { HTTP_METHOD, HTTP_ROUTE, RESOURCE_NAME, SPAN_TYPE } = require('../../../../../ext/tags')
+const { WEB } = require('../../../../../ext/types')
 
 const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
@@ -41,13 +43,13 @@ function getSpanContextTags (span) {
 }
 
 function isWebServerSpan (tags) {
-  return tags['span.type'] === 'web'
+  return tags[SPAN_TYPE] === WEB
 }
 
 function endpointNameFromTags (tags) {
-  return tags['resource.name'] || [
-    tags['http.method'],
-    tags['http.route']
+  return tags[RESOURCE_NAME] || [
+    tags[HTTP_METHOD],
+    tags[HTTP_ROUTE]
   ].filter(v => v).join(' ')
 }
 
@@ -99,7 +101,7 @@ class NativeWallProfiler {
 
     if (this._codeHotspotsEnabled && !this._emittedFFMessage && this._logger) {
       this._logger.debug(
-        `Wall profiler: Enable config_trace_show_breakdown_profiling_for_node feature flag to see code hotspots.`)
+        `Wall profiler: Enable trace_show_breakdown_profiling_for_node feature flag to see code hotspots.`)
       this._emittedFFMessage = true
     }
 

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -117,8 +117,16 @@ function Hook (modules, options, onrequire) {
         // abort if _resolveLookupPaths return null
         return exports
       }
-      const res = Module._findPath(name, [basedir, ...paths])
-      if (res !== filename) {
+
+      let res
+      try {
+        res = Module._findPath(name, [basedir, ...paths])
+      } catch (e) {
+        // case where the file specified in package.json "main" doesn't exist
+        // in this case, the file is treated as module-internal
+      }
+
+      if (!res || res !== filename) {
         // this is a module-internal file
         // use the module-relative path to the file, prefixed by original module name
         name = name + path.sep + path.relative(basedir, filename)

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
@@ -131,6 +131,12 @@ describe('IAST TaintTracking Operations', () => {
       const iastContext = {}
       const transactionId = 'id'
       taintTrackingOperations.createTransaction(transactionId, iastContext)
+      const expected = {
+        value: 'parent',
+        child: {
+          value: 'child'
+        }
+      }
       const obj = {
         value: 'parent',
         child: {
@@ -144,7 +150,7 @@ describe('IAST TaintTracking Operations', () => {
         .calledWithExactly(transactionId, 'child', 'child.value', null)
       expect(taintedUtilsMock.newTaintedString.secondCall).to.have.been
         .calledWithExactly(transactionId, 'parent', 'value', null)
-      expect(result).to.equal(obj)
+      expect(result).to.be.deep.equal(expected)
     })
 
     it('Should call newTaintedString in object keys when keyTainting is true', () => {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 1.1,
   "suite": [
     {
       "type": "SOURCES",
@@ -207,7 +207,8 @@
           {
             "origin": "http.request.parameter",
             "name": "secret",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcde"
           }
         ],
         "vulnerabilities": [
@@ -220,7 +221,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcde"
                 }
               ]
             }
@@ -938,7 +940,8 @@
           {
             "origin": "http.request.parameter",
             "name": "username",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -951,7 +954,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "value": "'"
@@ -989,7 +993,8 @@
           {
             "origin": "http.request.parameter",
             "name": "user_id",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abc"
           }
         ],
         "vulnerabilities": [
@@ -1002,7 +1007,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abc"
                 }
               ]
             }
@@ -1037,7 +1043,8 @@
           {
             "origin": "http.request.parameter",
             "name": "password",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcde"
           }
         ],
         "vulnerabilities": [
@@ -1050,7 +1057,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcde"
                 },
                 {
                   "value": "'"
@@ -1088,7 +1096,8 @@
           {
             "origin": "http.request.parameter",
             "name": "password",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcde"
           }
         ],
         "vulnerabilities": [
@@ -1101,7 +1110,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcde"
                 },
                 {
                   "redacted": true
@@ -1142,7 +1152,8 @@
           {
             "origin": "http.request.parameter",
             "name": "first_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -1155,7 +1166,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "redacted": true
@@ -1196,7 +1208,8 @@
           {
             "origin": "http.request.parameter",
             "name": "last_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abc"
           }
         ],
         "vulnerabilities": [
@@ -1212,7 +1225,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abc"
                 },
                 {
                   "redacted": true
@@ -1253,7 +1267,8 @@
           {
             "origin": "http.request.parameter",
             "name": "clause",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijklmnopq"
           }
         ],
         "vulnerabilities": [
@@ -1266,7 +1281,16 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "mnop"
+                },
+                {
+                  "source": 0,
+                  "value": "'"
                 }
               ]
             }
@@ -1301,7 +1325,8 @@
           {
             "origin": "http.request.parameter",
             "name": "clause",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijklmnop"
           }
         ],
         "vulnerabilities": [
@@ -1314,7 +1339,12 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "mnop"
                 },
                 {
                   "redacted": true
@@ -1373,17 +1403,20 @@
           {
             "origin": "http.request.parameter",
             "name": "first_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           },
           {
             "origin": "http.request.parameter",
             "name": "last_name",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abc"
           },
           {
             "origin": "http.request.parameter",
             "name": "password",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijkl"
           }
         ],
         "vulnerabilities": [
@@ -1396,21 +1429,24 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "redacted": true
                 },
                 {
                   "source": 1,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abc"
                 },
                 {
                   "value": "' and password LIKE '"
                 },
                 {
                   "source": 2,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijkl"
                 },
                 {
                   "redacted": true
@@ -1463,7 +1499,8 @@
           {
             "origin": "http.request.parameter",
             "name": "query",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijk"
           }
         ],
         "vulnerabilities": [
@@ -1479,7 +1516,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "redacted": true
@@ -1492,12 +1530,77 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "redacted": true
                 },
                 {
+                  "value": "'"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Full query tainted",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from table where name LIKE '%searchparam%' OR description LIKE '%searchparam%'",
+            "ranges": [
+              {
+                "start": 0,
+                "end": 87,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "query",
+                  "parameterValue": "select * from table where name LIKE '%searchparam%' OR description LIKE '%searchparam%'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "query",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxy"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "source": 0,
+                  "value": "select * from table where name LIKE '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "LMNOPQRSTUVWX"
+                },
+                {
+                  "source": 0,
+                  "value": "' OR description LIKE '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "LMNOPQRSTUVWX"
+                },
+                {
+                  "source": 0,
                   "value": "'"
                 }
               ]
@@ -1673,7 +1776,8 @@
           {
             "origin": "http.request.parameter",
             "name": "cn",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijk"
           }
         ],
         "vulnerabilities": [
@@ -1686,7 +1790,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "value": ")\n(!(cn="
@@ -1705,14 +1810,16 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "fghijk"
                 },
                 {
                   "value": ")(cn="
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdef"
                 },
                 {
                   "redacted": true
@@ -1759,7 +1866,8 @@
           {
             "origin": "http.request.parameter",
             "name": "file",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefghijk"
           }
         ],
         "vulnerabilities": [
@@ -1784,7 +1892,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefghijk"
                 },
                 {
                   "value": ")\n(bin="
@@ -1888,7 +1997,8 @@
           {
             "origin": "http.request.parameter",
             "name": "file",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefgh"
           }
         ],
         "vulnerabilities": [
@@ -1904,7 +2014,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefgh"
                 }
               ]
             }
@@ -1945,7 +2056,8 @@
           {
             "origin": "http.request.parameter",
             "name": "file",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcdefgh"
           }
         ],
         "vulnerabilities": [
@@ -1961,7 +2073,8 @@
                 },
                 {
                   "source": 0,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcdefgh"
                 }
               ]
             }
@@ -2010,7 +2123,8 @@
           {
             "origin": "http.request.parameter",
             "name": "argument",
-            "redacted": true
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -2027,7 +2141,8 @@
                 },
                 {
                   "source": 1,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 }
               ]
             }
@@ -2189,7 +2304,7 @@
                 "end": 36,
                 "iinfo": {
                   "type": "http.request.parameter",
-                  "parameterName": "fist_name",
+                  "parameterName": "first_name",
                   "parameterValue": "john"
                 }
               }
@@ -2206,8 +2321,9 @@
           },
           {
             "origin": "http.request.parameter",
-            "name": "fist_name",
-            "redacted": true
+            "name": "first_name",
+            "redacted": true,
+            "pattern": "abcd"
           }
         ],
         "vulnerabilities": [
@@ -2227,7 +2343,8 @@
                 },
                 {
                   "source": 1,
-                  "redacted": true
+                  "redacted": true,
+                  "pattern": "abcd"
                 },
                 {
                   "value": "&last_name="
@@ -2342,6 +2459,222 @@
             "type": "WEAK_RANDOMNESS",
             "evidence": {
               "value": "java.util.Math"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive source should be redacted fully in the evidence (source matches)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'john'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 43,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "password",
+                  "parameterValue": "username = 'john'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "password",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopq"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "abcdefghijklmnopq"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive sources should be redacted fully in the evidence (source does not match)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'my user'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 46,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "password",
+                  "parameterValue": "username = 'my%20user'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "password",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopqrstuv"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "********************"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive tainted range (source matches)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'john'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 43,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "clause",
+                  "parameterValue": "username = 'john'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "clause",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopq"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "mnop"
+                },
+                {
+                  "source": 0,
+                  "value": "'"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Sensitive tainted range (source does not match)",
+      "input": [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'my user'",
+            "ranges": [
+              {
+                "start": 26,
+                "end": 46,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "clause",
+                  "parameterValue": "username = 'my%20user'"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "clause",
+            "redacted": true,
+            "pattern": "abcdefghijklmnopqrstuv"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                {
+                  "value": "select * from users where "
+                },
+                {
+                  "source": 0,
+                  "value": "username = '"
+                },
+                {
+                  "source": 0,
+                  "redacted": true,
+                  "pattern": "*******"
+                },
+                {
+                  "source": 0,
+                  "value": "'"
+                }
+              ]
             }
           }
         ]


### PR DESCRIPTION
- Note that this is the final v2.x release!
- Removing ESM test commits (present in sibling releases) due to Node.js version incompat

### Bug Fixes
- core: fix grpc tests (#3522)
- esbuild: honor the .external build setting (#3492)
- core: fix duplicate next spans and incorrect req/res in hooks (#3494)
- core: fix Resource Name Not Bubbling to Web Span in Next.js (#3537)
- ci-visibility: fix jest parameters being modified (#3526)
- iast: fix taint object method (#3505)

### Improvements
- iast: enable iast telemetry metrics if iast is enabled (#3482)
- core: remove hardcoded string literals for tags, use predefined constants instead (#3503)
- ci-visibility: send suites and tests skipped by ITR (#3497)
- core: add Testing To Ensure Support for Next.js Standalone (#3493)

### Features
- core: emit warning on v2.x branch (#3523)
- iast: length based evidence redaction (#3423)
