### PR TITLE
[ci-visibility] Fix empty test status

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -50,12 +50,11 @@ moduleType.forEach(({
   type,
   testCommand
 }) => {
+  // cypress only supports esm on versions >= 10.0.0
+  if (type === 'esm' && semver.satisfies(version, '<10.0.0')) {
+    return
+  }
   describe(`cypress@${version} ${type}`, function () {
-    // cypress only supports esm on versions >= 10.0.0
-    if (type === 'esm' && semver.satisfies(version, '<10.0.0')) {
-      return
-    }
-
     this.retries(2)
     this.timeout(60000)
     let sandbox, cwd, receiver, childProcess, webAppPort


### PR DESCRIPTION
### What does this PR do?
Move the early return _before_ the `describe`.

### Motivation
By having the early return _after_ the `describe` we're getting empty test statuses in ci visibility. This is something we probably need to fix in the mocha plugin, but for the moment let's fix it in user land.

