### PR TITLE
allow unix URLs for datastreams

### DIFF
--- a/packages/dd-trace/src/datastreams/writer.js
+++ b/packages/dd-trace/src/datastreams/writer.js
@@ -15,12 +15,9 @@ function makeRequest (data, url, cb) {
       'Datadog-Meta-Tracer-Version': pkg.version,
       'Content-Type': 'application/msgpack',
       'Content-Encoding': 'gzip'
-    }
+    },
+    url
   }
-
-  options.protocol = url.protocol
-  options.hostname = url.hostname
-  options.port = url.port
 
   log.debug(() => `Request to the intake: ${JSON.stringify(options)}`)
 

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -1,0 +1,44 @@
+'use strict'
+const pkg = require('../../../../package.json')
+const stubRequest = sinon.stub()
+
+const { DataStreamsWriter } = proxyquire(
+  '../src/datastreams/writer', {
+    '../exporters/common/request': stubRequest
+})
+
+require('../setup/tap')
+
+describe('DataStreamWriter unix', () => {
+
+  let writer
+  const unixConfig = {
+    hostname: '',
+    url: new URL('unix:///var/run/datadog/apm.socket'),
+    port: ''
+  }
+
+  it("should construct unix config", () => {
+    writer = new DataStreamsWriter(unixConfig);
+    expect(writer._url).to.equal(unixConfig.url);
+  })
+
+  it("should call 'request' through flush with correct options", () => {
+    writer = new DataStreamsWriter(unixConfig);
+    writer.flush({}):
+    expect(stubRequest).to.be.calledWith(
+      {},
+      {
+        path: '/v0.1/pipeline_stats',
+        method: 'POST',
+        headers: {
+          'Datadog-Meta-Lang': 'javascript',
+          'Datadog-Meta-Tracer-Version': pkg.version,
+          'Content-Type': 'application/msgpack',
+          'Content-Encoding': 'gzip'
+        },
+        url: unixConfig.url
+      }
+    )
+  })
+})

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -1,13 +1,21 @@
 'use strict'
+require('../setup/tap')
 const pkg = require('../../../../package.json')
 const stubRequest = sinon.stub()
+const msgpack = require('msgpack-lite')
+const codec = msgpack.createCodec({ int64: true })
+
+const stubZlib = {
+  gzip: (payload, _opts, fn) => {
+    fn(undefined, payload)
+  }
+}
 
 const { DataStreamsWriter } = proxyquire(
   '../src/datastreams/writer', {
-    '../exporters/common/request': stubRequest
+    '../exporters/common/request': stubRequest,
+    'zlib': stubZlib
   })
-
-require('../setup/tap')
 
 describe('DataStreamWriter unix', () => {
   let writer
@@ -25,19 +33,20 @@ describe('DataStreamWriter unix', () => {
   it("should call 'request' through flush with correct options", () => {
     writer = new DataStreamsWriter(unixConfig)
     writer.flush({})
-    expect(stubRequest).to.be.calledWith(
-      {},
-      {
-        path: '/v0.1/pipeline_stats',
-        method: 'POST',
-        headers: {
-          'Datadog-Meta-Lang': 'javascript',
-          'Datadog-Meta-Tracer-Version': pkg.version,
-          'Content-Type': 'application/msgpack',
-          'Content-Encoding': 'gzip'
-        },
-        url: unixConfig.url
-      }
-    )
+    const stubRequestCall = stubRequest.getCalls().at(0)
+    const decodedPayload = msgpack.decode(stubRequestCall?.args[0], { codec })
+    const requestOptions = stubRequestCall?.args[1]
+    expect(decodedPayload).to.deep.equal({})
+    expect(requestOptions).to.deep.equal({
+      path: '/v0.1/pipeline_stats',
+      method: 'POST',
+      headers: {
+        'Datadog-Meta-Lang': 'javascript',
+        'Datadog-Meta-Tracer-Version': pkg.version,
+        'Content-Type': 'application/msgpack',
+        'Content-Encoding': 'gzip'
+      },
+      url: unixConfig.url
+    })
   })
 })

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -5,12 +5,11 @@ const stubRequest = sinon.stub()
 const { DataStreamsWriter } = proxyquire(
   '../src/datastreams/writer', {
     '../exporters/common/request': stubRequest
-})
+  })
 
 require('../setup/tap')
 
 describe('DataStreamWriter unix', () => {
-
   let writer
   const unixConfig = {
     hostname: '',
@@ -18,14 +17,14 @@ describe('DataStreamWriter unix', () => {
     port: ''
   }
 
-  it("should construct unix config", () => {
-    writer = new DataStreamsWriter(unixConfig);
-    expect(writer._url).to.equal(unixConfig.url);
+  it('should construct unix config', () => {
+    writer = new DataStreamsWriter(unixConfig)
+    expect(writer._url).to.equal(unixConfig.url)
   })
 
   it("should call 'request' through flush with correct options", () => {
-    writer = new DataStreamsWriter(unixConfig);
-    writer.flush({}):
+    writer = new DataStreamsWriter(unixConfig)
+    writer.flush({})
     expect(stubRequest).to.be.calledWith(
       {},
       {


### PR DESCRIPTION
### What does this PR do?
- commits taken directly from #3689
- closes #3689
- closes #4024

### Motivation
- allows DSM to work with UNIX sockets
