### PR TITLE
don't process a span if the request is missing

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -73,6 +73,10 @@ class NextPlugin extends ServerPlugin {
     const span = store.span
     const req = this._requests.get(span)
 
+
+    // if the request has been cancelled or otherwise removed, don't process the span
+    if (!req) return
+
     // Only use error page names if there's not already a name
     const current = span.context()._tags['next.page']
     if (current && ['/404', '/500', '/_error', '/_not-found'].includes(page)) {


### PR DESCRIPTION
### What does this PR do?
This PR short circuits tracing when an expected request is no longer in the internal map

### Motivation
when a timeout occurs, the client responds with an error, notifying datadog that this request is done. However, it's possible that work still happens on the server, which leads to the tracer still trying to operate on a request that is missing.

dd-trace should guard against this case, as there is no downside to doing nothing if the request is missing





### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

