### PR TITLE
datastreams: Handle unix protocol

### DIFF
--- a/packages/dd-trace/src/datastreams/writer.js
+++ b/packages/dd-trace/src/datastreams/writer.js
@@ -15,12 +15,9 @@ function makeRequest (data, url, cb) {
       'Datadog-Meta-Tracer-Version': pkg.version,
       'Content-Type': 'application/msgpack',
       'Content-Encoding': 'gzip'
-    }
+    },
+    url
   }
-
-  options.protocol = url.protocol
-  options.hostname = url.hostname
-  options.port = url.port
 
   log.debug(() => `Request to the intake: ${JSON.stringify(options)}`)
 


### PR DESCRIPTION
### What does this PR do?

Let the downstream function handle the different types of URL correctly.
Right now, the tracer throws error like:
``` Protocol "unix:" not supported. Expected "http:"```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

