### PR TITLE
restify: emit on DC channels w/ async handlers

### DIFF
--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -50,7 +50,12 @@ function wrapFn (fn) {
     enterChannel.publish({ req, route })
 
     try {
-      return fn.apply(this, arguments)
+      const result = fn.apply(this, arguments)
+      if (result && typeof result === 'object' && typeof result.then === 'function') {
+        nextChannel.publish({ req })
+        finishChannel.publish({ req })
+      }
+      return result
     } catch (error) {
       errorChannel.publish({ req, error })
       nextChannel.publish({ req })

--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -52,8 +52,16 @@ function wrapFn (fn) {
     try {
       const result = fn.apply(this, arguments)
       if (result && typeof result === 'object' && typeof result.then === 'function') {
-        nextChannel.publish({ req })
-        finishChannel.publish({ req })
+        return result.then(function () {
+          nextChannel.publish({ req })
+          finishChannel.publish({ req })
+          return arguments
+        }).catch(function (error) {
+          errorChannel.publish({ req, error })
+          nextChannel.publish({ req })
+          finishChannel.publish({ req })
+          throw err
+        })
       }
       return result
     } catch (error) {

--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -60,7 +60,7 @@ function wrapFn (fn) {
           errorChannel.publish({ req, error })
           nextChannel.publish({ req })
           finishChannel.publish({ req })
-          throw err
+          throw error
         })
       }
       return result

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -85,6 +85,35 @@ describe('Plugin', () => {
           })
         })
 
+        it('should support routing with async functions and middleware', done => {
+          const server = restify.createServer()
+
+          server.get(
+            '/user/:id',
+            async function middleware () {},
+            async function handler (req, res) {
+              res.send('hello, ' + req.params.id)
+            }
+          )
+
+          getPort().then(port => {
+            agent
+              .use(traces => {
+                expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
+                expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
+                expect(traces[0][0].meta).to.have.property('component', 'restify')
+              })
+              .then(done)
+              .catch(done)
+
+            appListener = server.listen(port, 'localhost', () => {
+              axios
+                .get(`http://localhost:${port}/user/123`)
+                .catch(done)
+            })
+          })
+        })
+
         it('should run handlers in the request scope', done => {
           const server = restify.createServer()
           const interval = setInterval(() => {


### PR DESCRIPTION
### What does this PR do?
- now emits on `next` & `finish` channels when a handler / middleware is a promise
- previously it would only emit on `exit`

### Motivation
- fixes a bug where Restify routes are repeated once per async handler / middleware

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.