### PR TITLE
Fix integration tests by pinned chai to v4 as v5 went ESM-only

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -38,7 +38,7 @@ const mochaCommonOptions = {
 
 const jestCommonOptions = {
   name: 'jest',
-  dependencies: ['jest', 'chai', 'jest-jasmine2'],
+  dependencies: ['jest', 'chai@v4', 'jest-jasmine2'],
   expectedStdout: 'Test Suites: 2 passed',
   expectedCoverageFiles: [
     'ci-visibility/test/sum.js',
@@ -51,7 +51,7 @@ const testFrameworks = [
   {
     ...mochaCommonOptions,
     testFile: 'ci-visibility/run-mocha.js',
-    dependencies: ['mocha', 'chai', 'nyc'],
+    dependencies: ['mocha', 'chai@v4', 'nyc'],
     expectedCoverageFiles: [
       'ci-visibility/run-mocha.js',
       'ci-visibility/test/sum.js',
@@ -64,7 +64,7 @@ const testFrameworks = [
   {
     ...mochaCommonOptions,
     testFile: 'ci-visibility/run-mocha.mjs',
-    dependencies: ['mocha', 'chai', 'nyc', '@istanbuljs/esm-loader-hook'],
+    dependencies: ['mocha', 'chai@v4', 'nyc', '@istanbuljs/esm-loader-hook'],
     expectedCoverageFiles: [
       'ci-visibility/run-mocha.mjs',
       'ci-visibility/test/sum.js',


### PR DESCRIPTION
### What does this PR do?

Fixes the integration tests for ci-app as chai just released an ESM-only major release and we weren't pinning to any particular range.

### Motivation

Continuing the battle against red CI. ⚔️ 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.