### PR TITLE
First prototype of a timeline profiler

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -28,6 +28,7 @@ require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki
 require,node-abort-controller,MIT,Copyright (c) 2019 Steve Faulkner
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey
+require,pprof-format,MIT,Copyright 2022 Stephen Belanger
 require,protobufjs,BSD-3-Clause,Copyright 2016 Daniel Wirtz
 require,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
@@ -62,7 +63,6 @@ dev,mocha,MIT,Copyright 2011-2018 JS Foundation and contributors https://js.foun
 dev,multer,MIT,Copyright 2014 Hage Yaapa
 dev,nock,MIT,Copyright 2017 Pedro Teixeira and other contributors
 dev,nyc,ISC,Copyright 2015 Contributors
-dev,pprof-format,MIT,Copyright 2022 Stephen Belanger
 dev,proxyquire,MIT,Copyright 2013 Thorsten Lorenz
 dev,rimraf,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "node-abort-controller": "^3.1.1",
     "opentracing": ">=0.12.1",
     "path-to-regexp": "^0.1.2",
+    "pprof-format": "^2.0.7", 
     "protobufjs": "^7.2.4",
     "retry": "^0.13.1",
     "semver": "^7.5.4"
@@ -133,7 +134,6 @@
     "multer": "^1.4.5-lts.1",
     "nock": "^11.3.3",
     "nyc": "^15.1.0",
-    "pprof-format": "^2.0.7",
     "proxyquire": "^1.8.0",
     "rimraf": "^3.0.0",
     "sinon": "^15.2.0",

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -10,6 +10,7 @@ const { ConsoleLogger } = require('./loggers/console')
 const WallProfiler = require('./profilers/wall')
 const SpaceProfiler = require('./profilers/space')
 const TimelineProfiler = require('./profilers/timeline')
+const GCProfiler = require('./profilers/gc')
 const { oomExportStrategies, snapshotKinds } = require('./constants')
 const { tagger } = require('./tagger')
 const { isFalse, isTrue } = require('../util')
@@ -240,7 +241,9 @@ function getProfiler (name, options) {
       return new SpaceProfiler(options)
     case 'timeline':
       return new TimelineProfiler(options)
-    default:
+    case 'gc':
+        return new GCProfiler(options)
+      default:
       options.logger.error(`Unknown profiler "${name}"`)
   }
 }

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -9,6 +9,7 @@ const { FileExporter } = require('./exporters/file')
 const { ConsoleLogger } = require('./loggers/console')
 const WallProfiler = require('./profilers/wall')
 const SpaceProfiler = require('./profilers/space')
+const TimelineProfiler = require('./profilers/timeline')
 const { oomExportStrategies, snapshotKinds } = require('./constants')
 const { tagger } = require('./tagger')
 const { isFalse, isTrue } = require('../util')
@@ -237,6 +238,8 @@ function getProfiler (name, options) {
       return new WallProfiler(options)
     case 'space':
       return new SpaceProfiler(options)
+    case 'timeline':
+      return new TimelineProfiler(options)
     default:
       options.logger.error(`Unknown profiler "${name}"`)
   }

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -72,11 +72,12 @@ class AgentExporter {
       ['profiler_version', version],
       ['format', 'pprof'],
 
-      ['tags[]', 'language:javascript'],
+      ['tags[]', 'language:nodejs'],
       ['tags[]', 'runtime:nodejs'],
       ['tags[]', `runtime_version:${process.version}`],
       ['tags[]', `profiler_version:${version}`],
       ['tags[]', 'format:pprof'],
+      ['tags[]', 'hotdog-szegedi'],
       ...Object.entries(tags).map(([key, value]) => ['tags[]', `${key}:${value}`])
     ]
 

--- a/packages/dd-trace/src/profiling/index.js
+++ b/packages/dd-trace/src/profiling/index.js
@@ -3,6 +3,7 @@
 const { Profiler, ServerlessProfiler } = require('./profiler')
 const WallProfiler = require('./profilers/wall')
 const SpaceProfiler = require('./profilers/space')
+const TimelineProfiler = require('./profilers/timeline')
 const { AgentExporter } = require('./exporters/agent')
 const { FileExporter } = require('./exporters/file')
 const { ConsoleLogger } = require('./loggers/console')
@@ -15,5 +16,6 @@ module.exports = {
   FileExporter,
   WallProfiler,
   SpaceProfiler,
+  TimelineProfiler,
   ConsoleLogger
 }

