### PR TITLE
ASM - Update collected request headers [APPSEC-11226]

### DIFF
--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -21,7 +21,7 @@ const contentHeaderList = [
   'content-type'
 ]
 
-const REQUEST_HEADERS_PASSMAP = mapHeaderAndTags([
+const REQUEST_HEADERS_MAP = mapHeaderAndTags([
   'accept',
   'accept-encoding',
   'accept-language',
@@ -33,17 +33,15 @@ const REQUEST_HEADERS_PASSMAP = mapHeaderAndTags([
 
   ...ipHeaderList,
   ...contentHeaderList
-])
+], 'http.request.headers.')
 
-const RESPONSE_HEADERS_PASSMAP = mapHeaderAndTags([
-  ...contentHeaderList
-], 'http.response.headers.')
-
-function mapHeaderAndTags (headerList, tagPrefix = 'http.request.headers.') {
-  return new Map(headerList.map(headerName => [headerName, `${tagPrefix}${formatHeaderName(headerName)}`]))
-}
+const RESPONSE_HEADERS_MAP = mapHeaderAndTags(contentHeaderList, 'http.response.headers.')
 
 const metricsQueue = new Map()
+
+function mapHeaderAndTags (headerList, tagPrefix) {
+  return new Map(headerList.map(headerName => [headerName, `${tagPrefix}${formatHeaderName(headerName)}`]))
+}
 
 function filterHeaders (headers, passMap) {
   const result = {}
@@ -111,7 +109,7 @@ function reportAttack (attackData) {
 
   const currentTags = rootSpan.context()._tags
 
-  const newTags = filterHeaders(req.headers, REQUEST_HEADERS_PASSMAP)
+  const newTags = filterHeaders(req.headers, REQUEST_HEADERS_MAP)
 
   newTags['appsec.event'] = 'true'
 
@@ -157,7 +155,7 @@ function finishRequest (req, res) {
 
   if (!rootSpan.context()._tags['appsec.event']) return
 
-  const newTags = filterHeaders(res.getHeaders(), RESPONSE_HEADERS_PASSMAP)
+  const newTags = filterHeaders(res.getHeaders(), RESPONSE_HEADERS_MAP)
 
   if (req.route && typeof req.route.path === 'string') {
     newTags['http.endpoint'] = req.route.path

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -42,12 +42,12 @@ function mapHeaderAndTags (headerList, tagPrefix) {
   return new Map(headerList.map(headerName => [headerName, `${tagPrefix}${formatHeaderName(headerName)}`]))
 }
 
-function filterHeaders (headers, passMap) {
+function filterHeaders (headers, map) {
   const result = {}
 
   if (!headers) return result
 
-  for (const [headerName, tagName] of passMap) {
+  for (const [headerName, tagName] of map) {
     const headerValue = headers[headerName]
     if (headerValue) {
       result[tagName] = '' + headerValue

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -29,7 +29,6 @@ const REQUEST_HEADERS_MAP = mapHeaderAndTags([
   'accept-language',
   'host',
   'user-agent',
-
   'forwarded',
   'via',
 
@@ -48,10 +47,10 @@ function filterHeaders (headers, passMap) {
 
   if (!headers) return result
 
-  for (const nameAndTagPair of passMap) {
-    const headerValue = headers[nameAndTagPair[0]]
+  for (const [headerName, tagName] of passMap) {
+    const headerValue = headers[headerName]
     if (headerValue) {
-      result[nameAndTagPair[1]] = '' + headerValue
+      result[tagName] = '' + headerValue
     }
   }
 

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -3,6 +3,7 @@
 const Limiter = require('../rate_limiter')
 const { storage } = require('../../../datadog-core')
 const web = require('../plugins/util/web')
+const { ipHeaderList } = require('../plugins/util/ip_extractor')
 const {
   incrementWafInitMetric,
   updateWafRequestsMetricTags,
@@ -13,54 +14,52 @@ const {
 // default limiter, configurable with setRateLimit()
 let limiter = new Limiter(100)
 
-// TODO: use precomputed maps instead
-const REQUEST_HEADERS_PASSLIST = [
-  'accept',
-  'accept-encoding',
-  'accept-language',
-  'content-encoding',
-  'content-language',
-  'content-length',
-  'content-type',
-  'forwarded',
-  'forwarded-for',
-  'host',
-  'true-client-ip',
-  'user-agent',
-  'via',
-  'x-client-ip',
-  'x-cluster-client-ip',
-  'x-forwarded',
-  'x-forwarded-for',
-  'x-real-ip'
-]
-
-const RESPONSE_HEADERS_PASSLIST = [
+const contentHeaderList = [
   'content-encoding',
   'content-language',
   'content-length',
   'content-type'
 ]
 
+const REQUEST_HEADERS_PASSMAP = mapHeaderAndTags([
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'host',
+  'user-agent',
+
+  'forwarded',
+  'via',
+
+  ...ipHeaderList,
+  ...contentHeaderList
+])
+
+const RESPONSE_HEADERS_PASSMAP = mapHeaderAndTags([
+  ...contentHeaderList
+], 'http.response.headers.')
+
+function mapHeaderAndTags (headerList, tagPrefix = 'http.request.headers.') {
+  return new Map(headerList.map(headerName => [headerName, `${tagPrefix}${formatHeaderName(headerName)}`]))
+}
+
 const metricsQueue = new Map()
 
-function filterHeaders (headers, passlist, prefix) {
+function filterHeaders (headers, passMap) {
   const result = {}
 
   if (!headers) return result
 
-  for (let i = 0; i < passlist.length; ++i) {
-    const headerName = passlist[i]
-
-    if (headers[headerName]) {
-      result[`${prefix}${formatHeaderName(headerName)}`] = '' + headers[headerName]
+  for (const nameAndTagPair of passMap) {
+    const headerValue = headers[nameAndTagPair[0]]
+    if (headerValue) {
+      result[nameAndTagPair[1]] = '' + headerValue
     }
   }
 
   return result
 }
 
-// TODO: this can be precomputed at start time
 function formatHeaderName (name) {
   return name
     .trim()
@@ -86,7 +85,7 @@ function reportWafInit (wafVersion, rulesVersion, diagnosticsRules = {}) {
 function reportMetrics (metrics) {
   // TODO: metrics should be incremental, there already is an RFC to report metrics
   const store = storage.getStore()
-  const rootSpan = store && store.req && web.root(store.req)
+  const rootSpan = store?.req && web.root(store.req)
   if (!rootSpan) return
 
   if (metrics.duration) {
@@ -106,13 +105,13 @@ function reportMetrics (metrics) {
 
 function reportAttack (attackData) {
   const store = storage.getStore()
-  const req = store && store.req
+  const req = store?.req
   const rootSpan = web.root(req)
   if (!rootSpan) return
 
   const currentTags = rootSpan.context()._tags
 
-  const newTags = filterHeaders(req.headers, REQUEST_HEADERS_PASSLIST, 'http.request.headers.')
+  const newTags = filterHeaders(req.headers, REQUEST_HEADERS_PASSMAP)
 
   newTags['appsec.event'] = 'true'
 
@@ -158,7 +157,7 @@ function finishRequest (req, res) {
 
   if (!rootSpan.context()._tags['appsec.event']) return
 
-  const newTags = filterHeaders(res.getHeaders(), RESPONSE_HEADERS_PASSLIST, 'http.response.headers.')
+  const newTags = filterHeaders(res.getHeaders(), RESPONSE_HEADERS_PASSMAP)
 
   if (req.route && typeof req.route.path === 'string') {
     newTags['http.endpoint'] = req.route.path
@@ -180,5 +179,6 @@ module.exports = {
   reportAttack,
   reportWafUpdate: incrementWafUpdatesMetric,
   finishRequest,
-  setRateLimit
+  setRateLimit,
+  mapHeaderAndTags
 }

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -14,6 +14,8 @@ const {
 // default limiter, configurable with setRateLimit()
 let limiter = new Limiter(100)
 
+const metricsQueue = new Map()
+
 const contentHeaderList = [
   'content-encoding',
   'content-language',
@@ -36,8 +38,6 @@ const REQUEST_HEADERS_MAP = mapHeaderAndTags([
 ], 'http.request.headers.')
 
 const RESPONSE_HEADERS_MAP = mapHeaderAndTags(contentHeaderList, 'http.response.headers.')
-
-const metricsQueue = new Map()
 
 function mapHeaderAndTags (headerList, tagPrefix) {
   return new Map(headerList.map(headerName => [headerName, `${tagPrefix}${formatHeaderName(headerName)}`]))

--- a/packages/dd-trace/src/plugins/util/ip_extractor.js
+++ b/packages/dd-trace/src/plugins/util/ip_extractor.js
@@ -48,8 +48,8 @@ function extractIp (config, req) {
 
   let firstPrivateIp
   if (headers) {
-    for (let i = 0; i < ipHeaderList.length; i++) {
-      const firstIp = findFirstIp(headers[ipHeaderList[i]])
+    for (const ipHeaderName of ipHeaderList) {
+      const firstIp = findFirstIp(headers[ipHeaderName])
 
       if (firstIp.public) {
         return firstIp.public
@@ -59,7 +59,7 @@ function extractIp (config, req) {
     }
   }
 
-  return firstPrivateIp || (req.socket && req.socket.remoteAddress)
+  return firstPrivateIp || req.socket?.remoteAddress
 }
 
 function findFirstIp (str) {
@@ -68,8 +68,8 @@ function findFirstIp (str) {
 
   const splitted = str.split(',')
 
-  for (let i = 0; i < splitted.length; i++) {
-    const chunk = splitted[i].trim()
+  for (const part of splitted) {
+    const chunk = part.trim()
 
     // TODO: strip port and interface data ?
 
@@ -90,5 +90,6 @@ function findFirstIp (str) {
 }
 
 module.exports = {
-  extractIp
+  extractIp,
+  ipHeaderList
 }

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -54,12 +54,12 @@ describe('reporter', () => {
         'user-agent': 42,
         secret: 'password',
         'x-forwarded-for': '10'
-      }, [
+      }, Reporter.mapHeaderAndTags([
         'host',
         'user-agent',
         'x-forwarded-for',
         'x-client-ip'
-      ], 'prefix.')
+      ], 'prefix.'))
 
       expect(result).to.deep.equal({
         'prefix.host': 'localhost',


### PR DESCRIPTION
### What does this PR do?
- Makes appsec reporter use same header list than ip_extractor to include: `fastly-client-ip`, `cf-connecting-ip`, `cf-connecting-ipv6` headers
- Precompute at startup a map with the header and its tag to avoid to do it in runtime

### Motivation
Update the appsec list of collected request headers

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

