### PR TITLE
[ci-visibility] Fix test source file to be relative to the repository root

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -24,7 +24,8 @@ const {
   TEST_ITR_SKIPPING_TYPE,
   TEST_ITR_SKIPPING_COUNT,
   TEST_ITR_UNSKIPPABLE,
-  TEST_ITR_FORCED_RUN
+  TEST_ITR_FORCED_RUN,
+  TEST_SOURCE_FILE
 } = require('../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../packages/dd-trace/src/constants')
 
@@ -514,6 +515,10 @@ testFrameworks.forEach(({
         if (extraStdout) {
           assert.include(testOutput, extraStdout)
         }
+
+        testSpans.forEach(testSpan => {
+          assert.equal(testSpan.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/test/ci-visibility-test'), true)
+        })
 
         done()
       })

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -202,6 +202,7 @@ versions.forEach(version => {
                 assert.exists(testSuiteId)
                 assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
                 assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+                console.log('meta[TEST_SOURCE_FILE]', meta[TEST_SOURCE_FILE])
                 assert.equal(meta[TEST_SOURCE_FILE].startsWith('ci-visibility/features'), true)
               })
 

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -202,7 +202,6 @@ versions.forEach(version => {
                 assert.exists(testSuiteId)
                 assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
                 assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-                console.log('meta[TEST_SOURCE_FILE]', meta[TEST_SOURCE_FILE])
                 assert.equal(meta[TEST_SOURCE_FILE].startsWith('ci-visibility/features'), true)
               })
 

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -283,7 +283,6 @@ moduleType.forEach(({
             assert.exists(testSuiteId)
             assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
             assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-            console.log('meta[TEST_SOURCE_FILE]', meta[TEST_SOURCE_FILE])
             assert.equal(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'), true)
           })
         }, 25000)

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -26,7 +26,8 @@ const {
   TEST_ITR_SKIPPING_COUNT,
   TEST_ITR_SKIPPING_TYPE,
   TEST_ITR_UNSKIPPABLE,
-  TEST_ITR_FORCED_RUN
+  TEST_ITR_FORCED_RUN,
+  TEST_SOURCE_FILE
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const semver = require('semver')
@@ -282,6 +283,7 @@ moduleType.forEach(({
             assert.exists(testSuiteId)
             assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
             assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+            assert.equal(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'), true)
           })
         }, 25000)
 

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -283,6 +283,7 @@ moduleType.forEach(({
             assert.exists(testSuiteId)
             assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
             assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+            console.log('meta[TEST_SOURCE_FILE]', meta[TEST_SOURCE_FILE])
             assert.equal(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'), true)
           })
         }, 25000)

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -273,8 +273,10 @@ async function curlAndAssertMessage (agent, procOrUrl, fn, timeout, expectedMess
 }
 
 function getCiVisAgentlessConfig (port) {
+  // We remove GITHUB_WORKSPACE so the repository root is not assigned to dd-trace-js
+  const { GITHUB_WORKSPACE, ...rest } = process.env
   return {
-    ...process.env,
+    ...rest,
     DD_API_KEY: '1',
     DD_CIVISIBILITY_AGENTLESS_ENABLED: 1,
     DD_CIVISIBILITY_AGENTLESS_URL: `http://127.0.0.1:${port}`,
@@ -283,8 +285,10 @@ function getCiVisAgentlessConfig (port) {
 }
 
 function getCiVisEvpProxyConfig (port) {
+  // We remove GITHUB_WORKSPACE so the repository root is not assigned to dd-trace-js
+  const { GITHUB_WORKSPACE, ...rest } = process.env
   return {
-    ...process.env,
+    ...rest,
     DD_TRACE_AGENT_PORT: port,
     NODE_OPTIONS: '-r dd-trace/ci/init',
     DD_CIVISIBILITY_AGENTLESS_ENABLED: '0'

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -104,6 +104,7 @@ versions.forEach((version) => {
 
             testEvents.forEach(testEvent => {
               assert.exists(testEvent.content.metrics[TEST_SOURCE_START])
+              console.log('testEvent.content.meta[TEST_SOURCE_FILE]', testEvent.content.meta[TEST_SOURCE_FILE])
               assert.equal(
                 testEvent.content.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/playwright-tests/'), true
               )

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -12,7 +12,12 @@ const {
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const webAppServer = require('../ci-visibility/web-app-server')
-const { TEST_STATUS, TEST_SOURCE_START, TEST_TYPE } = require('../../packages/dd-trace/src/plugins/util/test')
+const {
+  TEST_STATUS,
+  TEST_SOURCE_START,
+  TEST_TYPE,
+  TEST_SOURCE_FILE
+} = require('../../packages/dd-trace/src/plugins/util/test')
 
 const versions = ['1.18.0', 'latest']
 
@@ -99,6 +104,9 @@ versions.forEach((version) => {
 
             testEvents.forEach(testEvent => {
               assert.exists(testEvent.content.metrics[TEST_SOURCE_START])
+              assert.equal(
+                testEvent.content.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/playwright-tests/'), true
+              )
             })
 
             stepEvents.forEach(stepEvent => {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -54,7 +54,7 @@ versions.forEach((version) => {
 
     reportMethods.forEach((reportMethod) => {
       context(`reporting via ${reportMethod}`, () => {
-        it.only('can run and report tests', (done) => {
+        it('can run and report tests', (done) => {
           const envVars = reportMethod === 'agentless'
             ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
           const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
@@ -104,7 +104,6 @@ versions.forEach((version) => {
 
             testEvents.forEach(testEvent => {
               assert.exists(testEvent.content.metrics[TEST_SOURCE_START])
-              console.log('testEvent.content.meta[TEST_SOURCE_FILE]', testEvent.content.meta[TEST_SOURCE_FILE])
               assert.equal(
                 testEvent.content.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/playwright-tests/'), true
               )
@@ -134,8 +133,6 @@ versions.forEach((version) => {
               stdio: 'pipe'
             }
           )
-          childProcess.stdout.pipe(process.stdout)
-          childProcess.stderr.pipe(process.stderr)
         })
       })
     })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -54,7 +54,7 @@ versions.forEach((version) => {
 
     reportMethods.forEach((reportMethod) => {
       context(`reporting via ${reportMethod}`, () => {
-        it('can run and report tests', (done) => {
+        it.only('can run and report tests', (done) => {
           const envVars = reportMethod === 'agentless'
             ? getCiVisAgentlessConfig(receiver.port) : getCiVisEvpProxyConfig(receiver.port)
           const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
@@ -134,6 +134,8 @@ versions.forEach((version) => {
               stdio: 'pipe'
             }
           )
+          childProcess.stdout.pipe(process.stdout)
+          childProcess.stderr.pipe(process.stderr)
         })
       })
     })

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -96,11 +96,11 @@ function wrapRun (pl, isLatestVersion) {
 
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     return asyncResource.runInAsyncScope(() => {
-      const testSuiteFullPath = this.pickle.uri
+      const testFileAbsolutePath = this.pickle.uri
 
-      if (!pickleResultByFile[testSuiteFullPath]) { // first test in suite
+      if (!pickleResultByFile[testFileAbsolutePath]) { // first test in suite
         isUnskippable = isMarkedAsUnskippable(this.pickle)
-        const testSuitePath = getTestSuitePath(testSuiteFullPath, process.cwd())
+        const testSuitePath = getTestSuitePath(testFileAbsolutePath, process.cwd())
         isForcedToRun = isUnskippable && skippableSuites.includes(testSuitePath)
 
         testSuiteStartCh.publish({ testSuitePath, isUnskippable, isForcedToRun, itrCorrelationId })
@@ -113,7 +113,7 @@ function wrapRun (pl, isLatestVersion) {
 
       testStartCh.publish({
         testName: this.pickle.name,
-        fullTestSuite: testSuiteFullPath,
+        testFileAbsolutePath,
         testSourceLine
       })
       try {
@@ -123,21 +123,21 @@ function wrapRun (pl, isLatestVersion) {
           const { status, skipReason, errorMessage } = isLatestVersion
             ? getStatusFromResultLatest(result) : getStatusFromResult(result)
 
-          if (!pickleResultByFile[testSuiteFullPath]) {
-            pickleResultByFile[testSuiteFullPath] = [status]
+          if (!pickleResultByFile[testFileAbsolutePath]) {
+            pickleResultByFile[testFileAbsolutePath] = [status]
           } else {
-            pickleResultByFile[testSuiteFullPath].push(status)
+            pickleResultByFile[testFileAbsolutePath].push(status)
           }
           testFinishCh.publish({ status, skipReason, errorMessage })
           // last test in suite
-          if (pickleResultByFile[testSuiteFullPath].length === pickleByFile[testSuiteFullPath].length) {
-            const testSuiteStatus = getSuiteStatusFromTestStatuses(pickleResultByFile[testSuiteFullPath])
+          if (pickleResultByFile[testFileAbsolutePath].length === pickleByFile[testFileAbsolutePath].length) {
+            const testSuiteStatus = getSuiteStatusFromTestStatuses(pickleResultByFile[testFileAbsolutePath])
             if (global.__coverage__) {
               const coverageFiles = getCoveredFilenamesFromCoverage(global.__coverage__)
 
               testSuiteCodeCoverageCh.publish({
                 coverageFiles,
-                suiteFile: testSuiteFullPath
+                suiteFile: testFileAbsolutePath
               })
               // We need to reset coverage to get a code coverage per suite
               // Before that, we preserve the original coverage

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -97,7 +97,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       const rootDir = config.globalConfig ? config.globalConfig.rootDir : config.rootDir
       this.rootDir = rootDir
       this.testSuite = getTestSuitePath(context.testPath, rootDir)
-      this.testFileFullPath = context.testPath
+      this.testFileAbsolutePath = context.testPath
       this.nameToParams = {}
       this.global._ddtrace = global._ddtrace
 
@@ -134,7 +134,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           testStartCh.publish({
             name: getJestTestName(event.test),
             suite: this.testSuite,
-            testFileFullPath: this.testFileFullPath,
+            testFileAbsolutePath: this.testFileAbsolutePath,
             runner: 'jest-circus',
             testParameters,
             frameworkVersion: jestVersion
@@ -166,7 +166,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           testSkippedCh.publish({
             name: getJestTestName(event.test),
             suite: this.testSuite,
-            testFileFullPath: this.testFileFullPath,
+            testFileAbsolutePath: this.testFileAbsolutePath,
             runner: 'jest-circus',
             frameworkVersion: jestVersion,
             testStartLine: getTestLineStart(event.test.asyncError, this.testSuite)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -97,6 +97,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       const rootDir = config.globalConfig ? config.globalConfig.rootDir : config.rootDir
       this.rootDir = rootDir
       this.testSuite = getTestSuitePath(context.testPath, rootDir)
+      this.testFileFullPath = context.testPath
       this.nameToParams = {}
       this.global._ddtrace = global._ddtrace
 
@@ -133,6 +134,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           testStartCh.publish({
             name: getJestTestName(event.test),
             suite: this.testSuite,
+            testFileFullPath: this.testFileFullPath,
             runner: 'jest-circus',
             testParameters,
             frameworkVersion: jestVersion
@@ -164,6 +166,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           testSkippedCh.publish({
             name: getJestTestName(event.test),
             suite: this.testSuite,
+            testFileFullPath: this.testFileFullPath,
             runner: 'jest-circus',
             frameworkVersion: jestVersion,
             testStartLine: getTestLineStart(event.test.asyncError, this.testSuite)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -123,7 +123,7 @@ class CucumberPlugin extends CiPlugin {
       }
 
       const relativeCoverageFiles = [...coverageFiles, suiteFile]
-        .map(filename => getTestSuitePath(filename, this.sourceRoot))
+        .map(filename => getTestSuitePath(filename, this.repositoryRoot))
 
       this.telemetry.distribution(TELEMETRY_CODE_COVERAGE_NUM_FILES, {}, relativeCoverageFiles.length)
 
@@ -137,10 +137,10 @@ class CucumberPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_FINISHED, 'suite', { library: 'istanbul' })
     })
 
-    this.addSub('ci:cucumber:test:start', ({ testName, fullTestSuite, testSourceLine }) => {
+    this.addSub('ci:cucumber:test:start', ({ testName, testFileAbsolutePath, testSourceLine }) => {
       const store = storage.getStore()
-      const testSuite = getTestSuitePath(fullTestSuite, this.sourceRoot)
-      const testSourceFile = getTestSuitePath(fullTestSuite, this.repositoryRoot)
+      const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
+      const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
       const testSpan = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
 
       this.enter(testSpan, store)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -14,7 +14,8 @@ const {
   TEST_ITR_UNSKIPPABLE,
   TEST_ITR_FORCED_RUN,
   TEST_CODE_OWNERS,
-  ITR_CORRELATION_ID
+  ITR_CORRELATION_ID,
+  TEST_SOURCE_FILE
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -139,7 +140,8 @@ class CucumberPlugin extends CiPlugin {
     this.addSub('ci:cucumber:test:start', ({ testName, fullTestSuite, testSourceLine }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(fullTestSuite, this.sourceRoot)
-      const testSpan = this.startTestSpan(testName, testSuite, testSourceLine)
+      const testSourceFile = getTestSuitePath(fullTestSuite, this.repositoryRoot)
+      const testSpan = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
 
       this.enter(testSpan, store)
     })
@@ -191,12 +193,15 @@ class CucumberPlugin extends CiPlugin {
     })
   }
 
-  startTestSpan (testName, testSuite, testSourceLine) {
+  startTestSpan (testName, testSuite, testSourceFile, testSourceLine) {
     return super.startTestSpan(
       testName,
       testSuite,
       this.testSuiteSpan,
-      { [TEST_SOURCE_START]: testSourceLine }
+      {
+        [TEST_SOURCE_START]: testSourceLine,
+        [TEST_SOURCE_FILE]: testSourceFile
+      }
     )
   }
 }

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -141,8 +141,6 @@ class CucumberPlugin extends CiPlugin {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
-      console.log('testFileAbsolutePath', testFileAbsolutePath)
-      console.log('this.repositoryRoot', this.repositoryRoot)
       const testSpan = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
 
       this.enter(testSpan, store)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -141,6 +141,8 @@ class CucumberPlugin extends CiPlugin {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
+      console.log('testFileAbsolutePath', testFileAbsolutePath)
+      console.log('this.repositoryRoot', this.repositoryRoot)
       const testSpan = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
 
       this.enter(testSpan, store)

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -364,6 +364,8 @@ module.exports = (on, config) => {
       const skippedTestSpan = getTestSpan(cypressTestName, spec.relative)
       if (spec.absolute && repositoryRoot) {
         skippedTestSpan.setTag(TEST_SOURCE_FILE, getTestSuitePath(spec.absolute, repositoryRoot))
+      } else {
+        skippedTestSpan.setTag(TEST_SOURCE_FILE, spec.relative)
       }
       skippedTestSpan.setTag(TEST_STATUS, 'skip')
       if (isSkippedByItr) {
@@ -395,6 +397,11 @@ module.exports = (on, config) => {
       }
       if (itrCorrelationId) {
         finishedTest.testSpan.setTag(ITR_CORRELATION_ID, itrCorrelationId)
+      }
+      if (spec.absolute && repositoryRoot) {
+        finishedTest.testSpan.setTag(TEST_SOURCE_FILE, getTestSuitePath(spec.absolute, repositoryRoot))
+      } else {
+        finishedTest.testSpan.setTag(TEST_SOURCE_FILE, spec.relative)
       }
       finishedTest.testSpan.finish(finishedTest.finishTime)
     })
@@ -497,7 +504,7 @@ module.exports = (on, config) => {
       return activeSpan ? { traceId: activeSpan.context().toTraceId() } : {}
     },
     'dd:afterEach': ({ test, coverage }) => {
-      const { state, error, isRUMActive, testSourceLine, testSuite, testName, testSourceFileAbsolute } = test
+      const { state, error, isRUMActive, testSourceLine, testSuite, testName } = test
       if (activeSpan) {
         if (coverage && isCodeCoverageEnabled && tracer._tracer._exporter && tracer._tracer._exporter.exportCoverage) {
           const coverageFiles = getCoveredFilenamesFromCoverage(coverage)
@@ -526,11 +533,6 @@ module.exports = (on, config) => {
         }
         if (testSourceLine) {
           activeSpan.setTag(TEST_SOURCE_START, testSourceLine)
-        }
-        if (testSourceFileAbsolute) {
-          activeSpan.setTag(TEST_SOURCE_FILE, getTestSuitePath(testSourceFileAbsolute, repositoryRoot))
-        } else {
-          activeSpan.setTag(TEST_SOURCE_FILE, testSuite)
         }
         const finishedTest = {
           testName,

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -35,6 +35,7 @@ afterEach(() => {
     }
     try {
       testInfo.testSourceLine = Cypress.mocha.getRunner().currentRunnable.invocationDetails.line
+      testInfo.testSourceFileAbsolute = Cypress.mocha.getRunner().currentRunnable.invocationDetails.absoluteFile
     } catch (e) {}
 
     if (win.DD_RUM) {

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -35,7 +35,6 @@ afterEach(() => {
     }
     try {
       testInfo.testSourceLine = Cypress.mocha.getRunner().currentRunnable.invocationDetails.line
-      testInfo.testSourceFileAbsolute = Cypress.mocha.getRunner().currentRunnable.invocationDetails.absoluteFile
     } catch (e) {}
 
     if (win.DD_RUM) {

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -51,15 +51,18 @@ describe('Plugin', function () {
       this.timeout(testTimeout)
       it('instruments tests', function (done) {
         process.env.DD_TRACE_AGENT_PORT = agentListenPort
+        const testSuiteFolder = semver.intersects(version, '>=10')
+          ? 'app-10' : 'app'
+
         cypressExecutable.run({
-          project: semver.intersects(version, '>=10')
-            ? './packages/datadog-plugin-cypress/test/app-10' : './packages/datadog-plugin-cypress/test/app',
+          project: `./packages/datadog-plugin-cypress/test/${testSuiteFolder}`,
           config: {
             baseUrl: `http://localhost:${appPort}`
           },
           quiet: true,
           headless: true
         })
+
         agent.use(traces => {
           const passedTestSpan = traces[0][0]
           const failedTestSpan = traces[1][0]
@@ -77,7 +80,8 @@ describe('Plugin', function () {
             [TEST_NAME]: 'can visit a page renders a hello world',
             [TEST_STATUS]: 'pass',
             [TEST_SUITE]: 'cypress/integration/integration-test.js',
-            [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
+            [TEST_SOURCE_FILE]:
+              `packages/datadog-plugin-cypress/test/${testSuiteFolder}/cypress/integration/integration-test.js`,
             [TEST_TYPE]: 'browser',
             [ORIGIN_KEY]: CI_APP_ORIGIN,
             [TEST_IS_RUM_ACTIVE]: 'true',
@@ -102,7 +106,8 @@ describe('Plugin', function () {
             [TEST_NAME]: 'can visit a page will fail',
             [TEST_STATUS]: 'fail',
             [TEST_SUITE]: 'cypress/integration/integration-test.js',
-            [TEST_SOURCE_FILE]: 'cypress/integration/integration-test.js',
+            [TEST_SOURCE_FILE]:
+              `packages/datadog-plugin-cypress/test/${testSuiteFolder}/cypress/integration/integration-test.js`,
             [TEST_TYPE]: 'browser',
             [ORIGIN_KEY]: CI_APP_ORIGIN,
             [ERROR_TYPE]: 'AssertionError',

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -295,7 +295,7 @@ class JestPlugin extends CiPlugin {
       testParameters,
       frameworkVersion,
       testStartLine,
-      testFileFullPath
+      testFileAbsolutePath
     } = test
 
     const extraTags = {
@@ -306,8 +306,8 @@ class JestPlugin extends CiPlugin {
     if (testStartLine) {
       extraTags[TEST_SOURCE_START] = testStartLine
     }
-    if (testFileFullPath) {
-      extraTags[TEST_SOURCE_FILE] = getTestSuitePath(testFileFullPath, this.repositoryRoot)
+    if (testFileAbsolutePath) {
+      extraTags[TEST_SOURCE_FILE] = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
     } else {
       // If for whatever we don't have the full path, we'll set the source file to the suite name
       extraTags[TEST_SOURCE_FILE] = suite

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -14,7 +14,9 @@ const {
   TEST_ITR_UNSKIPPABLE,
   TEST_ITR_FORCED_RUN,
   TEST_CODE_OWNERS,
-  ITR_CORRELATION_ID
+  ITR_CORRELATION_ID,
+  TEST_SOURCE_FILE,
+  getTestSuitePath
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -286,7 +288,15 @@ class JestPlugin extends CiPlugin {
   }
 
   startTestSpan (test) {
-    const { suite, name, runner, testParameters, frameworkVersion, testStartLine } = test
+    const {
+      suite,
+      name,
+      runner,
+      testParameters,
+      frameworkVersion,
+      testStartLine,
+      testFileFullPath
+    } = test
 
     const extraTags = {
       [JEST_TEST_RUNNER]: runner,
@@ -295,6 +305,12 @@ class JestPlugin extends CiPlugin {
     }
     if (testStartLine) {
       extraTags[TEST_SOURCE_START] = testStartLine
+    }
+    if (testFileFullPath) {
+      extraTags[TEST_SOURCE_FILE] = getTestSuitePath(testFileFullPath, this.repositoryRoot)
+    } else {
+      // If for whatever we don't have the full path, we'll set the source file to the suite name
+      extraTags[TEST_SOURCE_FILE] = suite
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -15,7 +15,8 @@ const {
   TEST_ITR_UNSKIPPABLE,
   TEST_ITR_FORCED_RUN,
   TEST_CODE_OWNERS,
-  ITR_CORRELATION_ID
+  ITR_CORRELATION_ID,
+  TEST_SOURCE_FILE
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -243,6 +244,14 @@ class MochaPlugin extends CiPlugin {
 
     const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.sourceRoot)
     const testSuiteSpan = this._testSuites.get(testSuiteAbsolutePath)
+
+    const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
+
+    if (testSourceFile) {
+      extraTags[TEST_SOURCE_FILE] = testSourceFile
+    } else {
+      extraTags[TEST_SOURCE_FILE] = testSuite
+    }
 
     return super.startTestSpan(testName, testSuite, testSuiteSpan, extraTags)
   }

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -80,7 +80,8 @@ class PlaywrightPlugin extends CiPlugin {
     this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
-      const span = this.startTestSpan(testName, testSuite, testSuiteAbsolutePath, testSourceLine)
+      const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
+      const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
 
       this.enter(span, store)
     })
@@ -134,7 +135,7 @@ class PlaywrightPlugin extends CiPlugin {
       [TEST_SOURCE_START]: testSourceLine
     }
     if (testSourceFile) {
-      extraTags[TEST_SOURCE_FILE] = getTestSuitePath(testSourceFile, this.repositoryRoot)
+      extraTags[TEST_SOURCE_FILE] = testSourceFile || testSuite
     }
 
     return super.startTestSpan(testName, testSuite, testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -9,7 +9,8 @@ const {
   getTestSuitePath,
   getTestSuiteCommonTags,
   TEST_SOURCE_START,
-  TEST_CODE_OWNERS
+  TEST_CODE_OWNERS,
+  TEST_SOURCE_FILE
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -79,7 +80,7 @@ class PlaywrightPlugin extends CiPlugin {
     this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
-      const span = this.startTestSpan(testName, testSuite, testSourceLine)
+      const span = this.startTestSpan(testName, testSuite, testSuiteAbsolutePath, testSourceLine)
 
       this.enter(span, store)
     })
@@ -126,9 +127,17 @@ class PlaywrightPlugin extends CiPlugin {
     })
   }
 
-  startTestSpan (testName, testSuite, testSourceLine) {
+  startTestSpan (testName, testSuite, testSourceFile, testSourceLine) {
     const testSuiteSpan = this._testSuites.get(testSuite)
-    return super.startTestSpan(testName, testSuite, testSuiteSpan, { [TEST_SOURCE_START]: testSourceLine })
+
+    const extraTags = {
+      [TEST_SOURCE_START]: testSourceLine
+    }
+    if (testSourceFile) {
+      extraTags[TEST_SOURCE_FILE] = getTestSuitePath(testSourceFile, this.repositoryRoot)
+    }
+
+    return super.startTestSpan(testName, testSuite, testSuiteSpan, extraTags)
   }
 }
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -80,6 +80,8 @@ class PlaywrightPlugin extends CiPlugin {
     this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
+      console.log('REPOSITORY ROOT!', this.repositoryRoot)
+      console.log('testSuiteAbsolutePath', testSuiteAbsolutePath)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -80,8 +80,6 @@ class PlaywrightPlugin extends CiPlugin {
     this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
-      console.log('REPOSITORY ROOT!', this.repositoryRoot)
-      console.log('testSuiteAbsolutePath', testSuiteAbsolutePath)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -166,6 +166,8 @@ module.exports = class CiPlugin extends Plugin {
       [CI_WORKSPACE_PATH]: repositoryRoot
     } = this.testEnvironmentMetadata
 
+    this.repositoryRoot = repositoryRoot || process.cwd()
+
     this.codeOwnersEntries = getCodeOwnersFileEntries(repositoryRoot)
 
     this.isUnsupportedCIProvider = !ciProviderName

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -253,7 +253,6 @@ function getTestCommonTags (name, suite, version, testFramework) {
     [SAMPLING_PRIORITY]: AUTO_KEEP,
     [TEST_NAME]: name,
     [TEST_SUITE]: suite,
-    [TEST_SOURCE_FILE]: suite,
     [RESOURCE_NAME]: `${suite}.${name}`,
     [TEST_FRAMEWORK_VERSION]: version,
     [LIBRARY_VERSION]: ddTraceVersion


### PR DESCRIPTION
### What does this PR do?
Change the root file we use for calculating the relative path of source files: instead of using `process.cwd` we attempt to use the repository root. If we can't find it, we'll still fall back to `process.cwd`.

### Motivation
`test.source.file` should always be relative to the repository root. Otherwise our UI will not be able to show source code. 

### Plugin Checklist
- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

