### PR TITLE
Simpler IAST telemetry logs startup

### DIFF
--- a/packages/dd-trace/src/appsec/iast/telemetry/index.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/index.js
@@ -24,7 +24,7 @@ class Telemetry {
       telemetryMetrics.manager.set('iast', globalNamespace)
     }
 
-    telemetryLogs.start()
+    telemetryLogs.start(config)
   }
 
   stop () {

--- a/packages/dd-trace/src/appsec/iast/telemetry/log/index.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/log/index.js
@@ -32,9 +32,7 @@ function isLevelEnabled (level) {
 }
 
 function isLogCollectionEnabled (config) {
-  return config?.telemetry &&
-    config.telemetry.enabled &&
-    config.telemetry.logCollection
+  return config?.telemetry?.enabled && config.telemetry.logCollection
 }
 
 function start (aConfig, debug = false) {

--- a/packages/dd-trace/src/appsec/iast/telemetry/log/index.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/log/index.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const dc = require('../../../../../../diagnostics_channel')
 const logCollector = require('./log-collector')
 const { sendData } = require('../../../../telemetry/send-data')
 const log = require('../../../../log')
+const { createAppObject, createHostObject } = require('../../../../telemetry')
 
-const telemetryStartChannel = dc.channel('datadog:telemetry:start')
-const telemetryStopChannel = dc.channel('datadog:telemetry:stop')
+let enabled = false
+let debugLevelEnabled = false
 
 let config, application, host, interval
 
@@ -28,60 +28,56 @@ function sendLogs () {
 }
 
 function isLevelEnabled (level) {
-  return isLogCollectionEnabled(config) && level !== 'DEBUG'
+  return enabled && (level !== 'DEBUG' || debugLevelEnabled)
 }
 
 function isLogCollectionEnabled (config) {
-  return config && config.telemetry && config.telemetry.logCollection
+  return config?.telemetry &&
+    config.telemetry.enabled &&
+    config.telemetry.logCollection
 }
 
-function onTelemetryStart (msg) {
-  if (!msg || !isLogCollectionEnabled(msg.config)) {
-    log.info('IAST telemetry logs start event received but log collection is not enabled or configuration is incorrect')
-    return false
+function start (aConfig, debug = false) {
+  if (!isLogCollectionEnabled(aConfig)) {
+    return
   }
 
-  log.info('IAST telemetry logs starting')
+  log.debug('IAST telemetry logs starting')
 
-  config = msg.config
-  application = msg.application
-  host = msg.host
+  enabled = true
+  debugLevelEnabled = debug
+  config = aConfig
+  application = createAppObject(config)
+  host = createHostObject()
 
-  if (msg.heartbeatInterval) {
-    interval = setInterval(sendLogs, msg.heartbeatInterval)
+  if (interval) {
+    clearInterval(interval)
+  }
+
+  const heartbeatInterval = config.telemetry.heartbeatInterval
+  if (heartbeatInterval) {
+    interval = setInterval(sendLogs, heartbeatInterval)
     interval.unref()
   }
-
-  return true
-}
-
-function onTelemetryStop () {
-  stop()
-}
-
-function start () {
-  telemetryStartChannel.subscribe(onTelemetryStart)
-  telemetryStopChannel.subscribe(onTelemetryStop)
 }
 
 function stop () {
-  if (!isLogCollectionEnabled(config)) return
+  log.debug('IAST telemetry logs stopping')
 
-  log.info('IAST telemetry logs stopping')
-
+  enabled = false
+  debugLevelEnabled = false
   config = null
   application = null
   host = null
 
-  if (telemetryStartChannel.hasSubscribers) {
-    telemetryStartChannel.unsubscribe(onTelemetryStart)
+  if (interval) {
+    clearInterval(interval)
   }
-
-  if (telemetryStopChannel.hasSubscribers) {
-    telemetryStopChannel.unsubscribe(onTelemetryStop)
-  }
-
-  clearInterval(interval)
 }
 
-module.exports = { start, stop, publish, isLevelEnabled }
+module.exports = {
+  start,
+  stop,
+  publish,
+  isLevelEnabled
+}

--- a/packages/dd-trace/src/appsec/iast/telemetry/log/index.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/log/index.js
@@ -54,8 +54,7 @@ function start (aConfig, debug = false) {
 
   const heartbeatInterval = config.telemetry.heartbeatInterval
   if (heartbeatInterval) {
-    interval = setInterval(sendLogs, heartbeatInterval)
-    interval.unref()
+    interval = setInterval(sendLogs, heartbeatInterval).unref()
   }
 }
 

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -183,6 +183,8 @@ function updateConfig (changes, config) {
 }
 
 module.exports = {
+  createAppObject,
+  createHostObject,
   start,
   stop,
   updateIntegrations,

--- a/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
@@ -72,15 +72,15 @@ describe('Telemetry', () => {
           '../../../telemetry/metrics': telemetryMetrics
         })
 
-        const telemetryConfig = { enabled: true, metrics: true }
-        iastTelemetry.configure({
-          telemetry: telemetryConfig
-        }, 'OFF')
+        const config = {
+          telemetry: { enabled: true, metrics: true }
+        }
+        iastTelemetry.configure(config, 'OFF')
 
         expect(iastTelemetry.enabled).to.be.false
         expect(iastTelemetry.verbosity).to.be.equal(Verbosity.OFF)
         expect(telemetryMetrics.manager.set).to.not.be.called
-        expect(telemetryLogs.start).to.be.calledOnce
+        expect(telemetryLogs.start).to.be.calledOnceWithExactly(config)
       })
 
       it('should enable telemetry if metrics not enabled but DD_TELEMETRY_METRICS_ENABLED is undefined', () => {


### PR DESCRIPTION
### What does this PR do?
Changes the way IAST telemetry logs module is started:
- Removing the subscriptions to `datadog:telemetry:start` and `datadog:telemetry:stop`
- Using directly `createAppObject` and `createHostObject` from tracer telemetry module to obtain the data needed for `sendData`

### Motivation
Make IAST telemetry logs independent of the tracer telemetry module initialization.
We are able to capture some possible application startup errors that were previously missed because IAST doesn't have to wait for the tracer telemetry module to publish the `datadog:telemetry:start` event.

### Additional Notes
For non appsec team reviewers: the only modified file is `packages/dd-trace/src/telemetry/index.js`, now exporting `createAppObject` and `createHostObject` existing methods
