### PR TITLE
Update Next.js tests to work with Node 18

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -202,27 +202,15 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   next:
-    strategy:
-      matrix:
-        node-version: [16]
-        range: ['>=9.5 <11.1', '>=11.1 <13.2']
-        include:
-          - node-version: 18
-            range: '>=13.2'
     runs-on: ubuntu-latest
     env:
       PLUGINS: next
-      RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn install --ignore-engines
-      - run: yarn config set ignore-engines true
-      - run: yarn test:appsec:plugins:ci --ignore-engines
-      - if: always()
-        uses: ./.github/actions/testagent/logs
+      - run: yarn install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -207,10 +207,13 @@ jobs:
       PLUGINS: next
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:appsec:plugins:ci
+      - if: always()
+        uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -903,27 +903,18 @@ jobs:
 
   # TODO: fix performance issues and test more Node versions
   next:
-    strategy:
-      matrix:
-        node-version: [16]
-        range: ['>=9.5 <11.1', '>=11.1 <13.2']
-        include:
-          - node-version: 18
-            range: '>=13.2'
     runs-on: ubuntu-latest
     env:
       PLUGINS: next
-      RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn install --ignore-engines
-      - run: yarn config set ignore-engines true
-      - run: yarn test:plugins:ci --ignore-engines
+      - run: yarn install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v3

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -97,7 +97,7 @@ describe('Plugin', function () {
         execSync('yarn install', { cwd })
 
         // building in-process makes tests fail for an unknown reason
-        execSync('yarn exec next build', {
+        execSync('NODE_OPTIONS=--openssl-legacy-provider yarn exec next build', {
           cwd,
           env: {
             ...process.env,

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -21,7 +21,8 @@ describe('esm', () => {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)
       sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
-        false, ['./packages/datadog-plugin-next/test/integration-test/*'], 'yarn exec next build')
+        false, ['./packages/datadog-plugin-next/test/integration-test/*'],
+        'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build')
     })
 
     after(async () => {
@@ -39,7 +40,7 @@ describe('esm', () => {
 
     it('is instrumented', async () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
-        NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init`
+        NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init --openssl-legacy-provider`
       })
       return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
         assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/dd-trace/test/appsec/index.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.next.plugin.spec.js
@@ -48,7 +48,7 @@ describe('test suite', () => {
         execSync('yarn install', { cwd })
 
         // building in-process makes tests fail for an unknown reason
-        execSync('yarn exec next build', {
+        execSync('NODE_OPTIONS=--openssl-legacy-provider yarn exec next build', {
           cwd,
           env: {
             ...process.env,


### PR DESCRIPTION
### What does this PR do?
passes --openssl-legacy-provider as NODE_OPTIONS for next.js tests

### Motivation
Next.js tests for versions <13.2 failing on Node.js 18
