### PR TITLE
flush custom metrics before process exit

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -36,6 +36,10 @@ class Tracer extends NoopProxy {
         setInterval(() => {
           this.dogstatsd.flush()
         }, 10 * 1000).unref()
+
+        process.once('beforeExit', () => {
+          this.dogstatsd.flush()
+        })
       }
 
       if (config.spanLeakDebug > 0) {

--- a/packages/dd-trace/test/custom-metrics-app.js
+++ b/packages/dd-trace/test/custom-metrics-app.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+console.log('demo app started')
+
+const tracer = require('../../../').init()
+
+tracer.dogstatsd.increment('page.views.data')
+
+console.log('demo app finished')

--- a/packages/dd-trace/test/custom-metrics.spec.js
+++ b/packages/dd-trace/test/custom-metrics.spec.js
@@ -1,0 +1,62 @@
+'use strict'
+
+/* eslint-disable no-console */
+
+require('./setup/tap')
+
+const http = require('http')
+const path = require('path')
+const os = require('os')
+const { exec } = require('child_process')
+
+describe('Custom Metrics', () => {
+  let httpServer
+  let httpPort
+  let metricsData
+  let sockets
+
+  beforeEach((done) => {
+    sockets = []
+    httpServer = http.createServer((req, res) => {
+      let httpData = ''
+      req.on('data', d => { httpData += d.toString() })
+      req.on('end', () => {
+        res.statusCode = 200
+        res.end()
+        if (req.url === '/dogstatsd/v2/proxy') {
+          metricsData = httpData
+        }
+      })
+    }).listen(0, () => {
+      httpPort = httpServer.address().port
+      if (os.platform() === 'win32') {
+        done()
+        return
+      }
+      done()
+    })
+    httpServer.on('connection', socket => sockets.push(socket))
+  })
+
+  afterEach(() => {
+    httpServer.close()
+    sockets.forEach(socket => socket.destroy())
+  })
+
+  it('should send metrics before process exit', (done) => {
+    exec(`${process.execPath} ${path.join(__dirname, 'custom-metrics-app.js')}`, {
+      env: {
+        DD_TRACE_AGENT_URL: `http://127.0.0.1:${httpPort}`
+      }
+    }, (err, stdout, stderr) => {
+      if (err) return done(err)
+      if (stdout) console.log(stdout)
+      if (stderr) console.error(stderr)
+
+      // eslint-disable-next-line no-undef
+      expect(metricsData.split('#')[0]).to.equal('page.views.data:1|c|')
+
+      done()
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
- flushes custom metrics before process exits

### Motivation
- short lived apps might not live long enough for a scheduled metric flush