### PR TITLE
Configure parametric test to get the nodejs tracer in same way as sys…

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -62,15 +62,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_LIBRARY: nodejs
+      #keep this line until system-tests -> robertomonteromiguel/parametric_use_load_binary_nodejs merged
       NODEJS_DDTRACE_MODULE: datadog/dd-trace-js#${{ github.sha }}
     steps:
       - name: Checkout system tests
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
+          ref: 'robertomonteromiguel/parametric_use_load_binary_nodejs'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+      - name: Checkout dd-trace-js
+        uses: actions/checkout@v3
+        with:
+          path: 'binaries/dd-trace-js'
       - name: Build
         run: ./build.sh -i runner
       - name: Run

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -69,7 +69,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'DataDog/system-tests'
-          ref: 'robertomonteromiguel/parametric_use_load_binary_nodejs'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'


### PR DESCRIPTION
Configure parametric test to get the nodejs tracer in same way as sytem-tests.
The variable NODEJS_DDTRACE_MODULE will no longer be necessary after merge the system-tests PR "robertomonteromiguel/parametric_use_load_binary_nodejs" 
Once system-tests PR is merged we will create a new dd-trace-js PR to remove NODEJS_DDTRACE_MODULE definitively.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

