### PR TITLE
PROF-8523: Add Net events to timeline

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -74,13 +74,46 @@ class GCDecorator {
   }
 }
 
+// Maintains "lanes" (or virtual threads) to avoid overlaps in events. The
+// decorator starts out with no lanes, and dynamically adds them as needed.
+// Every event is put in the first lane where it doesn't overlap with the last
+// event in that lane. If there's no lane without overlaps, a new lane is
+// created.
+class Lanes {
+  constructor (stringTable, name) {
+    this.stringTable = stringTable
+    this.name = name
+    this.lanes = []
+  }
+
+  getLabelFor (item) {
+    const startTime = item.startTime
+    const endTime = startTime + item.duration
+
+    // Biases towards populating earlier lanes, but at least it's simple
+    for (const lane of this.lanes) {
+      if (lane.endTime <= startTime) {
+        lane.endTime = endTime
+        return lane.label
+      }
+    }
+    const label = labelFromStrStr(
+      this.stringTable,
+      THREAD_NAME,
+      `${this.name}-${this.lanes.length}`
+    )
+    this.lanes.push({ endTime, label })
+    return label
+  }
+}
+
 class DNSDecorator {
   constructor (stringTable) {
     this.stringTable = stringTable
     this.operationNameLabelKey = stringTable.dedup('operation')
     this.hostLabelKey = stringTable.dedup('host')
     this.addressLabelKey = stringTable.dedup('address')
-    this.lanes = []
+    this.lanes = new Lanes(stringTable, `${threadNamePrefix} DNS`)
   }
 
   decorateSample (sampleInput, item) {
@@ -107,32 +140,7 @@ class DNSDecorator {
           addLabel(this.hostLabelKey, detail.host)
         }
     }
-    labels.push(this.getLaneLabelFor(item))
-  }
-
-  // Maintains "lanes" (or virtual threads) to avoid overlaps in events. The
-  // decorator starts out with no lanes, and dynamically adds them as needed.
-  // Every event is put in the first lane where it doesn't overlap with the last
-  // event in that lane. If there's no lane without overlaps, a new lane is
-  // created.
-  getLaneLabelFor (item) {
-    const startTime = item.startTime
-    const endTime = startTime + item.duration
-
-    // Biases towards populating earlier lanes, but at least it's simple
-    for (const lane of this.lanes) {
-      if (lane.endTime <= startTime) {
-        lane.endTime = endTime
-        return lane.label
-      }
-    }
-    const label = labelFromStrStr(
-      this.stringTable,
-      THREAD_NAME,
-      `${threadNamePrefix} DNS-${this.lanes.length}`
-    )
-    this.lanes.push({ endTime, label })
-    return label
+    labels.push(this.lanes.getLabelFor(item))
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Gathers Net performance events and adds them to the timeline.

### Motivation
2023 Q4 Continuous Profiler OKR 5

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.