### PR TITLE
Collect the X-Amzn-Trace-Id header

### DIFF
--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -29,9 +29,10 @@ const REQUEST_HEADERS_MAP = mapHeaderAndTags([
   'accept-encoding',
   'accept-language',
   'host',
-  'user-agent',
   'forwarded',
+  'user-agent',
   'via',
+  'x-amzn-trace-id',
 
   ...ipHeaderList,
   ...contentHeaderList

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -271,6 +271,17 @@ describe('reporter', () => {
         'network.client.ip': '8.8.8.8'
       })
     })
+
+    it('should include x-amzn-trace-id header', () => {
+      req.headers['x-amzn-trace-id'] = 'aws-id'
+
+      const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]')
+
+      expect(result).to.not.be.false
+      expect(span.addTags).to.have.been.calledOnce
+      expect(span.addTags.firstCall.args[0]).to.not.undefined
+      expect(span.addTags.firstCall.args[0]['http.request.headers.x-amzn-trace-id']).to.be.eq('aws-id')
+    })
   })
 
   describe('reportWafUpdate', () => {


### PR DESCRIPTION
### What does this PR do?
Appsec reporter collects the `X-Amzn-Trace-Id` header.

### Motivation


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

