### PR TITLE
core: disable memcached.command by default

### DIFF
--- a/packages/datadog-plugin-memcached/src/index.js
+++ b/packages/datadog-plugin-memcached/src/index.js
@@ -9,15 +9,20 @@ class MemcachedPlugin extends CachePlugin {
   start ({ client, server, query }) {
     const address = getAddress(client, server, query)
 
+    const meta = {
+      'out.host': address[0],
+      [CLIENT_PORT_KEY]: address[1]
+    }
+
+    if (this.config.memcachedCommandEnabled) {
+      meta['memcached.command'] = query.command
+    }
+
     this.startSpan({
       service: this.serviceName({ pluginConfig: this.config, system: this.system }),
       resource: query.type,
       type: 'memcached',
-      meta: {
-        'memcached.command': query.command,
-        'out.host': address[0],
-        [CLIENT_PORT_KEY]: address[1]
-      }
+      meta
     })
   }
 }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -179,6 +179,11 @@ class Config {
       false
     )
 
+    const DD_TRACE_MEMCACHED_COMMAND_ENABLED = coalesce(
+      process.env.DD_TRACE_MEMCACHED_COMMAND_ENABLED,
+      false
+    )
+
     const DD_SERVICE = options.service ||
       process.env.DD_SERVICE ||
       process.env.DD_SERVICE_NAME ||
@@ -628,6 +633,9 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.isManualApiEnabled = this.isCiVisibility && isTrue(DD_CIVISIBILITY_MANUAL_API_ENABLED)
 
     this.openaiSpanCharLimit = DD_OPENAI_SPAN_CHAR_LIMIT
+
+    // Requires an accompanying DD_APM_OBFUSCATION_MEMCACHED_KEEP_COMMAND=true in the agent
+    this.memcachedCommandEnabled = isTrue(DD_TRACE_MEMCACHED_COMMAND_ENABLED)
 
     if (this.gitMetadataEnabled) {
       this.repositoryUrl = coalesce(

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -136,7 +136,8 @@ module.exports = class PluginManager {
       headerTags,
       dbmPropagationMode,
       dsmEnabled,
-      clientIpEnabled
+      clientIpEnabled,
+      memcachedCommandEnabled
     } = this._tracerConfig
 
     const sharedConfig = {}
@@ -151,6 +152,7 @@ module.exports = class PluginManager {
 
     sharedConfig.dbmPropagationMode = dbmPropagationMode
     sharedConfig.dsmEnabled = dsmEnabled
+    sharedConfig.memcachedCommandEnabled = memcachedCommandEnabled
 
     if (serviceMapping && serviceMapping[name]) {
       sharedConfig.service = serviceMapping[name]

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1224,6 +1224,15 @@ describe('Config', () => {
         const config = new Config(options)
         expect(config).to.have.property('isManualApiEnabled', true)
       })
+      it('should disable memcached command tagging by default', () => {
+        const config = new Config(options)
+        expect(config).to.have.property('memcachedCommandEnabled', false)
+      })
+      it('should enable memcached command tagging if DD_TRACE_MEMCACHED_COMMAND_ENABLED is enabled', () => {
+        process.env.DD_TRACE_MEMCACHED_COMMAND_ENABLED = 'true'
+        const config = new Config(options)
+        expect(config).to.have.property('memcachedCommandEnabled', true)
+      })
     })
     context('ci visibility mode is not enabled', () => {
       it('should not activate intelligent test runner or git metadata upload', () => {


### PR DESCRIPTION
### What does this PR do?
- only sends `memcached.command` when `DD_TRACE_MEMCACHED_COMMAND_ENABLED=true` is set

### Motivation
- existing behavior is incorrect
  - `memcached.query` is supposed to be the full query (command + args)
  - `memcached.command` is only supposed to be the command
  - allowing the existing incorrect behavior to continue working if the flag is set
- disable by default in case someone stores sensitive data in their memcached key