### PR TITLE
Only run DNS and Net timeline events integration tests on Node 16+

### DIFF
--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -13,6 +13,7 @@ const fsync = require('node:fs')
 const net = require('node:net')
 const zlib = require('node:zlib')
 const { Profile } = require('pprof-format')
+const semver = require('semver')
 
 async function checkProfiles (agent, proc, timeout,
   expectedProfileTypes = ['wall', 'space'], expectBadExit = false, multiplicity = 1) {
@@ -246,59 +247,61 @@ describe('profiler', () => {
     assert.equal(endpoints.size, 3)
   })
 
-  it('dns timeline events work', async () => {
-    const dnsEvents = await gatherNetworkTimelineEvents(cwd, 'profiler/dnstest.js', 'dns', 'DNS')
-    assert.sameDeepMembers(dnsEvents, [
-      { name: 'lookup', host: 'example.org' },
-      { name: 'lookup', host: 'example.com' },
-      { name: 'lookup', host: 'datadoghq.com' },
-      { name: 'queryA', host: 'datadoghq.com' },
-      { name: 'lookupService', address: '13.224.103.60', port: 80 }
-    ])
-  })
+  if (semver.gte(process.version, '16.0.0')) {
+    it('dns timeline events work', async () => {
+      const dnsEvents = await gatherNetworkTimelineEvents(cwd, 'profiler/dnstest.js', 'dns', 'DNS')
+      assert.sameDeepMembers(dnsEvents, [
+        { name: 'lookup', host: 'example.org' },
+        { name: 'lookup', host: 'example.com' },
+        { name: 'lookup', host: 'datadoghq.com' },
+        { name: 'queryA', host: 'datadoghq.com' },
+        { name: 'lookupService', address: '13.224.103.60', port: 80 }
+      ])
+    })
 
-  it('net timeline events work', async () => {
-    // Simple server that writes a constant message to the socket.
-    const msg = 'cya later!\n'
-    function createServer () {
-      const server = net.createServer((socket) => {
-        socket.end(msg, 'utf8')
-      }).on('error', (err) => {
-        throw err
-      })
-      return server
-    }
-    // Create two instances of the server
-    const server1 = createServer()
-    try {
-      const server2 = createServer()
+    it('net timeline events work', async () => {
+      // Simple server that writes a constant message to the socket.
+      const msg = 'cya later!\n'
+      function createServer () {
+        const server = net.createServer((socket) => {
+          socket.end(msg, 'utf8')
+        }).on('error', (err) => {
+          throw err
+        })
+        return server
+      }
+      // Create two instances of the server
+      const server1 = createServer()
       try {
-        // Have the servers listen on ephemeral ports
-        const p = new Promise(resolve => {
-          server1.listen(0, () => {
-            server2.listen(0, async () => {
-              resolve([server1.address().port, server2.address().port])
+        const server2 = createServer()
+        try {
+          // Have the servers listen on ephemeral ports
+          const p = new Promise(resolve => {
+            server1.listen(0, () => {
+              server2.listen(0, async () => {
+                resolve([server1.address().port, server2.address().port])
+              })
             })
           })
-        })
-        const [ port1, port2 ] = await p
-        const args = [String(port1), String(port2), msg]
-        // Invoke the profiled program, passing it the ports of the servers and
-        // the expected message.
-        const events = await gatherNetworkTimelineEvents(cwd, 'profiler/nettest.js', 'net', 'Net', args)
-        // The profiled program should have two TCP connection events to the two
-        // servers.
-        assert.sameDeepMembers(events, [
-          { name: 'connect', host: '127.0.0.1', port: port1 },
-          { name: 'connect', host: '127.0.0.1', port: port2 }
-        ])
+          const [ port1, port2 ] = await p
+          const args = [String(port1), String(port2), msg]
+          // Invoke the profiled program, passing it the ports of the servers and
+          // the expected message.
+          const events = await gatherNetworkTimelineEvents(cwd, 'profiler/nettest.js', 'net', 'Net', args)
+          // The profiled program should have two TCP connection events to the two
+          // servers.
+          assert.sameDeepMembers(events, [
+            { name: 'connect', host: '127.0.0.1', port: port1 },
+            { name: 'connect', host: '127.0.0.1', port: port2 }
+          ])
+        } finally {
+          server2.close()
+        }
       } finally {
-        server2.close()
+        server1.close()
       }
-    } finally {
-      server1.close()
-    }
-  })
+    })
+  }
 
   context('shutdown', () => {
     beforeEach(async () => {


### PR DESCRIPTION
### What does this PR do?
Restricts running DNS and Net timeline events integration tests only to Node 16 and above.

### Motivation
DNS and Net perf events aren't available in Node 14; the tests can't work.

### Additional Notes
Recommended to review in [whitespace-ignore mode](https://github.com/DataDog/dd-trace-js/pull/3879/files?w=1).

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.