### PR TITLE
chore: fix aws-sdk failing test suite

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -161,9 +161,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       localstack:
-        image: localstack/localstack:1.1.0
+        image: localstack/localstack:3.0.2
         env:
-          LOCALSTACK_SERVICES: dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless
+          LOCALSTACK_SERVICES: dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless,lambda
           EXTRA_CORS_ALLOWED_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           EXTRA_CORS_EXPOSE_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           AWS_DEFAULT_REGION: us-east-1
@@ -172,9 +172,26 @@ jobs:
           START_WEB: '0'
         ports:
           - 4566:4566
+      # we have two localstacks since upgrading localstack was causing lambda & S3 tests to fail
+      # To-Do: Debug localstack / lambda and localstack / S3
+      localstack-legacy:
+        image: localstack/localstack:1.1.0
+        ports:
+          - "127.0.0.1:4567:4567" # Edge
+        env:
+          LOCALSTACK_SERVICES: dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless
+          EXTRA_CORS_ALLOWED_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
+          EXTRA_CORS_EXPOSE_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
+          AWS_DEFAULT_REGION: us-east-1
+          FORCE_NONINTERACTIVE: 'true'
+          LAMBDA_EXECUTOR: local
+          START_WEB: '0'
+          GATEWAY_LISTEN: 127.0.0.1:4567
+          EDGE_PORT: 4567
+          EDGE_PORT_HTTP: 4567
     env:
       PLUGINS: aws-sdk
-      SERVICES: localstack
+      SERVICES: localstack localstack-legacy
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/testagent/start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,11 +87,26 @@ services:
     ports:
       - "127.0.0.1:8081:8081"
   localstack:
-    # TODO: Figure out why SNS doesn't work in >=1.2
-    # https://github.com/localstack/localstack/issues/7479
-    image: localstack/localstack:1.1.0
+    image: localstack/localstack:3.0.2
     ports:
       - "127.0.0.1:4566:4566" # Edge
+    environment:
+      - LOCALSTACK_SERVICES=dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless,lambda
+      - EXTRA_CORS_ALLOWED_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
+      - EXTRA_CORS_EXPOSE_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
+      - AWS_DEFAULT_REGION=us-east-1
+      - FORCE_NONINTERACTIVE=true
+      - START_WEB=0
+      - DEBUG=${DEBUG-}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+  localstack-legacy:
+    # we have two localstacks since upgrading localstack was causing lambda & S3 tests to fail
+    # To-Do: Debug localstack / lambda and localstack / S3
+    image: localstack/localstack:1.1.0
+    ports:
+      - "127.0.0.1:4567:4567" # Edge
     environment:
       - LOCALSTACK_SERVICES=dynamodb,kinesis,s3,sqs,sns,redshift,route53,logs,serverless
       - EXTRA_CORS_ALLOWED_HEADERS=x-amz-request-id,x-amzn-requestid,x-amz-id-2
@@ -99,6 +114,9 @@ services:
       - AWS_DEFAULT_REGION=us-east-1
       - FORCE_NONINTERACTIVE=true
       - START_WEB=0
