### PR TITLE
[ci-visibility] Add support for `evp_proxy/v4` (gzip compatible)

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -6,7 +6,7 @@ const CoverageWriter = require('../agentless/coverage-writer')
 const CiVisibilityExporter = require('../ci-visibility-exporter')
 
 const AGENT_EVP_PROXY_PATH_PREFIX = '/evp_proxy/v'
-const AGENT_EVP_PROXY_PATH_REGEX = /\/evp_proxy\/v(\d+)\//
+const AGENT_EVP_PROXY_PATH_REGEX = /\/evp_proxy\/v(\d+)\/?/
 
 function getLatestEvpProxyVersion (err, agentInfo) {
   if (err) {
@@ -45,6 +45,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       const evpProxyPrefix = `${AGENT_EVP_PROXY_PATH_PREFIX}${latestEvpProxyVersion}`
       if (isEvpCompatible) {
         this._isUsingEvpProxy = true
+        this.evpProxyPrefix = evpProxyPrefix
         this._writer = new AgentlessWriter({
           url: this._url,
           tags,

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -20,6 +20,7 @@ function getLatestEvpProxyVersion (err, agentInfo) {
       }
       return version > acc ? version : acc
     }
+    return acc
   }, 0)
 }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -6,6 +6,7 @@ const CoverageWriter = require('../agentless/coverage-writer')
 const CiVisibilityExporter = require('../ci-visibility-exporter')
 
 const AGENT_EVP_PROXY_PATH_PREFIX = '/evp_proxy/v'
+const AGENT_EVP_PROXY_PATH_REGEX = /\/evp_proxy\/v(\d+)\//
 
 function getLatestEvpProxyVersion (err, agentInfo) {
   if (err) {
@@ -13,7 +14,7 @@ function getLatestEvpProxyVersion (err, agentInfo) {
   }
   return agentInfo.endpoints.reduce((acc, endpoint) => {
     if (endpoint.includes(AGENT_EVP_PROXY_PATH_PREFIX)) {
-      const version = Number(endpoint.replace(AGENT_EVP_PROXY_PATH_PREFIX, ''))
+      const version = Number(endpoint.replace(AGENT_EVP_PROXY_PATH_REGEX, '$1'))
       if (isNaN(version)) {
         return acc
       }

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -5,10 +5,21 @@ const AgentlessWriter = require('../agentless/writer')
 const CoverageWriter = require('../agentless/coverage-writer')
 const CiVisibilityExporter = require('../ci-visibility-exporter')
 
-const AGENT_EVP_PROXY_PATH = '/evp_proxy/v2'
+const AGENT_EVP_PROXY_PATH_PREFIX = '/evp_proxy/v'
 
-function getIsEvpCompatible (err, agentInfo) {
-  return !err && agentInfo.endpoints.some(url => url.includes(AGENT_EVP_PROXY_PATH))
+function getLatestEvpProxyVersion (err, agentInfo) {
+  if (err) {
+    return 0
+  }
+  return agentInfo.endpoints.reduce((acc, endpoint) => {
+    if (endpoint.includes(AGENT_EVP_PROXY_PATH_PREFIX)) {
+      const version = Number(endpoint.replace(AGENT_EVP_PROXY_PATH_PREFIX, ''))
+      if (isNaN(version)) {
+        return acc
+      }
+      return version > acc ? version : acc
+    }
+  }, 0)
 }
 
 class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
@@ -25,17 +36,21 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
 
     this.getAgentInfo((err, agentInfo) => {
       this._isInitialized = true
-      const isEvpCompatible = getIsEvpCompatible(err, agentInfo)
+      const latestEvpProxyVersion = getLatestEvpProxyVersion(err, agentInfo)
+      const isEvpCompatible = latestEvpProxyVersion >= 2
+      const isGzipCompatible = latestEvpProxyVersion >= 4
+
+      const evpProxyPrefix = `${AGENT_EVP_PROXY_PATH_PREFIX}${latestEvpProxyVersion}`
       if (isEvpCompatible) {
         this._isUsingEvpProxy = true
         this._writer = new AgentlessWriter({
           url: this._url,
           tags,
-          evpProxyPrefix: AGENT_EVP_PROXY_PATH
+          evpProxyPrefix
         })
         this._coverageWriter = new CoverageWriter({
           url: this._url,
-          evpProxyPrefix: AGENT_EVP_PROXY_PATH
+          evpProxyPrefix
         })
       } else {
         this._writer = new AgentWriter({
@@ -51,6 +66,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       this._resolveCanUseCiVisProtocol(isEvpCompatible)
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
+      this._isGzipCompatible = isGzipCompatible
     })
   }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -21,6 +21,8 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     this._coverageWriter = new CoverageWriter({ url: this._coverageUrl })
 
     this._apiUrl = url || new URL(`https://api.${site}`)
+    // Agentless is always gzip compatible
+    this._isGzipCompatible = true
   }
 
   setUrl (url, coverageUrl = url, apiUrl = url) {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -108,6 +108,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,
+        evpProxyPrefix: this.evpProxyPrefix,
         custom: getTestConfigurationTags(this._config.tags),
         ...testConfiguration
       }
@@ -134,6 +135,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,
+        evpProxyPrefix: this.evpProxyPrefix,
         custom: getTestConfigurationTags(this._config.tags),
         ...testConfiguration
       }
@@ -172,14 +174,19 @@ class CiVisibilityExporter extends AgentInfoExporter {
       if (!canUseCiVisProtocol) {
         return
       }
-      sendGitMetadataRequest(this._getApiUrl(), !!this._isUsingEvpProxy, repositoryUrl, (err) => {
-        if (err) {
-          log.error(`Error uploading git metadata: ${err.message}`)
-        } else {
-          log.debug('Successfully uploaded git metadata')
+      sendGitMetadataRequest(
+        this._getApiUrl(),
+        { isEvpProxy: !!this._isUsingEvpProxy, evpProxyPrefix: this.evpProxyPrefix },
+        repositoryUrl,
+        (err) => {
+          if (err) {
+            log.error(`Error uploading git metadata: ${err.message}`)
+          } else {
+            log.debug('Successfully uploaded git metadata')
+          }
+          this._resolveGit(err)
         }
-        this._resolveGit(err)
-      })
+      )
     })
   }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -187,6 +187,7 @@ function uploadPackFile ({ url, isEvpProxy, evpProxyPrefix, packFileToUpload, re
 function generateAndUploadPackFiles ({
   url,
   isEvpProxy,
+  evpProxyPrefix,
   commitsToUpload,
   repositoryUrl,
   headCommit
@@ -216,6 +217,7 @@ function generateAndUploadPackFiles ({
         packFileToUpload: packFilesToUpload[packFileIndex++],
         url,
         isEvpProxy,
+        evpProxyPrefix,
         repositoryUrl,
         headCommit
       },
@@ -228,6 +230,7 @@ function generateAndUploadPackFiles ({
       packFileToUpload: packFilesToUpload[packFileIndex++],
       url,
       isEvpProxy,
+      evpProxyPrefix,
       repositoryUrl,
       headCommit
     },

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-itr-configuration.js
@@ -14,6 +14,7 @@ const {
 function getItrConfiguration ({
   url,
   isEvpProxy,
+  evpProxyPrefix,
   env,
   service,
   repositoryUrl,
@@ -38,7 +39,7 @@ function getItrConfiguration ({
   }
 
   if (isEvpProxy) {
-    options.path = '/evp_proxy/v2/api/v2/libraries/tests/services/setting'
+    options.path = `${evpProxyPrefix}/api/v2/libraries/tests/services/setting`
     options.headers['X-Datadog-EVP-Subdomain'] = 'api'
   } else {
     const apiKey = process.env.DATADOG_API_KEY || process.env.DD_API_KEY

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -15,6 +15,7 @@ const {
 function getSkippableSuites ({
   url,
   isEvpProxy,
+  evpProxyPrefix,
   env,
   service,
   repositoryUrl,
@@ -38,7 +39,7 @@ function getSkippableSuites ({
   }
 
   if (isEvpProxy) {
-    options.path = '/evp_proxy/v2/api/v2/ci/tests/skippable'
+    options.path = `${evpProxyPrefix}/api/v2/ci/tests/skippable`
     options.headers['X-Datadog-EVP-Subdomain'] = 'api'
   } else {
     const apiKey = process.env.DATADOG_API_KEY || process.env.DD_API_KEY

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -71,7 +71,7 @@ describe('git_metadata', () => {
       .reply(200, JSON.stringify({ data: latestCommits.map((sha) => ({ id: sha, type: 'commit' })) }))
 
     isShallowRepositoryStub.returns(true)
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(unshallowRepositoryStub).not.to.have.been.called
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
@@ -89,7 +89,7 @@ describe('git_metadata', () => {
       .reply(204)
 
     isShallowRepositoryStub.returns(true)
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(unshallowRepositoryStub).to.have.been.called
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
@@ -104,7 +104,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
       done()
@@ -120,7 +120,7 @@ describe('git_metadata', () => {
 
     getCommitsRevListStub.returns([])
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err).to.be.null
       // to check that it is not called
       expect(scope.isDone()).to.be.false
@@ -136,7 +136,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       // eslint-disable-next-line
       expect(err.message).to.contain('Error fetching commits to exclude: Error from https://api.test.com/api/v2/git/repository/search_commits: 404 Not Found. Response from the endpoint: "Not found SHA"')
       // to check that it is not called
@@ -153,7 +153,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err.message).to.contain("Can't parse commits to exclude response: Invalid commit type response")
       // to check that it is not called
       expect(scope.isDone()).to.be.false
@@ -169,7 +169,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err.message).to.contain("Can't parse commits to exclude response: Invalid commit format")
       // to check that it is not called
       expect(scope.isDone()).to.be.false
@@ -185,7 +185,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(502)
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err.message).to.contain('Could not upload packfiles: status code 502')
       expect(scope.isDone()).to.be.true
       done()
@@ -212,7 +212,7 @@ describe('git_metadata', () => {
       secondTemporaryPackFile
     ])
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
       done()
@@ -282,7 +282,7 @@ describe('git_metadata', () => {
       'not there either'
     ])
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err.message).to.contain('Could not read "not-there"')
       expect(scope.isDone()).to.be.false
       done()
@@ -298,7 +298,7 @@ describe('git_metadata', () => {
 
     generatePackFilesForCommitsStub.returns([])
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err.message).to.contain('Failed to generate packfiles')
       expect(scope.isDone()).to.be.false
       done()
@@ -314,7 +314,7 @@ describe('git_metadata', () => {
 
     getRepositoryUrlStub.returns('')
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err.message).to.contain('Repository URL is empty')
       expect(scope.isDone()).to.be.false
       done()
@@ -332,7 +332,7 @@ describe('git_metadata', () => {
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), false, '', (err) => {
+    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
       expect(err).to.be.null
       expect(scope.isDone()).to.be.true
       done()
@@ -349,10 +349,14 @@ describe('git_metadata', () => {
         done()
       })
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), true, '', (err) => {
-      expect(err).to.be.null
-      expect(scope.isDone()).to.be.true
-    })
+    gitMetadata.sendGitMetadata(
+      new URL('https://api.test.com'),
+      { isEvpProxy: true, evpProxyPrefix: '/evp_proxy/v2' },
+      '',
+      (err) => {
+        expect(err).to.be.null
+        expect(scope.isDone()).to.be.true
+      })
   })
 
   it('should use the input repository url and not call getRepositoryUrl', (done) => {
@@ -370,14 +374,18 @@ describe('git_metadata', () => {
       .post('/evp_proxy/v2/api/v2/git/repository/packfile')
       .reply(204)
 
-    gitMetadata.sendGitMetadata(new URL('https://api.test.com'), true, 'https://custom-git@datadog.com', (err) => {
-      expect(err).to.be.null
-      expect(scope.isDone()).to.be.true
-      requestPromise.then((repositoryUrl) => {
-        expect(getRepositoryUrlStub).not.to.have.been.called
-        expect(repositoryUrl).to.equal('https://custom-git@datadog.com')
-        done()
+    gitMetadata.sendGitMetadata(
+      new URL('https://api.test.com'),
+      { isEvpProxy: true, evpProxyPrefix: '/evp_proxy/v2' },
+      'https://custom-git@datadog.com',
+      (err) => {
+        expect(err).to.be.null
+        expect(scope.isDone()).to.be.true
+        requestPromise.then((repositoryUrl) => {
+          expect(getRepositoryUrlStub).not.to.have.been.called
+          expect(repositoryUrl).to.equal('https://custom-git@datadog.com')
+          done()
+        })
       })
-    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Check if the agent returns `v4` among its `evp_proxy` endpoints.

### Motivation
Allow using gzip with EVP proxy.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.


