### PR TITLE
PROF-8545: Eagerly release cached reference to web span tags when the span finishes

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -12,6 +12,7 @@ const runtimeMetrics = require('../runtime_metrics')
 const log = require('../log')
 const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../telemetry/metrics')
+const { channel } = require('dc-polyfill')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
 
@@ -29,6 +30,8 @@ const integrationCounters = {
   span_created: {},
   span_finished: {}
 }
+
+const finishCh = channel('dd-trace:span:finish')
 
 function getIntegrationCounter (event, integration) {
   const counters = integrationCounters[event]
@@ -176,6 +179,7 @@ class DatadogSpan {
     this._duration = finishTime - this._startTime
     this._spanContext._trace.finished.push(this)
     this._spanContext._isFinished = true
+    finishCh.publish(this)
     this._processor.process(this)
   }
 


### PR DESCRIPTION
### What does this PR do?
* Introduces a DC for observing span finishes
* Uses that DC to eagerly release cached reference to web span tags when the span finishes

### Motivation
Have profiler hold onto data for shorter period of time.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

