### PR TITLE
Fix graphql.resolve span durations

### DIFF
--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -80,6 +80,11 @@ class GraphQLResolvePlugin extends TracingPlugin {
     // this will disable resolve subscribers if `config.depth` is set to 0
     super.configure(config.depth === 0 ? false : config)
   }
+
+  finish (finishTime) {
+    this.activeSpan.finish(finishTime)
+    super.finish()
+  }
 }
 
 // helpers

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -9,6 +9,8 @@ const axios = require('axios')
 const http = require('http')
 const getPort = require('get-port')
 
+const SLOW_FIELD_RESOLVER_DELAY_MS = 100
+
 describe('Plugin', () => {
   let tracer
   let graphql
@@ -78,7 +80,15 @@ describe('Plugin', () => {
           resolve (obj, args) {
             return [{}, {}, {}]
           }
-        }
+        },
+        slowField: {
+          type: graphql.GraphQLString,
+          resolve (obj, args) {
+            return new Promise((r) => {
+              setTimeout(() => r('slow field'), SLOW_FIELD_RESOLVER_DELAY_MS)
+            })
+          }
+        },
       }
     })
 
@@ -376,6 +386,57 @@ describe('Plugin', () => {
             .catch(done)
 
           graphql.graphql({ schema, source }).catch(done)
+        })
+
+        it('should instrument each field resolver duration independently', done => {
+          const source = `
+            {
+              human {
+                name
+                slowField
+              }
+            }
+          `
+
+          let foundNameSpan = false
+          let foundSlowFieldSpan = false
+
+          const processTraces = (traces) => {
+            try {
+              for (const trace of traces) {
+                for (const span of trace) {
+                  if (span.name !== 'graphql.resolve') {
+                    continue
+                  }
+                  const spanDurationMs = Number(span.duration) / 1000000
+                  if (span.resource === 'slowField:String') {
+                    // 'slowField' resolver span should be at least as long as the delay
+                    expect(spanDurationMs).to.be.gte(SLOW_FIELD_RESOLVER_DELAY_MS)
+                    foundSlowFieldSpan = true
+                  } else if (span.resource === 'name:String') {
+                    // 'name' resolves immediately, while should be much less than the 'slowField' resolver delay
+                    expect(spanDurationMs).to.be.lt(SLOW_FIELD_RESOLVER_DELAY_MS / 2)
+                    foundNameSpan = true
+                  }
+
+                  if (foundNameSpan && foundSlowFieldSpan) {
+                    agent.unsubscribe(processTraces)
+                    done()
+                    return
+                  }
+                }
+              }
+            } catch (e) {
+              agent.unsubscribe(processTraces)
+              done(e)
+            }
+          }
+
+          agent.subscribe(processTraces)
+          graphql.graphql({ schema, source }).catch((e) => {
+            agent.unsubscribe(processTraces)
+            done(e)
+          })
         })
 
         it('should instrument nested field resolvers', done => {


### PR DESCRIPTION
### What does this PR do?
- Fix a bug in the graphql plugin that causes all `graphql.resolve` spans to have incorrect durations

### Motivation
- When looking at APM traces for graphql requests, we noticed that the `graphql.resolve` spans all seem to extend until the end of the parent `graphql.execute` span, rather than when that field resolver actually completes. This makes it hard to identify which specific field resolvers are performance bottlenecks of a graphql query.

Example 1 - note that all `graphql.resolve` spans extend to roughly the same end time, even for simple fields that should be trivially fast to resolve:
<img width="1234" alt="Screenshot 2024-01-03 at 11 52 15 PM" src="https://github.com/DataDog/dd-trace-js/assets/103462496/4f234b17-9bac-4077-96a8-65e4a0e30cf9">

Example 2 - on another, much more complex graphql query, it's even more apparent that something is wrong and causing all spans to extend until the entire `graphql.execute` span finishes; I would expect most of the purple bars to end earlier, and only one or a few long-tail field resolver spans would extend till the end.
<img width="1216" alt="Screenshot 2024-01-03 at 11 58 34 PM" src="https://github.com/DataDog/dd-trace-js/assets/103462496/1ffa030a-7711-4228-8a4a-047ed8374f1a">


### Additional Notes
I believe this was a regression introduced in PR #3177, which refactored TracingPlugin subclasses to move the common `span.finish()` calls into the TracingPlugin base class.

However, the [change to the graphql plugin's resolve operation in that PR](https://github.com/DataDog/dd-trace-js/commit/4e46109e9975a57e0b30e5275451d28782715e6c#diff-796b4c9573e0971daf318484cdd9517eb62524e5dc46764d8342adaa5339c29a) stopped passing the `finishTime` argument from the `finish` method through to `span.finish()`; the base `TracingPlugin.finish` method [does not use/accept any arguments and calls span.finish() with no args](https://github.com/DataDog/dd-trace-js/blob/e581914099f97ceca0f07343a0c40f8dc8d8ffcc/packages/dd-trace/src/plugins/tracing.js#L57-L59). Due to this change, `span.finish()` is being called without a finish time argument, and thus falls back to using the current time as the finish time.

Why does this result in all `resolve` spans finishing at the end of the `execute` span? If I'm understanding the code correctly, it looks like the graphql plugin defers finishing the `resolve` operations until the entire `execute` operation has completed - [here](https://github.com/DataDog/dd-trace-js/blob/0ccbc344320f5e1882535bf310836cb795bc4620/packages/datadog-instrumentations/src/graphql.js#L354-L365). Although this code is still publishing the field's recorded finishTime to the finish channel, it is no longer being passed through to the span (as discussed above), so all the `resolve` spans are marked as finished at the _current time_, after the overall `execute` has completed.

### Testing

The existing graphql plugin tests didn't appear to explicitly validate the span durations (other than a [basic greater-than-zero check](https://github.com/DataDog/dd-trace-js/blob/ed839d97ad53491c00655a892043243048bfd72c/packages/datadog-plugin-graphql/test/index.spec.js#L368)), so I made some guesses at how best to validate span durations within the existing test framework in order to add a unit test for this fix.

The new test introduces a new graphql field that intentionally takes a while to resolve (using setTimeout to create a real delay, as I didn't see an easy way to mock the time in these tests; let me know if there's a better way!), and confirms that this `slowField` `resolve` span is at least as long as that intentional delay, and, importantly, that a simple field's resolve span in the same graphql request is much shorter than that delay.