### PR TITLE
Change source origin from HTTP_REQUEST_PATH to HTTP_REQUEST_URI [APPSEC-11398]

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
@@ -6,8 +6,8 @@ const { getNodeModulesPaths } = require('../path-line')
 const { getRanges } = require('../taint-tracking/operations')
 const {
   HTTP_REQUEST_HEADER_VALUE,
-  HTTP_REQUEST_PATH,
-  HTTP_REQUEST_PATH_PARAM
+  HTTP_REQUEST_PATH_PARAM,
+  HTTP_REQUEST_URI
 } = require('../taint-tracking/source-types')
 
 const EXCLUDED_PATHS = getNodeModulesPaths('express/lib/response.js')
@@ -56,7 +56,7 @@ class UnvalidatedRedirectAnalyzer extends InjectionAnalyzer {
   }
 
   _isUrl (range) {
-    return range.iinfo.type === HTTP_REQUEST_PATH
+    return range.iinfo.type === HTTP_REQUEST_URI
   }
 
   _getExcludedPaths () {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -11,8 +11,8 @@ const {
   HTTP_REQUEST_HEADER_VALUE,
   HTTP_REQUEST_HEADER_NAME,
   HTTP_REQUEST_PARAMETER,
-  HTTP_REQUEST_PATH,
-  HTTP_REQUEST_PATH_PARAM
+  HTTP_REQUEST_PATH_PARAM,
+  HTTP_REQUEST_URI
 } = require('./source-types')
 
 class TaintTrackingPlugin extends SourceIastPlugin {
@@ -93,9 +93,9 @@ class TaintTrackingPlugin extends SourceIastPlugin {
   taintUrl (req, iastContext) {
     this.execSource({
       handler: function () {
-        req.url = newTaintedString(iastContext, req.url, 'req.url', HTTP_REQUEST_PATH)
+        req.url = newTaintedString(iastContext, req.url, HTTP_REQUEST_URI, HTTP_REQUEST_URI)
       },
-      tag: [HTTP_REQUEST_PATH],
+      tag: [HTTP_REQUEST_URI],
       iastContext
     })
   }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/source-types.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/source-types.js
@@ -8,5 +8,6 @@ module.exports = {
   HTTP_REQUEST_HEADER_VALUE: 'http.request.header',
   HTTP_REQUEST_PARAMETER: 'http.request.parameter',
   HTTP_REQUEST_PATH: 'http.request.path',
-  HTTP_REQUEST_PATH_PARAM: 'http.request.path.parameter'
+  HTTP_REQUEST_PATH_PARAM: 'http.request.path.parameter',
+  HTTP_REQUEST_URI: 'http.request.uri'
 }

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.spec.js
@@ -6,8 +6,8 @@ const overheadController = require('../../../../src/appsec/iast/overhead-control
 const {
   HTTP_REQUEST_HEADER_VALUE,
   HTTP_REQUEST_PARAMETER,
-  HTTP_REQUEST_PATH,
-  HTTP_REQUEST_PATH_PARAM
+  HTTP_REQUEST_PATH_PARAM,
+  HTTP_REQUEST_URI
 } = require('../../../../src/appsec/iast/taint-tracking/source-types')
 
 describe('unvalidated-redirect-analyzer', () => {
@@ -46,7 +46,7 @@ describe('unvalidated-redirect-analyzer', () => {
   }
   const URL_RANGE = {
     iinfo: {
-      type: HTTP_REQUEST_PATH,
+      type: HTTP_REQUEST_URI,
       parameterName: 'path'
     }
   }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
@@ -9,8 +9,8 @@ const {
   HTTP_REQUEST_COOKIE_NAME,
   HTTP_REQUEST_HEADER_NAME,
   HTTP_REQUEST_HEADER_VALUE,
-  HTTP_REQUEST_PATH,
-  HTTP_REQUEST_PATH_PARAM
+  HTTP_REQUEST_PATH_PARAM,
+  HTTP_REQUEST_URI
 } = require('../../../../src/appsec/iast/taint-tracking/source-types')
 
 const middlewareNextChannel = dc.channel('apm:express:middleware:next')
@@ -251,8 +251,8 @@ describe('IAST Taint tracking plugin', () => {
       expect(taintTrackingOperations.newTaintedString).to.be.calledOnceWith(
         iastContext,
         req.url,
-        'req.url',
-        HTTP_REQUEST_PATH
+        HTTP_REQUEST_URI,
+        HTTP_REQUEST_URI
       )
     })
   })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
@@ -10,11 +10,11 @@ const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
 const {
-  HTTP_REQUEST_PATH,
-  HTTP_REQUEST_PATH_PARAM
+  HTTP_REQUEST_PATH_PARAM,
+  HTTP_REQUEST_URI
 } = require('../../../../../src/appsec/iast/taint-tracking/source-types')
 
-describe('Path sourcing with express', () => {
+describe('URI sourcing with express', () => {
   let express
   let appListener
 
@@ -47,7 +47,7 @@ describe('Path sourcing with express', () => {
       iast.disable()
     })
 
-    it('should taint path', done => {
+    it('should taint uri', done => {
       const app = express()
       app.get('/path/*', (req, res) => {
         const store = storage.getStore()
@@ -55,7 +55,7 @@ describe('Path sourcing with express', () => {
         const isPathTainted = isTainted(iastContext, req.url)
         expect(isPathTainted).to.be.true
         const taintedPathValueRanges = getRanges(iastContext, req.url)
-        expect(taintedPathValueRanges[0].iinfo.type).to.be.equal(HTTP_REQUEST_PATH)
+        expect(taintedPathValueRanges[0].iinfo.type).to.be.equal(HTTP_REQUEST_URI)
         res.status(200).send()
       })
 

--- a/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
@@ -232,7 +232,7 @@ describe('Telemetry', () => {
       it('should have url source execution metric', (done) => {
         agent
           .use(traces => {
-            expect(traces[0][0].metrics['_dd.iast.telemetry.executed.source.http_request_path']).to.be.equal(1)
+            expect(traces[0][0].metrics['_dd.iast.telemetry.executed.source.http_request_uri']).to.be.equal(1)
           })
           .then(done)
           .catch(done)


### PR DESCRIPTION
### What does this PR do?
Change origin for URL tainted sources 

### Motivation
Align the source of tainted URL sources along all tracers
