### PR TITLE
[ci-visibility] Add correlation ID to ITR requests 

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -19,11 +19,13 @@ const DEFAULT_GIT_UPLOAD_STATUS = 200
 const DEFAULT_INFO_RESPONSE = {
   endpoints: ['/evp_proxy/v2']
 }
+const DEFAULT_CORRELATION_ID = '1234'
 
 let settings = DEFAULT_SETTINGS
 let suitesToSkip = DEFAULT_SUITES_TO_SKIP
 let gitUploadStatus = DEFAULT_GIT_UPLOAD_STATUS
 let infoResponse = DEFAULT_INFO_RESPONSE
+let correlationId = DEFAULT_CORRELATION_ID
 
 class FakeCiVisIntake extends FakeAgent {
   setInfoResponse (newInfoResponse) {
@@ -36,6 +38,10 @@ class FakeCiVisIntake extends FakeAgent {
 
   setSuitesToSkip (newSuitesToSkip) {
     suitesToSkip = newSuitesToSkip
+  }
+
+  setItrCorrelationId (newCorrelationId) {
+    correlationId = newCorrelationId
   }
 
   setSettings (newSettings) {
@@ -140,7 +146,10 @@ class FakeCiVisIntake extends FakeAgent {
       '/evp_proxy/v2/api/v2/ci/tests/skippable'
     ], (req, res) => {
       res.status(200).send(JSON.stringify({
-        data: suitesToSkip
+        data: suitesToSkip,
+        meta: {
+          correlation_id: correlationId
+        }
       }))
       this.emit('message', {
         headers: req.headers,

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -1151,6 +1151,31 @@ testFrameworks.forEach(({
           }).catch(done)
         })
       })
+      it('reports itr_correlation_id in test suites', (done) => {
+        const itrCorrelationId = '4321'
+        receiver.setItrCorrelationId(itrCorrelationId)
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+            testSuites.forEach(testSuite => {
+              assert.equal(testSuite.itr_correlation_id, itrCorrelationId)
+            })
+          }, 25000)
+        childProcess = exec(
+          runTestsWithCoverageCommand,
+          {
+            cwd,
+            env: getCiVisAgentlessConfig(receiver.port),
+            stdio: 'inherit'
+          }
+        )
+        childProcess.on('exit', () => {
+          eventsPromise.then(() => {
+            done()
+          }).catch(done)
+        })
+      })
     })
 
     describe('evp proxy', () => {
@@ -1588,6 +1613,31 @@ testFrameworks.forEach(({
             assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
           }, 25000)
 
+        childProcess = exec(
+          runTestsWithCoverageCommand,
+          {
+            cwd,
+            env: getCiVisEvpProxyConfig(receiver.port),
+            stdio: 'inherit'
+          }
+        )
+        childProcess.on('exit', () => {
+          eventsPromise.then(() => {
+            done()
+          }).catch(done)
+        })
+      })
+      it('reports itr_correlation_id in test suites', (done) => {
+        const itrCorrelationId = '4321'
+        receiver.setItrCorrelationId(itrCorrelationId)
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+            testSuites.forEach(testSuite => {
+              assert.equal(testSuite.itr_correlation_id, itrCorrelationId)
+            })
+          }, 25000)
         childProcess = exec(
           runTestsWithCoverageCommand,
           {

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -766,6 +766,32 @@ versions.forEach(version => {
                 })
               })
             }
+            it('reports itr_correlation_id in test suites', (done) => {
+              const itrCorrelationId = '4321'
+              receiver.setItrCorrelationId(itrCorrelationId)
+              const eventsPromise = receiver
+                .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+                  const events = payloads.flatMap(({ payload }) => payload.events)
+                  const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+                  testSuites.forEach(testSuite => {
+                    assert.equal(testSuite.itr_correlation_id, itrCorrelationId)
+                  })
+                }, 25000)
+
+              childProcess = exec(
+                runTestsWithCoverageCommand,
+                {
+                  cwd,
+                  env: envVars,
+                  stdio: 'inherit'
+                }
+              )
+              childProcess.on('exit', () => {
+                eventsPromise.then(() => {
+                  done()
+                }).catch(done)
+              })
+            })
           })
         })
       })

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -44,6 +44,7 @@ const patched = new WeakSet()
 let pickleByFile = {}
 const pickleResultByFile = {}
 let skippableSuites = []
