### PR TITLE
Expose a promise for profiler start

### DIFF
--- a/integration-tests/profiler/codehotspots.js
+++ b/integration-tests/profiler/codehotspots.js
@@ -39,4 +39,4 @@ function runBusySpans () {
   })
 }
 
-setTimeout(runBusySpans, 100)
+tracer.profilerStarted().then(runBusySpans)

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -21,7 +21,7 @@ class Tracer {
   }
 
   profilerStarted () {
-    return Promise.resolve()
+    return Promise.resolve(false)
   }
 
   trace (name, options, fn) {

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -20,6 +20,10 @@ class Tracer {
     return this
   }
 
+  profilerStarted () {
+    return Promise.resolve()
+  }
+
   trace (name, options, fn) {
     if (!fn) {
       fn = options

--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -17,7 +17,7 @@ module.exports = {
       error: (message) => log.error(message)
     }
 
-    profiler.start({
+    return profiler.start({
       enabled,
       service,
       version,
@@ -34,9 +34,5 @@ module.exports = {
 
   stop: () => {
     profiler.stop()
-  },
-
-  started: () => {
-    return profiler.started()
   }
 }

--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -34,5 +34,9 @@ module.exports = {
 
   stop: () => {
     profiler.stop()
+  },
+
+  started: () => {
+    return profiler.started()
   }
 }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -20,25 +20,10 @@ class Profiler extends EventEmitter {
     this._timer = undefined
     this._lastStart = undefined
     this._timeoutInterval = undefined
-    this._resetStarted()
-  }
-
-  started () {
-    return this._started
   }
 
   start (options) {
-    const started = this._start(options)
-    started.catch((err) => { if (options.logger) options.logger.error(err) })
-    started.then(this._startedResolve, this._startedReject)
-    return this
-  }
-
-  _resetStarted () {
-    this._started = new Promise((resolve, reject) => {
-      this._startedResolve = resolve
-      this._startedReject = reject
-    })
+    return this._start(options).catch((err) => { if (options.logger) options.logger.error(err) })
   }
 
   async _start (options) {
@@ -120,7 +105,6 @@ class Profiler extends EventEmitter {
 
     clearTimeout(this._timer)
     this._timer = undefined
-    this._resetStarted()
 
     return this
   }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -20,11 +20,25 @@ class Profiler extends EventEmitter {
     this._timer = undefined
     this._lastStart = undefined
     this._timeoutInterval = undefined
+    this._resetStarted()
+  }
+
+  started () {
+    return this._started
   }
 
   start (options) {
-    this._start(options).catch((err) => { if (options.logger) options.logger.error(err) })
+    const started = this._start(options)
+    started.catch((err) => { if (options.logger) options.logger.error(err) })
+    started.then(this._startedResolve, this._startedReject)
     return this
+  }
+
+  _resetStarted () {
+    this._started = new Promise((resolve, reject) => {
+      this._startedResolve = resolve
+      this._startedReject = reject
+    })
   }
 
   async _start (options) {
@@ -106,6 +120,7 @@ class Profiler extends EventEmitter {
 
     clearTimeout(this._timer)
     this._timer = undefined
+    this._resetStarted()
 
     return this
   }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -23,14 +23,19 @@ class Profiler extends EventEmitter {
   }
 
   start (options) {
-    return this._start(options).catch((err) => { if (options.logger) options.logger.error(err) })
+    return this._start(options).catch((err) => {
+      if (options.logger) {
+        options.logger.error(err)
+      }
+      return false
+    })
   }
 
   async _start (options) {
-    if (this._enabled) return
+    if (this._enabled) return true
 
     const config = this._config = new Config(options)
-    if (!config.enabled) return
+    if (!config.enabled) return false
 
     this._logger = config.logger
     this._enabled = true
@@ -66,9 +71,11 @@ class Profiler extends EventEmitter {
       }
 
       this._capture(this._timeoutInterval)
+      return true
     } catch (e) {
       this._logger.error(e)
       this._stop()
+      return false
     }
   }
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -67,6 +67,9 @@ class Tracer extends NoopProxy {
           log.error(e)
         }
       }
+      if (!this._profilerStarted) {
+        this._profilerStarted = Promise.resolve(false)
+      }
 
       if (config.runtimeMetrics) {
         runtimeMetrics.start(config)
@@ -105,6 +108,9 @@ class Tracer extends NoopProxy {
   }
 
   profilerStarted () {
+    if (!this._profilerStarted) {
+      throw new Error('profilerStarted() must be called after init()')
+    }
     return this._profilerStarted
   }
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -62,8 +62,7 @@ class Tracer extends NoopProxy {
         // do not stop tracer initialization if the profiler fails to be imported
         try {
           const profiler = require('./profiler')
-          profiler.start(config)
-          this._profilerStarted = profiler.started()
+          this._profilerStarted = profiler.start(config)
         } catch (e) {
           log.error(e)
         }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -63,6 +63,7 @@ class Tracer extends NoopProxy {
         try {
           const profiler = require('./profiler')
           profiler.start(config)
+          this._profilerStarted = profiler.started()
         } catch (e) {
           log.error(e)
         }
@@ -102,6 +103,10 @@ class Tracer extends NoopProxy {
     }
 
     return this
+  }
+
+  profilerStarted () {
+    return this._profilerStarted
   }
 
   use () {


### PR DESCRIPTION
### What does this PR do?
Expose a promise for profiler start. This makes tests that depend on it having been started less brittle as they don't need to sleep for a guessed duration.

### Motivation
I have one integration test that needs to ensure it starts doing things when the profilers are up and running to properly capture the activity. It's currently seldom flakes out, this is most likely why. I'll soon have more similar tests, so it'd be good to have a robust mechanism for this. You can see the adjusted test in the PR.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.