### PR TITLE
Pass resolver address as ephemeral type

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@datadog/native-appsec": "5.0.0",
+    "@datadog/native-appsec": "6.0.0",
     "@datadog/native-iast-rewriter": "2.2.2",
     "@datadog/native-iast-taint-tracking": "1.6.4",
     "@datadog/native-metrics": "^2.0.0",

--- a/packages/dd-trace/src/appsec/graphql.js
+++ b/packages/dd-trace/src/appsec/graphql.js
@@ -31,7 +31,7 @@ function onGraphqlStartResolve ({ context, resolverInfo }) {
 
   if (!resolverInfo || typeof resolverInfo !== 'object') return
 
-  const actions = waf.run({ [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: resolverInfo }, req)
+  const actions = waf.run({ ephemeral: { [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: resolverInfo } }, req)
   if (actions?.includes('block')) {
     const requestData = graphqlRequestData.get(req)
     if (requestData?.isInGraphqlRequest) {

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -9,7 +9,7 @@ const { setUserTags } = require('./set_user')
 const log = require('../../log')
 
 function isUserBlocked (user) {
-  const actions = waf.run({ [USER_ID]: user.id })
+  const actions = waf.run({ persistent: { [USER_ID]: user.id } })
 
   if (!actions) return false
 

--- a/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
+++ b/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
@@ -18,30 +18,42 @@ class WAFContextWrapper {
     this.addressesToSkip = new Set()
   }
 
-  run (params) {
+  run ({ persistent, ephemeral }) {
+    const payload = {}
+    let payloadHasData = false
     const inputs = {}
-    let someInputAdded = false
     const newAddressesToSkip = new Set(this.addressesToSkip)
 
-    // TODO: possible optimizaion: only send params that haven't already been sent with same value to this wafContext
-    for (const key of Object.keys(params)) {
-      // TODO: requiredAddresses is no longer used due to processor addresses are not included in the list. Check on
-      // future versions when the actual addresses are included in the 'loaded' section inside diagnostics.
-      if (!this.addressesToSkip.has(key)) {
-        inputs[key] = params[key]
-        if (preventDuplicateAddresses.has(key)) {
-          newAddressesToSkip.add(key)
+    if (persistent && typeof persistent === 'object') {
+      // TODO: possible optimizaion: only send params that haven't already been sent with same value to this wafContext
+      for (const key of Object.keys(persistent)) {
+        // TODO: requiredAddresses is no longer used due to processor addresses are not included in the list. Check on
+        // future versions when the actual addresses are included in the 'loaded' section inside diagnostics.
+        if (!this.addressesToSkip.has(key)) {
+          inputs[key] = persistent[key]
+          if (preventDuplicateAddresses.has(key)) {
+            newAddressesToSkip.add(key)
+          }
         }
-        someInputAdded = true
       }
     }
 
-    if (!someInputAdded) return
+    if (Object.keys(inputs).length) {
+      payload['persistent'] = inputs
+      payloadHasData = true
+    }
+
+    if (ephemeral && Object.keys(ephemeral).length) {
+      payload['ephemeral'] = ephemeral
+      payloadHasData = true
+    }
+
+    if (!payloadHasData) return
 
     try {
       const start = process.hrtime.bigint()
 
-      const result = this.ddwafContext.run(inputs, this.wafTimeout)
+      const result = this.ddwafContext.run(payload, this.wafTimeout)
 
       const end = process.hrtime.bigint()
 

--- a/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
+++ b/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
@@ -25,7 +25,7 @@ class WAFContextWrapper {
     const newAddressesToSkip = new Set(this.addressesToSkip)
 
     if (persistent && typeof persistent === 'object') {
-      // TODO: possible optimizaion: only send params that haven't already been sent with same value to this wafContext
+      // TODO: possible optimization: only send params that haven't already been sent with same value to this wafContext
       for (const key of Object.keys(persistent)) {
         // TODO: requiredAddresses is no longer used due to processor addresses are not included in the list. Check on
         // future versions when the actual addresses are included in the 'loaded' section inside diagnostics.

--- a/packages/dd-trace/test/appsec/graphql.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.spec.js
@@ -147,12 +147,11 @@ describe('GraphQL', () => {
 
       startGraphqlResolve.publish({ context, resolverInfo })
 
-      expect(waf.run).to.have.been.calledOnceWithExactly(
-        {
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        ephemeral: {
           [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: resolverInfo
-        },
-        {}
-      )
+        }
+      }, {})
     })
   })
 
@@ -190,12 +189,12 @@ describe('GraphQL', () => {
 
       startGraphqlResolve.publish({ context, resolverInfo })
 
-      expect(waf.run).to.have.been.calledOnceWithExactly(
-        {
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        ephemeral: {
           [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: resolverInfo
-        },
-        {}
-      )
+        }
+      }, {})
+
       expect(context.abortController.abort).not.to.have.been.called
 
       apolloChannel.asyncEnd.publish({ abortController })
@@ -221,13 +220,14 @@ describe('GraphQL', () => {
 
       startGraphqlResolve.publish({ context, resolverInfo })
 
-      expect(waf.run).to.have.been.calledOnceWithExactly(
-        {
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        ephemeral: {
           [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: resolverInfo
-        },
-        {}
-      )
+        }
+      }, {})
+
       expect(context.abortController.abort).to.have.been.called
+
       const abortData = {}
       apolloChannel.asyncEnd.publish({ abortController, abortData })
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -257,10 +257,12 @@ describe('AppSec Index', () => {
         'http.client_ip': '127.0.0.1'
       })
       expect(waf.run).to.have.been.calledOnceWithExactly({
-        'server.request.uri.raw': '/path',
-        'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
-        'server.request.method': 'POST',
-        'http.client_ip': '127.0.0.1'
+        persistent: {
+          'server.request.uri.raw': '/path',
+          'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
+          'server.request.method': 'POST',
+          'http.client_ip': '127.0.0.1'
+        }
       }, req)
     })
   })
@@ -307,8 +309,10 @@ describe('AppSec Index', () => {
       AppSec.incomingHttpEndTranslator({ req, res })
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
-        'server.response.status': '201',
-        'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 }
+        persistent: {
+          'server.response.status': '201',
+          'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 }
+        }
       }, req)
 
       expect(Reporter.finishRequest).to.have.been.calledOnceWithExactly(req, res)
@@ -348,8 +352,10 @@ describe('AppSec Index', () => {
       AppSec.incomingHttpEndTranslator({ req, res })
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
-        'server.response.status': '201',
-        'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 }
+        persistent: {
+          'server.response.status': '201',
+          'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 }
+        }
       }, req)
 
       expect(Reporter.finishRequest).to.have.been.calledOnceWithExactly(req, res)
@@ -399,12 +405,14 @@ describe('AppSec Index', () => {
       AppSec.incomingHttpEndTranslator({ req, res })
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
-        'server.response.status': '201',
-        'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 },
-        'server.request.body': { a: '1' },
-        'server.request.path_params': { c: '3' },
-        'server.request.cookies': { d: '4', e: '5' },
-        'server.request.query': { b: '2' }
+        persistent: {
+          'server.response.status': '201',
+          'server.response.headers.no_cookies': { 'content-type': 'application/json', 'content-lenght': 42 },
+          'server.request.body': { a: '1' },
+          'server.request.path_params': { c: '3' },
+          'server.request.cookies': { d: '4', e: '5' },
+          'server.request.query': { b: '2' }
+        }
       }, req)
       expect(Reporter.finishRequest).to.have.been.calledOnceWithExactly(req, res)
     })
@@ -447,10 +455,12 @@ describe('AppSec Index', () => {
       AppSec.incomingHttpStartTranslator({ req, res })
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
-        'server.request.uri.raw': '/path',
-        'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
-        'server.request.method': 'POST',
-        'http.client_ip': '127.0.0.1'
+        persistent: {
+          'server.request.uri.raw': '/path',
+          'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
+          'server.request.method': 'POST',
+          'http.client_ip': '127.0.0.1'
+        }
       }, req)
     })
 
@@ -480,10 +490,12 @@ describe('AppSec Index', () => {
       AppSec.incomingHttpStartTranslator({ req, res })
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
-        'server.request.uri.raw': '/path',
-        'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
-        'server.request.method': 'POST',
-        'http.client_ip': '127.0.0.1'
+        persistent: {
+          'server.request.uri.raw': '/path',
+          'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
+          'server.request.method': 'POST',
+          'http.client_ip': '127.0.0.1'
+        }
       }, req)
     })
 
@@ -513,11 +525,13 @@ describe('AppSec Index', () => {
       AppSec.incomingHttpStartTranslator({ req, res })
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
-        'server.request.uri.raw': '/path',
-        'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
-        'server.request.method': 'POST',
-        'http.client_ip': '127.0.0.1',
-        'waf.context.processor': { 'extract-schema': true }
+        persistent: {
+          'server.request.uri.raw': '/path',
+          'server.request.headers.no_cookies': { 'user-agent': 'Arachni', host: 'localhost' },
+          'server.request.method': 'POST',
+          'http.client_ip': '127.0.0.1',
+          'waf.context.processor': { 'extract-schema': true }
+        }
       }, req)
     })
   })
