### PR TITLE
Fix DBM service

### DIFF
--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -62,6 +62,7 @@ describe('Plugin', () => {
         describe('when sending messages', () => {
           withPeerService(
             () => tracer,
+            'amqp10',
             () => sender.send({ key: 'value' }),
             'localhost',
             'out.host'

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -55,6 +55,7 @@ describe('Plugin', () => {
           describe('when sending commands', () => {
             withPeerService(
               () => tracer,
+              'amqplib',
               () => channel.assertQueue('test', {}, () => {}),
               'localhost',
               'out.host'
@@ -132,6 +133,7 @@ describe('Plugin', () => {
           describe('when publishing messages', () => {
             withPeerService(
               () => tracer,
+              'amqplib',
               () => channel.assertQueue('test', {}, () => {}),
               'localhost',
               'out.host'

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -22,19 +22,21 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         beforeEach(done => {
-          require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
-            .connect((err, conn) => {
-              connection = conn
+          agent.load('amqplib').then(() => {
+            require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
+              .connect((err, conn) => {
+                connection = conn
 
-              if (err != null) {
-                return done(err)
-              }
+                if (err != null) {
+                  return done(err)
+                }
 
-              conn.createChannel((err, ch) => {
-                channel = ch
-                done(err)
+                conn.createChannel((err, ch) => {
+                  channel = ch
+                  return done(err)
+                })
               })
-            })
+          })
         })
 
         describe('without plugin', () => {
@@ -301,28 +303,25 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        before(() => {
-          return agent.load('amqplib', { service: 'test-custom-service' })
-        })
-
         after(() => {
           return agent.close({ ritmReset: false })
         })
 
         beforeEach(done => {
-          require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
-            .connect((err, conn) => {
-              connection = conn
+          agent.load('amqplib', { service: 'test-custom-service' }).then(() => {
+            require(`../../../versions/amqplib@${version}`).get('amqplib/callback_api')
+              .connect((err, conn) => {
+                connection = conn
+                if (err != null) {
+                  return done(err)
+                }
 
-              if (err !== null) {
-                return done(err)
-              }
-
-              conn.createChannel((err, ch) => {
-                channel = ch
-                done(err)
+                conn.createChannel((err, ch) => {
+                  channel = ch
+                  return done(err)
+                })
               })
-            })
+          })
         })
 
         it('should be configured with the correct values', done => {

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -57,6 +57,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'aws-sdk',
           (done) => s3.putObject({
             Bucket: bucketName,
             Key: 'test-key',

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -104,6 +104,7 @@ describe('Sns', () => {
 
     withPeerService(
       () => tracer,
+      'aws-sdk',
       (done) => sns.publish({
         TopicArn,
         Message: 'message 1'

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -53,6 +53,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'aws-sdk',
           (done) => sqs.sendMessage({
             MessageBody: 'test body',
             QueueUrl

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -45,6 +45,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'cassandra-driver',
           (done) => client.execute('SELECT now() FROM local;', err => err && done(err)),
           '127.0.0.1', 'db.cassandra.contact.points'
         )

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -57,6 +57,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'elasticsearch',
           () => client.search({
             index: 'docs',
             sort: 'name',

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -98,6 +98,7 @@ describe('Plugin', () => {
 
             withPeerService(
               () => tracer,
+              'grpc',
               async () => {
                 const client = await buildClient({
                   getUnary: (_, callback) => callback()

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -76,6 +76,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'http',
           spanProducerFn,
           'localhost',
           'out.host'

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -78,6 +78,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'http2',
           spanProducerFn,
           'localhost',
           'out.host'

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -58,6 +58,7 @@ describe('Plugin', () => {
 
           withPeerService(
             () => tracer,
+            'kafkajs',
             (done) => sendMessages(kafka, testTopic, messages).catch(done),
             '127.0.0.1:9092',
             'messaging.kafka.bootstrap.servers')

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -57,7 +57,8 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
-          (done) => connection.query('SELECT 1', (_) => { done() }),
+          'mariadb',
+          done => connection.query('SELECT 1', (err) => { err && done(err) }),
           'db', 'db.name')
 
         it('should propagate context to callbacks, with correct callback args', done => {

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -27,6 +27,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'memcached',
           done => memcached.get('test', err => err && done(err)),
           'localhost',
           'out.host'

--- a/packages/datadog-plugin-moleculer/test/index.spec.js
+++ b/packages/datadog-plugin-moleculer/test/index.spec.js
@@ -143,6 +143,7 @@ describe('Plugin', () => {
 
           withPeerService(
             () => tracer,
+            'moleculer',
             done => {
               broker.call('math.add', { a: 5, b: 3 }).catch(done)
             },

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -78,6 +78,7 @@ describe('Plugin', () => {
         describe('server', () => {
           withPeerService(
             () => tracer,
+            'mongodb-core',
             () => collection.insertOne({ a: 1 }, {}, () => {}),
             'test', 'peer.service'
           )

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -40,6 +40,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'mongodb-core',
           (done) => {
             const PeerCat = mongoose.model('PeerCat', { name: String })
             new PeerCat({ name: 'PeerCat' }).save().catch(done)

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -9,7 +9,7 @@ class MySQLPlugin extends DatabasePlugin {
 
   start (payload) {
     const service = this.serviceName({ pluginConfig: this.config, dbConfig: payload.conf, system: this.system })
-    this.startSpan(this.operationName(), {
+    const span = this.startSpan(this.operationName(), {
       service,
       resource: payload.sql,
       type: 'sql',
@@ -22,7 +22,7 @@ class MySQLPlugin extends DatabasePlugin {
         [CLIENT_PORT_KEY]: payload.conf.port
       }
     })
-    payload.sql = this.injectDbmQuery(payload.sql, service)
+    payload.sql = this.injectDbmQuery(span, payload.sql, service)
   }
 }
 

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -40,6 +40,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'mysql2',
           (done) => connection.query('SELECT 1', (_) => done()),
           'db', 'db.name')
 

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -77,6 +77,7 @@ describe('Plugin', () => {
 
     withPeerService(
       () => tracer,
+      'net',
       () => {
         const socket = new net.Socket()
         socket.connect(port, 'localhost')

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -244,7 +244,8 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
-          (done) => client.search({
+          'opensearch',
+          () => client.search({
             index: 'docs',
             sort: 'name',
             size: 100,

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -47,6 +47,7 @@ describe('Plugin', () => {
 
           withPeerService(
             () => tracer,
+            'oracledb',
             () => connection.execute(dbQuery),
             expectedPeerService,
             'db.instance'
@@ -173,6 +174,7 @@ describe('Plugin', () => {
 
           withPeerService(
             () => tracer,
+            'oracledb',
             () => connection.execute(dbQuery),
             expectedPeerService,
             'db.instance'

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -12,7 +12,7 @@ class PGPlugin extends DatabasePlugin {
     const service = this.serviceName({ pluginConfig: this.config, params })
     const originalStatement = this.maybeTruncate(query.text)
 
-    this.startSpan(this.operationName(), {
+    const span = this.startSpan(this.operationName(), {
       service,
       resource: originalStatement,
       type: 'sql',
@@ -27,7 +27,7 @@ class PGPlugin extends DatabasePlugin {
       }
     })
 
-    query.__ddInjectableQuery = this.injectDbmQuery(query.text, service, !!query.name)
+    query.__ddInjectableQuery = this.injectDbmQuery(span, query.text, service, !!query.name)
   }
 }
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -55,6 +55,7 @@ describe('Plugin', () => {
 
           withPeerService(
             () => tracer,
+            'pg',
             (done) => client.query('SELECT 1', (err, result) => {
               if (err) {
                 done()

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -62,6 +62,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'redis',
           (done) => client.get('bar').catch(done),
           '127.0.0.1', 'out.host')
 
@@ -146,6 +147,7 @@ describe('Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'redis',
           (done) => client.get('bar').catch(done),
           'localhost', 'out.host')
 

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -42,6 +42,7 @@ describe('Legacy Plugin', () => {
 
         withPeerService(
           () => tracer,
+          'redis',
           () => client.get('foo'),
           '127.0.0.1',
           'out.host'

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -49,6 +49,7 @@ describe('Plugin', () => {
           describe('sending a message', () => {
             withPeerService(
               () => tracer,
+              'rhea',
               () => context.sender.send({ body: 'Hello World!' }),
               'localhost',
               'out.host'

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -85,6 +85,7 @@ describe('Plugin', () => {
 
       withPeerService(
         () => tracer,
+        'tedious',
         (done) => connection.execSql(new tds.Request('SELECT 1', (err) => {
           if (err) return done(err)
         })), 'master', 'db.name'

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -26,8 +26,6 @@ class DatadogTracer {
     this._version = config.version
     this._env = config.env
     this._tags = config.tags
-    this._computePeerService = config.spanComputePeerService
-    this._peerServiceMapping = config.peerServiceMapping
     this._logInjection = config.logInjection
     this._debug = config.debug
     this._prioritySampler = new PrioritySampler(config.env, config.sampler)

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -72,11 +72,10 @@ module.exports = class PluginManager {
     const Plugin = pluginClasses[name]
 
     if (!Plugin) return
+    if (!this._tracerConfig) return // TODO: don't wait for tracer to be initialized
     if (!this._pluginsByName[name]) {
       this._pluginsByName[name] = new Plugin(this._tracer, this._tracerConfig)
     }
-    if (!this._tracerConfig) return // TODO: don't wait for tracer to be initialized
-
     const pluginConfig = this._configsByName[name] || {
       enabled: this._tracerConfig.plugins !== false
     }

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -64,10 +64,11 @@ class OutboundPlugin extends TracingPlugin {
      * peer service and add the value we overrode.
      */
     const peerService = peerData[PEER_SERVICE_KEY]
-    if (peerService && this.tracer._peerServiceMapping[peerService]) {
+    const mappedService = this._tracerConfig.peerServiceMapping?.[peerService]
+    if (peerService && mappedService) {
       return {
         ...peerData,
-        [PEER_SERVICE_KEY]: this.tracer._peerServiceMapping[peerService],
+        [PEER_SERVICE_KEY]: mappedService,
         [PEER_SERVICE_REMAP_KEY]: peerService
       }
     }
@@ -80,7 +81,7 @@ class OutboundPlugin extends TracingPlugin {
   }
 
   tagPeerService (span) {
-    if (this.tracer._computePeerService) {
+    if (this._tracerConfig.spanComputePeerService) {
       const peerData = this.getPeerService(span.context()._tags)
       if (peerData !== undefined) {
         span.addTags(this.getPeerServiceRemap(peerData))

--- a/packages/dd-trace/test/plugins/outbound.spec.js
+++ b/packages/dd-trace/test/plugins/outbound.spec.js
@@ -14,7 +14,7 @@ describe('OuboundPlugin', () => {
 
     beforeEach(() => {
       instance = new OutboundPlugin()
-      computePeerServiceStub = sinon.stub(instance, 'tracer')
+      computePeerServiceStub = sinon.stub(instance, '_tracerConfig')
       getPeerServiceStub = sinon.stub(instance, 'getPeerService')
       getRemapStub = sinon.stub(instance, 'getPeerServiceRemap')
     })
@@ -26,7 +26,7 @@ describe('OuboundPlugin', () => {
     })
 
     it('should attempt to remap when we found peer service', () => {
-      computePeerServiceStub.value({ _computePeerService: true })
+      computePeerServiceStub.value({ spanComputePeerService: true })
       getPeerServiceStub.returns({ foo: 'bar' })
       instance.tagPeerService({ context: () => { return { _tags: {} } }, addTags: () => {} })
 
@@ -35,7 +35,7 @@ describe('OuboundPlugin', () => {
     })
 
     it('should not attempt to remap if we found no peer service', () => {
-      computePeerServiceStub.value({ _computePeerService: true })
+      computePeerServiceStub.value({ spanComputePeerService: true })
       getPeerServiceStub.returns(undefined)
       instance.tagPeerService({ context: () => { return { _tags: {} } }, addTags: () => {} })
 
@@ -44,7 +44,7 @@ describe('OuboundPlugin', () => {
     })
 
     it('should do nothing when disabled', () => {
-      computePeerServiceStub.value({ _computePeerService: false })
+      computePeerServiceStub.value({ spanComputePeerService: false })
       instance.tagPeerService({ context: () => { return { _tags: {} } }, addTags: () => {} })
       expect(getPeerServiceStub).to.not.be.called
       expect(getRemapStub).to.not.be.called
@@ -118,20 +118,20 @@ describe('OuboundPlugin', () => {
     })
 
     it('should return peer data unchanged if there is no peer service', () => {
+      mappingStub = sinon.stub(instance, '_tracerConfig').value({})
       const mappingData = instance.getPeerServiceRemap({ 'foo': 'bar' })
-      mappingStub = sinon.stub(instance, 'tracer')
       expect(mappingData).to.deep.equal({ 'foo': 'bar' })
     })
 
     it('should return peer data unchanged if no mapping is available', () => {
-      mappingStub = sinon.stub(instance, 'tracer').value({ _peerServiceMapping: {} })
+      mappingStub = sinon.stub(instance, '_tracerConfig').value({ peerServiceMapping: {} })
       const mappingData = instance.getPeerServiceRemap(peerData)
       expect(mappingData).to.deep.equal(peerData)
     })
 
     it('should return peer data unchanged if no mapping item matches', () => {
-      mappingStub = sinon.stub(instance, 'tracer').value({
-        _peerServiceMapping: {
+      mappingStub = sinon.stub(instance, '_tracerConfig').value({
+        peerServiceMapping: {
           barsvc: 'bar',
           bazsvc: 'baz'
         }
@@ -141,8 +141,8 @@ describe('OuboundPlugin', () => {
     })
 
     it('should remap if a mapping item matches', () => {
-      mappingStub = sinon.stub(instance, 'tracer').value({
-        _peerServiceMapping: {
+      mappingStub = sinon.stub(instance, '_tracerConfig').value({
+        peerServiceMapping: {
           foosvc: 'foo',
           bazsvc: 'baz'
         }

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -139,13 +139,12 @@ function withNamingSchema (
   })
 }
 
-function withPeerService (tracer, spanGenerationFn, service, serviceSource, opts = {}) {
+function withPeerService (tracer, pluginName, spanGenerationFn, service, serviceSource, opts = {}) {
   describe('peer service computation' + (opts.desc ? ` ${opts.desc}` : ''), () => {
     let computePeerServiceSpy
     beforeEach(() => {
-      // FIXME: workaround due to the evaluation order of mocha beforeEach
-      const tracerObj = typeof tracer === 'function' ? tracer() : tracer
-      computePeerServiceSpy = sinon.stub(tracerObj._tracer, '_computePeerService').value(true)
+      const plugin = tracer()._pluginManager._pluginsByName[pluginName]
+      computePeerServiceSpy = sinon.stub(plugin._tracerConfig, 'spanComputePeerService').value(true)
     })
     afterEach(() => {
       computePeerServiceSpy.restore()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use peer service if available for DBM service computation. This repairs DBM issues that stem from the v1 naming schema.

### Notes
<!-- What inspired you to submit this pull request? -->
As a drive-by, I simplified to `_tracerConfig` for all configuration access. There's no need to keep this at the tracer level.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
