### PR TITLE
Modernize BP pipelines

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,6 +1,10 @@
 variables:
   BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-js
 
+  # Benchmark's env variables. Modify to tweak benchmark parameters.
+  UNCONFIDENCE_THRESHOLD: "5.0"
+  MD_REPORT_ONLY_CHANGES: "1"
+
 .benchmarks:
   stage: benchmarks
   when: on_success
@@ -18,10 +22,6 @@ variables:
       - platform/artifacts/
     expire_in: 3 months
   variables:
-    # Benchmark's env variables. Modify to tweak benchmark parameters.
-    UNCONFIDENCE_THRESHOLD: "5.0"
-    MD_REPORT_ONLY_CHANGES: "1"
-
     # Gitlab and BP specific env vars. Do not modify.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,5 +1,5 @@
 variables:
-  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/relenv-microbenchmarking-platform:dd-trace-js
+  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-js
 
 .benchmarks:
   stage: benchmarks
@@ -7,26 +7,22 @@ variables:
   tags: ["runner:apm-k8s-tweaked-metal"]
   image: $BASE_CI_IMAGE
   interruptible: true
-  timeout: 10m
+  timeout: 15m
   script:
-    - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
-    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    - git clone --branch dd-trace-js https://github.com/DataDog/relenv-microbenchmarking-platform /platform && cd /platform
-    - ./steps/capture-hardware-software-info.sh
-    - ./steps/run-benchmarks.sh
-    - ./steps/analyze-results.sh
-    - "./steps/upload-results-to-s3.sh || :"
+    - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - bp-runner bp-runner.yml --debug
   artifacts:
-    name: "reports"
+    name: "artifacts"
+    when: always
     paths:
-      - reports/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
-    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID # The ID of the current project. This ID is unique across all projects on the GitLab instance.
-    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME # "dd-trace-js"
-    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME # The branch or tag name for which project is built.
-    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
+    # Benchmark's env variables. Modify to tweak benchmark parameters.
+    UNCONFIDENCE_THRESHOLD: "5.0"
+    MD_REPORT_ONLY_CHANGES: "1"
 
+    # Gitlab and BP specific env vars. Do not modify.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
@@ -36,17 +32,11 @@ benchmarks-pr-comment:
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   script:
-    - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
-    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    - git clone --branch dd-trace-js https://github.com/DataDog/relenv-microbenchmarking-platform /platform && cd /platform
-    - ./steps/post-pr-comment.sh
+    - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - bp-runner bp-runner.pr-comment.yml --debug
   allow_failure: true
   variables:
-    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID # The ID of the current project. This ID is unique across all projects on the GitLab instance.
-    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME # "dd-trace-js"
-    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME # The branch or tag name for which project is built.
-    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
-
+    # Gitlab and BP specific env vars. Do not modify.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
 
 check-big-regressions:
@@ -55,16 +45,10 @@ check-big-regressions:
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   script:
-    - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
-    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    - git clone --branch dd-trace-js https://github.com/DataDog/relenv-microbenchmarking-platform /platform && cd /platform
-    - ./steps/fail-on-regression.sh
+    - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - bp-runner bp-runner.fail-on-regression.yml --debug
   variables:
-    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID # The ID of the current project. This ID is unique across all projects on the GitLab instance.
-    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME # "dd-trace-js"
-    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME # The branch or tag name for which project is built.
-    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
-
+    # Gitlab and BP specific env vars. Do not modify.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
 
 benchmark:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -32,7 +32,7 @@ benchmarks-pr-comment:
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   script:
-    - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - cd platform && git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js
     - bp-runner bp-runner.pr-comment.yml --debug
   allow_failure: true
   variables:
@@ -45,7 +45,7 @@ check-big-regressions:
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   script:
-    - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - cd platform && git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js
     - bp-runner bp-runner.fail-on-regression.yml --debug
   variables:
     # Gitlab and BP specific env vars. Do not modify.

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -32,7 +32,7 @@ benchmarks-pr-comment:
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   script:
-    - cd platform && git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js
+    - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js)
     - bp-runner bp-runner.pr-comment.yml --debug
   allow_failure: true
   variables:
@@ -45,7 +45,7 @@ check-big-regressions:
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   script:
-    - cd platform && git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js
+    - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js)
     - bp-runner bp-runner.fail-on-regression.yml --debug
   variables:
     # Gitlab and BP specific env vars. Do not modify.

--- a/benchmark/sirun/README.md
+++ b/benchmark/sirun/README.md
@@ -15,9 +15,9 @@ In order to run benchmarks using Docker, issue the following commands from the r
 $ docker build -t dd-trace-benchmark -f benchmark/sirun/Dockerfile .
 
 # Run the Docker Container
-$ docker run -it -v "$(pwd)":/app --platform=linux/amd64 dd-trace-benchmark bash
+$ docker run -it -v "$(pwd)":/app -e CPU_START_ID=0 --platform=linux/amd64 dd-trace-benchmark bash
 cd /app/benchmark/sirun
-./runall.sh
+SPLITS=10 GROUP=1 ./runall.sh
 cat results.ndjson
 ```
 

--- a/benchmark/sirun/README.md
+++ b/benchmark/sirun/README.md
@@ -15,9 +15,9 @@ In order to run benchmarks using Docker, issue the following commands from the r
 $ docker build -t dd-trace-benchmark -f benchmark/sirun/Dockerfile .
 
 # Run the Docker Container
-$ docker run -it -v "$(pwd)":/app -e CPU_START_ID=0 --platform=linux/amd64 dd-trace-benchmark bash
+$ docker run -it -v "$(pwd)":/app -e CPU_START_ID=0 -e SPLITS=10 --platform=linux/amd64 dd-trace-benchmark bash
 cd /app/benchmark/sirun
-SPLITS=10 GROUP=1 ./runall.sh
+for i in {1..SPLITS}; do GROUP=i ./runall.sh; done
 cat results.ndjson
 ```
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -25,13 +25,13 @@ nvm use 18
 # run each test in parallel for a given version of Node.js
 # once all of the tests have complete move on to the next version
 
-export CPU_AFFINITY=24 # Benchmarking Platform convention
+export CPU_AFFINITY="${CPU_START_ID:-24}" # Benchmarking Platform convention
 
 nvm use $MAJOR_VERSION # provided by each benchmark stage
 export VERSION=`nvm current`
 export ENABLE_AFFINITY=true
 echo "using Node.js ${VERSION}"
-CPU_AFFINITY=24 # reset for each node.js version
+CPU_AFFINITY="${CPU_START_ID:-24}" # reset for each node.js version
 SPLITS=${SPLITS:-1}
 GROUP=${GROUP:-1}
 BENCH_COUNT=0


### PR DESCRIPTION
### What does this PR do?

Simplifies BP pipelines as a part of our standardization effort.

CI/CD pipeline changes are present at https://github.com/DataDog/benchmarking-platform/tree/dd-trace-js

We now use bp-runner for abstracting away the complexity of cloning baseline and candidate branches, uploading to S3 and BP UI, capturing hardware info, and so on. 

So the end-result is [50 lines long .yml config](https://github.com/DataDog/benchmarking-platform/blob/dd-trace-js/bp-runner.yml) that specifies how to run benchmarks, instead of bash scripts.

The behavior of your benchmarks pipeline remains exactly the same as before, no changes to the logic of pipeline were introduced.

### Motivation

We want to ensure that all CI/CD pipelines for micro- and macrobenchmarks have latest fixes and improvements, and are in sync across all teams.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
