### PR TITLE
Add configurable IAST redaction pattern

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -122,7 +122,9 @@ tracer.init({
       maxConcurrentRequests: 4,
       maxContextOperations: 30,
       deduplicationEnabled: true,
-      redactionEnabled: true
+      redactionEnabled: true,
+      redactionNamePattern: 'password',
+      redactionValuePattern: 'bearer'
     }
   }
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -453,7 +453,15 @@ export declare interface TracerOptions {
        * Whether to enable vulnerability redaction
        * @default true
        */
-      redactionEnabled?: boolean
+      redactionEnabled?: boolean,
+      /**
+       * Specifies a regex that will redact sensitive source name in vulnerability report.
+       */
+      redactionNamePattern?: string,
+      /**
+       * Specifies a regex that will redact sensitive source value in vulnerability report.
+       */
+      redactionValuePattern?: string
     }
   };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -455,11 +455,11 @@ export declare interface TracerOptions {
        */
       redactionEnabled?: boolean,
       /**
-       * Specifies a regex that will redact sensitive source name in vulnerability report.
+       * Specifies a regex that will redact sensitive source names in vulnerability reports.
        */
       redactionNamePattern?: string,
       /**
-       * Specifies a regex that will redact sensitive source value in vulnerability report.
+       * Specifies a regex that will redact sensitive source values in vulnerability reports.
        */
       redactionValuePattern?: string
     }

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const iastLog = require('../../iast-log')
 const vulnerabilities = require('../../vulnerabilities')
 
 const { contains, intersects, remove } = require('./range-utils')
