### PR TITLE
Fix net plugin tests

### DIFF
--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -230,8 +230,14 @@ describe('Plugin', () => {
           socket.destroy()
 
           socket.once('close', () => {
-            expect(socket.eventNames()).to.not.include.members(events)
-            done()
+            setImmediate(() => {
+              // Node.js 21.2 broke this function. We'll have to do the more manual way for now.
+              // expect(socket.eventNames()).to.not.include.members(events)
+              for (const event of events) {
+                expect(socket.listeners(event)).to.have.lengthOf(0)
+              }
+              done()
+            })
           })
         })
       })


### PR DESCRIPTION
### What does this PR do?

Fixes the net plugin tests as a change to Node.js 21.2.0 broke the `emitter.eventNames()` function on streams. A stream will report having listeners for event names for which it actually does not have listeners.

### Motivation

Get CI back to green.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
