### PR TITLE
ci: no longer test sharedb against node v14

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1182,8 +1182,6 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
-      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - if: always()


### PR DESCRIPTION
### What does this PR do?
- no longer tests sharedb against node v14

### Motivation
- seems no longer compatible as of v4.1.2
- https://github.com/share/sharedb/commit/06cc3877fd9b53d1ddc3ecdd3df11f68fbdbb100#diff-3fb720f70ea34fb2975fd6c38ac4b6b6131373be2abfa4760dfaae8a25daaee2R11
- `Uncaught TypeError: util.hasOwn is not a function`