### PR TITLE
skip cassandra-driver and mongoose esm tests on node 14

### DIFF
--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -9,7 +9,8 @@ const {
 const { assert } = require('chai')
 const { NODE_MAJOR } = require('../../../../version')
 
-const describe = NODE_MAJOR < 16 ? globalThis.describe.skip : globalThis.describe
+// newer packages are not supported on older node versions
+const range = NODE_MAJOR < 16 ? '<3' : '>=4.4.0'
 
 describe('esm', () => {
   let agent
@@ -17,7 +18,7 @@ describe('esm', () => {
   let sandbox
 
   // test against later versions because server.mjs uses newer package syntax
-  withVersions('cassandra-driver', 'cassandra-driver', '>=4.4.0', version => {
+  withVersions('cassandra-driver', 'cassandra-driver', range, version => {
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`'cassandra-driver@${version}'`], false, [

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -7,6 +7,9 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const { NODE_MAJOR } = require('../../../../version')
+
+const describe = NODE_MAJOR < 16 ? globalThis.describe.skip : globalThis.describe
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -9,14 +9,15 @@ const {
 const { assert } = require('chai')
 const { NODE_MAJOR } = require('../../../../version')
 
-const describe = NODE_MAJOR < 16 ? globalThis.describe.skip : globalThis.describe
+// newer packages are not supported on older node versions
+const range = NODE_MAJOR < 16 ? '<5' : '>=4'
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
 
-  withVersions('mongoose', ['mongoose'], version => {
+  withVersions('mongoose', ['mongoose'], range, version => {
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`'mongoose@${version}'`], false, [

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -7,6 +7,9 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const { NODE_MAJOR } = require('../../../../version')
+
+const describe = NODE_MAJOR < 16 ? globalThis.describe.skip : globalThis.describe
 
 describe('esm', () => {
   let agent


### PR DESCRIPTION
### What does this PR do?
skip cassandra-driver and mongoose esm tests on node 14

### Motivation
making CI pass on v3.x release branch