### PR TITLE
[core] Ensure Explicit Timeouts from Underlying Request Socket are Recorded as Errors When Using Node 20

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -121,7 +121,7 @@ class HttpClientPlugin extends ClientPlugin {
     } else {
       // conditions for no error:
       // 1. not using a custom agent instance with custom timeout specified
-      // 2. no invocation of `req.setTimeout`
+      // 2. no invocation of `req.setTimeout` or `socket.setTimeout`
       if (!args.options.agent?.options.timeout && !customRequestTimeout) return
 
       span.setTag('error', 1)

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -900,6 +900,39 @@ describe('Plugin', () => {
               })
             })
           }).timeout(10000)
+
+          it('should record error if req.socket.setTimeout is used with Node 20', done => {
+            const app = express()
+
+            app.get('/user', async (req, res) => {
+              await new Promise(resolve => {
+                setTimeout(resolve, 6 * 1000)
+              })
+              res.status(200).send()
+            })
+
+            getPort().then(port => {
+              agent
+                .use(traces => {
+                  expect(traces[0][0]).to.have.property('error', 1)
+                })
+                .then(done)
+                .catch(done)
+
+              appListener = server(app, port, async () => {
+                const req = http.request(`${protocol}://localhost:${port}/user`, res => {
+                  res.on('data', () => { })
+                })
+
+                req.on('error', () => {})
+                req.on('socket', socket => {
+                  socket.setTimeout(5000)// match default timeout
+                })
+
+                req.end()
+              })
+            })
+          }).timeout(10000)
         }
 
         it('should only record a request once', done => {

--- a/packages/datadog-plugin-http/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-http/test/integration-test/server.mjs
@@ -10,5 +10,7 @@ const server = http.createServer(async (req, res) => {
   }
 }).listen(0, () => {
   const port = server.address().port
-  process.send({ port })
+  if (process.send) {
+    process.send({ port })
+  }
 })

--- a/packages/datadog-plugin-http2/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-http2/test/integration-test/server.mjs
@@ -7,5 +7,7 @@ const server = http2.createServer((req, res) => {
 
 server.listen(0, () => {
   const port = server.address().port
-  process.send({ port })
+  if (process.send) {
+    process.send({ port })
+  }
 })


### PR DESCRIPTION
### What does this PR do?
Makes sure intentional `setTimeout` calls on the underlying socket for a request are captured for recording errors on timeouts when using Node 20. See the linked PR below, but because Node 20 defaults to 5s timeouts on the global agent, we want to ignore those timeouts as errors, but record intentional ones as errors.

### Motivation
Addresses concern after merging #3841 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

