### PR TITLE
[profiling] Add `process_id` tag to profiles

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -75,6 +75,7 @@ class AgentExporter {
       ['tags[]', 'language:javascript'],
       ['tags[]', 'runtime:nodejs'],
       ['tags[]', `runtime_version:${process.version}`],
+      ['tags[]', `process_id:${process.pid}`],
       ['tags[]', `profiler_version:${version}`],
       ['tags[]', 'format:pprof'],
       ...Object.entries(tags).map(([key, value]) => ['tags[]', `${key}:${value}`])

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -75,6 +75,7 @@ describe('exporters/agent', function () {
       'language:javascript',
       'runtime:nodejs',
       `runtime_version:${process.version}`,
+      `process_id:${process.pid}`,
       `profiler_version:${version}`,
       'format:pprof',
       'runtime-id:a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6'
@@ -359,6 +360,7 @@ describe('exporters/agent', function () {
               'language:javascript',
               'runtime:nodejs',
               `runtime_version:${process.version}`,
+              `process_id:${process.pid}`,
               `profiler_version:${version}`,
               'format:pprof',
               'foo:bar'


### PR DESCRIPTION
### What does this PR do?
Add a `process_id` that contains process pid to profiles.

### Motivation
Improve integration of profiling within Processes product.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

