### PR TITLE
Fix tedious and elasticsearch plugin tests

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1209,9 +1209,6 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/16
-      - run: yarn test:plugins:ci
-      - run: yarn test:plugins:upstream
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - run: yarn test:plugins:upstream

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -85,7 +85,7 @@ jobs:
     services:
       aerospike:
         image: aerospike:ce-5.7.0.15
-        ports: 
+        ports:
           - "127.0.0.1:3000-3002:3000-3002"
     env:
       PLUGINS: aerospike
@@ -106,7 +106,7 @@ jobs:
     services:
       aerospike:
         image: aerospike:ce-6.4.0.3
-        ports: 
+        ports:
           - "127.0.0.1:3000-3002:3000-3002"
     env:
       PLUGINS: aerospike
@@ -434,8 +434,6 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
-      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - if: always()


### PR DESCRIPTION
### What does this PR do?

It seems the latest versions of tedious and elasticsearch are incompatible with node@16, so we shouldn't test them in that version.

https://github.com/DataDog/dd-trace-js/actions/runs/7210370990/job/19643398921?pr=3752

```
  1) esm
       with tedious >=1.0.0 (16.6.1)
         "before all" hook for "is instrumented":
     Error: Command failed: yarn add file:/tmp/60f5525a252b1033/dd-trace.tgz 'tedious@>=1.0.0'
error @azure/core-rest-pipeline@1.13.0: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.20.2"
```

https://github.com/DataDog/dd-trace-js/actions/runs/7210370990/job/19643383785?pr=3752
```
  1) esm
       with @elastic/elasticsearch >=8 (8.11.0)
         "before all" hook for "is instrumented":
     Error: Command failed: yarn add file:/tmp/6619782322b3a5db/dd-trace.tgz '@elastic/elasticsearch@>=8'
error @elastic/elasticsearch@8.11.0: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"
```


### Motivation

Improve CI

