### PR TITLE
fix error in http plugin when it was enabled after request start

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -76,6 +76,7 @@ class HttpClientPlugin extends ClientPlugin {
   }
 
   finish ({ req, res, span }) {
+    if (!span) return
     if (res) {
       const status = res.status || res.statusCode
 
@@ -98,6 +99,7 @@ class HttpClientPlugin extends ClientPlugin {
   }
 
   error ({ span, error }) {
+    if (!span) return
     if (error) {
       span.addTags({
         [ERROR_TYPE]: error.name,

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -964,6 +964,50 @@ describe('Plugin', () => {
         }
       })
 
+      describe('with late plugin initialization and an external subscriber', () => {
+        let ch
+        let sub
+
+        beforeEach(() => {
+          return agent.load('http', { server: false })
+            .then(() => {
+              ch = require('../../diagnostics_channel').channel('apm:http:client:request:start')
+              sub = () => {}
+              tracer = require('../../dd-trace')
+              http = require(protocol)
+            })
+        })
+
+        afterEach(() => {
+          ch.unsubscribe(sub)
+        })
+
+        it('should not crash', done => {
+          const app = (req, res) => {
+            res.end()
+          }
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              ch.subscribe(sub)
+
+              tracer.use('http', false)
+
+              const req = http.request(`${protocol}://localhost:${port}`, res => {
+                res.on('error', done)
+                res.on('data', () => {})
+                res.on('end', () => done())
+              })
+              req.on('error', done)
+
+              tracer.use('http', true)
+
+              req.end()
+            })
+          })
+        })
+      })
+
       describe('with service configuration', () => {
         let config
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix error in `http` plugin when it was enabled after request start.

### Motivation
<!-- What inspired you to submit this pull request? -->

Same issue as #3714 but for `http`.

Fixes #3652