### PR TITLE
openai: limiting library range to only v3.x

### DIFF
--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -10,7 +10,7 @@ const startCh = channel('apm:openai:request:start')
 const finishCh = channel('apm:openai:request:finish')
 const errorCh = channel('apm:openai:request:error')
 
-addHook({ name: 'openai', file: 'dist/api.js', versions: ['>=3.0.0'] }, exports => {
+addHook({ name: 'openai', file: 'dist/api.js', versions: ['>=3.0.0 <4'] }, exports => {
   const methodNames = Object.getOwnPropertyNames(exports.OpenAIApi.prototype)
   methodNames.shift() // remove leading 'constructor' method
 

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -15,7 +15,7 @@ describe('esm', () => {
 
   before(async function () {
     this.timeout(20000)
-    sandbox = await createSandbox(['openai', 'nock'], false, [
+    sandbox = await createSandbox(['openai@3', 'nock'], false, [
       `./packages/datadog-plugin-openai/test/integration-test/*`])
   })
 


### PR DESCRIPTION
### What does this PR do?
- limits the version range of the openai package that we test against to only include 3.x

### Motivation
- openai@v4 is a complete rewrite and breaks compat
- this should fix CI
- https://github.com/openai/openai-node/discussions/217