### PR TITLE
core: updating package.json dual license syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "apm"
   ],
   "author": "Datadog Inc. <info@datadoghq.com>",
-  "license": "BSD-3-Clause",
+  "license": "(Apache-2.0 OR BSD-3-Clause)",
   "bugs": {
     "url": "https://github.com/DataDog/dd-trace-js/issues"
   },


### PR DESCRIPTION
### What does this PR do?
- updates package.json to reflect our dual license
  - explanation of syntax https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license
  - our LICENSE file https://github.com/DataDog/dd-trace-js/blob/master/LICENSE

### Motivation
- currently the repo sidebar displays confusing information:

<img width="319" alt="Screenshot 2023-09-08 at 13 22 45" src="https://github.com/DataDog/dd-trace-js/assets/551402/d37dc543-9805-4d8f-a350-f24abd047e18">

- also, the npmjs.com license doesn't mention the Apache option:

<img width="373" alt="Screenshot 2023-09-08 at 13 36 38" src="https://github.com/DataDog/dd-trace-js/assets/551402/7983fcf4-51dd-4820-9a64-ae7637c89fe6">
