### PR TITLE
Remove wrapObjectProperty wrapper for Next.js

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -199,43 +199,23 @@ function finish (ctx, result, err) {
   return result
 }
 
-// transpiled functions in newer next.js versions can't be shimmed
-// because they're read-only, so we re-define the property needed here
-function wrapObjectProperty (module, func, wrapper) {
-  // create new copy of module with everything but 'func' in order to write over it
-  const entriesWithoutFunc = Object
-    .entries(module)
-    .filter(([key]) => key !== func)
-    .map(([key, value]) => [key, { value }])
-  const newModule = Object.defineProperties({}, Object.fromEntries(entriesWithoutFunc))
-
-  // create new descriptor for func that wraps the original
-  const origDescriptor = Object.getOwnPropertyDescriptor(module, func)
-  const newDescriptor = { ...origDescriptor }
-  newDescriptor.get = function () {
-    return wrapper(origDescriptor.get.call(this))
-  }
-
-  return Object.defineProperty(newModule, func, newDescriptor)
-}
-
 addHook({
   name: 'next',
   versions: ['>=13.4.13'],
   file: 'dist/server/lib/router-utils/resolve-routes.js'
-}, resolveRoutesModule => wrapObjectProperty(resolveRoutesModule, 'getResolveRoutes', wrapGetResolveRoutes))
+}, resolveRoutesModule => shimmer.wrap(resolveRoutesModule, 'getResolveRoutes', wrapGetResolveRoutes))
 
 addHook({
   name: 'next',
   versions: ['13.4.13'],
   file: 'dist/server/lib/setup-server-worker.js'
-}, setupServerWorker => wrapObjectProperty(setupServerWorker, 'initializeServerWorker', wrapSetupServerWorker))
+}, setupServerWorker => shimmer.wrap(setupServerWorker, 'initializeServerWorker', wrapSetupServerWorker))
 
 addHook({
   name: 'next',
   versions: ['>=13.4.15'],
   file: 'dist/server/lib/router-server.js'
-}, routerServer => wrapObjectProperty(routerServer, 'initialize', wrapInitialize))
+}, routerServer => shimmer.wrap(routerServer, 'initialize', wrapInitialize))
 
 addHook({ name: 'next', versions: ['>=13.2'], file: 'dist/server/next-server.js' }, nextServer => {
   const Server = nextServer.default


### PR DESCRIPTION
### What does this PR do?
Removes `wrapObjectProperty` for our Next.js instrumentation, since `shimmer.wrap` does this.

### Motivation
This should have been in #3538. However, I didn't realize `shimmer.wrap` can wrap a property on an object and return a new object with copied values already - I thought it just wrapped properties in-place, and when it was used to wrap a method, the original module passed into `addHook` had to be returned. Now, Next.js instrumentation that previously used `wrapObjectProperty` uses `shimmer.wrap` correctly.
