### PR TITLE
[ci-visibility] Add get known tests request

### DIFF
--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -1,0 +1,79 @@
+const request = require('../../exporters/common/request')
+const id = require('../../id')
+const log = require('../../log')
+
+function getKnownTests ({
+  url,
+  isEvpProxy,
+  evpProxyPrefix,
+  env,
+  service,
+  repositoryUrl,
+  sha,
+  osVersion,
+  osPlatform,
+  osArchitecture,
+  runtimeName,
+  runtimeVersion,
+  custom
+}, done) {
+  const options = {
+    path: '/api/v2/ci/libraries/tests',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'accept-encoding': 'gzip'
+    },
+    timeout: 20000,
+    url
+  }
+
+  if (isEvpProxy) {
+    options.path = `${evpProxyPrefix}/api/v2/ci/libraries/tests`
+    options.headers['X-Datadog-EVP-Subdomain'] = 'api'
+  } else {
+    const apiKey = process.env.DATADOG_API_KEY || process.env.DD_API_KEY
+    if (!apiKey) {
+      return done(new Error('Skippable suites were not fetched because Datadog API key is not defined.'))
+    }
+
+    options.headers['dd-api-key'] = apiKey
+  }
+
+  const data = JSON.stringify({
+    data: {
+      id: id().toString(10),
+      type: 'ci_app_libraries_tests_request',
+      attributes: {
+        configurations: {
+          'os.platform': osPlatform,
+          'os.version': osVersion,
+          'os.architecture': osArchitecture,
+          'runtime.name': runtimeName,
+          'runtime.version': runtimeVersion,
+          custom
+        },
+        service,
+        env,
+        repository_url: repositoryUrl,
+        sha
+      }
+    }
+  })
+
+  request(data, options, (err, res) => {
+    if (err) {
+      done(err)
+    } else {
+      try {
+        const { data: { attributes: { test_full_names: knownTests } } } = JSON.parse(res)
+        log.debug(() => `Number of received known tests: ${Object.keys(knownTests).length}`)
+        done(null, knownTests)
+      } catch (err) {
+        done(err)
+      }
+    }
+  })
+}
+
+module.exports = { getKnownTests }

