### PR TITLE
API security sample rate via RC

### DIFF
--- a/packages/dd-trace/src/appsec/activation.js
+++ b/packages/dd-trace/src/appsec/activation.js
@@ -1,27 +1,27 @@
 'use strict'
 
 const Activation = {
-  OneClick: 'OneClick',
-  Enabled: 'Enabled',
-  Disabled: 'Disabled',
+  ONECLICK: 'OneClick',
+  ENABLED: 'Enabled',
+  DISABLED: 'Disabled',
 
   fromConfig (config) {
     switch (config.appsec.enabled) {
       // ASM is activated by an env var DD_APPSEC_ENABLED=true
       case true:
-        return Activation.Enabled
+        return Activation.ENABLED
 
       // ASM is disabled by an env var DD_APPSEC_ENABLED=false
       case false:
-        return Activation.Disabled
+        return Activation.DISABLED
 
       // ASM is activated by one click remote config
       case undefined:
-        return Activation.OneClick
+        return Activation.ONECLICK
 
       // Any other value should never occur
       default:
-        return Activation.Disabled
+        return Activation.DISABLED
     }
   }
 }

--- a/packages/dd-trace/src/appsec/activation.js
+++ b/packages/dd-trace/src/appsec/activation.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const Activation = {
+  OneClick: 'OneClick',
+  Enabled: 'Enabled',
+  Disabled: 'Disabled',
+
+  fromConfig (config) {
+    switch (config.appsec.enabled) {
+      // ASM is activated by an env var DD_APPSEC_ENABLED=true
+      case true:
+        return Activation.Enabled
+
+      // ASM is disabled by an env var DD_APPSEC_ENABLED=false
+      case false:
+        return Activation.Disabled
+
+      // ASM is activated by one click remote config
+      case undefined:
+        return Activation.OneClick
+
+      // Any other value should never occur
+      default:
+        return Activation.Disabled
+    }
+  }
+}
+
+module.exports = Activation

