### PR TITLE
Handle headers with array values [APPSEC-11971]

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/hsts-header-missing-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/hsts-header-missing-analyzer.js
@@ -10,8 +10,11 @@ class HstsHeaderMissingAnalyzer extends MissingHeaderAnalyzer {
     super(HSTS_HEADER_MISSING, HSTS_HEADER_NAME)
   }
   _isVulnerableFromRequestAndResponse (req, res) {
-    const headerToCheck = res.getHeader(HSTS_HEADER_NAME)
-    return !this._isHeaderValid(headerToCheck) && this._isHttpsProtocol(req)
+    const headerValues = this._getHeaderValues(res, HSTS_HEADER_NAME)
+    return this._isHttpsProtocol(req) && (
+      headerValues.length === 0 ||
+      headerValues.some(headerValue => !this._isHeaderValid(headerValue))
+    )
   }
 
   _isHeaderValid (headerValue) {

--- a/packages/dd-trace/src/appsec/iast/analyzers/missing-header-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/missing-header-analyzer.js
@@ -50,7 +50,14 @@ class MissingHeaderAnalyzer extends Analyzer {
   }
 
   _getEvidence ({ res }) {
-    return { value: res.getHeader(this.headerName) }
+    const headerValues = this._getHeaderValues(res, this.headerName)
+    let value
+    if (headerValues.length === 1) {
+      value = headerValues[0]
+    } else if (headerValues.length > 0) {
+      value = JSON.stringify(headerValues)
+    }
+    return { value }
   }
 
   _isVulnerable ({ req, res }, context) {

--- a/packages/dd-trace/src/appsec/iast/analyzers/missing-header-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/missing-header-analyzer.js
@@ -28,6 +28,15 @@ class MissingHeaderAnalyzer extends Analyzer {
     }, (data) => this.analyze(data))
   }
 
+  _getHeaderValues (res, headerName) {
+    const headerValue = res.getHeader(headerName)
+    if (Array.isArray(headerValue)) {
+      return headerValue
+    } else {
+      return headerValue ? [headerValue.toString()] : []
+    }
+  }
+
   _getLocation () {
     return undefined
   }
@@ -56,9 +65,11 @@ class MissingHeaderAnalyzer extends Analyzer {
   }
 
   _isResponseHtml (res) {
-    const contentType = res.getHeader('content-type')
-    return contentType && HTML_CONTENT_TYPES.some(htmlContentType => {
-      return htmlContentType === contentType || contentType.startsWith(htmlContentType + ';')
+    const contentTypes = this._getHeaderValues(res, 'content-type')
+    return contentTypes.some(contentType => {
+      return contentType && HTML_CONTENT_TYPES.some(htmlContentType => {
+        return htmlContentType === contentType || contentType.startsWith(htmlContentType + ';')
+      })
     })
   }
 }

--- a/packages/dd-trace/src/appsec/iast/analyzers/xcontenttype-header-missing-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/xcontenttype-header-missing-analyzer.js
@@ -11,8 +11,8 @@ class XcontenttypeHeaderMissingAnalyzer extends MissingHeaderAnalyzer {
   }
 
   _isVulnerableFromRequestAndResponse (req, res) {
-    const headerToCheck = res.getHeader(XCONTENTTYPEOPTIONS_HEADER_NAME)
-    return !headerToCheck || headerToCheck.trim().toLowerCase() !== 'nosniff'
+    const headerValues = this._getHeaderValues(res, XCONTENTTYPEOPTIONS_HEADER_NAME)
+    return headerValues.length === 0 || headerValues.some(headerValue => headerValue.trim().toLowerCase() !== 'nosniff')
   }
 }
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
@@ -81,6 +81,24 @@ describe('hsts header missing analyzer', () => {
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
       }, makeRequestWithXFordwardedProtoHeader)
 
+      testThatRequestHasVulnerability((req, res) => {
+        res.setHeader('content-type', ['text/html'])
+        res.setHeader('Strict-Transport-Security', [])
+        res.end('<html><body><h1>Test</h1></body></html>')
+      }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
+        expect(vulnerabilities[0].evidence.value).to.be.deep.equal([])
+        expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
+      }, makeRequestWithXFordwardedProtoHeader)
+
+      testThatRequestHasVulnerability((req, res) => {
+        res.setHeader('content-type', ['text/html'])
+        res.setHeader('Strict-Transport-Security', ['invalid1', 'invalid2'])
+        res.end('<html><body><h1>Test</h1></body></html>')
+      }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
+        expect(vulnerabilities[0].evidence.value).to.be.deep.equal(['invalid1', 'invalid2'])
+        expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
+      }, makeRequestWithXFordwardedProtoHeader)
+
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('content-type', 'application/json')
         res.end('{"key": "test}')

