### PR TITLE
Add a security review section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,3 +22,11 @@
 
 ### Additional Notes
 <!-- Anything else we should know when reviewing? -->
+
+### Security 
+Datadog employees:
+- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
+- [ ] This PR doesn't touch any of that.
+
+Unsure? Have a question? Request a review!
+


### PR DESCRIPTION
### What does this PR do?
It adds a security review section to PR template

### Motivation
It's an additional checklist item for an action that is easy to forget and potentially high cost if missed.
