### PR TITLE
conti/add implement trace context and dsm propagation for aws-sdk sns sqs and kinesis 

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -112,9 +112,26 @@ jobs:
           START_WEB: '0'
         ports:
           - 4566:4566
+      # we have two localstacks since upgrading localstack was causing lambda tests to fail
+      # To-Do: Debug localstack and lambda
+      localstack-lambda:
+        image: localstack/localstack:1.1.0
+        ports:
+          - "127.0.0.1:4567:4567" # Edge
+        env:
+          LOCALSTACK_SERVICES: dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless
+          EXTRA_CORS_ALLOWED_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
+          EXTRA_CORS_EXPOSE_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
+          AWS_DEFAULT_REGION: us-east-1
+          FORCE_NONINTERACTIVE: 'true'
+          LAMBDA_EXECUTOR: local
+          START_WEB: '0'
+          GATEWAY_LISTEN: 127.0.0.1:4567
+          EDGE_PORT: 4567
+          EDGE_PORT_HTTP: 4567
     env:
       PLUGINS: aws-sdk
-      SERVICES: localstack
+      SERVICES: localstack localstack-lambda
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/testagent/start

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -112,9 +112,9 @@ jobs:
           START_WEB: '0'
         ports:
           - 4566:4566
-      # we have two localstacks since upgrading localstack was causing lambda tests to fail
-      # To-Do: Debug localstack and lambda
-      localstack-lambda:
+      # we have two localstacks since upgrading localstack was causing lambda & S3 tests to fail
+      # To-Do: Debug localstack / lambda and localstack / S3
+      localstack-legacy:
         image: localstack/localstack:1.1.0
         ports:
           - "127.0.0.1:4567:4567" # Edge
@@ -131,7 +131,7 @@ jobs:
           EDGE_PORT_HTTP: 4567
     env:
       PLUGINS: aws-sdk
-      SERVICES: localstack localstack-lambda
+      SERVICES: localstack localstack-legacy
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/testagent/start

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -101,9 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       localstack:
-        image: localstack/localstack:1.1.0
+        image: localstack/localstack:3.0.2
         env:
-          LOCALSTACK_SERVICES: dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless
+          LOCALSTACK_SERVICES: dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless,lambda
           EXTRA_CORS_ALLOWED_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           EXTRA_CORS_EXPOSE_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -121,9 +121,9 @@ jobs:
       - uses: ./.github/actions/node/setup
       - run: yarn install
       - uses: ./.github/actions/node/oldest
-      - run: yarn test:plugins:ci
+      - run: yarn test:plugins
       - uses: ./.github/actions/node/latest
-      - run: yarn test:plugins:ci
+      - run: yarn test:plugins
       - if: always()
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -121,9 +121,9 @@ jobs:
       - uses: ./.github/actions/node/setup
       - run: yarn install
       - uses: ./.github/actions/node/oldest
-      - run: yarn test:plugins
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
-      - run: yarn test:plugins
+      - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-  localstack-lambda:
+  localstack-legacy:
     image: localstack/localstack:1.1.0
     ports:
       - "127.0.0.1:4567:4567" # Edge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,13 +87,11 @@ services:
     ports:
       - "127.0.0.1:8081:8081"
   localstack:
-    # TODO: Figure out why SNS doesn't work in >=1.2
-    # https://github.com/localstack/localstack/issues/7479
-    image: localstack/localstack:1.1.0
+    image: localstack/localstack:3.0.2
     ports:
       - "127.0.0.1:4566:4566" # Edge
     environment:
-      - LOCALSTACK_SERVICES=dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless
+      - LOCALSTACK_SERVICES=dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless,lambda
       - EXTRA_CORS_ALLOWED_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
       - EXTRA_CORS_EXPOSE_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
       - AWS_DEFAULT_REGION=us-east-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,24 @@ services:
       - AWS_DEFAULT_REGION=us-east-1
       - FORCE_NONINTERACTIVE=true
       - START_WEB=0
