### PR TITLE
Fix release scripts

### DIFF
--- a/.github/workflows/release-3.yml
+++ b/.github/workflows/release-3.yml
@@ -15,6 +15,7 @@ jobs:
     environment: npm
     permissions:
       id-token: write
+      contents: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -15,6 +15,7 @@ jobs:
     environment: npm
     permissions:
       id-token: write
+      contents: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     outputs:


### PR DESCRIPTION
### What does this PR do?
Inspired by https://github.com/DataDog/dd-trace-js/pull/3697

Add `permissions: contents` for pushing a tag.

It seems it's required for pushing tags (though docs are not very clear): https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview



### Motivation
`git tag` is currently failing in release scripts: https://github.com/DataDog/dd-trace-js/actions/runs/6546633135/job/17777473091