@@ -582,7 +596,9 @@ describe('AppSec Index', () => {
         bodyParser.publish({ req, res, body, abortController })
 
         expect(waf.run).to.have.been.calledOnceWith({
-          'server.request.body': { key: 'value' }
+          persistent: {
+            'server.request.body': { key: 'value' }
+          }
         })
         expect(abortController.abort).not.to.have.been.called
         expect(res.end).not.to.have.been.called
@@ -596,7 +612,9 @@ describe('AppSec Index', () => {
         bodyParser.publish({ req, res, body, abortController })
 
         expect(waf.run).to.have.been.calledOnceWith({
-          'server.request.body': { key: 'value' }
+          persistent: {
+            'server.request.body': { key: 'value' }
+          }
         })
         expect(abortController.abort).to.have.been.called
         expect(res.end).to.have.been.called
@@ -621,7 +639,9 @@ describe('AppSec Index', () => {
         cookieParser.publish({ req, res, abortController, cookies })
 
         expect(waf.run).to.have.been.calledOnceWith({
-          'server.request.cookies': { key: 'value' }
+          persistent: {
+            'server.request.cookies': { key: 'value' }
+          }
         })
         expect(abortController.abort).not.to.have.been.called
         expect(res.end).not.to.have.been.called
@@ -634,7 +654,9 @@ describe('AppSec Index', () => {
         cookieParser.publish({ req, res, abortController, cookies })
 
         expect(waf.run).to.have.been.calledOnceWith({
-          'server.request.cookies': { key: 'value' }
+          persistent: {
+            'server.request.cookies': { key: 'value' }
+          }
         })
         expect(abortController.abort).to.have.been.called
         expect(res.end).to.have.been.called
@@ -660,7 +682,9 @@ describe('AppSec Index', () => {
         queryParser.publish({ req, res, query, abortController })
 
         expect(waf.run).to.have.been.calledOnceWith({
-          'server.request.query': { key: 'value' }
+          persistent: {
+            'server.request.query': { key: 'value' }
+          }
         })
         expect(abortController.abort).not.to.have.been.called
         expect(res.end).not.to.have.been.called
@@ -674,7 +698,9 @@ describe('AppSec Index', () => {
         queryParser.publish({ req, res, query, abortController })
 
         expect(waf.run).to.have.been.calledOnceWith({
-          'server.request.query': { key: 'value' }
+          persistent: {
+            'server.request.query': { key: 'value' }
+          }
         })
         expect(abortController.abort).to.have.been.called
         expect(res.end).to.have.been.called

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -21,8 +21,8 @@ describe('user_blocking', () => {
 
     before(() => {
       const runStub = sinon.stub(waf, 'run')
-      runStub.withArgs({ [USER_ID]: 'user' }).returns(['block'])
-      runStub.withArgs({ [USER_ID]: 'gooduser' }).returns([''])
+      runStub.withArgs({ persistent: { [USER_ID]: 'user' } }).returns(['block'])
+      runStub.withArgs({ persistent: { [USER_ID]: 'gooduser' } }).returns([''])
     })
 
     beforeEach(() => {

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -214,15 +214,19 @@ describe('WAF Manager', () => {
         ddwafContext.run.returns({ totalRuntime: 1, durationExt: 1 })
 
         wafContextWrapper.run({
-          'server.request.headers.no_cookies': { 'header': 'value' },
-          'server.request.uri.raw': 'https://testurl',
-          'processor.address': { 'extract-schema': true }
+          persistent: {
+            'server.request.headers.no_cookies': { 'header': 'value' },
+            'server.request.uri.raw': 'https://testurl',
+            'processor.address': { 'extract-schema': true }
+          }
         })
 
         expect(ddwafContext.run).to.be.calledOnceWithExactly({
-          'server.request.headers.no_cookies': { 'header': 'value' },
-          'server.request.uri.raw': 'https://testurl',
-          'processor.address': { 'extract-schema': true }
+          persistent: {
+            'server.request.headers.no_cookies': { 'header': 'value' },
+            'server.request.uri.raw': 'https://testurl',
+            'processor.address': { 'extract-schema': true }
+          }
         }, config.appsec.wafTimeout)
       })
 
@@ -235,7 +239,9 @@ describe('WAF Manager', () => {
 
         ddwafContext.run.returns(result)
         const params = {
-          'server.request.headers.no_cookies': { 'header': 'value' }
+          persistent: {
+            'server.request.headers.no_cookies': { 'header': 'value' }
+          }
         }
 
         wafContextWrapper.run(params)
@@ -252,7 +258,9 @@ describe('WAF Manager', () => {
 
         ddwafContext.run.returns(result)
         const params = {
-          'server.request.headers.no_cookies': { 'header': 'value' }
+          persistent: {
+            'server.request.headers.no_cookies': { 'header': 'value' }
+          }
         }
 
         wafContextWrapper.run(params)
@@ -266,7 +274,9 @@ describe('WAF Manager', () => {
       it('should not report attack when ddwafContext does not return events', () => {
         ddwafContext.run.returns({ totalRuntime: 1, durationExt: 1 })
         const params = {
-          'server.request.headers.no_cookies': { 'header': 'value' }
+          persistent: {
+            'server.request.headers.no_cookies': { 'header': 'value' }
+          }
         }
 
         wafContextWrapper.run(params)
@@ -277,7 +287,9 @@ describe('WAF Manager', () => {
       it('should not report attack when ddwafContext returns empty data', () => {
         ddwafContext.run.returns({ totalRuntime: 1, durationExt: 1, events: [] })
         const params = {
-          'server.request.headers.no_cookies': { 'header': 'value' }
+          persistent: {
+            'server.request.headers.no_cookies': { 'header': 'value' }
+          }
         }
 
         wafContextWrapper.run(params)
@@ -290,7 +302,9 @@ describe('WAF Manager', () => {
         ddwafContext.run.returns({ totalRuntime: 1, durationExt: 1, events: [], actions: actions })
 
         const params = {
-          'server.request.headers.no_cookies': { 'header': 'value' }
+          persistent: {
+            'server.request.headers.no_cookies': { 'header': 'value' }
+          }
         }
 
         const result = wafContextWrapper.run(params)
@@ -305,9 +319,11 @@ describe('WAF Manager', () => {
           derivatives: [{ '_dd.appsec.s.req.body': [8] }]
         }
         const params = {
-          'server.request.body': 'value',
-          'waf.context.processor': {
-            'extract-schema': true
+          persistent: {
+            'server.request.body': 'value',
+            'waf.context.processor': {
+              'extract-schema': true
+            }
           }
         }
 

--- a/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
+++ b/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
@@ -21,4 +21,33 @@ describe('WAFContextWrapper', () => {
 
     expect(ddwafContext.run).to.have.been.calledOnceWithExactly(payload, 1000)
   })
+
+  it('Should send ephemeral addreses every time', () => {
+    const ddwafContext = {
+      run: sinon.stub()
+    }
+    const wafContextWrapper = new WAFContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0')
+
+    const payload = {
+      persistent: {
+        [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
+      },
+      ephemeral: {
+        [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: { anotherKey: 'anotherValue' }
+      }
+    }
+
+    wafContextWrapper.run(payload)
+    wafContextWrapper.run(payload)
+
+    expect(ddwafContext.run).to.have.been.calledTwice
+    expect(ddwafContext.run.firstCall).to.have.been.calledWithExactly(payload, 1000)
+    expect(ddwafContext.run.secondCall).to.have.been.calledWithExactly({
+      ephemeral: {
+        [addresses.HTTP_INCOMING_GRAPHQL_RESOLVER]: {
+          anotherKey: 'anotherValue'
+        }
+      }
+    }, 1000)
+  })
 })

--- a/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
+++ b/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
@@ -11,7 +11,9 @@ describe('WAFContextWrapper', () => {
     const wafContextWrapper = new WAFContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0')
 
     const payload = {
-      [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
+      persistent: {
+        [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
+      }
     }
 
     wafContextWrapper.run(payload)

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,10 +412,10 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k= sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
 
-"@datadog/native-appsec@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-5.0.0.tgz"
-  integrity "sha1-5C539CBiUyrX3vo6eQkNyLAgwis= sha512-Ks8a4L49N40w+TJjj2e9ncGssUIEjo4wnmUFjPBRvlLGuVj1VJLxCx7ztpd8eTycM5QQlzggCDOP6CMEVmeZbA=="
+"@datadog/native-appsec@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-6.0.0.tgz#da753f8566ec5180ad9e83014cb44984b4bc878e"
+  integrity sha512-e7vH5usFoqov7FraPcA99fe80t2/qm4Cmno1T3iBhYlhyO6HD01ArDsCZ/sUvNIUR1ujxtbr8Z9WRGJ0qQ/FDA==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
Since graphql.server.resolver is a recurrent address which is sent multiple times during a request it needs to be passed as a ephemeral type in order to get API Security info from it.
This PR also updates waf bindings module to version 6.0.0 in order to make ephemeral addresses to work.

- [x] Unit tests.


