### PR TITLE
fix: add openai to plugins type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -829,6 +829,7 @@ interface Plugins {
   "mysql2": plugins.mysql2;
   "net": plugins.net;
   "next": plugins.next;
+  "openai": plugins.openai;
   "opensearch": plugins.opensearch;
   "oracledb": plugins.oracledb;
   "paperplane": plugins.paperplane;


### PR DESCRIPTION
### What does this PR do?
Adds "openai" to plugins type
### Motivation
<!-- What inspired you to submit this pull request? -->
<img width="732" alt="Screenshot 2023-09-13 at 4 07 09 PM" src="https://github.com/DataDog/dd-trace-js/assets/22024236/4891ed91-aa7c-4f20-a5a6-bffb7eb76347">

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
