### PR TITLE
Add `_dd.base_service` tag

### DIFF
--- a/ext/tags.d.ts
+++ b/ext/tags.d.ts
@@ -9,6 +9,7 @@ declare const tags: {
   MANUAL_KEEP: 'manual.keep'
   MANUAL_DROP: 'manual.drop'
   MEASURED: '_dd.measured'
+  BASE_SERVICE: '_dd.base_service'
   HTTP_URL: 'http.url'
   HTTP_METHOD: 'http.method'
   HTTP_STATUS_CODE: 'http.status_code'

--- a/ext/tags.js
+++ b/ext/tags.js
@@ -12,6 +12,7 @@ const tags = {
   MANUAL_KEEP: 'manual.keep',
   MANUAL_DROP: 'manual.drop',
   MEASURED: '_dd.measured',
+  BASE_SERVICE: '_dd.base_service',
 
   // HTTP
   HTTP_URL: 'http.url',

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -13,7 +13,7 @@ const SPAN_SAMPLING_MECHANISM = constants.SPAN_SAMPLING_MECHANISM
 const SPAN_SAMPLING_RULE_RATE = constants.SPAN_SAMPLING_RULE_RATE
 const SPAN_SAMPLING_MAX_PER_SECOND = constants.SPAN_SAMPLING_MAX_PER_SECOND
 const SAMPLING_MECHANISM_SPAN = constants.SAMPLING_MECHANISM_SPAN
-const MEASURED = tags.MEASURED
+const { MEASURED, BASE_SERVICE } = tags
 const ORIGIN_KEY = constants.ORIGIN_KEY
 const HOSTNAME_KEY = constants.HOSTNAME_KEY
 const TOP_LEVEL_KEY = constants.TOP_LEVEL_KEY
@@ -71,6 +71,11 @@ function extractTags (trace, span) {
 
   if (tags['span.kind'] && tags['span.kind'] !== 'internal') {
     addTag({}, trace.metrics, MEASURED, 1)
+  }
+
+  const tracerService = span.tracer()._service.toLowerCase()
+  if (tags['service.name']?.toLowerCase() !== tracerService) {
+    span.setTag(BASE_SERVICE, tracerService)
   }
 
   for (const tag in tags) {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -49,6 +49,7 @@ describe('format', () => {
       tracer: sinon.stub().returns({
         _service: 'test'
       }),
+      setTag: sinon.stub(),
       _startTime: 1500000000000.123456,
       _duration: 100
     }
@@ -85,6 +86,24 @@ describe('format', () => {
       expect(trace.error).to.equal(0)
       expect(trace.start).to.equal(span._startTime * 1e6)
       expect(trace.duration).to.equal(span._duration * 1e6)
+    })
+
+    describe('_dd.base_service', () => {
+      it('should infer the tag when span service changes', () => {
+        span.context()._tags['service.name'] = 'foo'
+
+        trace = format(span)
+
+        expect(span.setTag).to.have.been.calledWith('_dd.base_service', 'test')
+      })
+
+      it('should infer the tag when no changes occur', () => {
+        span.context()._tags['service.name'] = 'test'
+
+        trace = format(span)
+
+        expect(span.setTag).to.not.have.been.called
+      })
     })
 
     it('should extract Datadog specific tags', () => {

--- a/packages/dd-trace/test/plugins/tracing.spec.js
+++ b/packages/dd-trace/test/plugins/tracing.spec.js
@@ -3,6 +3,9 @@
 require('../setup/tap')
 
 const TracingPlugin = require('../../src/plugins/tracing')
+const agent = require('../plugins/agent')
+const plugins = require('../../src/plugins')
+const { channel } = require('../../../diagnostics_channel')
 
 describe('TracingPlugin', () => {
   describe('startSpan method', () => {
@@ -22,6 +25,94 @@ describe('TracingPlugin', () => {
         sinon.match({
           childOf: 'some parent span'
         })
+      )
+    })
+  })
+})
+
+describe('common Plugin behaviour', () => {
+  before(() => agent.load())
+  after(() => agent.close({ ritmReset: false }))
+  class CommonPlugin extends TracingPlugin {
+    static get id () { return 'commonPlugin' }
+    static get operation () { return 'dothings' }
+
+    start () {
+      return this.startSpan('common.operation', {
+        service: this.config.service || this._tracerConfig.service
+      }, true)
+    }
+  }
+
+  class SuffixPlugin extends TracingPlugin {
+    static get id () { return 'suffixPlugin' }
+    static get operation () { return 'dothings' }
+    start () {
+      return this.startSpan('common.operation', {
+        service: this.config.service || `${this.tracer._service}-suffix`
+      }, true)
+    }
+  }
+
+  const testPlugins = { 'commonPlugin': CommonPlugin, 'suffixPlugin': SuffixPlugin }
+  const loadChannel = channel('dd-trace:instrumentation:load')
+
+  before(() => {
+    for (const [name, cls] of Object.entries(testPlugins)) {
+      plugins[name] = cls
+      loadChannel.publish({ name })
+    }
+  })
+
+  after(() => { Object.keys(testPlugins).forEach(name => delete plugins[name]) })
+
+  describe('tagBaseService', () => {
+    function makeSpan (done, pluginName, pluginConf, spanExpectations) {
+      /**
+       * Make plugin `pluginName` generate a span given `pluginConf` plugin init
+       * and verify it against spanExpectations: span -> void
+       */
+      const startCh = channel(`apm:${pluginName}:dothings:start`)
+      const finishCh = channel(`apm:${pluginName}:dothings:finish`)
+
+      agent.reload(pluginName, pluginConf)
+
+      agent.use(
+        traces => {
+          const span = traces[0][0]
+          spanExpectations(span)
+        }
+      ).then(done).catch(done)
+
+      startCh.publish({ foo: 'bar' })
+      finishCh.publish({})
+    }
+
+    it('should tag when tracer service does not match plugin', done => {
+      makeSpan(
+        done, 'commonPlugin', { service: 'not-the-right-test' },
+        span => {
+          expect(span).to.have.property('service', 'not-the-right-test')
+          expect(span.meta).to.have.property('_dd.base_service', 'test')
+        }
+      )
+    })
+    it('should tag when plugin impl does not match tracer service', done => {
+      makeSpan(
+        done, 'suffixPlugin', {},
+        span => {
+          expect(span).to.have.property('service', 'test-suffix')
+          expect(span.meta).to.have.property('_dd.base_service', 'test')
+        }
+      )
+    })
+    it('should not tag when service matches tracer service', done => {
+      makeSpan(
+        done, 'commonPlugin', {},
+        span => {
+          expect(span).to.have.property('service', 'test')
+          expect(span.meta).to.not.have.property('_dd.base_service', 'test')
+        }
       )
     })
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `_dd.base_service` tag containing original tracer-wide configured service if it is not the service in produced spans.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is an initiative for every tracer that helps identify services that are modified in code from their `DD_SERVICE` default, to help remove nodes in service map that don't correspond to concrete services. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
