### PR TITLE
v6.0.0-pre

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.0.0-pre",
+  "version": "6.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
### What does this PR do?
Bump up version in package.json after v5 release

