### PR TITLE
fix empty strings being kept as valid values in config

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -765,9 +765,9 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     const defaults = this._defaults = {}
 
-    this._setValue(defaults, 'service', service)
-    this._setValue(defaults, 'env', undefined)
-    this._setValue(defaults, 'version', pkg.version)
+    this._setString(defaults, 'service', service)
+    this._setString(defaults, 'env', undefined)
+    this._setString(defaults, 'version', pkg.version)
     this._setUnit(defaults, 'sampleRate', undefined)
     this._setBoolean(defaults, 'logInjection', false)
     this._setArray(defaults, 'headerTags', [])
@@ -795,9 +795,9 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     tagger.add(tags, DD_TRACE_TAGS)
     tagger.add(tags, DD_TRACE_GLOBAL_TAGS)
 
-    this._setValue(env, 'service', DD_SERVICE || DD_SERVICE_NAME || tags.service)
-    this._setValue(env, 'env', DD_ENV || tags.env)
-    this._setValue(env, 'version', DD_VERSION || tags.version)
+    this._setString(env, 'service', DD_SERVICE || DD_SERVICE_NAME || tags.service)
+    this._setString(env, 'env', DD_ENV || tags.env)
+    this._setString(env, 'version', DD_VERSION || tags.version)
     this._setUnit(env, 'sampleRate', DD_TRACE_SAMPLE_RATE)
     this._setBoolean(env, 'logInjection', DD_LOGS_INJECTION)
     this._setArray(env, 'headerTags', DD_TRACE_HEADER_TAGS)
@@ -812,9 +812,9 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     tagger.add(tags, options.tags)
 
-    this._setValue(opts, 'service', options.service || tags.service)
-    this._setValue(opts, 'env', options.env || tags.env)
-    this._setValue(opts, 'version', options.version || tags.version)
+    this._setString(opts, 'service', options.service || tags.service)
+    this._setString(opts, 'env', options.env || tags.env)
+    this._setString(opts, 'version', options.version || tags.version)
     this._setUnit(opts, 'sampleRate', coalesce(options.sampleRate, options.ingestion.sampleRate))
     this._setBoolean(opts, 'logInjection', options.logInjection)
     this._setArray(opts, 'headerTags', options.headerTags)
@@ -873,6 +873,10 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     if (Array.isArray(value)) {
       this._setValue(obj, name, value)
     }
+  }
+
+  _setString (obj, name, value) {
+    obj[name] = value || undefined // unset for empty strings
   }
 
   _setTags (obj, name, value) {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -765,9 +765,9 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     const defaults = this._defaults = {}
 
-    this._setString(defaults, 'service', service)
-    this._setString(defaults, 'env', undefined)
-    this._setString(defaults, 'version', pkg.version)
+    this._setValue(defaults, 'service', service)
+    this._setValue(defaults, 'env', undefined)
+    this._setValue(defaults, 'version', pkg.version)
     this._setUnit(defaults, 'sampleRate', undefined)
     this._setBoolean(defaults, 'logInjection', false)
     this._setArray(defaults, 'headerTags', [])

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -328,7 +328,7 @@ describe('Config', () => {
 
     expect(config).to.have.property('service', 'node')
     expect(config).to.have.property('env', undefined)
-    expect(config).to.have.property('version', undefined)
+    expect(config).to.have.property('version', '')
   })
 
   it('should read case-insensitive booleans from environment variables', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -321,6 +321,16 @@ describe('Config', () => {
     })
   })
 
+  it('should ignore empty strings', () => {
+    process.env.DD_TAGS = 'service:,env:,version:'
+
+    const config = new Config()
+
+    expect(config).to.have.property('service', 'node')
+    expect(config).to.have.property('env', undefined)
+    expect(config).to.have.property('version', undefined)
+  })
+
   it('should read case-insensitive booleans from environment variables', () => {
     process.env.DD_TRACING_ENABLED = 'False'
     process.env.DD_TRACE_DEBUG = 'TRUE'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix empty strings being kept as valid values in config.

### Motivation
<!-- What inspired you to submit this pull request? -->

Empty strings should be skipped as in pretty much all cases they mean the absence of a value but from a source that always passes a string, for example an environment variable. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

