### PR TITLE
core: Fix Next.js App Router Resource Name

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -28,9 +28,9 @@ function wrapHandleApiRequest (handleApiRequest) {
         if (!handled) return handled
 
         return this.hasPage(pathname).then(pageFound => {
-          const page = pageFound ? pathname : getPageFromPath(pathname, this.dynamicRoutes)
+          const pageData = pageFound ? { page: pathname } : getPageFromPath(pathname, this.dynamicRoutes)
 
-          pageLoadChannel.publish({ page })
+          pageLoadChannel.publish(pageData)
 
           return handled
         })
@@ -83,15 +83,19 @@ function wrapFindPageComponents (findPageComponents) {
     const result = findPageComponents.apply(this, arguments)
 
     if (result) {
-      pageLoadChannel.publish({ page: getPagePath(pathname) })
+      pageLoadChannel.publish(getPagePath(pathname))
     }
 
     return result
   }
 }
 
-function getPagePath (page) {
-  return typeof page === 'object' ? page.pathname : page
+function getPagePath (maybePage) {
+  if (typeof maybePage !== 'object') return { page: maybePage }
+
+  const isAppPath = maybePage.isAppPath
+  const page = maybePage.pathname || maybePage.page
+  return { page, isAppPath }
 }
 
 function getPageFromPath (page, dynamicRoutes = []) {

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -64,7 +64,7 @@ class NextPlugin extends ServerPlugin {
     span.finish()
   }
 
-  pageLoad ({ page }) {
+  pageLoad ({ page, isAppPath }) {
     const store = storage.getStore()
 
     if (!store) return
@@ -74,9 +74,12 @@ class NextPlugin extends ServerPlugin {
 
     // Only use error page names if there's not already a name
     const current = span.context()._tags['next.page']
-    if (current && (page === '/404' || page === '/500' || page === '/_error')) {
+    if (current && ['/404', '/500', '/_error', '/_not-found'].includes(page)) {
       return
     }
+
+    // remove ending /route or /page for appDir projects
+    if (isAppPath) page = page.substring(0, page.lastIndexOf('/'))
 
     // This is for static files whose 'page' includes the whole file path
     // For normal page matches, like /api/hello/[name] and a req.url like /api/hello/world,

--- a/packages/datadog-plugin-next/test/app/api/appDir/[name]/route.js
+++ b/packages/datadog-plugin-next/test/app/api/appDir/[name]/route.js
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET (_request) {
+  return NextResponse.json({}, { status: 200 })
+}

--- a/packages/datadog-plugin-next/test/app/appDir/[name]/page.js
+++ b/packages/datadog-plugin-next/test/app/appDir/[name]/page.js
@@ -1,0 +1,3 @@
+export default function Page () {
+  return <h1>Hello World</h1>
+}

--- a/packages/datadog-plugin-next/test/app/layout.js
+++ b/packages/datadog-plugin-next/test/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout ({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -289,7 +289,7 @@ describe('Plugin', function () {
             ['/error/get_server_side_props', '/error/get_server_side_props', 500]
           ]
           pathTests.forEach(([url, expectedPath, statusCode]) => {
-            it(`should infer the corrrect resource (${expectedPath})`, done => {
+            it(`should infer the correct resource (${expectedPath})`, done => {
               agent
                 .use(traces => {
                   const spans = traces[0]
@@ -398,6 +398,41 @@ describe('Plugin', function () {
         })
       })
 
+      if (satisfies(pkg.version, '>=13.4.0')) {
+        describe('with app directory', () => {
+          startServer({ withConfig: false, standalone: false })
+
+          it('should infer the correct resource path for appDir routes', done => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[1]).to.have.property('resource', `GET /api/appDir/[name]`)
+              })
+              .then(done)
+              .catch(done)
+
+            axios
+              .get(`http://127.0.0.1:${port}/api/appDir/hello`)
+              .catch(done)
+          })
+
+          it('should infer the correct resource path for appDir pages', done => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[1]).to.have.property('resource', `GET /appDir/[name]`)
+                expect(spans[1].meta).to.have.property('http.status_code', '200')
+              })
+              .then(done)
+              .catch(done)
+
+            axios.get(`http://127.0.0.1:${port}/appDir/hello`)
+          })
+        })
+      }
+
       describe('with configuration', () => {
         startServer({ withConfig: true, standalone: false })
 
@@ -434,7 +469,7 @@ describe('Plugin', function () {
       // which affects how the tracer is passed down through NODE_OPTIONS, making tests fail
       // https://github.com/vercel/next.js/issues/53367
       // TODO investigate this further - traces appear in the UI for a small test app
-      if (satisfiesStandalone(pkg.version) && satisfies(pkg.version, '<13.4.13 >=13.4.19')) {
+      if (satisfiesStandalone(pkg.version) && !satisfies(pkg.version, '13.4.13 - 13.4.18')) {
         describe('with standalone', () => {
           startServer({ withConfig: false, standalone: true })
 


### PR DESCRIPTION
### What does this PR do?
Fixes resource names for `app` router projects. Previously, trying to hit an API endpoint would end the resource with `/route` (ie `/api/hello/world/route`), and likewise for pages would end with `/page`. This PR removes those endings. 

Additionally, this PR addresses a small issue that was brought up in Next.js 13.5.1 and possibly backported to 13.4.19, where a variable on an object we were inspecting to get the resource path group from changed from `pathname` to `page`.

### Motivation
Further the solidification of support for Next.js, especially since the App Router has been out of beta and is the recommended configuration for all Next.js projects since versions 13.4.x.