+      - GATEWAY_LISTEN=127.0.0.1:4567
+      - EDGE_PORT=4567
+      - EDGE_PORT_HTTP=4567
       - LAMBDA_EXECUTOR=local
   kafka:
     image: debezium/kafka:1.7

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -20,6 +20,7 @@ describe('Kinesis', () => {
     })
 
     before(function (done) {
+      this.timeout(0)
       AWS = require(`../../../versions/${kinesisClientName}@${version}`).get()
 
       const params = {

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -19,7 +19,7 @@ describe('Kinesis', () => {
       return agent.load('aws-sdk')
     })
 
-    before(done => {
+    before(function (done) {
       AWS = require(`../../../versions/${kinesisClientName}@${version}`).get()
 
       const params = {
@@ -40,7 +40,7 @@ describe('Kinesis', () => {
       }, (err, res) => {
         if (err) return done(err)
 
-        helpers.waitForActiveStream(kinesis, done)
+        helpers.waitForActiveStream(this, kinesis, done)
       })
     })
 

--- a/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
@@ -45,12 +45,16 @@ function putTestRecord (kinesis, data, cb) {
   }, cb)
 }
 
-function waitForActiveStream (kinesis, cb) {
+function waitForActiveStream (mocha, kinesis, cb) {
   kinesis.describeStream({
     StreamName: 'MyStream'
   }, (err, data) => {
-    if (err) return waitForActiveStream(kinesis, cb)
+    if (err) {
+      mocha.timeout(250)
+      return waitForActiveStream(kinesis, cb)
+    }
     if (data.StreamDescription.StreamStatus !== 'ACTIVE') {
+      mocha.timeout(250)
       return waitForActiveStream(kinesis, cb)
     }
 
@@ -62,7 +66,7 @@ function waitForDeletedStream (kinesis, cb) {
   kinesis.describeStream({
     StreamName: 'MyStream'
   }, (err, data) => {
-    if (!err) return waitForDeletedStream(kinesis, cb)
+    if (err) return waitForDeletedStream(kinesis, cb)
     cb()
   })
 }

--- a/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
@@ -66,7 +66,7 @@ function waitForDeletedStream (kinesis, cb) {
   kinesis.describeStream({
     StreamName: 'MyStream'
   }, (err, data) => {
-    if (err) return waitForDeletedStream(kinesis, cb)
+    if (!err) return waitForDeletedStream(kinesis, cb)
     cb()
   })
 }

--- a/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
@@ -50,11 +50,11 @@ function waitForActiveStream (mocha, kinesis, cb) {
     StreamName: 'MyStream'
   }, (err, data) => {
     if (err) {
-      mocha.timeout(250)
+      mocha.timeout(2000)
       return waitForActiveStream(mocha, kinesis, cb)
     }
     if (data.StreamDescription.StreamStatus !== 'ACTIVE') {
-      mocha.timeout(250)
+      mocha.timeout(2000)
       return waitForActiveStream(mocha, kinesis, cb)
     }
 

--- a/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
@@ -51,11 +51,11 @@ function waitForActiveStream (mocha, kinesis, cb) {
   }, (err, data) => {
     if (err) {
       mocha.timeout(250)
-      return waitForActiveStream(kinesis, cb)
+      return waitForActiveStream(mocha, kinesis, cb)
     }
     if (data.StreamDescription.StreamStatus !== 'ACTIVE') {
       mocha.timeout(250)
-      return waitForActiveStream(kinesis, cb)
+      return waitForActiveStream(mocha, kinesis, cb)
     }
 
     cb()

--- a/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
@@ -40,7 +40,7 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/${lambdaClientName}@${version}`).get()
 
-          lambda = new AWS.Lambda({ endpoint: 'http://127.0.0.1:4566', region: 'us-east-1' })
+          lambda = new AWS.Lambda({ endpoint: 'http://127.0.0.1:4567', region: 'us-east-1' })
           lambda.createFunction({
             FunctionName: 'ironmaiden',
             Code: { ZipFile },

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
         before(done => {
           AWS = require(`../../../versions/${s3ClientName}@${version}`).get()
 
-          s3 = new AWS.S3({ endpoint: 'http://127.0.0.1:4566', s3ForcePathStyle: true, region: 'us-east-1' })
+          s3 = new AWS.S3({ endpoint: 'http://127.0.0.1:4567', s3ForcePathStyle: true, region: 'us-east-1' })
           s3.createBucket({ Bucket: bucketName }, (err) => {
             if (err) return done(err)
             done()


### PR DESCRIPTION
### What does this PR do?
Aws tests have not passed for several months. This PR fixes the connection issues we were previously getting and upgrades the localstack image. Ideally we would like to only be using a newer image of localstack, but the older image is being kept due to failures of s3 tests and lambda tests when trying to use the newer image.

### Motivation
Fixes failing suite in order to unblock future PR's that will add DSM for AWS SQS and SNS

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