--- a/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
@@ -83,6 +83,15 @@ describe('hsts header missing analyzer', () => {
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', ['text/html'])
+        res.setHeader('Strict-Transport-Security', [])
+        res.end('<html><body><h1>Test</h1></body></html>')
+      }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
+        expect(vulnerabilities[0].evidence).to.be.undefined
+        expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
+      }, makeRequestWithXFordwardedProtoHeader)
+
+      testThatRequestHasVulnerability((req, res) => {
+        res.setHeader('content-type', ['text/html'])
         res.setHeader('Strict-Transport-Security', ['invalid1', 'invalid2'])
         res.end('<html><body><h1>Test</h1></body></html>')
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {

--- a/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
@@ -72,8 +72,22 @@ describe('hsts header missing analyzer', () => {
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
       }, makeRequestWithXFordwardedProtoHeader)
 
+      testThatRequestHasVulnerability((req, res) => {
+        res.setHeader('content-type', ['text/html'])
+        res.setHeader('Strict-Transport-Security', 'invalid')
+        res.end('<html><body><h1>Test</h1></body></html>')
+      }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
+        expect(vulnerabilities[0].evidence.value).to.be.equal('invalid')
+        expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
+      }, makeRequestWithXFordwardedProtoHeader)
+
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('content-type', 'application/json')
+        res.end('{"key": "test}')
+      }, HSTS_HEADER_MISSING, makeRequestWithXFordwardedProtoHeader)
+
+      testThatRequestHasNoVulnerability((req, res) => {
+        res.setHeader('content-type', ['application/json'])
         res.end('{"key": "test}')
       }, HSTS_HEADER_MISSING, makeRequestWithXFordwardedProtoHeader)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
@@ -83,19 +83,10 @@ describe('hsts header missing analyzer', () => {
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', ['text/html'])
-        res.setHeader('Strict-Transport-Security', [])
-        res.end('<html><body><h1>Test</h1></body></html>')
-      }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
-        expect(vulnerabilities[0].evidence.value).to.be.deep.equal([])
-        expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
-
-      testThatRequestHasVulnerability((req, res) => {
-        res.setHeader('content-type', ['text/html'])
         res.setHeader('Strict-Transport-Security', ['invalid1', 'invalid2'])
         res.end('<html><body><h1>Test</h1></body></html>')
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
-        expect(vulnerabilities[0].evidence.value).to.be.deep.equal(['invalid1', 'invalid2'])
+        expect(vulnerabilities[0].evidence.value).to.be.equal(JSON.stringify(['invalid1', 'invalid2']))
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
       }, makeRequestWithXFordwardedProtoHeader)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/xcontenttype-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/xcontenttype-header-missing-analyzer.spec.js
@@ -45,6 +45,15 @@ describe('xcontenttype header missing analyzer', () => {
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('XCONTENTTYPE_HEADER_MISSING:mocha'))
       })
 
+      testThatRequestHasVulnerability((req, res) => {
+        res.setHeader('content-type', ['text/html'])
+        res.setHeader('X-Content-Type-Options', 'whatever')
+        res.end('<html><body><h1>Test</h1></body></html>')
+      }, XCONTENTTYPE_HEADER_MISSING, 1, function (vulnerabilities) {
+        expect(vulnerabilities[0].evidence.value).to.be.equal('whatever')
+        expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('XCONTENTTYPE_HEADER_MISSING:mocha'))
+      })
+
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('content-type', 'application/json')
         res.end('{"key": "test}')
@@ -52,6 +61,12 @@ describe('xcontenttype header missing analyzer', () => {
 
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('content-type', 'text/html')
+        res.setHeader('X-Content-Type-Options', 'nosniff')
+        res.end('{"key": "test}')
+      }, XCONTENTTYPE_HEADER_MISSING)
+
+      testThatRequestHasNoVulnerability((req, res) => {
+        res.setHeader('content-type', ['text/html'])
         res.setHeader('X-Content-Type-Options', 'nosniff')
         res.end('{"key": "test}')
       }, XCONTENTTYPE_HEADER_MISSING)


### PR DESCRIPTION
### What does this PR do?
Fixes a problem in `MissingHeaderAnalyzer`s like `Strict-Transport-Security` or `X-Content-Type-Options` headers analyzers when the header contains an array value.

### Motivation


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

