### PR TITLE
add withVersions to all esm tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:integration:cypress": "mocha --colors --timeout 30000 \"integration-tests/cypress/*.spec.js\"",
     "test:integration:playwright": "mocha --colors --timeout 30000 \"integration-tests/playwright/*.spec.js\"",
     "test:integration:serverless": "mocha --colors --timeout 30000 \"integration-tests/serverless/*.spec.js\"",
-    "test:integration:plugins": "mocha --colors --timeout 30000 \"packages/datadog-plugin-*/test/integration-test/*.spec.js\"",
+    "test:integration:plugins": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/integration-test/**/*.spec.js\"",
     "test:unit:plugins": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/datadog-instrumentations/test/@($(echo $PLUGINS)).spec.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\" --exclude \"packages/datadog-plugin-@($(echo $PLUGINS))/test/integration-test/**/*.spec.js\"",
     "test:shimmer": "mocha --colors 'packages/datadog-shimmer/test/**/*.spec.js'",
     "test:shimmer:ci": "nyc --no-clean --include 'packages/datadog-shimmer/src/**/*.js' -- npm run test:shimmer",

--- a/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
@@ -12,39 +12,36 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
-
   withVersions('amqp10', 'amqp10', version => {
-    context('amqp10', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'amqp10@${version}'`, 'rhea'], false, [
-          `./packages/datadog-plugin-amqp10/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'amqp10@${version}'`, 'rhea'], false, [
+        `./packages/datadog-plugin-amqp10/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
@@ -13,36 +13,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['amqp10', 'rhea'], false, [
-      `./packages/datadog-plugin-amqp10/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('amqp10', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
+  withVersions('amqp10', 'amqp10', version => {
+    context('amqp10', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`amqp10@${version}`, 'rhea'], false, [
+          `./packages/datadog-plugin-amqp10/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
     context('amqp10', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`amqp10@${version}`, 'rhea'], false, [
+        sandbox = await createSandbox([`'amqp10@${version}'`, 'rhea'], false, [
           `./packages/datadog-plugin-amqp10/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
     describe('amqplib', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`amqplib`], false,
+        sandbox = await createSandbox([`'amqplib@${version}'`], false,
           [`./packages/datadog-plugin-amqplib/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -12,6 +12,7 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('amqplib', 'amqplib', '>=0.10.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -12,36 +12,38 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
-
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['amqplib'], false, [`./packages/datadog-plugin-amqplib/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('amqplib', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'amqp.command'), true)
+  withVersions('amqplib', 'amqplib', '>=0.10.0', version => {
+    describe('amqplib', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`amqplib`], false,
+          [`./packages/datadog-plugin-amqplib/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'amqp.command'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -13,37 +13,35 @@ describe('esm', () => {
   let proc
   let sandbox
   withVersions('amqplib', 'amqplib', '>=0.10.0', version => {
-    describe('amqplib', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'amqplib@${version}'`], false,
-          [`./packages/datadog-plugin-amqplib/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'amqp.command'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'amqplib@${version}'`], false,
+        [`./packages/datadog-plugin-amqplib/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'amqp.command'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
@@ -13,41 +13,43 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['aws-sdk'], false, [
-      `./packages/datadog-plugin-aws-sdk/test/integration-test/*`])
-  })
+  withVersions('aws-sdk', ['aws-sdk'], version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`aws-sdk@${version}`], false, [
+        `./packages/datadog-plugin-aws-sdk/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('aws-sdk', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'aws.request'), true)
-      })
+    context('aws-sdk', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'aws.request'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
-        {
-          'AWS_SECRET_ACCESS_KEY': '0000000000/00000000000000000000000000000',
-          'AWS_ACCESS_KEY_ID': '00000000000000000000'
-        }
-      )
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
+          {
+            'AWS_SECRET_ACCESS_KEY': '0000000000/00000000000000000000000000000',
+            'AWS_ACCESS_KEY_ID': '00000000000000000000'
+          }
+        )
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
@@ -33,23 +33,21 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('aws-sdk', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'aws.request'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'aws.request'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
-          {
-            'AWS_SECRET_ACCESS_KEY': '0000000000/00000000000000000000000000000',
-            'AWS_ACCESS_KEY_ID': '00000000000000000000'
-          }
-        )
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
+        {
+          'AWS_SECRET_ACCESS_KEY': '0000000000/00000000000000000000000000000',
+          'AWS_ACCESS_KEY_ID': '00000000000000000000'
+        }
+      )
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('aws-sdk', ['aws-sdk'], version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`aws-sdk@${version}`], false, [
+      sandbox = await createSandbox([`'aws-sdk@${version}'`], false, [
         `./packages/datadog-plugin-aws-sdk/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -14,7 +14,7 @@ describe('esm', () => {
   withVersions('bunyan', 'bunyan', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`bunyan@${version}`], false,
+      sandbox = await createSandbox([`'bunyan@${version}'`], false,
         [`./packages/datadog-plugin-bunyan/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -30,19 +30,16 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-
-    context('bunyan', () => {
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(
-          sandbox.folder,
-          'server.mjs',
-          agent.port,
-          (data) => {
-            const jsonObject = JSON.parse(data.toString())
-            expect(jsonObject).to.have.property('dd')
-          }
-        )
-      }).timeout(20000)
-    })
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(
+        sandbox.folder,
+        'server.mjs',
+        agent.port,
+        (data) => {
+          const jsonObject = JSON.parse(data.toString())
+          expect(jsonObject).to.have.property('dd')
+        }
+      )
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -11,36 +11,38 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  withVersions('bunyan', 'bunyan', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`bunyan@${version}`], false,
+        [`./packages/datadog-plugin-bunyan/test/integration-test/*`])
+    })
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['bunyan'], false, [`./packages/datadog-plugin-bunyan/test/integration-test/*`])
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('bunyan', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(
-        sandbox.folder,
-        'server.mjs',
-        agent.port,
-        (data) => {
-          const jsonObject = JSON.parse(data.toString())
-          expect(jsonObject).to.have.property('dd')
-        }
-      )
-    }).timeout(20000)
+    context('bunyan', () => {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(
+          sandbox.folder,
+          'server.mjs',
+          agent.port,
+          (data) => {
+            const jsonObject = JSON.parse(data.toString())
+            expect(jsonObject).to.have.property('dd')
+          }
+        )
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -7,7 +7,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -15,14 +14,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('cassandra-driver', 'cassandra-driver', '>=4.4.0', version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
-
     describe('cassandra-driver', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`cassandra-driver@${version}`], false, [
+        sandbox = await createSandbox([`'cassandra-driver@${version}'`], false, [
           `./packages/datadog-plugin-cassandra-driver/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -7,42 +7,49 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const semver = require('semver')
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['cassandra-driver'], false, [
-      `./packages/datadog-plugin-cassandra-driver/test/integration-test/*`])
-  })
+  withVersions('cassandra-driver', 'cassandra-driver', '>=4.4.0', version => {
+    // skip any semver incompatible versions
+    const describe = !semver.valid(version)
+      ? globalThis.describe.skip : globalThis.describe
 
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('cassandra-driver', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'cassandra.query'), true)
+    describe('cassandra-driver', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`cassandra-driver@${version}`], false, [
+          `./packages/datadog-plugin-cassandra-driver/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'cassandra.query'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -13,6 +13,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('cassandra-driver', 'cassandra-driver', '>=4.4.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -14,37 +14,35 @@ describe('esm', () => {
   let sandbox
 
   withVersions('cassandra-driver', 'cassandra-driver', '>=4.4.0', version => {
-    describe('cassandra-driver', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'cassandra-driver@${version}'`], false, [
-          `./packages/datadog-plugin-cassandra-driver/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'cassandra.query'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'cassandra-driver@${version}'`], false, [
+        `./packages/datadog-plugin-cassandra-driver/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'cassandra.query'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -14,7 +14,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  withVersions('connect', 'connect', version => {
+  withVersions('connect', 'connect', '>=3', version => {
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`connect@${version}`], false, [

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -14,34 +14,36 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['connect'], false, [
-      `./packages/datadog-plugin-connect/test/integration-test/*`])
-  })
+  withVersions('connect', 'connect', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`connect@${version}`], false, [
+        `./packages/datadog-plugin-connect/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('connect', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    context('connect', () => {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'connect.request'), true)
-      })
-    }).timeout(20000)
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'connect.request'), true)
+        })
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -14,6 +14,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('connect', 'connect', '>=3', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -34,16 +34,14 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('connect', () => {
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'connect.request'), true)
-        })
-      }).timeout(20000)
-    })
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'connect.request'), true)
+      })
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('connect', 'connect', '>=3', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`connect@${version}`], false, [
+      sandbox = await createSandbox([`'connect@${version}'`], false, [
         `./packages/datadog-plugin-connect/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -17,6 +17,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('couchbase', 'couchbase', '>=4.0.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -37,17 +37,15 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('couchbase', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'couchbase.upsert'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'couchbase.upsert'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-        await res
-      }).timeout(20000)
-    })
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -17,35 +17,37 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['couchbase'], false, [
-      `./packages/datadog-plugin-couchbase/test/integration-test/*`])
-  })
+  withVersions('couchbase', 'couchbase', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`couchbase@${version}`], false, [
+        `./packages/datadog-plugin-couchbase/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('couchbase', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'couchbase.upsert'), true)
-      })
+    context('couchbase', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'couchbase.upsert'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-      await res
-    }).timeout(20000)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  withVersions('couchbase', 'couchbase', version => {
+  withVersions('couchbase', 'couchbase', '>=4.0.0', version => {
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`couchbase@${version}`], false, [

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('couchbase', 'couchbase', '>=4.0.0', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`couchbase@${version}`], false, [
+      sandbox = await createSandbox([`'couchbase@${version}'`], false, [
         `./packages/datadog-plugin-couchbase/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -14,37 +14,35 @@ describe('esm', () => {
   let sandbox
 
   withVersions('elasticsearch', ['@elastic/elasticsearch'], version => {
-    describe('elasticsearch', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'@elastic/elasticsearch@${version}'`], false, [
-          `./packages/datadog-plugin-elasticsearch/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'elasticsearch.query'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'@elastic/elasticsearch@${version}'`], false, [
+        `./packages/datadog-plugin-elasticsearch/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'elasticsearch.query'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -7,7 +7,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -15,13 +14,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('elasticsearch', ['@elastic/elasticsearch'], version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
     describe('elasticsearch', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`@elastic/elasticsearch@${version}`], false, [
+        sandbox = await createSandbox([`'@elastic/elasticsearch@${version}'`], false, [
           `./packages/datadog-plugin-elasticsearch/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -7,42 +7,48 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const semver = require('semver')
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['@elastic/elasticsearch'], false, [
-      `./packages/datadog-plugin-elasticsearch/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('elasticsearch', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'elasticsearch.query'), true)
+  withVersions('elasticsearch', ['@elastic/elasticsearch'], version => {
+    // skip any semver incompatible versions
+    const describe = !semver.valid(version)
+      ? globalThis.describe.skip : globalThis.describe
+    describe('elasticsearch', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`@elastic/elasticsearch@${version}`], false, [
+          `./packages/datadog-plugin-elasticsearch/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'elasticsearch.query'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -7,7 +7,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -15,14 +14,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('express', 'express', version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
-
     describe('express', () => {
       before(async function () {
         this.timeout(50000)
-        sandbox = await createSandbox([`express@${version}`], false,
+        sandbox = await createSandbox([`'express@${version}'`], false,
           [`./packages/datadog-plugin-express/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -14,40 +14,38 @@ describe('esm', () => {
   let sandbox
 
   withVersions('express', 'express', version => {
-    describe('express', () => {
-      before(async function () {
-        this.timeout(50000)
-        sandbox = await createSandbox([`'express@${version}'`], false,
-          [`./packages/datadog-plugin-express/test/integration-test/*`])
-      })
-
-      after(async function () {
-        this.timeout(50000)
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(payload.length, 1)
-          assert.isArray(payload[0])
-          assert.strictEqual(payload[0].length, 4)
-          assert.propertyVal(payload[0][0], 'name', 'express.request')
-          assert.propertyVal(payload[0][1], 'name', 'express.middleware')
-        })
-      }).timeout(50000)
+    before(async function () {
+      this.timeout(50000)
+      sandbox = await createSandbox([`'express@${version}'`], false,
+        [`./packages/datadog-plugin-express/test/integration-test/*`])
     })
+
+    after(async function () {
+      this.timeout(50000)
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(payload.length, 1)
+        assert.isArray(payload[0])
+        assert.strictEqual(payload[0].length, 4)
+        assert.propertyVal(payload[0][0], 'name', 'express.request')
+        assert.propertyVal(payload[0][1], 'name', 'express.middleware')
+      })
+    }).timeout(50000)
   })
 })

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -15,56 +15,54 @@ describe('esm', () => {
   let sandbox
 
   withVersions('fastify', 'fastify', '>=3.0.0', version => {
-    describe('fastify', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'fastify@${version}'`], false,
-          [`./packages/datadog-plugin-fastify/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
-        })
-      }).timeout(20000)
-
-      it('* import fastify is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server1.mjs', agent.port)
-
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
-        })
-      }).timeout(20000)
-
-      //
-      it('Fastify import fastify is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
-
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
-        })
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'fastify@${version}'`], false,
+        [`./packages/datadog-plugin-fastify/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+      })
+    }).timeout(20000)
+
+    it('* import fastify is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server1.mjs', agent.port)
+
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+      })
+    }).timeout(20000)
+
+    //
+    it('Fastify import fastify is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
+
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+      })
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -8,59 +8,67 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const semver = require('semver')
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['fastify'], false, [`./packages/datadog-plugin-fastify/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('fastify', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+  withVersions('fastify', 'fastify', '>=3.0.0', version => {
+    // skip any semver incompatibale versions
+    const describe = !semver.valid(version)
+      ? globalThis.describe.skip : globalThis.describe
+    describe('fastify', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`fastify@${version}`], false,
+          [`./packages/datadog-plugin-fastify/test/integration-test/*`])
       })
-    }).timeout(20000)
 
-    it('* import fastify is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server1.mjs', agent.port)
-
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+      after(async () => {
+        await sandbox.remove()
       })
-    }).timeout(20000)
 
-    it('Fastify import fastify is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
-
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
       })
-    }).timeout(20000)
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+        })
+      }).timeout(20000)
+
+      it('* import fastify is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server1.mjs', agent.port)
+
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+        })
+      }).timeout(20000)
+
+      //
+      it('Fastify import fastify is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
+
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'fastify.request'), true)
+        })
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -8,7 +8,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -16,13 +15,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('fastify', 'fastify', '>=3.0.0', version => {
-    // skip any semver incompatibale versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
     describe('fastify', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`fastify@${version}`], false,
+        sandbox = await createSandbox([`'fastify@${version}'`], false,
           [`./packages/datadog-plugin-fastify/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -14,7 +14,9 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  withVersions('fastify', 'fastify', '>=3.0.0', version => {
+  // TODO: fastify instrumentation breaks with esm for version 4.23.2 but works for commonJS,
+  // fix it and change the versions tested
+  withVersions('fastify', 'fastify', '^3', version => {
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`'fastify@${version}'`], false,

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -12,38 +12,39 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
-
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['@google-cloud/pubsub'], false, [ './packages/dd-trace/src/id.js',
-      `./packages/datadog-plugin-google-cloud-pubsub/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('google-cloud-pubsub', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'pubsub.request'), true)
+  withVersions('google-cloud-pubsub', '@google-cloud/pubsub', '>=4.0.0', version => {
+    describe('google-cloud-pubsub', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`@google-cloud/pubsub@${version}`], false, [ './packages/dd-trace/src/id.js',
+          `./packages/datadog-plugin-google-cloud-pubsub/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
-        { PUBSUB_EMULATOR_HOST: 'localhost:8081' })
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'pubsub.request'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
+          { PUBSUB_EMULATOR_HOST: 'localhost:8081' })
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
     describe('google-cloud-pubsub', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`@google-cloud/pubsub@${version}`], false, [ './packages/dd-trace/src/id.js',
+        sandbox = await createSandbox([`'@google-cloud/pubsub@${version}'`], false, [ './packages/dd-trace/src/id.js',
           `./packages/datadog-plugin-google-cloud-pubsub/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -12,6 +12,7 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('google-cloud-pubsub', '@google-cloud/pubsub', '>=4.0.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -13,38 +13,36 @@ describe('esm', () => {
   let proc
   let sandbox
   withVersions('google-cloud-pubsub', '@google-cloud/pubsub', '>=4.0.0', version => {
-    describe('google-cloud-pubsub', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'@google-cloud/pubsub@${version}'`], false, [ './packages/dd-trace/src/id.js',
-          `./packages/datadog-plugin-google-cloud-pubsub/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'pubsub.request'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
-          { PUBSUB_EMULATOR_HOST: 'localhost:8081' })
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'@google-cloud/pubsub@${version}'`], false, [ './packages/dd-trace/src/id.js',
+        `./packages/datadog-plugin-google-cloud-pubsub/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'pubsub.request'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined,
+        { PUBSUB_EMULATOR_HOST: 'localhost:8081' })
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('graphql', 'graphql', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`graphql@${version}`], false, [
+      sandbox = await createSandbox([`'graphql@${version}'`], false, [
         `./packages/datadog-plugin-graphql/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
@@ -13,36 +13,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(50000)
-    sandbox = await createSandbox(['graphql'], false, [
-      `./packages/datadog-plugin-graphql/test/integration-test/*`])
-  })
+  withVersions('graphql', 'graphql', version => {
+    before(async function () {
+      this.timeout(50000)
+      sandbox = await createSandbox([`graphql@${version}`], false, [
+        `./packages/datadog-plugin-graphql/test/integration-test/*`])
+    })
 
-  after(async function () {
-    await sandbox.remove()
-  })
+    after(async function () {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('graphql', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'graphql.parse'), true)
-      })
+    context('graphql', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'graphql.parse'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(50000)
+        await res
+      }).timeout(50000)
+    })
   })
 })

--- a/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
@@ -33,18 +33,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('graphql', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'graphql.parse'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'graphql.parse'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(50000)
-    })
+      await res
+    }).timeout(50000)
   })
 })

--- a/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
@@ -33,17 +33,15 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('grpc', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'grpc.client'), true)
-        })
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'integration-test/server.mjs', agent.port)
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'grpc.client'), true)
+      })
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'integration-test/server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('grpc', '@grpc/grpc-js', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`@grpc/grpc-js@${version}`, '@grpc/proto-loader', 'get-port@^3.2.0'], false, [
+      sandbox = await createSandbox([`'@grpc/grpc-js@${version}'`, '@grpc/proto-loader', 'get-port@^3.2.0'], false, [
         `./packages/datadog-plugin-grpc/test/*`])
     })
 

--- a/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
@@ -13,35 +13,37 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['@grpc/grpc-js', '@grpc/proto-loader', 'get-port@^3.2.0'], false, [
-      `./packages/datadog-plugin-grpc/test/*`])
-  })
+  withVersions('grpc', '@grpc/grpc-js', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`@grpc/grpc-js@${version}`, '@grpc/proto-loader', 'get-port@^3.2.0'], false, [
+        `./packages/datadog-plugin-grpc/test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('grpc', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'grpc.client'), true)
-      })
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'integration-test/server.mjs', agent.port)
+    context('grpc', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'grpc.client'), true)
+        })
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'integration-test/server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('hapi', '@hapi/hapi', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`@hapi/hapi@${version}`], false, [
+      sandbox = await createSandbox([`'@hapi/hapi@${version}'`], false, [
         `./packages/datadog-plugin-hapi/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
@@ -14,34 +14,36 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['@hapi/hapi'], false, [
-      `./packages/datadog-plugin-hapi/test/integration-test/*`])
-  })
+  withVersions('hapi', '@hapi/hapi', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`@hapi/hapi@${version}`], false, [
+        `./packages/datadog-plugin-hapi/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('hapi', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    context('hapi', () => {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'hapi.request'), true)
-      })
-    }).timeout(20000)
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'hapi.request'), true)
+        })
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
@@ -34,16 +34,14 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('hapi', () => {
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'hapi.request'), true)
-        })
-      }).timeout(20000)
-    })
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'hapi.request'), true)
+      })
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -15,7 +15,7 @@ describe('esm', () => {
   withVersions('ioredis', 'ioredis', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`ioredis@${version}`], false, [
+      sandbox = await createSandbox([`'ioredis@${version}'`], false, [
         `./packages/datadog-plugin-ioredis/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -32,18 +32,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('ioredis', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -12,37 +12,38 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  withVersions('ioredis', 'ioredis', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`ioredis@${version}`], false, [
+        `./packages/datadog-plugin-ioredis/test/integration-test/*`])
+    })
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['ioredis'], false, [
-      `./packages/datadog-plugin-ioredis/test/integration-test/*`])
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    context('ioredis', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
+        })
 
-  context('ioredis', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
-      })
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
@@ -12,37 +12,38 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  withVersions('kafkajs', 'kafkajs', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`kafkajs@${version}`], false, [
+        `./packages/datadog-plugin-kafkajs/test/integration-test/*`])
+    })
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['kafkajs@>=1.4.0'], false, [
-      `./packages/datadog-plugin-kafkajs/test/integration-test/*`])
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    context('kafkajs', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'kafka.produce'), true)
+        })
 
-  context('kafkajs', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'kafka.produce'), true)
-      })
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
@@ -31,19 +31,16 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'kafka.produce'), true)
+      })
 
-    context('kafkajs', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'kafka.produce'), true)
-        })
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
@@ -15,7 +15,7 @@ describe('esm', () => {
   withVersions('kafkajs', 'kafkajs', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`kafkajs@${version}`], false, [
+      sandbox = await createSandbox([`'kafkajs@${version}'`], false, [
         `./packages/datadog-plugin-kafkajs/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-koa/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-koa/test/integration-test/client.spec.js
@@ -34,16 +34,14 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('koa', () => {
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'koa.request'), true)
-        })
-      }).timeout(50000)
-    })
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'koa.request'), true)
+      })
+    }).timeout(50000)
   })
 })

--- a/packages/datadog-plugin-koa/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-koa/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('koa', 'koa', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`koa@${version}`], false,
+      sandbox = await createSandbox([`'koa@${version}'`], false,
         [`./packages/datadog-plugin-koa/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-koa/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-koa/test/integration-test/client.spec.js
@@ -13,35 +13,37 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  withVersions('koa', 'koa', version => {
+    before(async function () {
+      this.timeout(50000)
+      sandbox = await createSandbox([`koa@${version}`], false,
+        [`./packages/datadog-plugin-koa/test/integration-test/*`])
+    })
 
-  before(async function () {
-    this.timeout(50000)
-    sandbox = await createSandbox(['koa'], false, [`./packages/datadog-plugin-koa/test/integration-test/*`])
-  })
+    after(async function () {
+      this.timeout(50000)
+      await sandbox.remove()
+    })
 
-  after(async function () {
-    this.timeout(50000)
-    await sandbox.remove()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    context('koa', () => {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-  context('koa', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'koa.request'), true)
-      })
-    }).timeout(50000)
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'koa.request'), true)
+        })
+      }).timeout(50000)
+    })
   })
 })

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -13,38 +13,40 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['limitd-client'], false, [
-      `./packages/datadog-plugin-limitd-client/test/integration-test/*`])
-  })
+  withVersions('limitd-client', 'limitd-client', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`limitd-client@${version}`], false, [
+        `./packages/datadog-plugin-limitd-client/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('limitd-client', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        // not asserting for a limitd-client trace,
-        // just asserting that we're not completely breaking when loading limitd-client with esm
-        assert.strictEqual(checkSpansForServiceName(payload, 'tcp.connect'), true)
-      })
+    context('limitd-client', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          // not asserting for a limitd-client trace,
+          // just asserting that we're not completely breaking when loading limitd-client with esm
+          assert.strictEqual(checkSpansForServiceName(payload, 'tcp.connect'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('limitd-client', 'limitd-client', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`limitd-client@${version}`], false, [
+      sandbox = await createSandbox([`'limitd-client@${version}'`], false, [
         `./packages/datadog-plugin-limitd-client/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -33,20 +33,18 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('limitd-client', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          // not asserting for a limitd-client trace,
-          // just asserting that we're not completely breaking when loading limitd-client with esm
-          assert.strictEqual(checkSpansForServiceName(payload, 'tcp.connect'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        // not asserting for a limitd-client trace,
+        // just asserting that we're not completely breaking when loading limitd-client with esm
+        assert.strictEqual(checkSpansForServiceName(payload, 'tcp.connect'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -13,36 +13,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['mariadb'], false, [
-      `./packages/datadog-plugin-mariadb/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('mariadb', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'mariadb.query'), true)
+  withVersions('mariadb', 'mariadb', '>=3.0.0', version => {
+    describe('mariadb', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`mariadb@${version}`], false, [
+          `./packages/datadog-plugin-mariadb/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'mariadb.query'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -14,37 +14,35 @@ describe('esm', () => {
   let sandbox
 
   withVersions('mariadb', 'mariadb', '>=3.0.0', version => {
-    describe('mariadb', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'mariadb@${version}'`], false, [
-          `./packages/datadog-plugin-mariadb/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'mariadb.query'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'mariadb@${version}'`], false, [
+        `./packages/datadog-plugin-mariadb/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'mariadb.query'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -13,6 +13,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('mariadb', 'mariadb', '>=3.0.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
     describe('mariadb', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`mariadb@${version}`], false, [
+        sandbox = await createSandbox([`'mariadb@${version}'`], false, [
           `./packages/datadog-plugin-mariadb/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
@@ -34,18 +34,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('memcached', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'memcached.command'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'memcached.command'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(50000)
-    })
+      await res
+    }).timeout(50000)
   })
 })

--- a/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('memcached', 'memcached', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`memcached@${version}`], false, [
+      sandbox = await createSandbox([`'memcached@${version}'`], false, [
         `./packages/datadog-plugin-memcached/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
@@ -13,37 +13,39 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(50000)
-    sandbox = await createSandbox(['memcached'], false, [
-      `./packages/datadog-plugin-memcached/test/integration-test/*`])
-  })
+  withVersions('memcached', 'memcached', version => {
+    before(async function () {
+      this.timeout(50000)
+      sandbox = await createSandbox([`memcached@${version}`], false, [
+        `./packages/datadog-plugin-memcached/test/integration-test/*`])
+    })
 
-  after(async function () {
-    this.timeout(50000)
-    await sandbox.remove()
-  })
+    after(async function () {
+      this.timeout(50000)
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('memcached', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'memcached.command'), true)
-      })
+    context('memcached', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'memcached.command'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(50000)
+        await res
+      }).timeout(50000)
+    })
   })
 })

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -18,6 +18,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('microgateway-core', 'microgateway-core', '>=3.0.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -18,34 +18,36 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['microgateway-core', 'get-port'], false, [
-      `./packages/datadog-plugin-microgateway-core/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('microgateway-core', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'microgateway.request'), true)
+  withVersions('microgateway-core', 'microgateway-core', '>=3.0.0', version => {
+    describe('microgateway-core', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`microgateway-core@${version}`, 'get-port'], false, [
+          `./packages/datadog-plugin-microgateway-core/test/integration-test/*`])
       })
-    }).timeout(20000)
+
+      after(async () => {
+        await sandbox.remove()
+      })
+
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'microgateway.request'), true)
+        })
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -19,35 +19,33 @@ describe('esm', () => {
   let sandbox
 
   withVersions('microgateway-core', 'microgateway-core', '>=3.0.0', version => {
-    describe('microgateway-core', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'microgateway-core@${version}'`, 'get-port'], false, [
-          `./packages/datadog-plugin-microgateway-core/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'microgateway.request'), true)
-        })
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'microgateway-core@${version}'`, 'get-port'], false, [
+        `./packages/datadog-plugin-microgateway-core/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'microgateway.request'), true)
+      })
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -22,7 +22,7 @@ describe('esm', () => {
     describe('microgateway-core', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`microgateway-core@${version}`, 'get-port'], false, [
+        sandbox = await createSandbox([`'microgateway-core@${version}'`, 'get-port'], false, [
           `./packages/datadog-plugin-microgateway-core/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -17,38 +17,35 @@ describe('esm', () => {
   let proc
   let sandbox
   withVersions('moleculer', 'moleculer', '>0.14.0', version => {
-    // only test newer versions
-    describe('moleculer', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'moleculer@${version}'`, 'get-port'], false, [
-          `./packages/datadog-plugin-moleculer/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'moleculer.action'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'moleculer@${version}'`, 'get-port'], false, [
+        `./packages/datadog-plugin-moleculer/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'moleculer.action'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -21,7 +21,7 @@ describe('esm', () => {
     describe('moleculer', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`moleculer@${version}`, 'get-port'], false, [
+        sandbox = await createSandbox([`'moleculer@${version}'`, 'get-port'], false, [
           `./packages/datadog-plugin-moleculer/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -16,6 +16,7 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('moleculer', 'moleculer', '>0.14.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -16,37 +16,39 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
-
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['moleculer', 'get-port'], false, [
-      `./packages/datadog-plugin-moleculer/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('moleculer', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'moleculer.action'), true)
+  withVersions('moleculer', 'moleculer', '>0.14.0', version => {
+    // only test newer versions
+    describe('moleculer', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`moleculer@${version}`, 'get-port'], false, [
+          `./packages/datadog-plugin-moleculer/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'moleculer.action'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -21,7 +21,7 @@ describe('esm', () => {
 
   withVersions('mongodb-core', 'mongodb', '>=4', version => {
     before(async function () {
-      this.timeout(20000)
+      this.timeout(30000)
       sandbox = await createSandbox([`'mongodb@${version}'`], false, [
         `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
     })
@@ -49,12 +49,12 @@ describe('esm', () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
       await res
-    }).timeout(20000)
+    }).timeout(30000)
   })
 
   withVersions('mongodb-core', 'mongodb-core', '>=3', version => {
     before(async function () {
-      this.timeout(20000)
+      this.timeout(30000)
       sandbox = await createSandbox([`'mongodb-core@${version}'`], false, [
         `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
     })
@@ -82,6 +82,6 @@ describe('esm', () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
 
       await res
-    }).timeout(20000)
+    }).timeout(30000)
   })
 })

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -20,72 +20,68 @@ describe('esm', () => {
   let sandbox
 
   withVersions('mongodb-core', 'mongodb', '>=4', version => {
-    describe('mongodb', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'mongodb@${version}'`], false, [
-          `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
-      })
-
-      after(async function () {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'mongodb@${version}'`], false, [
+        `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
     })
+
+    after(async function () {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 
   withVersions('mongodb-core', 'mongodb-core', '>=3', version => {
-    describe('mongodb-core', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'mongodb-core@${version}'`], false, [
-          `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
-      })
-
-      after(async function () {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'mongodb-core@${version}'`], false, [
+        `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
     })
+
+    after(async function () {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -8,7 +8,6 @@ const {
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
 const { NODE_MAJOR } = require('../../../../version')
-const semver = require('semver')
 
 // Error: Command failed: yarn add file:/tmp/1236761b054ee8e5/dd-trace.tgz mongodb mongodb-core
 // error bson@6.0.0: The engine "node" is incompatible with this module. Expected version ">=16.20.1". Got "14.21.3"
@@ -21,14 +20,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('mongodb-core', 'mongodb', '>=4', version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
-
     describe('mongodb', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`mongodb@${version}`], false, [
+        sandbox = await createSandbox([`'mongodb@${version}'`], false, [
           `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
       })
 
@@ -60,14 +55,10 @@ describe('esm', () => {
   })
 
   withVersions('mongodb-core', 'mongodb-core', '>=3', version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
-
     describe('mongodb-core', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`mongodb-core@${version}`], false, [
+        sandbox = await createSandbox([`'mongodb-core@${version}'`], false, [
           `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -8,6 +8,7 @@ const {
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
 const { NODE_MAJOR } = require('../../../../version')
+const semver = require('semver')
 
 // Error: Command failed: yarn add file:/tmp/1236761b054ee8e5/dd-trace.tgz mongodb mongodb-core
 // error bson@6.0.0: The engine "node" is incompatible with this module. Expected version ">=16.20.1". Got "14.21.3"
@@ -19,49 +20,81 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['mongodb', 'mongodb-core'], false, [
-      `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
-  })
+  withVersions('mongodb-core', 'mongodb', '>=4', version => {
+    // skip any semver incompatible versions
+    const describe = !semver.valid(version)
+      ? globalThis.describe.skip : globalThis.describe
 
-  after(async function () {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('mongodb-core', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+    describe('mongodb', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`mongodb@${version}`], false, [
+          `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-      await res
-    }).timeout(20000)
-  })
-  context('mongodb', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+      after(async function () {
+        await sandbox.remove()
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
 
-      await res
-    }).timeout(20000)
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
+  })
+
+  withVersions('mongodb-core', 'mongodb-core', '>=3', version => {
+    // skip any semver incompatible versions
+    const describe = !semver.valid(version)
+      ? globalThis.describe.skip : globalThis.describe
+
+    describe('mongodb-core', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`mongodb-core@${version}`], false, [
+          `./packages/datadog-plugin-mongodb-core/test/integration-test/*`])
+      })
+
+      after(async function () {
+        await sandbox.remove()
+      })
+
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server2.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -19,6 +19,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('mongodb-core', 'mongodb', '>=4', version => {
     before(async function () {
       this.timeout(30000)
@@ -52,6 +53,7 @@ describe('esm', () => {
     }).timeout(30000)
   })
 
+  // test against later versions because server2.mjs uses newer package syntax
   withVersions('mongodb-core', 'mongodb-core', '>=3', version => {
     before(async function () {
       this.timeout(30000)

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/server.mjs
@@ -6,5 +6,5 @@ await client.connect()
 const db = client.db('test_db')
 const collection = db.collection('test_collection')
 collection.insertOne({ a: 1 }, {}, () => {})
-await client.close()
-          
+setTimeout(() => { client.close() }, 1500)
+

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/server.mjs
@@ -1,8 +1,10 @@
 import 'dd-trace/init.js'
 import { MongoClient } from 'mongodb'
 
-const client = new MongoClient('mongodb://localhost:27017/test_db', { useUnifiedTopology: true })
+const client = new MongoClient('mongodb://127.0.0.1:27017')
 await client.connect()
 const db = client.db('test_db')
-await db.collection('test_collection').insertOne({ a: 1 })
+const collection = db.collection('test_collection')
+collection.insertOne({ a: 1 }, {}, () => {})
 await client.close()
+          

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -7,42 +7,50 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const { describe } = require('node:test')
+const semver = require('semver')
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['mongoose'], false, [
-      `./packages/datadog-plugin-mongoose/test/integration-test/*`])
-  })
+  withVersions('mongoose', ['mongoose'], version => {
+    // skip any semver incompatible versions
+    const describe = !semver.valid(version)
+      ? globalThis.describe.skip : globalThis.describe
 
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('mongoose', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+    describe('mongoose', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`mongoose@${version}`], false, [
+          `./packages/datadog-plugin-mongoose/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -7,8 +7,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const { describe } = require('node:test')
-const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -16,14 +14,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('mongoose', ['mongoose'], version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
-
     describe('mongoose', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`mongoose@${version}`], false, [
+        sandbox = await createSandbox([`'mongoose@${version}'`], false, [
           `./packages/datadog-plugin-mongoose/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -14,37 +14,35 @@ describe('esm', () => {
   let sandbox
 
   withVersions('mongoose', ['mongoose'], version => {
-    describe('mongoose', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'mongoose@${version}'`], false, [
-          `./packages/datadog-plugin-mongoose/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'mongoose@${version}'`], false, [
+        `./packages/datadog-plugin-mongoose/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'mongodb.query'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('mysql', 'mysql', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`mysql@${version}`], false, [
+      sandbox = await createSandbox([`'mysql@${version}'`], false, [
         `./packages/datadog-plugin-mysql/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -36,18 +36,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('mysql', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -16,37 +16,38 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
+  withVersions('mysql', 'mysql', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`mysql@${version}`], false, [
+        `./packages/datadog-plugin-mysql/test/integration-test/*`])
+    })
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['mysql'], false, [
-      `./packages/datadog-plugin-mysql/test/integration-test/*`])
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    context('mysql', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
+        })
 
-  context('mysql', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
-      })
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('mysql2', 'mysql2', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`mysql2@${version}`], false, [
+      sandbox = await createSandbox([`'mysql2@${version}'`], false, [
         `./packages/datadog-plugin-mysql2/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
@@ -37,18 +37,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('mysql2', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
@@ -17,36 +17,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['mysql2'], false, [
-      `./packages/datadog-plugin-mysql2/test/integration-test/*`])
-  })
+  withVersions('mysql2', 'mysql2', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`mysql2@${version}`], false, [
+        `./packages/datadog-plugin-mysql2/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('mysql2', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
-      })
+    context('mysql2', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'mysql.query'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -18,51 +18,11 @@ describe('esm', () => {
   let sandbox
 
   withVersions('next', 'next', DD_MAJOR >= 4 && '>=11', version => {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    // skip any semver incompatible versions
-=======
->>>>>>> 8f704e9fd (address feedback)
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)
       sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'], 'yarn exec next build')
-<<<<<<< HEAD
-=======
-    describe('next', () => {
-      before(async function () {
-        // next builds slower in the CI, match timeout with unit tests
-        this.timeout(120 * 1000)
-        sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
-          false, ['./packages/datadog-plugin-next/test/integration-test/*'], 'yarn exec next build')
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'next.request'), true)
-        })
-      }).timeout(120 * 1000)
->>>>>>> 8f1aa2fc4 (address feedback)
-=======
->>>>>>> 8f704e9fd (address feedback)
     })
 
     after(async () => {
@@ -79,23 +39,14 @@ describe('esm', () => {
     })
 
     it('is instrumented', async () => {
-<<<<<<< HEAD
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
         NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init`
       })
-=======
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
->>>>>>> 8f704e9fd (address feedback)
       return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
         assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
         assert.isArray(payload)
         assert.strictEqual(checkSpansForServiceName(payload, 'next.request'), true)
-<<<<<<< HEAD
       }, undefined, undefined, true)
-=======
-      })
->>>>>>> 8f704e9fd (address feedback)
     }).timeout(120 * 1000)
   })
 })

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -9,7 +9,6 @@ const {
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
 const { DD_MAJOR } = require('../../../../version')
-const semver = require('semver')
 
 const hookFile = 'dd-trace/loader-hook.mjs'
 
@@ -19,12 +18,45 @@ describe('esm', () => {
   let sandbox
 
   withVersions('next', 'next', DD_MAJOR >= 4 && '>=11', version => {
+<<<<<<< HEAD
     // skip any semver incompatible versions
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)
       sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'], 'yarn exec next build')
+=======
+    describe('next', () => {
+      before(async function () {
+        // next builds slower in the CI, match timeout with unit tests
+        this.timeout(120 * 1000)
+        sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
+          false, ['./packages/datadog-plugin-next/test/integration-test/*'], 'yarn exec next build')
+      })
+
+      after(async () => {
+        await sandbox.remove()
+      })
+
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'next.request'), true)
+        })
+      }).timeout(120 * 1000)
+>>>>>>> 8f1aa2fc4 (address feedback)
     })
 
     after(async () => {

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -8,7 +8,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const { DD_MAJOR } = require('../../../../version')
 
 const hookFile = 'dd-trace/loader-hook.mjs'
 
@@ -17,7 +16,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  withVersions('next', 'next', DD_MAJOR >= 4 && '>=11', version => {
+  withVersions('next', 'next', version => {
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -15,8 +15,8 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
-
-  withVersions('next', 'next', version => {
+  // match versions tested with unit tests
+  withVersions('next', 'next', '>=11', version => {
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -19,12 +19,16 @@ describe('esm', () => {
 
   withVersions('next', 'next', DD_MAJOR >= 4 && '>=11', version => {
 <<<<<<< HEAD
+<<<<<<< HEAD
     // skip any semver incompatible versions
+=======
+>>>>>>> 8f704e9fd (address feedback)
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)
       sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'], 'yarn exec next build')
+<<<<<<< HEAD
 =======
     describe('next', () => {
       before(async function () {
@@ -57,6 +61,8 @@ describe('esm', () => {
         })
       }).timeout(120 * 1000)
 >>>>>>> 8f1aa2fc4 (address feedback)
+=======
+>>>>>>> 8f704e9fd (address feedback)
     })
 
     after(async () => {
@@ -73,14 +79,23 @@ describe('esm', () => {
     })
 
     it('is instrumented', async () => {
+<<<<<<< HEAD
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
         NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init`
       })
+=======
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+>>>>>>> 8f704e9fd (address feedback)
       return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
         assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
         assert.isArray(payload)
         assert.strictEqual(checkSpansForServiceName(payload, 'next.request'), true)
+<<<<<<< HEAD
       }, undefined, undefined, true)
+=======
+      })
+>>>>>>> 8f704e9fd (address feedback)
     }).timeout(120 * 1000)
   })
 })

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -14,37 +14,35 @@ describe('esm', () => {
   let sandbox
 
   withVersions('openai', 'openai', version => {
-    describe('openai', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'openai@${version}'`, 'nock'], false, [
-          `./packages/datadog-plugin-openai/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'openai.request'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'openai@${version}'`, 'nock'], false, [
+        `./packages/datadog-plugin-openai/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'openai.request'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -7,7 +7,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -15,14 +14,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('openai', 'openai', version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
-
     describe('openai', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`openai@${version}`, 'nock'], false, [
+        sandbox = await createSandbox([`'openai@${version}'`, 'nock'], false, [
           `./packages/datadog-plugin-openai/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('opensearch', '@opensearch-project/opensearch', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`@opensearch-project/opensearch@${version}`], false, [
+      sandbox = await createSandbox([`'@opensearch-project/opensearch@${version}'`], false, [
         `./packages/datadog-plugin-opensearch/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
@@ -33,18 +33,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('opensearch', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'opensearch.query'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'opensearch.query'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
@@ -13,36 +13,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['@opensearch-project/opensearch'], false, [
-      `./packages/datadog-plugin-opensearch/test/integration-test/*`])
-  })
+  withVersions('opensearch', '@opensearch-project/opensearch', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`@opensearch-project/opensearch@${version}`], false, [
+        `./packages/datadog-plugin-opensearch/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('opensearch', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'opensearch.query'), true)
-      })
+    context('opensearch', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'opensearch.query'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
@@ -13,38 +13,40 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['oracledb@^5.0.0'], false, [
-      `./packages/datadog-plugin-oracledb/test/integration-test/*`])
-  })
+  withVersions('oracledb', 'oracledb', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`oracledb@${version}`], false, [
+        `./packages/datadog-plugin-oracledb/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('oracledb', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'oracle.query'), true)
-      })
+    context('oracledb', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'oracle.query'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
-        LD_LIBRARY_PATH: '/usr/lib/oracle/18.5/client64/lib:'
-      })
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
+          LD_LIBRARY_PATH: '/usr/lib/oracle/18.5/client64/lib:'
+        })
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('oracledb', 'oracledb', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`oracledb@${version}`], false, [
+      sandbox = await createSandbox([`'oracledb@${version}'`], false, [
         `./packages/datadog-plugin-oracledb/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
@@ -33,20 +33,18 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('oracledb', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'oracle.query'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'oracle.query'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
-          LD_LIBRARY_PATH: '/usr/lib/oracle/18.5/client64/lib:'
-        })
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
+        LD_LIBRARY_PATH: '/usr/lib/oracle/18.5/client64/lib:'
+      })
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('pg', 'pg', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`pg@${version}`], false, [
+      sandbox = await createSandbox([`'pg@${version}'`], false, [
         `./packages/datadog-plugin-pg/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -33,18 +33,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('pg', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'pg.query'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'pg.query'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -13,36 +13,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['pg'], false, [
-      `./packages/datadog-plugin-pg/test/integration-test/*`])
-  })
+  withVersions('pg', 'pg', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`pg@${version}`], false, [
+        `./packages/datadog-plugin-pg/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('pg', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'pg.query'), true)
-      })
+    context('pg', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'pg.query'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -13,37 +13,35 @@ describe('esm', () => {
   let sandbox
 
   withVersions('pino', 'pino', version => {
-    describe('pino', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'pino@${version}'`],
-          false, [`./packages/datadog-plugin-pino/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(
-          sandbox.folder,
-          'server.mjs',
-          agent.port,
-          (data) => {
-            const jsonObject = JSON.parse(data.toString())
-            expect(jsonObject).to.have.property('dd')
-          }
-        )
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'pino@${version}'`],
+        false, [`./packages/datadog-plugin-pino/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(
+        sandbox.folder,
+        'server.mjs',
+        agent.port,
+        (data) => {
+          const jsonObject = JSON.parse(data.toString())
+          expect(jsonObject).to.have.property('dd')
+        }
+      )
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -6,7 +6,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { expect } = require('chai')
-const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -14,14 +13,10 @@ describe('esm', () => {
   let sandbox
 
   withVersions('pino', 'pino', version => {
-    // skip any semver incompatible versions
-    const describe = !semver.valid(version)
-      ? globalThis.describe.skip : globalThis.describe
-
     describe('pino', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`pino@${version}`],
+        sandbox = await createSandbox([`'pino@${version}'`],
           false, [`./packages/datadog-plugin-pino/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -6,41 +6,49 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { expect } = require('chai')
+const semver = require('semver')
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['pino'], false, [`./packages/datadog-plugin-pino/test/integration-test/*`])
-  })
+  withVersions('pino', 'pino', version => {
+    // skip any semver incompatible versions
+    const describe = !semver.valid(version)
+      ? globalThis.describe.skip : globalThis.describe
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    describe('pino', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`pino@${version}`],
+          false, [`./packages/datadog-plugin-pino/test/integration-test/*`])
+      })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+      after(async () => {
+        await sandbox.remove()
+      })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
 
-  context('pino', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(
-        sandbox.folder,
-        'server.mjs',
-        agent.port,
-        (data) => {
-          const jsonObject = JSON.parse(data.toString())
-          expect(jsonObject).to.have.property('dd')
-        }
-      )
-    }).timeout(20000)
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(
+          sandbox.folder,
+          'server.mjs',
+          agent.port,
+          (data) => {
+            const jsonObject = JSON.parse(data.toString())
+            expect(jsonObject).to.have.property('dd')
+          }
+        )
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -7,12 +7,6 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
-const { NODE_MAJOR } = require('../../../../version')
-
-// Error: Command failed: yarn add file:/tmp/701a143ad8465e61/dd-trace.tgz 'redis@^4'
-// error @redis/client@1.5.10: The engine "node" is incompatible with this module.
-// Expected version ">=18". Got "16.20.2" error Found incompatible module.
-// const describe = NODE_MAJOR < 18 ? globalThis.describe.skip : globalThis.describe
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -12,37 +12,38 @@ describe('esm', () => {
   let agent
   let proc
   let sandbox
-
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['redis'], false, [
-      `./packages/datadog-plugin-redis/test/integration-test/*`])
-  })
-
-  after(async () => {
-    await sandbox.remove()
-  })
-
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
-
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
-
-  context('redis', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
+  withVersions('redis', 'redis', '>=4', version => {
+    describe('redis', () => {
+      before(async function () {
+        this.timeout(20000)
+        sandbox = await createSandbox([`redis@${version}`], false, [
+          `./packages/datadog-plugin-redis/test/integration-test/*`])
       })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      after(async () => {
+        await sandbox.remove()
+      })
 
-      await res
-    }).timeout(20000)
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -7,6 +7,12 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const { NODE_MAJOR } = require('../../../../version')
+
+// Error: Command failed: yarn add file:/tmp/701a143ad8465e61/dd-trace.tgz 'redis@^4'
+// error @redis/client@1.5.10: The engine "node" is incompatible with this module.
+// Expected version ">=18". Got "16.20.2" error Found incompatible module.
+const describe = NODE_MAJOR < 18 ? globalThis.describe.skip : globalThis.describe
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
     describe('redis', () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox([`redis@${version}`], false, [
+        sandbox = await createSandbox([`'redis@${version}'`], false, [
           `./packages/datadog-plugin-redis/test/integration-test/*`])
       })
 

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -12,12 +12,13 @@ const { NODE_MAJOR } = require('../../../../version')
 // Error: Command failed: yarn add file:/tmp/701a143ad8465e61/dd-trace.tgz 'redis@^4'
 // error @redis/client@1.5.10: The engine "node" is incompatible with this module.
 // Expected version ">=18". Got "16.20.2" error Found incompatible module.
-const describe = NODE_MAJOR < 18 ? globalThis.describe.skip : globalThis.describe
+// const describe = NODE_MAJOR < 18 ? globalThis.describe.skip : globalThis.describe
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('redis', 'redis', '>=4', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -13,37 +13,35 @@ describe('esm', () => {
   let proc
   let sandbox
   withVersions('redis', 'redis', '>=4', version => {
-    describe('redis', () => {
-      before(async function () {
-        this.timeout(20000)
-        sandbox = await createSandbox([`'redis@${version}'`], false, [
-          `./packages/datadog-plugin-redis/test/integration-test/*`])
-      })
-
-      after(async () => {
-        await sandbox.remove()
-      })
-
-      beforeEach(async () => {
-        agent = await new FakeAgent().start()
-      })
-
-      afterEach(async () => {
-        proc && proc.kill()
-        await agent.stop()
-      })
-
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
-        })
-
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
-
-        await res
-      }).timeout(20000)
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`'redis@${version}'`], false, [
+        `./packages/datadog-plugin-redis/test/integration-test/*`])
     })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
+
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'redis.command'), true)
+      })
+
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -13,7 +13,7 @@ describe('Legacy Plugin', () => {
   let sub
 
   describe('redis', () => {
-    withVersions('redis', 'redis', version => {
+    withVersions('redis', 'redis', '<4', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
       })

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('restify', 'restify', '>3', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`restify@${version}`],
+      sandbox = await createSandbox([`'restify@${version}'`],
         false, [`./packages/datadog-plugin-restify/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -14,33 +14,36 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['restify'], false, [`./packages/datadog-plugin-restify/test/integration-test/*`])
-  })
+  withVersions('restify', 'restify', '>3', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`restify@${version}`],
+        false, [`./packages/datadog-plugin-restify/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('restify', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    context('restify', () => {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'restify.request'), true)
-      })
-    }).timeout(20000)
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'restify.request'), true)
+        })
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -34,16 +34,14 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('restify', () => {
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'restify.request'), true)
-        })
-      }).timeout(20000)
-    })
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'restify.request'), true)
+      })
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -14,6 +14,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('restify', 'restify', '>3', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('rhea', 'rhea', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`rhea@${version}`], false, [
+      sandbox = await createSandbox([`'rhea@${version}'`], false, [
         `./packages/datadog-plugin-rhea/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
@@ -33,18 +33,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('rhea', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
@@ -13,36 +13,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['rhea'], false, [
-      `./packages/datadog-plugin-rhea/test/integration-test/*`])
-  })
+  withVersions('rhea', 'rhea', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`rhea@${version}`], false, [
+        `./packages/datadog-plugin-rhea/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('rhea', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
-      })
+    context('rhea', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'amqp.send'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-router/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-router/test/integration-test/client.spec.js
@@ -14,33 +14,36 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['router'], false, [`./packages/datadog-plugin-router/test/integration-test/*`])
-  })
+  withVersions('router', 'router', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`router@${version}`]
+        , false, [`./packages/datadog-plugin-router/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('router', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    context('router', () => {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'router.middleware'), true)
-      })
-    }).timeout(20000)
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'router.middleware'), true)
+        })
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-router/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-router/test/integration-test/client.spec.js
@@ -34,16 +34,14 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('router', () => {
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'router.middleware'), true)
-        })
-      }).timeout(20000)
-    })
+      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'router.middleware'), true)
+      })
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-router/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-router/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('router', 'router', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`router@${version}`]
+      sandbox = await createSandbox([`'router@${version}'`]
         , false, [`./packages/datadog-plugin-router/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -13,36 +13,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['sharedb'], false, [
-      `./packages/datadog-plugin-sharedb/test/integration-test/*`])
-  })
+  withVersions('sharedb', 'sharedb', '>=3', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`sharedb@${version}`], false, [
+        `./packages/datadog-plugin-sharedb/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('sharedb', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'sharedb.request'), true)
-      })
+    context('sharedb', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'sharedb.request'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -13,6 +13,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('sharedb', 'sharedb', '>=3', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -33,18 +33,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('sharedb', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'sharedb.request'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'sharedb.request'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('sharedb', 'sharedb', '>=3', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`sharedb@${version}`], false, [
+      sandbox = await createSandbox([`'sharedb@${version}'`], false, [
         `./packages/datadog-plugin-sharedb/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -39,18 +39,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('tedious', () => {
-      it('is instrumented', async () => {
-        const res = agent.assertMessageReceived(({ headers, payload }) => {
-          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-          assert.isArray(payload)
-          assert.strictEqual(checkSpansForServiceName(payload, 'tedious.request'), true)
-        })
+    it('is instrumented', async () => {
+      const res = agent.assertMessageReceived(({ headers, payload }) => {
+        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+        assert.isArray(payload)
+        assert.strictEqual(checkSpansForServiceName(payload, 'tedious.request'), true)
+      })
 
-        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-        await res
-      }).timeout(20000)
-    })
+      await res
+    }).timeout(20000)
   })
 })

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -22,7 +22,7 @@ describe('esm', () => {
   withVersions('tedious', 'tedious', '>=16.0.0', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`tedious@${version}`], false, [
+      sandbox = await createSandbox([`'tedious@${version}'`], false, [
         `./packages/datadog-plugin-tedious/test/integration-test/*`])
     })
 

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -19,36 +19,38 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(20000)
-    sandbox = await createSandbox(['tedious'], false, [
-      `./packages/datadog-plugin-tedious/test/integration-test/*`])
-  })
+  withVersions('tedious', 'tedious', version => {
+    before(async function () {
+      this.timeout(20000)
+      sandbox = await createSandbox([`tedious@${version}`], false, [
+        `./packages/datadog-plugin-tedious/test/integration-test/*`])
+    })
 
-  after(async () => {
-    await sandbox.remove()
-  })
+    after(async () => {
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('tedious', () => {
-    it('is instrumented', async () => {
-      const res = agent.assertMessageReceived(({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(checkSpansForServiceName(payload, 'tedious.request'), true)
-      })
+    context('tedious', () => {
+      it('is instrumented', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'tedious.request'), true)
+        })
 
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      await res
-    }).timeout(20000)
+        await res
+      }).timeout(20000)
+    })
   })
 })

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -19,6 +19,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('tedious', 'tedious', '>=16.0.0', version => {
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -19,7 +19,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  withVersions('tedious', 'tedious', version => {
+  withVersions('tedious', 'tedious', '>=16.0.0', version => {
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`tedious@${version}`], false, [

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -33,18 +33,16 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    context('winston', () => {
-      it('is instrumented', async () => {
-        proc = await spawnPluginIntegrationTestProc(
-          sandbox.folder,
-          'server.mjs',
-          agent.port,
-          (data) => {
-            const jsonObject = JSON.parse(data.toString())
-            expect(jsonObject).to.have.property('dd')
-          }
-        )
-      }).timeout(50000)
-    })
+    it('is instrumented', async () => {
+      proc = await spawnPluginIntegrationTestProc(
+        sandbox.folder,
+        'server.mjs',
+        agent.port,
+        (data) => {
+          const jsonObject = JSON.parse(data.toString())
+          expect(jsonObject).to.have.property('dd')
+        }
+      )
+    }).timeout(50000)
   })
 })

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -12,6 +12,7 @@ describe('esm', () => {
   let proc
   let sandbox
 
+  // test against later versions because server.mjs uses newer package syntax
   withVersions('winston', 'winston', '>=3', version => {
     before(async function () {
       this.timeout(50000)

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -12,36 +12,39 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  before(async function () {
-    this.timeout(50000)
-    sandbox = await createSandbox(['winston'], false, [`./packages/datadog-plugin-winston/test/integration-test/*`])
-  })
+  withVersions('winston', 'winston', '>=3', version => {
+    before(async function () {
+      this.timeout(50000)
+      sandbox = await createSandbox([`winston@${version}`]
+        , false, [`./packages/datadog-plugin-winston/test/integration-test/*`])
+    })
 
-  after(async function () {
-    this.timeout(50000)
-    await sandbox.remove()
-  })
+    after(async function () {
+      this.timeout(50000)
+      await sandbox.remove()
+    })
 
-  beforeEach(async () => {
-    agent = await new FakeAgent().start()
-  })
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
 
-  afterEach(async () => {
-    proc && proc.kill()
-    await agent.stop()
-  })
+    afterEach(async () => {
+      proc && proc.kill()
+      await agent.stop()
+    })
 
-  context('winston', () => {
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(
-        sandbox.folder,
-        'server.mjs',
-        agent.port,
-        (data) => {
-          const jsonObject = JSON.parse(data.toString())
-          expect(jsonObject).to.have.property('dd')
-        }
-      )
-    }).timeout(50000)
+    context('winston', () => {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(
+          sandbox.folder,
+          'server.mjs',
+          agent.port,
+          (data) => {
+            const jsonObject = JSON.parse(data.toString())
+            expect(jsonObject).to.have.property('dd')
+          }
+        )
+      }).timeout(50000)
+    })
   })
 })

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -15,7 +15,7 @@ describe('esm', () => {
   withVersions('winston', 'winston', '>=3', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`winston@${version}`]
+      sandbox = await createSandbox([`'winston@${version}'`]
         , false, [`./packages/datadog-plugin-winston/test/integration-test/*`])
     })
 

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -224,5 +224,11 @@
       "name": "q",
       "versions": ["2"]
     }
+  ],
+  "redis": [
+    {
+      "name": "redis",
+      "versions": ["^4"]
+    }
   ]
 }


### PR DESCRIPTION
### What does this PR do?
adds withVersions() helper method to all esm integration tests

### Motivation
currently esm tests install the latest npm package for an instrumentation, which causes CI tests to break from time to time since our instrumentations might not support the latest version of a package requiring us to manually have to downgrade the version installed in the esm integration test