### PR TITLE
Apply new rules for header injection detection to prevent false positives

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
@@ -47,8 +47,8 @@ class HeaderInjectionAnalyzer extends InjectionAnalyzer {
     const ranges = getRanges(iastContext, value)
     if (ranges?.length > 0) {
       return !(this.isCookieExclusion(lowerCasedHeaderName, ranges) ||
-        this.isAccessControlAllowOriginExclusion(lowerCasedHeaderName, ranges) ||
-        this.isSameHeaderExclusion(lowerCasedHeaderName, ranges))
+        this.isSameHeaderExclusion(lowerCasedHeaderName, ranges) ||
+        this.isAccessControlAllowOriginExclusion(lowerCasedHeaderName, ranges))
     }
 
     return false

--- a/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
@@ -44,9 +44,14 @@ class HeaderInjectionAnalyzer extends InjectionAnalyzer {
 
     if (this.isExcludedHeaderName(lowerCasedHeaderName) || typeof value !== 'string') return
 
-    return super._isVulnerable(value, iastContext) &&
-      !(this.isCookieExclusion(lowerCasedHeaderName, value, iastContext) ||
-        this.isAccessControlAllowOriginExclusion(lowerCasedHeaderName, value, iastContext))
+    const ranges = getRanges(iastContext, value)
+    if (ranges?.length > 0) {
+      return !(this.isCookieExclusion(lowerCasedHeaderName, ranges) ||
+        this.isAccessControlAllowOriginExclusion(lowerCasedHeaderName, ranges) ||
+        this.isSameHeaderExclusion(lowerCasedHeaderName, ranges))
+    }
+
+    return false
   }
 
   _getEvidence (headerInfo, iastContext) {
@@ -70,22 +75,26 @@ class HeaderInjectionAnalyzer extends InjectionAnalyzer {
     return EXCLUDED_HEADER_NAMES.includes(name)
   }
 
-  isCookieExclusion (name, value, iastContext) {
+  isCookieExclusion (name, ranges) {
     if (name === 'set-cookie') {
-      return getRanges(iastContext, value)
+      return ranges
         .every(range => range.iinfo.type === HTTP_REQUEST_COOKIE_VALUE || range.iinfo.type === HTTP_REQUEST_COOKIE_NAME)
     }
 
     return false
   }
 
-  isAccessControlAllowOriginExclusion (name, value, iastContext) {
+  isAccessControlAllowOriginExclusion (name, ranges) {
     if (name === 'access-control-allow-origin') {
-      return getRanges(iastContext, value)
+      return ranges
         .every(range => range.iinfo.type === HTTP_REQUEST_HEADER_VALUE)
     }
 
     return false
+  }
+
+  isSameHeaderExclusion (name, ranges) {
+    return ranges.length === 1 && name === ranges[0].iinfo.parameterName?.toLowerCase()
   }
 
   _getExcludedPaths () {

--- a/packages/dd-trace/test/appsec/iast/analyzers/header-injection.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/header-injection.express.plugin.spec.js
@@ -84,6 +84,22 @@ describe('Header injection vulnerability', () => {
         })
 
         testThatRequestHasNoVulnerability({
+          testDescription: 'should not have HEADER_INJECTION vulnerability ' +
+            'when is the header same header',
+          fn: (req, res) => {
+            setHeaderFunction('testheader', req.get('testheader'), res)
+          },
+          vulnerability: 'HEADER_INJECTION',
+          makeRequest: (done, config) => {
+            return axios.get(`http://localhost:${config.port}/`, {
+              headers: {
+                testheader: 'headerValue'
+              }
+            }).catch(done)
+          }
+        })
+
+        testThatRequestHasNoVulnerability({
           testDescription: 'should not have HEADER_INJECTION vulnerability when the header value is not tainted',
           fn: (req, res) => {
             setHeaderFunction('custom', 'not tainted string', res)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
If the header injection value is coming from other header with the same name, and it is the only tainted value in the new header, it will be considered safe.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prevent false positives

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