+let itrCorrelationId = ''
 let isForcedToRun = false
 let isUnskippable = false
 
@@ -102,7 +103,7 @@ function wrapRun (pl, isLatestVersion) {
         const testSuitePath = getTestSuitePath(testSuiteFullPath, process.cwd())
         isForcedToRun = isUnskippable && skippableSuites.includes(testSuitePath)
 
-        testSuiteStartCh.publish({ testSuitePath, isUnskippable, isForcedToRun })
+        testSuiteStartCh.publish({ testSuitePath, isUnskippable, isForcedToRun, itrCorrelationId })
       }
 
       const testSourceLine = this.gherkinDocument &&
@@ -304,6 +305,7 @@ addHook({
       this.pickleIds = picklesToRun
 
       skippedSuites = Array.from(filteredPickles.skippedSuites)
+      itrCorrelationId = skippableResponse.itrCorrelationId
     }
 
     pickleByFile = getPickleByFile(this)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -497,6 +497,7 @@ addHook({
       _ddTestCommand,
       _ddForcedToRun,
       _ddUnskippable,
+      _ddItrCorrelationId,
       ...restOfTestEnvironmentOptions
     } = testEnvironmentOptions
 

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -53,6 +53,7 @@ let isSuitesSkipped = false
 let skippedSuites = []
 const unskippableSuites = []
 let isForcedToRun = false
+let skippableSuitesCorrelationId = ''
 
 function getSuitesByTestFile (root) {
   const suitesByTestFile = {}
@@ -191,7 +192,12 @@ function mochaHook (Runner) {
         const isUnskippable = unskippableSuites.includes(suite.file)
         isForcedToRun = isUnskippable && suitesToSkip.includes(getTestSuitePath(suite.file, process.cwd()))
         asyncResource.runInAsyncScope(() => {
-          testSuiteStartCh.publish({ testSuite: suite.file, isUnskippable, isForcedToRun })
+          testSuiteStartCh.publish({
+            testSuite: suite.file,
+            isUnskippable,
+            isForcedToRun,
+            skippableSuitesCorrelationId
+          })
         })
       }
     })
@@ -395,11 +401,12 @@ addHook({
       }
     })
 
-    const onReceivedSkippableSuites = ({ err, skippableSuites }) => {
+    const onReceivedSkippableSuites = ({ err, skippableSuites, correlationId }) => {
       if (err) {
         suitesToSkip = []
       } else {
         suitesToSkip = skippableSuites
+        skippableSuitesCorrelationId = correlationId
       }
       // We remove the suites that we skip through ITR
       const filteredSuites = getFilteredSuites(runner.suite.suites)

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -53,7 +53,7 @@ let isSuitesSkipped = false
 let skippedSuites = []
 const unskippableSuites = []
 let isForcedToRun = false
-let skippableSuitesCorrelationId = ''
+let itrCorrelationId = ''
 
 function getSuitesByTestFile (root) {
   const suitesByTestFile = {}
@@ -196,7 +196,7 @@ function mochaHook (Runner) {
             testSuite: suite.file,
             isUnskippable,
             isForcedToRun,
-            skippableSuitesCorrelationId
+            itrCorrelationId
           })
         })
       }
@@ -401,12 +401,12 @@ addHook({
       }
     })
 
