### PR TITLE
PROF-8457 Emit thread names in wall profiles

### DIFF
--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -117,14 +117,17 @@ describe('profiler', () => {
     const spanKey = strings.dedup('span id')
     const rootSpanKey = strings.dedup('local root span id')
     const endpointKey = strings.dedup('trace endpoint')
+    const threadNameKey = strings.dedup('thread name')
+    const threadNameValue = strings.dedup('Main Event Loop')
     for (const sample of prof.sample) {
-      let ts, spanId, rootSpanId, endpoint
+      let ts, spanId, rootSpanId, endpoint, threadName
       for (const label of sample.label) {
         switch (label.key) {
           case tsKey: ts = label.num; break
           case spanKey: spanId = label.str; break
           case rootSpanKey: rootSpanId = label.str; break
           case endpointKey: endpoint = label.str; break
+          case threadNameKey: threadName = label.str; break
           default: assert.fail(`Unexpected label key ${strings.dedup(label.key)}`)
         }
       }
@@ -132,6 +135,8 @@ describe('profiler', () => {
       assert.isDefined(ts)
       assert.isTrue(ts <= procEnd)
       assert.isTrue(ts >= procStart)
+      // Thread name must be defined and exactly equal "Main Event Loop"
+      assert.equal(threadName, threadNameValue)
       // Either all or none of span-related labels are defined
       if (spanId || rootSpanId || endpoint) {
         assert.isDefined(spanId)

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -12,7 +12,7 @@ const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
 const profilerTelemetryMetrics = telemetryMetrics.manager.namespace('profilers')
 
-const threadName = (function() {
+const threadName = (function () {
   const { isMainThread, threadId } = require('node:worker_threads')
   const name = isMainThread ? 'Main' : `Worker #${threadId}`
   return `${name} Event Loop`

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -12,6 +12,12 @@ const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
 const profilerTelemetryMetrics = telemetryMetrics.manager.namespace('profilers')
 
+const threadName = (function() {
+  const { isMainThread, threadId } = require('node:worker_threads')
+  const name = isMainThread ? 'Main' : `Worker #${threadId}`
+  return `${name} Event Loop`
+})()
+
 let kSampleCount
 
 function getActiveSpan () {
@@ -24,7 +30,7 @@ function getStartedSpans (context) {
 }
 
 function generateLabels ({ context: { spanId, rootSpanId, webTags, endpoint }, timestamp }) {
-  const labels = {}
+  const labels = { 'thread name': threadName }
   if (spanId) {
     labels['span id'] = spanId
   }


### PR DESCRIPTION
 ### What does this PR do?
Adds a `thread name` label to wall samples. It is either `Main Event Loop` for the main thread, or `Worker #${threadId}` for workers.

### Motivation
It will provide more precise information when wall profiles are visualized on a timeline.