### PR TITLE
[ci-visibility] Fix slowness in `test-environment.spec.js`

### DIFF
--- a/packages/dd-trace/test/plugins/util/test-environment.spec.js
+++ b/packages/dd-trace/test/plugins/util/test-environment.spec.js
@@ -6,14 +6,14 @@ const fs = require('fs')
 const path = require('path')
 
 const proxyquire = require('proxyquire')
-const sanitizedExecStub = sinon.stub().returns('')
+const execFileSyncStub = sinon.stub().returns('')
 
 const { getCIMetadata } = require('../../../src/plugins/util/ci')
 const { CI_ENV_VARS, CI_NODE_LABELS } = require('../../../src/plugins/util/tags')
 
 const { getGitMetadata } = proxyquire('../../../src/plugins/util/git', {
-  './exec': {
-    'sanitizedExec': sanitizedExecStub
+  'child_process': {
+    'execFileSync': execFileSyncStub
   }
 })
 const { getTestEnvironmentMetadata } = proxyquire('../../../src/plugins/util/test', {


### PR DESCRIPTION
### What does this PR do?
Fix slowness in tracing tests. 

### Motivation
After https://github.com/DataDog/dd-trace-js/pull/3752, stubbing `sanitizedExec` within `git.js` did nothing: this produced that the tests in `packages/dd-trace/test/plugins/util/test-environment.spec.js` were actually executing `execFileSync`, slowing them down significantly. 