-    const onReceivedSkippableSuites = ({ err, skippableSuites, correlationId }) => {
+    const onReceivedSkippableSuites = ({ err, skippableSuites, itrCorrelationId: responseItrCorrelationId }) => {
       if (err) {
         suitesToSkip = []
       } else {
         suitesToSkip = skippableSuites
-        skippableSuitesCorrelationId = correlationId
+        itrCorrelationId = responseItrCorrelationId
       }
       // We remove the suites that we skip through ITR
       const filteredSuites = getFilteredSuites(runner.suite.suites)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -13,7 +13,8 @@ const {
   addIntelligentTestRunnerSpanTags,
   TEST_ITR_UNSKIPPABLE,
   TEST_ITR_FORCED_RUN,
-  TEST_CODE_OWNERS
+  TEST_CODE_OWNERS,
+  ITR_CORRELATION_ID
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -74,7 +75,7 @@ class CucumberPlugin extends CiPlugin {
       this.tracer._exporter.flush()
     })
 
-    this.addSub('ci:cucumber:test-suite:start', ({ testSuitePath, isUnskippable, isForcedToRun }) => {
+    this.addSub('ci:cucumber:test-suite:start', ({ testSuitePath, isUnskippable, isForcedToRun, itrCorrelationId }) => {
       const testSuiteMetadata = getTestSuiteCommonTags(
         this.command,
         this.frameworkVersion,
@@ -88,6 +89,9 @@ class CucumberPlugin extends CiPlugin {
       if (isForcedToRun) {
         this.telemetry.count(TELEMETRY_ITR_FORCED_TO_RUN, { testLevel: 'suite' })
         testSuiteMetadata[TEST_ITR_FORCED_RUN] = 'true'
+      }
+      if (itrCorrelationId) {
+        testSuiteMetadata[ITR_CORRELATION_ID] = itrCorrelationId
       }
       this.testSuiteSpan = this.tracer.startSpan('cucumber.test_suite', {
         childOf: this.testModuleSpan,

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -13,7 +13,8 @@ const {
   TEST_SOURCE_START,
   TEST_ITR_UNSKIPPABLE,
   TEST_ITR_FORCED_RUN,
-  TEST_CODE_OWNERS
+  TEST_CODE_OWNERS,
+  ITR_CORRELATION_ID
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -121,6 +122,7 @@ class JestPlugin extends CiPlugin {
         config._ddTestSessionId = this.testSessionSpan.context().toTraceId()
         config._ddTestModuleId = this.testModuleSpan.context().toSpanId()
         config._ddTestCommand = this.testSessionSpan.context()._tags[TEST_COMMAND]
+        config._ddItrCorrelationId = this.itrCorrelationId
       })
     })
 
@@ -129,6 +131,7 @@ class JestPlugin extends CiPlugin {
         _ddTestSessionId: testSessionId,
         _ddTestCommand: testCommand,
         _ddTestModuleId: testModuleId,
+        _ddItrCorrelationId: itrCorrelationId,
         _ddForcedToRun,
         _ddUnskippable,
         _ddTestCodeCoverageEnabled
@@ -154,6 +157,9 @@ class JestPlugin extends CiPlugin {
             testSuiteMetadata[TEST_ITR_FORCED_RUN] = 'true'
           }
         }
+      }
+      if (itrCorrelationId) {
+        testSuiteMetadata[ITR_CORRELATION_ID] = itrCorrelationId
       }
 
       this.testSuiteSpan = this.tracer.startSpan('jest.test_suite', {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -71,7 +71,7 @@ class MochaPlugin extends CiPlugin {
       testSuite,
       isUnskippable,
       isForcedToRun,
-      skippableSuitesCorrelationId
+      itrCorrelationId
     }) => {
       const store = storage.getStore()
       const testSuiteMetadata = getTestSuiteCommonTags(
@@ -101,8 +101,8 @@ class MochaPlugin extends CiPlugin {
       if (this.itrConfig?.isCodeCoverageEnabled) {
         this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_STARTED, 'suite', { library: 'istanbul' })
       }
-      if (skippableSuitesCorrelationId) {
-        testSuiteSpan.setTag(ITR_CORRELATION_ID, skippableSuitesCorrelationId)
+      if (itrCorrelationId) {
+        testSuiteSpan.setTag(ITR_CORRELATION_ID, itrCorrelationId)
       }
       this.enter(testSuiteSpan, store)
       this._testSuites.set(testSuite, testSuiteSpan)

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -83,7 +83,8 @@ function getSkippableSuites ({
     } else {
       let skippableSuites = []
       try {
-        skippableSuites = JSON.parse(res)
+        const parsedResponse = JSON.parse(res)
+        skippableSuites = parsedResponse
           .data
           .filter(({ type }) => type === testLevel)
           .map(({ attributes: { suite, name } }) => {
@@ -92,6 +93,7 @@ function getSkippableSuites ({
             }
             return { suite, name }
           })
+        const { meta: { correlation_id: correlationId } } = parsedResponse
         incrementCountMetric(
           testLevel === 'test'
             ? TELEMETRY_ITR_SKIPPABLE_TESTS_RESPONSE_TESTS : TELEMETRY_ITR_SKIPPABLE_TESTS_RESPONSE_SUITES,
@@ -100,7 +102,7 @@ function getSkippableSuites ({
         )
         distributionMetric(TELEMETRY_ITR_SKIPPABLE_TESTS_RESPONSE_BYTES, {}, res.length)
         log.debug(() => `Number of received skippable ${testLevel}s: ${skippableSuites.length}`)
-        done(null, skippableSuites)
+        done(null, skippableSuites, correlationId)
       } catch (err) {
         done(err)
       }

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -45,7 +45,12 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   }
 
   _encodeTestSuite (bytes, content) {
-    this._encodeMapPrefix(bytes, TEST_SUITE_KEYS_LENGTH)
+    let keysLength = TEST_SUITE_KEYS_LENGTH
+    if (content.meta.itr_correlation_id) {
+      keysLength++
+    }
+
+    this._encodeMapPrefix(bytes, keysLength)
     this._encodeString(bytes, 'type')
     this._encodeString(bytes, content.type)
 
@@ -57,6 +62,12 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
 
     this._encodeString(bytes, 'test_suite_id')
     this._encodeId(bytes, content.span_id)
+
+    if (content.meta.itr_correlation_id) {
+      this._encodeString(bytes, 'itr_correlation_id')
+      this._encodeString(bytes, content.meta.itr_correlation_id)
+      delete content.meta.itr_correlation_id
+    }
 
     this._encodeString(bytes, 'error')
     this._encodeNumber(bytes, content.error)
@@ -142,6 +153,9 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       totalKeysLength = totalKeysLength + 1
     }
     if (content.meta.test_suite_id) {
+      totalKeysLength = totalKeysLength + 1
+    }
+    if (content.meta.itr_correlation_id) {
       totalKeysLength = totalKeysLength + 1
     }
     this._encodeMapPrefix(bytes, totalKeysLength)

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -53,11 +53,11 @@ module.exports = class CiPlugin extends Plugin {
       if (!this.tracer._exporter || !this.tracer._exporter.getSkippableSuites) {
         return onDone({ err: new Error('CI Visibility was not initialized correctly') })
       }
-      this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites) => {
+      this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites, correlationId) => {
         if (err) {
           log.error(`Skippable suites could not be fetched. ${err.message}`)
         }
-        onDone({ err, skippableSuites })
+        onDone({ err, skippableSuites, correlationId })
       })
     })
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -60,6 +60,7 @@ const TEST_ITR_SKIPPING_COUNT = 'test.itr.tests_skipping.count'
 const TEST_CODE_COVERAGE_ENABLED = 'test.code_coverage.enabled'
 const TEST_ITR_UNSKIPPABLE = 'test.itr.unskippable'
 const TEST_ITR_FORCED_RUN = 'test.itr.forced_run'
+const ITR_CORRELATION_ID = 'itr_correlation_id'
 
 const TEST_CODE_COVERAGE_LINES_PCT = 'test.code_coverage.lines_pct'
 
@@ -111,6 +112,7 @@ module.exports = {
   TEST_CODE_COVERAGE_LINES_PCT,
   TEST_ITR_UNSKIPPABLE,
   TEST_ITR_FORCED_RUN,
+  ITR_CORRELATION_ID,
   addIntelligentTestRunnerSpanTags,
   getCoveredFilenamesFromCoverage,
   resetCoverage,

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -376,6 +376,9 @@ describe('CI Visibility Exporter', () => {
         const scope = nock(`http://localhost:${port}`)
           .post('/api/v2/ci/tests/skippable')
           .reply(200, JSON.stringify({
+            meta: {
+              correlation_id: '1234'
+            },
             data: [{
               type: 'suite',
               attributes: {


### PR DESCRIPTION
### What does this PR do?

* Extract `correlation_id` from the request to `skippable`.
* Attach this correlation id to events reported to datadog.

### Motivation
We want to be able to explain why a test was skipped. For this, we need a way to correlate requests to the skippable endpoint and events in our platform. We'll use a correlation ID for this.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

