### PR TITLE
add instrumentation shims for openai >= v4.x

### DIFF
--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -48,3 +48,95 @@ addHook({ name: 'openai', file: 'dist/api.js', versions: ['>=3.0.0 <4'] }, expor
 
   return exports
 })
+
+const V4_PACKAGE_SHIMS = [
+  {
+    file: 'resources/chat/completions.js',
+    targetClass: 'Completions',
+    methods: ['create']
+  },
+  {
+    file: 'resources/completions.js',
+    targetClass: 'Completions',
+    methods: ['create']
+  },
+  {
+    file: 'resources/embeddings.js',
+    targetClass: 'Embeddings',
+    methods: ['create']
+  },
+  {
+    file: 'resources/files.js',
+    targetClass: 'Files',
+    methods: ['create', 'del', 'list', 'retrieve', 'retrieveContent']
+  },
+  {
+    file: 'resources/images.js',
+    targetClass: 'Images',
+    methods: ['createVariation', 'edit', 'generate']
+  },
+  {
+    file: 'resources/fine-tuning/jobs.js',
+    targetClass: 'Jobs',
+    methods: ['cancel', 'create', 'list', 'listEvents', 'retrieve']
+  },
+  {
+    file: 'resources/models.js',
+    targetClass: 'Models',
+    methods: ['del', 'list', 'retrieve']
+  },
+  {
+    file: 'resources/moderation.js',
+    targetClass: 'Moderations',
+    methods: ['create']
+  },
+  {
+    file: 'resources/audio/transcriptions.js',
+    targetClass: 'Transcriptions',
+    methods: ['create']
+  },
+  {
+    file: 'resources/audio/translations.js',
+    targetClass: 'Translations',
+    methods: ['create']
+  }
+]
+
+for (const packageFile of V4_PACKAGE_SHIMS) {
+  addHook({ name: 'openai', file: packageFile.file, versions: ['>=4'] }, exports => {
+    const targetPrototype = exports[packageFile.targetClass].prototype
+
+    for (const methodName of packageFile.methods) {
+      shimmer.wrap(targetPrototype, methodName, fn => function () {
+        if (!startCh.hasSubscribers) {
+          return fn.apply(this, arguments)
+        }
+
+        startCh.publish({
+          methodName,
+          args: arguments,
+          basePath: this.client.baseURL,
+          apiKey: this.client.apiKey
+        })
+
+        return fn.apply(this, arguments)
+          .then((response) => {
+            finishCh.publish({
+              headers: response.headers,
+              body: response.data,
+              path: response.request.path,
+              method: response.request.method
+            })
+
+            return response
+          })
+          .catch((err) => {
+            errorCh.publish({err})
+
+            throw err
+          })
+      })
+    }
+    return exports
+  })
+}


### PR DESCRIPTION
### What does this PR do?

Adds instrumentation support for OpenAI's v4.x node client.

OpenAI API v3.x to v4.x Migration Guide including removed functions: https://github.com/openai/openai-node/discussions/217


### TODO

- [ ] Update plugin to handle changes to method names
- [ ] Request details aren't returned in the response, get path/method from somewhere else if possible

### Notes:


### Old to new function mapping

| v3.x Function         | New File                          | Class          | Method          | Reference                                                                                                                     |
|-----------------------|-----------------------------------|----------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------|
| createChatCompletion  | resources/chat/completions.ts     | Completions    | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/chat/completions.ts#L27     |
| createCompletion      | resources/completions.ts          | Completions    | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/completions.ts#L22          |
| createEmbedding       | resources/embeddings.ts           | Embeddings     | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/embeddings.ts#L11           |
| createFile            | resources/files.js                | Files          | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/files.ts#L27                |
| deleteFile            | resources/files.js                | Files          | del             | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/files.ts#L56                |
| downloadFile          | resources/files.js                | Files          | retrieveContent | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/files.ts#L72                |
| listFiles             | resources/files.js                | Files          | list            | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/files.ts#L43                |
| retrieveFile          | resources/files.js                | Files          | retrieve        | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/files.ts#L34                |
| createImage           | resources/images.js               | Images         | generate        | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/images.ts#L29               |
| createImageEdit       | resources/images.js               | Images         | edit            | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/images.ts#L22               |
| createImageVariation  | resources/images.js               | Images         | createVariation | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/images.ts#L12               |
| cancelFineTune        | resources/fine-tuning/jobs.js     | Jobs           | cancel          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/fine-tuning/jobs.ts#L53     |
| createFineTune        | resources/fine-tuning/jobs.js     | Jobs           | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/fine-tuning/jobs.ts#L19     |
| listFineTuneEvents    | resources/fine-tuning/jobs.js     | Jobs           | listEvents      | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/fine-tuning/jobs.ts#L69     |
| listFineTunes         | resources/fine-tuning/jobs.js     | Jobs           | list            | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/fine-tuning/jobs.ts#L40     |
| retrieveFineTune      | resources/fine-tuning/jobs.js     | Jobs           | retrieve        | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/fine-tuning/jobs.ts#L28     |
| deleteModel           | resources/models.js               | Models         | del             | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/models.ts#L29               |
| listModels            | resources/models.js               | Models         | list            | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/models.ts#L21               |
| retrieveModel         | resources/models.js               | Models         | retrieve        | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/models.ts#L13               |
| createModeration      | resources/moderation.js           | Moderations    | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/moderations.ts#L11          |
| createTranscription   | resources/audio/transcriptions.js | Transcriptions | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/audio/transcriptions.ts#L12 |
| createTranslation     | resources/audio/translations.ts   | Translations   | create          | https://github.com/openai/openai-node/blob/b6e7177e4e03803db2dfb7ccb0a173e6ccf555b1/src/resources/audio/translations.ts#L12   |
| createAnswer         | REMOVED                        |                |                 |                                                                                                                               |
| createClassification | REMOVED                        |                |                 |                                                                                                                               |
| createEdit            | REMOVED                       |                |                 |                                                                                                                               |
| createSearch         | REMOVED                        |                |                 |                                                                                                                               |
| listEngines          | REMOVED                        |                |                 |                                                                                                                               |
| retrieveEngine       | REMOVED                        |                |                 |                                                                                                                               |

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

