### PR TITLE
[core] Do Not Report HTTP Requests Over 5 Seconds as Errors on Node 20

### DIFF
--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -18,9 +18,19 @@ addHook({ name: 'https' }, hookFn)
 
 addHook({ name: 'http' }, hookFn)
 
+let customAgent = false
+
 function hookFn (http) {
   patch(http, 'request')
   patch(http, 'get')
+
+  // shim Agent to track if a custom agent is used
+  shimmer.wrap(http, 'Agent', function checkCustomAgent (Agent) {
+    return function () {
+      customAgent = true
+      return Agent.apply(this, arguments)
+    }
+  })
 
   return http
 }
@@ -58,6 +68,7 @@ function patch (http, methodName) {
         }
 
         const options = args.options
+        // console.log('options', options)
         const finish = () => {
           if (!finished) {
             finished = true
@@ -68,8 +79,15 @@ function patch (http, methodName) {
         try {
           const req = request.call(this, options, callback)
           const emit = req.emit
+          const setTimeout = req.setTimeout
+          let reqTimeout = false
 
           ctx.req = req
+
+          req.setTimeout = function () {
+            reqTimeout = true
+            return setTimeout.apply(this, arguments)
+          }
 
           req.emit = function (eventName, arg) {
             switch (eventName) {
@@ -88,6 +106,8 @@ function patch (http, methodName) {
               case 'error':
               case 'timeout':
                 ctx.error = arg
+                ctx.agent = { customAgent, timeout: this.agent.options.timeout }
+                ctx.reqTimeout = reqTimeout
                 errorChannel.publish(ctx)
               case 'abort': // deprecated and replaced by `close` in node 17
               case 'close':

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -98,8 +98,9 @@ class HttpClientPlugin extends ClientPlugin {
     span.finish()
   }
 
-  error ({ span, error }) {
+  error ({ span, error, agent = {}, reqTimeout }) {
     if (!span) return
+    // explicit error is set
     if (error) {
       span.addTags({
         [ERROR_TYPE]: error.name,
@@ -107,6 +108,10 @@ class HttpClientPlugin extends ClientPlugin {
         [ERROR_STACK]: error.stack
       })
     } else {
+      // check default agent timeout settings, don't tag as error
+      // Node 20 default 5s timeout does not provide error - sent as undefined
+      if (!reqTimeout && agent.timeout && !agent.customAgent) return
+
       span.setTag('error', 1)
     }
   }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -108,10 +108,9 @@ class HttpClientPlugin extends ClientPlugin {
       })
     } else {
       // conditions for no error:
-      // 1. not using a custom agent instance (args.options.agent is undefined or false)
-      // 2. no custom request timeout
-      // 3. for a default agent, a timeout must be specified (Node >=20 specific)
-      if (!args.options.agent && !customRequestTimeout && http.globalAgent.options.timeout) return
+      // 1. not using a custom agent instance with custom timeout specified
+      // 2. no invocation of `req.setTimeout`
+      if (!args.options.agent?.options.timeout && !customRequestTimeout) return
 
       span.setTag('error', 1)
     }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -98,7 +98,7 @@ class HttpClientPlugin extends ClientPlugin {
     span.finish()
   }
 
-  error ({ span, error, http, args, customRequestTimeout }) {
+  error ({ span, error, args, customRequestTimeout }) {
     if (!span) return
     if (error) {
       span.addTags({

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -820,7 +820,6 @@ describe('Plugin', () => {
               agent
                 .use(traces => {
                   expect(traces[0][0]).to.have.property('error', 0)
-                  // expect(traces[0][0].meta).to.have.property('http.status_code', '200') - can this be set?
                 })
                 .then(done)
                 .catch(done)
@@ -895,7 +894,7 @@ describe('Plugin', () => {
                 })
 
                 req.on('error', () => {})
-                req.setTimeout(5000)
+                req.setTimeout(5000) // match default timeout
 
                 req.end()
               })


### PR DESCRIPTION
### What does this PR do?
Makes sure timeouts recorded by the global agent above Node 20 that exceed the new 5s threshold are not reported as errors. Does this by checking three things before tagging timeouts as errors:

1. A custom agent with a custom timeout (`options.agent.options.timeout`) is not in play
2. A custom request timeout (via `req.setTimeout`) is not in play
3. ~~`http.globalAgent.options.timeout` is not set~~ This check was to ensure default timeouts do not happen with versions before. However, since there hasn't been a default timeout (`Infinity`) since Node 13, and the current supported tracer versions only support above Node 14, this check is not necessary. 

### Motivation
Fixes #3515 

Node 20 introduced a [change](https://github.com/nodejs/node/blob/60ffa9f1b377a5cdc388878e64ab5f305150e068/lib/_http_agent.js#L557) to the global agent that changed its timeout to 5s ([PR](https://github.com/nodejs/node/pull/43522/files)). On our end, this changed how errors are attached on timeouts, since supported Node versions for the tracer prior to Node 20 had no default timeout, any HTTP request above 5s that did not have a custom timeout specified would not be marked as erroneous. However, that behavior has changed with Node 20, and successful HTTP calls over 5s are marked as errors because they timeout (even with `keepAlive: true`). This PR changes that by checking the conditions mentioned above. Now, errors are _not_ recorded if the timeout happens when there is no custom agent with a custom timeout, or if `req.setTimeout` hasn't been invoked. If either have been, the timeout is still recorded as an error.

For `req.setTimeout` - it is "wrapped" only for the sake of seeing if it is invoked. Otherwise, it is difficult to discern if `req.socket.timeout` was set by the global agent or by the user. If set by the user, any timeout errors should be recorded. If set by the global agent, they should not. If the user has `req.setTimeout(5000)`, then `req.socket.timeout === 5000`. However, if they don't set it, then `req.socket.timeout === 5000` regardless.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!