### PR TITLE
[data streams] Add version tag

### DIFF
--- a/packages/dd-trace/src/datastreams/processor.js
+++ b/packages/dd-trace/src/datastreams/processor.js
@@ -66,7 +66,9 @@ class DataStreamsProcessor {
     port,
     url,
     env,
-    tags
+    tags,
+    version,
+    service
   } = {}) {
     this.writer = new DataStreamsWriter({
       hostname,
@@ -79,7 +81,8 @@ class DataStreamsProcessor {
     this.enabled = dsmEnabled
     this.env = env
     this.tags = tags || {}
-    this.service = this.tags.service || 'unnamed-nodejs-service'
+    this.service = service || 'unnamed-nodejs-service'
+    this.version = version || ''
     this.sequence = 0
 
     if (this.enabled) {
@@ -96,6 +99,7 @@ class DataStreamsProcessor {
       Service: this.service,
       Stats: serialized,
       TracerVersion: pkg.version,
+      Version: this.version,
       Lang: 'javascript'
     }
     this.writer.flush(payload)

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -109,6 +109,8 @@ describe('DataStreamsProcessor', () => {
     port: 8126,
     url: new URL('http://127.0.0.1:8126'),
     env: 'test',
+    version: 'v1',
+    service: 'service1',
     tags: { tag: 'some tag' }
   }
 
@@ -158,7 +160,8 @@ describe('DataStreamsProcessor', () => {
     processor.onInterval()
     expect(writer.flush).to.be.calledWith({
       Env: 'test',
-      Service: 'unnamed-nodejs-service',
+      Service: 'service1',
+      Version: 'v1',
       Stats: [{
         Start: new Uint64(1680000000000),
         Duration: new Uint64(10000000000),


### PR DESCRIPTION
### What does this PR do?

Tag data streams stats with version

### Motivation
Be able to correlate increase in throughput / latency with a new version.


[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
