### PR TITLE
[ci-visibility] Add custom tags capability to playwright tests

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests/landing-page-test.js
+++ b/integration-tests/ci-visibility/playwright-tests/landing-page-test.js
@@ -20,4 +20,12 @@ test.describe('playwright', () => {
       'Hello Warld'
     ])
   })
+  test('should work with annotated tests', async ({ page }) => {
+    test.info().annotations.push({ type: 'DD_TAGS[test.memory.usage]', description: 'low' })
+    // this is malformed and should be ignored
+    test.info().annotations.push({ type: 'DD_TAGS[test.invalid', description: 'high' })
+    await expect(page.locator('.hello-world')).toHaveText([
+      'Hello World'
+    ])
+  })
 })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -86,6 +86,7 @@ versions.forEach((version) => {
               'landing-page-test.js.should work with passing tests',
               'landing-page-test.js.should work with skipped tests',
               'landing-page-test.js.should work with fixme',
+              'landing-page-test.js.should work with annotated tests',
               'todo-list-page-test.js.should work with failing tests',
               'todo-list-page-test.js.should work with fixme root'
             ])
@@ -104,6 +105,12 @@ versions.forEach((version) => {
               assert.equal(stepEvent.content.name, 'playwright.step')
               assert.property(stepEvent.content.meta, 'playwright.step')
             })
+            const annotatedTest = testEvents.find(test =>
+              test.content.resource === 'landing-page-test.js.should work with annotated tests'
+            )
+
+            assert.propertyVal(annotatedTest.content.meta, 'test.memory.usage', 'low')
+            assert.notProperty(annotatedTest.content.meta, 'test.invalid')
           }).then(() => done()).catch(done)
 
           childProcess = exec(

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -72,7 +72,7 @@ class PlaywrightPlugin extends CiPlugin {
 
       this.enter(span, store)
     })
-    this.addSub('ci:playwright:test:finish', ({ testStatus, steps, error }) => {
+    this.addSub('ci:playwright:test:finish', ({ testStatus, steps, error, extraTags }) => {
       const store = storage.getStore()
       const span = store && store.span
       if (!span) return
@@ -81,6 +81,9 @@ class PlaywrightPlugin extends CiPlugin {
 
       if (error) {
         span.setTag('error', error)
+      }
+      if (extraTags) {
+        span.addTags(extraTags)
       }
 
       steps.forEach(step => {

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -13,7 +13,8 @@ const {
   getCoveredFilenamesFromCoverage,
   mergeCoverage,
   resetCoverage,
-  removeInvalidMetadata
+  removeInvalidMetadata,
+  parseAnnotations
 } = require('../../../src/plugins/util/test')
 
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA, CI_PIPELINE_URL } = require('../../../src/plugins/util/tags')
@@ -216,5 +217,34 @@ describe('metadata validation', () => {
     validMetadatas.forEach((validMetadata) => {
       expect(JSON.stringify(removeInvalidMetadata(validMetadata))).to.be.equal(JSON.stringify(validMetadata))
     })
+  })
+})
+
+describe('parseAnnotations', () => {
+  it('parses correctly shaped annotations', () => {
+    const tags = parseAnnotations([
+      {
+        type: 'DD_TAGS[test.requirement]',
+        description: 'high'
+      },
+      {
+        type: 'DD_TAGS[test.responsible_team]',
+        description: 'sales'
+      }
+    ])
+    expect(tags).to.eql({
+      'test.requirement': 'high',
+      'test.responsible_team': 'sales'
+    })
+  })
+  it('does not crash with invalid arguments', () => {
+    const tags = parseAnnotations([
+      {},
+      'invalid',
+      { type: 'DD_TAGS', description: 'yeah' },
+      { type: 'DD_TAGS[v', description: 'invalid' },
+      { type: 'test.requirement', description: 'sure' }
+    ])
+    expect(tags).to.eql({})
   })
 })


### PR DESCRIPTION
### What does this PR do?
Add the capability of adding custom tags to playwright tests. The way to do it is by using the [custom annotations API from playwright](https://playwright.dev/docs/test-annotations#custom-annotations): 
```javascript
test('user profile', async ({ page }) => {
  test.info().annotations.push({ type: 'DD_TAGS[test.memory.usage]', description: 'low' })
  // ...
});
```

The format of the annotation must be
```javascript
{ type: 'DD_TAGS[$TAG_NAME]', description: '$TAG_VALUE' }
```


### Motivation
Closes #2852

### Plugin Checklist

- [x] Unit tests.
