### PR TITLE
Fix ci for mongoose in node 14

### DIFF
--- a/packages/datadog-instrumentations/test/mongoose.spec.js
+++ b/packages/datadog-instrumentations/test/mongoose.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const { channel } = require('../src/helpers/instrument')
 const semver = require('semver')
+const { NODE_MAJOR } = require('../../../version')
 
 const startCh = channel('datadog:mongoose:model:filter:start')
 const finishCh = channel('datadog:mongoose:model:filter:finish')
@@ -14,6 +15,9 @@ describe('mongoose instrumentations', () => {
   iterationRanges.forEach(range => {
     describe(range, () => {
       withVersions('mongoose', ['mongoose'], range, (version) => {
+        const specificVersion = require(`../../../versions/mongoose@${version}`).version()
+        if (NODE_MAJOR === 14 && semver.satisfies(specificVersion, '>=8')) return
+
         let Test, dbName, id, mongoose
 
         function connect () {

--- a/packages/datadog-instrumentations/test/mongoose.spec.js
+++ b/packages/datadog-instrumentations/test/mongoose.spec.js
@@ -133,15 +133,17 @@ describe('mongoose instrumentations', () => {
               })
             }
 
-            it('continue working as expected with promise', (done) => {
-              Test.count({ type: 'test' }).then((res) => {
-                expect(res).to.be.equal(3)
+            if (!semver.satisfies(specificVersion, '>=8')) {
+              // Model.count method removed from mongoose 8.0.0
+              it('continue working as expected with promise', (done) => {
+                Test.count({ type: 'test' }).then((res) => {
+                  expect(res).to.be.equal(3)
 
-                done()
+                  done()
+                })
               })
-            })
-
-            testCallbacksCalled('count', [{ type: 'test' }])
+              testCallbacksCalled('count', [{ type: 'test' }])
+            }
           })
 
           if (semver.intersects(version, '>=6')) {
@@ -168,8 +170,8 @@ describe('mongoose instrumentations', () => {
               testCallbacksCalled('countDocuments', [{ type: 'test' }])
             })
           }
-
-          if (semver.intersects(version, '>=5')) {
+          if (semver.intersects(version, '>=5') && semver.satisfies(specificVersion, '<8')) {
+            // Model.count method removed from mongoose 8.0.0
             describe('deleteOne', () => {
               if (range !== '>=7') {
                 it('continue working as expected with cb', (done) => {
@@ -247,7 +249,7 @@ describe('mongoose instrumentations', () => {
             testCallbacksCalled('findOne', [{ type: 'test' }])
           })
 
-          if (semver.intersects(version, '>=6')) {
+          if (semver.intersects(version, '>=6') && semver.satisfies(specificVersion, '<8')) {
             describe('findOneAndDelete', () => {
               if (range !== '>=7') {
                 it('continue working as expected with cb', (done) => {

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -2,6 +2,7 @@
 
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
+const { NODE_MAJOR } = require('../../../version')
 
 describe('Plugin', () => {
   let id
@@ -10,6 +11,9 @@ describe('Plugin', () => {
 
   describe('mongoose', () => {
     withVersions('mongoose', ['mongoose'], (version) => {
+      const specificVersion = require(`../../../versions/mongoose@${version}`).version()
+      if (NODE_MAJOR === 14 && semver.satisfies(specificVersion, '>=8')) return
+
       let mongoose
 
       // This needs to be called synchronously right before each test to make

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -8,6 +8,7 @@ const {
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
 const { NODE_MAJOR } = require('../../../../version')
+const semver = require('semver')
 
 // newer packages are not supported on older node versions
 const range = NODE_MAJOR < 16 ? '<5' : '>=4'
@@ -18,6 +19,9 @@ describe('esm', () => {
   let sandbox
 
   withVersions('mongoose', ['mongoose'], range, version => {
+    const specificVersion = require(`../../../../versions/mongoose@${version}`).version()
+    if (NODE_MAJOR === 14 && semver.satisfies(specificVersion, '>=8')) return
+
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`'mongoose@${version}'`], false, [

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -110,7 +110,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
             }
           })
 
-          if (semver.satisfies(mongooseVersion, '>=6')) {
+          if (semver.satisfies(specificMongooseVersion, '>=6')) {
             testThatRequestHasNoVulnerability({
               testDescription: 'should not have NOSQL_MONGODB_INJECTION vulnerability with mongoose.sanitizeFilter',
               fn: async (req, res) => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -7,10 +7,14 @@ const semver = require('semver')
 const os = require('os')
 const path = require('path')
 const fs = require('fs')
+const { NODE_MAJOR } = require('../../../../../../version')
 
 describe('nosql injection detection in mongodb - whole feature', () => {
   withVersions('express', 'express', '>4.18.0', expressVersion => {
     withVersions('mongoose', 'mongoose', '>4.0.0', mongooseVersion => {
+      const specificMongooseVersion = require(`../../../../../../versions/mongoose@${mongooseVersion}`).version()
+      if (NODE_MAJOR === 14 && semver.satisfies(specificMongooseVersion, '>=8')) return
+
       const vulnerableMethodFilename = 'mongoose-vulnerable-method.js'
       let mongoose, Test, tmpFilePath
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Skip test suite in node 14 for mongoose 8.0.0 
- skip `Model.count` method tests from last mongoose in all node versions.

### Motivation
<!-- What inspired you to submit this pull request? -->
- mongoose 8 uses bson library version which uses `??=`, it is not supported in node 14.
- mongoose 8 removed the deprecated method Model.count 

CI execution in v3.x branch: PR (to delete): https://github.com/DataDog/dd-trace-js/pull/3757

plugin: https://github.com/DataDog/dd-trace-js/actions/runs/6729875788/job/18291540975?pr=3757
appsec: https://github.com/DataDog/dd-trace-js/actions/runs/6729875798/job/18291534934?pr=3757

