### PR TITLE
Use exact version for @datadog/native-appsec

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@datadog/native-appsec": "^4.0.0",
+    "@datadog/native-appsec": "4.0.0",
     "@datadog/native-iast-rewriter": "2.2.1",
     "@datadog/native-iast-taint-tracking": "1.6.3",
     "@datadog/native-metrics": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -385,7 +385,7 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@datadog/native-appsec@^4.0.0":
+"@datadog/native-appsec@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-4.0.0.tgz#ee08138b987dec557eac3650a43a972dac85b6a6"
   integrity sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==


### PR DESCRIPTION
### What does this PR do?
Remove the caret from `@datadog/native-appsec` dependency.

### Motivation
Second time we have this problem.
