### PR TITLE
[ci-visibility] Unskippable suites for cucumber

### DIFF
--- a/integration-tests/ci-visibility/features/greetings.feature
+++ b/integration-tests/ci-visibility/features/greetings.feature
@@ -1,3 +1,4 @@
+@datadog:unskippable
 Feature: Greetings
   Scenario: Say greetings
     When the greeter says greetings

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -570,29 +570,35 @@ versions.forEach(version => {
                 }
               ])
 
-              // TODO: add check for session and modules
               const eventsPromise = receiver
                 .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-                  const suites = payloads
-                    .flatMap(({ payload }) => payload.events)
-                    .filter(event => event.type === 'test_suite_end')
+                  const events = payloads.flatMap(({ payload }) => payload.events)
+                  const suites = events.filter(event => event.type === 'test_suite_end')
 
                   assert.equal(suites.length, 2)
 
+                  const testSession = events.find(event => event.type === 'test_session_end').content
+                  const testModule = events.find(event => event.type === 'test_session_end').content
+
+                  assert.propertyVal(testSession.meta, TEST_ITR_UNSKIPPABLE, 'true')
+                  assert.propertyVal(testSession.meta, TEST_ITR_FORCED_RUN, 'true')
+                  assert.propertyVal(testModule.meta, TEST_ITR_UNSKIPPABLE, 'true')
+                  assert.propertyVal(testModule.meta, TEST_ITR_FORCED_RUN, 'true')
+
                   const skippedSuite = suites.find(
                     event => event.content.resource === 'test_suite.ci-visibility/features/farewell.feature'
-                  )
+                  ).content
                   const forcedToRunSuite = suites.find(
                     event => event.content.resource === 'test_suite.ci-visibility/features/greetings.feature'
-                  )
+                  ).content
 
-                  assert.propertyVal(skippedSuite.content.meta, TEST_STATUS, 'skip')
-                  assert.notProperty(skippedSuite.content.meta, TEST_ITR_UNSKIPPABLE)
-                  assert.notProperty(skippedSuite.content.meta, TEST_ITR_FORCED_RUN)
+                  assert.propertyVal(skippedSuite.meta, TEST_STATUS, 'skip')
+                  assert.notProperty(skippedSuite.meta, TEST_ITR_UNSKIPPABLE)
+                  assert.notProperty(skippedSuite.meta, TEST_ITR_FORCED_RUN)
 
-                  assert.propertyVal(forcedToRunSuite.content.meta, TEST_STATUS, 'fail')
-                  assert.propertyVal(forcedToRunSuite.content.meta, TEST_ITR_UNSKIPPABLE, 'true')
-                  assert.propertyVal(forcedToRunSuite.content.meta, TEST_ITR_FORCED_RUN, 'true')
+                  assert.propertyVal(forcedToRunSuite.meta, TEST_STATUS, 'fail')
+                  assert.propertyVal(forcedToRunSuite.meta, TEST_ITR_UNSKIPPABLE, 'true')
+                  assert.propertyVal(forcedToRunSuite.meta, TEST_ITR_FORCED_RUN, 'true')
                 }, 25000)
 
               childProcess = exec(
@@ -625,14 +631,20 @@ versions.forEach(version => {
                 }
               ])
 
-              // TODO: add check for session and modules
               const eventsPromise = receiver
                 .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-                  const suites = payloads
-                    .flatMap(({ payload }) => payload.events)
-                    .filter(event => event.type === 'test_suite_end')
+                  const events = payloads.flatMap(({ payload }) => payload.events)
+                  const suites = events.filter(event => event.type === 'test_suite_end')
 
                   assert.equal(suites.length, 2)
+
+                  const testSession = events.find(event => event.type === 'test_session_end').content
+                  const testModule = events.find(event => event.type === 'test_session_end').content
+
+                  assert.propertyVal(testSession.meta, TEST_ITR_UNSKIPPABLE, 'true')
+                  assert.notProperty(testSession.meta, TEST_ITR_FORCED_RUN)
+                  assert.propertyVal(testModule.meta, TEST_ITR_UNSKIPPABLE, 'true')
+                  assert.notProperty(testModule.meta, TEST_ITR_FORCED_RUN)
 
                   const skippedSuite = suites.find(
                     event => event.content.resource === 'test_suite.ci-visibility/features/farewell.feature'

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -622,7 +622,7 @@ versions.forEach(version => {
                   attributes: {
                     suite: `${featuresPath}farewell.feature`
                   }
-                },
+                }
               ])
 
               // TODO: add check for session and modules

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -334,8 +334,8 @@ addHook({
         isSuitesSkipped,
         testCodeCoverageLinesTotal,
         numSkippedSuites: skippedSuites.length,
-        isUnskippable,
-        isForcedToRun
+        hasUnskippableSuites: isUnskippable,
+        hasForcedToRunSuites: isForcedToRun
       })
     })
     return success

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -31,6 +31,10 @@ const {
   getTestSuitePath
 } = require('../../dd-trace/src/plugins/util/test')
 
+const isMarkedAsUnskippable = (pickle) => {
+  return !!pickle.tags.find(tag => tag.name === '@datadog:unskippable')
+}
+
 // We'll preserve the original coverage here
 const originalCoverageMap = createCoverageMap()
 
@@ -39,6 +43,9 @@ const patched = new WeakSet()
 
 let pickleByFile = {}
 const pickleResultByFile = {}
