### PR TITLE
Add source code integration tags to profiles

### DIFF
--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -8,7 +8,7 @@ process.once('beforeExit', () => { profiler.stop() })
 
 module.exports = {
   start: config => {
-    const { service, version, env, url, hostname, port, tags } = config
+    const { service, version, env, url, hostname, port, tags, repositoryUrl, commitSHA } = config
     const { enabled, sourceMap, exporters } = config.profiling
     const logger = {
       debug: (message) => log.debug(message),
@@ -17,7 +17,7 @@ module.exports = {
       error: (message) => log.error(message)
     }
 
-    profiler.start({
+    return profiler.start({
       enabled,
       service,
       version,
@@ -28,7 +28,9 @@ module.exports = {
       url,
       hostname,
       port,
-      tags
+      tags,
+      repositoryUrl,
+      commitSHA
     })
   },
 

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -11,6 +11,7 @@ const WallProfiler = require('./profilers/wall')
 const SpaceProfiler = require('./profilers/space')
 const EventsProfiler = require('./profilers/events')
 const { oomExportStrategies, snapshotKinds } = require('./constants')
+const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../plugins/util/tags')
 const { tagger } = require('./tagger')
 const { isFalse, isTrue } = require('../util')
 
@@ -72,6 +73,13 @@ class Config {
       tagger.parse(options.tags),
       tagger.parse({ env, host, service, version, functionname })
     )
+
+    // Add source code integration tags if available
+    if (options.repositoryUrl && options.commitSHA) {
+      this.tags[GIT_REPOSITORY_URL] = options.repositoryUrl
+      this.tags[GIT_COMMIT_SHA] = options.commitSHA
+    }
+
     this.logger = ensureLogger(options.logger)
     const logger = this.logger
     function logExperimentalVarDeprecation (shortVarName) {

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -262,6 +262,18 @@ describe('config', () => {
     expect(config.tags).to.include({ env, service, version })
   })
 
+  it('should add source code integration tags if git metadata is available', () => {
+    const DUMMY_GIT_SHA = '13851f2b092e97acebab1b73f6c0e7818e795b50'
+    const DUMMY_REPOSITORY_URL = 'git@github.com:DataDog/sci_git_example.git'
+
+    const config = new Config({
+      repositoryUrl: DUMMY_REPOSITORY_URL,
+      commitSHA: DUMMY_GIT_SHA
+    })
+
+    expect(config.tags).to.include({ 'git.repository_url': DUMMY_REPOSITORY_URL, 'git.commit.sha': DUMMY_GIT_SHA })
+  })
+
   it('should support IPv6 hostname', () => {
     const options = {
       hostname: '::1'


### PR DESCRIPTION
### What does this PR do?
If `repositoryUrl` and `commitSHA` are set in profiler config, then set `git.repository_url` and `git.commit.sha` tags with these values respectively.

### Motivation
Make source code integration works in profiler UI when DD_GIT_REPOSITORY_URL / DD_GIT_COMMIT_SHA env variables are set.
