### PR TITLE
Serialize version to string in config

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -555,7 +555,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.plugins = !!coalesce(options.plugins, true)
     this.service = DD_SERVICE
     this.serviceMapping = DD_SERVICE_MAPPING
-    this.version = DD_VERSION
+    this.version = typeof DD_VERSION === 'object' ? JSON.stringify(DD_VERSION) : String(DD_VERSION)
     this.dogstatsd = {
       hostname: coalesce(dogstatsd.hostname, process.env.DD_DOGSTATSD_HOSTNAME, this.hostname),
       port: String(coalesce(dogstatsd.port, process.env.DD_DOGSTATSD_PORT, 8125))

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -155,6 +155,26 @@ describe('Config', () => {
     expect(config.tags).to.have.property('version', '1.2.3')
   })
 
+  it('should serialize version from integer to string', () => {
+    const config = new Config({
+      version: 1
+    })
+
+    expect(config).to.have.property('version', '1')
+    expect(config.tags).to.have.property('version', '1')
+  })
+
+  it('should serialize version from object to string', () => {
+    const config = new Config({
+      version: {
+        v: '1.2.3'
+      }
+    })
+
+    expect(config).to.have.property('version', '{"v":"1.2.3"}')
+    expect(config.tags).to.have.property('version', '{"v":"1.2.3"}')
+  })
+
   it('should initialize from environment variables', () => {
     process.env.DD_TRACE_AGENT_HOSTNAME = 'agent'
     process.env.DD_TRACE_AGENT_PORT = '6218'


### PR DESCRIPTION
### What does this PR do?
Serializes configuration version value to string.

### Motivation
Version value must be a string, as it is defined in the [interface](https://datadoghq.dev/dd-trace-js/interfaces/traceroptions.html#version), but the current implementation was not checking this value to ensure its correct type. 