--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -6,6 +6,7 @@ function getKnownTests ({
   url,
   isEvpProxy,
   evpProxyPrefix,
+  isGzipCompatible,
   env,
   service,
   repositoryUrl,
@@ -21,11 +22,14 @@ function getKnownTests ({
     path: '/api/v2/ci/libraries/tests',
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      'accept-encoding': 'gzip'
+      'Content-Type': 'application/json'
     },
     timeout: 20000,
     url
+  }
+
+  if (isGzipCompatible) {
+    options.headers['accept-encoding'] = 'gzip'
   }
 
   if (isEvpProxy) {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -140,6 +140,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         isEvpProxy: !!this._isUsingEvpProxy,
         evpProxyPrefix: this.evpProxyPrefix,
         custom: getTestConfigurationTags(this._config.tags),
+        isGzipCompatible: this._isGzipCompatible,
         ...testConfiguration
       }
       getKnownTestsRequest(configuration, callback)

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -83,7 +83,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
   shouldRequestKnownTests () {
     return !!(
       this._config.isEarlyFlakeDetectionEnabled &&
-      this._itrConfig?.isEarlyFlakeDetectionEnabled
+      this._libraryConfig?.isEarlyFlakeDetectionEnabled
     )
   }
 
@@ -125,7 +125,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
 
   getKnownTests (testConfiguration, callback) {
     if (!this.shouldRequestKnownTests()) {
-      return callback(null, undefined)
+      return callback(null)
     }
     this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {
       if (!canUseCiVisProtocol) {
@@ -199,6 +199,9 @@ class CiVisibilityExporter extends AgentInfoExporter {
 
   // Takes into account potential kill switches
   getConfiguration (remoteConfiguration) {
+    if (!remoteConfiguration) {
+      return {}
+    }
     const {
       isCodeCoverageEnabled,
       isSuitesSkippingEnabled,

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -94,7 +94,14 @@ function getLibraryConfiguration ({
           }
         } = JSON.parse(res)
 
-        const settings = { isCodeCoverageEnabled, isSuitesSkippingEnabled, isItrEnabled, requireGit }
+        const settings = {
+          isCodeCoverageEnabled,
+          isSuitesSkippingEnabled,
+          isItrEnabled,
+          requireGit,
+          // TODO: change to backend response
+          isEarlyFlakeDetectionEnabled: false
+        }
 
         log.debug(() => `Remote settings: ${JSON.stringify(settings)}`)
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -172,6 +172,11 @@ class Config {
       false
     )
 
+    const DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED = coalesce(
+      process.env.DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED,
+      true
+    )
+
     const DD_TRACE_MEMCACHED_COMMAND_ENABLED = coalesce(
       process.env.DD_TRACE_MEMCACHED_COMMAND_ENABLED,
       false
@@ -666,6 +671,7 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
 
     this.gitMetadataEnabled = isTrue(DD_TRACE_GIT_METADATA_ENABLED)
     this.isManualApiEnabled = this.isCiVisibility && isTrue(DD_CIVISIBILITY_MANUAL_API_ENABLED)
+    this.isEarlyFlakeDetectionEnabled = this.isCiVisibility && isTrue(DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED)
 
     this.openaiSpanCharLimit = DD_OPENAI_SPAN_CHAR_LIMIT
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -115,6 +115,18 @@ module.exports = class CiPlugin extends Plugin {
       })
       this.telemetry.count(TELEMETRY_ITR_SKIPPED, { testLevel: 'suite' }, skippedSuites.length)
     })
+
+    this.addSub(`ci:${this.constructor.id}:known-tests`, ({ onDone }) => {
+      if (!this.tracer._exporter?.getKnownTests) {
+        return onDone({ err: new Error('CI Visibility was not initialized correctly') })
+      }
+      this.tracer._exporter.getKnownTests(this.testConfiguration, (err, knownTests) => {
+        if (err) {
+          log.error(`Known tests could not be fetched. ${err.message}`)
+        }
+        onDone({ err, knownTests })
+      })
+    })
   }
 
   get telemetry () {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -650,7 +650,7 @@ describe('CI Visibility Exporter', () => {
           done()
         })
       })
-      it('should not accept gzip if the exporter is gzip compatible', (done) => {
+      it('should not accept gzip if the exporter is gzip incompatible', (done) => {
         let requestHeaders = {}
         const scope = nock(`http://localhost:${port}`)
           .post('/api/v2/ci/libraries/tests')

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -545,4 +545,82 @@ describe('CI Visibility Exporter', () => {
       })
     })
   })
+
+  describe('getKnownTests', () => {
+    context('if early flake detection is disabled', () => {
+      it('should resolve immediately to undefined', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/libraries/tests')
+          .reply(200)
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isEarlyFlakeDetectionEnabled: false })
+
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+
+        ciVisibilityExporter.getKnownTests({}, (err, knownTests) => {
+          expect(err).to.be.null
+          expect(knownTests).to.eql(undefined)
+          expect(scope.isDone()).not.to.be.true
+          done()
+        })
+      })
+    })
+    context('if early flake detection is enabled but can not use CI Visibility protocol', () => {
+      it('should raise an error', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/libraries/tests')
+          .reply(200)
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isEarlyFlakeDetectionEnabled: true })
+
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(false)
+        ciVisibilityExporter._itrConfig = { isEarlyFlakeDetectionEnabled: true }
+        ciVisibilityExporter.getKnownTests({}, (err) => {
+          expect(err.message).to.include(
+            'Known tests can not be requested because CI Visibility protocol can not be used'
+          )
+          expect(scope.isDone()).not.to.be.true
+          done()
+        })
+      })
+    })
+    context('if early flake detection is enabled and can use CI Vis Protocol', () => {
+      it('should request known tests', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/libraries/tests')
+          .reply(200, JSON.stringify({
+            data: {
+              attributes: {
+                test_full_names: ['suite1.test1', 'suite2.test2']
+              }
+            }
+          }))
+
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isEarlyFlakeDetectionEnabled: true })
+
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+        ciVisibilityExporter._itrConfig = { isEarlyFlakeDetectionEnabled: true }
+        ciVisibilityExporter.getKnownTests({}, (err, knownTests) => {
+          expect(err).to.be.null
+          expect(knownTests).to.eql(['suite1.test1', 'suite2.test2'])
+          expect(scope.isDone()).to.be.true
+          done()
+        })
+      })
+      it('should return an error if the request fails', (done) => {
+        const scope = nock(`http://localhost:${port}`)
+          .post('/api/v2/ci/libraries/tests')
+          .reply(500)
+        const ciVisibilityExporter = new CiVisibilityExporter({ port, isEarlyFlakeDetectionEnabled: true })
+
+        ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
+        ciVisibilityExporter._itrConfig = { isEarlyFlakeDetectionEnabled: true }
+        ciVisibilityExporter.getKnownTests({}, (err) => {
+          expect(err).not.to.be.null
+          expect(scope.isDone()).to.be.true
+          done()
+        })
+      })
+    })
+  })
 })

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -169,7 +169,8 @@ describe('CI Visibility Exporter', () => {
             requireGit: false,
             isCodeCoverageEnabled: true,
             isItrEnabled: true,
-            isSuitesSkippingEnabled: true
+            isSuitesSkippingEnabled: true,
+            isEarlyFlakeDetectionEnabled: false
           })
           expect(err).not.to.exist
           expect(scope.isDone()).to.be.true