+      - DEBUG=${DEBUG-}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+  localstack-lambda:
+    image: localstack/localstack:1.1.0
+    ports:
+      - "127.0.0.1:4567:4567" # Edge
+    environment:
+      - LOCALSTACK_SERVICES=dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless
+      - EXTRA_CORS_ALLOWED_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
+      - EXTRA_CORS_EXPOSE_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
+      - AWS_DEFAULT_REGION=us-east-1
+      - FORCE_NONINTERACTIVE=true
+      - START_WEB=0
+      - GATEWAY_LISTEN=127.0.0.1:4567
+      - EDGE_PORT=4567
+      - EDGE_PORT_HTTP=4567
       - LAMBDA_EXECUTOR=local
   kafka:
     image: debezium/kafka:1.7

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -1,9 +1,55 @@
 'use strict'
+const {
+  CONTEXT_PROPAGATION_KEY,
+  getSizeOrZero,
+  getHeadersSize
+} = require('../../../dd-trace/src/datastreams/processor')
+const { encodePathwayContext } = require('../../../dd-trace/src/datastreams/pathway')
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
+const { storage } = require('../../../datadog-core')
+
 class Kinesis extends BaseAwsSdkPlugin {
   static get id () { return 'kinesis' }
   static get peerServicePrecursors () { return ['streamname'] }
+
+  constructor (...args) {
+    super(...args)
+
+    // TODO(bengl) Find a way to create the response span tags without this WeakMap being populated
+    // in the base class
+    this.requestTags = new WeakMap()
+
+    this.addSub('apm:aws:response:start:kinesis', obj => {
+      const { request, response } = obj
+      const store = storage.getStore()
+      const plugin = this
+      const streamName = this.getStreamName(request.params, request.operation)
+      if (streamName) {
+        this.requestTags.streamName = streamName
+      }
+      const responseExtraction = this.responseExtract(request.params, request.operation, response)
+      if (responseExtraction && responseExtraction.maybeChildOf) {
+        obj.needsFinish = true
+        const options = {
+          childOf: responseExtraction.maybeChildOf,
+          tags: Object.assign(
+            {},
+            this.requestTags.get(request) || {},
+            { 'span.kind': 'server' }
+          )
+        }
+        const span = plugin.tracer.startSpan('aws.response', options)
+        this.responseExtractDSMContext(response, responseExtraction.traceContext, this.requestTags.streamName, span)
+        this.enter(span, store)
+      }
+    })
+
+    this.addSub('apm:aws:response:finish:kinesis', err => {
+      const { span } = storage.getStore()
+      this.finish(span, null, err)
+    })
+  }
 
   generateTags (params, operation, response) {
     if (!params || !params.StreamName) return {}
@@ -13,6 +59,13 @@ class Kinesis extends BaseAwsSdkPlugin {
       'aws.kinesis.stream_name': params.StreamName,
       'streamname': params.StreamName
     }
+  }
+
+  getStreamName (params, operation) {
+    if (!operation || operation !== 'getShardIterator') return null
+    if (!params || !params.StreamName) return null
+
+    return params.StreamName
   }
 
   // AWS-SDK will b64 kinesis payloads
@@ -31,6 +84,39 @@ class Kinesis extends BaseAwsSdkPlugin {
     }
   }
 
