### PR TITLE
[ci-visibility] Instrument suite parsing errors as failed suites

### DIFF
--- a/integration-tests/ci-visibility/test-parsing-error/parsing-error-2.js
+++ b/integration-tests/ci-visibility/test-parsing-error/parsing-error-2.js
@@ -1,0 +1,7 @@
+const { expect } = require('chao')
+
+describe('test-parsing-error-2', () => {
+  it('can report tests', () => {
+    expect(1 + 2).to.equal(3)
+  })
+})

--- a/integration-tests/ci-visibility/test-parsing-error/parsing-error.js
+++ b/integration-tests/ci-visibility/test-parsing-error/parsing-error.js
@@ -1,0 +1,7 @@
+const { expect } = require('chao')
+
+describe('test-parsing-error', () => {
+  it('can report tests', () => {
+    expect(1 + 2).to.equal(3)
+  })
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -363,23 +363,23 @@ function jestAdapterWrapper (jestAdapter, jestVersion) {
           status = 'fail'
         }
 
-        const coverageFiles = getCoveredFilenamesFromCoverage(environment.global.__coverage__)
-          .map(filename => getTestSuitePath(filename, environment.rootDir))
-
         /**
          * Child processes do not each request ITR configuration, so the jest's parent process
          * needs to pass them the configuration. This is done via _ddTestCodeCoverageEnabled, which
          * controls whether coverage is reported.
-         */
-        if (coverageFiles &&
-          environment.testEnvironmentOptions &&
-          environment.testEnvironmentOptions._ddTestCodeCoverageEnabled) {
+        */
+        if (environment.testEnvironmentOptions?._ddTestCodeCoverageEnabled) {
+          const coverageFiles = getCoveredFilenamesFromCoverage(environment.global.__coverage__)
+            .map(filename => getTestSuitePath(filename, environment.rootDir))
           asyncResource.runInAsyncScope(() => {
             testSuiteCodeCoverageCh.publish([...coverageFiles, environment.testSuite])
           })
         }
         testSuiteFinishCh.publish({ status, errorMessage })
         return suiteResults
+      }).catch(error => {
+        testSuiteFinishCh.publish({ status: 'fail', error })
+        throw error
       })
     })
   })

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -150,9 +150,11 @@ class JestPlugin extends CiPlugin {
       })
     })
 
-    this.addSub('ci:jest:test-suite:finish', ({ status, errorMessage }) => {
+    this.addSub('ci:jest:test-suite:finish', ({ status, errorMessage, error }) => {
       this.testSuiteSpan.setTag(TEST_STATUS, status)
-      if (errorMessage) {
+      if (error) {
+        this.testSuiteSpan.setTag('error', error)
+      } else if (errorMessage) {
         this.testSuiteSpan.setTag('error', new Error(errorMessage))
       }
       this.testSuiteSpan.finish()


### PR DESCRIPTION
### What does this PR do?
* `catch` jest `adapter` call to make sure we catch errors in the test file parsing phase. 
* Add tests.

### Motivation
If a test file (suite) in jest included parsing error, like importing a non existing dependency, we wouldn't catch this as a suite error. This PR fixes this. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
