### PR TITLE
[core] Next.js: Don't Trace Middleware

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -13,6 +13,8 @@ const queryParsedChannel = channel('apm:next:query-parsed')
 
 const requests = new WeakSet()
 
+const MIDDLEWARE_HEADER = 'x-middleware-invoke'
+
 function wrapHandleRequest (handleRequest) {
   return function (req, res, pathname, query) {
     return instrument(req, res, () => handleRequest.apply(this, arguments))
@@ -88,7 +90,8 @@ function instrument (req, res, handler) {
   req = req.originalRequest || req
   res = res.originalResponse || res
 
-  const isMiddleware = req.headers['x-middleware-invoke']
+  // TODO support middleware if a FR comes up?
+  const isMiddleware = req.headers[MIDDLEWARE_HEADER]
   if (isMiddleware || requests.has(req)) return handler()
 
   requests.add(req)

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -64,7 +64,7 @@ class NextPlugin extends ServerPlugin {
     span.finish()
   }
 
-  pageLoad ({ page, isAppPath }) {
+  pageLoad ({ page, isAppPath = false }) {
     const store = storage.getStore()
 
     if (!store) return

--- a/packages/datadog-plugin-next/test/middleware.js
+++ b/packages/datadog-plugin-next/test/middleware.js
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
 export default function middleware () {
+  // the existence of this file will test that having middleware
+  // doesn't break instrumentation in tests
   return NextResponse.next()
 }

--- a/packages/datadog-plugin-next/test/middleware.js
+++ b/packages/datadog-plugin-next/test/middleware.js
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export default function middleware () {
+  return NextResponse.next()
+}

--- a/packages/datadog-plugin-next/test/server.js
+++ b/packages/datadog-plugin-next/test/server.js
@@ -6,7 +6,7 @@ const { createServer } = require('http')
 const { parse } = require('url')
 const next = require('next') // eslint-disable-line import/no-extraneous-dependencies
 
-const app = next({ dir: __dirname, dev: false, quiet: true, hostname: HOSTNAME })
+const app = next({ dir: __dirname, dev: false, quiet: true, hostname: HOSTNAME, port: PORT })
 const handle = app.getRequestHandler()
 
 app.prepare().then(() => {


### PR DESCRIPTION
### What does this PR do?
Removes middleware tracing. 

### Motivation
~~Removing `render` function tracing is a response to a long-standing `TODO` - they aren't needed currently, and don't add anything meaningful to the tracing process (taking them out doesn't change tests success rate or appearance of traces in the UI).~~

~~Tracing `render` functions is still important, as some are provided on the top-level API (ie `app.render(...)`) and should be supported in tracing. However, some of what we were tracing before was not part of this top-level API - this PR reflects this properly now (`render`, `renderToHTML`, `renderError`, `renderErrorToHTML`, `render404`).~~

Removing `middleware` tracing fixes #3682. Newer versions of Next.js route requests coming in to the middleware through the same handler function we currently trace, making us start a span for middleware. Then, requests get re-routed from the middleware by throwing an error caught higher up than where we trace. So, not only do we finish the trace with an error, but when we go to trace the actual request endpoint with the same request object, we don't end up tracing it, as we check if we have already. Yet, the `pageLoad` logic still runs on our side, but not in the context of a span, so our logic breaks. By not tracing middleware at all, we still trace the actual request itself, and the problem is avoided. This is tested by just adding a middleware function, and ensuring that existing tests don't break (before, adding a middleware file without changes to instrumentation would break ~50% of tests).

It's unclear if middleware was ever traced properly in the first place, so not tracing it altogether until we find a better way to do it shouldn't remove useful spans.

