### PR TITLE
[ci-visibility] Fix appClosing telemetry event

### DIFF
--- a/packages/datadog-plugin-cypress/test/app-10/CODEOWNERS
+++ b/packages/datadog-plugin-cypress/test/app-10/CODEOWNERS
@@ -1,1 +1,0 @@
-cypress/integration/*   @datadog

--- a/packages/datadog-plugin-cypress/test/app/CODEOWNERS
+++ b/packages/datadog-plugin-cypress/test/app/CODEOWNERS
@@ -1,1 +1,0 @@
-cypress/integration/*   @datadog

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -64,59 +64,64 @@ describe('Plugin', function () {
           console.log('traces', traces)
           const passedTestSpan = traces[0][0]
           const failedTestSpan = traces[1][0]
-          expect(passedTestSpan.name).to.equal('cypress.test')
-          expect(passedTestSpan.resource).to.equal(
-            'cypress/integration/integration-test.js.can visit a page renders a hello world'
-          )
-          expect(passedTestSpan.type).to.equal('test')
-          expect(passedTestSpan.meta).to.contain({
-            language: 'javascript',
-            addTags: 'custom',
-            addTagsBeforeEach: 'custom',
-            addTagsAfterEach: 'custom',
-            [TEST_FRAMEWORK]: 'cypress',
-            [TEST_NAME]: 'can visit a page renders a hello world',
-            [TEST_STATUS]: 'pass',
-            [TEST_SUITE]: 'cypress/integration/integration-test.js',
-            [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
-            [TEST_TYPE]: 'browser',
-            [ORIGIN_KEY]: CI_APP_ORIGIN,
-            [TEST_IS_RUM_ACTIVE]: 'true',
-            [TEST_CODE_OWNERS]: JSON.stringify(['@datadog']),
-            [LIBRARY_VERSION]: ddTraceVersion,
-            [COMPONENT]: 'cypress'
-          })
-          expect(passedTestSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-          expect(passedTestSpan.metrics[TEST_SOURCE_START]).to.exist
+          try {
+            expect(passedTestSpan.name).to.equal('cypress.test')
+            expect(passedTestSpan.resource).to.equal(
+              'cypress/integration/integration-test.js.can visit a page renders a hello world'
+            )
+            expect(passedTestSpan.type).to.equal('test')
+            console.log('meta', passedTestSpan.meta)
+            expect(passedTestSpan.meta).to.contain({
+              language: 'javascript',
+              addTags: 'custom',
+              addTagsBeforeEach: 'custom',
+              addTagsAfterEach: 'custom',
+              [TEST_FRAMEWORK]: 'cypress',
+              [TEST_NAME]: 'can visit a page renders a hello world',
+              [TEST_STATUS]: 'pass',
+              [TEST_SUITE]: 'cypress/integration/integration-test.js',
+              [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
+              [TEST_TYPE]: 'browser',
+              [ORIGIN_KEY]: CI_APP_ORIGIN,
+              [TEST_IS_RUM_ACTIVE]: 'true',
+              [TEST_CODE_OWNERS]: JSON.stringify(['@datadog']),
+              [LIBRARY_VERSION]: ddTraceVersion,
+              [COMPONENT]: 'cypress'
+            })
+            expect(passedTestSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+            expect(passedTestSpan.metrics[TEST_SOURCE_START]).to.exist
 
-          expect(failedTestSpan.name).to.equal('cypress.test')
-          expect(failedTestSpan.resource).to.equal(
-            'cypress/integration/integration-test.js.can visit a page will fail'
-          )
-          expect(failedTestSpan.type).to.equal('test')
-          expect(failedTestSpan.meta).to.contain({
-            language: 'javascript',
-            addTags: 'custom',
-            addTagsBeforeEach: 'custom',
-            addTagsAfterEach: 'custom',
-            [TEST_FRAMEWORK]: 'cypress',
-            [TEST_NAME]: 'can visit a page will fail',
-            [TEST_STATUS]: 'fail',
-            [TEST_SUITE]: 'cypress/integration/integration-test.js',
-            [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
-            [TEST_TYPE]: 'browser',
-            [ORIGIN_KEY]: CI_APP_ORIGIN,
-            [ERROR_TYPE]: 'AssertionError',
-            [TEST_IS_RUM_ACTIVE]: 'true',
-            [COMPONENT]: 'cypress'
-          })
-          expect(failedTestSpan.meta).to.not.contain({
-            addTagsAfterFailure: 'custom'
-          })
-          expect(failedTestSpan.meta[ERROR_MESSAGE]).to.contain(
-            "expected '<div.hello-world>' to have text 'Bye World', but the text was 'Hello World'"
-          )
-          expect(failedTestSpan.metrics[TEST_SOURCE_START]).to.exist
+            expect(failedTestSpan.name).to.equal('cypress.test')
+            expect(failedTestSpan.resource).to.equal(
+              'cypress/integration/integration-test.js.can visit a page will fail'
+            )
+            expect(failedTestSpan.type).to.equal('test')
+            expect(failedTestSpan.meta).to.contain({
+              language: 'javascript',
+              addTags: 'custom',
+              addTagsBeforeEach: 'custom',
+              addTagsAfterEach: 'custom',
+              [TEST_FRAMEWORK]: 'cypress',
+              [TEST_NAME]: 'can visit a page will fail',
+              [TEST_STATUS]: 'fail',
+              [TEST_SUITE]: 'cypress/integration/integration-test.js',
+              [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
+              [TEST_TYPE]: 'browser',
+              [ORIGIN_KEY]: CI_APP_ORIGIN,
+              [ERROR_TYPE]: 'AssertionError',
+              [TEST_IS_RUM_ACTIVE]: 'true',
+              [COMPONENT]: 'cypress'
+            })
+            expect(failedTestSpan.meta).to.not.contain({
+              addTagsAfterFailure: 'custom'
+            })
+            expect(failedTestSpan.meta[ERROR_MESSAGE]).to.contain(
+              "expected '<div.hello-world>' to have text 'Bye World', but the text was 'Hello World'"
+            )
+            expect(failedTestSpan.metrics[TEST_SOURCE_START]).to.exist
+          } catch (e) {
+            console.error(e)
+          }
         }, { timeoutMs: testTimeout }).then(() => done()).catch(done)
       })
     })

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -57,10 +57,11 @@ describe('Plugin', function () {
           config: {
             baseUrl: `http://localhost:${appPort}`
           },
-          quiet: true,
+          // quiet: true,
           headless: true
         })
         agent.use(traces => {
+          console.log('traces', traces)
           const passedTestSpan = traces[0][0]
           const failedTestSpan = traces[1][0]
           expect(passedTestSpan.name).to.equal('cypress.test')

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -26,6 +26,14 @@ const { version: ddTraceVersion } = require('../../../package.json')
 const testTimeout = 60000
 
 describe('Plugin', function () {
+  let oldTelemetryEnabledValue
+  before(() => {
+    oldTelemetryEnabledValue = process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED
+    process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
+  })
+  after(() => {
+    process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = oldTelemetryEnabledValue
+  })
   let cypressExecutable
   let appPort
   let agentListenPort

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -17,7 +17,6 @@ const {
   TEST_IS_RUM_ACTIVE,
   CI_APP_ORIGIN,
   TEST_FRAMEWORK_VERSION,
-  TEST_CODE_OWNERS,
   LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 
@@ -61,67 +60,60 @@ describe('Plugin', function () {
           headless: true
         })
         agent.use(traces => {
-          console.log('traces', traces)
           const passedTestSpan = traces[0][0]
           const failedTestSpan = traces[1][0]
-          try {
-            expect(passedTestSpan.name).to.equal('cypress.test')
-            expect(passedTestSpan.resource).to.equal(
-              'cypress/integration/integration-test.js.can visit a page renders a hello world'
-            )
-            expect(passedTestSpan.type).to.equal('test')
-            console.log('meta', passedTestSpan.meta)
-            expect(passedTestSpan.meta).to.contain({
-              language: 'javascript',
-              addTags: 'custom',
-              addTagsBeforeEach: 'custom',
-              addTagsAfterEach: 'custom',
-              [TEST_FRAMEWORK]: 'cypress',
-              [TEST_NAME]: 'can visit a page renders a hello world',
-              [TEST_STATUS]: 'pass',
-              [TEST_SUITE]: 'cypress/integration/integration-test.js',
-              [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
-              [TEST_TYPE]: 'browser',
-              [ORIGIN_KEY]: CI_APP_ORIGIN,
-              [TEST_IS_RUM_ACTIVE]: 'true',
-              [TEST_CODE_OWNERS]: JSON.stringify(['@datadog']),
-              [LIBRARY_VERSION]: ddTraceVersion,
-              [COMPONENT]: 'cypress'
-            })
-            expect(passedTestSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
-            expect(passedTestSpan.metrics[TEST_SOURCE_START]).to.exist
+          expect(passedTestSpan.name).to.equal('cypress.test')
+          expect(passedTestSpan.resource).to.equal(
+            'cypress/integration/integration-test.js.can visit a page renders a hello world'
+          )
+          expect(passedTestSpan.type).to.equal('test')
+          expect(passedTestSpan.meta).to.contain({
+            language: 'javascript',
+            addTags: 'custom',
+            addTagsBeforeEach: 'custom',
+            addTagsAfterEach: 'custom',
+            [TEST_FRAMEWORK]: 'cypress',
+            [TEST_NAME]: 'can visit a page renders a hello world',
+            [TEST_STATUS]: 'pass',
+            [TEST_SUITE]: 'cypress/integration/integration-test.js',
+            [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
+            [TEST_TYPE]: 'browser',
+            [ORIGIN_KEY]: CI_APP_ORIGIN,
+            [TEST_IS_RUM_ACTIVE]: 'true',
+            [LIBRARY_VERSION]: ddTraceVersion,
+            [COMPONENT]: 'cypress'
+          })
+          expect(passedTestSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
+          expect(passedTestSpan.metrics[TEST_SOURCE_START]).to.exist
 
-            expect(failedTestSpan.name).to.equal('cypress.test')
-            expect(failedTestSpan.resource).to.equal(
-              'cypress/integration/integration-test.js.can visit a page will fail'
-            )
-            expect(failedTestSpan.type).to.equal('test')
-            expect(failedTestSpan.meta).to.contain({
-              language: 'javascript',
-              addTags: 'custom',
-              addTagsBeforeEach: 'custom',
-              addTagsAfterEach: 'custom',
-              [TEST_FRAMEWORK]: 'cypress',
-              [TEST_NAME]: 'can visit a page will fail',
-              [TEST_STATUS]: 'fail',
-              [TEST_SUITE]: 'cypress/integration/integration-test.js',
-              [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
-              [TEST_TYPE]: 'browser',
-              [ORIGIN_KEY]: CI_APP_ORIGIN,
-              [ERROR_TYPE]: 'AssertionError',
-              [TEST_IS_RUM_ACTIVE]: 'true',
-              [COMPONENT]: 'cypress'
-            })
-            expect(failedTestSpan.meta).to.not.contain({
-              addTagsAfterFailure: 'custom'
-            })
-            expect(failedTestSpan.meta[ERROR_MESSAGE]).to.contain(
-              "expected '<div.hello-world>' to have text 'Bye World', but the text was 'Hello World'"
-            )
-            expect(failedTestSpan.metrics[TEST_SOURCE_START]).to.exist
-          } catch (e) {
-            console.error(e)
-          }
+          expect(failedTestSpan.name).to.equal('cypress.test')
+          expect(failedTestSpan.resource).to.equal(
+            'cypress/integration/integration-test.js.can visit a page will fail'
+          )
+          expect(failedTestSpan.type).to.equal('test')
+          expect(failedTestSpan.meta).to.contain({
+            language: 'javascript',
+            addTags: 'custom',
+            addTagsBeforeEach: 'custom',
+            addTagsAfterEach: 'custom',
+            [TEST_FRAMEWORK]: 'cypress',
+            [TEST_NAME]: 'can visit a page will fail',
+            [TEST_STATUS]: 'fail',
+            [TEST_SUITE]: 'cypress/integration/integration-test.js',
+            [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
+            [TEST_TYPE]: 'browser',
+            [ORIGIN_KEY]: CI_APP_ORIGIN,
+            [ERROR_TYPE]: 'AssertionError',
+            [TEST_IS_RUM_ACTIVE]: 'true',
+            [COMPONENT]: 'cypress'
+          })
+          expect(failedTestSpan.meta).to.not.contain({
+            addTagsAfterFailure: 'custom'
+          })
+          expect(failedTestSpan.meta[ERROR_MESSAGE]).to.contain(
+            "expected '<div.hello-world>' to have text 'Bye World', but the text was 'Hello World'"
+          )
+          expect(failedTestSpan.metrics[TEST_SOURCE_START]).to.exist
         }, { timeoutMs: testTimeout }).then(() => done()).catch(done)
       })
     })

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -17,6 +17,7 @@ const {
   TEST_IS_RUM_ACTIVE,
   CI_APP_ORIGIN,
   TEST_FRAMEWORK_VERSION,
+  TEST_CODE_OWNERS,
   LIBRARY_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 
@@ -56,7 +57,7 @@ describe('Plugin', function () {
           config: {
             baseUrl: `http://localhost:${appPort}`
           },
-          // quiet: true,
+          quiet: true,
           headless: true
         })
         agent.use(traces => {
@@ -83,6 +84,7 @@ describe('Plugin', function () {
             [LIBRARY_VERSION]: ddTraceVersion,
             [COMPONENT]: 'cypress'
           })
+          expect(passedTestSpan.meta[TEST_CODE_OWNERS]).to.contain('@DataDog')
           expect(passedTestSpan.meta[TEST_FRAMEWORK_VERSION]).not.to.be.undefined
           expect(passedTestSpan.metrics[TEST_SOURCE_START]).to.exist
 

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -26,14 +26,6 @@ const { version: ddTraceVersion } = require('../../../package.json')
 const testTimeout = 60000
 
 describe('Plugin', function () {
-  let oldTelemetryEnabledValue
-  before(() => {
-    oldTelemetryEnabledValue = process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED
-    process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
-  })
-  after(() => {
-    process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = oldTelemetryEnabledValue
-  })
   let cypressExecutable
   let appPort
   let agentListenPort

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -285,7 +285,6 @@ function stop () {
 
   telemetryStopChannel.publish(getTelemetryData())
 
-  console.log('hey hey hey hey hey')
   config = undefined
 }
 

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -141,6 +141,9 @@ function appStarted (config) {
 }
 
 function appClosing () {
+  if (!config?.telemetry?.enabled) {
+    return
+  }
   const { reqType, payload } = createPayload('app-closing')
   sendData(config, application, host, reqType, payload)
   // we flush before shutting down. Only in CI Visibility
@@ -282,6 +285,7 @@ function stop () {
 
   telemetryStopChannel.publish(getTelemetryData())
 
+  console.log('hey hey hey hey hey')
   config = undefined
 }
 

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -160,6 +160,7 @@ describe('telemetry', () => {
     })
   })
 
+  // TODO: test it's called on beforeExit instead of calling directly
   it('should send app-closing', () => {
     telemetry.appClosing()
     return testSeq(5, 'app-closing', payload => {

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -187,6 +187,24 @@ describe('telemetry', () => {
       clearTimeout()
     })
   })
+
+  it('should not send app-closing if telemetry is not enabled', () => {
+    const sendDataStub = sinon.stub()
+    const notEnabledTelemetry = proxyquire('../../src/telemetry', {
+      './send-data': {
+        sendData: sendDataStub
+      }
+    })
+    notEnabledTelemetry.start({
+      telemetry: { enabled: false, heartbeatInterval: DEFAULT_HEARTBEAT_INTERVAL },
+      appsec: { enabled: false },
+      profiling: { enabled: false }
+    }, {
+      _pluginsByName: pluginsByName
+    })
+    notEnabledTelemetry.appClosing()
+    expect(sendDataStub.called).to.be.false
+  })
 })
 
 describe('telemetry app-heartbeat', () => {

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -160,13 +160,12 @@ describe('telemetry', () => {
     })
   })
 
-  // TODO: make this work regardless of the test runner
-  // it.skip('should send app-closing', () => {
-  //   process.emit('beforeExit')
-  //   return testSeq(5, 'app-closing', payload => {
-  //     expect(payload).to.deep.equal({})
-  //   })
-  // })
+  it('should send app-closing', () => {
+    telemetry.appClosing()
+    return testSeq(5, 'app-closing', payload => {
+      expect(payload).to.deep.equal({})
+    })
+  })
 
   it('should do nothing when not enabled', (done) => {
     telemetry.stop()


### PR DESCRIPTION
### What does this PR do?
`appClosing` is called in cypress and playwright but it could be done when telemetry is disabled. By checking it first we make sure we don't attempt to create telemetry events when we shouldn't.

**Unrelated change**: after https://github.com/DataDog/dd-trace-js/pull/4021 the code owners logic change so now the plugin tests are getting the root CODEOWNERS. I've updated the plugin tests to reflect this. 

### Motivation

Fix cypress plugin errors.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

