### PR TITLE
core: ensure custom/runtime metrics configured similarly

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -30,17 +30,7 @@ class Tracer extends NoopProxy {
 
       if (config.dogstatsd) {
         // Custom Metrics
-        this.dogstatsd = new dogstatsd.CustomMetrics({
-          host: config.dogstatsd.hostname,
-          port: config.dogstatsd.port,
-          tags: [
-            // these are the Runtime Metrics default tags
-            // Python also uses these as default Custom Metrics tags
-            `service:${config.tags.service}`,
-            `env:${config.tags.env}`,
-            `version:${config.tags.version}`
-          ]
-        })
+        this.dogstatsd = new dogstatsd.CustomMetrics(config)
 
         setInterval(() => {
           this.dogstatsd.flush()

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -323,7 +323,7 @@ describe('dogstatsd', () => {
 
   describe('CustomMetrics', () => {
     it('.gauge()', () => {
-      client = new CustomMetrics()
+      client = new CustomMetrics({ dogstatsd: {} })
 
       client.gauge('test.avg', 10, { foo: 'bar' })
       client.flush()
@@ -333,7 +333,7 @@ describe('dogstatsd', () => {
     })
 
     it('.increment()', () => {
-      client = new CustomMetrics()
+      client = new CustomMetrics({ dogstatsd: {} })
 
       client.increment('test.count', 10)
       client.flush()
@@ -343,7 +343,7 @@ describe('dogstatsd', () => {
     })
 
     it('.increment() with default', () => {
-      client = new CustomMetrics()
+      client = new CustomMetrics({ dogstatsd: {} })
 
       client.increment('test.count')
       client.flush()
@@ -353,7 +353,7 @@ describe('dogstatsd', () => {
     })
 
     it('.decrement()', () => {
-      client = new CustomMetrics()
+      client = new CustomMetrics({ dogstatsd: {} })
 
       client.decrement('test.count', 10)
       client.flush()
@@ -363,7 +363,7 @@ describe('dogstatsd', () => {
     })
 
     it('.decrement() with default', () => {
-      client = new CustomMetrics()
+      client = new CustomMetrics({ dogstatsd: {} })
 
       client.decrement('test.count')
       client.flush()
@@ -373,7 +373,7 @@ describe('dogstatsd', () => {
     })
 
     it('.distribution()', () => {
-      client = new CustomMetrics()
+      client = new CustomMetrics({ dogstatsd: {} })
 
       client.distribution('test.dist', 10)
       client.flush()

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -288,7 +288,7 @@ describe('TracerProxy', () => {
 
         proxy.init()
 
-        expect(noopDogStatsD._config().host).to.equal('localhost')
+        expect(noopDogStatsD._config().dogstatsd.hostname).to.equal('localhost')
 
         proxy.dogstatsd.increment('foo', 10, { alpha: 'bravo' })
         const incs = noopDogStatsD._increments()

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 require('./setup/tap')
+const { DogStatsDClient } = require('../src/dogstatsd')
 
 const os = require('os')
 
@@ -19,6 +20,8 @@ suiteDescribe('runtimeMetrics', () => {
     Client = sinon.spy(function () {
       return client
     })
+
+    Client.generateClientConfig = DogStatsDClient.generateClientConfig
 
     client = {
       gauge: sinon.spy(),


### PR DESCRIPTION
### What does this PR do?
- refactor metric config logic into a common location
- pass this config to both runtime and custom metrics

### Motivation
- runtime metrics and custom metrics should always be sent to the same place
- probably nobody will want them sent to multiple locations
- currently this can result in apps where RM are received but CM are dropped