### PR TITLE
Fix aws-sdk tests by making withNamingSchema handle multiple failures properly

### DIFF
--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -84,23 +84,25 @@ function withNamingSchema (
 
         const { opName, serviceName } = expected[versionName]
 
-        it(`should conform to the naming schema`, done => {
-          agent
-            .use(traces => {
-              const span = selectSpan(traces)
-              const expectedOpName = typeof opName === 'function'
-                ? opName()
-                : opName
-              const expectedServiceName = typeof serviceName === 'function'
-                ? serviceName()
-                : serviceName
+        it(`should conform to the naming schema`, () => {
+          return new Promise((resolve, reject) => {
+            agent
+              .use(traces => {
+                const span = selectSpan(traces)
+                const expectedOpName = typeof opName === 'function'
+                  ? opName()
+                  : opName
+                const expectedServiceName = typeof serviceName === 'function'
+                  ? serviceName()
+                  : serviceName
 
-              expect(span).to.have.property('name', expectedOpName)
-              expect(span).to.have.property('service', expectedServiceName)
-            })
-            .then(done)
-            .catch(done)
-          spanProducerFn(done)
+                expect(span).to.have.property('name', expectedOpName)
+                expect(span).to.have.property('service', expectedServiceName)
+              })
+              .then(resolve)
+              .catch(reject)
+            spanProducerFn(reject)
+          })
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?

Makes `withNamingSchema` more reliable by handling multiple failure cases properly.

### Motivation

If the trace assertions in `withNamingSchema` fail _and_ the test itself fails it will trigger a double-call to `done` which fails for the double-done rather than the actual failure. With this change it will fail for the right reason.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!