### PR TITLE
Prevent sending query address twice to the waf

### DIFF
--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -121,7 +121,7 @@ function incomingHttpEndTranslator ({ req, res }) {
     payload[addresses.HTTP_INCOMING_COOKIES] = req.cookies
   }
 
-  if (req.query !== undefined && req.query !== null) {
+  if (req.query !== undefined && req.query !== null && typeof req.query === 'object') {
     payload[addresses.HTTP_INCOMING_QUERY] = req.query
   }
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -121,7 +121,7 @@ function incomingHttpEndTranslator ({ req, res }) {
     payload[addresses.HTTP_INCOMING_COOKIES] = req.cookies
   }
 
-  if (req.query !== undefined && req.query !== null && typeof req.query === 'object') {
+  if (req.query && typeof req.query === 'object') {
     payload[addresses.HTTP_INCOMING_QUERY] = req.query
   }
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -121,7 +121,6 @@ function incomingHttpEndTranslator ({ req, res }) {
     payload[addresses.HTTP_INCOMING_COOKIES] = req.cookies
   }
 
-  // TODO: no need to analyze it if it was already done by the body-parser hook
   if (req.query !== undefined && req.query !== null) {
     payload[addresses.HTTP_INCOMING_QUERY] = req.query
   }

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -316,7 +316,7 @@ describe('AppSec Index', () => {
           remotePort: 8080
         },
         body: null,
-        query: { queryKey: 'queryValue' },
+        query: 'string',
         route: {},
         params: 'string',
         cookies: 'string'
@@ -337,8 +337,7 @@ describe('AppSec Index', () => {
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
         'server.response.status': 201,
-        'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 },
-        'server.request.query': { queryKey: 'queryValue' }
+        'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 }
       }, req)
 
       expect(Reporter.finishRequest).to.have.been.calledOnceWithExactly(req, res)

--- a/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
+++ b/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const WAFContextWrapper = require('../../../src/appsec/waf/waf_context_wrapper')
+const addresses = require('../../../src/appsec/addresses')
+describe('WAFContextWrapper', () => {
+  it('Should send HTTP_INCOMING_QUERY only once', () => {
+    const requiredAddresses = new Set([
+      addresses.HTTP_INCOMING_QUERY
+    ])
+    const ddwafContext = {
+      run: sinon.stub()
+    }
+    const wafContextWrapper = new WAFContextWrapper(ddwafContext, requiredAddresses,
+      1000, '1.14.0', '1.8.0')
+
+    const payload = {
+      [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
+    }
+
+    wafContextWrapper.run(payload)
+    wafContextWrapper.run(payload)
+
+    expect(ddwafContext.run).to.have.been.calledOnceWithExactly(payload, 1000)
+  })
+})

--- a/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
+++ b/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
@@ -2,6 +2,7 @@
 
 const WAFContextWrapper = require('../../../src/appsec/waf/waf_context_wrapper')
 const addresses = require('../../../src/appsec/addresses')
+
 describe('WAFContextWrapper', () => {
   it('Should send HTTP_INCOMING_QUERY only once', () => {
     const requiredAddresses = new Set([


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Prevent sending query address twice to the waf

### Motivation
<!-- What inspired you to submit this pull request? -->
Generated a system test failure in [nextjs support PR](https://github.com/DataDog/dd-trace-js/pull/3641). Fixing it in this PR preventing to send multiple times the query params address to the waf.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.