### PR TITLE
Remove user credentials from `DD_GIT_REPOSITORY_URL`

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -10,7 +10,7 @@ const coalesce = require('koalas')
 const tagger = require('./tagger')
 const { isTrue, isFalse } = require('./util')
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('./plugins/util/tags')
-const { getGitMetadataFromGitProperties } = require('./git_properties')
+const { getGitMetadataFromGitProperties, removeUserSensitiveInfo } = require('./git_properties')
 const { updateConfig } = require('./telemetry')
 const { getIsGCPFunction, getIsAzureFunctionConsumptionPlan } = require('./serverless')
 
@@ -638,9 +638,11 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.memcachedCommandEnabled = isTrue(DD_TRACE_MEMCACHED_COMMAND_ENABLED)
 
     if (this.gitMetadataEnabled) {
-      this.repositoryUrl = coalesce(
-        process.env.DD_GIT_REPOSITORY_URL,
-        this.tags[GIT_REPOSITORY_URL]
+      this.repositoryUrl = removeUserSensitiveInfo(
+        coalesce(
+          process.env.DD_GIT_REPOSITORY_URL,
+          this.tags[GIT_REPOSITORY_URL]
+        )
       )
       this.commitSHA = coalesce(
         process.env.DD_GIT_COMMIT_SHA,

--- a/packages/dd-trace/src/git_properties.js
+++ b/packages/dd-trace/src/git_properties.js
@@ -1,6 +1,20 @@
 const commitSHARegex = /git\.commit\.sha=([a-f\d]{40})/
 const repositoryUrlRegex = /git\.repository_url=([\w\d:@/.-]+)/
 
+function removeUserSensitiveInfo (repositoryUrl) {
+  try {
+    // repository URLs can contain username and password, so we want to filter those out
+    const parsedUrl = new URL(repositoryUrl)
+    if (parsedUrl.password) {
+      return `${parsedUrl.origin}${parsedUrl.pathname}`
+    }
+    return repositoryUrl
+  } catch (e) {
+    // if protocol isn't https, no password will be used
+    return repositoryUrl
+  }
+}
+
 function getGitMetadataFromGitProperties (gitPropertiesString) {
   if (!gitPropertiesString) {
     return {}
@@ -9,24 +23,11 @@ function getGitMetadataFromGitProperties (gitPropertiesString) {
   const repositoryUrlMatch = gitPropertiesString.match(repositoryUrlRegex)
 
   const repositoryUrl = repositoryUrlMatch ? repositoryUrlMatch[1] : undefined
-  let parsedUrl = repositoryUrl
-
-  if (repositoryUrl) {
-    try {
-      // repository URLs can contain username and password, so we want to filter those out
-      parsedUrl = new URL(repositoryUrl)
-      if (parsedUrl.password) {
-        parsedUrl = `${parsedUrl.origin}${parsedUrl.pathname}`
-      }
-    } catch (e) {
-      // if protocol isn't https, no password will be used
-    }
-  }
 
   return {
     commitSHA: commitSHAMatch ? commitSHAMatch[1] : undefined,
-    repositoryUrl: parsedUrl
+    repositoryUrl: removeUserSensitiveInfo(repositoryUrl)
   }
 }
 
-module.exports = { getGitMetadataFromGitProperties }
+module.exports = { getGitMetadataFromGitProperties, removeUserSensitiveInfo }

--- a/packages/dd-trace/src/git_properties.js
+++ b/packages/dd-trace/src/git_properties.js
@@ -5,7 +5,7 @@ function removeUserSensitiveInfo (repositoryUrl) {
   try {
     // repository URLs can contain username and password, so we want to filter those out
     const parsedUrl = new URL(repositoryUrl)
-    if (parsedUrl.password) {
+    if (parsedUrl.username || parsedUrl.password) {
       return `${parsedUrl.origin}${parsedUrl.pathname}`
     }
     return repositoryUrl

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1266,6 +1266,11 @@ describe('Config', () => {
       expect(config).to.have.property('commitSHA', DUMMY_COMMIT_SHA)
       expect(config).to.have.property('repositoryUrl', DUMMY_REPOSITORY_URL)
     })
+    it('reads DD_GIT_* env vars and filters out user data', () => {
+      process.env.DD_GIT_REPOSITORY_URL = 'https://user:password@github.com/DataDog/dd-trace-js.git'
+      const config = new Config({})
+      expect(config).to.have.property('repositoryUrl', 'https://github.com/DataDog/dd-trace-js.git')
+    })
     it('reads DD_TAGS env var', () => {
       process.env.DD_TAGS = `git.commit.sha:${DUMMY_COMMIT_SHA},git.repository_url:${DUMMY_REPOSITORY_URL}`
       process.env.DD_GIT_REPOSITORY_URL = DUMMY_REPOSITORY_URL


### PR DESCRIPTION
### What does this PR do?
Filter user credentials from `DD_GIT_REPOSITORY_URL`

### Motivation
If `DD_GIT_REPOSITORY_URL` includes user and password we don't want to send that to datadog.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
