### PR TITLE
[ci-visibility] Fix cucumber plugin tests for node<16

### DIFF
--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -57,7 +57,7 @@ describe('Plugin', function () {
   this.timeout(10000)
   withVersions('cucumber', '@cucumber/cucumber', version => {
     const specificVersion = require(`../../../versions/@cucumber/cucumber@${version}`).version()
-    if ((NODE_MAJOR === 14 || NODE_MAJOR === 16) && semver.satisfies(specificVersion, '>=10')) return
+    if ((NODE_MAJOR <= 16) && semver.satisfies(specificVersion, '>=10')) return
 
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 const path = require('path')
 const { PassThrough } = require('stream')
+const semver = require('semver')
 
 const proxyquire = require('proxyquire').noPreserveCache()
 const nock = require('nock')
@@ -23,6 +24,7 @@ const {
   TEST_SOURCE_START
 } = require('../../dd-trace/src/plugins/util/test')
 
+const { NODE_MAJOR } = require('../../../version')
 const { version: ddTraceVersion } = require('../../../package.json')
 
 const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
@@ -54,6 +56,9 @@ describe('Plugin', function () {
   let Cucumber
   this.timeout(10000)
   withVersions('cucumber', '@cucumber/cucumber', version => {
+    const specificVersion = require(`../../../versions/@cucumber/cucumber@${version}`).version()
+    if ((NODE_MAJOR === 14 || NODE_MAJOR === 16) && semver.satisfies(specificVersion, '>=10')) return
+
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache
       // before subsequent calls in whichever manner best suits your needs.


### PR DESCRIPTION
### What does this PR do?
Node<16 is no longer supported for cucumber, so we have to skip the tests.

### Motivation
Fix CI. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
