### PR TITLE
restify: resolve 0th promise arg, not arguments

### DIFF
--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -55,7 +55,7 @@ function wrapFn (fn) {
         return result.then(function () {
           nextChannel.publish({ req })
           finishChannel.publish({ req })
-          return arguments
+          return arguments[0]
         }).catch(function (error) {
           errorChannel.publish({ req, error })
           nextChannel.publish({ req })


### PR DESCRIPTION
### What does this PR do?
- resolves the 0th argument of the restify controller promise
- currently resolving the array-like `arguments` object

### Motivation
- fixes a customer issue