### PR TITLE
[ci-visibility] Fix telemetry in ci visibility

### DIFF
--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -169,12 +169,12 @@ class CucumberPlugin extends CiPlugin {
       }
 
       span.finish()
-      this.telemetry.ciVisEvent(
-        TELEMETRY_EVENT_FINISHED,
-        'test',
-        { hasCodeOwners: !!span.context()._tags[TEST_CODE_OWNERS] }
-      )
       if (!isStep) {
+        this.telemetry.ciVisEvent(
+          TELEMETRY_EVENT_FINISHED,
+          'test',
+          { hasCodeOwners: !!span.context()._tags[TEST_CODE_OWNERS] }
+        )
         finishAllTraceSpans(span)
       }
     })

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -39,7 +39,7 @@ const {
   incrementCountMetric,
   distributionMetric
 } = require('../../dd-trace/src/ci-visibility/telemetry')
-const { onBeforeExit: onBeforeExitTelemetry } = require('../../dd-trace/src/telemetry')
+const { appClosing: appClosingTelemetry } = require('../../dd-trace/src/telemetry')
 const {
   GIT_REPOSITORY_URL,
   GIT_COMMIT_SHA,
@@ -430,12 +430,12 @@ module.exports = (on, config) => {
       }
       if (exporter.flush) {
         exporter.flush(() => {
-          onBeforeExitTelemetry()
+          appClosingTelemetry()
           resolve(null)
         })
       } else if (exporter._writer) {
         exporter._writer.flush(() => {
-          onBeforeExitTelemetry()
+          appClosingTelemetry()
           resolve(null)
         })
       }

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -39,6 +39,7 @@ const {
   incrementCountMetric,
   distributionMetric
 } = require('../../dd-trace/src/ci-visibility/telemetry')
+const { onBeforeExit: onBeforeExitTelemetry } = require('../../dd-trace/src/telemetry')
 const {
   GIT_REPOSITORY_URL,
   GIT_COMMIT_SHA,
@@ -429,10 +430,12 @@ module.exports = (on, config) => {
       }
       if (exporter.flush) {
         exporter.flush(() => {
+          onBeforeExitTelemetry()
           resolve(null)
         })
       } else if (exporter._writer) {
         exporter._writer.flush(() => {
+          onBeforeExitTelemetry()
           resolve(null)
         })
       }

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -17,7 +17,7 @@ const {
   TELEMETRY_EVENT_CREATED,
   TELEMETRY_EVENT_FINISHED
 } = require('../../dd-trace/src/ci-visibility/telemetry')
-const { onBeforeExit: onBeforeExitTelemetry } = require('../../dd-trace/src/telemetry')
+const { appClosing: appClosingTelemetry } = require('../../dd-trace/src/telemetry')
 
 class PlaywrightPlugin extends CiPlugin {
   static get id () {
@@ -38,7 +38,7 @@ class PlaywrightPlugin extends CiPlugin {
       this.testSessionSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'session')
       finishAllTraceSpans(this.testSessionSpan)
-      onBeforeExitTelemetry()
+      appClosingTelemetry()
       this.tracer._exporter.flush(onDone)
     })
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -17,6 +17,7 @@ const {
   TELEMETRY_EVENT_CREATED,
   TELEMETRY_EVENT_FINISHED
 } = require('../../dd-trace/src/ci-visibility/telemetry')
+const { onBeforeExit: onBeforeExitTelemetry } = require('../../dd-trace/src/telemetry')
 
 class PlaywrightPlugin extends CiPlugin {
   static get id () {
@@ -37,6 +38,7 @@ class PlaywrightPlugin extends CiPlugin {
       this.testSessionSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'session')
       finishAllTraceSpans(this.testSessionSpan)
+      onBeforeExitTelemetry()
       this.tracer._exporter.flush(onDone)
     })
 

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -339,5 +339,6 @@ module.exports = {
   start,
   stop,
   updateIntegrations,
-  updateConfig
+  updateConfig,
+  onBeforeExit
 }

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -140,14 +140,18 @@ function appStarted (config) {
   return app
 }
 
-function onBeforeExit () {
-  process.removeListener('beforeExit', onBeforeExit)
+function appClosing () {
   const { reqType, payload } = createPayload('app-closing')
   sendData(config, application, host, reqType, payload)
   // we flush before shutting down. Only in CI Visibility
   if (config.isCiVisibility) {
     metricsManager.send(config, application, host)
   }
+}
+
+function onBeforeExit () {
+  process.removeListener('beforeExit', onBeforeExit)
+  appClosing()
 }
 
 function createAppObject (config) {
@@ -340,5 +344,5 @@ module.exports = {
   stop,
   updateIntegrations,
   updateConfig,
-  onBeforeExit
+  appClosing
 }

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -1,6 +1,7 @@
 
 const request = require('../exporters/common/request')
 const log = require('../log')
+const { isTrue } = require('../util')
 
 let agentTelemetry = true
 
@@ -49,13 +50,12 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
   const {
     hostname,
     port,
-    experimental,
     isCiVisibility
   } = config
 
   let url = config.url
 
-  const isCiVisibilityAgentlessMode = isCiVisibility && experimental?.exporter === 'datadog'
+  const isCiVisibilityAgentlessMode = isCiVisibility && isTrue(process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED)
 
   if (isCiVisibilityAgentlessMode) {
     try {

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -149,9 +149,9 @@ describe('sendData', () => {
   })
 
   it('should also work in CI Visibility agentless mode', () => {
+    process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED = 1
     sendDataModule.sendData(
       {
-        experimental: { exporter: 'datadog' },
         isCiVisibility: true,
         tags: { 'runtime-id': '123' },
         site: 'datadoghq.eu'
@@ -168,5 +168,6 @@ describe('sendData', () => {
     })
     const { url } = options
     expect(url).to.eql(new URL('https://instrumentation-telemetry-intake.eu1.datadoghq.com'))
+    delete process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED
   })
 })


### PR DESCRIPTION
### What does this PR do?

* Make sure telemetry is flushed before process ends in playwright and cypress: `beforeExit` does not work with these libraries.
* Fix test end telemetry in cucumber (we were including steps) 
* Change logic for checking if we're in agentless mode in `send-data.js`: we have other exporters that potentially work in agentless mode. 

### Motivation
Fix telemetry reporting in CI Visibility. 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

