### PR TITLE
Check for processor to exist before accessing it in crash situations

### DIFF
--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -53,7 +53,9 @@ function crashFlush () {
     log.debug('An impending timeout was reached, but no root span was found. No error will be tagged.')
   }
 
-  tracer._processor.killAll()
+  if(tracer._processor){
+    tracer._processor.killAll()
+  }
   if (activeSpan !== null) {
     activeSpan.finish()
   }


### PR DESCRIPTION
### What does this PR do?
In crash situations, a race condition can cause the processor of a tracer to be called before it is set up, leading to unwanted failure cases.

### Motivation
When having a lambda function time out very quickly, it can happen that the tracer is not fully initialized before the `crashFlush` function is called, failing to complete the code block with the following error
```
Cannot read properties of undefined (reading 'killAll')
stack:
TypeError: Cannot read properties of undefined (reading 'killAll'),
    at crashFlush (/opt/nodejs/node_modules/dd-trace/packages/dd-trace/src/lambda/handler.js:56:21),
    at /opt/nodejs/node_modules/dd-trace/packages/dd-trace/src/lambda/handler.js:14:3,
    at Channel.publish (node:diagnostics_channel:56:9),
    at Timeout._onTimeout (/opt/nodejs/node_modules/dd-trace/packages/dd-trace/src/lambda/handler.js:32:20),
    at listOnTimeout (node:internal/timers:569:17),
    at process.processTimers (node:internal/timers:512:7)

```
