### PR TITLE
Fix timeouts from aws-sdk kinesis tests

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -41,7 +41,7 @@ describe('Kinesis', () => {
       }, (err, res) => {
         if (err) return done(err)
 
-        helpers.waitForActiveStream(this, kinesis, done)
+        helpers.waitForActiveStream(kinesis, done)
       })
     })
 

--- a/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
@@ -45,17 +45,15 @@ function putTestRecord (kinesis, data, cb) {
   }, cb)
 }
 
-function waitForActiveStream (mocha, kinesis, cb) {
+function waitForActiveStream (kinesis, cb) {
   kinesis.describeStream({
     StreamName: 'MyStream'
   }, (err, data) => {
     if (err) {
-      mocha.timeout(2000)
-      return waitForActiveStream(mocha, kinesis, cb)
+      return waitForActiveStream(kinesis, cb)
     }
     if (data.StreamDescription.StreamStatus !== 'ACTIVE') {
-      mocha.timeout(2000)
-      return waitForActiveStream(mocha, kinesis, cb)
+      return waitForActiveStream(kinesis, cb)
     }
 
     cb()


### PR DESCRIPTION
### What does this PR do?

Not sure why the timeout was being adjusted back down from unlimited, but leaving it unlimited should allow kinesis to actually finish creating the stream...

### Motivation

`aws-sdk` has been a continuous pain in the quest for green CI. 😅 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.