+  responseExtract (params, operation, response, span = null) {
+    if (operation !== 'getRecords') return
+    if (params.Limit && params.Limit !== 1) return
+    if (!response || !response.Records || !response.Records[0] || response.Records.length > 1) return
+
+    const record = response.Records[0]
+
+    try {
+      const decodedData = JSON.parse(Buffer.from(record.Data).toString())
+
+      return {
+        maybeChildOf: this.tracer.extract('text_map', decodedData._datadog),
+        traceContext: decodedData._datadog
+      }
+    } catch (e) {
+      log.error(e)
+    }
+  }
+
+  responseExtractDSMContext (response, context, streamName, span) {
+    let payloadSize = 0
+    if (response && response.Records) {
+      for (const record of response.Records) {
+        payloadSize += getSizeOrZero(record.Data)
+      }
+      if (this.config.dsmEnabled && context && context[CONTEXT_PROPAGATION_KEY] && streamName) {
+        this.tracer.decodeDataStreamsContext(Buffer.from(context[CONTEXT_PROPAGATION_KEY]))
+        this.tracer
+          .setCheckpoint(['direction:in', `topic:${streamName}`, 'type:kinesis'], span, payloadSize)
+      }
+    }
+  }
+
   requestInject (span, request) {
     const operation = request.operation
     if (operation === 'putRecord' || operation === 'putRecords') {
@@ -39,6 +125,14 @@ class Kinesis extends BaseAwsSdkPlugin {
       }
 
       const traceData = {}
+      if (this.config.dsmEnabled) {
+        const payloadSize = getHeadersSize(request.params)
+        const stream = request.params.StreamName
+        const dataStreamsContext = this.tracer
+          .setCheckpoint(['direction:out', `topic:${stream}`, 'type:kinesis'], span, payloadSize)
+        const pathwayCtx = encodePathwayContext(dataStreamsContext)
+        traceData[CONTEXT_PROPAGATION_KEY] = pathwayCtx.toJSON()
+      }
       this.tracer.inject(span, 'text_map', traceData)
       let injectPath
       if (request.params.Records && request.params.Records.length > 0) {

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -1,4 +1,7 @@
 'use strict'
+
+const { CONTEXT_PROPAGATION_KEY, getHeadersSize } = require('../../../dd-trace/src/datastreams/processor')
+const { encodePathwayContext } = require('../../../dd-trace/src/datastreams/pathway')
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
@@ -11,12 +14,9 @@ class Sns extends BaseAwsSdkPlugin {
 
     if (!params.TopicArn && !(response.data && response.data.TopicArn)) return {}
     const TopicArn = params.TopicArn || response.data.TopicArn
-    // Split the ARN into its parts
-    // ex.'arn:aws:sns:us-east-1:123456789012:my-topic'
-    const arnParts = TopicArn.split(':')
 
-    // Get the topic name from the last part of the ARN
-    const topicName = arnParts[arnParts.length - 1]
+    const topicName = getTopicName(TopicArn)
+
     return {
       'resource.name': `${operation} ${params.TopicArn || response.data.TopicArn}`,
       'aws.sns.topic_arn': TopicArn,
@@ -71,12 +71,29 @@ class Sns extends BaseAwsSdkPlugin {
       return
     }
     const ddInfo = {}
+    if (this.config.dsmEnabled) {
+      const payloadSize = getHeadersSize(params)
+      const topicName = getTopicName(params.TopicArn)
+      const dataStreamsContext = this.tracer
+        .setCheckpoint(['direction:out', `topic:${topicName}`, 'type:sns'], span, payloadSize)
+      const pathwayCtx = encodePathwayContext(dataStreamsContext)
+      ddInfo[CONTEXT_PROPAGATION_KEY] = pathwayCtx.toJSON()
+    }
     this.tracer.inject(span, 'text_map', ddInfo)
     params.MessageAttributes._datadog = {
       DataType: 'Binary',
       BinaryValue: Buffer.from(JSON.stringify(ddInfo)) // BINARY types are automatically base64 encoded
     }
   }
+}
+
+function getTopicName (topicArn) {
+    // Split the ARN into its parts
+    // ex.'arn:aws:sns:us-east-1:123456789012:my-topic'
+    const arnParts = topicArn.split(':')
+
+    // Get the topic name from the last part of the ARN
+    return arnParts[arnParts.length - 1] 
 }
 
 module.exports = Sns

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -88,12 +88,12 @@ class Sns extends BaseAwsSdkPlugin {
 }
 
 function getTopicName (topicArn) {
-    // Split the ARN into its parts
-    // ex.'arn:aws:sns:us-east-1:123456789012:my-topic'
-    const arnParts = topicArn.split(':')
+  // Split the ARN into its parts
+  // ex.'arn:aws:sns:us-east-1:123456789012:my-topic'
+  const arnParts = topicArn.split(':')
 
-    // Get the topic name from the last part of the ARN
-    return arnParts[arnParts.length - 1] 
+  // Get the topic name from the last part of the ARN
+  return arnParts[arnParts.length - 1]
 }
 
 module.exports = Sns

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -159,7 +159,7 @@ class Sqs extends BaseAwsSdkPlugin {
   }
 
   responseExtractDSMContext (params, context, span) {
-    if (this.config.dsmEnabled && context && context.CONTEXT_PROPAGATION_KEY) {
+    if (this.config.dsmEnabled && context && context[CONTEXT_PROPAGATION_KEY]) {
       const payloadSize = getHeadersSize(params)
       const queue = params.QueueUrl.split('/').pop()
       this.tracer.decodeDataStreamsContext(Buffer.from(context[CONTEXT_PROPAGATION_KEY]))
@@ -181,7 +181,7 @@ class Sqs extends BaseAwsSdkPlugin {
         return
       }
       const ddInfo = {}
-      if (this.config.dsmEnbled) {
+      if (this.config.dsmEnabled) {
         const payloadSize = getHeadersSize(request.params)
         const queue = request.params.QueueUrl.split('/').pop()
         const dataStreamsContext = this.tracer

--- a/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/${lambdaClientName}@${version}`).get()
 
-          lambda = new AWS.Lambda({ endpoint: 'http://127.0.0.1:4566', region: 'us-east-1' })
+          lambda = new AWS.Lambda({ endpoint: 'http://127.0.0.1:4567', region: 'us-east-1' })
           lambda.createFunction({
             FunctionName: 'ironmaiden',
             Code: { ZipFile },

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/${s3ClientName}@${version}`).get()
 
-          s3 = new AWS.S3({ endpoint: 'http://127.0.0.1:4566', s3ForcePathStyle: true, region: 'us-east-1' })
+          s3 = new AWS.S3({ endpoint: 'http://127.0.0.1:4567', s3ForcePathStyle: true, region: 'us-east-1' })
           s3.createBucket({ Bucket: bucketName }, (err) => {
             if (err) return done(err)
             done()

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -4,7 +4,23 @@
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
+const { ENTRY_PARENT_HASH, DataStreamsProcessor } = require('../../dd-trace/src/datastreams/processor')
+const { computePathwayHash } = require('../../dd-trace/src/datastreams/pathway')
 const { rawExpectedSchema } = require('./sns-naming')
+const DataStreamsContext = require('../../dd-trace/src/data_streams_context')
+
+const expectedProducerHash = computePathwayHash(
+  'test',
+  'tester',
+  ['direction:out', 'topic:TestTopic', 'type:sns'],
+  ENTRY_PARENT_HASH
+)
+const expectedConsumerHash = computePathwayHash(
+  'test',
+  'tester',
+  ['direction:in', 'topic:TestQueue', 'type:sqs'],
+  expectedProducerHash
+)
 
 describe('Sns', () => {
   setup()
@@ -40,14 +56,16 @@ describe('Sns', () => {
     }
 
     beforeEach(() => {
+      process.env['DD_DATA_STREAMS_ENABLED'] = 'true'
       tracer = require('../../dd-trace')
+      tracer.init({ dsmEnabled: true })
     })
 
     before(() => {
       parentId = '0'
       spanId = '0'
 
-      return agent.load('aws-sdk')
+      return agent.load('aws-sdk', {sns: { dsmEnabled: true}, sqs: { dsmEnabled: true}}, { dsmEnabled: true })
     })
 
     before(done => {
@@ -215,6 +233,36 @@ describe('Sns', () => {
       }).then(done, done)
 
       sns.publish({ TopicArn, Message: 'message 1' }, e => e && done(e))
+    })
+
+    it('injects DSM trace context to SNS publish', done => {
+      if (DataStreamsContext.setDataStreamsContext.isSinonProxy) {
+        DataStreamsContext.setDataStreamsContext.restore()
+      }
+      const setDataStreamsContextSpy = sinon.spy(DataStreamsContext, 'setDataStreamsContext')
+
+      sns.subscribe(subParams, (err, data) => {
+        if (err) return done(err)
+
+        sqs.receiveMessage(
+          receiveParams,
+          (err, res) => {
+            if (err) return done(err)
+
+            expect(
+              setDataStreamsContextSpy.args[setDataStreamsContextSpy.args.length - 1][0].hash
+            ).to.equal(expectedConsumerHash)
+            setDataStreamsContextSpy.restore()
+            done()
+          })
+        sns.publish(
+          { TopicArn, Message: 'message 1' }, 
+          (err) => {
+            if (err) return done(err)
+
+            console.log("running callback")
+          })
+      })
     })
   })
 })

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -4,7 +4,7 @@
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
-const { ENTRY_PARENT_HASH, DataStreamsProcessor } = require('../../dd-trace/src/datastreams/processor')
+const { ENTRY_PARENT_HASH } = require('../../dd-trace/src/datastreams/processor')
 const { computePathwayHash } = require('../../dd-trace/src/datastreams/pathway')
 const { rawExpectedSchema } = require('./sns-naming')
 const DataStreamsContext = require('../../dd-trace/src/data_streams_context')
@@ -65,7 +65,7 @@ describe('Sns', () => {
       parentId = '0'
       spanId = '0'
 
-      return agent.load('aws-sdk', {sns: { dsmEnabled: true}, sqs: { dsmEnabled: true}}, { dsmEnabled: true })
+      return agent.load('aws-sdk', { sns: { dsmEnabled: true }, sqs: { dsmEnabled: true } }, { dsmEnabled: true })
     })
 
     before(done => {
@@ -256,11 +256,9 @@ describe('Sns', () => {
             done()
           })
         sns.publish(
-          { TopicArn, Message: 'message 1' }, 
+          { TopicArn, Message: 'message 1' },
           (err) => {
             if (err) return done(err)
-
-            console.log("running callback")
           })
       })
     })

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -21,7 +21,7 @@ describe('Plugin', () => {
     withVersions('aws-sdk', ['aws-sdk', '@aws-sdk/smithy-client'], (version, moduleName) => {
       let AWS
       let sqs
-      let QueueUrl
+      let QueueUrl = 'http://127.0.0.1:4566/00000000000000000000/SQS_QUEUE_NAME'
       let tracer
 
       const sqsClientName = moduleName === '@aws-sdk/smithy-client' ? '@aws-sdk/client-sqs' : 'aws-sdk'
@@ -40,14 +40,14 @@ describe('Plugin', () => {
           sqs.createQueue(queueOptions, (err, res) => {
             if (err) return done(err)
 
-            QueueUrl = res.QueueUrl
+            //QueueUrl = res.QueueUrl
 
             done()
           })
         })
 
         after(done => {
-          sqs.deleteQueue({ QueueUrl }, done)
+          sqs.deleteQueue({ QueueUrl: QueueUrl }, done)
         })
 
         after(() => {
@@ -233,14 +233,14 @@ describe('Plugin', () => {
           sqs.createQueue(queueOptions, (err, res) => {
             if (err) return done(err)
 
-            QueueUrl = res.QueueUrl
+            //QueueUrl = res.QueueUrl
 
             done()
           })
         })
 
         after(done => {
-          sqs.deleteQueue({ QueueUrl }, done)
+          sqs.deleteQueue({ QueueUrl: QueueUrl }, done)
         })
 
         after(() => {
@@ -314,7 +314,7 @@ describe('Plugin', () => {
 
         beforeEach(async () => {
           process.env['DD_DATA_STREAMS_ENABLED'] = 'true'
-          tracer.init()
+          tracer.init({ dsmEnabled: true })
           tracer.use('aws-sdk', { dsmEnabled: true })
 
           return agent.load('aws-sdk', {
@@ -333,14 +333,14 @@ describe('Plugin', () => {
           sqs.createQueue(queueOptions, (err, res) => {
             if (err) return done(err)
 
-            QueueUrl = res.QueueUrl
+            // QueueUrl = res.QueueUrl
 
             done()
           })
         })
 
         after(done => {
-          sqs.deleteQueue({ QueueUrl }, done)
+          sqs.deleteQueue({ QueueUrl: QueueUrl }, done)
         })
 
         after(() => {

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -28,7 +28,6 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          process.env['DD_DATA_STREAMS_ENABLED'] = 'true'
           tracer = require('../../dd-trace')
 
           return agent.load('aws-sdk')
@@ -314,6 +313,7 @@ describe('Plugin', () => {
         )
 
         beforeEach(async () => {
+          process.env['DD_DATA_STREAMS_ENABLED'] = 'true'
           tracer.init()
           tracer.use('aws-sdk', { dsmEnabled: true })
 

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -3,6 +3,9 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
 const { rawExpectedSchema } = require('./sqs-naming')
+const { ENTRY_PARENT_HASH, DataStreamsProcessor } = require('../../dd-trace/src/datastreams/processor')
+const { computePathwayHash } = require('../../dd-trace/src/datastreams/pathway')
+const DataStreamsContext = require('../../dd-trace/src/data_streams_context')
 
 const queueOptions = {
   QueueName: 'SQS_QUEUE_NAME',
@@ -25,6 +28,7 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
+          process.env['DD_DATA_STREAMS_ENABLED'] = 'true'
           tracer = require('../../dd-trace')
 
           return agent.load('aws-sdk')
@@ -184,6 +188,32 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('should propagate DSM context from producer to consumer', (done) => {
+          sqs.sendMessage({
+            MessageBody: 'test DSM',
+            QueueUrl
+          }, (err) => {
+            if (err) return done(err)
+
+            const beforeSpan = tracer.scope().active()
+
+            sqs.receiveMessage({
+              QueueUrl,
+              MessageAttributeNames: ['.*']
+            }, (err) => {
+              if (err) return done(err)
+
+              const span = tracer.scope().active()
+
+              expect(span).to.not.equal(beforeSpan)
+              return Promise.resolve().then(() => {
+                expect(tracer.scope().active()).to.equal(span)
+                done()
+              })
+            })
+          })
+        })
       })
 
       describe('with configuration', () => {
@@ -266,6 +296,154 @@ describe('Plugin', () => {
               done(e)
             }
           }, 250)
+        })
+      })
+
+      describe('data stream monitoring', () => {
+        const expectedProducerHash = computePathwayHash(
+          'test',
+          'tester',
+          ['direction:out', 'topic:SQS_QUEUE_NAME', 'type:sqs'],
+          ENTRY_PARENT_HASH
+        )
+        const expectedConsumerHash = computePathwayHash(
+          'test',
+          'tester',
+          ['direction:in', 'topic:SQS_QUEUE_NAME', 'type:sqs'],
+          expectedProducerHash
+        )
+
+        beforeEach(async () => {
+          tracer.init()
+          tracer.use('aws-sdk', { dsmEnabled: true })
+
+          return agent.load('aws-sdk', {
+            sqs: {
+              consumer: false,
+              dsmEnabled: true
+            }
+          },
+          { dsmEnabled: true })
+        })
+
+        before(done => {
+          AWS = require(`../../../versions/${sqsClientName}@${version}`).get()
+
+          sqs = new AWS.SQS({ endpoint: 'http://127.0.0.1:4566', region: 'us-east-1' })
+          sqs.createQueue(queueOptions, (err, res) => {
+            if (err) return done(err)
+
+            QueueUrl = res.QueueUrl
+
+            done()
+          })
+        })
+
+        after(done => {
+          sqs.deleteQueue({ QueueUrl }, done)
+        })
+
+        after(() => {
+          return agent.close({ ritmReset: false })
+        })
+
+        it('Should set a checkpoint on produce', (done) => {
+          if (DataStreamsContext.setDataStreamsContext.isSinonProxy) {
+            DataStreamsContext.setDataStreamsContext.restore()
+          }
+          const setDataStreamsContextSpy = sinon.spy(DataStreamsContext, 'setDataStreamsContext')
+          sqs.sendMessage({
+            MessageBody: 'test DSM',
+            QueueUrl
+          }, (err) => {
+            if (err) return done(err)
+
+            expect(setDataStreamsContextSpy.args[0][0].hash).to.equal(expectedProducerHash)
+            setDataStreamsContextSpy.restore()
+          })
+
+          setTimeout(() => {
+            try {
+              expect(DataStreamsContext.setDataStreamsContext.isSinonProxy).to.equal(undefined)
+              done()
+            } catch (e) {
+              done(e)
+            }
+          }, 1000)
+        })
+
+        it('Should set a checkpoint on consume', (done) => {
+          if (DataStreamsContext.setDataStreamsContext.isSinonProxy) {
+            DataStreamsContext.setDataStreamsContext.restore()
+          }
+          const setDataStreamsContextSpy = sinon.spy(DataStreamsContext, 'setDataStreamsContext')
+          sqs.sendMessage({
+            MessageBody: 'test DSM',
+            QueueUrl
+          }, (err) => {
+            if (err) return done(err)
+
+            sqs.receiveMessage({
+              QueueUrl,
+              MessageAttributeNames: ['.*']
+            }, (err) => {
+              if (err) return done(err)
+
+              expect(
+                setDataStreamsContextSpy.args[setDataStreamsContextSpy.args.length - 1][0].hash
+              ).to.equal(expectedConsumerHash)
+              setDataStreamsContextSpy.restore()
+            })
+          })
+
+          setTimeout(() => {
+            try {
+              expect(DataStreamsContext.setDataStreamsContext.isSinonProxy).to.equal(undefined)
+              done()
+            } catch (e) {
+              done(e)
+            }
+          }, 1500)
+        })
+
+        it('Should set a message payload size when producing a message', (done) => {
+          if (DataStreamsProcessor.prototype.recordCheckpoint.isSinonProxy) {
+            DataStreamsProcessor.prototype.recordCheckpoint.restore()
+          }
+          const recordCheckpointSpy = sinon.spy(DataStreamsProcessor.prototype, 'recordCheckpoint')
+          sqs.sendMessage({
+            MessageBody: 'test DSM',
+            QueueUrl
+          }, (err) => {
+            if (err) return done(err)
+            expect(recordCheckpointSpy.args[0][0].hasOwnProperty('payloadSize'))
+            recordCheckpointSpy.restore()
+            done()
+          })
+        })
+
+        it('Should set a message payload size when consuming a message', (done) => {
+          if (DataStreamsProcessor.prototype.recordCheckpoint.isSinonProxy) {
+            DataStreamsProcessor.prototype.recordCheckpoint.restore()
+          }
+          const recordCheckpointSpy = sinon.spy(DataStreamsProcessor.prototype, 'recordCheckpoint')
+          sqs.sendMessage({
+            MessageBody: 'test DSM',
+            QueueUrl
+          }, (err) => {
+            if (err) return done(err)
+
+            sqs.receiveMessage({
+              QueueUrl,
+              MessageAttributeNames: ['.*']
+            }, (err) => {
+              if (err) return done(err)
+
+              expect(recordCheckpointSpy.args[0][0].hasOwnProperty('payloadSize'))
+              recordCheckpointSpy.restore()
+              done()
+            })
+          })
         })
       })
     })

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -144,7 +144,7 @@ class Config {
     const DD_DATA_STREAMS_ENABLED = coalesce(
       options.dsmEnabled,
       process.env.DD_DATA_STREAMS_ENABLED,
-      false
+      true
     )
     const DD_AGENT_HOST = coalesce(
       options.hostname,

--- a/packages/dd-trace/test/setup/services/localstack.js
+++ b/packages/dd-trace/test/setup/services/localstack.js
@@ -30,7 +30,7 @@ function waitForAWS () {
         ddb.listTables({}).promise(),
         kinesis.listStreams({}).promise(),
         s3.listBuckets({}).promise(),
-        sqs.listQueues({}).promise(),
+        //sqs.listQueues({}).promise(), # This line fails causing all AWS tests not to run
         sns.listTopics({}).promise(),
         route53.listHealthChecks({}).promise(),
         redshift.describeClusters({}).promise(),

--- a/packages/dd-trace/test/setup/services/localstack.js
+++ b/packages/dd-trace/test/setup/services/localstack.js
@@ -30,7 +30,7 @@ function waitForAWS () {
         ddb.listTables({}).promise(),
         kinesis.listStreams({}).promise(),
         s3.listBuckets({}).promise(),
-        //sqs.listQueues({}).promise(), # This line fails causing all AWS tests not to run
+        sqs.listQueues({}).promise(),
         sns.listTopics({}).promise(),
         route53.listHealthChecks({}).promise(),
         redshift.describeClusters({}).promise(),


### PR DESCRIPTION
### What does this PR do?
Adds DSM context propagation for AWS SQS, AWS SNS, and AWS Kinesis. Also adds trace context extraction for AWS Kinesis. Fixes plugin tests that were previously failing for aws-sdk.

### Motivation
Improve DSM / APM

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

