### PR TITLE
Fix memory leak in rhea hooks

### DIFF
--- a/packages/datadog-instrumentations/src/rhea.js
+++ b/packages/datadog-instrumentations/src/rhea.js
@@ -52,7 +52,8 @@ addHook({ name: 'rhea', versions: ['>=1'], file: 'lib/link.js' }, obj => {
       startSendCh.publish({ targetAddress, host, port, msg })
       const delivery = send.apply(this, arguments)
       const context = {
-        asyncResource
+        asyncResource,
+        connection: this.connection
       }
       contexts.set(delivery, context)
 
@@ -80,7 +81,8 @@ addHook({ name: 'rhea', versions: ['>=1'], file: 'lib/link.js' }, obj => {
 
         if (msgObj.delivery) {
           const context = {
-            asyncResource
+            asyncResource,
+            connection: this.connection
           }
           contexts.set(msgObj.delivery, context)
           msgObj.delivery.update = wrapDeliveryUpdate(msgObj.delivery, msgObj.delivery.update)


### PR DESCRIPTION
### What does this PR do?

By making the connection available on the context, it can be accessed in `beforeFinish` to properly delete the delivery as originally intended.

### Motivation

This relates to support request [1407177](https://help.datadoghq.com/hc/en-us/requests/1407177) that we're working on with @tlhunter.

We observed a significant memory leak in one of our applications. Heap snapshots showed an increasing number of deliveries are retained and never removed on the `inFlightDeliveries` symbol on `Connection` objects.

![Heap snapshot](https://github.com/DataDog/dd-trace-js/assets/5547518/84bc6e2b-302d-46d7-b077-2cd103b6711b)

It looks like the bug exists since the plugin migration in #1895. Previously, the [function](https://github.com/DataDog/dd-trace-js/blob/7c0a0b4945a31080736487a60ed8465edbffbad5/packages/datadog-plugin-rhea/src/index.js#L189) that cleans up after a connection is closed had access to `Connection.inFlightDeliveries` via the delivery that was passed in and could remove the delivery from the set.
In the [current state](https://github.com/DataDog/dd-trace-js/blob/9f4acb0f5ab3d2a469350c0a60a9ce7ae73dca08/packages/datadog-instrumentations/src/rhea.js#L219), the code still looks roughly the same, but now it tries accessing the connection via the context, on which it doesn't exist, so the delivery can't be removed.

We can fix that by putting the connection on the context as well, which seems to work according to our heap snapshots and memory usage in production.

![2_memory](https://github.com/DataDog/dd-trace-js/assets/5547518/a5efe7a2-2c9b-41d0-9fc4-7eaf4ac99e7c)

If there's a better way to do this, feel free to update the PR directly. Another option would be to go the `delivery.link.connection` path, in which case we wouldn't even need the context in `beforeFinish`. The downside is relying more on the internal structure of the delivery to remain the same for the cleanup to continue to work.