### PR TITLE
[ci-visibility] Refactor ITR config to library config 

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -685,18 +685,18 @@ testFrameworks.forEach(({
       })
       it('can report code coverage', (done) => {
         let testOutput
-        const itrConfigRequestPromise = receiver.payloadReceived(
+        const libraryConfigRequestPromise = receiver.payloadReceived(
           ({ url }) => url === '/api/v2/libraries/tests/services/setting'
         )
         const codeCovRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcov')
         const eventsRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcycle')
 
         Promise.all([
-          itrConfigRequestPromise,
+          libraryConfigRequestPromise,
           codeCovRequestPromise,
           eventsRequestPromise
-        ]).then(([itrConfigRequest, codeCovRequest, eventsRequest]) => {
-          assert.propertyVal(itrConfigRequest.headers, 'dd-api-key', '1')
+        ]).then(([libraryConfigRequest, codeCovRequest, eventsRequest]) => {
+          assert.propertyVal(libraryConfigRequest.headers, 'dd-api-key', '1')
 
           const [coveragePayload] = codeCovRequest.payload
           assert.propertyVal(codeCovRequest.headers, 'dd-api-key', '1')
@@ -1294,19 +1294,19 @@ testFrameworks.forEach(({
       })
       it('can report code coverage', (done) => {
         let testOutput
-        const itrConfigRequestPromise = receiver.payloadReceived(
+        const libraryConfigRequestPromise = receiver.payloadReceived(
           ({ url }) => url === '/evp_proxy/v2/api/v2/libraries/tests/services/setting'
         )
         const codeCovRequestPromise = receiver.payloadReceived(({ url }) => url === '/evp_proxy/v2/api/v2/citestcov')
         const eventsRequestPromise = receiver.payloadReceived(({ url }) => url === '/evp_proxy/v2/api/v2/citestcycle')
 
         Promise.all([
-          itrConfigRequestPromise,
+          libraryConfigRequestPromise,
           codeCovRequestPromise,
           eventsRequestPromise
-        ]).then(([itrConfigRequest, codeCovRequest, eventsRequest]) => {
-          assert.notProperty(itrConfigRequest.headers, 'dd-api-key')
-          assert.propertyVal(itrConfigRequest.headers, 'x-datadog-evp-subdomain', 'api')
+        ]).then(([libraryConfigRequest, codeCovRequest, eventsRequest]) => {
+          assert.notProperty(libraryConfigRequest.headers, 'dd-api-key')
+          assert.propertyVal(libraryConfigRequest.headers, 'x-datadog-evp-subdomain', 'api')
 
           const [coveragePayload] = codeCovRequest.payload
           assert.notProperty(codeCovRequest.headers, 'dd-api-key')

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -285,23 +285,23 @@ versions.forEach(version => {
             })
             it('can report code coverage', (done) => {
               let testOutput
-              const itrConfigRequestPromise = receiver.payloadReceived(
+              const libraryConfigRequestPromise = receiver.payloadReceived(
                 ({ url }) => url.endsWith('/api/v2/libraries/tests/services/setting')
               )
               const codeCovRequestPromise = receiver.payloadReceived(({ url }) => url.endsWith('/api/v2/citestcov'))
               const eventsRequestPromise = receiver.payloadReceived(({ url }) => url.endsWith('/api/v2/citestcycle'))
 
               Promise.all([
-                itrConfigRequestPromise,
+                libraryConfigRequestPromise,
                 codeCovRequestPromise,
                 eventsRequestPromise
-              ]).then(([itrConfigRequest, codeCovRequest, eventsRequest]) => {
+              ]).then(([libraryConfigRequest, codeCovRequest, eventsRequest]) => {
                 const [coveragePayload] = codeCovRequest.payload
                 if (isAgentless) {
-                  assert.propertyVal(itrConfigRequest.headers, 'dd-api-key', '1')
+                  assert.propertyVal(libraryConfigRequest.headers, 'dd-api-key', '1')
                   assert.propertyVal(codeCovRequest.headers, 'dd-api-key', '1')
                 } else {
-                  assert.notProperty(itrConfigRequest.headers, 'dd-api-key')
+                  assert.notProperty(libraryConfigRequest.headers, 'dd-api-key')
                   assert.notProperty(codeCovRequest.headers, 'dd-api-key', '1')
                 }
 

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -16,7 +16,7 @@ const testSuiteStartCh = channel('ci:cucumber:test-suite:start')
 const testSuiteFinishCh = channel('ci:cucumber:test-suite:finish')
 const testSuiteCodeCoverageCh = channel('ci:cucumber:test-suite:code-coverage')
 
-const itrConfigurationCh = channel('ci:cucumber:itr-configuration')
+const libraryConfigurationCh = channel('ci:cucumber:library-configuration')
 const skippableSuitesCh = channel('ci:cucumber:test-suite:skippable')
 const sessionStartCh = channel('ci:cucumber:session:start')
 const sessionFinishCh = channel('ci:cucumber:session:finish')
@@ -272,7 +272,7 @@ addHook({
     })
 
     asyncResource.runInAsyncScope(() => {
-      itrConfigurationCh.publish({ onDone })
+      libraryConfigurationCh.publish({ onDone })
     })
 
     await configPromise

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -37,7 +37,7 @@ const testRunFinishCh = channel('ci:jest:test:finish')
 const testErrCh = channel('ci:jest:test:err')
 
 const skippableSuitesCh = channel('ci:jest:test-suite:skippable')
-const jestLibraryConfigurationCh = channel('ci:jest:library-configuration')
+const libraryConfigurationCh = channel('ci:jest:library-configuration')
 
 const itrSkippedSuitesCh = channel('ci:jest:itr:skipped-suites')
 
@@ -234,12 +234,12 @@ function cliWrapper (cli, jestVersion) {
     const configurationPromise = new Promise((resolve) => {
       onDone = resolve
     })
-    if (!jestLibraryConfigurationCh.hasSubscribers) {
+    if (!libraryConfigurationCh.hasSubscribers) {
       return runCLI.apply(this, arguments)
     }
 
     sessionAsyncResource.runInAsyncScope(() => {
-      jestLibraryConfigurationCh.publish({ onDone })
+      libraryConfigurationCh.publish({ onDone })
     })
 
     try {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -37,7 +37,7 @@ const testRunFinishCh = channel('ci:jest:test:finish')
 const testErrCh = channel('ci:jest:test:err')
 
 const skippableSuitesCh = channel('ci:jest:test-suite:skippable')
-const jestItrConfigurationCh = channel('ci:jest:itr-configuration')
+const jestLibraryConfigurationCh = channel('ci:jest:library-configuration')
 
 const itrSkippedSuitesCh = channel('ci:jest:itr:skipped-suites')
 
@@ -234,19 +234,19 @@ function cliWrapper (cli, jestVersion) {
     const configurationPromise = new Promise((resolve) => {
       onDone = resolve
     })
-    if (!jestItrConfigurationCh.hasSubscribers) {
+    if (!jestLibraryConfigurationCh.hasSubscribers) {
       return runCLI.apply(this, arguments)
     }
 
     sessionAsyncResource.runInAsyncScope(() => {
-      jestItrConfigurationCh.publish({ onDone })
+      jestLibraryConfigurationCh.publish({ onDone })
     })
 
     try {
-      const { err, itrConfig } = await configurationPromise
+      const { err, libraryConfig } = await configurationPromise
       if (!err) {
-        isCodeCoverageEnabled = itrConfig.isCodeCoverageEnabled
-        isSuitesSkippingEnabled = itrConfig.isSuitesSkippingEnabled
+        isCodeCoverageEnabled = libraryConfig.isCodeCoverageEnabled
+        isSuitesSkippingEnabled = libraryConfig.isSuitesSkippingEnabled
       }
     } catch (err) {
       log.error(err)

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -20,7 +20,7 @@ const skipCh = channel('ci:mocha:test:skip')
 const testFinishCh = channel('ci:mocha:test:finish')
 const parameterizedTestCh = channel('ci:mocha:test:parameterize')
 
-const itrConfigurationCh = channel('ci:mocha:itr-configuration')
+const libraryConfigurationCh = channel('ci:mocha:library-configuration')
 const skippableSuitesCh = channel('ci:mocha:test-suite:skippable')
 
 const testSessionStartCh = channel('ci:mocha:session:start')
@@ -384,7 +384,7 @@ addHook({
       return run.apply(this, arguments)
     }
 
-    if (!itrConfigurationCh.hasSubscribers || this.isWorker) {
+    if (!libraryConfigurationCh.hasSubscribers || this.isWorker) {
       if (this.isWorker) {
         isWorker = true
       }
@@ -439,7 +439,7 @@ addHook({
     }
 
     mochaRunAsyncResource.runInAsyncScope(() => {
-      itrConfigurationCh.publish({
+      libraryConfigurationCh.publish({
         onDone: mochaRunAsyncResource.bind(onReceivedConfiguration)
       })
     })

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -71,7 +71,6 @@ class CucumberPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'session')
       finishAllTraceSpans(this.testSessionSpan)
 
-      // TODO: inspect why this
       this.libraryConfig = null
       this.tracer._exporter.flush()
     })

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -47,7 +47,7 @@ class CucumberPlugin extends CiPlugin {
       hasUnskippableSuites,
       hasForcedToRunSuites
     }) => {
-      const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig || {}
+      const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.libraryConfig || {}
       addIntelligentTestRunnerSpanTags(
         this.testSessionSpan,
         this.testModuleSpan,
@@ -71,7 +71,8 @@ class CucumberPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'session')
       finishAllTraceSpans(this.testSessionSpan)
 
-      this.itrConfig = null
+      // TODO: inspect why this
+      this.libraryConfig = null
       this.tracer._exporter.flush()
     })
 
@@ -102,7 +103,7 @@ class CucumberPlugin extends CiPlugin {
         }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
-      if (this.itrConfig?.isCodeCoverageEnabled) {
+      if (this.libraryConfig?.isCodeCoverageEnabled) {
         this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_STARTED, 'suite', { library: 'istanbul' })
       }
     })
@@ -114,7 +115,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test-suite:code-coverage', ({ coverageFiles, suiteFile }) => {
-      if (!this.itrConfig?.isCodeCoverageEnabled) {
+      if (!this.libraryConfig?.isCodeCoverageEnabled) {
         return
       }
       if (!coverageFiles.length) {

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -119,14 +119,14 @@ function getSuiteStatus (suiteStats) {
   return 'pass'
 }
 
-function getItrConfig (tracer, testConfiguration) {
+function getLibraryConfiguration (tracer, testConfiguration) {
   return new Promise(resolve => {
-    if (!tracer._tracer._exporter || !tracer._tracer._exporter.getItrConfiguration) {
+    if (!tracer._tracer._exporter?.getLibraryConfiguration) {
       return resolve({ err: new Error('CI Visibility was not initialized correctly') })
     }
 
-    tracer._tracer._exporter.getItrConfiguration(testConfiguration, (err, itrConfig) => {
-      resolve({ err, itrConfig })
+    tracer._tracer._exporter.getLibraryConfiguration(testConfiguration, (err, libraryConfig) => {
+      resolve({ err, libraryConfig })
     })
   })
 }
@@ -136,7 +136,7 @@ function getSkippableTests (isSuitesSkippingEnabled, tracer, testConfiguration) 
     return Promise.resolve({ skippableTests: [] })
   }
   return new Promise(resolve => {
-    if (!tracer._tracer._exporter || !tracer._tracer._exporter.getItrConfiguration) {
+    if (!tracer._tracer._exporter?.getLibraryConfiguration) {
       return resolve({ err: new Error('CI Visibility was not initialized correctly') })
     }
     tracer._tracer._exporter.getSkippableSuites(testConfiguration, (err, skippableTests, correlationId) => {
@@ -284,12 +284,12 @@ module.exports = (on, config) => {
   }
 
   on('before:run', (details) => {
-    return getItrConfig(tracer, testConfiguration).then(({ err, itrConfig }) => {
+    return getLibraryConfiguration(tracer, testConfiguration).then(({ err, libraryConfig }) => {
       if (err) {
         log.error(err)
       } else {
-        isSuitesSkippingEnabled = itrConfig.isSuitesSkippingEnabled
-        isCodeCoverageEnabled = itrConfig.isCodeCoverageEnabled
+        isSuitesSkippingEnabled = libraryConfig.isSuitesSkippingEnabled
+        isCodeCoverageEnabled = libraryConfig.isCodeCoverageEnabled
       }
 
       return getSkippableTests(isSuitesSkippingEnabled, tracer, testConfiguration)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -223,7 +223,7 @@ class JestPlugin extends CiPlugin {
     })
 
     /**
-     * This can't use `this.itrConfig` like `ci:mocha:test-suite:code-coverage`
+     * This can't use `this.libraryConfig` like `ci:mocha:test-suite:code-coverage`
      * because this subscription happens in a different process from the one
      * fetching the ITR config.
      */

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -222,7 +222,6 @@ class MochaPlugin extends CiPlugin {
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'session')
         finishAllTraceSpans(this.testSessionSpan)
       }
-      // TODO: inspect why this
       this.libraryConfig = null
       this.tracer._exporter.flush()
     })

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -42,7 +42,7 @@ class MochaPlugin extends CiPlugin {
     this.sourceRoot = process.cwd()
 
     this.addSub('ci:mocha:test-suite:code-coverage', ({ coverageFiles, suiteFile }) => {
-      if (!this.itrConfig || !this.itrConfig.isCodeCoverageEnabled) {
+      if (!this.libraryConfig?.isCodeCoverageEnabled) {
         return
       }
       const testSuiteSpan = this._testSuites.get(suiteFile)
@@ -98,7 +98,7 @@ class MochaPlugin extends CiPlugin {
         }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
-      if (this.itrConfig?.isCodeCoverageEnabled) {
+      if (this.libraryConfig?.isCodeCoverageEnabled) {
         this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_STARTED, 'suite', { library: 'istanbul' })
       }
       if (itrCorrelationId) {
@@ -192,7 +192,7 @@ class MochaPlugin extends CiPlugin {
       error
     }) => {
       if (this.testSessionSpan) {
-        const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.itrConfig || {}
+        const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.libraryConfig || {}
         this.testSessionSpan.setTag(TEST_STATUS, status)
         this.testModuleSpan.setTag(TEST_STATUS, status)
 
@@ -222,7 +222,8 @@ class MochaPlugin extends CiPlugin {
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'session')
         finishAllTraceSpans(this.testSessionSpan)
       }
-      this.itrConfig = null
+      // TODO: inspect why this
+      this.libraryConfig = null
       this.tracer._exporter.flush()
     })
   }

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -79,6 +79,10 @@ class CiVisibilityExporter extends AgentInfoExporter {
       this._libraryConfig?.isSuitesSkippingEnabled)
   }
 
+  shouldRequestLibraryConfiguration () {
+    return this._config.isIntelligentTestRunnerEnabled
+  }
+
   canReportSessionTraces () {
     return this._canUseCiVisProtocol
   }
@@ -118,6 +122,9 @@ class CiVisibilityExporter extends AgentInfoExporter {
   getLibraryConfiguration (testConfiguration, callback) {
     const { repositoryUrl } = testConfiguration
     this.sendGitMetadata(repositoryUrl)
+    if (!this.shouldRequestLibraryConfiguration()) {
+      return callback(null, {})
+    }
     this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {
       if (!canUseCiVisProtocol) {
         return callback(null, {})

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -3,7 +3,7 @@
 const URL = require('url').URL
 
 const { sendGitMetadata: sendGitMetadataRequest } = require('./git/git_metadata')
-const { getItrConfiguration: getItrConfigurationRequest } = require('../intelligent-test-runner/get-itr-configuration')
+const { getLibraryConfiguration: getLibraryConfigurationRequest } = require('../requests/get-library-configuration')
 const { getSkippableSuites: getSkippableSuitesRequest } = require('../intelligent-test-runner/get-skippable-suites')
 const log = require('../../log')
 const AgentInfoExporter = require('../../exporters/common/agent-info-exporter')
@@ -76,12 +76,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
   shouldRequestSkippableSuites () {
     return !!(this._config.isIntelligentTestRunnerEnabled &&
       this._canUseCiVisProtocol &&
-      this._itrConfig &&
-      this._itrConfig.isSuitesSkippingEnabled)
-  }
-
-  shouldRequestItrConfiguration () {
-    return this._config.isIntelligentTestRunnerEnabled
+      this._libraryConfig?.isSuitesSkippingEnabled)
   }
 
   canReportSessionTraces () {
@@ -117,15 +112,12 @@ class CiVisibilityExporter extends AgentInfoExporter {
   }
 
   /**
-   * We can't request ITR configuration until we know whether we can use the
+   * We can't request library configuration until we know whether we can use the
    * CI Visibility Protocol, hence the this._canUseCiVisProtocol promise.
    */
-  getItrConfiguration (testConfiguration, callback) {
+  getLibraryConfiguration (testConfiguration, callback) {
     const { repositoryUrl } = testConfiguration
     this.sendGitMetadata(repositoryUrl)
-    if (!this.shouldRequestItrConfiguration()) {
-      return callback(null, {})
-    }
     this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {
       if (!canUseCiVisProtocol) {
         return callback(null, {})
@@ -139,28 +131,29 @@ class CiVisibilityExporter extends AgentInfoExporter {
         custom: getTestConfigurationTags(this._config.tags),
         ...testConfiguration
       }
-      getItrConfigurationRequest(configuration, (err, itrConfig) => {
+      getLibraryConfigurationRequest(configuration, (err, libraryConfig) => {
         /**
-         * **Important**: this._itrConfig remains empty in testing frameworks
-         * where the tests run in a subprocess, because `getItrConfiguration` is called only once.
+         * **Important**: this._libraryConfig remains empty in testing frameworks
+         * where the tests run in a subprocess, like Jest,
+         * because `getLibraryConfiguration` is called only once in the main process.
          */
-        this._itrConfig = itrConfig
+        this._libraryConfig = libraryConfig
 
         if (err) {
           callback(err, {})
-        } else if (itrConfig?.requireGit) {
+        } else if (libraryConfig?.requireGit) {
           // If the backend requires git, we'll wait for the upload to finish and request settings again
           this._gitUploadPromise.then(gitUploadError => {
             if (gitUploadError) {
               return callback(gitUploadError, {})
             }
-            getItrConfigurationRequest(configuration, (err, finalItrConfig) => {
-              this._itrConfig = finalItrConfig
-              callback(err, finalItrConfig)
+            getLibraryConfigurationRequest(configuration, (err, finalLibraryConfig) => {
+              this._libraryConfig = finalLibraryConfig
+              callback(err, finalLibraryConfig)
             })
           })
         } else {
-          callback(null, itrConfig)
+          callback(null, libraryConfig)
         }
       })
     })

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -9,9 +9,9 @@ const {
   TELEMETRY_GIT_REQUESTS_SETTINGS_ERRORS,
   TELEMETRY_GIT_REQUESTS_SETTINGS_RESPONSE,
   getErrorTypeFromStatusCode
-} = require('../../ci-visibility/telemetry')
+} = require('../telemetry')
 
-function getItrConfiguration ({
+function getLibraryConfiguration ({
   url,
   isEvpProxy,
   evpProxyPrefix,
@@ -117,4 +117,4 @@ function getItrConfiguration ({
   })
 }
 
-module.exports = { getItrConfiguration }
+module.exports = { getLibraryConfiguration }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -36,17 +36,17 @@ module.exports = class CiPlugin extends Plugin {
 
     this.rootDir = process.cwd() // fallback in case :session:start events are not emitted
 
-    this.addSub(`ci:${this.constructor.id}:itr-configuration`, ({ onDone }) => {
-      if (!this.tracer._exporter || !this.tracer._exporter.getItrConfiguration) {
+    this.addSub(`ci:${this.constructor.id}:library-configuration`, ({ onDone }) => {
+      if (!this.tracer._exporter || !this.tracer._exporter.getLibraryConfiguration) {
         return onDone({ err: new Error('CI Visibility was not initialized correctly') })
       }
-      this.tracer._exporter.getItrConfiguration(this.testConfiguration, (err, itrConfig) => {
+      this.tracer._exporter.getLibraryConfiguration(this.testConfiguration, (err, libraryConfig) => {
         if (err) {
           log.error(`Intelligent Test Runner configuration could not be fetched. ${err.message}`)
         } else {
-          this.itrConfig = itrConfig
+          this.libraryConfig = libraryConfig
         }
-        onDone({ err, itrConfig })
+        onDone({ err, libraryConfig })
       })
     })
 

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -106,7 +106,7 @@ describe('AgentProxyCiVisibilityExporter', () => {
         spanId: '1',
         files: []
       }
-      agentProxyCiVisibilityExporter._itrConfig = { isCodeCoverageEnabled: true }
+      agentProxyCiVisibilityExporter._libraryConfig = { isCodeCoverageEnabled: true }
       agentProxyCiVisibilityExporter.exportCoverage(coverage)
       expect(mockWriter.append).to.have.been.calledWith({ spanId: '1', traceId: '1', files: [] })
     })
@@ -213,7 +213,7 @@ describe('AgentProxyCiVisibilityExporter', () => {
         spanId: '1',
         files: []
       }
-      agentProxyCiVisibilityExporter._itrConfig = { isCodeCoverageEnabled: true }
+      agentProxyCiVisibilityExporter._libraryConfig = { isCodeCoverageEnabled: true }
       agentProxyCiVisibilityExporter.exportCoverage(coverage)
       expect(mockWriter.append).to.have.been.calledWith({ traceId: '1', spanId: '1', files: [] })
       await new Promise(resolve => setTimeout(resolve, flushInterval))

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -53,8 +53,7 @@ describe('CI Visibility Agentless Exporter', () => {
         isIntelligentTestRunnerEnabled: true,
         tags: {}
       })
-      expect(agentlessExporter.shouldRequestItrConfiguration()).to.be.true
-      agentlessExporter.getItrConfiguration({}, () => {
+      agentlessExporter.getLibraryConfiguration({}, () => {
         expect(scope.isDone()).to.be.true
         expect(agentlessExporter.canReportCodeCoverage()).to.be.true
         expect(agentlessExporter.shouldRequestSkippableSuites()).to.be.true
@@ -85,7 +84,7 @@ describe('CI Visibility Agentless Exporter', () => {
         tags: {}
       })
       agentlessExporter._resolveGit()
-      agentlessExporter.getItrConfiguration({}, () => {
+      agentlessExporter.getLibraryConfiguration({}, () => {
         agentlessExporter.getSkippableSuites({}, () => {
           expect(scope.isDone()).to.be.true
           done()
@@ -107,8 +106,7 @@ describe('CI Visibility Agentless Exporter', () => {
       const agentlessExporter = new AgentlessCiVisibilityExporter({
         url, isGitUploadEnabled: true, isIntelligentTestRunnerEnabled: true, tags: {}
       })
-      expect(agentlessExporter.shouldRequestItrConfiguration()).to.be.true
-      agentlessExporter.getItrConfiguration({}, () => {
+      agentlessExporter.getLibraryConfiguration({}, () => {
         expect(scope.isDone()).to.be.true
         expect(agentlessExporter.canReportCodeCoverage()).to.be.true
         expect(agentlessExporter.shouldRequestSkippableSuites()).to.be.true
@@ -130,7 +128,7 @@ describe('CI Visibility Agentless Exporter', () => {
       const agentlessExporter = new AgentlessCiVisibilityExporter({
         url, isGitUploadEnabled: true, isIntelligentTestRunnerEnabled: true, tags: {}
       })
-      agentlessExporter.getItrConfiguration({}, () => {
+      agentlessExporter.getLibraryConfiguration({}, () => {
         expect(scope.isDone()).to.be.true
         expect(agentlessExporter.canReportCodeCoverage()).to.be.true
         done()
@@ -162,8 +160,7 @@ describe('CI Visibility Agentless Exporter', () => {
         })
       }
 
-      expect(agentlessExporter.shouldRequestItrConfiguration()).to.be.true
-      agentlessExporter.getItrConfiguration({}, (err) => {
+      agentlessExporter.getLibraryConfiguration({}, (err) => {
         expect(scope.isDone()).not.to.be.true
         expect(err.message).to.contain(
           'Request to settings endpoint was not done because Datadog API key is not defined'

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -79,8 +79,8 @@ describe('CI Visibility Exporter', () => {
     })
   })
 
-  describe('getItrConfiguration', () => {
-    it('should upload git metadata when getItrConfiguration is called, regardless of ITR config', (done) => {
+  describe('getLibraryConfiguration', () => {
+    it('should upload git metadata when getLibraryConfiguration is called, regardless of ITR config', (done) => {
       const scope = nock(`http://localhost:${port}`)
         .post('/api/v2/git/repository/search_commits')
         .reply(200, JSON.stringify({
@@ -90,7 +90,7 @@ describe('CI Visibility Exporter', () => {
         .reply(202, '')
 
       const ciVisibilityExporter = new CiVisibilityExporter({ port, isGitUploadEnabled: true })
-      ciVisibilityExporter.getItrConfiguration({}, () => {
+      ciVisibilityExporter.getLibraryConfiguration({}, () => {
         expect(scope.isDone()).not.to.be.true
         done()
       })
@@ -102,8 +102,8 @@ describe('CI Visibility Exporter', () => {
           .reply(200)
 
         const ciVisibilityExporter = new CiVisibilityExporter({ port })
-        ciVisibilityExporter.getItrConfiguration({}, (err, itrConfig) => {
-          expect(itrConfig).to.eql({})
+        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
+          expect(libraryConfig).to.eql({})
           expect(err).to.be.null
           expect(scope.isDone()).not.to.be.true
           done()
@@ -137,7 +137,7 @@ describe('CI Visibility Exporter', () => {
           }
         })
 
-        ciVisibilityExporter.getItrConfiguration({}, () => {
+        ciVisibilityExporter.getLibraryConfiguration({}, () => {
           expect(scope.isDone()).to.be.true
           expect(customConfig).to.eql({
             'my_custom_config': 'my_custom_config_value'
@@ -162,8 +162,8 @@ describe('CI Visibility Exporter', () => {
 
         const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
 
-        ciVisibilityExporter.getItrConfiguration({}, (err, itrConfig) => {
-          expect(itrConfig).to.eql({
+        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
+          expect(libraryConfig).to.eql({
             requireGit: false,
             isCodeCoverageEnabled: true,
             isItrEnabled: true,
@@ -192,7 +192,7 @@ describe('CI Visibility Exporter', () => {
         const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
         expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.false
 
-        ciVisibilityExporter.getItrConfiguration({}, () => {
+        ciVisibilityExporter.getLibraryConfiguration({}, () => {
           expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.true
           done()
         })
@@ -227,12 +227,11 @@ describe('CI Visibility Exporter', () => {
           port, isIntelligentTestRunnerEnabled: true
         })
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        expect(ciVisibilityExporter.shouldRequestItrConfiguration()).to.be.true
-        ciVisibilityExporter.getItrConfiguration({}, (err, itrConfig) => {
+        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
           expect(scope.isDone()).to.be.true
           expect(err).to.be.null
           // the second request returns require_git: false
-          expect(itrConfig.requireGit).to.be.false
+          expect(libraryConfig.requireGit).to.be.false
           expect(hasUploadedGit).to.be.true
           done()
         })
@@ -269,12 +268,11 @@ describe('CI Visibility Exporter', () => {
           port, isIntelligentTestRunnerEnabled: true
         })
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        expect(ciVisibilityExporter.shouldRequestItrConfiguration()).to.be.true
-        ciVisibilityExporter.getItrConfiguration({}, (err, itrConfig) => {
+        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
           expect(scope.isDone()).to.be.true
           expect(err).to.be.null
           // the second request returns require_git: false
-          expect(itrConfig.requireGit).to.be.false
+          expect(libraryConfig.requireGit).to.be.false
           done()
         })
         ciVisibilityExporter._resolveGit()
@@ -352,7 +350,7 @@ describe('CI Visibility Exporter', () => {
           }
         })
 
-        ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
+        ciVisibilityExporter._libraryConfig = { isSuitesSkippingEnabled: true }
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
 
         ciVisibilityExporter.getSkippableSuites({}, () => {
@@ -393,7 +391,7 @@ describe('CI Visibility Exporter', () => {
           isGitUploadEnabled: true
         })
 
-        ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
+        ciVisibilityExporter._libraryConfig = { isSuitesSkippingEnabled: true }
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
 
         ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites) => {
@@ -413,7 +411,7 @@ describe('CI Visibility Exporter', () => {
 
         const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
 
-        ciVisibilityExporter._itrConfig = { isSuitesSkippingEnabled: true }
+        ciVisibilityExporter._libraryConfig = { isSuitesSkippingEnabled: true }
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
 
         ciVisibilityExporter.getSkippableSuites({}, (err, skippableSuites) => {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -90,193 +90,178 @@ describe('CI Visibility Exporter', () => {
         .reply(202, '')
 
       const ciVisibilityExporter = new CiVisibilityExporter({ port, isGitUploadEnabled: true })
-      ciVisibilityExporter.getLibraryConfiguration({}, () => {
-        expect(scope.isDone()).not.to.be.true
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      ciVisibilityExporter.getLibraryConfiguration({}, () => {})
+      ciVisibilityExporter._gitUploadPromise.then(() => {
+        expect(scope.isDone()).to.be.true
         done()
       })
     })
-    context('if ITR is not enabled', () => {
-      it('should resolve immediately if ITR is not enabled', (done) => {
-        const scope = nock(`http://localhost:${port}`)
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200)
-
-        const ciVisibilityExporter = new CiVisibilityExporter({ port })
-        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
-          expect(libraryConfig).to.eql({})
-          expect(err).to.be.null
-          expect(scope.isDone()).not.to.be.true
-          done()
+    it('should add custom configurations', (done) => {
+      let customConfig
+      const scope = nock(`http://localhost:${port}`)
+        .post('/api/v2/libraries/tests/services/setting', function (body) {
+          customConfig = body.data.attributes.configurations.custom
+          return true
         })
-      })
-    })
-    context('if ITR is enabled', () => {
-      it('should add custom configurations', (done) => {
-        let customConfig
-        const scope = nock(`http://localhost:${port}`)
-          .post('/api/v2/libraries/tests/services/setting', function (body) {
-            customConfig = body.data.attributes.configurations.custom
-            return true
-          })
-          .reply(200, JSON.stringify({
-            data: {
-              attributes: {
-                itr_enabled: true,
-                require_git: false,
-                code_coverage: true,
-                tests_skipping: true
-              }
+        .reply(200, JSON.stringify({
+          data: {
+            attributes: {
+              itr_enabled: true,
+              require_git: false,
+              code_coverage: true,
+              tests_skipping: true
             }
-          }))
-
-        const ciVisibilityExporter = new CiVisibilityExporter({
-          port,
-          isIntelligentTestRunnerEnabled: true,
-          tags: {
-            'test.configuration.my_custom_config': 'my_custom_config_value'
           }
-        })
+        }))
 
-        ciVisibilityExporter.getLibraryConfiguration({}, () => {
-          expect(scope.isDone()).to.be.true
-          expect(customConfig).to.eql({
-            'my_custom_config': 'my_custom_config_value'
-          })
-          done()
-        })
-        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        port,
+        isIntelligentTestRunnerEnabled: true,
+        tags: {
+          'test.configuration.my_custom_config': 'my_custom_config_value'
+        }
       })
-      it('should request the API after EVP proxy is resolved', (done) => {
-        const scope = nock(`http://localhost:${port}`)
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200, JSON.stringify({
-            data: {
-              attributes: {
-                itr_enabled: true,
-                require_git: false,
-                code_coverage: true,
-                tests_skipping: true
-              }
-            }
-          }))
 
-        const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
-
-        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
-          expect(libraryConfig).to.eql({
-            requireGit: false,
-            isCodeCoverageEnabled: true,
-            isItrEnabled: true,
-            isSuitesSkippingEnabled: true
-          })
-          expect(err).not.to.exist
-          expect(scope.isDone()).to.be.true
-          done()
+      ciVisibilityExporter.getLibraryConfiguration({}, () => {
+        expect(scope.isDone()).to.be.true
+        expect(customConfig).to.eql({
+          'my_custom_config': 'my_custom_config_value'
         })
-        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+        done()
       })
-      it('should update shouldRequestSkippableSuites if test skipping is enabled', (done) => {
-        nock(`http://localhost:${port}`)
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200, JSON.stringify({
-            data: {
-              attributes: {
-                itr_enabled: true,
-                require_git: false,
-                code_coverage: true,
-                tests_skipping: true
-              }
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+    })
+    it('should request the API after EVP proxy is resolved', (done) => {
+      const scope = nock(`http://localhost:${port}`)
+        .post('/api/v2/libraries/tests/services/setting')
+        .reply(200, JSON.stringify({
+          data: {
+            attributes: {
+              itr_enabled: true,
+              require_git: false,
+              code_coverage: true,
+              tests_skipping: true
             }
-          }))
+          }
+        }))
 
-        const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
-        expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.false
+      const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
 
-        ciVisibilityExporter.getLibraryConfiguration({}, () => {
-          expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.true
-          done()
+      ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
+        expect(libraryConfig).to.eql({
+          requireGit: false,
+          isCodeCoverageEnabled: true,
+          isItrEnabled: true,
+          isSuitesSkippingEnabled: true
         })
-        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+        expect(err).not.to.exist
+        expect(scope.isDone()).to.be.true
+        done()
       })
-      it('will retry ITR configuration request if require_git is true', (done) => {
-        const TIME_TO_UPLOAD_GIT = 50
-        let hasUploadedGit = false
-        const scope = nock(`http://localhost:${port}`)
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200, JSON.stringify({
-            data: {
-              attributes: {
-                require_git: true,
-                code_coverage: true,
-                tests_skipping: true
-              }
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+    })
+    it('should update shouldRequestSkippableSuites if test skipping is enabled', (done) => {
+      nock(`http://localhost:${port}`)
+        .post('/api/v2/libraries/tests/services/setting')
+        .reply(200, JSON.stringify({
+          data: {
+            attributes: {
+              itr_enabled: true,
+              require_git: false,
+              code_coverage: true,
+              tests_skipping: true
             }
-          }))
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200, JSON.stringify({
-            data: {
-              attributes: {
-                require_git: false,
-                code_coverage: true,
-                tests_skipping: true
-              }
-            }
-          }))
+          }
+        }))
 
-        const ciVisibilityExporter = new CiVisibilityExporter({
-          port, isIntelligentTestRunnerEnabled: true
-        })
-        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
-          expect(scope.isDone()).to.be.true
-          expect(err).to.be.null
-          // the second request returns require_git: false
-          expect(libraryConfig.requireGit).to.be.false
-          expect(hasUploadedGit).to.be.true
-          done()
-        })
-        // Git upload finishes after a bit
-        setTimeout(() => {
-          ciVisibilityExporter._resolveGit()
-          hasUploadedGit = true
-        }, TIME_TO_UPLOAD_GIT)
+      const ciVisibilityExporter = new CiVisibilityExporter({ port, isIntelligentTestRunnerEnabled: true })
+      expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.false
+
+      ciVisibilityExporter.getLibraryConfiguration({}, () => {
+        expect(ciVisibilityExporter.shouldRequestSkippableSuites()).to.be.true
+        done()
       })
-      it('will retry ITR configuration request immediately if git upload is already finished', (done) => {
-        const scope = nock(`http://localhost:${port}`)
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200, JSON.stringify({
-            data: {
-              attributes: {
-                require_git: true,
-                code_coverage: true,
-                tests_skipping: true
-              }
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+    })
+    it('will retry library configuration request if require_git is true', (done) => {
+      const TIME_TO_UPLOAD_GIT = 50
+      let hasUploadedGit = false
+      const scope = nock(`http://localhost:${port}`)
+        .post('/api/v2/libraries/tests/services/setting')
+        .reply(200, JSON.stringify({
+          data: {
+            attributes: {
+              require_git: true,
+              code_coverage: true,
+              tests_skipping: true
             }
-          }))
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200, JSON.stringify({
-            data: {
-              attributes: {
-                require_git: false,
-                code_coverage: true,
-                tests_skipping: true
-              }
+          }
+        }))
+        .post('/api/v2/libraries/tests/services/setting')
+        .reply(200, JSON.stringify({
+          data: {
+            attributes: {
+              require_git: false,
+              code_coverage: true,
+              tests_skipping: true
             }
-          }))
+          }
+        }))
 
-        const ciVisibilityExporter = new CiVisibilityExporter({
-          port, isIntelligentTestRunnerEnabled: true
-        })
-        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
-          expect(scope.isDone()).to.be.true
-          expect(err).to.be.null
-          // the second request returns require_git: false
-          expect(libraryConfig.requireGit).to.be.false
-          done()
-        })
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        port, isIntelligentTestRunnerEnabled: true
+      })
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
+        expect(scope.isDone()).to.be.true
+        expect(err).to.be.null
+        // the second request returns require_git: false
+        expect(libraryConfig.requireGit).to.be.false
+        expect(hasUploadedGit).to.be.true
+        done()
+      })
+      // Git upload finishes after a bit
+      setTimeout(() => {
         ciVisibilityExporter._resolveGit()
+        hasUploadedGit = true
+      }, TIME_TO_UPLOAD_GIT)
+    })
+    it('will retry library configuration request immediately if git upload is already finished', (done) => {
+      const scope = nock(`http://localhost:${port}`)
+        .post('/api/v2/libraries/tests/services/setting')
+        .reply(200, JSON.stringify({
+          data: {
+            attributes: {
+              require_git: true,
+              code_coverage: true,
+              tests_skipping: true
+            }
+          }
+        }))
+        .post('/api/v2/libraries/tests/services/setting')
+        .reply(200, JSON.stringify({
+          data: {
+            attributes: {
+              require_git: false,
+              code_coverage: true,
+              tests_skipping: true
+            }
+          }
+        }))
+
+      const ciVisibilityExporter = new CiVisibilityExporter({
+        port, isIntelligentTestRunnerEnabled: true
       })
+      ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+      ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
+        expect(scope.isDone()).to.be.true
+        expect(err).to.be.null
+        // the second request returns require_git: false
+        expect(libraryConfig.requireGit).to.be.false
+        done()
+      })
+      ciVisibilityExporter._resolveGit()
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

* Rename ITR configuration to library configuration
* This renaming should have _no logical changes_. 

### Motivation
This is a refactor in preparation for https://github.com/DataDog/dd-trace-js/pull/3956. 

Now the settings that we receive from that endpoint are not exclusive to intelligent test runner.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