--- a/packages/dd-trace/src/appsec/api_security_sampler.js
+++ b/packages/dd-trace/src/appsec/api_security_sampler.js
@@ -24,7 +24,6 @@ function parseRequestSampling (requestSampling) {
   if (isNaN(parsed)) {
     log.warn(`Incorrect API Security request sampling value: ${requestSampling}`)
 
-    // NOTE: 0 or 0.1 the default value?
     parsed = 0
   } else {
     parsed = Math.min(1, Math.max(0, parsed))

--- a/packages/dd-trace/src/appsec/api_security_sampler.js
+++ b/packages/dd-trace/src/appsec/api_security_sampler.js
@@ -19,16 +19,18 @@ function setRequestSampling (sampling) {
 }
 
 function parseRequestSampling (requestSampling) {
-  const parsed = parseFloat(requestSampling)
+  let parsed = parseFloat(requestSampling)
 
-  if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) {
-    return parsed
-  } else {
+  if (isNaN(parsed)) {
     log.warn(`Incorrect API Security request sampling value: ${requestSampling}`)
 
     // NOTE: 0 or 0.1 the default value?
-    return 0
+    parsed = 0
+  } else {
+    parsed = Math.min(1, Math.max(0, parsed))
   }
+
+  return parsed
 }
 
 function sampleRequest () {

--- a/packages/dd-trace/src/appsec/api_security_sampler.js
+++ b/packages/dd-trace/src/appsec/api_security_sampler.js
@@ -1,0 +1,27 @@
+'use strict'
+
+let enabled
+let requestSampling
+
+function configure (apiSecurityConfig) {
+  enabled = apiSecurityConfig.enabled
+  requestSampling = apiSecurityConfig.requestSampling
+}
+
+function disable () {
+  enabled = false
+}
+
+function sampleRequest () {
+  if (!enabled || !requestSampling) {
+    return false
+  }
+
+  return Math.random() <= requestSampling
+}
+
+module.exports = {
+  configure,
+  disable,
+  sampleRequest
+}

--- a/packages/dd-trace/src/appsec/api_security_sampler.js
+++ b/packages/dd-trace/src/appsec/api_security_sampler.js
@@ -1,15 +1,34 @@
 'use strict'
 
+const log = require('../log')
+
 let enabled
 let requestSampling
 
-function configure (apiSecurityConfig) {
-  enabled = apiSecurityConfig.enabled
-  requestSampling = apiSecurityConfig.requestSampling
+function configure ({ apiSecurity }) {
+  enabled = apiSecurity.enabled
+  setRequestSampling(apiSecurity.requestSampling)
 }
 
 function disable () {
   enabled = false
+}
+
+function setRequestSampling (sampling) {
+  requestSampling = parseRequestSampling(sampling)
+}
+
+function parseRequestSampling (requestSampling) {
+  const parsed = parseFloat(requestSampling)
+
+  if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) {
+    return parsed
+  } else {
+    log.warn(`Incorrect API Security request sampling value: ${requestSampling}`)
+
+    // NOTE: 0 or 0.1 the default value?
+    return 0
+  }
 }
 
 function sampleRequest () {
@@ -23,5 +42,6 @@ function sampleRequest () {
 module.exports = {
   configure,
   disable,
+  setRequestSampling,
   sampleRequest
 }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -43,7 +43,7 @@ function enable (_config) {
 
     Reporter.setRateLimit(_config.appsec.rateLimit)
 
-    apiSecuritySampler.configure(_config.appsec.apiSecurity)
+    apiSecuritySampler.configure(_config.appsec)
 
     incomingHttpRequestStart.subscribe(incomingHttpStartTranslator)
     incomingHttpRequestEnd.subscribe(incomingHttpEndTranslator)

--- a/packages/dd-trace/src/appsec/remote_config/capabilities.js
+++ b/packages/dd-trace/src/appsec/remote_config/capabilities.js
@@ -9,5 +9,6 @@ module.exports = {
   ASM_USER_BLOCKING: 1n << 7n,
   ASM_CUSTOM_RULES: 1n << 8n,
   ASM_CUSTOM_BLOCKING_RESPONSE: 1n << 9n,
-  ASM_TRUSTED_IPS: 1n << 10n
+  ASM_TRUSTED_IPS: 1n << 10n,
+  ASM_API_SECURITY_SAMPLE_RATE: 1n << 11n
 }

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -18,6 +18,10 @@ function enable (config) {
       rc.updateCapabilities(RemoteConfigCapabilities.ASM_ACTIVATION, true)
     }
 
+    if (config.appsec.apiSecurity?.enabled) {
+      rc.updateCapabilities(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
+    }
+
     rc.on('ASM_FEATURES', (action, rcConfig) => {
       if (!rcConfig) return
 
@@ -46,7 +50,6 @@ function enableWafUpdate (appsecConfig) {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
-    rc.updateCapabilities(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, !!appsecConfig.apiSecurity?.enabled)
 
     rc.on('ASM_DATA', noop)
     rc.on('ASM_DD', noop)

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -89,7 +89,6 @@ function disableWafUpdate () {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_RULES, false)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, false)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_TRUSTED_IPS, false)
-    rc.updateCapabilities(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
 
     rc.off('ASM_DATA', noop)
     rc.off('ASM_DD', noop)

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -36,6 +36,24 @@ function enable (config) {
   return rc
 }
 
+function enableOrDisableAppsec (action, rcConfig, config) {
+  if (typeof rcConfig.asm?.enabled === 'boolean') {
+    let shouldEnable
+
+    if (action === 'apply' || action === 'modify') {
+      shouldEnable = rcConfig.asm.enabled // take control
+    } else {
+      shouldEnable = config.appsec.enabled // give back control to local config
+    }
+
+    if (shouldEnable) {
+      require('..').enable(config)
+    } else {
+      require('..').disable()
+    }
+  }
+}
+
 function enableWafUpdate (appsecConfig) {
   if (rc && appsecConfig && !appsecConfig.customRulesProvided) {
     // dirty require to make startup faster for serverless
@@ -78,24 +96,6 @@ function disableWafUpdate () {
     rc.off('ASM', noop)
 
     rc.off(RemoteConfigManager.kPreUpdate, RuleManager.updateWafFromRC)
-  }
-}
-
-function enableOrDisableAppsec (action, rcConfig, config) {
-  if (typeof rcConfig.asm?.enabled === 'boolean') {
-    let shouldEnable
-
-    if (action === 'apply' || action === 'modify') {
-      shouldEnable = rcConfig.asm.enabled // take control
-    } else {
-      shouldEnable = config.appsec.enabled // give back control to local config
-    }
-
-    if (shouldEnable) {
-      require('..').enable(config)
-    } else {
-      require('..').disable()
-    }
   }
 }
 

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -25,7 +25,7 @@ function enable (config) {
         enableOrDisableAppsec(action, rcConfig, config)
       }
 
-      updateApiSecuritySampleRate(rcConfig)
+      apiSecuritySampler.setRequestSampling(rcConfig.api_security?.request_sample_rate)
     })
   }
 
@@ -46,7 +46,7 @@ function enableWafUpdate (appsecConfig) {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
-    rc.updateCapabilities(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
+    rc.updateCapabilities(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, !!appsecConfig.apiSecurity?.enabled)
 
     rc.on('ASM_DATA', noop)
     rc.on('ASM_DD', noop)
@@ -92,16 +92,6 @@ function enableOrDisableAppsec (action, rcConfig, config) {
       require('..').enable(config)
     } else {
       require('..').disable()
-    }
-  }
-}
-
-function updateApiSecuritySampleRate (rcConfig) {
-  if (rcConfig.api_security?.request_sample_rate !== undefined) {
-    const requestSampling = parseFloat(rcConfig.api_security?.request_sample_rate)
-
-    if (!isNaN(requestSampling) && requestSampling >= 0 && requestSampling <= 1) {
-      apiSecuritySampler.configure({ enabled: requestSampling > 0, requestSampling })
     }
   }
 }

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -13,15 +13,15 @@ function enable (config) {
 
   const activation = Activation.fromConfig(config)
 
-  if (activation !== Activation.Disabled) {
-    if (activation === Activation.OneClick) {
+  if (activation !== Activation.DISABLED) {
+    if (activation === Activation.ONECLICK) {
       rc.updateCapabilities(RemoteConfigCapabilities.ASM_ACTIVATION, true)
     }
 
     rc.on('ASM_FEATURES', (action, rcConfig) => {
       if (!rcConfig) return
 
-      if (activation === Activation.OneClick) {
+      if (activation === Activation.ONECLICK) {
         enableOrDisableAppsec(action, rcConfig, config)
       }
 

--- a/packages/dd-trace/test/appsec/activation.spec.js
+++ b/packages/dd-trace/test/appsec/activation.spec.js
@@ -11,31 +11,31 @@ describe('Appsec Activation', () => {
     }
   })
 
-  it('should return OneClick with undefined value', () => {
+  it('should return ONECLICK with undefined value', () => {
     config.appsec.enabled = undefined
     const activation = Activation.fromConfig(config)
 
-    expect(activation).to.equal(Activation.OneClick)
+    expect(activation).to.equal(Activation.ONECLICK)
   })
 
-  it('should return Enabled with true value', () => {
+  it('should return ENABLED with true value', () => {
     config.appsec.enabled = true
     const activation = Activation.fromConfig(config)
 
-    expect(activation).to.equal(Activation.Enabled)
+    expect(activation).to.equal(Activation.ENABLED)
   })
 
-  it('should return Disabled with false value', () => {
+  it('should return DISABLED with false value', () => {
     config.appsec.enabled = false
     const activation = Activation.fromConfig(config)
 
-    expect(activation).to.equal(Activation.Disabled)
+    expect(activation).to.equal(Activation.DISABLED)
   })
 
-  it('should return Disabled with invalid value', () => {
+  it('should return DISABLED with invalid value', () => {
     config.appsec.enabled = 'invalid'
     const activation = Activation.fromConfig(config)
 
-    expect(activation).to.equal(Activation.Disabled)
+    expect(activation).to.equal(Activation.DISABLED)
   })
 })

--- a/packages/dd-trace/test/appsec/activation.spec.js
+++ b/packages/dd-trace/test/appsec/activation.spec.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const Activation = require('../../src/appsec/activation')
+
+describe('Appsec Activation', () => {
+  let config
+
+  beforeEach(() => {
+    config = {
+      appsec: {}
+    }
+  })
+
+  it('should return OneClick with undefined value', () => {
+    config.appsec.enabled = undefined
+    const activation = Activation.fromConfig(config)
+
+    expect(activation).to.equal(Activation.OneClick)
+  })
+
+  it('should return Enabled with true value', () => {
+    config.appsec.enabled = true
+    const activation = Activation.fromConfig(config)
+
+    expect(activation).to.equal(Activation.Enabled)
+  })
+
+  it('should return Disabled with false value', () => {
+    config.appsec.enabled = false
+    const activation = Activation.fromConfig(config)
+
+    expect(activation).to.equal(Activation.Disabled)
+  })
+
+  it('should return Disabled with invalid value', () => {
+    config.appsec.enabled = 'invalid'
+    const activation = Activation.fromConfig(config)
+
+    expect(activation).to.equal(Activation.Disabled)
+  })
+})

--- a/packages/dd-trace/test/appsec/api_security_sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security_sampler.spec.js
@@ -48,6 +48,14 @@ describe('Api Security Sampler', () => {
       expect(apiSecuritySampler.sampleRequest()).to.false
     })
 
+    it('should not sample request if incorrect config value', () => {
+      config.apiSecurity.requestSampling = NaN
+
+      apiSecuritySampler.configure(config)
+
+      expect(apiSecuritySampler.sampleRequest()).to.false
+    })
+
     it('should sample request according to the config', () => {
       config.apiSecurity.requestSampling = 1
 

--- a/packages/dd-trace/test/appsec/api_security_sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security_sampler.spec.js
@@ -40,7 +40,7 @@ describe('Api Security Sampler', () => {
       expect(apiSecuritySampler.sampleRequest()).to.true
     })
 
-    it('should not sample request if enabled and sampling greater than random', () => {
+    it('should not sample request if enabled and sampling less than random', () => {
       config.apiSecurity.requestSampling = 0.1
 
       apiSecuritySampler.configure(config)

--- a/packages/dd-trace/test/appsec/api_security_sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security_sampler.spec.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const apiSecuritySampler = require('../../src/appsec/api_security_sampler')
+
+describe('Api Security Sampler', () => {
+  let config
+
+  beforeEach(() => {
+    config = {
+      enabled: true,
+      requestSampling: 1
+    }
+
+    sinon.stub(Math, 'random').returns(0.3)
+  })
+
+  afterEach(sinon.restore)
+
+  describe('sampleRequest', () => {
+    it('should sample request if enabled and sampling 1', () => {
+      apiSecuritySampler.configure(config)
+
+      expect(apiSecuritySampler.sampleRequest()).to.true
+    })
+
+    it('should not sample request if enabled and sampling 0', () => {
+      config.requestSampling = 0
+      apiSecuritySampler.configure(config)
+
+      expect(apiSecuritySampler.sampleRequest()).to.false
+    })
+
+    it('should sample request if enabled and sampling greater than random', () => {
+      config.requestSampling = 0.5
+
+      apiSecuritySampler.configure(config)
+
+      expect(apiSecuritySampler.sampleRequest()).to.true
+    })
+
+    it('should not sample request if enabled and sampling greater than random', () => {
+      config.requestSampling = 0.1
+
+      apiSecuritySampler.configure(config)
+
+      expect(apiSecuritySampler.sampleRequest()).to.false
+    })
+
+    it('should sample request according to the config', () => {
+      config.requestSampling = 1
+
+      apiSecuritySampler.configure(config)
+
+      expect(apiSecuritySampler.sampleRequest()).to.true
+
+      apiSecuritySampler.configure({ enabled: false, requestSampling: 0 })
+
+      expect(apiSecuritySampler.sampleRequest()).to.false
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/api_security_sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security_sampler.spec.js
@@ -7,8 +7,10 @@ describe('Api Security Sampler', () => {
 
   beforeEach(() => {
     config = {
-      enabled: true,
-      requestSampling: 1
+      apiSecurity: {
+        enabled: true,
+        requestSampling: 1
+      }
     }
 
     sinon.stub(Math, 'random').returns(0.3)
@@ -24,14 +26,14 @@ describe('Api Security Sampler', () => {
     })
 
     it('should not sample request if enabled and sampling 0', () => {
-      config.requestSampling = 0
+      config.apiSecurity.requestSampling = 0
       apiSecuritySampler.configure(config)
 
       expect(apiSecuritySampler.sampleRequest()).to.false
     })
 
     it('should sample request if enabled and sampling greater than random', () => {
-      config.requestSampling = 0.5
+      config.apiSecurity.requestSampling = 0.5
 
       apiSecuritySampler.configure(config)
 
@@ -39,7 +41,7 @@ describe('Api Security Sampler', () => {
     })
 
     it('should not sample request if enabled and sampling greater than random', () => {
-      config.requestSampling = 0.1
+      config.apiSecurity.requestSampling = 0.1
 
       apiSecuritySampler.configure(config)
 
@@ -47,13 +49,13 @@ describe('Api Security Sampler', () => {
     })
 
     it('should sample request according to the config', () => {
-      config.requestSampling = 1
+      config.apiSecurity.requestSampling = 1
 
       apiSecuritySampler.configure(config)
 
       expect(apiSecuritySampler.sampleRequest()).to.true
 
-      apiSecuritySampler.configure({ enabled: false, requestSampling: 0 })
+      apiSecuritySampler.setRequestSampling(0)
 
       expect(apiSecuritySampler.sampleRequest()).to.false
     })

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -358,7 +358,7 @@ describe('Remote Config index', () => {
         rc.updateCapabilities.resetHistory()
         remoteConfig.disableWafUpdate()
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(9)
+        expect(rc.updateCapabilities.callCount).to.be.equal(8)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, false)
         expect(rc.updateCapabilities.getCall(1))
@@ -375,8 +375,6 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, false)
         expect(rc.updateCapabilities.getCall(7))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, false)
-        expect(rc.updateCapabilities.getCall(8))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
 
         expect(rc.off.callCount).to.be.equal(4)
         expect(rc.off.getCall(0)).to.have.been.calledWith('ASM_DATA')

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -32,7 +32,8 @@ describe('Remote Config index', () => {
     }
 
     apiSecuritySampler = {
-      configure: sinon.stub()
+      configure: sinon.stub(),
+      setRequestSampling: sinon.stub()
     }
 
     appsec = {
@@ -144,7 +145,7 @@ describe('Remote Config index', () => {
             }
           })
 
-          expect(apiSecuritySampler.configure).to.be.calledOnceWithExactly({ enabled: true, requestSampling: 0.5 })
+          expect(apiSecuritySampler.setRequestSampling).to.be.calledOnceWithExactly(0.5)
         })
 
         it('should update apiSecuritySampler config and disable it', () => {
@@ -154,7 +155,7 @@ describe('Remote Config index', () => {
             }
           })
 
-          expect(apiSecuritySampler.configure).to.be.calledOnceWithExactly({ enabled: false, requestSampling: 0 })
+          expect(apiSecuritySampler.setRequestSampling).to.be.calledOnceWithExactly(0)
         })
 
         it('should not update apiSecuritySampler config with values greater than 1', () => {
@@ -213,7 +214,7 @@ describe('Remote Config index', () => {
             }
           })
 
-          expect(apiSecuritySampler.configure).to.be.calledOnceWithExactly({ enabled: true, requestSampling: 0.5 })
+          expect(apiSecuritySampler.setRequestSampling).to.be.calledOnceWithExactly(0.5)
         })
       })
     })
@@ -261,7 +262,7 @@ describe('Remote Config index', () => {
         expect(rc.updateCapabilities.getCall(7))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
         expect(rc.updateCapabilities.getCall(8))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
 
         expect(rc.on.callCount).to.be.equal(5)
         expect(rc.on.getCall(0)).to.have.been.calledWith('ASM_FEATURES')
@@ -294,7 +295,7 @@ describe('Remote Config index', () => {
         expect(rc.updateCapabilities.getCall(7))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
         expect(rc.updateCapabilities.getCall(8))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
 
         expect(rc.on.callCount).to.be.equal(5)
         expect(rc.on.getCall(0)).to.have.been.calledWith('ASM_FEATURES')
@@ -306,6 +307,34 @@ describe('Remote Config index', () => {
 
       it('should activate if appsec enabled is not defined', () => {
         config.appsec = {}
+        remoteConfig.enable(config)
+        remoteConfig.enableWafUpdate(config.appsec)
+
+        expect(rc.updateCapabilities.callCount).to.be.equal(10)
+        expect(rc.updateCapabilities.getCall(0))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_ACTIVATION, true)
+        expect(rc.updateCapabilities.getCall(1))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, true)
+        expect(rc.updateCapabilities.getCall(2))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_USER_BLOCKING, true)
+        expect(rc.updateCapabilities.getCall(3))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_DD_RULES, true)
+        expect(rc.updateCapabilities.getCall(4))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_EXCLUSIONS, true)
+        expect(rc.updateCapabilities.getCall(5))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, true)
+        expect(rc.updateCapabilities.getCall(6))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
+        expect(rc.updateCapabilities.getCall(7))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
+        expect(rc.updateCapabilities.getCall(8))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
+        expect(rc.updateCapabilities.getCall(9))
+          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
+      })
+
+      it('should activate ASM_API_SECURITY_SAMPLE_RATE if apiSecurity is enabled', () => {
+        config.appsec = { apiSecurity: { enabled: true } }
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -82,6 +82,30 @@ describe('Remote Config index', () => {
       expect(rc.on).to.not.have.been.called
     })
 
+    it('should listen ASM_API_SECURITY_SAMPLE_RATE when appsec.enabled=undefined and appSecurity.enabled=true', () => {
+      config.appsec = { enabled: undefined, apiSecurity: { enabled: true } }
+
+      remoteConfig.enable(config)
+
+      expect(RemoteConfigManager).to.have.been.calledOnceWithExactly(config)
+      expect(rc.updateCapabilities).to.have.been.calledTwice
+      expect(rc.updateCapabilities.firstCall)
+        .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_ACTIVATION, true)
+      expect(rc.updateCapabilities.secondCall)
+        .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
+    })
+
+    it('should listen ASM_API_SECURITY_SAMPLE_RATE when appsec.enabled=true and appSecurity.enabled=true', () => {
+      config.appsec = { enabled: true, apiSecurity: { enabled: true } }
+
+      remoteConfig.enable(config)
+
+      expect(RemoteConfigManager).to.have.been.calledOnceWithExactly(config)
+      expect(rc.updateCapabilities).to.have.been.calledOnce
+      expect(rc.updateCapabilities.firstCall)
+        .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
+    })
+
     describe('ASM_FEATURES remote config listener', () => {
       let listener
 
@@ -244,7 +268,7 @@ describe('Remote Config index', () => {
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(9)
+        expect(rc.updateCapabilities.callCount).to.be.equal(8)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, true)
         expect(rc.updateCapabilities.getCall(1))
@@ -261,8 +285,6 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
         expect(rc.updateCapabilities.getCall(7))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
-        expect(rc.updateCapabilities.getCall(8))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
 
         expect(rc.on.callCount).to.be.equal(5)
         expect(rc.on.getCall(0)).to.have.been.calledWith('ASM_FEATURES')
@@ -277,7 +299,7 @@ describe('Remote Config index', () => {
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(9)
+        expect(rc.updateCapabilities.callCount).to.be.equal(8)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, true)
         expect(rc.updateCapabilities.getCall(1))
@@ -294,8 +316,6 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
         expect(rc.updateCapabilities.getCall(7))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
-        expect(rc.updateCapabilities.getCall(8))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
 
         expect(rc.on.callCount).to.be.equal(5)
         expect(rc.on.getCall(0)).to.have.been.calledWith('ASM_FEATURES')
@@ -310,7 +330,7 @@ describe('Remote Config index', () => {
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 
-        expect(rc.updateCapabilities.callCount).to.be.equal(10)
+        expect(rc.updateCapabilities.callCount).to.be.equal(9)
         expect(rc.updateCapabilities.getCall(0))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_ACTIVATION, true)
         expect(rc.updateCapabilities.getCall(1))
@@ -329,36 +349,6 @@ describe('Remote Config index', () => {
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
         expect(rc.updateCapabilities.getCall(8))
           .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
-        expect(rc.updateCapabilities.getCall(9))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, false)
-      })
-
-      it('should activate ASM_API_SECURITY_SAMPLE_RATE if apiSecurity is enabled', () => {
-        config.appsec = { apiSecurity: { enabled: true } }
-        remoteConfig.enable(config)
-        remoteConfig.enableWafUpdate(config.appsec)
-
-        expect(rc.updateCapabilities.callCount).to.be.equal(10)
-        expect(rc.updateCapabilities.getCall(0))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_ACTIVATION, true)
-        expect(rc.updateCapabilities.getCall(1))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_IP_BLOCKING, true)
-        expect(rc.updateCapabilities.getCall(2))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_USER_BLOCKING, true)
-        expect(rc.updateCapabilities.getCall(3))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_DD_RULES, true)
-        expect(rc.updateCapabilities.getCall(4))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_EXCLUSIONS, true)
-        expect(rc.updateCapabilities.getCall(5))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_REQUEST_BLOCKING, true)
-        expect(rc.updateCapabilities.getCall(6))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_RULES, true)
-        expect(rc.updateCapabilities.getCall(7))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
-        expect(rc.updateCapabilities.getCall(8))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
-        expect(rc.updateCapabilities.getCall(9))
-          .to.have.been.calledWithExactly(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
Adds new RC `ASM_API_SECURITY_SAMPLE_RATE` capability

When API Security has been enabled setting `DD_EXPERIMENTAL_API_SECURITY_ENABLED=true`, report the `ASM_API_SECURITY_SAMPLE_RATE` and wait for the changes on the additional setting in the `ASM_FEATURES` product
```
{
  "api_security": {
    "request_sample_rate": 0.1
  }  
}
```

`request_sample_rate` is a float with allowed values between 0 and 1 (both inclusive)

Two possible states for the tracer with API Security activated with `DD_EXPERIMENTAL_API_SECURITY_ENABLED=true`

- ASM is activated by one click remote config. The tracer must register the `ASM_FEATURES` product and receive all information, both for asm activation and api sample rate.
- ASM is activated by an env var `DD_APPSEC_ENABLED=true`. The tracer must register the `ASM_FEATURES` product (this is new from previous tracers behaviour) and only receive information about api sample rate.

### Motivation


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

