### PR TITLE
[core] Default Error Tagging for Pages in Next.js

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -65,7 +65,7 @@ function wrapRenderToHTML (renderToHTML) {
 
 function wrapRenderErrorToHTML (renderErrorToHTML) {
   return function (err, req, res, pathname, query) {
-    return instrument(req, res, () => renderErrorToHTML.apply(this, arguments))
+    return instrument(req, res, err, () => renderErrorToHTML.apply(this, arguments))
   }
 }
 
@@ -76,8 +76,8 @@ function wrapRenderToResponse (renderToResponse) {
 }
 
 function wrapRenderErrorToResponse (renderErrorToResponse) {
-  return function (ctx) {
-    return instrument(ctx.req, ctx.res, () => renderErrorToResponse.apply(this, arguments))
+  return function (ctx, err) {
+    return instrument(ctx.req, ctx.res, err, () => renderErrorToResponse.apply(this, arguments))
   }
 }
 
@@ -111,13 +111,23 @@ function getPageFromPath (page, dynamicRoutes = []) {
   return getPagePath(page)
 }
 
-function instrument (req, res, handler) {
+function instrument (req, res, error, handler) {
+  if (typeof error === 'function') {
+    handler = error
+    error = null
+  }
+
   req = req.originalRequest || req
   res = res.originalResponse || res
 
   // TODO support middleware properly in the future?
   const isMiddleware = req.headers[MIDDLEWARE_HEADER]
-  if (isMiddleware || requests.has(req)) return handler()
+  if (isMiddleware || requests.has(req)) {
+    if (error) {
+      errorChannel.publish({ error })
+    }
+    return handler()
+  }
 
   requests.add(req)
 

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -6,6 +6,8 @@ const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const web = require('../../dd-trace/src/plugins/util/web')
 
+const errorPages = ['/404', '/500', '/_error', '/_not-found']
+
 class NextPlugin extends ServerPlugin {
   static get id () {
     return 'next'
@@ -93,18 +95,18 @@ class NextPlugin extends ServerPlugin {
     // safeguard against missing req in complicated timeout scenarios
     if (!req) return
 
-    const errorPages = ['/404', '/500', '/_error', '/_not-found']
-
     // Only use error page names if there's not already a name
     const current = span.context()._tags['next.page']
-    if (current && errorPages.includes(page)) {
+    const isErrorPage = errorPages.includes(page)
+
+    if (current && isErrorPage) {
       return
     }
 
     // remove ending /route or /page for appDir projects
     // need to check if not an error page too, as those are marked as app directory
     // in newer versions
-    if (isAppPath && !errorPages.includes(page)) page = page.substring(0, page.lastIndexOf('/'))
+    if (isAppPath && !isErrorPage) page = page.substring(0, page.lastIndexOf('/'))
 
     // handle static resource
     if (isStatic) {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -344,6 +344,25 @@ describe('Plugin', function () {
               .get(`http://127.0.0.1:${port}/hello/world`)
               .catch(done)
           })
+
+          it('should attach errors by default', done => {
+            agent
+              .use(traces => {
+                const spans = traces[0]
+
+                expect(spans[1]).to.have.property('name', 'next.request')
+                expect(spans[1]).to.have.property('error', 1)
+
+                expect(spans[1].meta).to.have.property('http.status_code', '500')
+                expect(spans[1].meta).to.have.property('error.message', 'fail')
+                expect(spans[1].meta).to.have.property('error.type', 'Error')
+                expect(spans[1].meta['error.stack']).to.exist
+              })
+              .then(done)
+              .catch(done)
+
+            axios.get(`http://127.0.0.1:${port}/error/get_server_side_props`)
+          })
         })
 
         describe('for static files', () => {


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where default errors for pages were not tagged appropriately for pages in Next.js servers. Additionally, a couple small safeguarding issues within the `pageLoad` listener on the plugin side.

### Motivation
Issues with not seeing error/error stacks on Next.js spans. This PR now attaches the error for pages by default, and doesn't just mark the span as having an error without a stack. For API routes, however, it is necessary to do something like:

```javascript
// /api/some/route.js
export default (req, res) => {
  try {
    // something that will error
  } catch (e) {
    req.error = e // specifically "error"
  }
}
```

This is due to complexity of trying to intercept the error from Next.js internals (since it is not thrown or passed to an easily accessible spot). However, we've had support for setting an error on the request for a little bit now.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

