### PR TITLE
Fix dogstatsd tag documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -649,7 +649,7 @@ export declare interface DogStatsD {
    * Increments a metric by the specified value, optionally specifying tags.
    * @param {string} stat The dot-separated metric name.
    * @param {number} value The amount to increment the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `[ 'foo:bar' ]`. Values are combined with config.tags.
+   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
    */
   increment(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
 
@@ -657,7 +657,7 @@ export declare interface DogStatsD {
    * Decrements a metric by the specified value, optionally specifying tags.
    * @param {string} stat The dot-separated metric name.
    * @param {number} value The amount to decrement the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `[ 'foo:bar' ]`. Values are combined with config.tags.
+   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
    */
   decrement(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
 
@@ -665,7 +665,7 @@ export declare interface DogStatsD {
    * Sets a distribution value, optionally specifying tags.
    * @param {string} stat The dot-separated metric name.
    * @param {number} value The amount to increment the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `[ 'foo:bar' ]`. Values are combined with config.tags.
+   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
    */
   distribution(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
 
@@ -673,7 +673,7 @@ export declare interface DogStatsD {
    * Sets a gauge value, optionally specifying tags.
    * @param {string} stat The dot-separated metric name.
    * @param {number} value The amount to increment the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `[ 'foo:bar' ]`. Values are combined with config.tags.
+   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
    */
   gauge(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
 


### PR DESCRIPTION
Shepherding #3594 by @christophflick-toast. Closes #3594.

### What does this PR do?
Just a minor fix in the documentation for the dogstatsd metrics functions
The corresponding docs fix is here: https://github.com/DataDog/documentation/pull/19542

### Motivation
Working with this and noticed the docs in the d.ts are off.
