### PR TITLE
[ci-visibility] Fix cucumber integration tests

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -29,8 +29,8 @@ const {
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
 const hookFile = 'dd-trace/loader-hook.mjs'
-const isOldNode = semver.satisfies(process.version, '<=12')
-const versions = ['7.0.0', isOldNode ? '8' : 'latest']
+const isOldNode = semver.satisfies(process.version, '<=16')
+const versions = ['7.0.0', isOldNode ? '9' : 'latest']
 
 const moduleType = [
   {


### PR DESCRIPTION
### What does this PR do?
Pin cucumber version to `9` if the node version is <=16.

### Motivation
[Latest cucumber-js release](https://github.com/cucumber/cucumber-js/releases/tag/v10.0.0) dropped support for node@16.

