### PR TITLE
Activate AVM OSS via environment variable

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -438,6 +438,12 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       5 // seconds
     )
 
+    const DD_APPSEC_SCA_ENABLED = coalesce(
+      options.sca && (options.sca === true || options.sca.enabled === true),
+      process.env.DD_APPSEC_SCA_ENABLED,
+      false
+    )
+
     const iastOptions = options?.experimental?.iast
     const DD_IAST_ENABLED = coalesce(
       iastOptions &&
@@ -646,6 +652,11 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       enabled: DD_REMOTE_CONFIGURATION_ENABLED,
       pollInterval: DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS
     }
+
+    this.sca = {
+      enabled: isTrue(DD_APPSEC_SCA_ENABLED)
+    }
+
     this.iast = {
       enabled: isTrue(DD_IAST_ENABLED),
       requestSampling: DD_IAST_REQUEST_SAMPLING,

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -89,10 +89,9 @@ class Tracer extends NoopProxy {
         runtimeMetrics.start(config)
       }
 
-      if (config.tracing) {
-        // TODO: This should probably not require tracing to be enabled.
-        telemetry.start(config, this._pluginManager)
+      telemetry.start(config, this._pluginManager)
 
+      if (config.tracing) {
         // dirty require for now so zero appsec code is executed unless explicitly enabled
         if (config.appsec.enabled) {
           require('./appsec').enable(config)

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -6,6 +6,7 @@ const dependencies = require('./dependencies')
 const { sendData } = require('./send-data')
 const { errors } = require('../startup-log')
 const { manager: metricsManager } = require('./metrics')
+const log = require('../log')
 
 const telemetryStartChannel = dc.channel('datadog:telemetry:start')
 const telemetryStopChannel = dc.channel('datadog:telemetry:stop')
@@ -82,6 +83,9 @@ function getProducts (config) {
   const products = {
     appsec: {
       enabled: config.appsec.enabled
+    },
+    appsec_sca: {
+      enabled: config.sca?.enabled
     },
     profiler: {
       version: tracerVersion,
@@ -246,6 +250,10 @@ function extendedHeartbeat (config) {
 
 function start (aConfig, thePluginManager) {
   if (!aConfig.telemetry.enabled) {
+    if (aConfig.sca?.enabled) {
+      log.warn('DD_APPSEC_SCA_ENABLED requires enabling telemetry to work.')
+    }
+
     return
   }
   config = aConfig

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -116,6 +116,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.apiSecurity.requestSampling', 0.1)
     expect(config).to.have.nested.property('remoteConfig.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 5)
+    expect(config).to.have.nested.property('sca.enabled', false)
     expect(config).to.have.nested.property('iast.enabled', false)
     expect(config).to.have.nested.property('iast.redactionEnabled', true)
     expect(config).to.have.nested.property('iast.redactionNamePattern', null)
@@ -218,6 +219,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING = 'extended'
     process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = '42'
+    process.env.DD_APPSEC_SCA_ENABLED = 'true'
     process.env.DD_IAST_ENABLED = 'true'
     process.env.DD_IAST_REQUEST_SAMPLING = '40'
     process.env.DD_IAST_MAX_CONCURRENT_REQUESTS = '3'
@@ -305,6 +307,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.apiSecurity.requestSampling', 1)
     expect(config).to.have.nested.property('remoteConfig.enabled', false)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
+    expect(config).to.have.nested.property('sca.enabled', true)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 40)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 3)
@@ -456,6 +459,9 @@ describe('Config', () => {
       appsec: false,
       remoteConfig: {
         pollInterval: 42
+      },
+      sca: {
+        enabled: true
       },
       traceId128BitGenerationEnabled: true,
       traceId128BitLoggingEnabled: true
@@ -690,6 +696,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING = 'disabled'
     process.env.DD_EXPERIMENTAL_API_SECURITY_ENABLED = 'false'
     process.env.DD_API_SECURITY_REQUEST_SAMPLE_RATE = 0.5
+    process.env.DD_APPSEC_SCA_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
     process.env.DD_IAST_REDACTION_NAME_PATTERN = 'name_pattern_to_be_overriden_by_options'
@@ -763,6 +770,7 @@ describe('Config', () => {
       remoteConfig: {
         pollInterval: 42
       },
+      sca: true,
       traceId128BitGenerationEnabled: false,
       traceId128BitLoggingEnabled: false
     })
@@ -811,6 +819,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.apiSecurity.enabled', true)
     expect(config).to.have.nested.property('appsec.apiSecurity.requestSampling', 1.0)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
+    expect(config).to.have.nested.property('sca.enabled', true)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 30)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 2)

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -70,6 +70,7 @@ describe('telemetry', () => {
       },
       circularObject,
       appsec: { enabled: true },
+      sca: { enabled: true },
       profiling: { enabled: true },
       peerServiceMapping: {
         'service_1': 'remapped_service_1',
@@ -94,6 +95,7 @@ describe('telemetry', () => {
     return testSeq(1, 'app-started', payload => {
       expect(payload).to.have.property('products').that.deep.equal({
         appsec: { enabled: true },
+        appsec_sca: { enabled: true },
         profiler: { version: tracerVersion, enabled: true }
       })
       expect(payload).to.have.property('configuration').that.deep.equal([
@@ -108,6 +110,7 @@ describe('telemetry', () => {
         { name: 'circularObject.child.field', value: 'child_value', origin: 'unknown' },
         { name: 'circularObject.field', value: 'parent_value', origin: 'unknown' },
         { name: 'appsec.enabled', value: true, origin: 'unknown' },
+        { name: 'sca.enabled', value: true, origin: 'unknown' },
         { name: 'profiling.enabled', value: true, origin: 'unknown' },
         { name: 'peerServiceMapping.service_1', value: 'remapped_service_1', origin: 'unknown' },
         { name: 'peerServiceMapping.service_2', value: 'remapped_service_2', origin: 'unknown' },
@@ -189,6 +192,27 @@ describe('telemetry', () => {
   })
 })
 
+describe('AVM OSS', () => {
+  let telemetry
+
+  it('should log a warning when sca is enabled and telemetry no', () => {
+    const logSpy = {
+      warn: sinon.spy()
+    }
+
+    telemetry = proxyquire('../../src/telemetry', {
+      '../log': logSpy
+    })
+
+    telemetry.start({
+      telemetry: { enabled: false },
+      sca: { enabled: true },
+    })
+
+    expect(logSpy.warn).to.have.been.calledOnceWith('DD_APPSEC_SCA_ENABLED requires enabling telemetry to work.')
+  })
+})
+
 describe('telemetry app-heartbeat', () => {
   let telemetry
   const HEARTBEAT_INTERVAL = 60
@@ -228,6 +252,7 @@ describe('telemetry app-heartbeat', () => {
         'runtime-id': '1a2b3c'
       },
       appsec: { enabled: false },
+      sca: { enabled: true },
       profiling: { enabled: false }
     }, {
       _pluginsByName: {}
@@ -323,6 +348,7 @@ describe('Telemetry extended heartbeat', () => {
       service: 'test service',
       version: '1.2.3-beta4',
       appsec: { enabled: true },
+      sca: { enabled: true },
       profiling: { enabled: true },
       env: 'preprod',
       tags: {
@@ -397,6 +423,7 @@ describe('Telemetry retry', () => {
       service: 'test service',
       version: '1.2.3-beta4',
       appsec: { enabled: true },
+      sca: { enabled: true },
       profiling: { enabled: true },
       env: 'preprod',
       tags: {
@@ -483,6 +510,7 @@ describe('Telemetry retry', () => {
       service: 'test service',
       version: '1.2.3-beta4',
       appsec: { enabled: true },
+      sca: { enabled: true },
       profiling: { enabled: true },
       env: 'preprod',
       tags: {
@@ -552,6 +580,7 @@ describe('Telemetry retry', () => {
       service: 'test service',
       version: '1.2.3-beta4',
       appsec: { enabled: true },
+      sca: { enabled: true },
       profiling: { enabled: true },
       env: 'preprod',
       tags: {
@@ -613,6 +642,7 @@ describe('Telemetry retry', () => {
       service: 'test service',
       version: '1.2.3-beta4',
       appsec: { enabled: true },
+      sca: { enabled: true },
       profiling: { enabled: true },
       env: 'preprod',
       tags: {
@@ -695,6 +725,7 @@ describe('Telemetry retry', () => {
       service: 'test service',
       version: '1.2.3-beta4',
       appsec: { enabled: true },
+      sca: { enabled: true },
       profiling: { enabled: true },
       env: 'preprod',
       tags: {
@@ -715,6 +746,11 @@ describe('Telemetry retry', () => {
         { name: 'foo2', enabled: true, auto_enabled: true },
         { name: 'bar2', enabled: false, auto_enabled: true }
       ]
+    })
+    expect(extendedHeartbeatPayload['products']).to.deep.include({
+      appsec: { enabled: true },
+      appsec_sca: { enabled: true },
+      profiler: { version: tracerVersion, enabled: true }
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Adds a new configuration `DD_APPSEC_SCA_ENABLED`, used to enable AVM OSS.
The value of this new configuration is sent via telemetry to the backend in `applications.products` header.
Starts telemetry client regardless if tracing is enabled.

### Motivation
Customers need a way to enable AVM OSS via an environment variable, just as they enable APM or other products or features, instead of having to do it exclusively through the UI.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

