### PR TITLE
Fix flakiness in integration tests

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -208,10 +208,10 @@ async function createSandbox (dependencies = [], isGitRepo = false,
   await exec(`yarn pack --filename ${out}`) // TODO: cache this
   await exec(`yarn add ${allDependencies.join(' ')}`, { cwd: folder, env: restOfEnv })
 
-  integrationTestsPaths.forEach(async (path) => {
+  for (const path of integrationTestsPaths) {
     await exec(`cp -R ${path} ${folder}`)
     await exec(`sync ${folder}`)
-  })
+  }
 
   if (followUpCommand) {
     await exec(followUpCommand, { cwd: folder, env: restOfEnv })

--- a/integration-tests/startup.spec.js
+++ b/integration-tests/startup.spec.js
@@ -129,7 +129,9 @@ describe('startup', () => {
     })
 
     it('works for hostname and port', async () => {
-      proc = await spawnProc(startupTestFile)
+      proc = await spawnProc(startupTestFile, {
+        cwd
+      })
       return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
         assert.propertyVal(headers, 'host', '127.0.0.1:8126')
         assert.isArray(payload)


### PR DESCRIPTION
### What does this PR do?
The `.forEach` loop was returning before its promises were resolved, so it could happen that after calling `sandbox = await createSandbox` you would attempt to read files from `sandbox.folder` that weren't there. 

### Motivation
Fix flakiness in integration tests.

