### PR TITLE
Update pprof-nodejs to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@datadog/native-iast-rewriter": "2.1.3",
     "@datadog/native-iast-taint-tracking": "1.6.1",
     "@datadog/native-metrics": "^2.0.0",
-    "@datadog/pprof": "4.0.0",
+    "@datadog/pprof": "4.0.1",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,10 +415,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-3.2.0.tgz#ab822caf18999a84f144dd4e0261d6e9274f4c5f"
-  integrity sha512-kOhWHCWB80djnMCr5KNKBAy1Ih/jK/PIj6yqnZwL1Wqni/h6IBPRUMhtIxcYJMRgsZVYrFXUV20AVXTZCzFokw==
+"@datadog/pprof@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-4.0.1.tgz#f8629ecb62646d90ed49b6252dd0583d8d5001d3"
+  integrity sha512-TavqyiyQZOaUM9eQB07r8+K/T1CqKyOdsUGxpN79+BF+eOQBpTj/Cte6KdlhcUSKL3h5hSjC+vlgA7uW2qtVhA==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
Update pprof-nodejs to 4.0.1

### Motivation
4.0.1 adds support for node 21

