### PR TITLE
fix failing Nextjs tests on Node versions < 18

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -13,7 +13,8 @@ const { rawExpectedSchema } = require('./naming')
 
 const BUILD_COMMAND = NODE_MAJOR < 18
   ? 'yarn exec next build' : 'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build'
-const VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11 <13.2' : '>=11'
+let VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11.1 <13.2' : '>=11.1'
+VERSIONS_TO_TEST = DD_MAJOR >= 4 ? VERSIONS_TO_TEST : '>=9.5 <11.1'
 
 describe('Plugin', function () {
   let server
@@ -23,7 +24,7 @@ describe('Plugin', function () {
     const satisfiesStandalone = version => satisfies(version, '>=12.0.0')
 
     // TODO: Figure out why 10.x tests are failing.
-    withVersions('next', 'next', DD_MAJOR >= 4 && VERSIONS_TO_TEST, version => {
+    withVersions('next', 'next', VERSIONS_TO_TEST, version => {
       const pkg = require(`${__dirname}/../../../versions/next@${version}/node_modules/next/package.json`)
 
       const startServer = ({ withConfig, standalone }, schemaVersion = 'v0', defaultToGlobalService = false) => {

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ const BUILD_COMMAND = NODE_MAJOR < 18
 const NODE_OPTIONS = NODE_MAJOR < 18 ? `--loader=${hookFile} --require dd-trace/init`
   : `--loader=${hookFile} --require dd-trace/init --openssl-legacy-provider`
 
-const VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11 <13.2' : '>=11'
+const VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11.1 <13.2' : '>=11.1'
 
 describe('esm', () => {
   let agent

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -8,21 +8,29 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const { NODE_MAJOR } = require('../../../../version')
 
 const hookFile = 'dd-trace/loader-hook.mjs'
+
+const BUILD_COMMAND = NODE_MAJOR < 18
+  ? 'yarn exec next build' : 'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build'
+const NODE_OPTIONS = NODE_MAJOR < 18 ? `--loader=${hookFile} --require dd-trace/init`
+  : `--loader=${hookFile} --require dd-trace/init --openssl-legacy-provider`
+
+const VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11 <13.2' : '>=11'
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
   // match versions tested with unit tests
-  withVersions('next', 'next', '>=11', version => {
+  withVersions('next', 'next', VERSIONS_TO_TEST, version => {
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)
       sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'],
-        'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build')
+        BUILD_COMMAND)
     })
 
     after(async () => {
@@ -40,7 +48,7 @@ describe('esm', () => {
 
     it('is instrumented', async () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
-        NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init --openssl-legacy-provider`
+        NODE_OPTIONS
       })
       return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
         assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/dd-trace/test/appsec/index.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.next.plugin.spec.js
@@ -13,7 +13,8 @@ const agent = require('../plugins/agent')
 
 const BUILD_COMMAND = NODE_MAJOR < 18
   ? 'yarn exec next build' : 'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build'
-const VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11 <13.2' : '>=11'
+let VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11.1 <13.2' : '>=11.1'
+VERSIONS_TO_TEST = DD_MAJOR >= 4 ? VERSIONS_TO_TEST : '>=9.5 <11.1'
 
 describe('test suite', () => {
   let server
@@ -21,7 +22,7 @@ describe('test suite', () => {
 
   const satisfiesStandalone = version => satisfies(version, '>=12.0.0')
 
-  withVersions('next', 'next', DD_MAJOR >= 4 && VERSIONS_TO_TEST, version => {
+  withVersions('next', 'next', VERSIONS_TO_TEST, version => {
     const realVersion = require(`${__dirname}/../../../../versions/next@${version}`).version()
 
     function initApp (appName) {

--- a/packages/dd-trace/test/appsec/index.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.next.plugin.spec.js
@@ -8,8 +8,12 @@ const { writeFileSync } = require('fs')
 const { satisfies } = require('semver')
 const path = require('path')
 
-const { DD_MAJOR } = require('../../../../version')
+const { DD_MAJOR, NODE_MAJOR } = require('../../../../version')
 const agent = require('../plugins/agent')
+
+const BUILD_COMMAND = NODE_MAJOR < 18
+  ? 'yarn exec next build' : 'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build'
+const VERSIONS_TO_TEST = NODE_MAJOR < 18 ? '>=11 <13.2' : '>=11'
 
 describe('test suite', () => {
   let server
@@ -17,7 +21,7 @@ describe('test suite', () => {
 
   const satisfiesStandalone = version => satisfies(version, '>=12.0.0')
 
-  withVersions('next', 'next', DD_MAJOR >= 4 && '>=11', version => {
+  withVersions('next', 'next', DD_MAJOR >= 4 && VERSIONS_TO_TEST, version => {
     const realVersion = require(`${__dirname}/../../../../versions/next@${version}`).version()
 
     function initApp (appName) {
@@ -48,7 +52,7 @@ describe('test suite', () => {
         execSync('yarn install', { cwd })
 
         // building in-process makes tests fail for an unknown reason
-        execSync('NODE_OPTIONS=--openssl-legacy-provider yarn exec next build', {
+        execSync(BUILD_COMMAND, {
           cwd,
           env: {
             ...process.env,


### PR DESCRIPTION
### What does this PR do?
Adds explicit handling of Next js tests on different Node versions

### Motivation
Next js tests failing on release branches after updating the Nextjs CI build in this PR: https://github.com/DataDog/dd-trace-js/pull/3935

