### PR TITLE
Add blocklist to next plugin

### DIFF
--- a/packages/datadog-plugin-next/test/datadog.js
+++ b/packages/datadog-plugin-next/test/datadog.js
@@ -3,6 +3,7 @@ module.exports = require('../../..').init({
   flushInterval: 0,
   plugins: false
 }).use('next', process.env.WITH_CONFIG ? {
+  blocklist: ["/api/health"],
   validateStatus: code => false,
   hooks: {
     request: (span, req) => {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -409,6 +409,21 @@ describe('Plugin', function () {
             .get(`http://127.0.0.1:${port}/api/hello/world`)
             .catch(done)
         })
+
+        it('should support URL filtering', done => {
+          agent
+            .use(traces => {
+              const spans = traces[0]
+
+              expect(spans).to.haveLength(0);
+            })
+            .then(done)
+            .catch(done)
+
+          axios
+            .get(`http://127.0.0.1:${port}/api/health`)
+            .catch(done)
+        })
       })
 
       if (satisfiesStandalone(pkg.version)) {

--- a/packages/datadog-plugin-next/test/pages/api/health/index.js
+++ b/packages/datadog-plugin-next/test/pages/api/health/index.js
@@ -1,0 +1,5 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+    res.status(204);
+}


### PR DESCRIPTION
### What does this PR do?

The installation of Next.js that I'm working on exposes health check endpoints using Next.js API routes. Using the `express` plugin (among others), I can ignore these routes from being reported, but for the `next` plugin it doesn't seem like I can (not sure if it's possible to add that configuration to e.g. the `http` plugin and have those requests hidden without explicitly configuring the `next` plugin.

This pull request isn't done, but I wanted to open this to understand if updating this library is the only way that I'd be able to ignore some requests in my Next.js application.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Attempting to add some potentially necessary functionality / understand more about how to ignore certain routes from being recorded.
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
