### PR TITLE
[ci-visibility] Fix logic to add unskippable and forced to run tags in `jest`

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -984,7 +984,7 @@ testFrameworks.forEach(({
             const events = payloads.flatMap(({ payload }) => payload.events)
             const suites = events.filter(event => event.type === 'test_suite_end')
 
-            assert.equal(suites.length, 2)
+            assert.equal(suites.length, 3)
 
             const testSession = events.find(event => event.type === 'test_session_end').content
             const testModule = events.find(event => event.type === 'test_module_end').content
@@ -993,12 +993,19 @@ testFrameworks.forEach(({
             assert.propertyVal(testModule.meta, TEST_ITR_FORCED_RUN, 'true')
             assert.propertyVal(testModule.meta, TEST_ITR_UNSKIPPABLE, 'true')
 
+            const passedSuite = suites.find(
+              event => event.content.resource === 'test_suite.ci-visibility/unskippable-test/test-to-run.js'
+            )
             const skippedSuite = suites.find(
               event => event.content.resource === 'test_suite.ci-visibility/unskippable-test/test-to-skip.js'
             )
             const forcedToRunSuite = suites.find(
               event => event.content.resource === 'test_suite.ci-visibility/unskippable-test/test-unskippable.js'
             )
+            // It does not mark as unskippable if there is no docblock
+            assert.propertyVal(passedSuite.content.meta, TEST_STATUS, 'pass')
+            assert.notProperty(passedSuite.content.meta, TEST_ITR_UNSKIPPABLE)
+            assert.notProperty(passedSuite.content.meta, TEST_ITR_FORCED_RUN)
 
             assert.propertyVal(skippedSuite.content.meta, TEST_STATUS, 'skip')
             assert.notProperty(skippedSuite.content.meta, TEST_ITR_UNSKIPPABLE)
@@ -1012,6 +1019,7 @@ testFrameworks.forEach(({
         let TESTS_TO_RUN = 'unskippable-test/test-'
         if (name === 'mocha') {
           TESTS_TO_RUN = JSON.stringify([
+            './unskippable-test/test-to-run.js',
             './unskippable-test/test-to-skip.js',
             './unskippable-test/test-unskippable.js'
           ])
@@ -1050,7 +1058,7 @@ testFrameworks.forEach(({
             const events = payloads.flatMap(({ payload }) => payload.events)
             const suites = events.filter(event => event.type === 'test_suite_end')
 
-            assert.equal(suites.length, 2)
+            assert.equal(suites.length, 3)
 
             const testSession = events.find(event => event.type === 'test_session_end').content
             const testModule = events.find(event => event.type === 'test_module_end').content
@@ -1059,12 +1067,20 @@ testFrameworks.forEach(({
             assert.notProperty(testModule.meta, TEST_ITR_FORCED_RUN)
             assert.propertyVal(testModule.meta, TEST_ITR_UNSKIPPABLE, 'true')
 
+            const passedSuite = suites.find(
+              event => event.content.resource === 'test_suite.ci-visibility/unskippable-test/test-to-run.js'
+            )
             const skippedSuite = suites.find(
               event => event.content.resource === 'test_suite.ci-visibility/unskippable-test/test-to-skip.js'
             ).content
             const nonSkippedSuite = suites.find(
               event => event.content.resource === 'test_suite.ci-visibility/unskippable-test/test-unskippable.js'
             ).content
+
+            // It does not mark as unskippable if there is no docblock
+            assert.propertyVal(passedSuite.content.meta, TEST_STATUS, 'pass')
+            assert.notProperty(passedSuite.content.meta, TEST_ITR_UNSKIPPABLE)
+            assert.notProperty(passedSuite.content.meta, TEST_ITR_FORCED_RUN)
 
             assert.propertyVal(skippedSuite.meta, TEST_STATUS, 'skip')
 
@@ -1077,6 +1093,7 @@ testFrameworks.forEach(({
         let TESTS_TO_RUN = 'unskippable-test/test-'
         if (name === 'mocha') {
           TESTS_TO_RUN = JSON.stringify([
+            './unskippable-test/test-to-run.js',
             './unskippable-test/test-to-skip.js',
             './unskippable-test/test-unskippable.js'
           ])

--- a/integration-tests/ci-visibility/unskippable-test/test-to-run.js
+++ b/integration-tests/ci-visibility/unskippable-test/test-to-run.js
@@ -1,0 +1,7 @@
+const { expect } = require('chai')
+
+describe('test-to-run', () => {
+  it('can report tests', () => {
+    expect(1 + 2).to.equal(3)
+  })
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -495,6 +495,8 @@ addHook({
       _ddTestModuleId,
       _ddTestSessionId,
       _ddTestCommand,
+      _ddForcedToRun,
+      _ddUnskippable,
       ...restOfTestEnvironmentOptions
     } = testEnvironmentOptions
 

--- a/packages/datadog-plugin-jest/test/util.spec.js
+++ b/packages/datadog-plugin-jest/test/util.spec.js
@@ -153,18 +153,24 @@ describe('getJestSuitesToRun', () => {
 
   it('adds extra `testEnvironmentOptions` if suite is unskippable or forced to run', () => {
     const skippableSuites = ['fixtures/test-unskippable.js']
-    const testContext = { config: { testEnvironmentOptions: {} } }
+    // tests share a config object
+    const globalConfig = { testEnvironmentOptions: {} }
     const tests = [
-      { path: path.join(__dirname, './fixtures/test-to-run.js') },
+      {
+        path: path.join(__dirname, './fixtures/test-to-run.js'),
+        context: { config: globalConfig }
+      },
       {
         path: path.join(__dirname, './fixtures/test-unskippable.js'),
-        context: testContext
+        context: { config: globalConfig }
       }
     ]
     const rootDir = __dirname
 
     getJestSuitesToRun(skippableSuites, tests, rootDir)
-    expect(testContext.config.testEnvironmentOptions['_ddUnskippable']).to.equal(true)
-    expect(testContext.config.testEnvironmentOptions['_ddForcedToRun']).to.equal(true)
+    expect(globalConfig.testEnvironmentOptions['_ddUnskippable'])
+      .to.eql(JSON.stringify({ 'fixtures/test-unskippable.js': true }))
+    expect(globalConfig.testEnvironmentOptions['_ddForcedToRun'])
+      .to.eql(JSON.stringify({ 'fixtures/test-unskippable.js': true }))
   })
 })


### PR DESCRIPTION
### What does this PR do?

* `test.context.config.testEnvironmentOptions` is shared for all suites, so as soon as we add a value in that dictionary, it's there for all the suites. 
* This made it so that as soon as there was _one_ unskippable suite, every suite was marked as such. 
* This PR adds two dictionaries to `testEnvironmentOptions` whose keys are the suites that are unskippable and were forced to run. This dictionary is available to the jest workers, which can determine whether to add the tags or not.

### Motivation
Fix the logic we used to add the tags for unskippable and forced to run suites.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

