### PR TITLE
Fix Mongo Tests for New Version

### DIFF
--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -5,8 +5,8 @@ const agent = require('../../dd-trace/test/plugins/agent')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
 const withTopologies = fn => {
-  const isOldNode = semver.satisfies(process.version, '<=12')
-  const range = isOldNode ? '>=2 <5' : '>=2' // TODO: remove when 2.x support is removed.
+  const isOldNode = semver.satisfies(process.version, '<=14')
+  const range = isOldNode ? '>=2 <6' : '>=2' // TODO: remove when 3.x support is removed.
   withVersions('mongodb-core', 'mongodb', range, (version, moduleName) => {
     describe('using the default topology', () => {
       fn(async () => {


### PR DESCRIPTION
### What does this PR do?
Changes range in mongodb-core tests for new version of mongodb which drops support for node 14.

### Motivation
Fix CI
