### PR TITLE
PROF-8850: Fix flaky code hotspots test

### DIFF
--- a/integration-tests/profiler.spec.js
+++ b/integration-tests/profiler.spec.js
@@ -230,6 +230,13 @@ describe('profiler', () => {
         assert.isDefined(rootSpanId, encoded)
 
         rootSpans.add(rootSpanId)
+        if (spanId === rootSpanId) {
+          // It is possible to catch a sample executing in the root span before
+          // it entered the nested span; we ignore these too, although we'll
+          // still record the root span ID as we want to assert there'll only be
+          // 3 of them.
+          continue
+        }
         const spanData = { rootSpanId, endpoint }
         const existingSpanData = spans.get(spanId)
         if (existingSpanData) {

--- a/integration-tests/profiler/codehotspots.js
+++ b/integration-tests/profiler/codehotspots.js
@@ -8,8 +8,8 @@ function busyLoop () {
   const start = process.hrtime.bigint()
   for (;;) {
     const now = process.hrtime.bigint()
-    // Busy cycle for 20ms
-    if (now - start > 20000000n) {
+    // Busy cycle for 100ms
+    if (now - start > 100000000n) {
       break
     }
   }


### PR DESCRIPTION
### What does this PR do?
Fixes the flaky "code hotspots and endpoint tracing works" when it fails with 
```
      + expected - actual

      -10
      +9
      
      at Context.<anonymous> (integration-tests/profiler.spec.js:258:14)
```
(Yep, finally tracked it down! :tada:)

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.