### PR TITLE
[ci-visibility] Do not modify mocha config if CI visibility fails to init

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -215,7 +215,7 @@ async function createSandbox (dependencies = [], isGitRepo = false, integrationT
     await exec('git config user.name "John Doe"', { cwd: folder })
     await exec('git config commit.gpgsign false', { cwd: folder })
     await exec(
-      'git add -A && git commit -m "first commit" --no-verify && git remote add origin git@git.com:datadog/example',
+      'git add -A && git commit -m "first commit" --no-verify && git remote add origin git@git.com:datadog/example.git',
       { cwd: folder }
     )
   }

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -441,6 +441,9 @@ addHook({
   file: 'lib/cli/run-helpers.js'
 }, (run) => {
   shimmer.wrap(run, 'runMocha', runMocha => async function () {
+    if (!testStartCh.hasSubscribers) {
+      return runMocha.apply(this, arguments)
+    }
     const mocha = arguments[0]
     /**
      * This attaches `run` to the global context, which we'll call after

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -139,13 +139,13 @@ function removeInvalidMetadata (metadata) {
   return Object.keys(metadata).reduce((filteredTags, tag) => {
     if (tag === GIT_REPOSITORY_URL) {
       if (!validateGitRepositoryUrl(metadata[GIT_REPOSITORY_URL])) {
-        log.error('DD_GIT_REPOSITORY_URL must be a valid URL')
+        log.error(`Repository URL is not a valid repository URL: ${metadata[GIT_REPOSITORY_URL]}.`)
         return filteredTags
       }
     }
     if (tag === GIT_COMMIT_SHA) {
       if (!validateGitCommitSha(metadata[GIT_COMMIT_SHA])) {
-        log.error('DD_GIT_COMMIT_SHA must be a full-length git SHA')
+        log.error(`Git commit SHA must be a full-length git SHA: ${metadata[GIT_COMMIT_SHA]}.`)
         return filteredTags
       }
     }


### PR DESCRIPTION
### What does this PR do?
Check if there are event listeners in the `runMocha` hook before changing mocha config. 

### Motivation
If CI Visibility fails to init (such as when passing an invalid `DD_SITE`), we should not modify `mocha` in any way, but we were doing so in the `runMocha` wrapper. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
