### PR TITLE
[ci-visibility] Attempt to use repository root to find CODEOWNERS file

### DIFF
--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -45,7 +45,8 @@ const {
   GIT_REPOSITORY_URL,
   GIT_COMMIT_SHA,
   GIT_BRANCH,
-  CI_PROVIDER_NAME
+  CI_PROVIDER_NAME,
+  CI_WORKSPACE_PATH
 } = require('../../dd-trace/src/plugins/util/tags')
 const {
   OS_VERSION,
@@ -186,7 +187,8 @@ module.exports = (on, config) => {
     [RUNTIME_NAME]: runtimeName,
     [RUNTIME_VERSION]: runtimeVersion,
     [GIT_BRANCH]: branch,
-    [CI_PROVIDER_NAME]: ciProviderName
+    [CI_PROVIDER_NAME]: ciProviderName,
+    [CI_WORKSPACE_PATH]: repositoryRoot
   } = testEnvironmentMetadata
 
   const isUnsupportedCIProvider = !ciProviderName
@@ -205,7 +207,7 @@ module.exports = (on, config) => {
     testLevel: 'test'
   }
 
-  const codeOwnersEntries = getCodeOwnersFileEntries()
+  const codeOwnersEntries = getCodeOwnersFileEntries(repositoryRoot)
 
   let activeSpan = null
   let testSessionSpan = null

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -27,7 +27,7 @@ const {
   TELEMETRY_EVENT_CREATED,
   TELEMETRY_ITR_SKIPPED
 } = require('../ci-visibility/telemetry')
-const { CI_PROVIDER_NAME, GIT_REPOSITORY_URL, GIT_COMMIT_SHA, GIT_BRANCH } = require('./util/tags')
+const { CI_PROVIDER_NAME, GIT_REPOSITORY_URL, GIT_COMMIT_SHA, GIT_BRANCH, CI_WORKSPACE_PATH } = require('./util/tags')
 const { OS_VERSION, OS_PLATFORM, OS_ARCHITECTURE, RUNTIME_NAME, RUNTIME_VERSION } = require('./util/env')
 
 module.exports = class CiPlugin extends Plugin {
@@ -140,7 +140,6 @@ module.exports = class CiPlugin extends Plugin {
   configure (config) {
     super.configure(config)
     this.testEnvironmentMetadata = getTestEnvironmentMetadata(this.constructor.id, this.config)
-    this.codeOwnersEntries = getCodeOwnersFileEntries()
 
     const {
       [GIT_REPOSITORY_URL]: repositoryUrl,
@@ -151,8 +150,11 @@ module.exports = class CiPlugin extends Plugin {
       [RUNTIME_NAME]: runtimeName,
       [RUNTIME_VERSION]: runtimeVersion,
       [GIT_BRANCH]: branch,
-      [CI_PROVIDER_NAME]: ciProviderName
+      [CI_PROVIDER_NAME]: ciProviderName,
+      [CI_WORKSPACE_PATH]: repositoryRoot
     } = this.testEnvironmentMetadata
+
+    this.codeOwnersEntries = getCodeOwnersFileEntries(repositoryRoot)
 
     this.isUnsupportedCIProvider = !ciProviderName
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -281,16 +281,34 @@ const POSSIBLE_CODEOWNERS_LOCATIONS = [
   '.gitlab/CODEOWNERS'
 ]
 
-function getCodeOwnersFileEntries (rootDir = process.cwd()) {
-  let codeOwnersContent
-
-  POSSIBLE_CODEOWNERS_LOCATIONS.forEach(location => {
+function readCodeOwners (rootDir) {
+  for (const location of POSSIBLE_CODEOWNERS_LOCATIONS) {
     try {
-      codeOwnersContent = fs.readFileSync(`${rootDir}/${location}`).toString()
+      return fs.readFileSync(path.join(rootDir, location)).toString()
     } catch (e) {
       // retry with next path
     }
-  })
+  }
+  return ''
+}
+
+function getCodeOwnersFileEntries (rootDir) {
+  let codeOwnersContent
+  let usedRootDir = rootDir
+  let isTriedCwd = false
+
+  if (!usedRootDir) {
+    usedRootDir = process.cwd()
+    isTriedCwd = true
+  }
+
+  codeOwnersContent = readCodeOwners(usedRootDir)
+
+  // If we haven't found CODEOWNERS in the provided root dir, we try with process.cwd()
+  if (!codeOwnersContent && !isTriedCwd) {
+    codeOwnersContent = readCodeOwners(process.cwd())
+  }
+
   if (!codeOwnersContent) {
     return null
   }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -297,8 +297,10 @@ function getCodeOwnersFileEntries (rootDir) {
   let usedRootDir = rootDir
   let isTriedCwd = false
 
-  if (!usedRootDir) {
-    usedRootDir = process.cwd()
+  const processCwd = process.cwd()
+
+  if (!usedRootDir || usedRootDir === processCwd) {
+    usedRootDir = processCwd
     isTriedCwd = true
   }
 
@@ -306,7 +308,7 @@ function getCodeOwnersFileEntries (rootDir) {
 
   // If we haven't found CODEOWNERS in the provided root dir, we try with process.cwd()
   if (!codeOwnersContent && !isTriedCwd) {
-    codeOwnersContent = readCodeOwners(process.cwd())
+    codeOwnersContent = readCodeOwners(processCwd)
   }
 
   if (!codeOwnersContent) {

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -83,6 +83,23 @@ describe('getCodeOwnersFileEntries', () => {
 
     expect(codeOwnersFileEntries).to.equal(null)
   })
+  it('tries both input rootDir and process.cwd()', () => {
+    const rootDir = path.join(__dirname, '__not_found__')
+    const oldCwd = process.cwd()
+
+    process.chdir(path.join(__dirname, '__test__'))
+    const codeOwnersFileEntries = getCodeOwnersFileEntries(rootDir)
+
+    expect(codeOwnersFileEntries[0]).to.eql({
+      pattern: 'packages/dd-trace/test/plugins/util/test.spec.js',
+      owners: ['@datadog-ci-app']
+    })
+    expect(codeOwnersFileEntries[1]).to.eql({
+      pattern: 'packages/dd-trace/test/plugins/util/*',
+      owners: ['@datadog-dd-trace-js']
+    })
+    process.chdir(oldCwd)
+  })
 })
 
 describe('getCodeOwnersForFilename', () => {

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -79,9 +79,13 @@ describe('getCodeOwnersFileEntries', () => {
   })
   it('returns null if CODEOWNERS can not be found', () => {
     const rootDir = path.join(__dirname, '__not_found__')
+    // We have to change the working directory,
+    // otherwise it will find the CODEOWNERS file in the root of dd-trace-js
+    const oldCwd = process.cwd()
+    process.chdir(path.join(__dirname))
     const codeOwnersFileEntries = getCodeOwnersFileEntries(rootDir)
-
     expect(codeOwnersFileEntries).to.equal(null)
+    process.chdir(oldCwd)
   })
   it('tries both input rootDir and process.cwd()', () => {
     const rootDir = path.join(__dirname, '__not_found__')


### PR DESCRIPTION
### What does this PR do?

* Use `CI_WORKSPACE_PATH` (repository root) as `rootDir` for finding CODEOWNERS file.
* If that does not work, we still fallback to `process.cwd()`. 

### Motivation
Maximize the likelihood of finding the CODEOWNERS file.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

