### PR TITLE
[profiling] Disable oom monitoring on windows

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -360,9 +360,7 @@ describe('profiler', () => {
         })
         return checkProfiles(agent, proc, timeout, ['space'], true)
       })
-    }
 
-    if (process.platform !== 'win32') { // PROF-8905
       it('sends a heap profile on OOM with external process and exits successfully', async () => {
         proc = fork(oomTestFile, {
           cwd,
@@ -375,23 +373,21 @@ describe('profiler', () => {
         })
         return checkProfiles(agent, proc, timeout, ['space'], false, 2)
       })
-    }
 
-    it('sends a heap profile on OOM with async callback', async () => {
-      proc = fork(oomTestFile, {
-        cwd,
-        execArgv: oomExecArgv,
-        env: {
-          ...oomEnv,
-          DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 10000000,
-          DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 1,
-          DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'async'
-        }
+      it('sends a heap profile on OOM with async callback', async () => {
+        proc = fork(oomTestFile, {
+          cwd,
+          execArgv: oomExecArgv,
+          env: {
+            ...oomEnv,
+            DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE: 10000000,
+            DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 1,
+            DD_PROFILING_EXPERIMENTAL_OOM_EXPORT_STRATEGIES: 'async'
+          }
+        })
+        return checkProfiles(agent, proc, timeout, ['space'], true)
       })
-      return checkProfiles(agent, proc, timeout, ['space'], true)
-    })
 
-    if (process.platform !== 'win32') { // PROF-8905
       it('sends heap profiles on OOM with multiple strategies', async () => {
         proc = fork(oomTestFile, {
           cwd,
@@ -405,9 +401,7 @@ describe('profiler', () => {
         })
         return checkProfiles(agent, proc, timeout, ['space'], true, 2)
       })
-    }
 
-    if (process.platform !== 'win32') { // PROF-8905
       it('sends a heap profile on OOM in worker thread and exits successfully', async () => {
         proc = fork(oomTestFile, [1, 50], {
           cwd,

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -97,11 +97,15 @@ class Config {
     // depending on those (code hotspots and endpoint collection) need to default
     // to false on Windows.
     const samplingContextsAvailable = process.platform !== 'win32'
-    function checkOptionAllowed (option, description) {
-      if (option && !samplingContextsAvailable) {
+    function checkOptionAllowed (option, description, condition) {
+      if (option && !condition) {
         throw new Error(`${description} not supported on ${process.platform}.`)
       }
     }
+    function checkOptionWithSamplingContextAllowed (option, description) {
+      checkOptionAllowed(option, description, samplingContextsAvailable)
+    }
+
     this.flushInterval = flushInterval
     this.uploadTimeout = uploadTimeout
     this.sourceMap = sourceMap
@@ -110,7 +114,7 @@ class Config {
       DD_PROFILING_ENDPOINT_COLLECTION_ENABLED,
       DD_PROFILING_EXPERIMENTAL_ENDPOINT_COLLECTION_ENABLED, samplingContextsAvailable))
     logExperimentalVarDeprecation('ENDPOINT_COLLECTION_ENABLED')
-    checkOptionAllowed(this.endpointCollectionEnabled, 'Endpoint collection')
+    checkOptionWithSamplingContextAllowed(this.endpointCollectionEnabled, 'Endpoint collection')
 
     this.pprofPrefix = pprofPrefix
     this.v8ProfilerBugWorkaroundEnabled = isTrue(coalesce(options.v8ProfilerBugWorkaround,
@@ -127,8 +131,13 @@ class Config {
       new AgentExporter(this)
     ], this)
 
+    // OOM monitoring does not work well on Windows, so it is disabled by default.
+    const oomMonitoringSupported = process.platform !== 'win32'
+
     const oomMonitoringEnabled = isTrue(coalesce(options.oomMonitoring,
-      DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED, true))
+      DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED, oomMonitoringSupported))
+    checkOptionWithSamplingContextAllowed(oomMonitoringEnabled, 'OOM monitoring', oomMonitoringSupported)
+
     const heapLimitExtensionSize = coalesce(options.oomHeapLimitExtensionSize,
       Number(DD_PROFILING_EXPERIMENTAL_OOM_HEAP_LIMIT_EXTENSION_SIZE), 0)
     const maxHeapExtensionCount = coalesce(options.oomMaxHeapExtensionCount,
@@ -158,17 +167,17 @@ class Config {
       DD_PROFILING_TIMELINE_ENABLED,
       DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED, false))
     logExperimentalVarDeprecation('TIMELINE_ENABLED')
-    checkOptionAllowed(this.timelineEnabled, 'Timeline view')
+    checkOptionWithSamplingContextAllowed(this.timelineEnabled, 'Timeline view')
 
     this.codeHotspotsEnabled = isTrue(coalesce(options.codeHotspotsEnabled,
       DD_PROFILING_CODEHOTSPOTS_ENABLED,
       DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED, samplingContextsAvailable))
     logExperimentalVarDeprecation('CODEHOTSPOTS_ENABLED')
-    checkOptionAllowed(this.codeHotspotsEnabled, 'Code hotspots')
+    checkOptionWithSamplingContextAllowed(this.codeHotspotsEnabled, 'Code hotspots')
 
     this.cpuProfilingEnabled = isTrue(coalesce(options.cpuProfilingEnabled,
       DD_PROFILING_EXPERIMENTAL_CPU_ENABLED, false))
-    checkOptionAllowed(this.cpuProfilingEnabled, 'CPU profiling')
+    checkOptionWithSamplingContextAllowed(this.cpuProfilingEnabled, 'CPU profiling')
 
     this.profilers = ensureProfilers(profilers, this)
   }


### PR DESCRIPTION
### What does this PR do?
OOM monitoring currently does not work on Windows (process aborts before being able to send a last profile). This commit disables it by default on Windows.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

