### PR TITLE
[ci-visibility] Agentless telemetry for CI Visibility

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -611,7 +611,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.startupLogs = isTrue(DD_TRACE_STARTUP_LOGS)
     // Disabled for CI Visibility's agentless
     this.telemetry = {
-      enabled: DD_TRACE_EXPORTER !== 'datadog' && isTrue(DD_INSTRUMENTATION_TELEMETRY_ENABLED),
+      enabled: isTrue(DD_INSTRUMENTATION_TELEMETRY_ENABLED),
       heartbeatInterval: DD_TELEMETRY_HEARTBEAT_INTERVAL,
       debug: isTrue(DD_TELEMETRY_DEBUG),
       logCollection: isTrue(DD_TELEMETRY_LOG_COLLECTION_ENABLED),

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -77,14 +77,13 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
   }
 
   const options = {
+    url,
+    hostname,
+    port,
     method: 'POST',
     path: isCiVisibilityAgentlessMode ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
     headers: getHeaders(config, application, reqType)
   }
-
-  options.url = url
-  options.hostname = hostname
-  options.port = port
 
   const data = JSON.stringify({
     api_version: 'v2',

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -33,12 +33,11 @@ function getAgentlessTelemetryEndpoint (site) {
   if (site === 'datad0g.com') { // staging
     return 'https://all-http-intake.logs.datad0g.com'
   }
-  if (DATA_CENTERS.includes(site)) {
-    return `https://instrumentation-telemetry-intake.${site}`
-  }
   if (site === 'datadoghq.eu') {
     return 'https://instrumentation-telemetry-intake.eu1.datadoghq.com'
   }
+  
+  return `https://instrumentation-telemetry-intake.${site}`
 }
 
 let seqId = 0

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -1,15 +1,8 @@
 
 const request = require('../exporters/common/request')
 const log = require('../log')
-let agentTelemetry = true
 
-const DATA_CENTERS = [
-  'datadoghq.com',
-  'us3.datadoghq.com',
-  'us5.datadoghq.com',
-  'ap1.datadoghq.com',
-  'eu1.datadoghq.com'
-]
+let agentTelemetry = true
 
 function getHeaders (config, application, reqType) {
   const headers = {
@@ -36,7 +29,6 @@ function getAgentlessTelemetryEndpoint (site) {
   if (site === 'datadoghq.eu') {
     return 'https://instrumentation-telemetry-intake.eu1.datadoghq.com'
   }
-  
   return `https://instrumentation-telemetry-intake.${site}`
 }
 

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -3,6 +3,14 @@ const request = require('../exporters/common/request')
 const log = require('../log')
 let agentTelemetry = true
 
+const DATA_CENTERS = [
+  'datadoghq.com',
+  'us3.datadoghq.com',
+  'us5.datadoghq.com',
+  'ap1.datadoghq.com',
+  'eu1.datadoghq.com'
+]
+
 function getHeaders (config, application, reqType) {
   const headers = {
     'content-type': 'application/json',
@@ -15,7 +23,22 @@ function getHeaders (config, application, reqType) {
   if (debug) {
     headers['dd-telemetry-debug-enabled'] = 'true'
   }
+  if (config.apiKey) {
+    headers['dd-api-key'] = config.apiKey
+  }
   return headers
+}
+
+function getAgentlessTelemetryEndpoint (site) {
+  if (site === 'datad0g.com') { // staging
+    return 'https://all-http-intake.logs.datad0g.com'
+  }
+  if (DATA_CENTERS.includes(site)) {
+    return `https://instrumentation-telemetry-intake.${site}`
+  }
+  if (site === 'datadoghq.eu') {
+    return 'https://instrumentation-telemetry-intake.eu1.datadoghq.com'
+  }
 }
 
 let seqId = 0
@@ -35,17 +58,31 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
   const {
     hostname,
     port,
-    url
+    experimental,
+    isCiVisibility
   } = config
 
+  let url
+
+  const isCiVisibilityAgentlessMode = isCiVisibility && experimental?.exporter === 'datadog'
+
+  if (isCiVisibilityAgentlessMode) {
+    url = config.url || new URL(getAgentlessTelemetryEndpoint(config.site))
+  }
+
   const options = {
-    url,
-    hostname,
-    port,
     method: 'POST',
-    path: '/telemetry/proxy/api/v2/apmtelemetry',
+    path: isCiVisibilityAgentlessMode ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
     headers: getHeaders(config, application, reqType)
   }
+
+  if (url) {
+    options.url = url
+  } else {
+    options.hostname = hostname
+    options.port = port
+  }
+
   const data = JSON.stringify({
     api_version: 'v2',
     naming_schema_version: config.spanAttributeSchema ? config.spanAttributeSchema : '',
@@ -65,24 +102,13 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
         agentTelemetry = false
       }
       // figure out which data center to send to
-      let backendUrl
-      const dataCenters = [
-        'datadoghq.com',
-        'us3.datadoghq.com',
-        'us5.datadoghq.com',
-        'ap1.datadoghq.com',
-        'eu1.datadoghq.com'
-      ]
-      if (config.site === 'datad0g.com') { // staging
-        backendUrl = 'https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry'
-      } else if (dataCenters.includes(config.site)) {
-        backendUrl = 'https://instrumentation-telemetry-intake.' + config.site + '/api/v2/apmtelemetry'
-      }
+      const backendUrl = getAgentlessTelemetryEndpoint(config.site)
       const backendHeader = { ...options.headers, 'DD-API-KEY': process.env.DD_API_KEY }
       const backendOptions = {
         ...options,
         url: backendUrl,
-        headers: backendHeader
+        headers: backendHeader,
+        path: '/api/v2/apmtelemetry'
       }
       if (backendUrl) {
         request(data, backendOptions, (error) => { log.error(error) })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1298,6 +1298,10 @@ describe('Config', () => {
         const config = new Config(options)
         expect(config).to.have.property('memcachedCommandEnabled', true)
       })
+      it('should enable telemetry', () => {
+        const config = new Config(options)
+        expect(config).to.nested.property('telemetry.enabled', true)
+      })
     })
     context('ci visibility mode is not enabled', () => {
       it('should not activate intelligent test runner or git metadata upload', () => {

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -147,4 +147,26 @@ describe('sendData', () => {
     expect(data.request_type).to.equal('message-batch')
     expect(data.payload).to.deep.equal(expectedPayload)
   })
+
+  it('should also work in CI Visibility agentless mode', () => {
+    sendDataModule.sendData(
+      {
+        experimental: { exporter: 'datadog' },
+        isCiVisibility: true,
+        tags: { 'runtime-id': '123' },
+        site: 'datadoghq.eu'
+      },
+      application,
+      'test', 'req-type'
+    )
+
+    expect(request).to.have.been.calledOnce
+    const options = request.getCall(0).args[1]
+    expect(options).to.include({
+      method: 'POST',
+      path: '/api/v2/apmtelemetry'
+    })
+    const { url } = options
+    expect(url).to.eql(new URL('https://instrumentation-telemetry-intake.eu1.datadoghq.com'))
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Add support for agentless telemetry for CI Visibility. 

### Motivation
Get visibility into users of agentless mode. 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

