### PR TITLE
Fix `exporting-pipeline` benchmark

### DIFF
--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -45,7 +45,8 @@ function createSpan (parent) {
   }
   const span = {
     context: () => context,
-    tracer: () => ({}),
+    tracer: () => { return { _service: 'exporting-pipeline-sirun' } },
+    setTag: () => {},
     _startTime: 1415926,
     _duration: 100
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The sirun `exporting-pipeline` benchmark has been crashing since the merge of `afc84ea`, which introduced logic relying on the `_service` string of a span's parent tracer. Since this benchmark created spans with a fake tracer, updating the shape of that fake tracer fixes the issue.
