### PR TITLE
Revert "enable tracing header injection for AWS requests (#3796)"

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -114,28 +114,6 @@ describe('Plugin', () => {
           s3.listBuckets({}, e => e && done(e))
         })
 
-        // different versions of aws-sdk use different casings and different AWS headers
-        it('should include tracing headers and not cause a 403 error', (done) => {
-          const HttpClientPlugin = require('../../datadog-plugin-http/src/client.js')
-          const spy = sinon.spy(HttpClientPlugin.prototype, 'bindStart')
-          agent.use(traces => {
-            const headers = new Set(
-              Object.keys(spy.firstCall.firstArg.args.options.headers)
-                .map(x => x.toLowerCase())
-            )
-            spy.restore()
-
-            expect(headers).to.include('authorization')
-            expect(headers).to.include('x-amz-date')
-            expect(headers).to.include('x-datadog-trace-id')
-            expect(headers).to.include('x-datadog-parent-id')
-            expect(headers).to.include('x-datadog-sampling-priority')
-            expect(headers).to.include('x-datadog-tags')
-          }).then(done, done)
-
-          s3.listBuckets({}, e => e && done(e))
-        })
-
         it('should mark error responses', (done) => {
           let error
 

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -232,6 +232,110 @@ describe('Plugin', () => {
         })
       })
 
