### PR TITLE
[ci-visibility] Speed up git unshallow

### DIFF
--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -111,7 +111,7 @@ function getLatestCommits () {
   }
 }
 
-function getCommitsToInclude (commitsToExclude, commitsToInclude) {
+function getCommitsRevList (commitsToExclude, commitsToInclude) {
   const commitsToExcludeString = commitsToExclude.map(commit => `^${commit}`)
 
   try {
@@ -236,7 +236,7 @@ module.exports = {
   getLatestCommits,
   getRepositoryUrl,
   generatePackFilesForCommits,
-  getCommitsToInclude,
+  getCommitsRevList,
   GIT_REV_LIST_MAX_BUFFER,
   isShallowRepository,
   unshallowRepository

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -111,7 +111,7 @@ function getLatestCommits () {
   }
 }
 
-function getCommitsToUpload (commitsToExclude, commitsToInclude) {
+function getCommitsToInclude (commitsToExclude, commitsToInclude) {
   const commitsToExcludeString = commitsToExclude.map(commit => `^${commit}`)
 
   try {
@@ -236,7 +236,7 @@ module.exports = {
   getLatestCommits,
   getRepositoryUrl,
   generatePackFilesForCommits,
-  getCommitsToUpload,
+  getCommitsToInclude,
   GIT_REV_LIST_MAX_BUFFER,
   isShallowRepository,
   unshallowRepository

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -23,7 +23,7 @@ describe('git_metadata', () => {
 
   let getLatestCommitsStub
   let getRepositoryUrlStub
-  let getCommitsToUploadStub
+  let getCommitsRevListStub
   let generatePackFilesForCommitsStub
   let isShallowRepositoryStub
   let unshallowRepositoryStub
@@ -42,7 +42,7 @@ describe('git_metadata', () => {
 
   beforeEach(() => {
     getLatestCommitsStub = sinon.stub().returns(latestCommits)
-    getCommitsToUploadStub = sinon.stub().returns(latestCommits)
+    getCommitsRevListStub = sinon.stub().returns(latestCommits)
     getRepositoryUrlStub = sinon.stub().returns('git@github.com:DataDog/dd-trace-js.git')
     isShallowRepositoryStub = sinon.stub().returns(false)
     unshallowRepositoryStub = sinon.stub()
@@ -54,7 +54,7 @@ describe('git_metadata', () => {
         getLatestCommits: getLatestCommitsStub,
         getRepositoryUrl: getRepositoryUrlStub,
         generatePackFilesForCommits: generatePackFilesForCommitsStub,
-        getCommitsToUpload: getCommitsToUploadStub,
+        getCommitsRevList: getCommitsRevListStub,
         isShallowRepository: isShallowRepositoryStub,
         unshallowRepository: unshallowRepositoryStub
       }
@@ -65,9 +65,25 @@ describe('git_metadata', () => {
     nock.cleanAll()
   })
 
-  it('should unshallow if the repo is shallow', (done) => {
+  it('does not unshallow if every commit is already in backend', (done) => {
     const scope = nock('https://api.test.com')
       .post('/api/v2/git/repository/search_commits')
+      .reply(200, JSON.stringify({ data: latestCommits.map((sha) => ({ id: sha, type: 'commit' })) }))
+
+    isShallowRepositoryStub.returns(true)
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+      expect(unshallowRepositoryStub).not.to.have.been.called
+      expect(err).to.be.null
+      expect(scope.isDone()).to.be.true
+      done()
+    })
+  })
+
+  it('should unshallow if the repo is shallow and not every commit is in the backend', (done) => {
+    const scope = nock('https://api.test.com')
+      .post('/api/v2/git/repository/search_commits')
+      .reply(200, JSON.stringify({ data: [] }))
+      .post('/api/v2/git/repository/search_commits') // calls a second time after unshallowing
       .reply(200, JSON.stringify({ data: [] }))
       .post('/api/v2/git/repository/packfile')
       .reply(204)
@@ -102,7 +118,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    getCommitsToUploadStub.returns([])
+    getCommitsRevListStub.returns([])
 
     gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
       expect(err).to.be.null
@@ -165,7 +181,7 @@ describe('git_metadata', () => {
   it('should fail if the packfile request returns anything other than 204', (done) => {
     const scope = nock('https://api.test.com')
       .post('/api/v2/git/repository/search_commits')
-      .reply(200, JSON.stringify({ data: latestCommits.map((sha) => ({ id: sha, type: 'commit' })) }))
+      .reply(200, JSON.stringify({ data: [] }))
       .post('/api/v2/git/repository/packfile')
       .reply(502)
 

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -142,11 +142,11 @@ describe('git', () => {
   })
 })
 
-describe('getCommitsToUpload', () => {
+describe('getCommitsRevList', () => {
   it('gets the commits to upload if the repository is smaller than the limit', () => {
     const logErrorSpy = sinon.spy()
 
-    const { getCommitsToUpload } = proxyquire('../../../src/plugins/util/git',
+    const { getCommitsRevList } = proxyquire('../../../src/plugins/util/git',
       {
         'child_process': {
           'execFileSync': (command, flags, options) =>
@@ -157,14 +157,14 @@ describe('getCommitsToUpload', () => {
         }
       }
     )
-    getCommitsToUpload([], [])
+    getCommitsRevList([], [])
     expect(logErrorSpy).not.to.have.been.called
   })
 
   it('does not crash and logs the error if the repository is bigger than the limit', () => {
     const logErrorSpy = sinon.spy()
 
-    const { getCommitsToUpload } = proxyquire('../../../src/plugins/util/git',
+    const { getCommitsRevList } = proxyquire('../../../src/plugins/util/git',
       {
         'child_process': {
           'execFileSync': (command, flags, options) =>
@@ -175,7 +175,7 @@ describe('getCommitsToUpload', () => {
         }
       }
     )
-    const commitsToUpload = getCommitsToUpload([], [])
+    const commitsToUpload = getCommitsRevList([], [])
     expect(logErrorSpy).to.have.been.called
     expect(commitsToUpload.length).to.equal(0)
   })


### PR DESCRIPTION
### What does this PR do?
Change the steps we follow to unshallow repositories.

Old:
* Check if repository is shallow
* If it is, unshallow
* Request known commits in `search_commits` 

New:
* Request known commits in `search_commits`
* If all the commits we've got in `git rev-list` are in the backend already, do not unshallow.
* If not all commits are in the backend already, check if repository is shallow.
* If it is, unshallow.
* Call `search_commits` again with new unshallowed commits.

### Motivation
Speed up unshallowing process.

