### PR TITLE
chore(datastream): handle unix url

### DIFF
--- a/packages/dd-trace/src/datastreams/writer.js
+++ b/packages/dd-trace/src/datastreams/writer.js
@@ -15,12 +15,9 @@ function makeRequest (data, url, cb) {
       'Datadog-Meta-Tracer-Version': pkg.version,
       'Content-Type': 'application/msgpack',
       'Content-Encoding': 'gzip'
-    }
+    },
+    url
   }
-
-  options.protocol = url.protocol
-  options.hostname = url.hostname
-  options.port = url.port
 
   log.debug(() => `Request to the intake: ${JSON.stringify(options)}`)
 

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -1,0 +1,44 @@
+'use strict'
+const pkg = require('../../../../package.json')
+const stubRequest = sinon.stub()
+
+const { DataStreamsWriter } = proxyquire(
+  '../src/datastreams/writer', {
+    '../exporters/common/request': stubRequest
+})
+
+require('../setup/tap')
+
+describe('DataStreamWriter unix', () => {
+
+  let writer
+  const unixConfig = {
+    hostname: '',
+    url: new URL('unix:///var/run/datadog/apm.socket'),
+    port: ''
+  }
+
+  it("should construct unix config", () => {
+    writer = new DataStreamsWriter(unixConfig);
+    expect(writer._url).to.equal(unixConfig.url);
+  })
+
+  it("should call 'request' through flush with correct options", () => {
+    writer = new DataStreamsWriter(unixConfig);
+    writer.flush({}):
+    expect(stubRequest).to.be.calledWith(
+      {},
+      {
+        path: '/v0.1/pipeline_stats',
+        method: 'POST',
+        headers: {
+          'Datadog-Meta-Lang': 'javascript',
+          'Datadog-Meta-Tracer-Version': pkg.version,
+          'Content-Type': 'application/msgpack',
+          'Content-Encoding': 'gzip'
+        },
+        url: unixConfig.url
+      }
+    )
+  })
+})

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -1,13 +1,21 @@
 'use strict'
+require('../setup/tap')
 const pkg = require('../../../../package.json')
 const stubRequest = sinon.stub()
+const msgpack = require('msgpack-lite')
+const codec = msgpack.createCodec({ int64: true })
+
+const stubZlib = {
+  gzip: (payload, _opts, fn) => {
+    fn(undefined, payload)
+  }
+}
 
 const { DataStreamsWriter } = proxyquire(
   '../src/datastreams/writer', {
-    '../exporters/common/request': stubRequest
+    '../exporters/common/request': stubRequest,
+    'zlib': stubZlib
   })
-
-require('../setup/tap')
 
 describe('DataStreamWriter unix', () => {
   let writer
@@ -25,19 +33,20 @@ describe('DataStreamWriter unix', () => {
   it("should call 'request' through flush with correct options", () => {
     writer = new DataStreamsWriter(unixConfig)
     writer.flush({})
-    expect(stubRequest).to.be.calledWith(
-      {},
-      {
-        path: '/v0.1/pipeline_stats',
-        method: 'POST',
-        headers: {
-          'Datadog-Meta-Lang': 'javascript',
-          'Datadog-Meta-Tracer-Version': pkg.version,
-          'Content-Type': 'application/msgpack',
-          'Content-Encoding': 'gzip'
-        },
-        url: unixConfig.url
-      }
-    )
+    const stubRequestCall = stubRequest.getCalls().at(0)
+    const decodedPayload = msgpack.decode(stubRequestCall?.args[0], { codec })
+    const requestOptions = stubRequestCall?.args[1]
+    expect(decodedPayload).to.deep.equal({})
+    expect(requestOptions).to.deep.equal({
+      path: '/v0.1/pipeline_stats',
+      method: 'POST',
+      headers: {
+        'Datadog-Meta-Lang': 'javascript',
+        'Datadog-Meta-Tracer-Version': pkg.version,
+        'Content-Type': 'application/msgpack',
+        'Content-Encoding': 'gzip'
+      },
+      url: unixConfig.url
+    })
   })
 })

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -5,12 +5,11 @@ const stubRequest = sinon.stub()
 const { DataStreamsWriter } = proxyquire(
   '../src/datastreams/writer', {
     '../exporters/common/request': stubRequest
-})
+  })
 
 require('../setup/tap')
 
 describe('DataStreamWriter unix', () => {
-
   let writer
   const unixConfig = {
     hostname: '',
@@ -18,14 +17,14 @@ describe('DataStreamWriter unix', () => {
     port: ''
   }
 
-  it("should construct unix config", () => {
-    writer = new DataStreamsWriter(unixConfig);
-    expect(writer._url).to.equal(unixConfig.url);
+  it('should construct unix config', () => {
+    writer = new DataStreamsWriter(unixConfig)
+    expect(writer._url).to.equal(unixConfig.url)
   })
 
   it("should call 'request' through flush with correct options", () => {
-    writer = new DataStreamsWriter(unixConfig);
-    writer.flush({}):
+    writer = new DataStreamsWriter(unixConfig)
+    writer.flush({})
     expect(stubRequest).to.be.calledWith(
       {},
       {


### PR DESCRIPTION
### What does this PR do?

ATM there is a bug with datastream when you give a `DD_TRACE_AGENT_URL` equal to a unix socket like `unix:///var/run/datadog/apm.socket`
<img width="1177" alt="Capture d’écran 2023-10-06 à 16 18 55" src="https://github.com/DataDog/dd-trace-js/assets/9024389/ac769296-5c03-4559-a172-c5833cfd31d5">

So this PR fix this bug

<!-- A brief description of the change being made with this pull request. -->

This PR change what its send to the `request` function from `exporters/common/request`
Before it was not sending the `url` object but only the **protocol**, **port** and **hostname**
By doing this way, `request` is not unable to create correctly the `options` for a `socket` call.

<img width="361" alt="image" src="https://github.com/DataDog/dd-trace-js/assets/9024389/3397cdd3-d96d-49f2-bf10-20b88fa3e764">

if you don't give the url object in options, it won't set the mandatory `socketPath` to make it work.



### Motivation
<!-- What inspired you to submit this pull request? -->
I'm using DD in my company and we are trying to use datastream.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [X] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