+      it('should skip injecting if the Authorization header contains an AWS signature', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = server(app, port, () => {
+            fetch(`http://localhost:${port}/`, {
+              headers: {
+                Authorization: 'AWS4-HMAC-SHA256 ...'
+              }
+            })
+          })
+        })
+      })
+
+      it('should skip injecting if one of the Authorization headers contains an AWS signature', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = server(app, port, () => {
+            fetch(`http://localhost:${port}/`, {
+              headers: {
+                Authorization: ['AWS4-HMAC-SHA256 ...']
+              }
+            })
+          })
+        })
+      })
+
+      it('should skip injecting if the X-Amz-Signature header is set', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = server(app, port, () => {
+            fetch(`http://localhost:${port}/`, {
+              headers: {
+                'X-Amz-Signature': 'abc123'
+              }
+            })
+          })
+        })
+      })
+
+      it('should skip injecting if the X-Amz-Signature query param is set', done => {
+        const app = express()
+
+        app.get('/', (req, res) => {
+          try {
+            expect(req.get('x-datadog-trace-id')).to.be.undefined
+            expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+            res.status(200).send()
+
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+
+        getPort().then(port => {
+          appListener = server(app, port, () => {
+            fetch(`http://localhost:${port}/?X-Amz-Signature=abc123`)
+          })
+        })
+      })
+
       it('should handle connection errors', done => {
         getPort().then(port => {
           let error

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -462,6 +462,124 @@ describe('Plugin', () => {
           })
         })
 
+        it('should skip injecting if the Authorization header contains an AWS signature', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const req = http.request({
+                port,
+                headers: {
+                  Authorization: 'AWS4-HMAC-SHA256 ...'
+                }
+              })
+
+              req.end()
+            })
+          })
+        })
+
+        it('should skip injecting if one of the Authorization headers contains an AWS signature', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const req = http.request({
+                port,
+                headers: {
+                  Authorization: ['AWS4-HMAC-SHA256 ...']
+                }
+              })
+
+              req.end()
+            })
+          })
+        })
+
+        it('should skip injecting if the X-Amz-Signature header is set', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const req = http.request({
+                port,
+                headers: {
+                  'X-Amz-Signature': 'abc123'
+                }
+              })
+
+              req.end()
+            })
+          })
+        })
+
+        it('should skip injecting if the X-Amz-Signature query param is set', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const req = http.request({
+                port,
+                path: '/?X-Amz-Signature=abc123'
+              })
+
+              req.end()
+            })
+          })
+        })
+
         it('should run the callback in the parent context', done => {
           const app = express()
 

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -62,7 +62,9 @@ class Http2ClientPlugin extends ClientPlugin {
 
     addHeaderTags(span, headers, HTTP_REQUEST_HEADERS, this.config)
 
-    this.tracer.inject(span, HTTP_HEADERS, headers)
+    if (!hasAmazonSignature(headers, path)) {
+      this.tracer.inject(span, HTTP_HEADERS, headers)
+    }
 
     message.parentStore = store
     message.currentStore = { ...store, span }
@@ -129,6 +131,29 @@ function extractSessionDetails (authority, options) {
   }
 
   return { protocol, port, host }
+}
+
+function hasAmazonSignature (headers, path) {
+  if (headers) {
+    headers = Object.keys(headers)
+      .reduce((prev, next) => Object.assign(prev, {
+        [next.toLowerCase()]: headers[next]
+      }), {})
+
+    if (headers['x-amz-signature']) {
+      return true
+    }
+
+    if ([].concat(headers['authorization']).some(startsWith('AWS4-HMAC-SHA256'))) {
+      return true
+    }
+  }
+
+  return path && path.toLowerCase().indexOf('x-amz-signature=') !== -1
+}
+
+function startsWith (searchString) {
+  return value => String(value).startsWith(searchString)
 }
 
 function getStatusValidator (config) {

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -381,6 +381,139 @@ describe('Plugin', () => {
           })
         })
 
+        it('should skip injecting if the Authorization header contains an AWS signature', done => {
+          const app = (stream, headers) => {
+            try {
+              expect(headers['x-datadog-trace-id']).to.be.undefined
+              expect(headers['x-datadog-parent-id']).to.be.undefined
+
+              stream.respond({
+                ':status': 200
+              })
+              stream.end()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          }
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const headers = {
+                Authorization: 'AWS4-HMAC-SHA256 ...'
+              }
+              const client = http2
+                .connect(`${protocol}://localhost:${port}`)
+                .on('error', done)
+
+              const req = client.request(headers)
+              req.on('error', done)
+
+              req.end()
+            })
+          })
+        })
+
+        it('should skip injecting if one of the Authorization headers contains an AWS signature', done => {
+          const app = (stream, headers) => {
+            try {
+              expect(headers['x-datadog-trace-id']).to.be.undefined
+              expect(headers['x-datadog-parent-id']).to.be.undefined
+
+              stream.respond({
+                ':status': 200
+              })
+              stream.end()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          }
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const headers = {
+                Authorization: ['AWS4-HMAC-SHA256 ...']
+              }
+              const client = http2
+                .connect(`${protocol}://localhost:${port}`)
+                .on('error', done)
+
+              const req = client.request(headers)
+              req.on('error', done)
+
+              req.end()
+            })
+          })
+        })
+
+        it('should skip injecting if the X-Amz-Signature header is set', done => {
+          const app = (stream, headers) => {
+            try {
+              expect(headers['x-datadog-trace-id']).to.be.undefined
+              expect(headers['x-datadog-parent-id']).to.be.undefined
+
+              stream.respond({
+                ':status': 200
+              })
+              stream.end()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          }
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const headers = {
+                'X-Amz-Signature': 'abc123'
+              }
+              const client = http2
+                .connect(`${protocol}://localhost:${port}`)
+                .on('error', done)
+
+              const req = client.request(headers)
+              req.on('error', done)
+
+              req.end()
+            })
+          })
+        })
+
+        it('should skip injecting if the X-Amz-Signature query param is set', done => {
+          const app = (stream, headers) => {
+            try {
+              expect(headers['x-datadog-trace-id']).to.be.undefined
+              expect(headers['x-datadog-parent-id']).to.be.undefined
+
+              stream.respond({
+                ':status': 200
+              })
+              stream.end()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          }
+
+          getPort().then(port => {
+            appListener = server(app, port, () => {
+              const client = http2
+                .connect(`${protocol}://localhost:${port}`)
+                .on('error', done)
+
+              const req = client.request({ ':path': '/?X-Amz-Signature=abc123' })
+              req.on('error', done)
+
+              req.end()
+            })
+          })
+        })
+
         it('should run the callback in the parent context', done => {
           const app = (stream, headers) => {
             stream.respond({


### PR DESCRIPTION
### What does this PR do?
- reverts PR #3796
- reverts commit 14c1eb0ba7bb1648881affb1f1aa520f94bc5fbc

### Motivation
- @rochdev and @astuyve are both confident this is a breaking change