### PR TITLE
Optimize system-tests CI

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -23,23 +23,24 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
     steps:
-      - name: Setup python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
       - name: Checkout system tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
 
       - name: Checkout dd-trace-js
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'binaries/dd-trace-js'
 
-      - name: Build
-        run: ./build.sh
+      - name: Build weblog
+        run: ./build.sh -i weblog
+
+      - name: Build runner
+        uses: ./.github/actions/install_runner
+
+      - name: Build agent
+        run: ./build.sh -i agent
 
       - name: Run
         run: ./run.sh TRACER_ESSENTIAL_SCENARIOS
@@ -72,9 +73,8 @@ jobs:
         run: ./build.sh -i runner
       - name: Run
         run: ./run.sh PARAMETRIC
-        
       - name: Compress artifact
-        if: ${{ always() }}  
+        if: ${{ always() }}
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What does this PR do?

Use a dedicated action to build runner for system tests. This actions uses a cache that reduces build time (around 70s).

### Motivation
Optimize CI time

### Additional Notes
If system tests are green, it's ok !
