### PR TITLE
[profiling] Update pprof version

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@datadog/native-iast-rewriter": "2.0.1",
     "@datadog/native-iast-taint-tracking": "1.5.0",
     "@datadog/native-metrics": "^2.0.0",
-    "@datadog/pprof": "3.1.0",
+    "@datadog/pprof": "3.2.0",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^1.14.0",

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -31,6 +31,7 @@ class Config {
       DD_PROFILING_UPLOAD_PERIOD,
       DD_PROFILING_PPROF_PREFIX,
       DD_PROFILING_HEAP_ENABLED,
+      DD_PROFILING_V8_PROFILER_BUG_WORKAROUND,
       DD_PROFILING_WALLTIME_ENABLED,
       DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED,
       DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE,
@@ -76,7 +77,8 @@ class Config {
     this.debugSourceMaps = isTrue(coalesce(options.debugSourceMaps, DD_PROFILING_DEBUG_SOURCE_MAPS, false))
     this.endpointCollectionEnabled = endpointCollectionEnabled
     this.pprofPrefix = pprofPrefix
-
+    this.v8ProfilerBugWorkaroundEnabled = isTrue(coalesce(options.v8ProfilerBugWorkaround,
+      DD_PROFILING_V8_PROFILER_BUG_WORKAROUND, true))
     const hostname = coalesce(options.hostname, DD_AGENT_HOST) || 'localhost'
     const port = coalesce(options.port, DD_TRACE_AGENT_PORT) || 8126
     this.url = new URL(coalesce(options.url, DD_TRACE_AGENT_URL, format({

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -5,6 +5,7 @@ const { storage } = require('../../../../datadog-core')
 const dc = require('../../../../diagnostics_channel')
 const { HTTP_METHOD, HTTP_ROUTE, RESOURCE_NAME, SPAN_TYPE } = require('../../../../../ext/tags')
 const { WEB } = require('../../../../../ext/types')
+const runtimeMetrics = require('../../runtime_metrics')
 
 const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
@@ -83,6 +84,7 @@ class NativeWallProfiler {
     this._flushIntervalMillis = options.flushInterval || 60 * 1e3 // 60 seconds
     this._codeHotspotsEnabled = !!options.codeHotspotsEnabled
     this._endpointCollectionEnabled = !!options.endpointCollectionEnabled
+    this._v8ProfilerBugWorkaroundEnabled = !!options.v8ProfilerBugWorkaroundEnabled
     this._mapper = undefined
     this._pprof = undefined
 
@@ -122,7 +124,8 @@ class NativeWallProfiler {
       durationMillis: this._flushIntervalMillis,
       sourceMapper: this._mapper,
       withContexts: this._codeHotspotsEnabled,
-      lineNumbers: false
+      lineNumbers: false,
+      workaroundV8Bug: this._v8ProfilerBugWorkaroundEnabled
     })
 
     if (this._codeHotspotsEnabled) {
@@ -172,7 +175,18 @@ class NativeWallProfiler {
       this._enter()
       this._lastSampleCount = 0
     }
-    return this._pprof.time.stop(restart, this._codeHotspotsEnabled ? generateLabels : undefined)
+    const profile = this._pprof.time.stop(restart, this._codeHotspotsEnabled ? generateLabels : undefined)
+    if (restart) {
+      const v8BugDetected = this._pprof.time.v8ProfilerStuckEventLoopDetected()
+      if (v8BugDetected === 1) {
+        this._logger?.warn('Wall profiler: possible v8 profiler stuck event loop detected.')
+        runtimeMetrics.increment('runtime.node.profiler.v8_cpu_profiler_maybe_stuck_event_loop', undefined, true)
+      } else if (v8BugDetected === 2) {
+        this._logger?.warn('Wall profiler: v8 profiler stuck event loop detected.')
+        runtimeMetrics.increment('runtime.node.profiler.v8_cpu_profiler_stuck_event_loop', undefined, true)
+      }
+    }
+    return profile
   }
 
   profile () {

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -44,6 +44,7 @@ describe('config', () => {
     expect(config.profilers[0]).to.be.an.instanceof(WallProfiler)
     expect(config.profilers[0].codeHotspotsEnabled()).false
     expect(config.profilers[1]).to.be.an.instanceof(SpaceProfiler)
+    expect(config.v8ProfilerBugWorkaroundEnabled).true
   })
 
   it('should support configuration options', () => {
@@ -132,7 +133,8 @@ describe('config', () => {
   it('should support profiler config with DD_PROFILING_PROFILERS', () => {
     process.env = {
       DD_PROFILING_PROFILERS: 'wall',
-      DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED: '1'
+      DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED: '1',
+      DD_PROFILING_V8_PROFILER_BUG_WORKAROUND: '0'
     }
     const options = {
       logger: {
@@ -149,6 +151,7 @@ describe('config', () => {
     expect(config.profilers.length).to.equal(1)
     expect(config.profilers[0]).to.be.an.instanceOf(WallProfiler)
     expect(config.profilers[0].codeHotspotsEnabled()).true
+    expect(config.v8ProfilerBugWorkaroundEnabled).false
   })
 
   it('should support profiler config with DD_PROFILING_XXX_ENABLED', () => {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -38,6 +38,8 @@ async function createProfile (periodType) {
     logger: {
       error (err) {
         throw err
+      },
+      warn (err) {
       }
     }
   })

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -16,6 +16,7 @@ describe('profilers/native/wall', () => {
       time: {
         start: sinon.stub(),
         stop: sinon.stub().returns('profile'),
+        v8ProfilerStuckEventLoopDetected: sinon.stub().returns(false),
         constants: {
           kSampleCount: 0
         }
@@ -53,7 +54,8 @@ describe('profilers/native/wall', () => {
         durationMillis: 60000,
         sourceMapper: undefined,
         withContexts: false,
-        lineNumbers: false
+        lineNumbers: false,
+        workaroundV8Bug: false
       })
   })
 
@@ -70,7 +72,8 @@ describe('profilers/native/wall', () => {
         durationMillis: 60000,
         sourceMapper: undefined,
         withContexts: false,
-        lineNumbers: false
+        lineNumbers: false,
+        workaroundV8Bug: false
       })
   })
 
@@ -143,7 +146,8 @@ describe('profilers/native/wall', () => {
         durationMillis: 60000,
         sourceMapper: mapper,
         withContexts: false,
-        lineNumbers: false
+        lineNumbers: false,
+        workaroundV8Bug: false
       })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,10 +414,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-3.1.0.tgz#d58aac33985dbb71f77d85a41023a35f1ad55290"
-  integrity sha512-Bg8O8yrHeL2KKHXhLoAAT33ZfzLnZ6rWfOjy8PkcNhUJy3UwNVLbUoApf+99EyLjqpzpk/kZXrIAMBzMMB8ilg==
+"@datadog/pprof@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-3.2.0.tgz#ab822caf18999a84f144dd4e0261d6e9274f4c5f"
+  integrity sha512-kOhWHCWB80djnMCr5KNKBAy1Ih/jK/PIj6yqnZwL1Wqni/h6IBPRUMhtIxcYJMRgsZVYrFXUV20AVXTZCzFokw==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?

Bump pprof version to 3.1.1 to benefit from two important bug fixes:
* Empty profiles when a worker thread is started (https://github.com/DataDog/pprof-nodejs/pull/121)
* 100% CPU usage and empty profiles because of a probable v8 bug (https://github.com/DataDog/pprof-nodejs/pull/125)

When 100% CPU usage/empty profiles situation is detected, emit `runtime.node.profiler.v8_cpu_profiler_maybe_stuck_event_loop` / `runtime.node.profiler.v8_cpu_profiler_stuck_event_loop` metrics depending on the level of confidence.