### PR TITLE
fix: Do not reuse `requestOptions` object

### DIFF
--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -122,7 +122,7 @@ class RemoteConfigManager extends EventEmitter {
   }
 
   poll (cb) {
-    request(this.getPayload(), this.requestOptions, (err, data, statusCode) => {
+    request(this.getPayload(), Object.assign({}, this.requestOptions), (err, data, statusCode) => {
       // 404 means RC is disabled, ignore it
       if (statusCode === 404) return cb()
 


### PR DESCRIPTION
### What does this PR do?

Ensures a fresh options object is passed to `request` on each request.

### Motivation

This is good practice and protects against potential memory leaks such as https://github.com/getsentry/sentry-javascript/issues/8654 which just cost me [several days](https://twitter.com/tommoor/status/1732036521341911281) of debugging time.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

