### PR TITLE
Enable appsec telemetry before waf init

### DIFF
--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -32,6 +32,8 @@ function enable (_config) {
   if (isEnabled) return
 
   try {
+    appsecTelemetry.enable(_config.telemetry)
+
     setTemplates(_config)
 
     RuleManager.applyRules(_config.appsec.rules, _config.appsec)
@@ -39,8 +41,6 @@ function enable (_config) {
     remoteConfig.enableWafUpdate(_config.appsec)
 
     Reporter.setRateLimit(_config.appsec.rateLimit)
-
-    appsecTelemetry.enable(_config.telemetry)
 
     incomingHttpRequestStart.subscribe(incomingHttpStartTranslator)
     incomingHttpRequestEnd.subscribe(incomingHttpEndTranslator)

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -645,6 +645,26 @@ describe('AppSec Index', () => {
       })
     })
   })
+
+  describe('Metrics', () => {
+    afterEach(() => {
+      appsec.disable()
+    })
+
+    it('should increment waf.init metric', () => {
+      sinon.restore()
+
+      sinon.stub(Reporter, 'reportWafInit')
+
+      appsec.enable(new Config({
+        appsec: {
+          enabled: true
+        }
+      }))
+
+      expect(Reporter.reportWafInit).to.be.calledOnce
+    })
+  })
 })
 
 describe('IP blocking', () => {

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -649,6 +649,17 @@ describe('AppSec Index', () => {
 
   describe('Metrics', () => {
     const appsecNamespace = telemetryMetrics.manager.namespace('appsec')
+    let config
+
+    beforeEach(() => {
+      sinon.restore()
+
+      config = new Config({
+        appsec: {
+          enabled: true
+        }
+      })
+    })
 
     afterEach(() => {
       appsec.disable()
@@ -657,14 +668,6 @@ describe('AppSec Index', () => {
     })
 
     it('should increment waf.init metric', () => {
-      sinon.restore()
-
-      const config = new Config({
-        appsec: {
-          enabled: true
-        }
-      })
-
       config.telemetry.enabled = true
       config.telemetry.metrics = true
 
@@ -676,17 +679,20 @@ describe('AppSec Index', () => {
       expect(metrics.series[0].metric).to.equal('waf.init')
     })
 
-    it('should not increment waf.init metric', () => {
-      sinon.restore()
-
-      const config = new Config({
-        appsec: {
-          enabled: true
-        }
-      })
-
+    it('should not increment waf.init metric if metrics are not enabled', () => {
       config.telemetry.enabled = true
       config.telemetry.metrics = false
+
+      appsec.enable(config)
+
+      const metrics = appsecNamespace.metrics.toJSON()
+
+      expect(metrics).to.be.undefined
+    })
+
+    it('should not increment waf.init metric if telemetry is not enabled', () => {
+      config.telemetry.enabled = false
+      config.telemetry.metrics = true
 
       appsec.enable(config)
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -654,6 +654,8 @@ describe('AppSec Index', () => {
     beforeEach(() => {
       sinon.restore()
 
+      appsecNamespace.reset()
+
       config = new Config({
         appsec: {
           enabled: true
@@ -663,7 +665,9 @@ describe('AppSec Index', () => {
 
     afterEach(() => {
       appsec.disable()
+    })
 
+    after(() => {
       appsecNamespace.reset()
     })
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -21,6 +21,7 @@ const getPort = require('get-port')
 const blockedTemplate = require('../../src/appsec/blocked_templates')
 const { storage } = require('../../../datadog-core')
 const addresses = require('../../src/appsec/addresses')
+const telemetryMetrics = require('../../src/telemetry/metrics')
 
 describe('AppSec Index', () => {
   let config
@@ -647,22 +648,51 @@ describe('AppSec Index', () => {
   })
 
   describe('Metrics', () => {
+    const appsecNamespace = telemetryMetrics.manager.namespace('appsec')
+
     afterEach(() => {
       appsec.disable()
+
+      appsecNamespace.reset()
     })
 
-    it('should call reportWafInit', () => {
+    it('should increment waf.init metric', () => {
       sinon.restore()
 
-      sinon.stub(Reporter, 'reportWafInit')
-
-      appsec.enable(new Config({
+      const config = new Config({
         appsec: {
           enabled: true
         }
-      }))
+      })
 
-      expect(Reporter.reportWafInit).to.be.calledOnce
+      config.telemetry.enabled = true
+      config.telemetry.metrics = true
+
+      appsec.enable(config)
+
+      const metrics = appsecNamespace.metrics.toJSON()
+
+      expect(metrics.series.length).to.equal(1)
+      expect(metrics.series[0].metric).to.equal('waf.init')
+    })
+
+    it('should not increment waf.init metric', () => {
+      sinon.restore()
+
+      const config = new Config({
+        appsec: {
+          enabled: true
+        }
+      })
+
+      config.telemetry.enabled = true
+      config.telemetry.metrics = false
+
+      appsec.enable(config)
+
+      const metrics = appsecNamespace.metrics.toJSON()
+
+      expect(metrics).to.be.undefined
     })
   })
 })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -651,7 +651,7 @@ describe('AppSec Index', () => {
       appsec.disable()
     })
 
-    it('should increment waf.init metric', () => {
+    it('should call reportWafInit', () => {
       sinon.restore()
 
       sinon.stub(Reporter, 'reportWafInit')


### PR DESCRIPTION
### What does this PR do?
Enables appsec telemetry before waf init

### Motivation
`waf.init` metrics were missing

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
