### PR TITLE
Add install_signature to app-started telemetry event

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -522,6 +522,19 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       0
     )
 
+    const DD_INSTRUMENTATION_INSTALL_ID = coalesce(
+      process.env.DD_INSTRUMENTATION_INSTALL_ID,
+      null
+    )
+    const DD_INSTRUMENTATION_INSTALL_TIME = coalesce(
+      process.env.DD_INSTRUMENTATION_INSTALL_TIME,
+      null
+    )
+    const DD_INSTRUMENTATION_INSTALL_TYPE = coalesce(
+      process.env.DD_INSTRUMENTATION_INSTALL_TYPE,
+      null
+    )
+
     const ingestion = options.ingestion || {}
     const dogstatsd = coalesce(options.dogstatsd, {})
     const sampler = {
@@ -670,6 +683,12 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.isAzureFunctionConsumptionPlan = isAzureFunctionConsumptionPlan
 
     this.spanLeakDebug = Number(DD_TRACE_SPAN_LEAK_DEBUG)
+
+    this.installSignature = {
+      id: DD_INSTRUMENTATION_INSTALL_ID,
+      time: DD_INSTRUMENTATION_INSTALL_TIME,
+      type: DD_INSTRUMENTATION_INSTALL_TYPE
+    }
 
     this._applyDefaults()
     this._applyEnvironment()

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -112,10 +112,25 @@ function flatten (input, result = [], prefix = [], traversedObjects = null) {
   return result
 }
 
+function getInstallSignature (config) {
+  const { installSignature: sig } = config
+  if (sig && (sig.id || sig.time || sig.type)) {
+    return {
+      install_id: sig.id,
+      install_time: sig.time,
+      install_type: sig.type
+    }
+  }
+}
+
 function appStarted (config) {
   const app = {
     products: getProducts(config),
     configuration: flatten(config)
+  }
+  const installSignature = getInstallSignature(config)
+  if (installSignature) {
+    app.install_signature = installSignature
   }
   // TODO: add app.error with correct error codes
   // if (errors.agentError) {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -121,6 +121,9 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.redactionNamePattern', null)
     expect(config).to.have.nested.property('iast.redactionValuePattern', null)
     expect(config).to.have.nested.property('iast.telemetryVerbosity', 'INFORMATION')
+    expect(config).to.have.nested.property('installSignature.id', null)
+    expect(config).to.have.nested.property('installSignature.time', null)
+    expect(config).to.have.nested.property('installSignature.type', null)
   })
 
   it('should support logging', () => {
@@ -229,6 +232,9 @@ describe('Config', () => {
     process.env.DD_EXPERIMENTAL_PROFILING_ENABLED = 'true'
     process.env.DD_EXPERIMENTAL_API_SECURITY_ENABLED = 'true'
     process.env.DD_API_SECURITY_REQUEST_SAMPLE_RATE = 1
+    process.env.DD_INSTRUMENTATION_INSTALL_ID = '68e75c48-57ca-4a12-adfc-575c4b05fcbe'
+    process.env.DD_INSTRUMENTATION_INSTALL_TYPE = 'k8s_single_step'
+    process.env.DD_INSTRUMENTATION_INSTALL_TIME = '1703188212'
 
     const config = new Config()
 
@@ -308,6 +314,11 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
     expect(config).to.have.nested.property('iast.redactionValuePattern', 'REDACTION_VALUE_PATTERN')
     expect(config).to.have.nested.property('iast.telemetryVerbosity', 'DEBUG')
+    expect(config).to.have.deep.property('installSignature', {
+      id: '68e75c48-57ca-4a12-adfc-575c4b05fcbe',
+      type: 'k8s_single_step',
+      time: '1703188212'
+    })
   })
 
   it('should read case-insensitive booleans from environment variables', () => {

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -74,6 +74,11 @@ describe('telemetry', () => {
       peerServiceMapping: {
         'service_1': 'remapped_service_1',
         'service_2': 'remapped_service_2'
+      },
+      installSignature: {
+        id: '68e75c48-57ca-4a12-adfc-575c4b05fcbe',
+        type: 'k8s_single_step',
+        time: '1703188212'
       }
     }, {
       _pluginsByName: pluginsByName
@@ -105,8 +110,16 @@ describe('telemetry', () => {
         { name: 'appsec.enabled', value: true, origin: 'unknown' },
         { name: 'profiling.enabled', value: true, origin: 'unknown' },
         { name: 'peerServiceMapping.service_1', value: 'remapped_service_1', origin: 'unknown' },
-        { name: 'peerServiceMapping.service_2', value: 'remapped_service_2', origin: 'unknown' }
+        { name: 'peerServiceMapping.service_2', value: 'remapped_service_2', origin: 'unknown' },
+        { name: 'installSignature.id', value: '68e75c48-57ca-4a12-adfc-575c4b05fcbe', origin: 'unknown' },
+        { name: 'installSignature.type', value: 'k8s_single_step', origin: 'unknown' },
+        { name: 'installSignature.time', value: '1703188212', origin: 'unknown' }
       ])
+      expect(payload).to.have.property('install_signature').that.deep.equal({
+        install_id: '68e75c48-57ca-4a12-adfc-575c4b05fcbe',
+        install_type: 'k8s_single_step',
+        install_time: '1703188212'
+      })
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Adds `install_signature` data to `app-started` telemetry event.

### Motivation

Onboarding team wants visibility into success of different onboarding methods using a telemetry indicator.

Jira: [Update Node.js library to handle install signature](https://datadoghq.atlassian.net/browse/AIT-9231)

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
