### PR TITLE
allow metrics UDP fallback in case of network errors

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -67,16 +67,14 @@ class DogStatsDClient {
     request(buffer, this._httpOptions, (err) => {
       if (err) {
         log.error('HTTP error from agent: ' + err.stack)
-        if (err.status) {
+        if (err.status === 404) {
           // Inside this if-block, we have connectivity to the agent, but
           // we're not getting a 200 from the proxy endpoint. If it's a 404,
           // then we know we'll never have the endpoint, so just clear out the
           // options. Either way, we can give UDP a try.
-          if (err.status === 404) {
-            this._httpOptions = null
-          }
-          this._sendUdp(queue)
+          this._httpOptions = null
         }
+        this._sendUdp(queue)
       }
     })
   }


### PR DESCRIPTION
### What does this PR do?
- allows metrics to fallback to UDP when network errors happen
- currently `err.status`, which is an HTTP error, should be unset
- retains behavior where an HTTP 404 response allows for permanent fallback

### Motivation
- a customer request regarding an agentless setup with an otel collector