### PR TITLE
Szegedi/profiler ssi

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -33,6 +33,7 @@ const integrationCounters = {
   spans_finished: {}
 }
 
+const startCh = channel('dd-trace:span:start')
 const finishCh = channel('dd-trace:span:finish')
 
 function getIntegrationCounter (event, integration) {
@@ -96,6 +97,7 @@ class DatadogSpan {
       unfinishedRegistry.register(this, operationName, this)
     }
     spanleak.addSpan(this, operationName)
+    startCh.publish(this)
   }
 
   toString () {

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -20,6 +20,7 @@ class Config {
     const {
       DD_AGENT_HOST,
       DD_ENV,
+      DD_INJECTION_ENABLED,
       DD_PROFILING_CODEHOTSPOTS_ENABLED,
       DD_PROFILING_DEBUG_SOURCE_MAPS,
       DD_PROFILING_ENABLED,
@@ -49,6 +50,7 @@ class Config {
     } = process.env
 
     const enabled = isTrue(coalesce(options.enabled, DD_PROFILING_ENABLED, true))
+    const injected = (DD_INJECTION_ENABLED || '').split(',').includes('profiling')
     const env = coalesce(options.env, DD_ENV)
     const service = options.service || DD_SERVICE || 'node'
     const host = os.hostname()
@@ -64,6 +66,7 @@ class Config {
       DD_PROFILING_PPROF_PREFIX, '')
 
     this.enabled = enabled
+    this.injected = injected
     this.service = service
     this.env = env
     this.host = host

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -7,6 +7,7 @@ const { threadNamePrefix } = require('./profilers/shared')
 const dc = require('dc-polyfill')
 
 const firstTraceExported = messageWasPublished('dd-trace:trace:exported')
+const firstSpanStarted = messageWasPublished('dd-trace:span:started')
 
 function maybeSourceMap (sourceMap, SourceMapper, debug) {
   if (!sourceMap) return
@@ -51,6 +52,10 @@ class Profiler extends EventEmitter {
 
     const config = this._config = new Config(options)
     if (!config.enabled) return false
+
+    if (config.injected) {
+      await firstSpanStarted
+    }
 
     this._logger = config.logger
     this._enabled = true

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -10,6 +10,9 @@ const { SpanStatsProcessor } = require('./span_stats')
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
 
+const dc = require('dc-polyfill')
+const exportedCh = dc.channel('dd-trace:trace:exported')
+
 class SpanProcessor {
   constructor (exporter, prioritySampler, config) {
     this._exporter = exporter
@@ -52,6 +55,7 @@ class SpanProcessor {
 
       if (formatted.length !== 0 && trace.isRecording !== false) {
         this._exporter.export(formatted)
+        exportedCh.publish()
       }
 
       this._erase(trace, active)


### PR DESCRIPTION
### What does this PR do?
Detects SSI injection and modifies profiler behavior accordingly. The logic currently:
- checks if comma-tokenized value of the `DD_INJECTION_ENABLED` environment variable has the token `profiling`, which is the signal Datadog Agent sends to indicate it's injecting other env vars into process' as part of SSI.
- when it is present, the profiler behavior is modified. If it is enabled, it will delay starting the profiler until a tracing span has been created in the process, and it also won't send profiles to the agent (and instead discard them) until at least one trace was sent to the agent.

❗ This, for now, is a prototype and a proof-of-concept. We will definitely iterate on heuristics, and we might want to build a solution for not repeating the heuristic across worker threads.

### Motivation
Continuous Profiler Q1 '24 OKR 4

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.