### PR TITLE
PROF-8850: Add diagnostic to flaky test

### DIFF
--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -214,10 +214,14 @@ describe('profiler', () => {
       // Thread name must be defined and exactly equal "Main Event Loop"
       assert.equal(threadName, threadNameValue)
       // Either all or none of span-related labels are defined
-      if (spanId || rootSpanId || endpoint) {
+      if (endpoint === undefined) {
+        // It is possible to catch a sample executing in tracer's startSpan so
+        // that endpoint is not yet set. We'll ignore those samples.
+        continue
+      }
+      if (spanId || rootSpanId) {
         assert.isDefined(spanId)
         assert.isDefined(rootSpanId)
-        assert.isDefined(endpoint)
 
         rootSpans.add(rootSpanId)
         const spanData = { rootSpanId, endpoint }

--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -63,7 +63,7 @@ async function getLatestProfile (cwd, pattern) {
     .name
   const pprofGzipped = await fs.readFile(path.join(cwd, pprofEntry))
   const pprofUnzipped = zlib.gunzipSync(pprofGzipped)
-  return Profile.decode(pprofUnzipped)
+  return { profile: Profile.decode(pprofUnzipped), encoded: pprofGzipped.toString('base64') }
 }
 
 async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args) {
@@ -81,9 +81,9 @@ async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args
   await processExitPromise(proc, 5000)
   const procEnd = BigInt(Date.now() * 1000000)
 
-  const prof = await getLatestProfile(cwd, /^events_.+\.pprof$/)
+  const { profile, encoded } = await getLatestProfile(cwd, /^events_.+\.pprof$/)
 
-  const strings = prof.stringTable
+  const strings = profile.stringTable
   const tsKey = strings.dedup('end_timestamp_ns')
   const eventKey = strings.dedup('event')
   const hostKey = strings.dedup('host')
@@ -92,7 +92,7 @@ async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args
   const nameKey = strings.dedup('operation')
   const eventValue = strings.dedup(eventType)
   const events = []
-  for (const sample of prof.sample) {
+  for (const sample of profile.sample) {
     let ts, event, host, address, port, name
     for (const label of sample.label) {
       switch (label.key) {
@@ -102,18 +102,18 @@ async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args
         case hostKey: host = label.str; break
         case addressKey: address = label.str; break
         case portKey: port = label.num; break
-        default: assert.fail(`Unexpected label key ${label.key} ${strings.strings[label.key]}`)
+        default: assert.fail(`Unexpected label key ${label.key} ${strings.strings[label.key]} ${encoded}`)
       }
     }
     // Timestamp must be defined and be between process start and end time
-    assert.isDefined(ts)
-    assert.isTrue(ts <= procEnd)
-    assert.isTrue(ts >= procStart)
+    assert.isDefined(ts, encoded)
+    assert.isTrue(ts <= procEnd, encoded)
+    assert.isTrue(ts >= procStart, encoded)
     // Gather only DNS events; ignore sporadic GC events
     if (event === eventValue) {
-      assert.isDefined(name)
+      assert.isDefined(name, encoded)
       // Exactly one of these is defined
-      assert.isTrue(!!address !== !!host)
+      assert.isTrue(!!address !== !!host, encoded)
       const ev = { name: strings.strings[name] }
       if (address) {
         ev.address = strings.strings[address]
@@ -169,7 +169,7 @@ describe('profiler', () => {
     await processExitPromise(proc, 5000)
     const procEnd = BigInt(Date.now() * 1000000)
 
-    const prof = await getLatestProfile(cwd, /^wall_.+\.pprof$/)
+    const { profile, encoded } = await getLatestProfile(cwd, /^wall_.+\.pprof$/)
 
     // We check the profile for following invariants:
     // - every sample needs to have an 'end_timestamp_ns' label that has values (nanos since UNIX
@@ -182,7 +182,7 @@ describe('profiler', () => {
     const rootSpans = new Set()
     const endpoints = new Set()
     const spans = new Map()
-    const strings = prof.stringTable
+    const strings = profile.stringTable
     const tsKey = strings.dedup('end_timestamp_ns')
     const spanKey = strings.dedup('span id')
     const rootSpanKey = strings.dedup('local root span id')
@@ -191,7 +191,7 @@ describe('profiler', () => {
     const threadIdKey = strings.dedup('thread id')
     const osThreadIdKey = strings.dedup('os thread id')
     const threadNameValue = strings.dedup('Main Event Loop')
-    for (const sample of prof.sample) {
+    for (const sample of profile.sample) {
       let ts, spanId, rootSpanId, endpoint, threadName, threadId, osThreadId
       for (const label of sample.label) {
         switch (label.key) {
@@ -202,17 +202,17 @@ describe('profiler', () => {
           case threadNameKey: threadName = label.str; break
           case threadIdKey: threadId = label.str; break
           case osThreadIdKey: osThreadId = label.str; break
-          default: assert.fail(`Unexpected label key ${strings.dedup(label.key)}`)
+          default: assert.fail(`Unexpected label key ${strings.dedup(label.key)} ${encoded}`)
         }
       }
       // Timestamp must be defined and be between process start and end time
-      assert.isDefined(ts)
-      assert.isNumber(osThreadId)
-      assert.equal(threadId, strings.dedup('0'))
-      assert.isTrue(ts <= procEnd)
-      assert.isTrue(ts >= procStart)
+      assert.isDefined(ts, encoded)
+      assert.isNumber(osThreadId, encoded)
+      assert.equal(threadId, strings.dedup('0'), encoded)
+      assert.isTrue(ts <= procEnd, encoded)
+      assert.isTrue(ts >= procStart, encoded)
       // Thread name must be defined and exactly equal "Main Event Loop"
-      assert.equal(threadName, threadNameValue)
+      assert.equal(threadName, threadNameValue, encoded)
       // Either all or none of span-related labels are defined
       if (endpoint === undefined) {
         // It is possible to catch a sample executing in tracer's startSpan so
@@ -220,15 +220,15 @@ describe('profiler', () => {
         continue
       }
       if (spanId || rootSpanId) {
-        assert.isDefined(spanId)
-        assert.isDefined(rootSpanId)
+        assert.isDefined(spanId, encoded)
+        assert.isDefined(rootSpanId, encoded)
 
         rootSpans.add(rootSpanId)
         const spanData = { rootSpanId, endpoint }
         const existingSpanData = spans.get(spanId)
         if (existingSpanData) {
           // Span's root span and endpoint must be consistent across samples
-          assert.deepEqual(spanData, existingSpanData)
+          assert.deepEqual(spanData, existingSpanData, encoded)
         } else {
           // New span id, store span data
           spans.set(spanId, spanData)
@@ -241,16 +241,16 @@ describe('profiler', () => {
               endpoints.add(endpoint)
               break
             default:
-              assert.fail(`Unexpected endpoint value ${endpointVal}`)
+              assert.fail(`Unexpected endpoint value ${endpointVal} ${encoded}`)
           }
         }
       }
     }
     // Need to have a total of 9 different spans, with 3 different root spans
     // and 3 different endpoints.
-    assert.equal(spans.size, 9)
-    assert.equal(rootSpans.size, 3)
-    assert.equal(endpoints.size, 3)
+    assert.equal(spans.size, 9, encoded)
+    assert.equal(rootSpans.size, 3, encoded)
+    assert.equal(endpoints.size, 3, encoded)
   })
 
   if (semver.gte(process.version, '16.0.0')) {


### PR DESCRIPTION
### What does this PR do?
Fixes one problem with the code hotspots integration test. Adds diagnostic to be able to identify other flakiness.

The code hotspots test sometimes observes 10 different spans, but the test program is only supposed to create 9 spans. I couldn't reproduce this locally, so I added the base64-encoded contents of the gzipped pprof file to the error messages for further investigation.

I did manage to observe another problem: sometimes there'd be spans without endpoints present. It _seems_ [possible](https://gist.github.com/szegedi/d6bf2ab0839d63130dd831f238f68b5d#file-span_before_endpoint-L7) when we capture a sample in span setup, so I decided the test should be more lenient and skip those samples instead of declaring failure.

### Motivation
We want consistently green builds.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.