### PR TITLE
PROF-8714: GA Code hotspots and endpoint collection by defaulting them to true

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -98,7 +98,7 @@ class Config {
     this.debugSourceMaps = isTrue(coalesce(options.debugSourceMaps, DD_PROFILING_DEBUG_SOURCE_MAPS, false))
     this.endpointCollectionEnabled = isTrue(coalesce(options.endpointCollection,
       DD_PROFILING_ENDPOINT_COLLECTION_ENABLED,
-      DD_PROFILING_EXPERIMENTAL_ENDPOINT_COLLECTION_ENABLED, false))
+      DD_PROFILING_EXPERIMENTAL_ENDPOINT_COLLECTION_ENABLED, true))
     logExperimentalVarDeprecation('ENDPOINT_COLLECTION_ENABLED')
 
     this.pprofPrefix = pprofPrefix
@@ -148,7 +148,7 @@ class Config {
 
     this.codeHotspotsEnabled = isTrue(coalesce(options.codeHotspotsEnabled,
       DD_PROFILING_CODEHOTSPOTS_ENABLED,
-      DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED, false))
+      DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED, true))
     logExperimentalVarDeprecation('CODEHOTSPOTS_ENABLED')
 
     this.cpuProfilingEnabled = isTrue(coalesce(options.cpuProfilingEnabled,

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -48,7 +48,7 @@ describe('config', () => {
     expect(config.logger).to.be.an.instanceof(ConsoleLogger)
     expect(config.exporters[0]).to.be.an.instanceof(AgentExporter)
     expect(config.profilers[0]).to.be.an.instanceof(WallProfiler)
-    expect(config.profilers[0].codeHotspotsEnabled()).false
+    expect(config.profilers[0].codeHotspotsEnabled()).true
     expect(config.profilers[1]).to.be.an.instanceof(SpaceProfiler)
     expect(config.v8ProfilerBugWorkaroundEnabled).true
     expect(config.cpuProfilingEnabled).false
@@ -63,7 +63,7 @@ describe('config', () => {
       exporters: 'agent,file',
       profilers: 'space,wall',
       url: 'http://localhost:1234/',
-      codeHotspotsEnabled: true
+      codeHotspotsEnabled: false
     }
 
     const config = new Config(options)
@@ -86,7 +86,7 @@ describe('config', () => {
     expect(config.profilers.length).to.equal(2)
     expect(config.profilers[0]).to.be.an.instanceOf(SpaceProfiler)
     expect(config.profilers[1]).to.be.an.instanceOf(WallProfiler)
-    expect(config.profilers[1].codeHotspotsEnabled()).true
+    expect(config.profilers[1].codeHotspotsEnabled()).false
   })
 
   it('should filter out invalid profilers', () => {
@@ -130,7 +130,6 @@ describe('config', () => {
   it('should support profiler config with DD_PROFILING_PROFILERS', () => {
     process.env = {
       DD_PROFILING_PROFILERS: 'wall',
-      DD_PROFILING_CODEHOTSPOTS_ENABLED: '1',
       DD_PROFILING_V8_PROFILER_BUG_WORKAROUND: '0',
       DD_PROFILING_EXPERIMENTAL_CPU_ENABLED: '1'
     }
@@ -184,7 +183,6 @@ describe('config', () => {
   it('should prioritize options over env variables', () => {
     process.env = {
       DD_PROFILING_PROFILERS: 'space',
-      DD_PROFILING_CODEHOTSPOTS_ENABLED: '1',
       DD_PROFILING_ENDPOINT_COLLECTION_ENABLED: '1'
     }
     const options = {


### PR DESCRIPTION
### What does this PR do?
Changes the defaults for code hotspots and endpoint collection to true.

### Motivation
Making these features GA.

### Additional Notes
🎉 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.