### PR TITLE
Implement extended sampling

### DIFF
--- a/packages/dd-trace/src/sampling_rule.js
+++ b/packages/dd-trace/src/sampling_rule.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const { globMatch } = require('../src/util')
+const RateLimiter = require('./rate_limiter')
+const Sampler = require('./sampler')
+
+class AlwaysMatcher {
+  match () {
+    return true
+  }
+}
+
+class GlobMatcher {
+  constructor (pattern, locator) {
+    this.pattern = pattern
+    this.locator = locator
+  }
+
+  match (span) {
+    const subject = this.locator(span)
+    if (!subject) return false
+    return globMatch(this.pattern, subject)
+  }
+}
+
+class RegExpMatcher {
+  constructor (pattern, locator) {
+    this.pattern = pattern
+    this.locator = locator
+  }
+
+  match (span) {
+    const subject = this.locator(span)
+    if (!subject) return false
+    return this.pattern.test(subject)
+  }
+}
+
+function matcher (pattern, locator) {
+  if (pattern instanceof RegExp) {
+    return new RegExpMatcher(pattern, locator)
+  }
+
+  if (typeof pattern === 'string' && pattern !== '*') {
+    return new GlobMatcher(pattern, locator)
+  }
+
+  return new AlwaysMatcher()
+}
+
+function makeTagLocator (tag) {
+  return (span) => span.context()._tags[tag]
+}
+
+function nameLocator (span) {
+  return span.context()._name
+}
+
+function serviceLocator (span) {
+  const { _tags: tags } = span.context()
+  return tags.service ||
+    tags['service.name'] ||
+    span.tracer()._service
+}
+
+class SamplingRule {
+  constructor ({ name, service, resource, tags, sampleRate = 1.0, maxPerSecond } = {}) {
+    this.matchers = []
+
+    if (name) {
+      this.matchers.push(matcher(name, nameLocator))
+    }
+    if (service) {
+      this.matchers.push(matcher(service, serviceLocator))
+    }
+    if (resource) {
+      this.matchers.push(matcher(resource, makeTagLocator('resource.name')))
+    }
+    for (const [key, value] of Object.entries(tags || {})) {
+      this.matchers.push(matcher(value, makeTagLocator(key)))
+    }
+
+    this._sampler = new Sampler(sampleRate)
+    this._limiter = undefined
+
+    if (Number.isFinite(maxPerSecond)) {
+      this._limiter = new RateLimiter(maxPerSecond)
+    }
+  }
+
+  static from (config) {
+    return new SamplingRule(config)
+  }
+
+  get sampleRate () {
+    return this._sampler.rate()
+  }
+
+  get effectiveRate () {
+    return this._limiter && this._limiter.effectiveRate()
+  }
+
+  get maxPerSecond () {
+    return this._limiter && this._limiter._rateLimit
+  }
+
+  match (span) {
+    for (const matcher of this.matchers) {
+      if (!matcher.match(span)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  sample () {
+    if (!this._sampler.isSampled()) {
+      return false
+    }
+
+    if (this._limiter) {
+      return this._limiter.isAllowed()
+    }
+
+    return true
+  }
+}
+
+module.exports = SamplingRule

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -24,6 +24,7 @@ const USER_KEEP = ext.priority.USER_KEEP
 describe('PrioritySampler', () => {
   let PrioritySampler
   let prioritySampler
+  let SamplingRule
   let Sampler
   let sampler
   let context
@@ -32,7 +33,8 @@ describe('PrioritySampler', () => {
   beforeEach(() => {
     context = {
       _tags: {
-        'service.name': 'test'
+        'service.name': 'test',
+        'resource.name': 'resource'
       },
       _sampling: {},
       _trace: {
@@ -65,8 +67,13 @@ describe('PrioritySampler', () => {
     })
     Sampler.withArgs(0.5).returns(sampler)
 
-    PrioritySampler = proxyquire('../src/priority_sampler', {
+    SamplingRule = proxyquire('../src/sampling_rule', {
       './sampler': Sampler
+    })
+
+    PrioritySampler = proxyquire('../src/priority_sampler', {
+      './sampler': Sampler,
+      './sampling_rule': SamplingRule
     })
 
     prioritySampler = new PrioritySampler('test')
@@ -182,60 +189,11 @@ describe('PrioritySampler', () => {
       expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_RULE)
     })
 
-    it('should support a sample rate from a rule on service as string', () => {
-      context._tags['service.name'] = 'test'
-
+    it('should support a rule-based sampling', () => {
       prioritySampler = new PrioritySampler('test', {
         rules: [
-          { sampleRate: 0, service: 'foo' },
-          { sampleRate: 1, service: 'test' }
-        ]
-      })
-      prioritySampler.sample(context)
-
-      expect(context._sampling).to.have.property('priority', USER_KEEP)
-      expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_RULE)
-    })
-
-    it('should support a sample rate from a rule on service as regex', () => {
-      context._tags['service.name'] = 'test'
-
-      prioritySampler = new PrioritySampler('test', {
-        rules: [
-          { sampleRate: 0, service: /fo/ },
-          { sampleRate: 1, service: /tes/ }
-        ]
-      })
-      prioritySampler.sample(context)
-
-      expect(context._sampling).to.have.property('priority', USER_KEEP)
-      expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_RULE)
-    })
-
-    it('should support a sample rate from a rule on name as string', () => {
-      context._name = 'foo'
-      context._tags['service.name'] = 'test'
-
-      prioritySampler = new PrioritySampler('test', {
-        rules: [
-          { sampleRate: 0, name: 'bar' },
-          { sampleRate: 1, name: 'foo' }
-        ]
-      })
-      prioritySampler.sample(context)
-
-      expect(context._sampling).to.have.property('priority', USER_KEEP)
-      expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_RULE)
-    })
-
-    it('should support a sample rate from a rule on name as regex', () => {
-      context._name = 'foo'
-      context._tags['service.name'] = 'test'
-
-      prioritySampler = new PrioritySampler('test', {
-        rules: [
-          { sampleRate: 0, name: /ba/ },
-          { sampleRate: 1, name: /fo/ }
+          { sampleRate: 0, service: 'foo', resource: /res.*/ },
+          { sampleRate: 1, service: 'test', resource: /res.*/ }
         ]
       })
       prioritySampler.sample(context)

--- a/packages/dd-trace/test/sampling_rule.spec.js
+++ b/packages/dd-trace/test/sampling_rule.spec.js
@@ -1,0 +1,409 @@
+'use strict'
+
+require('./setup/tap')
+
+const { expect } = require('chai')
+const id = require('../src/id')
+
+function createDummySpans () {
+  const operations = [
+    'operation',
+    'sub_operation',
+    'second_operation',
+    'sub_second_operation_1',
+    'sub_second_operation_2',
+    'sub_sub_second_operation_2',
+    'custom_service_span_1',
+    'custom_service_span_2',
+    'renamed_operation',
+    'tagged_operation',
+    'resource_named_operation'
+  ]
+
+  const ids = [
+    id('0234567812345671'),
+    id('0234567812345672'),
+    id('0234567812345673'),
+    id('0234567812345674'),
+    id('0234567812345675'),
+    id('0234567812345676'),
+    id('0234567812345677'),
+    id('0234567812345678'),
+    id('0234567812345679'),
+    id('0234567812345680'),
+    id('0234567812345681')
+  ]
+
+  const spans = []
+  const spanContexts = []
+
+  for (let idx = 0; idx < operations.length; idx++) {
+    const operation = operations[idx]
+    const id = ids[idx]
+    const spanContext = {
+      _spanId: id,
+      _sampling: {},
+      _trace: {
+        started: []
+      },
+      _name: operation,
+      _tags: {}
+    }
+
+    // Give first span a custom service name
+    if ([6, 7].includes(idx)) {
+      spanContext._tags['service.name'] = 'span-service'
+    }
+
+    if (idx === 8) {
+      spanContext._name = 'renamed'
+    }
+
+    if (idx === 9) {
+      spanContext._tags['tagged'] = 'yup'
+      spanContext._tags['and'] = 'this'
+      spanContext._tags['not'] = 'this'
+    }
+
+    if (idx === 10) {
+      spanContext._tags['resource.name'] = 'named'
+    }
+
+    const span = {
+      context: sinon.stub().returns(spanContext),
+      tracer: sinon.stub().returns({
+        _service: 'test'
+      }),
+      _name: operation
+    }
+
+    spanContexts.push(spanContext)
+    spans.push(span)
+  }
+
+  return { spans, spanContexts }
+}
+
+describe('sampling rule', () => {
+  let spans
+  let spanContexts
+  let SamplingRule
+  let rule
+
+  beforeEach(() => {
+    const info = createDummySpans()
+    spans = info.spans
+    spanContexts = info.spanContexts
+
+    spanContexts[0]._trace.started.push(...spans)
+
+    SamplingRule = require('../src/sampling_rule')
+  })
+
+  describe('match', () => {
+    it('should match with exact strings', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation'
+      })
+
+      expect(rule.match(spans[0])).to.equal(true)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(false)
+      expect(rule.match(spans[10])).to.equal(false)
+    })
+
+    it('should match with regexp', () => {
+      rule = new SamplingRule({
+        service: /test/,
+        name: /op.*/
+      })
+
+      expect(rule.match(spans[0])).to.equal(true)
+      expect(rule.match(spans[1])).to.equal(true)
+      expect(rule.match(spans[2])).to.equal(true)
+      expect(rule.match(spans[3])).to.equal(true)
+      expect(rule.match(spans[4])).to.equal(true)
+      expect(rule.match(spans[5])).to.equal(true)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(true)
+      expect(rule.match(spans[10])).to.equal(true)
+    })
+
+    it('should match with postfix glob', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'op*'
+      })
+
+      expect(rule.match(spans[0])).to.equal(true)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(false)
+      expect(rule.match(spans[10])).to.equal(false)
+    })
+
+    it('should match with prefix glob', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: '*operation'
+      })
+
+      expect(rule.match(spans[0])).to.equal(true)
+      expect(rule.match(spans[1])).to.equal(true)
+      expect(rule.match(spans[2])).to.equal(true)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(true)
+      expect(rule.match(spans[10])).to.equal(true)
+    })
+
+    it('should match with single character any matcher', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'o?eration'
+      })
+
+      expect(rule.match(spans[0])).to.equal(true)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(false)
+      expect(rule.match(spans[10])).to.equal(false)
+    })
+
+    it('should consider missing service as match-all for service name', () => {
+      rule = new SamplingRule({
+        name: 'sub_second_operation_*'
+      })
+
+      expect(rule.match(spans[0])).to.equal(false)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      // Only 3 and 4 should match because of the name pattern
+      expect(rule.match(spans[3])).to.equal(true)
+      expect(rule.match(spans[4])).to.equal(true)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(false)
+      expect(rule.match(spans[10])).to.equal(false)
+    })
+
+    it('should consider missing name as match-all for span name', () => {
+      rule = new SamplingRule({
+        service: 'test'
+      })
+
+      expect(rule.match(spans[0])).to.equal(true)
+      expect(rule.match(spans[1])).to.equal(true)
+      expect(rule.match(spans[2])).to.equal(true)
+      expect(rule.match(spans[3])).to.equal(true)
+      expect(rule.match(spans[4])).to.equal(true)
+      expect(rule.match(spans[5])).to.equal(true)
+      expect(rule.match(spans[8])).to.equal(true)
+      expect(rule.match(spans[9])).to.equal(true)
+      expect(rule.match(spans[10])).to.equal(true)
+      // Should not match because of different service name
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+    })
+
+    it('should use span service name tags where present', () => {
+      rule = new SamplingRule({
+        service: 'span-service'
+      })
+
+      expect(rule.match(spans[0])).to.equal(false)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(true)
+      expect(rule.match(spans[7])).to.equal(true)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(false)
+      expect(rule.match(spans[10])).to.equal(false)
+    })
+
+    it('should match renamed spans', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'renamed'
+      })
+
+      expect(rule.match(spans[0])).to.equal(false)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(true)
+      expect(rule.match(spans[9])).to.equal(false)
+      expect(rule.match(spans[10])).to.equal(false)
+    })
+
+    it('should match tag sets', () => {
+      rule = new SamplingRule({
+        tags: {
+          tagged: 'yup',
+          and: 'this'
+        }
+      })
+
+      expect(rule.match(spans[0])).to.equal(false)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(true)
+      expect(rule.match(spans[10])).to.equal(false)
+    })
+
+    it('should match resource name', () => {
+      rule = new SamplingRule({
+        resource: 'named'
+      })
+
+      expect(rule.match(spans[0])).to.equal(false)
+      expect(rule.match(spans[1])).to.equal(false)
+      expect(rule.match(spans[2])).to.equal(false)
+      expect(rule.match(spans[3])).to.equal(false)
+      expect(rule.match(spans[4])).to.equal(false)
+      expect(rule.match(spans[5])).to.equal(false)
+      expect(rule.match(spans[6])).to.equal(false)
+      expect(rule.match(spans[7])).to.equal(false)
+      expect(rule.match(spans[8])).to.equal(false)
+      expect(rule.match(spans[9])).to.equal(false)
+      expect(rule.match(spans[10])).to.equal(true)
+    })
+  })
+
+  describe('sampleRate', () => {
+    beforeEach(() => {
+      sinon.stub(Math, 'random').returns(0.5)
+    })
+
+    afterEach(() => {
+      Math.random.restore()
+    })
+
+    it('should sample on allowed sample rate', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation',
+        sampleRate: 1.0,
+        maxPerSecond: 1
+      })
+
+      expect(rule.sample()).to.equal(true)
+    })
+
+    it('should not sample on non-allowed sample rate', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation',
+        sampleRate: 0.3,
+        maxPerSecond: 1
+      })
+
+      expect(rule.sample()).to.equal(false)
+    })
+  })
+
+  describe('maxPerSecond', () => {
+    it('should not create limiter without finite maxPerSecond', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation',
+        sampleRate: 1.0
+      })
+
+      expect(rule._limiter).to.equal(undefined)
+      expect(rule.maxPerSecond).to.equal(undefined)
+    })
+
+    it('should create limiter with finite maxPerSecond', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation',
+        sampleRate: 1.0,
+        maxPerSecond: 123
+      })
+
+      expect(rule._limiter).to.not.equal(undefined)
+      expect(rule).to.have.property('maxPerSecond', 123)
+    })
+
+    it('should not sample spans past the rate limit', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation',
+        sampleRate: 1.0,
+        maxPerSecond: 1
+      })
+
+      expect(rule.sample()).to.equal(true)
+      expect(rule.sample()).to.equal(false)
+    })
+
+    it('should allow unlimited rate limits', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation',
+        sampleRate: 1.0
+      })
+
+      for (let i = 0; i < 1e3; i++) {
+        expect(rule.sample()).to.equal(true)
+      }
+    })
+
+    it('should sample if enough time has elapsed', () => {
+      rule = new SamplingRule({
+        service: 'test',
+        name: 'operation',
+        sampleRate: 1.0,
+        maxPerSecond: 1
+      })
+
+      const clock = sinon.useFakeTimers(new Date())
+      expect(rule.sample()).to.equal(true)
+      expect(rule.sample()).to.equal(false)
+      clock.tick(1000)
+      expect(rule.sample()).to.equal(true)
+    })
+  })
+})

