### PR TITLE
Fix LDAPi vulnerability location when using ldapjs-promise

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/ldap-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/ldap-injection-analyzer.js
@@ -1,6 +1,9 @@
 'use strict'
 const InjectionAnalyzer = require('./injection-analyzer')
 const { LDAP_INJECTION } = require('../vulnerabilities')
+const { getNodeModulesPaths } = require('../path-line')
+
+const EXCLUDED_PATHS = getNodeModulesPaths('ldapjs-promise')
 
 class LdapInjectionAnalyzer extends InjectionAnalyzer {
   constructor () {
@@ -9,6 +12,10 @@ class LdapInjectionAnalyzer extends InjectionAnalyzer {
 
   onConfigure () {
     this.addSub('datadog:ldapjs:client:search', ({ base, filter }) => this.analyzeAll(base, filter))
+  }
+
+  _getExcludedPaths () {
+    return EXCLUDED_PATHS
   }
 }
 

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -66,7 +66,7 @@ function globMatch (pattern, subject) {
 function calculateDDBasePath (dirname) {
   const dirSteps = dirname.split(path.sep)
   const packagesIndex = dirSteps.lastIndexOf('packages')
-  return dirSteps.slice(0, packagesIndex).join(path.sep) + path.sep
+  return dirSteps.slice(0, packagesIndex + 1).join(path.sep) + path.sep
 }
 
 module.exports = {

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/ldap-injection-methods.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/ldap-injection-methods.js
@@ -1,0 +1,7 @@
+'use strict'
+
+function executeSearch (client, base, filter) {
+  return client.search(base, filter)
+}
+
+module.exports = { executeSearch }

--- a/packages/dd-trace/test/appsec/iast/path-line.spec.js
+++ b/packages/dd-trace/test/appsec/iast/path-line.spec.js
@@ -21,7 +21,7 @@ class CallSiteMock {
 }
 
 describe('path-line', function () {
-  const PATH_LINE_PATH = path.join('packages', 'dd-trace', 'src', 'appsec', 'iast', 'path-line.js')
+  const PATH_LINE_PATH = path.join('dd-trace', 'src', 'appsec', 'iast', 'path-line.js')
 
   const tmpdir = os.tmpdir()
   const firstSep = tmpdir.indexOf(path.sep)
@@ -50,19 +50,20 @@ describe('path-line', function () {
 
   describe('calculateDDBasePath', () => {
     it('/node_modules/dd-trace', () => {
-      const basePath = path.join(rootPath, 'node_modules', 'dd-trace', path.sep)
+      const basePath = path.join(rootPath, 'node_modules', 'dd-trace', 'packages', path.sep)
       const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
       expect(result).to.be.equals(basePath)
     })
 
     it('/packages/project/path/node_modules/dd-trace', () => {
-      const basePath = path.join(rootPath, 'packages', 'project', 'path', 'node_modules', 'dd-trace', path.sep)
+      const basePath =
+        path.join(rootPath, 'packages', 'project', 'path', 'node_modules', 'dd-trace', 'packages', path.sep)
       const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
       expect(result).to.be.equals(basePath)
     })
 
     it('/project/path/node_modules/dd-trace', () => {
-      const basePath = path.join(rootPath, 'project', 'path', 'node_modules', 'dd-trace', path.sep)
+      const basePath = path.join(rootPath, 'project', 'path', 'node_modules', 'dd-trace', 'packages', path.sep)
       const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
       expect(result).to.be.equals(basePath)
     })

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -127,6 +127,16 @@
       "versions": ["6.1.0"]
     }
   ],
+  "ldapjs": [
+    {
+      "name": "ldapjs",
+      "versions": [">= 2"]
+    },
+    {
+      "name": "ldapjs-promise",
+      "versions": [">=2"]
+    }
+  ],
   "mariadb": [
     {
       "name": "mariadb",


### PR DESCRIPTION
### What does this PR do?
Fixes the location for detected SQLi when code base uses `ldapjs-promise` lib

### Motivation
Provide the correct location for detected vulnerabilities.

### Plugin Checklist
- [x] Unit tests.

### Additional Notes
There is an additional change in `calculateDDBasePath` util:
- Previously _DDBasePath_ was computed to `project_root`, which leads to the exclusion of traces from `versions` folder, used in plugins test.
- Now it is computed to `project_root/packages` to avoid exclusion of traces from `versions` folder.
