### PR TITLE
Emit 'end_timestamp_ns' label for wall profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@datadog/native-iast-rewriter": "2.1.3",
     "@datadog/native-iast-taint-tracking": "1.5.0",
     "@datadog/native-metrics": "^2.0.0",
-    "@datadog/pprof": "3.2.0",
+    "@datadog/pprof": "4.0.0",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^1.14.0",

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -23,7 +23,7 @@ function getStartedSpans (context) {
   return context._trace.started
 }
 
-function generateLabels ({ spanId, rootSpanId, webTags, endpoint }) {
+function generateLabels ({ context: { spanId, rootSpanId, webTags, endpoint }, timestamp }) {
   const labels = {}
   if (spanId) {
     labels['span id'] = spanId
@@ -37,6 +37,8 @@ function generateLabels ({ spanId, rootSpanId, webTags, endpoint }) {
     // fallback to endpoint computed when sample was taken
     labels['trace endpoint'] = endpoint
   }
+  // Incoming timestamps are in microseconds, we emit nanos.
+  labels['end_timestamp_ns'] = timestamp * 1000n
 
   return labels
 }


### PR DESCRIPTION
### What does this PR do?
* Upgrades pprof-nodejs to 4.0.0
* Adjusts the signature of a label-generator callback in the wall profiler to match the new signature expected by 4.0.0
* Uses the extra data provided in the new signature to add the `end_timestamp_ns` label to samples, thus enabling them to be visualized on a timeline.

### Motivation
We're gradually building out the profiler timelines functionality for Node.js.