@@ -261,6 +262,20 @@ class SensitiveHandler {
       }
     } else {
       valueParts.push({ redacted: true })
+    }
+  }
+
+  setRedactionPatterns (redactionNamePattern, redactionValuePattern) {
+    try {
+      if (redactionNamePattern) this._namePattern = new RegExp(redactionNamePattern, 'gmi')
+    } catch (e) {
+      iastLog.warn('Redaction name pattern is not valid')
+    }
+
+    try {
+      if (redactionValuePattern) this._valuePattern = new RegExp(redactionValuePattern, 'gmi')
+    } catch (e) {
+      iastLog.warn('Redaction value pattern is not valid')
     }
   }
 }

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
@@ -266,16 +266,20 @@ class SensitiveHandler {
   }
 
   setRedactionPatterns (redactionNamePattern, redactionValuePattern) {
-    try {
-      if (redactionNamePattern) this._namePattern = new RegExp(redactionNamePattern, 'gmi')
-    } catch (e) {
-      iastLog.warn('Redaction name pattern is not valid')
+    if (redactionNamePattern) {
+      try {
+        this._namePattern = new RegExp(redactionNamePattern, 'gmi')
+      } catch (e) {
+        iastLog.warn('Redaction name pattern is not valid')
+      }
     }
 
-    try {
-      if (redactionValuePattern) this._valuePattern = new RegExp(redactionValuePattern, 'gmi')
-    } catch (e) {
-      iastLog.warn('Redaction value pattern is not valid')
+    if (redactionValuePattern) {
+      try {
+        this._valuePattern = new RegExp(redactionValuePattern, 'gmi')
+      } catch (e) {
+        iastLog.warn('Redaction value pattern is not valid')
+      }
     }
   }
 }

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
@@ -8,8 +8,9 @@ class VulnerabilityFormatter {
     this._redactVulnearbilities = true
   }
 
-  setRedactVulnerabilities (shouldRedactVulnerabilities) {
+  setRedactVulnerabilities (shouldRedactVulnerabilities, redactionNamePattern, redactionValuePattern) {
     this._redactVulnearbilities = shouldRedactVulnerabilities
+    sensitiveHandler.setRedactionPatterns(redactionNamePattern, redactionValuePattern)
   }
 
   extractSourcesFromVulnerability (vulnerability) {

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -95,7 +95,11 @@ function deduplicateVulnerabilities (vulnerabilities) {
 
 function start (config, _tracer) {
   deduplicationEnabled = config.iast.deduplicationEnabled
-  vulnerabilitiesFormatter.setRedactVulnerabilities(config.iast.redactionEnabled)
+  vulnerabilitiesFormatter.setRedactVulnerabilities(
+    config.iast.redactionEnabled,
+    config.iast.redactionNamePattern,
+    config.iast.redactionValuePattern
+  )
   if (deduplicationEnabled) {
     startClearCacheTimer()
   }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -492,6 +492,18 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       true
     )
 
+    const DD_IAST_REDACTION_NAME_PATTERN = coalesce(
+      iastOptions && iastOptions.redactionNamePattern,
+      process.env.DD_IAST_REDACTION_NAME_PATTERN,
+      null
+    )
+
+    const DD_IAST_REDACTION_VALUE_PATTERN = coalesce(
+      iastOptions && iastOptions.redactionValuePattern,
+      process.env.DD_IAST_REDACTION_VALUE_PATTERN,
+      null
+    )
+
     const DD_IAST_TELEMETRY_VERBOSITY = coalesce(
       iastOptions && iastOptions.telemetryVerbosity,
       process.env.DD_IAST_TELEMETRY_VERBOSITY,
@@ -620,6 +632,8 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       maxContextOperations: DD_IAST_MAX_CONTEXT_OPERATIONS,
       deduplicationEnabled: DD_IAST_DEDUPLICATION_ENABLED,
       redactionEnabled: DD_IAST_REDACTION_ENABLED,
+      redactionNamePattern: DD_IAST_REDACTION_NAME_PATTERN,
+      redactionValuePattern: DD_IAST_REDACTION_VALUE_PATTERN,
       telemetryVerbosity: DD_IAST_TELEMETRY_VERBOSITY
     }
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -461,7 +461,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     const defaultIastRequestSampling = 30
     const iastRequestSampling = coalesce(
-      parseInt(iastOptions && iastOptions.requestSampling),
+      parseInt(iastOptions?.requestSampling),
       parseInt(process.env.DD_IAST_REQUEST_SAMPLING),
       defaultIastRequestSampling
     )
@@ -469,43 +469,43 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       iastRequestSampling > 100 ? defaultIastRequestSampling : iastRequestSampling
 
     const DD_IAST_MAX_CONCURRENT_REQUESTS = coalesce(
-      parseInt(iastOptions && iastOptions.maxConcurrentRequests),
+      parseInt(iastOptions?.maxConcurrentRequests),
       parseInt(process.env.DD_IAST_MAX_CONCURRENT_REQUESTS),
       2
     )
 
     const DD_IAST_MAX_CONTEXT_OPERATIONS = coalesce(
-      parseInt(iastOptions && iastOptions.maxContextOperations),
+      parseInt(iastOptions?.maxContextOperations),
       parseInt(process.env.DD_IAST_MAX_CONTEXT_OPERATIONS),
       2
     )
 
     const DD_IAST_DEDUPLICATION_ENABLED = coalesce(
-      iastOptions && iastOptions.deduplicationEnabled,
+      iastOptions?.deduplicationEnabled,
       process.env.DD_IAST_DEDUPLICATION_ENABLED && isTrue(process.env.DD_IAST_DEDUPLICATION_ENABLED),
       true
     )
 
     const DD_IAST_REDACTION_ENABLED = coalesce(
-      iastOptions && iastOptions.redactionEnabled,
+      iastOptions?.redactionEnabled,
       !isFalse(process.env.DD_IAST_REDACTION_ENABLED),
       true
     )
 
     const DD_IAST_REDACTION_NAME_PATTERN = coalesce(
-      iastOptions && iastOptions.redactionNamePattern,
+      iastOptions?.redactionNamePattern,
       process.env.DD_IAST_REDACTION_NAME_PATTERN,
       null
     )
 
     const DD_IAST_REDACTION_VALUE_PATTERN = coalesce(
-      iastOptions && iastOptions.redactionValuePattern,
+      iastOptions?.redactionValuePattern,
       process.env.DD_IAST_REDACTION_VALUE_PATTERN,
       null
     )
 
     const DD_IAST_TELEMETRY_VERBOSITY = coalesce(
-      iastOptions && iastOptions.telemetryVerbosity,
+      iastOptions?.telemetryVerbosity,
       process.env.DD_IAST_TELEMETRY_VERBOSITY,
       'INFORMATION'
     )

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -447,7 +447,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       5 // seconds
     )
 
-    const iastOptions = options.experimental && options.experimental.iast
+    const iastOptions = options?.experimental?.iast
     const DD_IAST_ENABLED = coalesce(
       iastOptions &&
       (iastOptions === true || iastOptions.enabled === true),

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/evidence-redaction/sensitive-handler.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/evidence-redaction/sensitive-handler.spec.js
@@ -2,6 +2,8 @@
 
 const sensitiveHandler =
   require('../../../../../src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler')
+const { DEFAULT_IAST_REDACTION_NAME_PATTERN, DEFAULT_IAST_REDACTION_VALUE_PATTERN } =
+  require('../../../../../src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-regex')
 
 const { suite } = require('../resources/evidence-redaction-suite.json')
 
@@ -18,6 +20,84 @@ function doTest (testCase, parameter) {
 }
 
 describe('Sensitive handler', () => {
+  beforeEach(() => {
+    sensitiveHandler.setRedactionPatterns(DEFAULT_IAST_REDACTION_NAME_PATTERN, DEFAULT_IAST_REDACTION_VALUE_PATTERN)
+  })
+
+  describe('Custom redaction patterns', () => {
+    describe('Default redaction patterns', () => {
+      it('should use default patterns when null ones are set', () => {
+        sensitiveHandler.setRedactionPatterns(null, null)
+        expect(sensitiveHandler._namePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_NAME_PATTERN)
+        expect(sensitiveHandler._valuePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_VALUE_PATTERN)
+      })
+
+      it('should use default name pattern when custom name pattern is null', () => {
+        const customValuePattern = 'valuePattern'
+        sensitiveHandler.setRedactionPatterns(null, customValuePattern)
+        expect(sensitiveHandler._namePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_NAME_PATTERN)
+        expect(sensitiveHandler._valuePattern.source).to.be.equals(customValuePattern)
+      })
+
+      it('should use default value pattern when custom value pattern is null', () => {
+        const customNamePattern = 'namePattern'
+        sensitiveHandler.setRedactionPatterns(customNamePattern, null)
+        expect(sensitiveHandler._namePattern.source).to.be.equals(customNamePattern)
+        expect(sensitiveHandler._valuePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_VALUE_PATTERN)
+      })
+    })
+
+    describe('Not valid custom patterns', () => {
+      const iastLog = require('../../../../../src/appsec/iast/iast-log')
+
+      beforeEach(() => {
+        sinon.stub(iastLog, 'warn')
+      })
+
+      afterEach(() => {
+        sinon.restore()
+      })
+
+      it('should use default patterns when not valid ones are set', () => {
+        sensitiveHandler.setRedactionPatterns('(unterminated_group', 'unmatched)')
+        expect(sensitiveHandler._namePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_NAME_PATTERN)
+        expect(sensitiveHandler._valuePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_VALUE_PATTERN)
+
+        expect(iastLog.warn).to.have.been.calledTwice
+        expect(iastLog.warn.firstCall.args[0]).to.be.equals('Redaction name pattern is not valid')
+        expect(iastLog.warn.secondCall.args[0]).to.be.equals('Redaction value pattern is not valid')
+      })
+
+      it('should use default name pattern when custom name pattern is not valid', () => {
+        const customValuePattern = 'valuePattern'
+        sensitiveHandler.setRedactionPatterns('(unterminated_group', customValuePattern)
+        expect(sensitiveHandler._namePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_NAME_PATTERN)
+        expect(sensitiveHandler._valuePattern.source).to.be.equals(customValuePattern)
+
+        expect(iastLog.warn).to.have.been.calledOnceWithExactly('Redaction name pattern is not valid')
+      })
+
+      it('should use default value pattern when custom value pattern is not valid', () => {
+        const customNamePattern = 'namePattern'
+        sensitiveHandler.setRedactionPatterns(customNamePattern, 'unmatched)')
+        expect(sensitiveHandler._namePattern.source).to.be.equals(customNamePattern)
+        expect(sensitiveHandler._valuePattern.source).to.be.equals(DEFAULT_IAST_REDACTION_VALUE_PATTERN)
+
+        expect(iastLog.warn).to.have.been.calledOnceWithExactly('Redaction value pattern is not valid')
+      })
+    })
+
+    it('Valid custom patterns', () => {
+      expect(sensitiveHandler.isSensibleName('sensibleName')).to.be.false
+      expect(sensitiveHandler.isSensibleValue('sensibleValue')).to.be.false
+
+      sensitiveHandler.setRedactionPatterns('sensibleName', 'sensibleValue')
+
+      expect(sensitiveHandler.isSensibleName('sensibleName')).to.be.true
+      expect(sensitiveHandler.isSensibleValue('sensibleValue')).to.be.true
+    })
+  })
+
   describe('Sensible sources', () => {
     suite.filter(testCase => testCase.type === 'SOURCES').forEach((testCase) => {
       for (const name in testCase.parameters) {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
@@ -91,4 +91,16 @@ describe('Vulnerability formatter', () => {
       expect(json.vulnerabilities[0].location.column).to.be.undefined
     })
   })
+
+  it('should set custom redaction patterns', () => {
+    const sensitiveHandler =
+      require('../../../../src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler')
+
+    sinon.stub(sensitiveHandler, 'setRedactionPatterns')
+
+    vulnerabilityFormatter.setRedactVulnerabilities(true, 'customNamePattern', 'customValuePattern')
+
+    expect(sensitiveHandler.setRedactionPatterns)
+      .to.have.been.calledOnceWithExactly('customNamePattern', 'customValuePattern')
+  })
 })

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const vulnerabilityFormatter = require('../../../../src/appsec/iast/vulnerabilities-formatter')
+const sensitiveHandler =
+  require('../../../../src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler')
 
 const { suite } = require('./resources/evidence-redaction-suite.json')
 
@@ -92,15 +94,20 @@ describe('Vulnerability formatter', () => {
     })
   })
 
-  it('should set custom redaction patterns', () => {
-    const sensitiveHandler =
-      require('../../../../src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler')
+  describe('Custom redaction patterns', () => {
+    beforeEach(() => {
+      sinon.stub(sensitiveHandler, 'setRedactionPatterns')
+    })
 
-    sinon.stub(sensitiveHandler, 'setRedactionPatterns')
+    afterEach(() => {
+      sinon.restore()
+    })
 
-    vulnerabilityFormatter.setRedactVulnerabilities(true, 'customNamePattern', 'customValuePattern')
+    it('should set custom redaction patterns', () => {
+      vulnerabilityFormatter.setRedactVulnerabilities(true, 'customNamePattern', 'customValuePattern')
 
-    expect(sensitiveHandler.setRedactionPatterns)
-      .to.have.been.calledOnceWithExactly('customNamePattern', 'customValuePattern')
+      expect(sensitiveHandler.setRedactionPatterns)
+        .to.have.been.calledOnceWithExactly('customNamePattern', 'customValuePattern')
+    })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -474,11 +474,13 @@ describe('vulnerability-reporter', () => {
     it('should set evidence redaction on vulnerability formatter', () => {
       const config = {
         iast: {
-          redactionEnabled: true
+          redactionEnabled: true,
+          redactionNamePattern: null,
+          redactionValuePattern: null
         }
       }
       start(config)
-      expect(vulnerabilityFormatter.setRedactVulnerabilities).to.have.been.calledOnceWithExactly(true)
+      expect(vulnerabilityFormatter.setRedactVulnerabilities).to.have.been.calledOnceWithExactly(true, null, null)
     })
   })
 })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -115,6 +115,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 5)
     expect(config).to.have.nested.property('iast.enabled', false)
     expect(config).to.have.nested.property('iast.redactionEnabled', true)
+    expect(config).to.have.nested.property('iast.redactionNamePattern', null)
+    expect(config).to.have.nested.property('iast.redactionValuePattern', null)
     expect(config).to.have.nested.property('iast.telemetryVerbosity', 'INFORMATION')
   })
 
@@ -215,6 +217,8 @@ describe('Config', () => {
     process.env.DD_IAST_MAX_CONTEXT_OPERATIONS = '4'
     process.env.DD_IAST_DEDUPLICATION_ENABLED = false
     process.env.DD_IAST_REDACTION_ENABLED = false
+    process.env.DD_IAST_REDACTION_NAME_PATTERN = 'REDACTION_NAME_PATTERN'
+    process.env.DD_IAST_REDACTION_VALUE_PATTERN = 'REDACTION_VALUE_PATTERN'
     process.env.DD_IAST_TELEMETRY_VERBOSITY = 'DEBUG'
     process.env.DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = 'true'
     process.env.DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = 'true'
@@ -291,6 +295,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.maxContextOperations', 4)
     expect(config).to.have.nested.property('iast.deduplicationEnabled', false)
     expect(config).to.have.nested.property('iast.redactionEnabled', false)
+    expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
+    expect(config).to.have.nested.property('iast.redactionValuePattern', 'REDACTION_VALUE_PATTERN')
     expect(config).to.have.nested.property('iast.telemetryVerbosity', 'DEBUG')
   })
 
@@ -411,6 +417,8 @@ describe('Config', () => {
           maxContextOperations: 5,
           deduplicationEnabled: false,
           redactionEnabled: false,
+          redactionNamePattern: 'REDACTION_NAME_PATTERN',
+          redactionValuePattern: 'REDACTION_VALUE_PATTERN',
           telemetryVerbosity: 'DEBUG'
         }
       },
@@ -467,6 +475,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.maxContextOperations', 5)
     expect(config).to.have.nested.property('iast.deduplicationEnabled', false)
     expect(config).to.have.nested.property('iast.redactionEnabled', false)
+    expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
+    expect(config).to.have.nested.property('iast.redactionValuePattern', 'REDACTION_VALUE_PATTERN')
     expect(config).to.have.nested.property('iast.telemetryVerbosity', 'DEBUG')
     expect(config).to.have.deep.nested.property('sampler', {
       sampleRate: 0.5,
@@ -761,6 +771,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.maxContextOperations', 2)
     expect(config).to.have.nested.property('iast.deduplicationEnabled', true)
     expect(config).to.have.nested.property('iast.redactionEnabled', true)
+    expect(config).to.have.nested.property('iast.redactionNamePattern', null)
+    expect(config).to.have.nested.property('iast.redactionValuePattern', null)
   })
 
   it('should give priority to non-experimental options', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -705,7 +705,7 @@ describe('Config', () => {
         iast: {
           enabled: true,
           redactionNamePattern: 'REDACTION_NAME_PATTERN',
-          redactionValuePattern: 'REDACTION_VALUE_PATTERN',
+          redactionValuePattern: 'REDACTION_VALUE_PATTERN'
         }
       },
       appsec: {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -658,6 +658,8 @@ describe('Config', () => {
     process.env.DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING = 'disabled'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
+    process.env.DD_IAST_REDACTION_NAME_PATTERN = 'name_pattern_to_be_overriden_by_options'
+    process.env.DD_IAST_REDACTION_VALUE_PATTERN = 'value_pattern_to_be_overriden_by_options'
     process.env.DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = 'true'
     process.env.DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = 'true'
 
@@ -701,7 +703,9 @@ describe('Config', () => {
         exporter: 'agent',
         enableGetRumData: false,
         iast: {
-          enabled: true
+          enabled: true,
+          redactionNamePattern: 'REDACTION_NAME_PATTERN',
+          redactionValuePattern: 'REDACTION_VALUE_PATTERN',
         }
       },
       appsec: {
@@ -771,8 +775,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.maxContextOperations', 2)
     expect(config).to.have.nested.property('iast.deduplicationEnabled', true)
     expect(config).to.have.nested.property('iast.redactionEnabled', true)
-    expect(config).to.have.nested.property('iast.redactionNamePattern', null)
-    expect(config).to.have.nested.property('iast.redactionValuePattern', null)
+    expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
+    expect(config).to.have.nested.property('iast.redactionValuePattern', 'REDACTION_VALUE_PATTERN')
   })
 
   it('should give priority to non-experimental options', () => {


### PR DESCRIPTION
### What does this PR do?
Provides a way for customer to set custom IAST redaction pattern to identify sensitive name/values .

### Motivation
Align the feature with all IAST tracers.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions].
- [x] TypeScript [tests].
