### PR TITLE
[ci-visibility] Fix playwright latest release

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -82,6 +82,7 @@ module.exports = {
   'pg': () => require('../pg'),
   'pino': () => require('../pino'),
   'pino-pretty': () => require('../pino'),
+  'playwright': () => require('../playwright'),
   'promise-js': () => require('../promise-js'),
   'promise': () => require('../promise'),
   'q': () => require('../q'),

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -254,7 +254,7 @@ addHook({
 addHook({
   name: '@playwright/test',
   file: 'lib/dispatcher.js',
-  versions: ['>=1.18.0  <1.30.0']
+  versions: ['>=1.18.0 <1.30.0']
 }, dispatcherHook)
 
 addHook({
@@ -266,11 +266,23 @@ addHook({
 addHook({
   name: '@playwright/test',
   file: 'lib/runner/dispatcher.js',
-  versions: ['>=1.31.0']
+  versions: ['>=1.31.0 <1.38.0']
 }, (dispatcher) => dispatcherHookNew(dispatcher, dispatcherRunWrapperNew))
 
 addHook({
   name: '@playwright/test',
   file: 'lib/runner/runner.js',
-  versions: ['>=1.31.0']
+  versions: ['>=1.31.0 <1.38.0']
 }, runnerHook)
+
+// From >=1.38.0
+addHook({
+  name: 'playwright',
+  file: 'lib/runner/runner.js',
+  versions: ['>=1.38.0']
+}, runnerHook)
+addHook({
+  name: 'playwright',
+  file: 'lib/runner/dispatcher.js',
+  versions: ['>=1.38.0']
+}, (dispatcher) => dispatcherHookNew(dispatcher, dispatcherRunWrapperNew))

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -64,6 +64,7 @@ module.exports = {
   get 'pg' () { return require('../../../datadog-plugin-pg/src') },
   get 'pino' () { return require('../../../datadog-plugin-pino/src') },
   get 'pino-pretty' () { return require('../../../datadog-plugin-pino/src') },
+  get 'playwright' () { return require('../../../datadog-plugin-playwright/src') },
   get 'redis' () { return require('../../../datadog-plugin-redis/src') },
   get 'restify' () { return require('../../../datadog-plugin-restify/src') },
   get 'rhea' () { return require('../../../datadog-plugin-rhea/src') },


### PR DESCRIPTION
### What does this PR do?
There was some internal reorg of the packages in the repository and this broke our instrumentation.

### Motivation
Fixes #3639 

Fix [v1.38.0 playwright release](https://github.com/microsoft/playwright/releases/tag/v1.38.0).

Tests are now passing: https://github.com/DataDog/dd-trace-js/actions/runs/6248770201/job/16964070478?pr=3646 (they weren't [before](https://github.com/DataDog/dd-trace-js/actions/runs/6237778080/job/16932135175))

