### PR TITLE
reduce test flakiness from cp -R command

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -205,6 +205,7 @@ async function createSandbox (dependencies = [], isGitRepo = false, integrationT
 
   integrationTestsPaths.forEach(async (path) => {
     await exec(`cp -R ${path} ${folder}`)
+    await exec(`sync ${folder}`)
   })
 
   if (isGitRepo) {


### PR DESCRIPTION
### What does this PR do?
adds a sync command after a copy command in createSandbox to ensure all files are imported by the time the function exits

### Motivation
test flakiness related to files not being found in the integration test sandbox