### PR TITLE
[ci-visibility] Use system's node instead of the bundled one in cypress tests

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -53,7 +53,7 @@ jobs:
   integration-cypress:
     strategy:
       matrix:
-        version: [16, latest]
+        version: [18, latest]
         # 6.7.0 is the minimum version we support
         cypress-version: [6.7.0, latest]
     runs-on: ubuntu-latest

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -53,7 +53,10 @@ jobs:
   integration-cypress:
     strategy:
       matrix:
-        version: [18, latest]
+        # Important: This is outside the minimum supported version of dd-trace-js
+        # Node > 16 does not work with Cypress@6.7.0 (not even without our plugin)
+        # TODO: figure out what to do with this: we might have to deprecate support for cypress@6.7.0
+        version: [16, latest]
         # 6.7.0 is the minimum version we support
         cypress-version: [6.7.0, latest]
     runs-on: ubuntu-latest

--- a/integration-tests/cypress-config.json
+++ b/integration-tests/cypress-config.json
@@ -4,5 +4,6 @@
   "pluginsFile": "cypress/plugins-old/index.js",
   "supportFile": "cypress/support/e2e.js",
   "integrationFolder": "cypress/e2e",
-  "defaultCommandTimeout": 100
+  "defaultCommandTimeout": 100,
+  "nodeVersion": "system"
 }

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -201,7 +201,7 @@ moduleType.forEach(({
       })
     })
 
-    it.only('can run and report tests', (done) => {
+    it('can run and report tests', (done) => {
       const receiverPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
           const events = payloads.flatMap(({ payload }) => payload.events)
@@ -301,9 +301,6 @@ moduleType.forEach(({
           stdio: 'pipe'
         }
       )
-
-      childProcess.stdout.pipe(process.stdout)
-      childProcess.stderr.pipe(process.stderr)
 
       childProcess.on('exit', () => {
         receiverPromise.then(() => {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -30,6 +30,7 @@ const {
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const semver = require('semver')
+const { NODE_MAJOR } = require('../../version')
 
 const version = process.env.CYPRESS_VERSION
 const hookFile = 'dd-trace/loader-hook.mjs'
@@ -54,6 +55,9 @@ moduleType.forEach(({
 }) => {
   // cypress only supports esm on versions >= 10.0.0
   if (type === 'esm' && semver.satisfies(version, '<10.0.0')) {
+    return
+  }
+  if (version === '6.7.0' && NODE_MAJOR > 16) {
     return
   }
   describe(`cypress@${version} ${type}`, function () {
@@ -197,7 +201,7 @@ moduleType.forEach(({
       })
     })
 
-    it('can run and report tests', (done) => {
+    it.only('can run and report tests', (done) => {
       const receiverPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
           const events = payloads.flatMap(({ payload }) => payload.events)
@@ -297,6 +301,9 @@ moduleType.forEach(({
           stdio: 'pipe'
         }
       )
+
+      childProcess.stdout.pipe(process.stdout)
+      childProcess.stderr.pipe(process.stderr)
 
       childProcess.on('exit', () => {
         receiverPromise.then(() => {


### PR DESCRIPTION
### What does this PR do?
The `nodeVersion` old configuration parameter (https://docs.cypress.io/guides/references/legacy-configuration#Node-version) allows you to specify the version of node you use for your plugins. By default it's the bundled in cypress, but you can change it to system.

### Motivation
* Do not use an old version of node.
* Fix cypress tests in https://github.com/DataDog/dd-trace-js/pull/4009

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

