### PR TITLE
[ci-visibility] Use gzip for skippable endpoint if it's available

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -107,6 +107,7 @@ class CiVisibilityExporter extends AgentInfoExporter {
         env: this._config.env,
         service: this._config.service,
         isEvpProxy: !!this._isUsingEvpProxy,
+        isGzipCompatible: this._isGzipCompatible,
         evpProxyPrefix: this.evpProxyPrefix,
         custom: getTestConfigurationTags(this._config.tags),
         ...testConfiguration

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -16,6 +16,7 @@ function getSkippableSuites ({
   url,
   isEvpProxy,
   evpProxyPrefix,
+  isGzipCompatible,
   env,
   service,
   repositoryUrl,
@@ -36,6 +37,10 @@ function getSkippableSuites ({
     },
     timeout: 20000,
     url
+  }
+
+  if (isGzipCompatible) {
+    options.headers['accept-encoding'] = 'gzip'
   }
 
   if (isEvpProxy) {


### PR DESCRIPTION
### What does this PR do?
Use gzip for skippable endpoint if it's available in the exporter.

### Motivation
Reduce the size of the payload.

### Plugin Checklist
- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

