### PR TITLE
v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.0.0-pre",
+  "version": "5.0.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
### Breaking Changes

More information about the breaking changes from this release can be found in
the [migration guide](https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md).

* **core:** drop support for Node 16 (#3905)
* **core:** fix TypeScript errors (#3912)

### Features

* **profiling:** Add experimental CPU profiler (#3895)

### Improvements

* **profiling:** GA Code hotspots and endpoint collection (#3940)

### Bug Fixes

* **core:** Handle google-cloud-pubsub subscription closing (#2716)

