### PR TITLE
Fix google-cloud-pubsub and startup test

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -369,7 +369,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       pubsub:
-        image: ridedott/pubsub-emulator
+        image: ghcr.io/ridedott/pubsub-emulator
         ports:
           - 8081:8081
     env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     ports:
       - "127.0.0.1:9231:9231"
   google-cloud-pubsub:
-    image: ridedott/pubsub-emulator
+    image: ghcr.io/ridedott/pubsub-emulator
     ports:
       - "127.0.0.1:8081:8081"
   localstack:

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -158,7 +158,7 @@ class FakeAgent extends EventEmitter {
 }
 
 function spawnProc (filename, options = {}, stdioHandler) {
-  const proc = fork(filename, options)
+  const proc = fork(filename, { ...options, stdio: 'pipe' })
   return new Promise((resolve, reject) => {
     proc
       .on('message', ({ port }) => {
@@ -284,8 +284,7 @@ async function spawnPluginIntegrationTestProc (cwd, serverFile, agentPort, stdio
   env = { ...env, ...additionalEnvArgs }
   return spawnProc(path.join(cwd, serverFile), {
     cwd,
-    env,
-    stdio: 'pipe'
+    env
   }, stdioHandler)
 }
 


### PR DESCRIPTION
### What does this PR do?
* Following https://github.com/ridedott/pubsub-emulator-docker/pull/24, ridedott/pubsub-emulator is not published anymore on dockerhub.
* Startup integration-test was failing following #3559 because `stdio:pipe` is required to be able to use `proc.stdout.on`.
