### PR TITLE
make 128bit ids default even in v4.x release line

### DIFF
--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -3,7 +3,6 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { DD_MAJOR } = require('../../../version')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -455,9 +454,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = DD_MAJOR >= 5
-              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
-              : '0000000000000000'
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
@@ -537,9 +534,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = DD_MAJOR >= 5
-              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
-              : '0000000000000000'
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -3,7 +3,6 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { DD_MAJOR } = require('../../../version')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -445,9 +444,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = DD_MAJOR >= 5
-              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
-              : '0000000000000000'
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
@@ -527,9 +524,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = DD_MAJOR >= 5
-              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
-              : '0000000000000000'
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -7,7 +7,6 @@ const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/c
 const net = require('net')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 const EventEmitter = require('events')
-const { DD_MAJOR } = require('../../../version')
 
 const clients = {
   pg: pg => pg.Client
@@ -484,9 +483,7 @@ describe('Plugin', () => {
 
         it('query text should contain traceparent', done => {
           agent.use(traces => {
-            const expectedTimePrefix = DD_MAJOR >= 5
-              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
-              : '0000000000000000'
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
             expect(seenTraceId).to.equal(traceId)
@@ -568,9 +565,7 @@ describe('Plugin', () => {
           }
 
           agent.use(traces => {
-            const expectedTimePrefix = DD_MAJOR >= 5
-              ? Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
-              : '0000000000000000'
+            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -13,7 +13,6 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('./plugins/util/tags')
 const { getGitMetadataFromGitProperties, removeUserSensitiveInfo } = require('./git_properties')
 const { updateConfig } = require('./telemetry')
 const { getIsGCPFunction, getIsAzureFunctionConsumptionPlan } = require('./serverless')
-const { DD_MAJOR } = require('../../../version')
 
 const fromEntries = Object.fromEntries || (entries =>
   entries.reduce((obj, [k, v]) => Object.assign(obj, { [k]: v }), {}))
@@ -373,7 +372,7 @@ class Config {
     const DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = coalesce(
       options.traceId128BitGenerationEnabled,
       process.env.DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED,
-      DD_MAJOR >= 5
+      true
     )
 
     const DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = coalesce(


### PR DESCRIPTION
### What does this PR do?
- sort of a partial revert for #3656 
- makes 128 bit ID generation the default for v4.x release line, not just upcoming v5.x

### Motivation
- this change isn't a major breaking change after all

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