--- a/packages/dd-trace/src/profiling/profilers/gc.js
+++ b/packages/dd-trace/src/profiling/profilers/gc.js
@@ -1,0 +1,144 @@
+const { performance, constants, PerformanceObserver } = require('node:perf_hooks')
+const { END_TIMESTAMP } = require('./shared')
+const semver = require('semver')
+const { Function, Label, Line, Location, Profile, Sample, StringTable, ValueType } = require('pprof-format')
+const pprof = require('@datadog/pprof/')
+
+const node16 = semver.gte(process.version, '16.0.0')
+const MS_TO_NS = 1000000
+
+function bigintReplacer (key, value) {
+  if (typeof value === 'bigint') {
+    return value.toString()
+  } else {
+    return value
+  }
+}
+
+class GarbageCollection {
+  constructor (options = {}) {
+    this.type = 'gc'
+    this._flushIntervalNanos = (options.flushInterval || 60000) * 1e6 // 60 sec
+    this._observer = undefined
+    this.entries = []
+  }
+
+  start () {
+    if (!this._observer) {
+      function add (items) {
+        this.entries.push(...items.getEntries())
+      }
+      this._observer = new PerformanceObserver(add.bind(this))
+    }
+    this._observer.observe({ type: 'gc' })
+  }
+
+  stop () {
+    if (this._observer) {
+      this._observer.disconnect()
+    }
+  }
+
+  profile () {
+    const stringTable = new StringTable()
+    const timestampLabelKey = stringTable.dedup(END_TIMESTAMP)
+    const kindLabelKey = stringTable.dedup('gc type')
+    const reasonLabelKey = stringTable.dedup('gc reason')
+    const kindLabels = []
+    const reasonLabels = []
+    const locations = []
+    const functions = []
+    const locationsPerKind = []
+    const flagObj = {}
+
+    for (const [key, value] of Object.entries(constants)) {
+      if (key.startsWith('NODE_PERFORMANCE_GC_FLAGS_')) {
+        flagObj[key.substring(26).toLowerCase()] = value
+      } else if (key.startsWith('NODE_PERFORMANCE_GC_')) {
+        // It's a constant for a kind of GC
+        const kind = key.substring(20).toLowerCase()
+        kindLabels[value] = new Label({ key: kindLabelKey, str: stringTable.dedup(kind) })
+        // Construct a single-frame "location" too
+        const fn = new Function({ id: functions.length + 1, name: stringTable.dedup(`${kind} GC`) })
+        functions.push(fn)
+        const line = new Line({ functionId: fn.id })
+        const location = new Location({ id: locations.length + 1, line: [line] })
+        locations.push(location)
+        locationsPerKind[value] = [location.id]
+      }
+    }
+
+    const gcEventLabel = new Label({ key: stringTable.dedup('event'), str: stringTable.dedup('gc') })
+    const dateOffset = BigInt(Math.round(performance.timeOrigin * MS_TO_NS))
+
+    let durationFrom = Number.POSITIVE_INFINITY
+    let durationTo = 0
+
+    function getReasonLabel (flags) {
+      if (flags === 0) {
+        return null
+      }
+      let reasonLabel = reasonLabels[flags]
+      if (!reasonLabel) {
+        const reasons = []
+        for (const [key, value] of Object.entries(flagObj)) {
+          if (value & flags) {
+            reasons.push(key)
+          }
+        }
+        const reasonStr = reasons.join(',')
+        reasonLabel = new Label({ key: reasonLabelKey, str: stringTable.dedup(reasonStr) })
+        reasonLabels[flags] = reasonLabel
+      }
+      return reasonLabel
+    }
+
+    const samples = this.entries.map((item) => {
+      const { startTime, duration } = item
+      const { kind, flags } = node16 ? item.detail : item
+      const endTime = startTime + duration
+      if (durationFrom > startTime) durationFrom = startTime
+      if (durationTo < endTime) durationTo = endTime
+      const labels = [
+        gcEventLabel,
+        new Label({ key: timestampLabelKey, num: dateOffset + BigInt(Math.round(endTime * MS_TO_NS)) }),
+        kindLabels[kind]
+      ]
+      const reasonLabel = getReasonLabel(flags)
+      if (reasonLabel) {
+        labels.push(reasonLabel)
+      }
+      const sample = new Sample({
+        value: [Math.round(duration * MS_TO_NS)],
+        label: labels,
+        locationId: locationsPerKind[kind]
+      })
+      return sample
+    })
+
+    this.entries = []
+
+    const timeValueType = new ValueType({
+      type: stringTable.dedup('timeline'),
+      unit: stringTable.dedup('nanoseconds')
+    })
+
+    return new Profile({
+      sampleType: [timeValueType],
+      timeNanos: dateOffset + BigInt(Math.round(durationFrom * MS_TO_NS)),
+      periodType: timeValueType,
+      period: this._flushIntervalNanos,
+      durationNanos: Math.max(0, Math.round((durationTo - durationFrom) * MS_TO_NS)),
+      sample: samples,
+      location: locations,
+      function: functions,
+      stringTable: stringTable
+    })
+  }
+
+  encode (profile) {
+    return pprof.encode(profile)
+  }
+}
+
+module.exports = GarbageCollection

--- a/packages/dd-trace/src/profiling/profilers/shared.js
+++ b/packages/dd-trace/src/profiling/profilers/shared.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  END_TIMESTAMP: 'end_timestamp_ns',
+  ROOT_SPAN_ID: 'local root span id',
+  SPAN_ID: 'span id'
+}

