### PR TITLE
[ci-visibility] New ITR settings logic 

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -98,21 +98,16 @@ class CiVisibilityExporter extends AgentInfoExporter {
     if (!this.shouldRequestSkippableSuites()) {
       return callback(null, [])
     }
-    this._gitUploadPromise.then(gitUploadError => {
-      if (gitUploadError) {
-        return callback(gitUploadError, [])
-      }
-      const configuration = {
-        url: this._getApiUrl(),
-        site: this._config.site,
-        env: this._config.env,
-        service: this._config.service,
-        isEvpProxy: !!this._isUsingEvpProxy,
-        custom: getTestConfigurationTags(this._config.tags),
-        ...testConfiguration
-      }
-      getSkippableSuitesRequest(configuration, callback)
-    })
+    const configuration = {
+      url: this._getApiUrl(),
+      site: this._config.site,
+      env: this._config.env,
+      service: this._config.service,
+      isEvpProxy: !!this._isUsingEvpProxy,
+      custom: getTestConfigurationTags(this._config.tags),
+      ...testConfiguration
+    }
+    getSkippableSuitesRequest(configuration, callback)
   }
 
   /**
@@ -129,21 +124,26 @@ class CiVisibilityExporter extends AgentInfoExporter {
       if (!canUseCiVisProtocol) {
         return callback(null, {})
       }
-      const configuration = {
-        url: this._getApiUrl(),
-        env: this._config.env,
-        service: this._config.service,
-        isEvpProxy: !!this._isUsingEvpProxy,
-        custom: getTestConfigurationTags(this._config.tags),
-        ...testConfiguration
-      }
-      getItrConfigurationRequest(configuration, (err, itrConfig) => {
-        /**
-         * **Important**: this._itrConfig remains empty in testing frameworks
-         * where the tests run in a subprocess, because `getItrConfiguration` is called only once.
-         */
-        this._itrConfig = itrConfig
-        callback(err, itrConfig)
+      this._gitUploadPromise.then(gitUploadError => {
+        if (gitUploadError) {
+          return callback(gitUploadError, {})
+        }
+        const configuration = {
+          url: this._getApiUrl(),
+          env: this._config.env,
+          service: this._config.service,
+          isEvpProxy: !!this._isUsingEvpProxy,
+          custom: getTestConfigurationTags(this._config.tags),
+          ...testConfiguration
+        }
+        getItrConfigurationRequest(configuration, (err, itrConfig) => {
+          /**
+           * **Important**: this._itrConfig remains empty in testing frameworks
+           * where the tests run in a subprocess, because `getItrConfiguration` is called only once.
+           */
+          this._itrConfig = itrConfig
+          callback(err, itrConfig)
+        })
       })
     })
   }

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -147,7 +147,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         if (err) {
           callback(err, {})
         } else if (itrConfig?.requireGit) {
-          // If it requires git upload, we'll wait for the request to finish and request it again
+          // If the backend requires git, we'll wait for the upload to finish and request settings again
           this._gitUploadPromise.then(gitUploadError => {
             if (gitUploadError) {
               return callback(gitUploadError, {})

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -144,8 +144,10 @@ class CiVisibilityExporter extends AgentInfoExporter {
          */
         this._itrConfig = itrConfig
 
-        // If it requires git upload, we'll wait for the request to finish and request it again
-        if (itrConfig.requireGit) {
+        if (err) {
+          callback(err, {})
+        } else if (itrConfig?.requireGit) {
+          // If it requires git upload, we'll wait for the request to finish and request it again
           this._gitUploadPromise.then(gitUploadError => {
             if (gitUploadError) {
               return callback(gitUploadError, {})
@@ -156,7 +158,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
             })
           })
         } else {
-          callback(err, itrConfig)
+          callback(null, itrConfig)
         }
       })
     })

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -15,6 +15,7 @@ function getItrConfiguration ({
   runtimeName,
   runtimeVersion,
   branch,
+  testLevel = 'suite',
   custom
 }, done) {
   const options = {
@@ -23,7 +24,8 @@ function getItrConfiguration ({
     headers: {
       'Content-Type': 'application/json'
     },
-    url
+    url,
+    timeout: 20000
   }
 
   if (isEvpProxy) {
@@ -42,7 +44,7 @@ function getItrConfiguration ({
       id: id().toString(10),
       type: 'ci_app_test_service_libraries_settings',
       attributes: {
-        test_level: 'suite',
+        test_level: testLevel,
         configurations: {
           'os.platform': osPlatform,
           'os.version': osVersion,

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -75,6 +75,7 @@ function getItrConfiguration ({
 
         let isCodeCoverageEnabled = attributes.code_coverage
         let isSuitesSkippingEnabled = attributes.tests_skipping
+        const { require_git: requireGit } = attributes
 
         log.debug(() => `Remote settings: ${JSON.stringify({ isCodeCoverageEnabled, isSuitesSkippingEnabled })}`)
 
@@ -87,7 +88,7 @@ function getItrConfiguration ({
           log.debug(() => 'Dangerously set test skipping to true')
         }
 
-        done(null, { isCodeCoverageEnabled, isSuitesSkippingEnabled })
+        done(null, { isCodeCoverageEnabled, isSuitesSkippingEnabled, requireGit })
       } catch (err) {
         done(err)
       }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -124,7 +124,8 @@ module.exports = class CiPlugin extends Plugin {
       osArchitecture,
       runtimeName,
       runtimeVersion,
-      branch
+      branch,
+      testLevel: 'suite'
     }
   }
 

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -41,6 +41,7 @@ describe('CI Visibility Agentless Exporter', () => {
         .reply(200, JSON.stringify({
           data: {
             attributes: {
+              require_git: false,
               code_coverage: true,
               tests_skipping: true
             }
@@ -66,6 +67,7 @@ describe('CI Visibility Agentless Exporter', () => {
         .reply(200, JSON.stringify({
           data: {
             attributes: {
+              require_git: false,
               code_coverage: true,
               tests_skipping: true
             }
@@ -96,6 +98,7 @@ describe('CI Visibility Agentless Exporter', () => {
         .reply(200, JSON.stringify({
           data: {
             attributes: {
+              require_git: false,
               code_coverage: true,
               tests_skipping: true
             }
@@ -118,6 +121,7 @@ describe('CI Visibility Agentless Exporter', () => {
         .reply(200, JSON.stringify({
           data: {
             attributes: {
+              require_git: false,
               code_coverage: true,
               tests_skipping: true
             }
@@ -141,6 +145,7 @@ describe('CI Visibility Agentless Exporter', () => {
         .reply(200, JSON.stringify({
           data: {
             attributes: {
+              require_git: false,
               code_coverage: true,
               tests_skipping: true
             }


### PR DESCRIPTION
### What does this PR do?
* If `require_git` field is `true`, we'll wait for git upload and re-request settings.

### Motivation
We want to reduce the overhead that code coverage adds to ITR. Instead of requesting the libraries to run code coverage _always_, we'll disable it from time to time. This decision will be done at the **backend**. For the backend to be able to take this decision, git metadata needs to have been uploaded. We don't want to affect _every_ customer, even those not using ITR, so we've added a `require_git` field to the settings API: if it's `true`, we'll wait for git upload and re do the request. If it's `false`, we'll proceed as always (this is the case for all customers not using ITR). 


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
