### PR TITLE
PROF-8545: Restore eager release of tags, adapt endpoint profiling code

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -12,6 +12,7 @@ const runtimeMetrics = require('../runtime_metrics')
 const log = require('../log')
 const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../telemetry/metrics')
+const { channel } = require('../../../diagnostics_channel')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
 
@@ -29,6 +30,8 @@ const integrationCounters = {
   span_created: {},
   span_finished: {}
 }
+
+const finishCh = channel('dd-trace:span:finish')
 
 function getIntegrationCounter (event, integration) {
   const counters = integrationCounters[event]
@@ -176,6 +179,7 @@ class DatadogSpan {
     this._duration = finishTime - this._startTime
     this._spanContext._trace.finished.push(this)
     this._spanContext._isFinished = true
+    finishCh.publish(this)
     this._processor.process(this)
   }
 

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -138,6 +138,10 @@ class SpanProcessor {
       }
     }
 
+    for (const span of trace.finished) {
+      span.context()._tags = {}
+    }
+
     trace.started = active
     trace.finished = []
   }


### PR DESCRIPTION
### What does this PR do?
Restores eager cleaning of tags for finished and exported spans. Since this also affects the way wall profiler can compute endpoints, that code needs to be adapted as well.

### Motivation
Reports of too high memory pressure since we removed eager cleaning of tags.

### Additional Notes
The implementation ended up being quite involved. Without eager clearing of tags, we could simply defer the lookup of the "web span" (the span with endpoint information; either the active span or one of its parents) to the `_updateContext` method, which'd only run once every 10ms when we detected that the profiler took a sample.
* With eager clearing of the tags, we have to bring this mechanism back to `_enter`, wall profiler's `enter` async hook, which runs much more often.
* In order to (hopefully) reduce the performance impact of that, we perform this lookup once per span (presuming one span gets activated multiple times), and cache the lookup result in the span's context object with a private symbol.
* Additionally, we'll register every sample context (of which there's about 6000 at the end of a 60 second profiling interval) interested in receiving endpoint information with its relevant web span context under another private symbol. We only do that if we couldn't eagerly compute the endpoint in `_updateContext()` and had to defer it. Then when the web span ends but before its tags are cleared, we'll compute the endpoint and set it in all registered sample contexts, at the same time releasing sample contexts' reference to span's tags. This is an optimization so that those ~3000 sample contexts don't hold on to some spans' tags for ~30 seconds, 'cause the same logic does run in `generateLabels()` as well every 60 seconds.

The resulting code is more complex than I'd like it to be, but it's unfortunately necessary to cover all edge cases while still trying to move as much processing as possible out of `_enter()` method for performance reasons. It's the usual tradeoff between simplicity and performance, really. See #3759 for a much simplified take that eschews performance optimizations and only does minimal changes to ensure correctness.

The code could get significantly simpler if we didn't want to minimize the performance overhead in `_enter` and/or we didn't strive to release references to objects we don't need ASAP. We generally strive to move processing (and thus flow data) from `_enter` (frequently invoked) to `_updateContext` (invoked 1x every ~10ms after a sample is taken to update the context object for the sample) and `generateLabels` (callback invoked by the profiler ~6000x times in a loop, but all at once every 60s when we serialize the current profile.) In this scheme of things `_spanFinished` is merely an optimization to compute the endpoint if it couldn't be done in `_updateContext` but can be done if span finishes before `generateLabels` is invoked, so we don't hold on to finished span's tags for longer than necessary.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.