### PR TITLE
Fix Next.js 9.5 Build Error

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -79,6 +79,12 @@ describe('Plugin', function () {
 
         delete pkg.workspaces
 
+        // builds fail for next.js 9.5 using node 14 due to webpack issues
+        // note that webpack version cannot be set in v9.5 in next.config.js so we do it here instead
+        // the link below highlights the initial support for webpack 5 (used to fix this issue) in next.js 9.5
+        // https://nextjs.org/blog/next-9-5#webpack-5-support-beta
+        if (realVersion.startsWith('9')) pkg.resolutions = { webpack: '^5.0.0' }
+
         writeFileSync(`${__dirname}/package.json`, JSON.stringify(pkg, null, 2))
 
         // installing here for standalone purposes, copying `nodules` above was not generating the server file properly


### PR DESCRIPTION
### What does this PR do?
Makes sure tests for Next.js v9.5 use webpack 5 to avoid build issues.

### Motivation
We want to be able to run all tests using Node 14 on the 3.x release line, and version 9.5 of Next.js had issues building with webpack when this node version was used. This change makes sure our tests build the test Next.js app using webpack 5.
