### PR TITLE
Fix hapi tests

### DIFF
--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -51,7 +51,7 @@ describe('Plugin', () => {
             .then(_port => {
               port = _port
               server = Hapi.server({
-                address: '127.0.0.1',
+                address: 'localhost',
                 port
               })
               return server.start()
@@ -69,9 +69,9 @@ describe('Plugin', () => {
 
               if (Hapi.Server.prototype.connection) {
                 server = new Hapi.Server()
-                server.connection({ address: '127.0.0.1', port })
+                server.connection({ address: 'localhost', port })
               } else {
-                server = new Hapi.Server('127.0.0.1', port)
+                server = new Hapi.Server('localhost', port)
               }
 
               server.start(done)


### PR DESCRIPTION
### What does this PR do?

Fixes the hapi test failures. Apparently it just needed to use `localhost` rather than `127.0.0.1` for the host to bind.

### Motivation

CI should be green.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
