### PR TITLE
[core] Propagate Resource Name Changes From Next.js Hooks

### DIFF
--- a/packages/datadog-plugin-next/test/datadog.js
+++ b/packages/datadog-plugin-next/test/datadog.js
@@ -2,10 +2,16 @@ module.exports = require('../../..').init({
   service: 'test',
   flushInterval: 0,
   plugins: false
-}).use('next', process.env.WITH_CONFIG ? {
+}).use('next', Number(process.env.WITH_CONFIG) ? {
   validateStatus: code => false,
   hooks: {
-    request: (span, req) => {
+    request: (span, req, res) => {
+      // convert error
+      const statusCode = res.statusCode
+      if ((statusCode < 200 || statusCode > 299) && statusCode !== 304) {
+        span.setTag('resource.name', `GET /${statusCode}`)
+      }
+
       // to count the number of times this hook has run between all processes
       const times = Number(process.env.TIMES_HOOK_CALLED) + 1
       process.env.TIMES_HOOK_CALLED = times + 1


### PR DESCRIPTION
### What does this PR do?
Allows changes to the `resource.name` tag for a Next.js span to be propagated to the parent `web` (whichever framework that may be).

### Motivation
Allows for conditionally changing the resource name for a Next.js span to be propagated appropriately to the parent `web` framework span, so it can be categorized properly in the Datadog UI. This could be useful for collapsing Next.js error pages into generic `/404`, `/500`, etc. Before, all resource names of this kind had their resources as the default page path (e.g. `/api/hello/[name]`. For large amounts of `404`s, the cardinality of this could become unmanageable in the Datadog UI. With this change, one can now do:

```javascript
tracer.use('next', {
  hooks: {
    request: (req, res, span) => {
      if (res.statusCode === 404) { // or any other kind of filter, maybe the same as `validateStatus`
        span.setTag('resource.name', `${req.method} /404`)
    }
  }
})
```

### Additional Notes
This change will only affect Next.js versions through Next 14 that don't use the App Router. From investigation, starting at Next 14, all 404s are categorized as `/_not-found` immediately upon request handling when using the App Router, not going through the normal `route` &rarr; `errorPage` flow. Thus, custom collapsing shouldn't be needed in Next 14 + App Router setups (although they won't be tagged as `${req.method} /404`, but `${req.method} /_not-found`, the cardinality for these errors should still be 1).

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

