### PR TITLE
Enable telemetry metrics by default

### DIFF
--- a/packages/dd-trace/src/appsec/iast/telemetry/index.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/index.js
@@ -5,17 +5,9 @@ const telemetryLogs = require('./log')
 const { Verbosity, getVerbosity } = require('./verbosity')
 const { initRequestNamespace, finalizeRequestNamespace, globalNamespace } = require('./namespaces')
 
-function isIastMetricsEnabled (metrics) {
-  // TODO: let DD_TELEMETRY_METRICS_ENABLED as undefined in config.js to avoid read here the env property
-  return process.env.DD_TELEMETRY_METRICS_ENABLED !== undefined ? metrics : true
-}
-
 class Telemetry {
   configure (config, verbosity) {
-    const telemetryAndMetricsEnabled = config &&
-      config.telemetry &&
-      config.telemetry.enabled &&
-      isIastMetricsEnabled(config.telemetry.metrics)
+    const telemetryAndMetricsEnabled = config?.telemetry?.enabled && config.telemetry.metrics
 
     this.verbosity = telemetryAndMetricsEnabled ? getVerbosity(verbosity) : Verbosity.OFF
     this.enabled = this.verbosity !== Verbosity.OFF

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -251,7 +251,7 @@ class Config {
     )
     const DD_TELEMETRY_METRICS_ENABLED = coalesce(
       process.env.DD_TELEMETRY_METRICS_ENABLED,
-      false
+      true
     )
     const DD_TRACE_AGENT_PROTOCOL_VERSION = coalesce(
       options.protocolVersion,

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
@@ -308,11 +308,8 @@ describe('IAST TaintTracking Operations', () => {
         [taintTrackingOperations.IAST_TRANSACTION_ID]: 'id'
       }
       iastTelemetry.configure({
-        telemetry: { enabled: true, metrics: true },
-        iast: {
-          telemetryVerbosity: 'INFORMATION'
-        }
-      })
+        telemetry: { enabled: true, metrics: true }
+      }, 'INFORMATION')
 
       const requestTaintedAdd = sinon.stub(REQUEST_TAINTED, 'add')
 

--- a/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
@@ -66,7 +66,7 @@ describe('Telemetry', () => {
         expect(telemetryLogs.start).to.be.calledOnce
       })
 
-      it('should NOT enable telemetry if verbosity is OFF', () => {
+      it('should not enable telemetry if verbosity is OFF', () => {
         const iastTelemetry = proxyquire('../../../../src/appsec/iast/telemetry', {
           './log': telemetryLogs,
           '../../../telemetry/metrics': telemetryMetrics
@@ -83,12 +83,8 @@ describe('Telemetry', () => {
         expect(telemetryLogs.start).to.be.calledOnce
       })
 
-      it('should enable telemetry if metrics not enabled but DD_TELEMETRY_METRICS_ENABLED is undefined', () => {
-        const origTelemetryMetricsEnabled = process.env.DD_TELEMETRY_METRICS_ENABLED
-
-        delete process.env.DD_TELEMETRY_METRICS_ENABLED
-
-        const telemetryConfig = { enabled: true, metrics: false }
+      it('should enable telemetry if telemetry.metrics is true', () => {
+        const telemetryConfig = { enabled: true, metrics: true }
         iastTelemetry.configure({
           telemetry: telemetryConfig
         })
@@ -97,15 +93,9 @@ describe('Telemetry', () => {
         expect(iastTelemetry.verbosity).to.be.equal(Verbosity.INFORMATION)
         expect(telemetryMetrics.manager.set).to.be.calledOnce
         expect(telemetryLogs.start).to.be.calledOnce
-
-        process.env.DD_TELEMETRY_METRICS_ENABLED = origTelemetryMetricsEnabled
       })
 
-      it('should not enable telemetry if metrics not enabled but DD_TELEMETRY_METRICS_ENABLED is defined', () => {
-        const origTelemetryMetricsEnabled = process.env.DD_TELEMETRY_METRICS_ENABLED
-
-        process.env.DD_TELEMETRY_METRICS_ENABLED = 'false'
-
+      it('should not enable telemetry if telemetry.metrics is false', () => {
         const telemetryConfig = { enabled: true, metrics: false }
         iastTelemetry.configure({
           telemetry: telemetryConfig
@@ -115,8 +105,6 @@ describe('Telemetry', () => {
         expect(iastTelemetry.verbosity).to.be.equal(Verbosity.OFF)
         expect(telemetryMetrics.manager.set).to.not.be.called
         expect(telemetryLogs.start).to.be.calledOnce
-
-        process.env.DD_TELEMETRY_METRICS_ENABLED = origTelemetryMetricsEnabled
       })
     })
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -935,7 +935,7 @@ describe('Config', () => {
     expect(config.telemetry.heartbeatInterval).to.eq(60000)
     expect(config.telemetry.logCollection).to.be.false
     expect(config.telemetry.debug).to.be.false
-    expect(config.telemetry.metrics).to.be.false
+    expect(config.telemetry.metrics).to.be.true
   })
 
   it('should set DD_TELEMETRY_HEARTBEAT_INTERVAL', () => {
@@ -960,13 +960,13 @@ describe('Config', () => {
     process.env.DD_TRACE_TELEMETRY_ENABLED = origTraceTelemetryValue
   })
 
-  it('should set DD_TELEMETRY_METRICS_ENABLED', () => {
+  it('should not set DD_TELEMETRY_METRICS_ENABLED', () => {
     const origTelemetryMetricsEnabledValue = process.env.DD_TELEMETRY_METRICS_ENABLED
-    process.env.DD_TELEMETRY_METRICS_ENABLED = 'true'
+    process.env.DD_TELEMETRY_METRICS_ENABLED = 'false'
 
     const config = new Config()
 
-    expect(config.telemetry.metrics).to.be.true
+    expect(config.telemetry.metrics).to.be.false
 
     process.env.DD_TELEMETRY_METRICS_ENABLED = origTelemetryMetricsEnabledValue
   })


### PR DESCRIPTION
### What does this PR do?
Sets `DD_TELEMETRY_METRICS_ENABLED` true by default to start sending IAST and appsec metrics automatically.

### Motivation
The [telemetry api docs](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/producing-telemetry.md#when-to-use-it-8) indicate that it is possible to set it true by default.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