@@ -574,7 +575,7 @@ describe('CI Visibility Exporter', () => {
         const ciVisibilityExporter = new CiVisibilityExporter({ port, isEarlyFlakeDetectionEnabled: true })
 
         ciVisibilityExporter._resolveCanUseCiVisProtocol(false)
-        ciVisibilityExporter._itrConfig = { isEarlyFlakeDetectionEnabled: true }
+        ciVisibilityExporter._libraryConfig = { isEarlyFlakeDetectionEnabled: true }
         ciVisibilityExporter.getKnownTests({}, (err) => {
           expect(err.message).to.include(
             'Known tests can not be requested because CI Visibility protocol can not be used'
@@ -599,7 +600,7 @@ describe('CI Visibility Exporter', () => {
         const ciVisibilityExporter = new CiVisibilityExporter({ port, isEarlyFlakeDetectionEnabled: true })
 
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        ciVisibilityExporter._itrConfig = { isEarlyFlakeDetectionEnabled: true }
+        ciVisibilityExporter._libraryConfig = { isEarlyFlakeDetectionEnabled: true }
         ciVisibilityExporter.getKnownTests({}, (err, knownTests) => {
           expect(err).to.be.null
           expect(knownTests).to.eql(['suite1.test1', 'suite2.test2'])
@@ -614,7 +615,7 @@ describe('CI Visibility Exporter', () => {
         const ciVisibilityExporter = new CiVisibilityExporter({ port, isEarlyFlakeDetectionEnabled: true })
 
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        ciVisibilityExporter._itrConfig = { isEarlyFlakeDetectionEnabled: true }
+        ciVisibilityExporter._libraryConfig = { isEarlyFlakeDetectionEnabled: true }
         ciVisibilityExporter.getKnownTests({}, (err) => {
           expect(err).not.to.be.null
           expect(scope.isDone()).to.be.true

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1266,6 +1266,7 @@ describe('Config', () => {
       delete process.env.DD_CIVISIBILITY_ITR_ENABLED
       delete process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED
       delete process.env.DD_CIVISIBILITY_MANUAL_API_ENABLED
+      delete process.env.DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED
       options = {}
     })
     context('ci visibility mode is enabled', () => {
@@ -1311,6 +1312,15 @@ describe('Config', () => {
       it('should enable telemetry', () => {
         const config = new Config(options)
         expect(config).to.nested.property('telemetry.enabled', true)
+      })
+      it('should enable early flake detection by default', () => {
+        const config = new Config(options)
+        expect(config).to.have.property('isEarlyFlakeDetectionEnabled', true)
+      })
+      it('should disable early flake detection if DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED is false', () => {
+        process.env.DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED = 'false'
+        const config = new Config(options)
+        expect(config).to.have.property('isEarlyFlakeDetectionEnabled', false)
       })
     })
     context('ci visibility mode is not enabled', () => {


### PR DESCRIPTION
### What does this PR do?
Add get known tests logic. 

It's the first piece of the "Early flake detection" feature:
* we detect what tests are new in your feature branch
* we run them multiple times to check if they're flaky to stop you from merging flaky tests to the default branch 

This PR just adds the necessary logic to request the known tests for a given test service (so the test framework can be aware of what tests are new).


### Motivation
The early flake detection changes are considerable, so I'm splitting the changes in different PRs so it's easier to review.

This PR:
* Adds `getKnownTests` request.
* Adds `getKnownTests` to the ci visibility exporter, so plugins can request known tests.
* Adds corresponding tests.

This PR does **not** include usage of the known tests by any test framework. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

