### PR TITLE
Fix SQLi location when using knex [APPSEC-10688]

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -80,7 +80,7 @@ jobs:
           - 5432:5432
     env:
       PG_TEST_NATIVE: 'true'
-      PLUGINS: pg
+      PLUGINS: pg|knex
       SERVICES: postgres
     steps:
       - uses: actions/checkout@v2

--- a/packages/datadog-instrumentations/src/knex.js
+++ b/packages/datadog-instrumentations/src/knex.js
@@ -48,7 +48,7 @@ addHook({
       }, this).apply(this)
     }
 
-    startRawQueryCh.publish({ sql })
+    startRawQueryCh.publish({ sql, dialect: this.dialect })
 
     const rawResult = raw.apply(this, arguments)
     wrapThenRaw(rawResult.then, onFinish, asyncResource)

--- a/packages/datadog-instrumentations/src/knex.js
+++ b/packages/datadog-instrumentations/src/knex.js
@@ -59,14 +59,9 @@ addHook({
 })
 
 function wrapThenRaw (origThen, onFinish, ar) {
-  return function then (onFulfilled, onRejected, onProgress) {
+  return function then (onFulfilled, onRejected) {
     arguments[0] = wrapCallback(ar, onFulfilled, onFinish)
     arguments[1] = wrapCallback(ar, onRejected, onFinish)
-
-    // not standard but sometimes supported
-    if (onProgress) {
-      arguments[2] = wrapCallback(ar, onProgress, onFinish)
-    }
 
     return origThen.apply(this, arguments)
   }

--- a/packages/datadog-instrumentations/src/knex.js
+++ b/packages/datadog-instrumentations/src/knex.js
@@ -58,20 +58,20 @@ addHook({
   return Knex
 })
 
-function wrapThenRaw (origThen, onFinish, ar) {
+function wrapThenRaw (origThen, onFinish, asyncResource) {
   return function then (onFulfilled, onRejected) {
-    arguments[0] = wrapCallback(ar, onFulfilled, onFinish)
-    arguments[1] = wrapCallback(ar, onRejected, onFinish)
+    arguments[0] = wrapCallback(asyncResource, onFulfilled, onFinish)
+    arguments[1] = wrapCallback(asyncResource, onRejected, onFinish)
 
     return origThen.apply(this, arguments)
   }
 }
 
-function wrapCallback (ar, callback, onFinish) {
+function wrapCallback (asyncResource, callback, onFinish) {
   if (typeof callback !== 'function') return callback
 
   return function () {
-    return ar.runInAsyncScope(() => {
+    return asyncResource.runInAsyncScope(() => {
       onFinish()
       return callback.apply(this, arguments)
     })

--- a/packages/datadog-instrumentations/src/knex.js
+++ b/packages/datadog-instrumentations/src/knex.js
@@ -1,8 +1,12 @@
 'use strict'
 
-const { addHook } = require('./helpers/instrument')
+const { AsyncResource } = require('async_hooks')
+const { addHook, channel } = require('./helpers/instrument')
 const { wrapThen } = require('./helpers/promise')
 const shimmer = require('../../datadog-shimmer')
+
+const startRawQueryCh = channel('datadog:knex:raw:start')
+const finishRawQueryCh = channel('datadog:knex:raw:finish')
 
 patch('lib/query/builder.js')
 patch('lib/raw.js')
@@ -17,4 +21,64 @@ function patch (file) {
     shimmer.wrap(Builder.prototype, 'then', wrapThen)
     return Builder
   })
+}
+
+addHook({
+  name: 'knex',
+  versions: ['>=2'],
+  file: 'lib/knex-builder/Knex.js'
+}, Knex => {
+  shimmer.wrap(Knex.Client.prototype, 'raw', raw => function () {
+    if (!startRawQueryCh.hasSubscribers) {
+      return raw.apply(this, arguments)
+    }
+
+    const sql = arguments[0]
+
+    // Skip query done by Knex to get the value used for undefined
+    if (sql === 'DEFAULT') {
+      return raw.apply(this, arguments)
+    }
+
+    const asyncResource = new AsyncResource('bound-anonymous-fn')
+
+    function onFinish () {
+      asyncResource.bind(function () {
+        finishRawQueryCh.publish()
+      }, this).apply(this)
+    }
+
+    startRawQueryCh.publish({ sql })
+
+    const rawResult = raw.apply(this, arguments)
+    wrapThenRaw(rawResult.then, onFinish, asyncResource)
+
+    return rawResult
+  })
+  return Knex
+})
+
+function wrapThenRaw (origThen, onFinish, ar) {
+  return function then (onFulfilled, onRejected, onProgress) {
+    arguments[0] = wrapCallback(ar, onFulfilled, onFinish)
+    arguments[1] = wrapCallback(ar, onRejected, onFinish)
+
+    // not standard but sometimes supported
+    if (onProgress) {
+      arguments[2] = wrapCallback(ar, onProgress, onFinish)
+    }
+
+    return origThen.apply(this, arguments)
+  }
+}
+
+function wrapCallback (ar, callback, onFinish) {
+  if (typeof callback !== 'function') return callback
+
+  return function () {
+    return ar.runInAsyncScope(() => {
+      onFinish()
+      return callback.apply(this, arguments)
+    })
+  }
 }

--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -32,7 +32,10 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
     this.addSub('datadog:mysql:pool:query:start', ({ sql }) => this.getStoreAndAnalyze(sql, 'MYSQL'))
     this.addSub('datadog:mysql:pool:query:finish', () => this.returnToParentStore())
 
-    this.addSub('datadog:knex:raw:start', ({ sql }) => this.getStoreAndAnalyze(sql, 'KNEX'))
+    this.addSub('datadog:knex:raw:start', ({ sql, dialect: knexDialect }) => {
+      const dialect = this.normalizeKnexDialect(knexDialect)
+      this.getStoreAndAnalyze(sql, dialect)
+    })
     this.addSub('datadog:knex:raw:finish', () => this.returnToParentStore())
   }
 
@@ -85,6 +88,20 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
 
   _getExcludedPaths () {
     return EXCLUDED_PATHS
+  }
+
+  normalizeKnexDialect (knexDialect) {
+    if (knexDialect === 'postgresql') {
+      return 'POSTGRES'
+    }
+
+    if (knexDialect === 'sqlite3') {
+      return 'SQLITE'
+    }
+
+    if (typeof knexDialect === 'string') {
+      return knexDialect.toUpperCase()
+    }
   }
 }
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -8,7 +8,7 @@ const { getIastContext } = require('../iast-context')
 const { addVulnerability } = require('../vulnerability-reporter')
 const { getNodeModulesPaths } = require('../path-line')
 
-const EXCLUDED_PATHS = getNodeModulesPaths('mysql', 'mysql2', 'sequelize', 'pg-pool')
+const EXCLUDED_PATHS = getNodeModulesPaths('mysql', 'mysql2', 'sequelize', 'pg-pool', 'knex')
 
 class SqlInjectionAnalyzer extends InjectionAnalyzer {
   constructor () {
@@ -31,6 +31,9 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
 
     this.addSub('datadog:mysql:pool:query:start', ({ sql }) => this.getStoreAndAnalyze(sql, 'MYSQL'))
     this.addSub('datadog:mysql:pool:query:finish', () => this.returnToParentStore())
+
+    this.addSub('datadog:knex:raw:start', ({ sql }) => this.getStoreAndAnalyze(sql, 'KNEX'))
+    this.addSub('datadog:knex:raw:finish', () => this.returnToParentStore())
   }
 
   getStoreAndAnalyze (query, dialect) {

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/knex-sql-injection-methods.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/knex-sql-injection-methods.js
@@ -1,0 +1,44 @@
+'use strict'
+
+function executeKnexRawQuery (knex, sql) {
+  return knex.raw(sql)
+}
+
+function executeKnexNestedRawQuery (knex, taintedSql, notTaintedSql) {
+  return knex.raw(notTaintedSql).then(() => {
+    knex.raw(taintedSql)
+  })
+}
+
+function executeKnexNestedRawQueryOnRejectedInThen (knex, taintedSql, sqlToFail) {
+  return knex.raw(sqlToFail).then(
+    () => {},
+    () => {
+      knex.raw(taintedSql)
+    }
+  )
+}
+
+function executeKnexNestedRawQueryWitCatch (knex, taintedSql, sqlToFail) {
+  return knex.raw(sqlToFail)
+    .then(
+      () => {}
+    )
+    .catch(() => {
+      knex.raw(taintedSql)
+    })
+}
+
+function executeKnexNestedRawQueryAsCallback (knex, taintedSql, sqlToFail, cb) {
+  knex.raw(sqlToFail).asCallback(() => {
+    knex.raw(taintedSql).asCallback(cb)
+  })
+}
+
+module.exports = {
+  executeKnexRawQuery,
+  executeKnexNestedRawQuery,
+  executeKnexNestedRawQueryOnRejectedInThen,
+  executeKnexNestedRawQueryWitCatch,
+  executeKnexNestedRawQueryAsCallback
+}

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/sql-injection-methods.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/sql-injection-methods.js
@@ -8,8 +8,7 @@ function executeQueryWithCallback (sql, clientOrPool, cb) {
   return clientOrPool.query(sql, cb)
 }
 
-function executeKnexRawQuery (knex, sql) {
-  return knex.raw(sql)
+module.exports = {
+  executeQuery,
+  executeQueryWithCallback
 }
-
-module.exports = { executeQuery, executeQueryWithCallback, executeKnexRawQuery }

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/sql-injection-methods.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/sql-injection-methods.js
@@ -8,4 +8,8 @@ function executeQueryWithCallback (sql, clientOrPool, cb) {
   return clientOrPool.query(sql, cb)
 }
 
-module.exports = { executeQuery, executeQueryWithCallback }
+function executeKnexRawQuery (knex, sql) {
+  return knex.raw(sql)
+}
+
+module.exports = { executeQuery, executeQueryWithCallback, executeKnexRawQuery }

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
@@ -13,6 +13,7 @@ const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability
 describe('sql-injection-analyzer with knex', () => {
   withVersions('knex', 'knex', knexVersion => {
     if (!semver.satisfies(knexVersion, '>=2')) return
+
     withVersions('pg', 'pg', pgVersion => {
       let knex
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const semver = require('semver')
+const { prepareTestServerForIast } = require('../utils')
+const { storage } = require('../../../../../datadog-core')
+const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
+const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
+const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
+
+describe('sql-injection-analyzer with knex', () => {
+  withVersions('knex', 'knex', knexVersion => {
+    if (!semver.satisfies(knexVersion, '>=2')) return
+    withVersions('pg', 'pg', pgVersion => {
+      let knex
+
+      prepareTestServerForIast('knex + pg',
+        (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
+          const srcFilePath = path.join(__dirname, 'resources', 'sql-injection-methods.js')
+          const dstFilePath = path.join(os.tmpdir(), 'sql-injection-methods.js')
+          let queryMethods
+
+          beforeEach(() => {
+            vulnerabilityReporter.clearCache()
+
+            const Knex = require(`../../../../../../versions/knex@${knexVersion}`).get()
+            knex = Knex({
+              client: 'pg',
+              connection: {
+                host: '127.0.0.1',
+                database: 'postgres',
+                user: 'postgres',
+                password: 'postgres'
+              }
+            })
+
+            fs.copyFileSync(srcFilePath, dstFilePath)
+            queryMethods = require(dstFilePath)
+          })
+
+          afterEach(() => {
+            knex.destroy()
+            fs.unlinkSync(dstFilePath)
+          })
+
+          testThatRequestHasVulnerability(() => {
+            const store = storage.getStore()
+            const iastCtx = iastContextFunctions.getIastContext(store)
+
+            let sql = 'SELECT 1'
+            sql = newTaintedString(iastCtx, sql, 'param', 'Request')
+
+            return queryMethods.executeKnexRawQuery(knex, sql)
+          }, 'SQL_INJECTION', {
+            occurrences: 1,
+            location: {
+              path: 'sql-injection-methods.js',
+              line: 12
+            }
+          })
+
+          testThatRequestHasNoVulnerability(() => {
+            return knex.raw('SELECT 1')
+          }, 'SQL_INJECTION')
+        })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
@@ -164,4 +164,29 @@ describe('sql-injection-analyzer', () => {
       expect(analyze).to.be.calledOnceWith('SELECT 1')
     })
   })
+
+  describe('knex dialects', () => {
+    const sqlInjectionAnalyzer = require('../../../../src/appsec/iast/analyzers/sql-injection-analyzer')
+
+    const knexDialects = {
+      'mssql': 'MSSQL',
+      'oracle': 'ORACLE',
+      'mysql': 'MYSQL',
+      'redshift': 'REDSHIFT',
+      'postgresql': 'POSTGRES',
+      'sqlite3': 'SQLITE'
+    }
+
+    Object.keys(knexDialects).forEach((knexDialect) => {
+      it(`should normalize knex dialect ${knexDialect} to uppercase`, () => {
+        const normalizedDialect = sqlInjectionAnalyzer.normalizeKnexDialect(knexDialect)
+        expect(normalizedDialect).to.equals(knexDialects[knexDialect])
+      })
+    })
+
+    it('should not fail when normalizing a non string knex dialect', () => {
+      const normalizedDialect = sqlInjectionAnalyzer.normalizeKnexDialect()
+      expect(normalizedDialect).to.be.undefined
+    })
+  })
 })

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
@@ -29,7 +29,7 @@ describe('sql-injection-analyzer', () => {
   sqlInjectionAnalyzer.configure(true)
 
   it('should subscribe to mysql, mysql2 and pg start query channel', () => {
-    expect(sqlInjectionAnalyzer._subscriptions).to.have.lengthOf(9)
+    expect(sqlInjectionAnalyzer._subscriptions).to.have.lengthOf(11)
     expect(sqlInjectionAnalyzer._subscriptions[0]._channel.name).to.equals('apm:mysql:query:start')
     expect(sqlInjectionAnalyzer._subscriptions[1]._channel.name).to.equals('apm:mysql2:query:start')
     expect(sqlInjectionAnalyzer._subscriptions[2]._channel.name).to.equals('apm:pg:query:start')
@@ -39,6 +39,8 @@ describe('sql-injection-analyzer', () => {
     expect(sqlInjectionAnalyzer._subscriptions[6]._channel.name).to.equals('datadog:pg:pool:query:finish')
     expect(sqlInjectionAnalyzer._subscriptions[7]._channel.name).to.equals('datadog:mysql:pool:query:start')
     expect(sqlInjectionAnalyzer._subscriptions[8]._channel.name).to.equals('datadog:mysql:pool:query:finish')
+    expect(sqlInjectionAnalyzer._subscriptions[9]._channel.name).to.equals('datadog:knex:raw:start')
+    expect(sqlInjectionAnalyzer._subscriptions[10]._channel.name).to.equals('datadog:knex:raw:finish')
   })
 
   it('should not detect vulnerability when no query', () => {


### PR DESCRIPTION
### What does this PR do?
Fixes location for detected SQLi vulnerability when code base uses `knex` `raw` to query the DB.

### Motivation
Provide the correct location for detected vulnerabilities.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
**For non appsec team reviewers**: In this PR an instrumentation to `Knex.Client.prototype.raw` method is added in order to be able to detect SQLi vulnerabilities in that point, and to get the real file/line for customer code base.
The only file modified out of appsec scope is the instrumentation file [packages/datadog-instrumentations/src/knex.js](https://github.com/DataDog/dd-trace-js/pull/3607/files#diff-38070525edaaab78d1d6d8daabd081094fca60ae658d79074919c2442f51d028), to send start and finish events when knex.raw is executed and its callback is resolved/rejected when using `then`, `catch` or `asCallback`.
