### PR TITLE
force hyphen prefix when propagating decision making header of 0

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -343,10 +343,10 @@ class TextMapPropagator {
               spanContext._trace.origin = value
               break
             case 't.dm': {
-              const mechanism = -Math.abs(parseInt(value, 10))
+              const mechanism = Math.abs(parseInt(value, 10))
               if (Number.isInteger(mechanism)) {
                 spanContext._sampling.mechanism = mechanism
-                spanContext._trace.tags['_dd.p.dm'] = String(mechanism)
+                spanContext._trace.tags['_dd.p.dm'] = `-${mechanism}`
               }
               break
             }

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -759,6 +759,20 @@ describe('TextMapPropagator', () => {
         expect(carrier['x-datadog-tags']).to.include('_dd.p.dm=-4')
         expect(spanContext._trace.tags['_dd.p.dm']).to.eql('-4')
       })
+
+      it('should maintain hyphen prefix when a default mechanism of 0 is received', () => {
+        textMap['traceparent'] = '01-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01'
+        textMap['tracestate'] = 'other=bleh,dd=t.foo_bar_baz_:abc_!@#$%^&*()_+`-~;s:2;o:foo;t.dm:-0'
+        config.tracePropagationStyle.extract = ['tracecontext']
+
+        const carrier = {}
+        const spanContext = propagator.extract(textMap)
+
+        propagator.inject(spanContext, carrier)
+
+        expect(carrier['x-datadog-tags']).to.include('_dd.p.dm=-0')
+        expect(spanContext._trace.tags['_dd.p.dm']).to.eql('-0')
+      })
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Changes propagation of the decision making header to always add a hyphen, even for a header of 0

### Motivation
I believe the change made in https://github.com/DataDog/dd-trace-js/pull/2998 is not complete for the following reasons

1. an incoming header of `-0` will be changed to `_dd.p.dm=0` instead of the expected `_dd.p.dm=-0`
2. it stores a negative value in the internal `_sampling.mechanism` field - AFAICT the value here should be zero or positive, it's only when the value is propagated in the `_dd.p.dm` tag that a hyphen should be added

compare to: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/priority_sampler.js#L168
