### PR TITLE
fixing the BigInt serialization issue

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -36,10 +36,14 @@ class MongodbCorePlugin extends DatabasePlugin {
   }
 }
 
+function sanitizeBigInt (data) {
+  return JSON.stringify(data, (_key, value) => typeof value === 'bigint' ? value.toString() : value)
+}
+
 function getQuery (cmd) {
   if (!cmd || typeof cmd !== 'object' || Array.isArray(cmd)) return
-  if (cmd.query) return JSON.stringify(limitDepth(cmd.query))
-  if (cmd.filter) return JSON.stringify(limitDepth(cmd.filter))
+  if (cmd.query) return sanitizeBigInt(limitDepth(cmd.query))
+  if (cmd.filter) return sanitizeBigInt(limitDepth(cmd.filter))
 }
 
 function getResource (plugin, ns, query, operationName) {


### PR DESCRIPTION
### What does this PR do?
Sanitizing BigInt values in mongo tracing

### Motivation
We faced an issue in tracing mongo calls using BigInt values, we created an issue [here](https://github.com/DataDog/dd-trace-js/issues/3548)

this should be a solution in this case

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
