### PR TITLE
PROF-8545: Memoize web tags in all ancestors

### DIFF
--- a/integration-tests/profiler/codehotspots.js
+++ b/integration-tests/profiler/codehotspots.js
@@ -18,13 +18,11 @@ function busyLoop () {
 let counter = 0
 
 function runBusySpans () {
-  tracer.trace('x' + counter, (span, done) => {
-    span.setTag('span.type', 'web')
-    span.setTag('resource.name', `endpoint-${counter}`)
+  tracer.trace('x' + counter, { type: 'web', resource: `endpoint-${counter}` }, (_, done) => {
     setImmediate(() => {
       for (let i = 0; i < 3; ++i) {
         const z = i
-        tracer.trace('y' + i, (span2, done2) => {
+        tracer.trace('y' + i, (_, done2) => {
           setTimeout(() => {
             busyLoop()
             done2()


### PR DESCRIPTION

### What does this PR do?
* Now memoizing web tags recursively in all ancestor spans; ideally the lookup will stop at the immediate parent as it already has its web tags memoized.
* Changed nomenclature from "cached" to "memoized".

### Motivation
* It is unnecessary with every span to traverse up the ancestor chain to the web span to get its tags, because most likely the immediate parent also already has it memoized, so it's enough to use the reference of the parent's memoization.
* The recursive method is an easier to understand, cleaner implementation of the previously used loop.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
