### PR TITLE
Check only query and body parameters in nosql injections

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -48,6 +48,14 @@ describe('nosql injection detection in mongodb - whole feature', () => {
       })
 
       prepareTestServerForIastInExpress('Test without sanitization middlewares', expressVersion,
+        (expressApp) => {
+          expressApp.get('/path/:parameter', async function (req, res) {
+            await collection.find({
+              key: req.params.parameter
+            })
+            res.end()
+          })
+        },
         (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
           testThatRequestHasVulnerability({
             fn: async (req, res) => {
@@ -70,6 +78,15 @@ describe('nosql injection detection in mongodb - whole feature', () => {
               })
 
               expect(someRedacted).to.be.true
+            }
+          })
+
+          testThatRequestHasNoVulnerability({
+            testDescription: 'should not have NOSQL_MONGODB_INJECTION vulnerability with path params',
+            fn: function noop () {},
+            vulnerability: 'NOSQL_MONGODB_INJECTION',
+            makeRequest: (done, config) => {
+              axios.get(`http://localhost:${config.port}/path/parameterValue`).catch(done)
             }
           })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In NoSQL injections vulnerability detections, check only tainted strings that comes from request parameter or body. Ignore path-params, headers, etc.

### Motivation
<!-- What inspired you to submit this pull request? -->
NoSQL injections can happen in query strings and body, when a malicious user can try to change the mongodb query syntax.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
