### PR TITLE
PROF-8551: Call the right method to unsubscribe from a channel

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -223,7 +223,7 @@ class NativeWallProfiler {
     const profile = this._stop(false)
     if (this._codeHotspotsEnabled) {
       beforeCh.unsubscribe(this._enter)
-      enterCh.subscribe(this._enter)
+      enterCh.unsubscribe(this._enter)
       this._profilerState = undefined
     }
 


### PR DESCRIPTION
### What does this PR do?
Fixes a method call on profiler stop to unsubscribe from a diagnostic channel.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
