### PR TITLE
core: ensure master CI jobs test node v14

### DIFF
--- a/.github/actions/node/oldest/action.yml
+++ b/.github/actions/node/oldest/action.yml
@@ -1,7 +1,7 @@
-name: Node 16
+name: Node 14
 runs:
   using: composite
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '14'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:appsec:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:appsec:ci
       - uses: ./.github/actions/node/18
@@ -88,6 +90,8 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/14
+      - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/18
@@ -111,6 +115,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/18
@@ -139,6 +145,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/18

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:lambda:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:lambda:ci
       - uses: ./.github/actions/node/18

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -262,6 +262,8 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
@@ -450,6 +452,8 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
@@ -469,6 +473,8 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
@@ -743,6 +749,8 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
@@ -757,7 +765,7 @@ jobs:
   next:
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [14, 16]
         range: ['>=9.5 <11.1', '>=11.1 <13.2']
         include:
           - node-version: 18
@@ -1060,6 +1068,9 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
+      - run: yarn test:plugins:upstream
       - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - run: yarn test:plugins:upstream

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1049,6 +1049,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v2
 
+  # tedious is incompatible with node v14
   tedious:
     runs-on: ubuntu-latest
     services:
@@ -1068,7 +1069,7 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/14
+      - uses: ./.github/actions/node/16
       - run: yarn test:plugins:ci
       - run: yarn test:plugins:upstream
       - uses: ./.github/actions/node/16

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:profiler:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:profiler:ci
       - uses: ./.github/actions/node/18

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -33,7 +33,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [14, 16, 18, latest]
+        version: [16, 18, latest] # playwright incompatible with node v14
         framework: [cucumber, playwright]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,7 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [16, 18, latest]
+        version: [14, 16, 18, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [16, latest]
+        version: [14, 16, 18, latest]
         framework: [cucumber, playwright]
     runs-on: ubuntu-latest
     env:
@@ -53,7 +53,7 @@ jobs:
   integration-cypress:
     strategy:
       matrix:
-        version: [16, latest]
+        version: [14, 16, 18, latest]
         # 6.7.0 is the minimum version we support
         cypress-version: [6.7.0, latest]
     runs-on: ubuntu-latest

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:trace:core:ci
       - uses: ./.github/actions/node/16
       - run: yarn test:trace:core:ci
       - uses: ./.github/actions/node/18

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "dependencies": {
     "@datadog/native-appsec": "^3.2.0",


### PR DESCRIPTION
### What does this PR do?
- runs CI jobs against Node.js v14

### Motivation
- master mostly tests v16, 18, and v20
- this means we're skipping v14 which is used in an active release line (v3.x)
- currently PRs can pass then fail once we do a v3.x release
- master should run CI against any version of Node.js supported by any active release line