### PR TITLE
mongodb-core: fix serialization of BigInt values in query

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -36,10 +36,14 @@ class MongodbCorePlugin extends DatabasePlugin {
   }
 }
 
+function sanitizeBigInt (data) {
+  return JSON.stringify(data, (_key, value) => typeof value === 'bigint' ? value.toString() : value)
+}
+
 function getQuery (cmd) {
   if (!cmd || typeof cmd !== 'object' || Array.isArray(cmd)) return
-  if (cmd.query) return JSON.stringify(limitDepth(cmd.query))
-  if (cmd.filter) return JSON.stringify(limitDepth(cmd.filter))
+  if (cmd.query) return sanitizeBigInt(limitDepth(cmd.query))
+  if (cmd.filter) return sanitizeBigInt(limitDepth(cmd.filter))
 }
 
 function getResource (plugin, ns, query, operationName) {


### PR DESCRIPTION
### What does this PR do?
- closes #3550
  - this is a fork of that PR which then adds tests
  - implement a custom JSON serializer which checks if a type is a BigInt and if so converts it into a string
- fixes #3548

### Motivation
- dd-trace attempts to pass a BigInt instance to `JSON.stringify()` which then throws an error

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js