### PR TITLE
Add consecuitve ranges case to evidence redaction suite

### DIFF
--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/resources/evidence-redaction-suite.json
@@ -3095,6 +3095,120 @@
           }
         ]
       }
+    },
+    {
+      "type": "VULNERABILITIES",
+      "description": "Consecutive ranges - at the beginning",
+      "input": [
+        {
+          "type": "UNVALIDATED_REDIRECT",
+          "evidence": {
+            "value": "https://user:password@datadoghq.com:443/api/v1/test/123/?param1=pone&param2=ptwo#fragment1=fone&fragment2=ftwo",
+            "ranges": [
+              {
+                "start": 0,
+                "end": 4,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "protocol",
+                  "parameterValue": "http"
+                }
+              },
+              {
+                "start": 4,
+                "end": 5,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "secure",
+                  "parameterValue": "s"
+                }
+              },
+              {
+                "start": 22,
+                "end": 35,
+                "iinfo": {
+                  "type": "http.request.parameter",
+                  "parameterName": "host",
+                  "parameterValue": "datadoghq.com"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expected": {
+        "sources": [
+          {
+            "origin": "http.request.parameter",
+            "name": "protocol",
+            "value": "http"
+          },
+          {
+            "origin": "http.request.parameter",
+            "name": "secure",
+            "value": "s"
+          },
+          {
+            "origin": "http.request.parameter",
+            "name": "host",
+            "value": "datadoghq.com"
+          }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "UNVALIDATED_REDIRECT",
+            "evidence": {
+              "valueParts": [
+                {
+                  "source": 0,
+                  "value": "http"
+                },
+                {
+                  "source": 1,
+                  "value": "s"
+                },
+                {
+                  "value": "://"
+                },
+                {
+                  "redacted": true
+                },
+                {
+                  "value": "@"
+                },
+                {
+                  "source": 2,
+                  "value": "datadoghq.com"
+                },
+                {
+                  "value": ":443/api/v1/test/123/?param1="
+                },
+                {
+                  "redacted": true
+                },
+                {
+                  "value": "&param2="
+                },
+                {
+                  "redacted": true
+                },
+                {
+                  "value": "#fragment1="
+                },
+                {
+                  "redacted": true
+                },
+                {
+                  "value": "&fragment2="
+                },
+                {
+                  "redacted": true
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?
Adds a new test case to check the evidence redaction when two tainted ranges are placed consecutively.

### Motivation
Synchronize evidence redaction test suite across all tracers.