### PR TITLE
Fix Webpack-Related Build Errors in Next.js Unit Tests

### DIFF
--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -11,6 +11,13 @@ const config = {
   experimental: {}
 }
 
+// Ensure webpack 5 is used by default for older versions
+if (satisfies(VERSION, '<11')) {
+  config.future = {
+    webpack5: true
+  }
+}
+
 // In older versions of Next.js (11.0.1 and before), the webpack config doesn't support 'node' prefixes by default
 // So, any "node" prefixes are replaced for these older versions by this webpack plugin
 // Additionally, webpack was having problems with our use of 'worker_threads', so we don't resolve it
@@ -24,9 +31,11 @@ if (satisfies(VERSION, '<11.1.0')) {
 
     config.resolve.preferRelative = true
 
+    // for future errors, any node:* module that produces a webpack build error should be added here
     config.resolve.fallback = {
       ...config.resolve.fallback,
-      worker_threads: false
+      worker_threads: false,
+      perf_hooks: false
     }
 
     return config


### PR DESCRIPTION
### What does this PR do?
Fixes webpack build errors in Next.js unit tests for older versions.

### Motivation
Make sure tests can pass as more `node:*` modules are used within the project. There's probably a better way to enforce this reliably so that these small PRs don't have to go up in the future. For now, adding it to `config.resolve.fallback` in `next.config.js` seems to do the trick.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

