### PR TITLE
PROF-8829: Fix recording times

### DIFF
--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -139,7 +139,7 @@ class Profiler extends EventEmitter {
     try {
       // collect profiles synchronously so that profilers can be safely stopped asynchronously
       for (const profiler of this._config.profilers) {
-        const profile = profiler.profile()
+        const profile = profiler.profile(start, end)
         if (!profile) continue
         profiles.push({ profiler, profile })
       }

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -174,7 +174,7 @@ class EventsProfiler {
     }
   }
 
-  profile () {
+  profile (startDate, endDate) {
     if (this.entries.length === 0) {
       // No events in the period; don't produce a profile
       return null
@@ -204,8 +204,6 @@ class EventsProfiler {
     }
     const timestampLabelKey = stringTable.dedup(END_TIMESTAMP)
 
-    let durationFrom = Number.POSITIVE_INFINITY
-    let durationTo = 0
     const dateOffset = BigInt(Math.round(performance.timeOrigin * MS_TO_NS))
 
     const samples = this.entries.map((item) => {
@@ -217,8 +215,6 @@ class EventsProfiler {
       }
       const { startTime, duration } = item
       const endTime = startTime + duration
-      if (durationFrom > startTime) durationFrom = startTime
-      if (durationTo < endTime) durationTo = endTime
       const sampleInput = {
         value: [Math.round(duration * MS_TO_NS)],
         locationId,
@@ -240,10 +236,10 @@ class EventsProfiler {
 
     return new Profile({
       sampleType: [timeValueType],
-      timeNanos: dateOffset + BigInt(Math.round(durationFrom * MS_TO_NS)),
+      timeNanos: endDate.getTime() * MS_TO_NS,
       periodType: timeValueType,
-      period: this._flushIntervalNanos,
-      durationNanos: Math.max(0, Math.round((durationTo - durationFrom) * MS_TO_NS)),
+      period: 1,
+      durationNanos: (endDate.getTime() - startDate.getTime()) * MS_TO_NS,
       sample: samples,
       location: locations,
       function: functions,


### PR DESCRIPTION
### What does this PR do?
Ensures subsequent profiles are emitted with back-to-back recording timestamps. The recording end time of a profile becomes the recording start time of the next profile.

### Motivation
Before this change, the recording start time of the next profile would be considered to be the instant after profiles were submitted, while the recording end of the previous one was the instant just before profiles were gathered. This would result in the time period between the two to not be considered. While most of that period is spent serializing and submitting the profile (so, it's our library code) it contains async boundaries, so other work can also get scheduled. 

It doesn't matter much for flame graphs and aggregate views, but the timeline only shows events between recording start time and recording end time, so it had the potential to not display samples, GC events etc. in the first few tens(!) of milliseconds (observed between 40-70ms.)

### Additional Notes
I also enhanced the timeline events profiler to use the top-level profiler provided start and end times to emit better profile duration and time data, as well as to keep late events for the next profile. This latter state should not in fact occur as long as there's only synchronous processing between `_collect` in `profiler.js` capturing `new Date()` for the end date and the timeline profiler generating the profile, but I figured better be safe than sorry about missing events.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.