+let skippableSuites = []
+let isForcedToRun = false
+let isUnskippable = false
 
 function getSuiteStatusFromTestStatuses (testStatuses) {
   if (testStatuses.some(status => status === 'fail')) {
@@ -91,7 +98,11 @@ function wrapRun (pl, isLatestVersion) {
       const testSuiteFullPath = this.pickle.uri
 
       if (!pickleResultByFile[testSuiteFullPath]) { // first test in suite
-        testSuiteStartCh.publish(testSuiteFullPath)
+        isUnskippable = isMarkedAsUnskippable(this.pickle)
+        const testSuitePath = getTestSuitePath(testSuiteFullPath, process.cwd())
+        isForcedToRun = isUnskippable && skippableSuites.includes(testSuitePath)
+
+        testSuiteStartCh.publish({ testSuitePath, isUnskippable, isForcedToRun })
       }
 
       const testSourceLine = this.gherkinDocument &&
@@ -221,8 +232,11 @@ function getFilteredPickles (runtime, suitesToSkip) {
   return runtime.pickleIds.reduce((acc, pickleId) => {
     const test = runtime.eventDataCollector.getPickle(pickleId)
     const testSuitePath = getTestSuitePath(test.uri, process.cwd())
+
+    const isUnskippable = isMarkedAsUnskippable(test)
     const isSkipped = suitesToSkip.includes(testSuitePath)
-    if (isSkipped) {
+
+    if (isSkipped && !isUnskippable) {
       acc.skippedSuites.add(testSuitePath)
     } else {
       acc.picklesToRun.push(pickleId)
@@ -270,7 +284,11 @@ addHook({
       skippableSuitesCh.publish({ onDone })
     })
 
-    const { err, skippableSuites } = await skippableSuitesPromise
+    const skippableResponse = await skippableSuitesPromise
+
+    const err = skippableResponse.err
+    skippableSuites = skippableResponse.skippableSuites
+
     let skippedSuites = []
     let isSuitesSkipped = false
 
@@ -315,7 +333,9 @@ addHook({
         status: success ? 'pass' : 'fail',
         isSuitesSkipped,
         testCodeCoverageLinesTotal,
-        numSkippedSuites: skippedSuites.length
+        numSkippedSuites: skippedSuites.length,
+        isUnskippable,
+        isForcedToRun
       })
     })
     return success

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -32,8 +32,8 @@ class CucumberPlugin extends CiPlugin {
       isSuitesSkipped,
       numSkippedSuites,
       testCodeCoverageLinesTotal,
-      isUnskippable,
-      isForcedToRun
+      hasUnskippableSuites,
+      hasForcedToRunSuites
     }) => {
       const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig || {}
       addIntelligentTestRunnerSpanTags(
@@ -46,8 +46,8 @@ class CucumberPlugin extends CiPlugin {
           testCodeCoverageLinesTotal,
           skippingCount: numSkippedSuites,
           skippingType: 'suite',
-          isUnskippable,
-          isForcedToRun
+          hasUnskippableSuites,
+          hasForcedToRunSuites
         }
       )
 

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -10,7 +10,9 @@ const {
   finishAllTraceSpans,
   getTestSuitePath,
   getTestSuiteCommonTags,
-  addIntelligentTestRunnerSpanTags
+  addIntelligentTestRunnerSpanTags,
+  TEST_ITR_UNSKIPPABLE,
+  TEST_ITR_FORCED_RUN
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -29,7 +31,9 @@ class CucumberPlugin extends CiPlugin {
       status,
       isSuitesSkipped,
       numSkippedSuites,
-      testCodeCoverageLinesTotal
+      testCodeCoverageLinesTotal,
+      isUnskippable,
+      isForcedToRun
     }) => {
       const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig || {}
       addIntelligentTestRunnerSpanTags(
@@ -41,7 +45,9 @@ class CucumberPlugin extends CiPlugin {
           isCodeCoverageEnabled,
           testCodeCoverageLinesTotal,
           skippingCount: numSkippedSuites,
-          skippingType: 'suite'
+          skippingType: 'suite',
+          isUnskippable,
+          isForcedToRun
         }
       )
 
@@ -55,13 +61,19 @@ class CucumberPlugin extends CiPlugin {
       this.tracer._exporter.flush()
     })
 
-    this.addSub('ci:cucumber:test-suite:start', (testSuiteFullPath) => {
+    this.addSub('ci:cucumber:test-suite:start', ({ testSuitePath, isUnskippable, isForcedToRun }) => {
       const testSuiteMetadata = getTestSuiteCommonTags(
         this.command,
         this.frameworkVersion,
-        getTestSuitePath(testSuiteFullPath, this.sourceRoot),
+        testSuitePath,
         'cucumber'
       )
+      if (isUnskippable) {
+        testSuiteMetadata[TEST_ITR_UNSKIPPABLE] = 'true'
+      }
+      if (isForcedToRun) {
+        testSuiteMetadata[TEST_ITR_FORCED_RUN] = 'true'
+      }
       this.testSuiteSpan = this.tracer.startSpan('cucumber.test_suite', {
         childOf: this.testModuleSpan,
         tags: {


### PR DESCRIPTION
### What does this PR do?
Related: https://github.com/DataDog/dd-trace-js/pull/3661

### Motivation
Add the option to mark suites as unskippable by ITR. 

The way it works is by adding a cucumber's [tag](https://cucumber.io/docs/cucumber/api/?lang=javascript#tags) to the feature file:
```
@datadog:unskippable
Feature: Greetings
  Scenario: Say greetings
  ...
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