--- a/packages/dd-trace/src/profiling/profilers/timeline.js
+++ b/packages/dd-trace/src/profiling/profilers/timeline.js
@@ -323,7 +323,7 @@ class Timeline {
       timeNanos: dateNow,
       periodType: timeValueType,
       period: this._flushIntervalNanos,
-      duration: Math.max(0, Number(durationTo - durationFrom)),
+      durationNanos: Math.max(0, Number(durationTo - durationFrom)),
       sample: samples,
       location: locations,
       function: functions,

--- a/packages/dd-trace/src/profiling/profilers/timeline.js
+++ b/packages/dd-trace/src/profiling/profilers/timeline.js
@@ -1,0 +1,361 @@
+'use strict'
+
+const asyncHooks = require('async_hooks')
+const { storage } = require('../../../../datadog-core')
+const { Function, Label, Line, Location, Profile, Sample, StringTable, ValueType } = require('pprof-format')
+const pprof = require('@datadog/pprof/')
+const { END_TIMESTAMP, ROOT_SPAN_ID, SPAN_ID } = require('./shared')
+const UINT_PERIOD = 2n ** 64n;
+
+function getActiveSpan () {
+  const store = storage.getStore()
+  return store && store.span
+}
+
+function endOfQuantum (t, q) {
+  return ((t / q) + (t < 0n ? 0n : 1n)) * q
+}
+
+function startOfQuantum (t, q) {
+  return ((t / q) - (t < 0n ? 1n : 0n)) * q
+}
+
+class Timeline {
+  constructor (options = {}) {
+    this.type = 'timeline'
+    this._samplingIntervalNanos = BigInt(Math.floor(options.samplingInterval || 1e9 / 99)) // 99hz
+    this._flushIntervalNanos = (options.flushInterval || 60000) * 1e6 // 60 sec
+    // The structure of this._accumulators object is as follows: top-level
+    // property names are span IDs in decimal string encoding. Empty string is
+    // used as the property name for execution context not associated with a
+    // span. Every such span property value is itself an object, with properties
+    // "rootSpanId" for local root span ID (when identifiable), and "ref" for a
+    // reference count. It will have further properties named after the event
+    // type. The value of these properties is an array of objects representing
+    // the quanta, with "end" property as hrtime bigint of the quantum end, and
+    // "duration" as the duration in nanoseconds (a number). So something like:
+    /*
+    { "": { "ref": 4,
+            "TCPWRAP": [{ "end": 1096775635496890n, "duration": 175000},
+                        { "end": 1096780645597850n, "duration": 1154541},...],
+            "HTTPCLIENTREQUEST": [{ "end": 1096775635496890n, "duration": 84416},
+                                  { "end": 1096780645597850n, "duration": 494125}, ...]
+      },
+      "8902676252807731318": { "rootSpanId": "6976680365829768426", "ref": 1,
+            "FSREQCALLBACK": [{ "end": 1096778231456460n, "duration": 1220918},
+                              { "end": 1096778241557470n, "duration": 774915}, ...],
+            "ZLIB": [{ "end": 1096778342567570n, "duration": 397250},
+                     { "end": 1096778352668580n, "duration": 237210}, ...]
+      },
+      ...
+    }
+    */
+    // A single span might be referenced from multiple active async tasks, that's
+    // what we track with "ref". A span whose ref is 0 and that has no recorded
+    // durations of any event type will be removed during a profile() call.
+
+    this._accumulators = new Map()
+    this._active = new Map()
+    // hrtime is uint64_t, and it can overflow. For this reason, we'll be
+    // subtracting _timeOrigin from it in order to keep it (roughly) in the
+    // [0-flushIntervalNanos] range. _timeOrigin will be advanced each time we
+    // report the profile by roughly flushIntervalNanos, with 64-bit overflow so
+    // it hews to hrtime. At the same time already recorded times ('end'
+    // properties in quanta and 'start' of activity objects in the _active map)
+    // will be decremented by the same amount, essentially getting rebased to
+    // the new time origin. Note that for this reason, time instants can
+    // sometimes become negative, which is fine. The intricacies of correctly
+    // handling hrtime 64-bit overflow are handled in _hrnow and _report.
+    this._timeOrigin = startOfQuantum(process.hrtime.bigint(), this._samplingIntervalNanos)
+  }
+
+  start () {
+    if (!this._hook) {
+      this._hook = asyncHooks.createHook({
+        init: this._init.bind(this),
+        before: this._before.bind(this),
+        after: this._after.bind(this),
+        destroy: this._destroy.bind(this)
+      })
+    }
+    this._hook.enable()
+  }
+
+  stop () {
+    const profile = this.profile()
+    if (this._hook) {
+      this._hook.disable()
+    }
+    return profile
+  }
+
+  profile () {
+    const dateNow = Date.now() * 1000000
+    const hrNow = this._hrnow()
+    return this._createProfileFromReport(this._reportUntil(hrNow), dateNow, hrNow)
+  }
+
+  encode (profile) {
+    return pprof.encode(profile)
+  }
+
+  _init (asyncId, type) {
+    if (type !== 'TickObject' && type !== 'Timeout') {
+      const span = getActiveSpan()
+      const ctx = span?.context()
+      const spanId = ctx?.toSpanId()
+      const activity = this._createActivity(type, spanId, ctx)
+      this._active.set(asyncId, activity)
+    }
+  }
+
+  _before (asyncId) {
+    const activity = this._active.get(asyncId)
+    if (activity) {
+      this._startActivity(activity, this._hrnow())
+    }
+  }
+
+  // time parameter is only explicitly passed for testing
+  _after (asyncId) {
+    const activity = this._active.get(asyncId)
+    if (activity) {
+      this._stopActivity(activity, this._hrnow())
+    }
+  }
+
+  _destroy (asyncId) {
+    const activity = this._active.get(asyncId)
+    if (activity) {
+      --activity.spanData.ref
+    }
+  }
+
+  _hrnow() {
+    const now = process.hrtime.bigint() - this._timeOrigin
+    if (now >= 0) {
+      return now
+    }
+    // hrtime is uint64_t and had an overflow since last update to _timeOrigin,
+    // so we need to undo the overflow. Because of the overflow, hrtime will
+    // have a very small magnitude, and _timeOrigin will be close to
+    // UINT_PERIOD, so "now" will be close to -UINT_PERIOD. Adding UINT_PERIOD
+    // will bring it back into the (roughly) [0-flushIntervalNanos] range.
+    return now + UINT_PERIOD
+  }
+
+  _createActivity (type, spanId, ctx) {
+    const spanKey = spanId ?? ''
+    let spanData = this._accumulators.get(spanKey)
+    let quanta
+    if (!spanData) {
+      quanta = []
+      spanData = new Map()
+      spanData.rootSpanId = ctx?._trace.started[0]?.context().toSpanId(),
+      spanData.ref = 1
+      spanData.set(type, quanta)
+      this._accumulators.set(spanKey, spanData)
+    } else {
+      spanData.ref++
+      quanta = spanData.get(type)
+      if (!quanta) {
+        quanta = []
+        spanData.set(type, quanta)
+      }
+    }
+    return { spanData, quanta, running: false, start: 0n }
+  }
+
+  _startActivity(activity, time) {
+    activity.start = time
+    activity.running = true
+  }
+
+  _stopActivity(activity, time) {
+    activity.running = false
+    this._addDuration(activity.quanta, activity.start, time)
+  }
+
+  _addDuration (quanta, start, end) {
+    // Chop up the duration of this (after-before) activation into quanta at
+    // 10ms boundaries; add these quantized durations to the sum quantums,
+    // creating new ones as needed.
+    while (start < end) {
+      // end ns of the current quantum
+      const quantumEnd = endOfQuantum(start, this._samplingIntervalNanos)
+      // end ns of the activation
+      const endInQuantum = end < quantumEnd ? end : quantumEnd
+      // Duration should always fit in a JS number; 2^53 is good for 104 days
+      // worth of nanoseconds
+      const duration = Number(endInQuantum - start)
+      // Most likely quantum is the last one in the quanta array (the most
+      // recent), so we work from it backwards until we either...
+      let i = quanta.length - 1
+      for (; i >= 0; --i) {
+        const quantum = quanta[i]
+        if (quantum.end === quantumEnd) {
+          // ... find the right quantum for this partial duration, or...
+          quantum.duration += duration
+          break
+        } else if (quantum.end < quantumEnd) {
+          // ... an insertion point for a new one.
+          quanta.splice(i + 1, 0, { end: quantumEnd, duration: duration })
+          break
+        }
+      }
+      if (i === -1) {
+        // ... special case for insertion point being at the front of the array
+        quanta.splice(0, 0, { end: quantumEnd, duration: duration })
+      }
+      // advance start to the next quantum
+      start = quantumEnd
+    }
+  }
+
+  // All duration quanta reportable in a profile, meaning those that happened
+  // until the specified time. Written as a generator to separate the logic of
+  // selecting the data to report from the actual building of profile objects.
+  // The reported information is removed from _accumulators. All remaining
+  // information's timestamps are rebased on time.
+  * _reportUntil (time) {
+    const currQuantumEnd = endOfQuantum(time, this._samplingIntervalNanos)
+    const currQuantumStart = startOfQuantum(time, this._samplingIntervalNanos)
+
+    // Add partial duration of currently running activities that started
+    // before the current time quantum into their previous time quantum
+    // durations. Note that since Node.JS is single-threaded, this'll only apply
+    // to real async activities (e.g. ZLIB, crypto operations.)
+    for(const activity of this._active.values()) {
+      if (activity.running) {
+        if (activity.start < currQuantumStart) {
+          this._addDuration(activity.quanta, activity.start, currQuantumStart)
+          // Since we reported the activity duration up to currQuantumStart,
+          // we need to adjust its start to currQuantumStart. Since we'll also
+          // rebase _timeOrigin to currQuantumStart, the new start becomes 0.
+          activity.start = 0n
+        } else {
+          // Running activity started in the current time quantum has no
+          // reportable duration, but should have its start rebased on the new
+          // time origin.
+          activity.start -= currQuantumStart
+        }
+      }
+    }
+
+    for (const [spanKey, spanData] of this._accumulators) {
+      let hasEntries = false
+      const { rootSpanId } = spanData
+      const spanId = spanKey !== '' ? spanKey : undefined
+      for (const [type, quanta] of spanData) {
+        let i = quanta.length - 1
+        for (; i >= 0; --i) {
+          if (quanta[i].end < currQuantumEnd) break
+        }
+        if (i >= 0) {
+          yield { type, spanId, rootSpanId, quanta: quanta.splice(0, i + 1) }
+        }
+        if (!hasEntries && quanta.length) {
+          hasEntries = true
+        }
+        // Adjust end times in the remaining quanta
+        for (const quantum of quanta) {
+          quantum.end -= currQuantumStart
+        }
+      }
+      if (!hasEntries && spanData.ref === 0 && spanKey !== '') {
+        // Delete empty spans
+        this._accumulators.delete(spanKey)
+      }
+    }
+    // Finally, shift the time origin
+    this._timeOrigin = BigInt.asUintN(64, this._timeOrigin + currQuantumStart)
+  }
+
+  // Takes a generator from _reportUntil and creates a pprof Profile from it.
+  // Additionally takes a current epoch date (in nanos) and a current
+  // high-resolution time in nanoseconds.
+  _createProfileFromReport (accs, dateNow, hrNow) {
+    const stringTable = new StringTable()
+    const timestampLabelKey = stringTable.dedup(END_TIMESTAMP)
+    const spanLabelKey = stringTable.dedup(SPAN_ID)
+    const rootSpanLabelKey = stringTable.dedup(ROOT_SPAN_ID)
+    const typeLabelKey = stringTable.dedup('async_resource_type')
+
+    const samples = []
+    const locations = []
+    const locationsPerType = {}
+    const functions = []
+
+    const spanLabels = {}
+    const typeLabels = {}
+
+    function makeLabel (key, str, labels) {
+      if (str) {
+        let label = labels[str]
+        if (!label) {
+          label = new Label({ key, str: stringTable.dedup(str) })
+          labels[str] = label
+        }
+        return label
+      }
+    }
+
+    const dateOffset = BigInt(dateNow) - hrNow
+
+    let durationFrom = hrNow + this._samplingIntervalNanos
+    let durationTo = 0n
+
+    for (;;) {
+      const next = accs.next()
+      if (next.done) break
+
+      const { type, spanId, rootSpanId, quanta } = next.value
+      let location = locationsPerType[type]
+      if (!location) {
+        const fn = new Function({ id: functions.length + 1, name: stringTable.dedup(type) })
+        functions.push(fn)
+        const line = new Line({ functionId: fn.id })
+        location = new Location({ id: locations.length + 1, line: [line] })
+        locations.push(location)
+        locationsPerType[type] = location
+      }
+      const spanLabel = makeLabel(spanLabelKey, spanId, spanLabels)
+      const rootSpanLabel = makeLabel(rootSpanLabelKey, rootSpanId, spanLabels)
+      const typeLabel = makeLabel(typeLabelKey, type, typeLabels)
+
+      for (const q of quanta) {
+        const end = q.end
+        const start = end - this._samplingIntervalNanos
+        if (end > durationTo) durationTo = end
+        if (start < durationFrom) durationFrom = start
+        const labels = [new Label({ key: timestampLabelKey, num: q.end + dateOffset }), typeLabel]
+        if (spanLabel) labels.push(spanLabel)
+        if (rootSpanLabel) labels.push(rootSpanLabel)
+        samples.push(new Sample({
+          locationId: [location.id],
+          value: [Number(q.duration)],
+          label: labels
+        }))
+      }
+    }
+
+    const timeValueType = new ValueType({
+      type: stringTable.dedup('timeline'),
+      unit: stringTable.dedup('nanoseconds')
+    })
+
+    return new Profile({
+      sampleType: [timeValueType],
+      timeNanos: dateNow,
+      periodType: timeValueType,
+      period: this._flushIntervalNanos,
+      duration: Math.max(0, Number(durationTo - durationFrom)),
+      sample: samples,
+      location: locations,
+      function: functions,
+      stringTable: stringTable
+    })
+  }
+}
+
+module.exports = Timeline

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -7,6 +7,7 @@ const { HTTP_METHOD, HTTP_ROUTE, RESOURCE_NAME, SPAN_TYPE } = require('../../../
 const { WEB } = require('../../../../../ext/types')
 const runtimeMetrics = require('../../runtime_metrics')
 const telemetryMetrics = require('../../telemetry/metrics')
+const { END_TIMESTAMP, ROOT_SPAN_ID, SPAN_ID } = require('./shared')
 
 const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
@@ -26,10 +27,10 @@ function getStartedSpans (context) {
 function generateLabels ({ context: { spanId, rootSpanId, webTags, endpoint }, timestamp }) {
   const labels = {}
   if (spanId) {
-    labels['span id'] = spanId
+    labels[SPAN_ID] = spanId
   }
   if (rootSpanId) {
-    labels['local root span id'] = rootSpanId
+    labels[ROOT_SPAN_ID] = rootSpanId
   }
   if (webTags && Object.keys(webTags).length !== 0) {
     labels['trace endpoint'] = endpointNameFromTags(webTags)
@@ -38,7 +39,7 @@ function generateLabels ({ context: { spanId, rootSpanId, webTags, endpoint }, t
     labels['trace endpoint'] = endpoint
   }
   // Incoming timestamps are in microseconds, we emit nanos.
-  labels['end_timestamp_ns'] = timestamp * 1000n
+  labels[END_TIMESTAMP] = timestamp * 1000n
 
   return labels
 }

--- a/packages/dd-trace/test/profiling/profilers/timeline.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/timeline.spec.js
@@ -9,7 +9,7 @@ describe('profilers/timeline', () => {
   const TimelineProfiler = require('../../../src/profiling/profilers/timeline')
 
   it('should summarize durations', () => {
-    const profiler = new TimelineProfiler({samplingInterval: 100})
+    const profiler = new TimelineProfiler({samplingInterval: 100000000})
     // create a duration accumulator
     const { quanta: q } = profiler._createActivity('X')
     const expectedAccs = new Map()
@@ -22,111 +22,107 @@ describe('profilers/timeline', () => {
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
 
     // add first duration
-    profiler._addDuration(q, 10n, 20n)
-    expectedQuanta.push({'end': 100n, 'duration': 10})
+    profiler._addDuration(q, 10, 20)
+    expectedQuanta.push({'end': 100, 'duration': 10})
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
 
     // add another duration into the same time quantum
-    profiler._addDuration(q, 20n, 35n)
+    profiler._addDuration(q, 20, 35)
     expectedQuanta[0].duration += 15
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
 
     // add a duration that spills over into a new later quantum
-    profiler._addDuration(q, 80n, 120n)
+    profiler._addDuration(q, 80, 120)
     expectedQuanta[0].duration += 20
-    expectedQuanta.push({'end': 200n, 'duration': 20})
+    expectedQuanta.push({'end': 200, 'duration': 20})
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
 
     // add a duration that spills over into a new earlier quantum
-    profiler._addDuration(q, -10n, 10n)
+    profiler._addDuration(q, -10, 10)
     expectedQuanta[0].duration += 10
-    expectedQuanta.unshift({'end': 0n, 'duration': 10})
+    expectedQuanta.unshift({'end': 0, 'duration': 10})
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
 
     // add a duration that creates a new quantum with space in between
-    profiler._addDuration(q, 420n, 440n)
-    expectedQuanta.push({'end': 500n, 'duration': 20})
+    profiler._addDuration(q, 420, 440)
+    expectedQuanta.push({'end': 500, 'duration': 20})
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
 
     // add a duration that creates a new intermediate quantum to the left of an
     // existing one with overlap
-    profiler._addDuration(q, 375n, 410n)
+    profiler._addDuration(q, 375, 410)
     expectedQuanta[3].duration += 10
-    expectedQuanta.splice(3, 0, {'end': 400n, 'duration': 25})
+    expectedQuanta.splice(3, 0, {'end': 400, 'duration': 25})
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
 
     // add a duration that creates a new intermediate quantum to the right of an
     // existing one with overlap
-    profiler._addDuration(q, 175n, 210n)
+    profiler._addDuration(q, 175, 210)
     expectedQuanta[2].duration += 25
-    expectedQuanta.splice(3, 0, {'end': 300n, 'duration': 10})
+    expectedQuanta.splice(3, 0, {'end': 300, 'duration': 10})
     expect(profiler._accumulators).to.deep.equal(expectedAccs)
   })
 
-  it('should report durations and update time', () => {
-    const profiler = new TimelineProfiler({samplingInterval: 100})
-    profiler._timeOrigin = 0n
+  it('should report durations', () => {
+    const profiler = new TimelineProfiler({samplingInterval: 100000000})
     // Add few durations
     const { spanData, quanta: qx } = profiler._createActivity('X');
-    profiler._addDuration(qx, 10n, 20n)
-    profiler._addDuration(qx, 110n, 130n)
-    profiler._addDuration(qx, 210n, 240n)
-    profiler._addDuration(qx, 310n, 350n)
+    profiler._addDuration(qx, 10, 20)
+    profiler._addDuration(qx, 110, 130)
+    profiler._addDuration(qx, 210, 240)
+    profiler._addDuration(qx, 310, 350)
 
     // Dereference the span data
     spanData.ref--
     expect(spanData.ref).to.equal(0)
 
-    const g1 = profiler._reportUntil(299n)
+    const g1 = profiler._reportUntil(299)
     expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: undefined, rootSpanId: undefined,
-        quanta: [{end: 100n, duration: 10}, {end:200n, duration: 20}]
+        quanta: [{end: 100, duration: 10}, {end:200, duration: 20}]
     }, done: false})
     expect(g1.next().done).to.equal(true)
 
-    // Reported values have been removed; all remaining end times have been
-    // reduced by startOfQuantum(250n), which is 200n
-    expect(profiler._accumulators.get('').get('X')).to.deep.equal([{end: 100n, duration: 30}, {end:200n, duration: 40}])
-    expect(profiler._timeOrigin).to.equal(200n)
+    // Reported values have been removed
+    expect(profiler._accumulators.get('').get('X')).to.deep.equal([{end: 300, duration: 30}, {end:400, duration: 40}])
 
     // report remaining data
-    const g2 = profiler._reportUntil(300n)
+    const g2 = profiler._reportUntil(500)
     expect(g2.next()).to.deep.equal({value: { type: 'X', spanId: undefined, rootSpanId: undefined,
-        quanta: [{end: 100n, duration: 30}, {end:200n, duration: 40}]
+        quanta: [{end: 300, duration: 30}, {end:400, duration: 40}]
     }, done: false})
     expect(g2.next().done).to.equal(true)
     // No data remains. The '' global "span" is not deleted even though it is
     // dereferenced.
     expect(profiler._accumulators.get('').get('X')).to.deep.equal([])
-    expect(profiler._timeOrigin).to.equal(500n)
   })
 
   it('should delete unreferenced spans', () => {
-    const profiler = new TimelineProfiler({samplingInterval: 100})
+    const profiler = new TimelineProfiler({samplingInterval: 100000000})
     // Add few durations
     const { spanData, quanta: qx } = profiler._createActivity('X', '1234567890');
-    profiler._addDuration(qx, 10n, 20n)
-    profiler._addDuration(qx, 110n, 130n)
-    profiler._addDuration(qx, 210n, 240n)
-    profiler._addDuration(qx, 310n, 350n)
+    profiler._addDuration(qx, 10, 20)
+    profiler._addDuration(qx, 110, 130)
+    profiler._addDuration(qx, 210, 240)
+    profiler._addDuration(qx, 310, 350)
 
     // Dereference the span data
     spanData.ref--
     expect(spanData.ref).to.equal(0)
 
     // Report some data
-    const g1 = profiler._reportUntil(299n)
+    const g1 = profiler._reportUntil(299)
     expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: '1234567890', rootSpanId: undefined,
-        quanta: [{end: 100n, duration: 10}, {end:200n, duration: 20}]
+        quanta: [{end: 100, duration: 10}, {end:200, duration: 20}]
     }, done: false})
     expect(g1.next().done).to.equal(true)
 
     // Span data is not deleted despite being dereferenced as it still has data
-    expect(profiler._accumulators.get('1234567890').get('X')).to.deep.equal([{end: 100n, duration: 30}, {end:200n, duration: 40}])
+    expect(profiler._accumulators.get('1234567890').get('X')).to.deep.equal([{end: 300, duration: 30}, {end:400, duration: 40}])
 
     // report remaining data
-    const g2 = profiler._reportUntil(300n)
+    const g2 = profiler._reportUntil(500)
     expect(g2.next()).to.deep.equal({value: { type: 'X', spanId: '1234567890', rootSpanId: undefined,
-        quanta: [{end: 100n, duration: 30}, {end:200n, duration: 40}]
+        quanta: [{end: 300, duration: 30}, {end:400, duration: 40}]
     }, done: false})
     expect(g2.next().done).to.equal(true)
     // No data remains, span data was deleted
@@ -134,7 +130,7 @@ describe('profilers/timeline', () => {
   })
 
   it('should add partial activity durations when reporting', () => {
-    const profiler = new TimelineProfiler({samplingInterval: 100})
+    const profiler = new TimelineProfiler({samplingInterval: 100000000})
     // Add few durations
     const activity1 = profiler._createActivity('X', '1');
     profiler._active.set(1, activity1)
@@ -145,27 +141,27 @@ describe('profilers/timeline', () => {
     const activity4 = profiler._createActivity('X', '2');
     profiler._active.set(4, activity4)
     // These will add to durations, but not running when reporting
-    profiler._startActivity(activity3, 10n)
-    profiler._stopActivity(activity3, 30n)
-    profiler._startActivity(activity4, 10n)
-    profiler._stopActivity(activity4, 40n)
+    profiler._startActivity(activity3, 10)
+    profiler._stopActivity(activity3, 30)
+    profiler._startActivity(activity4, 10)
+    profiler._stopActivity(activity4, 40)
     // These two will be running when reporting
-    profiler._startActivity(activity1, 50n)
-    profiler._startActivity(activity2, 110n)
-    const g1 = profiler._reportUntil(111n) // reported until 100n quanta
+    profiler._startActivity(activity1, 50)
+    profiler._startActivity(activity2, 110)
+    const g1 = profiler._reportUntil(111) // reported until 100 quanta
     // duration 70, as activity3 added 20, and activity1 added 50 until 100
     expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: '1', rootSpanId: undefined,
-        quanta: [{end: 100n, duration: 70}]
+        quanta: [{end: 100, duration: 70}]
     }, done: false})
     // duration 30, as activity4 added it. activity2 not reported as it started
-    // after 100n quanta
+    // after 100 quanta
     expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: '2', rootSpanId: undefined,
-        quanta: [{end: 100n, duration: 30}]
+        quanta: [{end: 100, duration: 30}]
     }, done: false})
     expect(activity1.running).to.be.true
-    expect(activity1.start).to.equal(0n)
+    expect(activity1.start).to.equal(100)
     expect(activity2.running).to.be.true
-    expect(activity2.start).to.equal(10n)
+    expect(activity2.start).to.equal(110)
     expect(activity3.running).to.be.false
     expect(activity4.running).to.be.false
   })

--- a/packages/dd-trace/test/profiling/profilers/timeline.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/timeline.spec.js
@@ -1,0 +1,172 @@
+'use strict'
+
+require('../../setup/tap')
+
+const { ok } = require('assert')
+const { expect } = require('chai')
+
+describe('profilers/timeline', () => {
+  const TimelineProfiler = require('../../../src/profiling/profilers/timeline')
+
+  it('should summarize durations', () => {
+    const profiler = new TimelineProfiler({samplingInterval: 100})
+    // create a duration accumulator
+    const { quanta: q } = profiler._createActivity('X')
+    const expectedAccs = new Map()
+    const expectedSpanData = new Map()
+    const expectedQuanta = []
+    expectedSpanData.set('X', expectedQuanta)
+    expectedSpanData.rootSpanId = undefined
+    expectedSpanData.ref = 1
+    expectedAccs.set('', expectedSpanData)
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+
+    // add first duration
+    profiler._addDuration(q, 10n, 20n)
+    expectedQuanta.push({'end': 100n, 'duration': 10})
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+
+    // add another duration into the same time quantum
+    profiler._addDuration(q, 20n, 35n)
+    expectedQuanta[0].duration += 15
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+
+    // add a duration that spills over into a new later quantum
+    profiler._addDuration(q, 80n, 120n)
+    expectedQuanta[0].duration += 20
+    expectedQuanta.push({'end': 200n, 'duration': 20})
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+
+    // add a duration that spills over into a new earlier quantum
+    profiler._addDuration(q, -10n, 10n)
+    expectedQuanta[0].duration += 10
+    expectedQuanta.unshift({'end': 0n, 'duration': 10})
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+
+    // add a duration that creates a new quantum with space in between
+    profiler._addDuration(q, 420n, 440n)
+    expectedQuanta.push({'end': 500n, 'duration': 20})
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+
+    // add a duration that creates a new intermediate quantum to the left of an
+    // existing one with overlap
+    profiler._addDuration(q, 375n, 410n)
+    expectedQuanta[3].duration += 10
+    expectedQuanta.splice(3, 0, {'end': 400n, 'duration': 25})
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+
+    // add a duration that creates a new intermediate quantum to the right of an
+    // existing one with overlap
+    profiler._addDuration(q, 175n, 210n)
+    expectedQuanta[2].duration += 25
+    expectedQuanta.splice(3, 0, {'end': 300n, 'duration': 10})
+    expect(profiler._accumulators).to.deep.equal(expectedAccs)
+  })
+
+  it('should report durations and update time', () => {
+    const profiler = new TimelineProfiler({samplingInterval: 100})
+    profiler._timeOrigin = 0n
+    // Add few durations
+    const { spanData, quanta: qx } = profiler._createActivity('X');
+    profiler._addDuration(qx, 10n, 20n)
+    profiler._addDuration(qx, 110n, 130n)
+    profiler._addDuration(qx, 210n, 240n)
+    profiler._addDuration(qx, 310n, 350n)
+
+    // Dereference the span data
+    spanData.ref--
+    expect(spanData.ref).to.equal(0)
+
+    const g1 = profiler._reportUntil(299n)
+    expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: undefined, rootSpanId: undefined,
+        quanta: [{end: 100n, duration: 10}, {end:200n, duration: 20}]
+    }, done: false})
+    expect(g1.next().done).to.equal(true)
+
+    // Reported values have been removed; all remaining end times have been
+    // reduced by startOfQuantum(250n), which is 200n
+    expect(profiler._accumulators.get('').get('X')).to.deep.equal([{end: 100n, duration: 30}, {end:200n, duration: 40}])
+    expect(profiler._timeOrigin).to.equal(200n)
+
+    // report remaining data
+    const g2 = profiler._reportUntil(300n)
+    expect(g2.next()).to.deep.equal({value: { type: 'X', spanId: undefined, rootSpanId: undefined,
+        quanta: [{end: 100n, duration: 30}, {end:200n, duration: 40}]
+    }, done: false})
+    expect(g2.next().done).to.equal(true)
+    // No data remains. The '' global "span" is not deleted even though it is
+    // dereferenced.
+    expect(profiler._accumulators.get('').get('X')).to.deep.equal([])
+    expect(profiler._timeOrigin).to.equal(500n)
+  })
+
+  it('should delete unreferenced spans', () => {
+    const profiler = new TimelineProfiler({samplingInterval: 100})
+    // Add few durations
+    const { spanData, quanta: qx } = profiler._createActivity('X', '1234567890');
+    profiler._addDuration(qx, 10n, 20n)
+    profiler._addDuration(qx, 110n, 130n)
+    profiler._addDuration(qx, 210n, 240n)
+    profiler._addDuration(qx, 310n, 350n)
+
+    // Dereference the span data
+    spanData.ref--
+    expect(spanData.ref).to.equal(0)
+
+    // Report some data
+    const g1 = profiler._reportUntil(299n)
+    expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: '1234567890', rootSpanId: undefined,
+        quanta: [{end: 100n, duration: 10}, {end:200n, duration: 20}]
+    }, done: false})
+    expect(g1.next().done).to.equal(true)
+
+    // Span data is not deleted despite being dereferenced as it still has data
+    expect(profiler._accumulators.get('1234567890').get('X')).to.deep.equal([{end: 100n, duration: 30}, {end:200n, duration: 40}])
+
+    // report remaining data
+    const g2 = profiler._reportUntil(300n)
+    expect(g2.next()).to.deep.equal({value: { type: 'X', spanId: '1234567890', rootSpanId: undefined,
+        quanta: [{end: 100n, duration: 30}, {end:200n, duration: 40}]
+    }, done: false})
+    expect(g2.next().done).to.equal(true)
+    // No data remains, span data was deleted
+    expect(profiler._accumulators).to.deep.equal(new Map())
+  })
+
+  it('should add partial activity durations when reporting', () => {
+    const profiler = new TimelineProfiler({samplingInterval: 100})
+    // Add few durations
+    const activity1 = profiler._createActivity('X', '1');
+    profiler._active.set(1, activity1)
+    const activity2 = profiler._createActivity('X', '2')
+    profiler._active.set(2, activity2)
+    const activity3 = profiler._createActivity('X', '1');
+    profiler._active.set(3, activity3)
+    const activity4 = profiler._createActivity('X', '2');
+    profiler._active.set(4, activity4)
+    // These will add to durations, but not running when reporting
+    profiler._startActivity(activity3, 10n)
+    profiler._stopActivity(activity3, 30n)
+    profiler._startActivity(activity4, 10n)
+    profiler._stopActivity(activity4, 40n)
+    // These two will be running when reporting
+    profiler._startActivity(activity1, 50n)
+    profiler._startActivity(activity2, 110n)
+    const g1 = profiler._reportUntil(111n) // reported until 100n quanta
+    // duration 70, as activity3 added 20, and activity1 added 50 until 100
+    expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: '1', rootSpanId: undefined,
+        quanta: [{end: 100n, duration: 70}]
+    }, done: false})
+    // duration 30, as activity4 added it. activity2 not reported as it started
+    // after 100n quanta
+    expect(g1.next()).to.deep.equal({value: { type: 'X', spanId: '2', rootSpanId: undefined,
+        quanta: [{end: 100n, duration: 30}]
+    }, done: false})
+    expect(activity1.running).to.be.true
+    expect(activity1.start).to.equal(0n)
+    expect(activity2.running).to.be.true
+    expect(activity2.start).to.equal(10n)
+    expect(activity3.running).to.be.false
+    expect(activity4.running).to.be.false
+  })
+})


### PR DESCRIPTION
A prototype implementation of a new profiler type ("timeline") that can be operated simultaneously with "wall" profiler to gather information suitable for presentation as a timeline from async_hooks. This one takes the coarser-grained approach and essentially summarizes durations of various async events in 10ms (actually, 1/99s for Datadog reasons) quanta. Another approach with full-fidelity activation information would be possible, but we'd need to start emitting the Go execution trace format for that.