### PR TITLE
[profiling]  Add thread id labels to heap and wall profiles

### DIFF
--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -188,9 +188,11 @@ describe('profiler', () => {
     const rootSpanKey = strings.dedup('local root span id')
     const endpointKey = strings.dedup('trace endpoint')
     const threadNameKey = strings.dedup('thread name')
+    const threadIdKey = strings.dedup('thread id')
+    const osThreadIdKey = strings.dedup('os thread id')
     const threadNameValue = strings.dedup('Main Event Loop')
     for (const sample of prof.sample) {
-      let ts, spanId, rootSpanId, endpoint, threadName
+      let ts, spanId, rootSpanId, endpoint, threadName, threadId, osThreadId
       for (const label of sample.label) {
         switch (label.key) {
           case tsKey: ts = label.num; break
@@ -198,11 +200,15 @@ describe('profiler', () => {
           case rootSpanKey: rootSpanId = label.str; break
           case endpointKey: endpoint = label.str; break
           case threadNameKey: threadName = label.str; break
+          case threadIdKey: threadId = label.str; break
+          case osThreadIdKey: osThreadId = label.str; break
           default: assert.fail(`Unexpected label key ${strings.dedup(label.key)}`)
         }
       }
       // Timestamp must be defined and be between process start and end time
       assert.isDefined(ts)
+      assert.isNumber(osThreadId)
+      assert.equal(threadId, strings.dedup('0'))
       assert.isTrue(ts <= procEnd)
       assert.isTrue(ts >= procStart)
       // Thread name must be defined and exactly equal "Main Event Loop"

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -1,5 +1,5 @@
 const { performance, constants, PerformanceObserver } = require('node:perf_hooks')
-const { END_TIMESTAMP } = require('./shared')
+const { END_TIMESTAMP_LABEL } = require('./shared')
 const semver = require('semver')
 const { Function, Label, Line, Location, Profile, Sample, StringTable, ValueType } = require('pprof-format')
 const pprof = require('@datadog/pprof/')
@@ -202,7 +202,7 @@ class EventsProfiler {
       decorator.eventTypeLabel = labelFromStrStr(stringTable, 'event', eventType)
       decorators[eventType] = decorator
     }
-    const timestampLabelKey = stringTable.dedup(END_TIMESTAMP)
+    const timestampLabelKey = stringTable.dedup(END_TIMESTAMP_LABEL)
 
     let durationFrom = Number.POSITIVE_INFINITY
     let durationTo = 0

--- a/packages/dd-trace/src/profiling/profilers/shared.js
+++ b/packages/dd-trace/src/profiling/profilers/shared.js
@@ -2,8 +2,38 @@
 
 const { isMainThread, threadId } = require('node:worker_threads')
 
+const END_TIMESTAMP_LABEL = 'end_timestamp_ns'
+const THREAD_NAME_LABEL = 'thread name'
+const OS_THREAD_ID_LABEL = 'os thread id'
+const THREAD_ID_LABEL = 'thread id'
+const threadNamePrefix = isMainThread ? 'Main' : `Worker #${threadId}`
+const eventLoopThreadName = `${threadNamePrefix} Event Loop`
+
+function getThreadLabels () {
+  const pprof = require('@datadog/pprof')
+  const nativeThreadId = pprof.getNativeThreadId()
+  return {
+    [THREAD_NAME_LABEL]: eventLoopThreadName,
+    [THREAD_ID_LABEL]: `${threadId}`,
+    [OS_THREAD_ID_LABEL]: `${nativeThreadId}`
+  }
+}
+
+function cacheThreadLabels () {
+  let labels
+  return () => {
+    if (!labels) {
+      labels = getThreadLabels()
+    }
+    return labels
+  }
+}
+
 module.exports = {
-  END_TIMESTAMP: 'end_timestamp_ns',
-  THREAD_NAME: 'thread name',
-  threadNamePrefix: isMainThread ? 'Main' : `Worker #${threadId}`
+  END_TIMESTAMP_LABEL,
+  THREAD_NAME_LABEL,
+  THREAD_ID_LABEL,
+  threadNamePrefix,
+  eventLoopThreadName,
+  getThreadLabels: cacheThreadLabels()
 }

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { oomExportStrategies } = require('../constants')
+const { getThreadLabels } = require('./shared')
 
 function strategiesToCallbackMode (strategies, callbackMode) {
   return strategies.includes(oomExportStrategies.ASYNC_CALLBACK) ? callbackMode.Async : 0
@@ -33,7 +34,7 @@ class NativeSpaceProfiler {
   }
 
   profile () {
-    return this._pprof.heap.profile(undefined, this._mapper)
+    return this._pprof.heap.profile(undefined, this._mapper, getThreadLabels)
   }
 
   encode (profile) {


### PR DESCRIPTION
### What does this PR do?
Add thread id labels (`thread id` for the worker thread id and `os thread id` for native thread id) to wall and heap profiles.

### Motivation
Allow to identify in the UI from which worker thread the profile is emitted.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

