### PR TITLE
[ci-visibility] Add flags to force code coverage reporting and test skipping

### DIFF
--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -68,12 +68,16 @@ function getItrConfiguration ({
         const {
           data: {
             attributes: {
-              code_coverage: isCodeCoverageEnabled,
-              tests_skipping: isSuitesSkippingEnabled
+              code_coverage: codeCoverage,
+              tests_skipping: testsSkipping
             }
           }
         } = JSON.parse(res)
+        const isCodeCoverageEnabled = !!process.env.DD_CIVISIBILITY_DANGEROUSLY_FORCE_COVERAGE || codeCoverage
+        const isSuitesSkippingEnabled = !!process.env.DD_CIVISIBILITY_DANGEROUSLY_FORCE_TEST_SKIPPING || testsSkipping
+
         const config = { isCodeCoverageEnabled, isSuitesSkippingEnabled }
+
         log.debug(() => `Received settings: ${config}`)
         done(null, config)
       } catch (err) {

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -74,7 +74,7 @@ function getItrConfiguration ({
         let isCodeCoverageEnabled = attributes.code_coverage
         let isSuitesSkippingEnabled = attributes.tests_skipping
 
-        log.debug(() => `Remote settings: ${{ isCodeCoverageEnabled, isSuitesSkippingEnabled }}}`)
+        log.debug(() => `Remote settings: ${{ isCodeCoverageEnabled, isSuitesSkippingEnabled }}`)
 
         if (process.env.DD_CIVISIBILITY_DANGEROUSLY_FORCE_COVERAGE) {
           isCodeCoverageEnabled = true

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -67,19 +67,25 @@ function getItrConfiguration ({
       try {
         const {
           data: {
-            attributes: {
-              code_coverage: codeCoverage,
-              tests_skipping: testsSkipping
-            }
+            attributes
           }
         } = JSON.parse(res)
-        const isCodeCoverageEnabled = !!process.env.DD_CIVISIBILITY_DANGEROUSLY_FORCE_COVERAGE || codeCoverage
-        const isSuitesSkippingEnabled = !!process.env.DD_CIVISIBILITY_DANGEROUSLY_FORCE_TEST_SKIPPING || testsSkipping
 
-        const config = { isCodeCoverageEnabled, isSuitesSkippingEnabled }
+        let isCodeCoverageEnabled = attributes.code_coverage
+        let isSuitesSkippingEnabled = attributes.tests_skipping
 
-        log.debug(() => `Received settings: ${config}`)
-        done(null, config)
+        log.debug(() => `Remote settings: ${{ isCodeCoverageEnabled, isSuitesSkippingEnabled }}}`)
+
+        if (process.env.DD_CIVISIBILITY_DANGEROUSLY_FORCE_COVERAGE) {
+          isCodeCoverageEnabled = true
+          log.debug(() => 'Dangerously set code coverage to true')
+        }
+        if (process.env.DD_CIVISIBILITY_DANGEROUSLY_FORCE_TEST_SKIPPING) {
+          isSuitesSkippingEnabled = true
+          log.debug(() => 'Dangerously set test skipping to true')
+        }
+
+        done(null, { isCodeCoverageEnabled, isSuitesSkippingEnabled })
       } catch (err) {
         done(err)
       }


### PR DESCRIPTION
### What does this PR do?

* Add `DD_CIVISIBILITY_DANGEROUSLY_FORCE_COVERAGE`
* Add `DD_CIVISIBILITY_DANGEROUSLY_FORCE_TEST_SKIPPING`

These two flags activate code coverage reporting and test skipping regardless of backend configuration. 

### Motivation

Allow these flags to be active for testing purposes. The suffix `DANGEROUSLY` is intended as a deterrent. It's based on react's [dangerouslySetInnerHTML](https://legacy.reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml).

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

