### PR TITLE
PROF-8520: Emit address and port as separate labels

### DIFF
--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -200,12 +200,13 @@ describe('profiler', () => {
     const eventKey = strings.dedup('event')
     const hostKey = strings.dedup('host')
     const addressKey = strings.dedup('address')
+    const portKey = strings.dedup('port')
     const threadNameKey = strings.dedup('thread name')
     const nameKey = strings.dedup('operation')
     const dnsEventValue = strings.dedup('dns')
     const dnsEvents = []
     for (const sample of prof.sample) {
-      let ts, event, host, address, name, threadName
+      let ts, event, host, address, port, name, threadName
       for (const label of sample.label) {
         switch (label.key) {
           case tsKey: ts = label.num; break
@@ -213,6 +214,7 @@ describe('profiler', () => {
           case eventKey: event = label.str; break
           case hostKey: host = label.str; break
           case addressKey: address = label.str; break
+          case portKey: port = label.num; break
           case threadNameKey: threadName = label.str; break
           default: assert.fail(`Unexpected label key ${label.key} ${strings.strings[label.key]}`)
         }
@@ -231,6 +233,7 @@ describe('profiler', () => {
         const ev = { name: strings.strings[name] }
         if (address) {
           ev.address = strings.strings[address]
+          ev.port = port
         } else {
           ev.host = strings.strings[host]
         }
@@ -242,7 +245,7 @@ describe('profiler', () => {
       { name: 'lookup', host: 'example.com' },
       { name: 'lookup', host: 'datadoghq.com' },
       { name: 'queryA', host: 'datadoghq.com' },
-      { name: 'lookupService', address: '13.224.103.60:80' }
+      { name: 'lookupService', address: '13.224.103.60', port: 80 }
     ])
   })
 

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -113,6 +113,7 @@ class DNSDecorator {
     this.operationNameLabelKey = stringTable.dedup('operation')
     this.hostLabelKey = stringTable.dedup('host')
     this.addressLabelKey = stringTable.dedup('address')
+    this.portLabelKey = stringTable.dedup('port')
     this.lanes = new Lanes(stringTable, `${threadNamePrefix} DNS`)
   }
 
@@ -130,7 +131,8 @@ class DNSDecorator {
         addLabel(this.hostLabelKey, detail.hostname)
         break
       case 'lookupService':
-        addLabel(this.addressLabelKey, `${detail.host}:${detail.port}`)
+        addLabel(this.addressLabelKey, detail.host)
+        labels.push(new Label({ key: this.portLabelKey, num: detail.port }))
         break
       case 'getHostByAddr':
         addLabel(this.addressLabelKey, detail.host)
@@ -148,7 +150,8 @@ class NetDecorator {
   constructor (stringTable) {
     this.stringTable = stringTable
     this.operationNameLabelKey = stringTable.dedup('operation')
-    this.addressLabelKey = stringTable.dedup('address')
+    this.hostLabelKey = stringTable.dedup('host')
+    this.portLabelKey = stringTable.dedup('port')
     this.lanes = new Lanes(stringTable, `${threadNamePrefix} Net`)
   }
 
@@ -162,7 +165,8 @@ class NetDecorator {
     addLabel(this.operationNameLabelKey, op)
     if (op === 'connect') {
       const detail = item.detail
-      addLabel(this.addressLabelKey, `${detail.host}:${detail.port}`)
+      addLabel(this.stringTable, this.hostLabelKey, detail.host)
+      labels.push(new Label({ key: this.portLabelKey, num: detail.port }))
     }
     labels.push(this.lanes.getLabelFor(item))
   }


### PR DESCRIPTION
### What does this PR do?
Emits address and port as separate labels for DNS and Net events instead of a concatenated "address:port" string.

### Motivation
It's more compact like that (one string per address in string table) and also avoids string concatenation.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.