### PR TITLE
Fix flakiness in `serverless-performance`

### DIFF
--- a/.github/workflows/serverless-performance.yml
+++ b/.github/workflows/serverless-performance.yml
@@ -22,14 +22,17 @@ jobs:
         with:
           repository: DataDog/datadog-lambda-js
           path: datadog-lambda-js
-      - name: See vars
+      - name: Try stuff
         run: |
-          echo $GITHUB_HEAD_REF
-          echo $GITHUB_SHA
+          yarn global add node-gyp
       - name: Update package.json to the current ref
         run: |
           cd datadog-lambda-js
           yarn add https://github.com/DataDog/dd-trace-js#refs/heads/${GITHUB_HEAD_REF}
+      - name: Check
+        run: |
+          echo /home/runner/.config/yarn/global/yarn-error.log
+        if: always()
       - name: Build the layer
         env:
           NODE_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/serverless-performance.yml
+++ b/.github/workflows/serverless-performance.yml
@@ -22,16 +22,16 @@ jobs:
         with:
           repository: DataDog/datadog-lambda-js
           path: datadog-lambda-js
-      - name: Try stuff
+      - name: Install node-gyp
         run: |
           yarn global add node-gyp
       - name: Update package.json to the current ref
         run: |
           cd datadog-lambda-js
-          yarn add https://github.com/DataDog/dd-trace-js#refs/heads/${GITHUB_HEAD_REF}
+          yarn add --dev https://github.com/DataDog/dd-trace-js#refs/heads/${GITHUB_HEAD_REF}
       - name: Check
         run: |
-          echo /home/runner/.config/yarn/global/yarn-error.log
+          cat /home/runner/.config/yarn/global/yarn-error.log
         if: always()
       - name: Build the layer
         env:

--- a/.github/workflows/serverless-performance.yml
+++ b/.github/workflows/serverless-performance.yml
@@ -22,10 +22,14 @@ jobs:
         with:
           repository: DataDog/datadog-lambda-js
           path: datadog-lambda-js
+      - name: See vars
+        run: |
+          echo $GITHUB_HEAD_REF
+          echo $GITHUB_SHA
       - name: Update package.json to the current ref
         run: |
           cd datadog-lambda-js
-          yarn add https://github.com/DataDog/dd-trace-js#refs/heads/$GITHUB_HEAD_REF --save-dev
+          yarn add https://github.com/DataDog/dd-trace-js#${GITHUB_SHA}
       - name: Build the layer
         env:
           NODE_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/serverless-performance.yml
+++ b/.github/workflows/serverless-performance.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Update package.json to the current ref
         run: |
           cd datadog-lambda-js
-          yarn add dd-trace@https://github.com/DataDog/dd-trace-js#${GITHUB_SHA}
+          yarn add https://github.com/DataDog/dd-trace-js#refs/heads/${GITHUB_HEAD_REF}
       - name: Build the layer
         env:
           NODE_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/serverless-performance.yml
+++ b/.github/workflows/serverless-performance.yml
@@ -31,7 +31,7 @@ jobs:
           yarn add --dev https://github.com/DataDog/dd-trace-js#refs/heads/${GITHUB_HEAD_REF}
       - name: Check
         run: |
-          cat /home/runner/.config/yarn/global/yarn-error.log
+          [ -f /home/runner/.config/yarn/global/yarn-error.log ] && cat /home/runner/.config/yarn/global/yarn-error.log
         if: always()
       - name: Build the layer
         env:

--- a/.github/workflows/serverless-performance.yml
+++ b/.github/workflows/serverless-performance.yml
@@ -29,10 +29,6 @@ jobs:
         run: |
           cd datadog-lambda-js
           yarn add --dev https://github.com/DataDog/dd-trace-js#refs/heads/${GITHUB_HEAD_REF}
-      - name: Check
-        run: |
-          [ -f /home/runner/.config/yarn/global/yarn-error.log ] && cat /home/runner/.config/yarn/global/yarn-error.log
-        if: always()
       - name: Build the layer
         env:
           NODE_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/serverless-performance.yml
+++ b/.github/workflows/serverless-performance.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Update package.json to the current ref
         run: |
           cd datadog-lambda-js
-          yarn add https://github.com/DataDog/dd-trace-js#${GITHUB_SHA}
+          yarn add dd-trace@https://github.com/DataDog/dd-trace-js#${GITHUB_SHA}
       - name: Build the layer
         env:
           NODE_VERSION: ${{ matrix.node-version }}


### PR DESCRIPTION
### What does this PR do?
Install `node-gyp` globally before installing dd-trace-js in datadog-lambda-js. 

### Motivation
Fix flakiness: 

I retried the job multiple times and it seems to always pass: https://github.com/DataDog/dd-trace-js/actions/runs/6391068265?pr=3672

Comparing results with master (I created a PR just to test): https://github.com/DataDog/dd-trace-js/actions/runs/6390872478/job/17345173635?pr=3673, it seems it's improved considerably.

