### PR TITLE
PROF-8872: Better handling of multiple errors thrown in FakeAgent

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -87,7 +87,7 @@ class FakeAgent extends EventEmitter {
     const errors = []
 
     const timeoutObj = setTimeout(() => {
-      resultReject([...errors, new Error('timeout')])
+      resultReject(new Error('timeout', { cause: { errors } }))
     }, timeout)
 
     const resultPromise = new Promise((resolve, reject) => {
@@ -126,7 +126,7 @@ class FakeAgent extends EventEmitter {
     const errors = []
 
     const timeoutObj = setTimeout(() => {
-      resultReject([...errors, new Error('timeout')])
+      resultReject(new Error('timeout', { cause: { errors } }))
     }, timeout)
 
     const resultPromise = new Promise((resolve, reject) => {

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -87,7 +87,8 @@ class FakeAgent extends EventEmitter {
     const errors = []
 
     const timeoutObj = setTimeout(() => {
-      resultReject(new Error('timeout', { cause: { errors } }))
+      const errorsMsg = errors.length === 0 ? '' : `, additionally:\n${errors.map(e => e.stack).join('\n')}\n===\n`
+      resultReject(new Error(`timeout${errorsMsg}`, { cause: { errors } }))
     }, timeout)
 
     const resultPromise = new Promise((resolve, reject) => {
@@ -126,7 +127,8 @@ class FakeAgent extends EventEmitter {
     const errors = []
 
     const timeoutObj = setTimeout(() => {
-      resultReject(new Error('timeout', { cause: { errors } }))
+      const errorsMsg = errors.length === 0 ? '' : `, additionally:\n${errors.map(e => e.stack).join('\n')}\n===\n`
+      resultReject(new Error(`timeout${errorsMsg}`, { cause: { errors } }))
     }, timeout)
 
     const resultPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
### What does this PR do?
Changes the way multiple errors are reported back from FakeAgent timeouts. Previously, an array was returned for asynchronously thrown exceptions in addition to the timeout exception, but Mocha then complains that it was not an Error that was thrown. I'm now both setting them as the `cause` object of the Error for programmatic inspection, and also adding their stacks to the timeout's message so they all show up in the CI error report.

### Motivation
Working on #3945 I needed better visibility into timeout exceptions and if they might have additional underlying causes.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.