### PR TITLE
core: enable 128-bit ids by default for v5+

### DIFF
--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -454,14 +454,17 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
+          const clock = sinon.useFakeTimers(new Date())
           connection.query('SELECT 1 + 1 AS solution', () => {
+            clock.restore()
             queryText = connection._protocol._queue[0].sql
           })
         })
@@ -531,14 +534,17 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
+          const clock = sinon.useFakeTimers(new Date())
           pool.query('SELECT 1 + 1 AS solution', () => {
+            clock.restore()
             queryText = pool._allConnections[0]._protocol._queue[0].sql
           })
         })

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { DD_MAJOR } = require('../../../version')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -454,7 +455,9 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = DD_MAJOR >= 5
+              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+              : '0000000000000000'
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
@@ -534,7 +537,9 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = DD_MAJOR >= 5
+              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+              : '0000000000000000'
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -444,14 +444,17 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
             `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
+          const clock = sinon.useFakeTimers(new Date())
           const connect = connection.query('SELECT 1 + 1 AS solution', () => {
+            clock.restore()
             queryText = connect.sql
           })
         })
@@ -521,14 +524,17 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const traceId = traces[0][0].trace_id.toString(16).padStart(32, '0')
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
             expect(queryText).to.equal(
               `/*dddbs='post',dde='tester',ddps='test',ddpv='8.4.0',` +
             `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
+          const clock = sinon.useFakeTimers(new Date())
           const queryPool = pool.query('SELECT 1 + 1 AS solution', () => {
+            clock.restore()
             queryText = queryPool.sql
           })
         })

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { DD_MAJOR } = require('../../../version')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -444,7 +445,9 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = DD_MAJOR >= 5
+              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+              : '0000000000000000'
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
@@ -524,7 +527,9 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = DD_MAJOR >= 5
+              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+              : '0000000000000000'
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -7,6 +7,7 @@ const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/c
 const net = require('net')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 const EventEmitter = require('events')
+const { DD_MAJOR } = require('../../../version')
 
 const clients = {
   pg: pg => pg.Client
@@ -483,7 +484,9 @@ describe('Plugin', () => {
 
         it('query text should contain traceparent', done => {
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = DD_MAJOR >= 5
+              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+              : '0000000000000000'
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
             expect(seenTraceId).to.equal(traceId)
@@ -565,7 +568,9 @@ describe('Plugin', () => {
           }
 
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = DD_MAJOR >= 5
+              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+              : '0000000000000000'
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -371,7 +371,7 @@ class Config {
     const DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = coalesce(
       options.traceId128BitGenerationEnabled,
       process.env.DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED,
-      false
+      true
     )
 
     const DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = coalesce(

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -13,6 +13,7 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('./plugins/util/tags')
 const { getGitMetadataFromGitProperties, removeUserSensitiveInfo } = require('./git_properties')
 const { updateConfig } = require('./telemetry')
 const { getIsGCPFunction, getIsAzureFunctionConsumptionPlan } = require('./serverless')
+const { DD_MAJOR } = require('../../../version')
 
 const fromEntries = Object.fromEntries || (entries =>
   entries.reduce((obj, [k, v]) => Object.assign(obj, { [k]: v }), {}))
@@ -368,10 +369,11 @@ class Config {
       isGCPFunction || isAzureFunctionConsumptionPlan
     )
 
+    // the tracer generates 128 bit IDs by default as of v5
     const DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = coalesce(
       options.traceId128BitGenerationEnabled,
       process.env.DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED,
-      true
+      DD_MAJOR >= 5
     )
 
     const DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = coalesce(

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -2,6 +2,9 @@
 
 const { AUTO_KEEP } = require('../../../../ext/priority')
 
+// the lowercase, hex encoded upper 64 bits of a 128-bit trace id, if present
+const TRACE_ID_128 = '_dd.p.tid'
+
 class DatadogSpanContext {
   constructor (props) {
     props = props || {}
@@ -35,8 +38,8 @@ class DatadogSpanContext {
 
   toTraceparent () {
     const flags = this._sampling.priority >= AUTO_KEEP ? '01' : '00'
-    const traceId = this._traceId.toBuffer().length <= 8 && this._trace.tags['_dd.p.tid']
-      ? this._trace.tags['_dd.p.tid'] + this._traceId.toString(16).padStart(16, '0')
+    const traceId = this._traceId.toBuffer().length <= 8 && this._trace.tags[TRACE_ID_128]
+      ? this._trace.tags[TRACE_ID_128] + this._traceId.toString(16).padStart(16, '0')
       : this._traceId.toString(16).padStart(32, '0')
     const spanId = this._spanId.toString(16).padStart(16, '0')
     const version = (this._traceparent && this._traceparent.version) || '00'

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -36,7 +36,7 @@ class DatabasePlugin extends StoragePlugin {
     const { encodedDddbs, encodedDde, encodedDdps, encodedDdpv } = this.serviceTags
 
     return `dddbs='${encodedDddbs}',dde='${encodedDde}',` +
-    `ddps='${encodedDdps}',ddpv='${encodedDdpv}'`
+      `ddps='${encodedDdps}',ddpv='${encodedDdpv}'`
   }
 
   getDbmServiceName (span, tracerService) {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -89,7 +89,7 @@ describe('Config', () => {
     expect(config).to.have.property('reportHostname', false)
     expect(config).to.have.property('scope', undefined)
     expect(config).to.have.property('logLevel', 'debug')
-    expect(config).to.have.property('traceId128BitGenerationEnabled', false)
+    expect(config).to.have.property('traceId128BitGenerationEnabled', true)
     expect(config).to.have.property('traceId128BitLoggingEnabled', false)
     expect(config).to.have.property('spanAttributeSchema', 'v0')
     expect(config).to.have.property('spanComputePeerService', false)


### PR DESCRIPTION
### What does this PR do?
- makes 128 bit ID generation the default
- but only for v5+ of the tracer

### Motivation
- ~entropy~
- compatibility

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js
