### PR TITLE
esbuild: early bailout when loading app local modules

### DIFF
--- a/integration-tests/esbuild.spec.js
+++ b/integration-tests/esbuild.spec.js
@@ -52,4 +52,24 @@ describe('esbuild', () => {
       process.chdir(CWD)
     }
   })
+
+  it('handles typescript apps that import without file extensions', () => {
+    // eslint-disable-next-line no-console
+    console.log(`cd ${TEST_DIR}`)
+    process.chdir(TEST_DIR)
+
+    try {
+      // eslint-disable-next-line no-console
+      console.log('node ./build-and-test-typescript.mjs')
+      chproc.execSync('node ./build-and-test-typescript.mjs', {
+        timeout: 1000 * 30
+      })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err)
+      process.exit(1)
+    } finally {
+      process.chdir(CWD)
+    }
+  })
 })

--- a/integration-tests/esbuild/build-and-test-typescript.mjs
+++ b/integration-tests/esbuild/build-and-test-typescript.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import fs from 'fs'
+
+import * as esbuild from 'esbuild'
+
+import ddPlugin from '../../esbuild.js'
+
+await esbuild.build({
+  entryPoints: ['typescript-app.ts'],
+  bundle: true,
+  outfile: 'typescript-app-out.js',
+  minify: false,
+  sourcemap: false,
+  platform: 'node',
+  target: 'es2022',
+  plugins: [ddPlugin],
+  external: [
+    'graphql/language/visitor',
+    'graphql/language/printer',
+    'graphql/utilities',
+  ],
+})
+
+console.log('ok') // eslint-disable-line no-console
+fs.rmSync('typescript-app-out.js')

--- a/integration-tests/esbuild/typescript-app.ts
+++ b/integration-tests/esbuild/typescript-app.ts
@@ -1,0 +1,6 @@
+import greeter from './typescript-dep'
+
+const name = 'World'
+
+console.log(greeter(name))
+

--- a/integration-tests/esbuild/typescript-dep.ts
+++ b/integration-tests/esbuild/typescript-dep.ts
@@ -1,0 +1,4 @@
+export default function greeter(person: string) {
+  return `Hello ${person}!`
+}
+


### PR DESCRIPTION
### What does this PR do?
- bail out of the esbuild bundling process early if the currently considered file is local to the application
- we only need to bundling if we're requiring a package from the outside or if we're in a package requiring from the inside
- also treats filenames beginning with `@` as local filenames, a common convention with Next.js (and Vue?)

### Motivation
- should fix #3547

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
