### PR TITLE
[ci-visibility] Fix cypress if ci vis init fails

### DIFF
--- a/integration-tests/cypress-config.json
+++ b/integration-tests/cypress-config.json
@@ -4,6 +4,5 @@
   "pluginsFile": "cypress/plugins-old/index.js",
   "supportFile": "cypress/support/e2e.js",
   "integrationFolder": "cypress/e2e",
-  "defaultCommandTimeout": 100,
-  "quiet": true
+  "defaultCommandTimeout": 100
 }

--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -12,9 +12,9 @@ async function runCypress () {
           })
         }
       },
-      video: false
-    },
-    quiet: true
+      video: false,
+      screenshotOnRunFailure: false
+    }
   })
 }
 

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -6,5 +6,5 @@ module.exports = {
     }
   },
   video: false,
-  quiet: true
+  screenshotOnRunFailure: false
 }


### PR DESCRIPTION
### What does this PR do?
Check if we're correctly initialized (by checking if the tracer is noop) and disable cypress plugin if the init is wrong.

### Motivation
Do not crash when CI Visibility init fails. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
