### PR TITLE
Create a GitHub security policy via SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+This document outlines the security policy for the Datadog Node.js Tracer (aka `dd-trace-js`) and what to do if you discover a security vulnerability in the project.
+Most notably, please do not share the details in a public forum (such as in a discussion, issue, or pull request) but instead reach out to us with the details.
+This gives us an opportunity to release a fix for others to benefit from by the time details are made public.
+
+
+## Supported Versions
+
+We accept vulnerability submissions for any [currently maintained release lines](https://github.com/DataDog/dd-trace-js#version-release-lines-and-maintenance).
+
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in the Datadog Node.js Tracer (or any Datadog product for that matter) please submit details to the following email address:
+
+* [security@datadoghq.com](mailto:security@datadoghq.com)


### PR DESCRIPTION
### What does this PR do?
- adds a security policy
- this file appears in the GitHub UI when users visit the security screen
- [more details on SECURITY.md](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)

### Motivation
- currently a user might think to submit a public issue which isn't what we want