### PR TITLE
Ignore header vulnerabilities in cors headers

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
@@ -85,7 +85,7 @@ class HeaderInjectionAnalyzer extends InjectionAnalyzer {
   }
 
   isAccessControlAllowExclusion (name, ranges) {
-    if (name && name.startsWith('access-control-allow-')) {
+    if (name?.startsWith('access-control-allow-')) {
       return ranges
         .every(range => range.iinfo.type === HTTP_REQUEST_HEADER_VALUE)
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/header-injection-analyzer.js
@@ -48,7 +48,7 @@ class HeaderInjectionAnalyzer extends InjectionAnalyzer {
     if (ranges?.length > 0) {
       return !(this.isCookieExclusion(lowerCasedHeaderName, ranges) ||
         this.isSameHeaderExclusion(lowerCasedHeaderName, ranges) ||
-        this.isAccessControlAllowOriginExclusion(lowerCasedHeaderName, ranges))
+        this.isAccessControlAllowExclusion(lowerCasedHeaderName, ranges))
     }
 
     return false
@@ -84,8 +84,8 @@ class HeaderInjectionAnalyzer extends InjectionAnalyzer {
     return false
   }
 
-  isAccessControlAllowOriginExclusion (name, ranges) {
-    if (name === 'access-control-allow-origin') {
+  isAccessControlAllowExclusion (name, ranges) {
+    if (name && name.startsWith('access-control-allow-')) {
       return ranges
         .every(range => range.iinfo.type === HTTP_REQUEST_HEADER_VALUE)
     }

--- a/packages/dd-trace/test/appsec/iast/analyzers/header-injection.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/header-injection.express.plugin.spec.js
@@ -239,6 +239,37 @@ describe('Header injection vulnerability', () => {
             }).catch(done)
           }
         })
+
+        testThatRequestHasNoVulnerability({
+          fn: (req, res) => {
+            setHeaderFunction('Access-Control-Allow-Origin', req.headers['origin'], res)
+            setHeaderFunction('Access-Control-Allow-Headers', req.headers['access-control-request-headers'], res)
+            setHeaderFunction('Access-Control-Allow-Methods', req.headers['access-control-request-methods'], res)
+          },
+          testDescription: 'Should not have vulnerability with CORS headers',
+          vulnerability: 'HEADER_INJECTION',
+          occurrencesAndLocation: {
+            occurrences: 1,
+            location: {
+              path: setHeaderFunctionFilename,
+              line: 4
+            }
+          },
+          cb: (headerInjectionVulnerabilities) => {
+            const evidenceString = headerInjectionVulnerabilities[0].evidence.valueParts
+              .map(part => part.value).join('')
+            expect(evidenceString).to.be.equal('custom: value')
+          },
+          makeRequest: (done, config) => {
+            return axios.options(`http://localhost:${config.port}/`, {
+              headers: {
+                'origin': 'http://custom-origin',
+                'Access-Control-Request-Headers': 'TestHeader',
+                'Access-Control-Request-Methods': 'GET'
+              }
+            }).catch(done)
+          }
+        })
       })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Prevent creating header injection vulnerability when the source of the tainted string is a header and it's setting cors header.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prevent false positive detections in header injection vulnerabilities
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.


### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

[APPSEC-50467]



[APPSEC-50467]: https://datadoghq.atlassian.net/browse/APPSEC-50467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