### PR TITLE
Fix supported MongoDB versions in NoSQL injection test

### DIFF
--- a/packages/datadog-instrumentations/src/mongodb.js
+++ b/packages/datadog-instrumentations/src/mongodb.js
@@ -29,7 +29,7 @@ const collectionMethodsWithTwoFilters = [
 
 const startCh = channel('datadog:mongodb:collection:filter:start')
 
-addHook({ name: 'mongodb', versions: ['>=3.3 <5', '>=5 <6', '>=6'] }, mongodb => {
+addHook({ name: 'mongodb', versions: ['>=3.3 <5', '5', '>=6'] }, mongodb => {
   [...collectionMethodsWithFilter, ...collectionMethodsWithTwoFilters].forEach(methodName => {
     if (!(methodName in mongodb.Collection.prototype)) return
 

--- a/packages/datadog-instrumentations/src/mongodb.js
+++ b/packages/datadog-instrumentations/src/mongodb.js
@@ -29,7 +29,7 @@ const collectionMethodsWithTwoFilters = [
 
 const startCh = channel('datadog:mongodb:collection:filter:start')
 
-addHook({ name: 'mongodb', versions: ['>=3.3'] }, mongodb => {
+addHook({ name: 'mongodb', versions: ['>=3.3 <5', '>=5 <6', '>=6'] }, mongodb => {
   [...collectionMethodsWithFilter, ...collectionMethodsWithTwoFilters].forEach(methodName => {
     if (!(methodName in mongodb.Collection.prototype)) return
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -1,14 +1,27 @@
 'use strict'
 
-const { prepareTestServerForIastInExpress } = require('../utils')
 const axios = require('axios')
-const agent = require('../../../plugins/agent')
-const path = require('path')
-const os = require('os')
 const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const semver = require('semver')
+const { prepareTestServerForIastInExpress } = require('../utils')
+const agent = require('../../../plugins/agent')
+
 describe('nosql injection detection in mongodb - whole feature', () => {
   withVersions('express', 'express', '>4.18.0', expressVersion => {
     withVersions('mongodb', 'mongodb', mongodbVersion => {
+      const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
+
+      const satisfiesNodeVersionForMongo3and4 =
+        (semver.satisfies(process.version, '<14.20.1') && semver.satisfies(mongodb.version(), '>=3.3 <5'))
+      const satisfiesNodeVersionForMongo5 =
+        (semver.satisfies(process.version, '>=14.20.1 <16.20.1') && semver.satisfies(mongodb.version(), '>=5 <6'))
+      const satisfiesNodeVersionForMongo6 =
+        (semver.satisfies(process.version, '>=16.20.1') && semver.satisfies(mongodb.version(), '>=6'))
+
+      if (!satisfiesNodeVersionForMongo3and4 && !satisfiesNodeVersionForMongo5 && !satisfiesNodeVersionForMongo6) return
+
       const vulnerableMethodFilename = 'mongodb-vulnerable-method.js'
       let collection, tmpFilePath
 
@@ -17,7 +30,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
       })
 
       before(async () => {
-        const { MongoClient } = require(`../../../../../../versions/mongodb@${mongodbVersion}`).get()
+        const { MongoClient } = mongodb.get()
         const client = new MongoClient('mongodb://127.0.0.1:27017')
         await client.connect()
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -16,7 +16,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
       const satisfiesNodeVersionForMongo3and4 =
         (semver.satisfies(process.version, '<14.20.1') && semver.satisfies(mongodb.version(), '>=3.3 <5'))
       const satisfiesNodeVersionForMongo5 =
-        (semver.satisfies(process.version, '>=14.20.1 <16.20.1') && semver.satisfies(mongodb.version(), '>=5 <6'))
+        (semver.satisfies(process.version, '>=14.20.1 <16.20.1') && semver.satisfies(mongodb.version(), '5'))
       const satisfiesNodeVersionForMongo6 =
         (semver.satisfies(process.version, '>=16.20.1') && semver.satisfies(mongodb.version(), '>=6'))
 

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -44,7 +44,7 @@
   "express-mongo-sanitize": [
     {
       "name": "mongodb",
-      "versions": [">=3.3"]
+      "versions": [">=3.3 <5", ">=5 <6", ">=6"]
     },
     {
       "name": "mongodb-core",

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -44,7 +44,7 @@
   "express-mongo-sanitize": [
     {
       "name": "mongodb",
-      "versions": [">=3.3 <5", ">=5 <6", ">=6"]
+      "versions": [">=3.3 <5", "5", ">=6"]
     },
     {
       "name": "mongodb-core",


### PR DESCRIPTION
### What does this PR do?
Runs MongoDb NoSQL injection test only with supported versions.

### Motivation
Supported `mongodb` versions supports different node versions, leading to some tests to fail when run in old node versions.
