### PR TITLE
Revert "[core] Ensure Explicit Timeouts from Underlying Request Socket are Recorded as Errors When Using Node 20 (#3853)"

### DIFF
--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -69,28 +69,16 @@ function patch (http, methodName) {
         try {
           const req = request.call(this, options, callback)
           const emit = req.emit
-
-          const requestSetTimeout = req.setTimeout
+          const setTimeout = req.setTimeout
 
           ctx.req = req
 
           // tracked to accurately discern custom request socket timeout
           let customRequestTimeout = false
-
           req.setTimeout = function () {
             customRequestTimeout = true
-            return requestSetTimeout.apply(this, arguments)
+            return setTimeout.apply(this, arguments)
           }
-
-          req.on('socket', socket => {
-            if (socket) {
-              const socketSetTimeout = socket.setTimeout
-              socket.setTimeout = function () {
-                customRequestTimeout = true
-                return socketSetTimeout.apply(this, arguments)
-              }
-            }
-          })
 
           req.emit = function (eventName, arg) {
             switch (eventName) {

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -121,7 +121,7 @@ class HttpClientPlugin extends ClientPlugin {
     } else {
       // conditions for no error:
       // 1. not using a custom agent instance with custom timeout specified
-      // 2. no invocation of `req.setTimeout` or `socket.setTimeout`
+      // 2. no invocation of `req.setTimeout`
       if (!args.options.agent?.options.timeout && !customRequestTimeout) return
 
       span.setTag('error', 1)

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -900,39 +900,6 @@ describe('Plugin', () => {
               })
             })
           }).timeout(10000)
-
-          it('should record error if req.socket.setTimeout is used with Node 20', done => {
-            const app = express()
-
-            app.get('/user', async (req, res) => {
-              await new Promise(resolve => {
-                setTimeout(resolve, 6 * 1000)
-              })
-              res.status(200).send()
-            })
-
-            getPort().then(port => {
-              agent
-                .use(traces => {
-                  expect(traces[0][0]).to.have.property('error', 1)
-                })
-                .then(done)
-                .catch(done)
-
-              appListener = server(app, port, async () => {
-                const req = http.request(`${protocol}://localhost:${port}/user`, res => {
-                  res.on('data', () => { })
-                })
-
-                req.on('error', () => {})
-                req.on('socket', socket => {
-                  socket.setTimeout(5000)// match default timeout
-                })
-
-                req.end()
-              })
-            })
-          }).timeout(10000)
         }
 
         it('should only record a request once', done => {

--- a/packages/datadog-plugin-http/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-http/test/integration-test/server.mjs
@@ -10,7 +10,5 @@ const server = http.createServer(async (req, res) => {
   }
 }).listen(0, () => {
   const port = server.address().port
-  if (process.send) {
-    process.send({ port })
-  }
+  process.send({ port })
 })

--- a/packages/datadog-plugin-http2/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-http2/test/integration-test/server.mjs
@@ -7,7 +7,5 @@ const server = http2.createServer((req, res) => {
 
 server.listen(0, () => {
   const port = server.address().port
-  if (process.send) {
-    process.send({ port })
-  }
+  process.send({ port })
 })


### PR DESCRIPTION
### What does this PR do?

This reverts commit 59c8ea4e7c4dd025e6a5f2ec0e9f939e44f8a70a.

### Motivation

Patching `socket.setTimeout` causes a lexical context leak as sockets get reused so it will wrap the previous wrap each time, holding every context which passes through that setTimeout patch forever.
