### PR TITLE
Prevent ldapjs-promise >= v3 test with node 14

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
@@ -171,6 +171,8 @@ describe('ldap-injection-analyzer with ldapjs', () => {
   })
 
   withVersions('ldapjs', 'ldapjs-promise', promiseVersion => {
+    if (isOldNode && promiseVersion !== '2.0.0') return
+
     prepareTestServerForIast('ldapjs-promise', (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       const srcFilePath = path.join(__dirname, 'resources', 'ldap-injection-methods.js')
       const dstFilePath = path.join(os.tmpdir(), 'ldap-injection-methods.js')


### PR DESCRIPTION
### What does this PR do?
This PR adds a condition to run `ldapjs-promise` test with compatible node versions. 

### Motivation
`ldapjs-promise` on its version 3.x depends on `ldapjs` v3.x. This last one [does not support node v14 and lower](https://github.com/ldapjs/node-ldapjs/tree/master#nodejs-version-support).

### Additional Notes
engine field from `ldapjs-promise` [package.json](https://github.com/wslyhbb/node-ldapjs-promise/blob/a911933daad93114245ff57b480f9509be7f6a84/package.json) states that the library supports node v14, but it is not true since it dependes on `ldapjs` v3.x
