### PR TITLE
PROF-8520: Add DNS events to timeline

### DIFF
--- a/integration-tests/profiler/dnstest.js
+++ b/integration-tests/profiler/dnstest.js
@@ -1,0 +1,13 @@
+const dns = require('node:dns')
+
+require('dd-trace').init().profilerStarted().then(() => {
+  dns.lookupService('13.224.103.60', 80, () => {})
+  dns.lookup('example.org', () => {})
+  dns.lookup('example.com', () => {})
+  dns.lookup('datadoghq.com', () => {})
+  dns.resolve4('datadoghq.com', () => {})
+  dns.lookup('dfslkgsjkrtgrdg.com', () => {})
+})
+
+// Give the event processor chance to collect events
+setTimeout(() => {}, 3000)

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -86,7 +86,7 @@ class GCDecorator {
 class DNSDecorator {
   constructor (stringTable) {
     this.stringTable = stringTable
-    this.operationNameLabelKey = stringTable.dedup('operation name')
+    this.operationNameLabelKey = stringTable.dedup('operation')
     this.hostLabelKey = stringTable.dedup('host')
     this.addressLabelKey = stringTable.dedup('address')
   }

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -114,13 +114,9 @@ class DNSDecorator {
 const decoratorTypes = {
   gc: GCDecorator
 }
-const threadNames = {
-  gc: 'GC'
-}
 // Needs at least node 16 for DNS
 if (node16) {
   decoratorTypes.dns = DNSDecorator
-  threadNames.dns = 'DNS'
 }
 
 /**
@@ -177,8 +173,6 @@ class EventsProfiler {
     for (const [eventType, DecoratorCtor] of Object.entries(decoratorTypes)) {
       const decorator = new DecoratorCtor(stringTable)
       decorator.eventTypeLabel = labelFromStrStr(stringTable, 'event', eventType)
-      decorator.threadNameLabel = labelFromStrStr(stringTable, THREAD_NAME,
-        `${threadNamePrefix} ${threadNames[eventType]}`)
       decorators[eventType] = decorator
     }
     const timestampLabelKey = stringTable.dedup(END_TIMESTAMP)
@@ -203,7 +197,6 @@ class EventsProfiler {
         locationId,
         label: [
           decorator.eventTypeLabel,
-          decorator.threadNameLabel,
           new Label({ key: timestampLabelKey, num: dateOffset + BigInt(Math.round(endTime * MS_TO_NS)) })
         ]
       }

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -14,8 +14,83 @@ const MS_TO_NS = 1000000
 // perf_hooks events, the emitted pprof file uses the type "timeline".
 const pprofValueType = 'timeline'
 const pprofValueUnit = 'nanoseconds'
-const threadName = `${threadNamePrefix} GC`
 
+function labelFromStr (stringTable, key, valStr) {
+  return new Label({ key, str: stringTable.dedup(valStr) })
+}
+
+function labelFromStrStr (stringTable, keyStr, valStr) {
+  return labelFromStr(stringTable, stringTable.dedup(keyStr), valStr)
+}
+
+class GCDecorator {
+  constructor (stringTable, locations, functions) {
+    this.stringTable = stringTable
+    this.reasonLabelKey = stringTable.dedup('gc reason')
+    this.kindLabels = []
+    this.reasonLabels = []
+    this.locationsPerKind = []
+    this.flagObj = {}
+
+    const kindLabelKey = stringTable.dedup('gc type')
+
+    // Create labels for all GC performance flags and kinds of GC
+    for (const [key, value] of Object.entries(constants)) {
+      if (key.startsWith('NODE_PERFORMANCE_GC_FLAGS_')) {
+        this.flagObj[key.substring(26).toLowerCase()] = value
+      } else if (key.startsWith('NODE_PERFORMANCE_GC_')) {
+        // It's a constant for a kind of GC
+        const kind = key.substring(20).toLowerCase()
+        this.kindLabels[value] = labelFromStr(stringTable, kindLabelKey, kind)
+        // Construct a single-frame "location" too
+        const fn = new Function({ id: functions.length + 1, name: stringTable.dedup(`${kind} GC`) })
+        functions.push(fn)
+        const line = new Line({ functionId: fn.id })
+        const location = new Location({ id: locations.length + 1, line: [line] })
+        locations.push(location)
+        this.locationsPerKind[value] = [location.id]
+      }
+    }
+  }
+
+  decorateSample (sampleInput, item) {
+    const { kind, flags } = node16 ? item.detail : item
+    sampleInput.label.push(this.kindLabels[kind])
+    const reasonLabel = this.getReasonLabel(flags)
+    if (reasonLabel) {
+      sampleInput.label.push(reasonLabel)
+    }
+    sampleInput.locationId = this.locationsPerKind[kind]
+  }
+
+  getReasonLabel (flags) {
+    if (flags === 0) {
+      return null
+    }
+    let reasonLabel = this.reasonLabels[flags]
+    if (!reasonLabel) {
+      const reasons = []
+      for (const [key, value] of Object.entries(this.flagObj)) {
+        if (value & flags) {
+          reasons.push(key)
+        }
+      }
+      const reasonStr = reasons.join(',')
+      reasonLabel = labelFromStr(this.stringTable, this.reasonLabelKey, reasonStr)
+      this.reasonLabels[flags] = reasonLabel
+    }
+    return reasonLabel
+  }
+}
+
+// Keys correspond to PerformanceEntry.entryType, values are constructor
+// functions for type-specific decorators.
+const decoratorTypes = {
+  gc: GCDecorator
+}
+const threadNames = {
+  gc: 'GC'
+}
 /**
  * This class generates pprof files with timeline events sourced from Node.js
  * performance measurement APIs.
@@ -35,8 +110,7 @@ class EventsProfiler {
     if (!this._observer) {
       this._observer = new PerformanceObserver(add.bind(this))
     }
-    // Currently only support GC
-    this._observer.observe({ entryTypes: ['gc'] })
+    this._observer.observe({ entryTypes: Object.keys(decoratorTypes) })
   }
 
   stop () {
@@ -52,91 +126,44 @@ class EventsProfiler {
     }
 
     const stringTable = new StringTable()
-    const timestampLabelKey = stringTable.dedup(END_TIMESTAMP)
-    const kindLabelKey = stringTable.dedup('gc type')
-    const reasonLabelKey = stringTable.dedup('gc reason')
-    const kindLabels = []
-    const reasonLabels = []
     const locations = []
     const functions = []
-    const locationsPerKind = []
-    const flagObj = {}
-
-    function labelFromStr (key, valStr) {
-      return new Label({ key, str: stringTable.dedup(valStr) })
+    const decorators = {}
+    for (const [eventType, DecoratorCtor] of Object.entries(decoratorTypes)) {
+      const decorator = new DecoratorCtor(stringTable, locations, functions)
+      decorator.eventTypeLabel = labelFromStrStr(stringTable, 'event', eventType)
+      decorator.threadNameLabel = labelFromStrStr(stringTable, THREAD_NAME,
+        `${threadNamePrefix} ${threadNames[eventType]}`)
+      decorators[eventType] = decorator
     }
-
-    function labelFromStrStr (keyStr, valStr) {
-      return labelFromStr(stringTable.dedup(keyStr), valStr)
-    }
-
-    // Create labels for all GC performance flags and kinds of GC
-    for (const [key, value] of Object.entries(constants)) {
-      if (key.startsWith('NODE_PERFORMANCE_GC_FLAGS_')) {
-        flagObj[key.substring(26).toLowerCase()] = value
-      } else if (key.startsWith('NODE_PERFORMANCE_GC_')) {
-        // It's a constant for a kind of GC
-        const kind = key.substring(20).toLowerCase()
-        kindLabels[value] = labelFromStr(kindLabelKey, kind)
-        // Construct a single-frame "location" too
-        const fn = new Function({ id: functions.length + 1, name: stringTable.dedup(`${kind} GC`) })
-        functions.push(fn)
-        const line = new Line({ functionId: fn.id })
-        const location = new Location({ id: locations.length + 1, line: [line] })
-        locations.push(location)
-        locationsPerKind[value] = [location.id]
-      }
-    }
-
-    const gcEventLabel = labelFromStrStr('event', 'gc')
-    const threadLabel = labelFromStrStr(THREAD_NAME, threadName)
-
-    function getReasonLabel (flags) {
-      if (flags === 0) {
-        return null
-      }
-      let reasonLabel = reasonLabels[flags]
-      if (!reasonLabel) {
-        const reasons = []
-        for (const [key, value] of Object.entries(flagObj)) {
-          if (value & flags) {
-            reasons.push(key)
-          }
-        }
-        const reasonStr = reasons.join(',')
-        reasonLabel = labelFromStr(reasonLabelKey, reasonStr)
-        reasonLabels[flags] = reasonLabel
-      }
-      return reasonLabel
-    }
+    const timestampLabelKey = stringTable.dedup(END_TIMESTAMP)
 
     let durationFrom = Number.POSITIVE_INFINITY
     let durationTo = 0
     const dateOffset = BigInt(Math.round(performance.timeOrigin * MS_TO_NS))
 
     const samples = this.entries.map((item) => {
+      const decorator = decorators[item.entryType]
+      if (!decorator) {
+        // Shouldn't happen but it's better to not rely on observer only getting
+        // requested event types.
+        return null
+      }
       const { startTime, duration } = item
-      const { kind, flags } = node16 ? item.detail : item
       const endTime = startTime + duration
       if (durationFrom > startTime) durationFrom = startTime
       if (durationTo < endTime) durationTo = endTime
-      const labels = [
-        gcEventLabel,
-        threadLabel,
-        new Label({ key: timestampLabelKey, num: dateOffset + BigInt(Math.round(endTime * MS_TO_NS)) }),
-        kindLabels[kind]
-      ]
-      const reasonLabel = getReasonLabel(flags)
-      if (reasonLabel) {
-        labels.push(reasonLabel)
-      }
-      const sample = new Sample({
+      const sampleInput = {
         value: [Math.round(duration * MS_TO_NS)],
-        label: labels,
-        locationId: locationsPerKind[kind]
-      })
-      return sample
-    })
+        label: [
+          decorator.eventTypeLabel,
+          decorator.threadNameLabel,
+          new Label({ key: timestampLabelKey, num: dateOffset + BigInt(Math.round(endTime * MS_TO_NS)) })
+        ]
+      }
+      decorator.decorateSample(sampleInput, item)
+      return new Sample(sampleInput)
+    }).filter(v => v)
 
     this.entries = []
 


### PR DESCRIPTION
### What does this PR do?
Gathers DNS performance events and adds them to the timeline.

### Motivation
2023 Q4 Continuous Profiler OKR 5

### Additional Notes
This is best reviewed commit by commit, or at least by reviewing the first commit separately, then the others together. The reason for this is that the first commit refactors the timeline profiler from only gathering GC events to having an architecture for gathering multiple types of events. This already pays off in spades – you can see how "Add DNS" is a pretty small commit after the refactor – but it will make adding Net events similarly trivial too.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.