### PR TITLE
Fix Next.js Build Errors When `node:*` Modules Present

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -101,7 +101,7 @@ describe('Plugin', function () {
           cwd,
           env: {
             ...process.env,
-            version
+            VERSION: realVersion
           },
           stdio: ['pipe', 'ignore', 'pipe']
         })

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -1,6 +1,46 @@
-module.exports = {
+// Build config dynamically for ease in testing and modification
+
+const { satisfies } = require('semver')
+
+const { VERSION } = process.env // Next.js version to dynamically modify parts
+
+const config = {
   eslint: {
     ignoreDuringBuilds: true
   },
-  output: 'standalone'
+  experimental: {}
 }
+
+// In older versions of Next.js (11.0.1 and before), the webpack config doesn't support 'node' prefixes by default
+// So, any "node" prefixes are replaced for these older versions by this webpack plugin
+// Additionally, webpack was having problems with our use of 'worker_threads', so we don't resolve it
+if (satisfies(VERSION, '<11.1.0')) {
+  config.webpack = (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(/^node:/, resource => {
+        resource.request = resource.request.replace(/^node:/, '')
+      })
+    )
+
+    config.resolve.preferRelative = true
+
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      worker_threads: false
+    }
+
+    return config
+  }
+}
+
+// standalone only enabled in versions it is present
+if (satisfies(VERSION, '>=12.0.0')) {
+  config.output = 'standalone'
+}
+
+// appDir needs to be enabled as experimental
+if (satisfies(VERSION, '>=13.3.0 <13.4.0')) {
+  config.experimental.appDir = true
+}
+
+module.exports = config


### PR DESCRIPTION
### What does this PR do?
Fixes webpack-related build issues for the older versions of Next.js that we test. It accomplishes this by also refactoring the file itself to dynamically build up the config file based on the version of Next.js that we're building in order to reduce possible errors and warnings.

This error occurred in the first place because of our current use of `require(node:worker_threads)` in part of the profiler code not being liked by the the webpack instance used by Next in older versions (`11.0.1` and earlier). This only happened because we require the tracer in some pages files that ended up client-side.

### Motivation
Fix CI for Next.js. Additionally, ease in testing new features that need to be specified in `next.config.js`, but only for certain versions.

### Additional Notes
Important to note that versions after `11.0.1` that use our tracer, whether it be on server-side code or client-side builds, do not have this issue. Any workarounds for users using our tracer & `next@11.0.1` or earlier can follow the workaround this PR uses.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

