### PR TITLE
PROF-8545: (Simplified) Restore eager release of tags, adapt endpoint profiling code

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -234,6 +234,9 @@ class NativeWallProfiler {
       beforeCh.unsubscribe(this._enter)
       enterCh.unsubscribe(this._enter)
       this._profilerState = undefined
+      this._lastSpan = undefined
+      this._lastStartedSpans = undefined
+      this._webTags = undefined
     }
 
     this._started = false

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -120,7 +120,7 @@ class NativeWallProfiler {
       this._pprof.time.setContext(this._currentContext)
       this._lastSpan = undefined
       this._lastStartedSpans = undefined
-      this._webTags = undefined
+      this._lastWebTags = undefined
       this._lastSampleCount = 0
 
       beforeCh.subscribe(this._enter)
@@ -156,19 +156,19 @@ class NativeWallProfiler {
         for (let i = startedSpans.length - 1; i >= 0; i--) {
           const tags = getSpanContextTags(startedSpans[i])
           if (isWebServerSpan(tags)) {
-            this._webTags = tags
+            this._lastWebTags = tags
             found = true
             break
           }
         }
         if (!found) {
-          this._webTags = undefined
+          this._lastWebTags = undefined
         }
       }
     } else {
       this._lastStartedSpans = undefined
       this._lastSpan = undefined
-      this._webTags = undefined
+      this._lastWebTags = undefined
     }
   }
 
@@ -183,11 +183,11 @@ class NativeWallProfiler {
         context.rootSpanId = rootSpan.context().toSpanId()
       }
     }
-    if (this._webTags) {
-      context.webTags = this._webTags
+    if (this._lastWebTags) {
+      context.webTags = this._lastWebTags
       // endpoint may not be determined yet, but keep it as fallback
       // if tags are not available anymore during serialization
-      context.endpoint = endpointNameFromTags(this._webTags)
+      context.endpoint = endpointNameFromTags(this._lastWebTags)
     }
   }
 
@@ -236,7 +236,7 @@ class NativeWallProfiler {
       this._profilerState = undefined
       this._lastSpan = undefined
       this._lastStartedSpans = undefined
-      this._webTags = undefined
+      this._lastWebTags = undefined
     }
 
     this._started = false

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -150,6 +150,9 @@ class NativeWallProfiler {
       this._lastStartedSpans = startedSpans
       if (this._endpointCollectionEnabled) {
         let found = false
+        // Find the first webspan starting from the end:
+        // There might be several webspans, for example with next.js, http plugin creates a first span
+        // and then next.js plugin creates a child span, and this child span haves the correct endpoint information.
         for (let i = startedSpans.length - 1; i >= 0; i--) {
           const tags = getSpanContextTags(startedSpans[i])
           if (isWebServerSpan(tags)) {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -138,6 +138,10 @@ class SpanProcessor {
       }
     }
 
+    for (const span of trace.finished) {
+      span.context()._tags = {}
+    }
+
     trace.started = active
     trace.finished = []
   }

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -105,7 +105,7 @@ describe('Tracer', () => {
         expect(trace.meta).to.not.have.property(BASE_SERVICE)
       })
 
-      it('should be set when tracer.trace service matched configured service', () => {
+      it('should not be set when tracer.trace service matched configured service', () => {
         tracer.trace('name', { service: 'service' }, () => {})
         const trace = tracer._exporter.export.getCall(0).args[0][0]
         expect(trace).to.have.property(EXPORT_SERVICE_NAME, 'service')

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -13,6 +13,7 @@ const { DD_MAJOR } = require('../../../version')
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
+const EXPORT_SERVICE_NAME = 'service'
 const BASE_SERVICE = tags.BASE_SERVICE
 
 const describeOrphanable = DD_MAJOR < 4 ? describe : describe.skip
@@ -39,6 +40,7 @@ describe('Tracer', () => {
 
     tracer = new Tracer(config)
     tracer._exporter.setUrl = sinon.stub()
+    tracer._exporter.export = sinon.stub()
     tracer._prioritySampler.configure = sinon.stub()
   })
 
@@ -89,38 +91,25 @@ describe('Tracer', () => {
     })
 
     describe('_dd.base_service', () => {
-      let genSpan
-
       it('should be set when tracer.trace service mismatches configured service', () => {
-        tracer.trace('name', { service: 'custom' }, span => {
-          genSpan = span
-        })
-        const tags = genSpan.context()._tags
-        expect(genSpan).to.be.instanceof(Span)
-        expect(tags).to.include({
-          [BASE_SERVICE]: 'service',
-          [SERVICE_NAME]: 'custom'
-        })
+        tracer.trace('name', { service: 'custom' }, () => {})
+        const trace = tracer._exporter.export.getCall(0).args[0][0]
+        expect(trace).to.have.property(EXPORT_SERVICE_NAME, 'custom')
+        expect(trace.meta).to.have.property(BASE_SERVICE, 'service')
       })
 
       it('should not be set when tracer.trace service is not supplied', () => {
-        tracer.trace('name', {}, span => {
-          genSpan = span
-        })
-        const tags = genSpan.context()._tags
-        expect(genSpan).to.be.instanceof(Span)
-        expect(tags).to.have.property(SERVICE_NAME, 'service')
-        expect(tags).to.not.have.property(BASE_SERVICE)
+        tracer.trace('name', {}, () => {})
+        const trace = tracer._exporter.export.getCall(0).args[0][0]
+        expect(trace).to.have.property(EXPORT_SERVICE_NAME, 'service')
+        expect(trace.meta).to.not.have.property(BASE_SERVICE)
       })
 
       it('should be set when tracer.trace service matched configured service', () => {
-        tracer.trace('name', { service: 'service' }, span => {
-          genSpan = span
-        })
-        const tags = genSpan.context()._tags
-        expect(genSpan).to.be.instanceof(Span)
-        expect(tags).to.have.property(SERVICE_NAME, 'service')
-        expect(tags).to.not.have.property(BASE_SERVICE)
+        tracer.trace('name', { service: 'service' }, () => {})
+        const trace = tracer._exporter.export.getCall(0).args[0][0]
+        expect(trace).to.have.property(EXPORT_SERVICE_NAME, 'service')
+        expect(trace.meta).to.not.have.property(BASE_SERVICE)
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
Restores eager releasing of tags for finished and exported spans. Since this also affects the way wall profiler can compute endpoints, that code needs to be adapted as well.

### Motivation
Reports of too high memory pressure since we removed eager cleaning of tags.

### Additional Notes
The implementation is much simpler than that in #3755. It eschews complications that were merely performance optimizations: release of tags held by sampling context when the span ends, and reduction of work for repeated lookup of web spans for a single span. This is the minimal code change necessary to keep operating correctly in face of restored eager tag release in `span_processor.js`.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.