### PR TITLE
PROF-8458: Fix for Node 14

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -36,7 +36,7 @@ class EventsProfiler {
       this._observer = new PerformanceObserver(add.bind(this))
     }
     // Currently only support GC
-    this._observer.observe({ type: 'gc' })
+    this._observer.observe({ entryTypes: ['gc'] })
   }
 
   stop () {


### PR DESCRIPTION
### What does this PR do?
Fixes an API usage incompatible with Node 14

### Motivation
It breaks on Node 14

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.