--- a/packages/dd-trace/test/span_sampler.spec.js
+++ b/packages/dd-trace/test/span_sampler.spec.js
@@ -2,575 +2,279 @@
 
 require('./setup/tap')
 
-const { expect } = require('chai')
 const id = require('../src/id')
 
-function createDummySpans () {
-  const operations = [
-    'operation',
-    'sub_operation',
-    'second_operation',
-    'sub_second_operation_1',
-    'sub_second_operation_2',
-    'sub_sub_second_operation_2',
-    'custom_service_span_1',
-    'custom_service_span_2',
-    'renamed_operation'
-  ]
+describe('span sampler', () => {
+  const spies = {}
+  let SpanSampler
+  let SamplingRule
 
-  const ids = [
-    id('0234567812345671'),
-    id('0234567812345672'),
-    id('0234567812345673'),
-    id('0234567812345674'),
-    id('0234567812345675'),
-    id('0234567812345676'),
-    id('0234567812345677')
-  ]
+  beforeEach(() => {
+    if (!SamplingRule) {
+      SamplingRule = require('../src/sampling_rule')
+      spies.match = sinon.spy(SamplingRule.prototype, 'match')
+      spies.sample = sinon.spy(SamplingRule.prototype, 'sample')
+      spies.sampleRate = sinon.spy(SamplingRule.prototype, 'sampleRate', ['get'])
+      spies.maxPerSecond = sinon.spy(SamplingRule.prototype, 'maxPerSecond', ['get'])
+    }
 
-  const spans = []
-  const spanContexts = []
+    SpanSampler = proxyquire('../src/span_sampler', {
+      './sampling_rule': SamplingRule
+    })
+  })
 
-  for (let idx = 0; idx < operations.length; idx++) {
-    const operation = operations[idx]
-    const id = ids[idx]
+  it('should not sample anything when trace is kept', done => {
+    const sampler = new SpanSampler({})
+
     const spanContext = {
-      _spanId: id,
-      _sampling: {},
+      _spanId: id('1234567812345678'),
+      _sampling: {
+        priority: 2
+      },
       _trace: {
         started: []
       },
-      _name: operation,
+      _name: 'operation',
       _tags: {}
     }
-
-    // Give first span a custom service name
-    if ([6, 7].includes(idx)) {
-      spanContext._tags['service.name'] = 'span-service'
-    }
-
-    if (idx === 8) {
-      spanContext._name = 'renamed'
-    }
-
-    const span = {
+    spanContext._trace.started.push({
       context: sinon.stub().returns(spanContext),
       tracer: sinon.stub().returns({
         _service: 'test'
       }),
-      _name: operation
+      _name: 'operation'
+    })
+
+    try {
+      const ingested = sampler.sample(spanContext)
+      expect(ingested).to.be.undefined
+      done()
+    } catch (err) { done(err) }
+  })
+
+  it('adds _spanSampling when sampled successfully', () => {
+    const sampler = new SpanSampler({
+      spanSamplingRules: [
+        {
+          service: 'test',
+          name: 'operation',
+          sampleRate: 1.0,
+          maxPerSecond: 5
+        }
+      ]
+    })
+
+    const spanContext = {
+      _spanId: id('1234567812345678'),
+      _sampling: {},
+      _trace: {
+        started: []
+      },
+      _name: 'operation',
+      _tags: {}
+    }
+    spanContext._trace.started.push({
+      context: sinon.stub().returns(spanContext),
+      tracer: sinon.stub().returns({
+        _service: 'test'
+      }),
+      _name: 'operation'
+    })
+
+    sampler.sample(spanContext)
+
+    expect(spies.match).to.be.called
+    expect(spies.sample).to.be.called
+    expect(spies.sampleRate.get).to.be.called
+    expect(spies.maxPerSecond.get).to.be.called
+
+    expect(spanContext._spanSampling).to.eql({
+      sampleRate: 1.0,
+      maxPerSecond: 5
+    })
+  })
+
+  it('should stop at first rule match', () => {
+    const sampler = new SpanSampler({
+      spanSamplingRules: [
+        {
+          service: 'does-not-match',
+          name: 'operation',
+          sampleRate: 1.0,
+          maxPerSecond: 3
+        },
+        {
+          service: 'test',
+          name: 'operation',
+          sampleRate: 1.0,
+          maxPerSecond: 5
+        },
+        {
+          service: 'test',
+          name: 'operation',
+          sampleRate: 1.0,
+          maxPerSecond: 10
+        }
+      ]
+    })
+
+    const spanContext = {
+      _spanId: id('1234567812345678'),
+      _sampling: {},
+      _trace: {
+        started: []
+      },
+      _name: 'operation',
+      _tags: {}
+    }
+    spanContext._trace.started.push({
+      context: sinon.stub().returns(spanContext),
+      tracer: sinon.stub().returns({
+        _service: 'test'
+      }),
+      _name: 'operation'
+    })
+
+    sampler.sample(spanContext)
+
+    expect(spies.match).to.be.called
+    expect(spies.sample).to.be.called
+    expect(spies.sampleRate.get).to.be.called
+    expect(spies.maxPerSecond.get).to.be.called
+
+    expect(spanContext._spanSampling).to.eql({
+      sampleRate: 1.0,
+      maxPerSecond: 5
+    })
+  })
+
+  it('should sample multiple spans with one rule', () => {
+    const sampler = new SpanSampler({
+      spanSamplingRules: [
+        {
+          service: 'test',
+          name: '*operation',
+          sampleRate: 1.0,
+          maxPerSecond: 5
+        }
+      ]
+    })
+
+    // Create two span contexts
+    const started = []
+    const firstSpanContext = {
+      _spanId: id('1234567812345678'),
+      _sampling: {},
+      _trace: {
+        started
+      },
+      _name: 'operation',
+      _tags: {}
+    }
+    const secondSpanContext = {
+      ...firstSpanContext,
+      _spanId: id('1234567812345679'),
+      _name: 'second operation'
     }
 
-    spanContexts.push(spanContext)
-    spans.push(span)
-  }
-
-  return { spans, spanContexts }
-}
-
-describe('span sampler', () => {
-  let spans
-  let spanContexts
-  let SpanSampler
-  let sampler
-
-  beforeEach(() => {
-    const info = createDummySpans()
-    spans = info.spans
-    spanContexts = info.spanContexts
-
-    spanContexts[0]._trace.started.push(...spans)
-
-    SpanSampler = require('../src/span_sampler')
-  })
-
-  describe('without drop', () => {
-    beforeEach(() => {
-      spanContexts[0]._sampling.priority = 2 // user keep
+    // Add spans for both to the context
+    started.push({
+      context: sinon.stub().returns(firstSpanContext),
+      tracer: sinon.stub().returns({
+        _service: 'test'
+      }),
+      _name: 'operation'
+    })
+    started.push({
+      context: sinon.stub().returns(secondSpanContext),
+      tracer: sinon.stub().returns({
+        _service: 'test'
+      }),
+      _name: 'operation'
     })
 
-    afterEach(() => {
-      delete spanContexts[0]._sampling.priority
-    })
+    sampler.sample(firstSpanContext)
 
-    it('should not sample anything when trace is kept', done => {
-      sampler = new SpanSampler({})
-      try {
-        const ingested = sampler.sample(spanContexts[0])
-        expect(ingested).to.be.undefined
-        done()
-      } catch (err) { done(err) }
+    expect(spies.match).to.be.called
+    expect(spies.sample).to.be.called
+    expect(spies.sampleRate.get).to.be.called
+    expect(spies.maxPerSecond.get).to.be.called
+
+    expect(firstSpanContext._spanSampling).to.eql({
+      sampleRate: 1.0,
+      maxPerSecond: 5
+    })
+    expect(secondSpanContext._spanSampling).to.eql({
+      sampleRate: 1.0,
+      maxPerSecond: 5
     })
   })
 
-  describe('rules match properly', () => {
-    it('should properly sample a single span', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 5
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()._spanSampling).to.eql({
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      })
-      expect(spans[1].context()._spanSampling).to.be.undefined
-      expect(spans[2].context()._spanSampling).to.be.undefined
-      expect(spans[3].context()._spanSampling).to.be.undefined
-      expect(spans[4].context()._spanSampling).to.be.undefined
-      expect(spans[5].context()._spanSampling).to.be.undefined
-      expect(spans[6].context()._spanSampling).to.be.undefined
-      expect(spans[7].context()._spanSampling).to.be.undefined
-      expect(spans[8].context()._spanSampling).to.be.undefined
+  it('should sample mutiple spans with multiple rules', () => {
+    const sampler = new SpanSampler({
+      spanSamplingRules: [
+        {
+          service: 'test',
+          name: 'operation',
+          sampleRate: 1.0,
+          maxPerSecond: 5
+        },
+        {
+          service: 'test',
+          name: 'second*',
+          sampleRate: 1.0,
+          maxPerSecond: 3
+        }
+      ]
     })
 
-    it('should consider missing service as match-all for service name', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            name: 'sub_second_operation_*',
-            sampleRate: 1.0,
-            maxPerSecond: 5
-          }
-        ]
-      })
+    // Create two span contexts
+    const started = []
+    const firstSpanContext = {
+      _spanId: id('1234567812345678'),
+      _sampling: {},
+      _trace: {
+        started
+      },
+      _name: 'operation',
+      _tags: {}
+    }
+    const secondSpanContext = {
+      ...firstSpanContext,
+      _spanId: id('1234567812345679'),
+      _name: 'second operation'
+    }
 
-      const spanSampling = {
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      }
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()._spanSampling).to.be.undefined
-      expect(spans[1].context()._spanSampling).to.be.undefined
-      expect(spans[2].context()._spanSampling).to.be.undefined
-      // Only 3 and 4 should match because of the name pattern
-      expect(spans[3].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[4].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[5].context()._spanSampling).to.be.undefined
-      expect(spans[6].context()._spanSampling).to.be.undefined
-      expect(spans[7].context()._spanSampling).to.be.undefined
-      expect(spans[8].context()._spanSampling).to.be.undefined
+    // Add spans for both to the context
+    started.push({
+      context: sinon.stub().returns(firstSpanContext),
+      tracer: sinon.stub().returns({
+        _service: 'test'
+      }),
+      _name: 'operation'
+    })
+    started.push({
+      context: sinon.stub().returns(secondSpanContext),
+      tracer: sinon.stub().returns({
+        _service: 'test'
+      }),
+      _name: 'operation'
     })
 
-    it('should consider missing name as match-all for span name', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            sampleRate: 1.0,
-            maxPerSecond: 10
-          }
-        ]
-      })
+    sampler.sample(firstSpanContext)
 
-      const spanSampling = {
-        sampleRate: 1.0,
-        maxPerSecond: 10
-      }
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[1].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[2].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[3].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[4].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[5].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[8].context()._spanSampling).to.eql(spanSampling)
-      // Should not match because of different service name
-      expect(spans[6].context()._spanSampling).to.be.undefined
-      expect(spans[7].context()._spanSampling).to.be.undefined
+    expect(spies.match).to.be.called
+    expect(spies.sample).to.be.called
+    expect(spies.sampleRate.get).to.be.called
+    expect(spies.maxPerSecond.get).to.be.called
+
+    expect(firstSpanContext._spanSampling).to.eql({
+      sampleRate: 1.0,
+      maxPerSecond: 5
     })
-
-    it('should stop at first rule match', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 5
-          },
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 10
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()._spanSampling).to.eql({
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      })
-      expect(spans[1].context()._spanSampling).to.be.undefined
-      expect(spans[2].context()._spanSampling).to.be.undefined
-      expect(spans[3].context()._spanSampling).to.be.undefined
-      expect(spans[4].context()._spanSampling).to.be.undefined
-      expect(spans[5].context()._spanSampling).to.be.undefined
-      expect(spans[6].context()._spanSampling).to.be.undefined
-      expect(spans[7].context()._spanSampling).to.be.undefined
-      expect(spans[8].context()._spanSampling).to.be.undefined
-    })
-
-    it('should use span service name tags where present', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'span-service',
-            sampleRate: 1.0,
-            maxPerSecond: 5
-          }
-        ]
-      })
-
-      const spanSampling = {
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      }
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()._spanSampling).to.be.undefined
-      expect(spans[1].context()._spanSampling).to.be.undefined
-      expect(spans[2].context()._spanSampling).to.be.undefined
-      expect(spans[3].context()._spanSampling).to.be.undefined
-      expect(spans[4].context()._spanSampling).to.be.undefined
-      expect(spans[5].context()._spanSampling).to.be.undefined
-      expect(spans[6].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[7].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[8].context()._spanSampling).to.be.undefined
-    })
-
-    it('should properly sample multiple single spans with one rule', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: '*_2',
-            sampleRate: 1.0,
-            maxPerSecond: 5
-          }
-        ]
-      })
-
-      const spanSampling = {
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      }
-      sampler.sample(spanContexts[0])
-      expect(spans[1].context()._spanSampling).to.be.undefined
-      expect(spans[2].context()._spanSampling).to.be.undefined
-      expect(spans[3].context()._spanSampling).to.be.undefined
-      expect(spans[4].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[5].context()._spanSampling).to.eql(spanSampling)
-      expect(spans[6].context()._spanSampling).to.be.undefined
-      expect(spans[7].context()._spanSampling).to.be.undefined
-      expect(spans[8].context()._spanSampling).to.be.undefined
-    })
-
-    it('should properly sample mutiple single spans with multiple rules', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 5
-          },
-          {
-            service: 'test',
-            name: '*_second*',
-            sampleRate: 1.0,
-            maxPerSecond: 10
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()._spanSampling, {
-        sampleRate: 1.0,
-        maxPerSecond: 5
-      })
-      expect(spans[3].context()._spanSampling, {
-        sampleRate: 1.0,
-        maxPerSecond: 10
-      })
-      expect(spans[4].context()._spanSampling, {
-        sampleRate: 1.0,
-        maxPerSecond: 10
-      })
-      expect(spans[5].context()._spanSampling, {
-        sampleRate: 1.0,
-        maxPerSecond: 10
-      })
-    })
-
-    it('should properly sample renamed spans', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'renamed',
-            sampleRate: 1.0,
-            maxPerSecond: 1
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()._spanSampling).to.be.undefined
-      expect(spans[1].context()._spanSampling).to.be.undefined
-      expect(spans[2].context()._spanSampling).to.be.undefined
-      expect(spans[3].context()._spanSampling).to.be.undefined
-      expect(spans[4].context()._spanSampling).to.be.undefined
-      expect(spans[5].context()._spanSampling).to.be.undefined
-      expect(spans[6].context()._spanSampling).to.be.undefined
-      expect(spans[7].context()._spanSampling).to.be.undefined
-      expect(spans[8].context()._spanSampling).to.eql({
-        sampleRate: 1.0,
-        maxPerSecond: 1
-      })
-    })
-  })
-
-  describe('sampleRate', () => {
-    beforeEach(() => {
-      sinon.stub(Math, 'random')
-    })
-
-    afterEach(() => {
-      Math.random.restore()
-    })
-
-    it('should sample a matched span on allowed sample rate', () => {
-      Math.random.returns(0.5)
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 1
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
-    })
-
-    it('should not sample a matched span on non-allowed sample rate', () => {
-      Math.random.returns(0.5)
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 0.3,
-            maxPerSecond: 1
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      for (const span of spans) {
-        expect(span.context()).to.not.haveOwnProperty('_spanSampling')
-      }
-    })
-
-    it('should selectively sample based on sample rates', () => {
-      Math.random.returns(0.5)
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 0.3,
-            maxPerSecond: 1
-          },
-          {
-            service: 'test',
-            name: 'second_operation',
-            sampleRate: 1.0,
-            maxPerSecond: 1
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[2].context()).to.haveOwnProperty('_spanSampling')
-      expect(spans[0].context()).to.not.haveOwnProperty('_spanSampling')
-    })
-  })
-
-  describe('maxPerSecond', () => {
-    it('should not create limiter without finite maxPerSecond', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0
-          }
-        ]
-      })
-
-      const rule = sampler._rules[0]
-      expect(rule._limiter).to.equal(undefined)
-      expect(rule.maxPerSecond).to.equal(undefined)
-    })
-
-    it('should create limiter with finite maxPerSecond', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 123
-          }
-        ]
-      })
-
-      const rule = sampler._rules[0]
-      expect(rule._limiter).to.not.equal(undefined)
-      expect(rule).to.have.property('maxPerSecond', 123)
-    })
-
-    it('should not sample spans past the rate limit', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 1
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
-      delete spans[0].context()._spanSampling
-
-      // with how quickly these tests execute, the limiter should not allow the
-      // next call to sample any spans
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()).to.not.haveOwnProperty('_spanSampling')
-    })
-
-    it('should map different rules to different rate limiters', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 1
-          },
-          {
-            service: 'test',
-            name: 'sub_operation',
-            sampleRate: 1.0,
-            maxPerSecond: 2
-          }
-        ]
-      })
-
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
-      expect(spans[1].context()).to.haveOwnProperty('_spanSampling')
-      delete spans[0].context()._spanSampling
-      delete spans[1].context()._spanSampling
-
-      // with how quickly these tests execute, the limiter should not allow the
-      // next call to sample any spans
-      sampler.sample(spanContexts[0])
-      expect(spans[0].context()).to.not.haveOwnProperty('_spanSampling')
-      expect(spans[1].context()).to.haveOwnProperty('_spanSampling')
-    })
-
-    it('should map limit by all spans matching pattern', () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'sub_second_operation_*',
-            sampleRate: 1.0,
-            maxPerSecond: 3
-          }
-        ]
-      })
-
-      // First time around both should have spanSampling to prove match
-      sampler.sample(spanContexts[0])
-      expect(spans[3].context()).to.haveOwnProperty('_spanSampling')
-      expect(spans[4].context()).to.haveOwnProperty('_spanSampling')
-      delete spans[3].context()._spanSampling
-      delete spans[4].context()._spanSampling
-
-      // Second time around only first should have spanSampling to prove limits
-      sampler.sample(spanContexts[0])
-      expect(spans[3].context()).to.haveOwnProperty('_spanSampling')
-      expect(spans[4].context()).to.not.haveOwnProperty('_spanSampling')
-    })
-
-    it('should allow unlimited rate limits', async () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0
-          }
-        ]
-      })
-
-      const interval = setInterval(() => {
-        sampler.sample(spanContexts[0])
-        expect(spans[0].context()).to.haveOwnProperty('_spanSampling')
-        delete spans[0].context()._spanSampling
-      }, 1)
-
-      await new Promise(resolve => {
-        setTimeout(resolve, 1000)
-      })
-
-      clearInterval(interval)
-    })
-
-    it('should sample if enough time has elapsed', async () => {
-      sampler = new SpanSampler({
-        spanSamplingRules: [
-          {
-            service: 'test',
-            name: 'operation',
-            sampleRate: 1.0,
-            maxPerSecond: 1
-          }
-        ]
-      })
-
-      await new Promise(resolve => {
-        sampler.sample(spanContexts[0])
-        const before = spans[0].context()._spanSampling
-        delete spans[0].context()._spanSampling
-
-        setTimeout(() => {
-          sampler.sample(spanContexts[0])
-          const after = spans[0].context()._spanSampling
-          delete spans[0].context()._spanSampling
-
-          expect(before).to.eql(after)
-          resolve()
-        }, 1000)
-      })
+    expect(secondSpanContext._spanSampling).to.eql({
+      sampleRate: 1.0,
+      maxPerSecond: 3
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?

Adds glob pattern and per-rule limit support to `DD_TRACE_SAMPLING_RULES` and adds support for `resource` and `tags` matchers to both `DD_TRACE_SAMPLING_RULES` and `DD_SPAN_SAMPLING_RULES`.

### Motivation

Users often want to be able to set sample rates by tag or resource name.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.