### PR TITLE
[ci-visibility] Fix `DD_TAGS`

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -1,15 +1,11 @@
 /* eslint-disable no-console */
 const tracer = require('../packages/dd-trace')
-const { ORIGIN_KEY } = require('../packages/dd-trace/src/constants')
 const { isTrue } = require('../packages/dd-trace/src/util')
 
 const isJestWorker = !!process.env.JEST_WORKER_ID
 
 const options = {
   startupLogs: false,
-  tags: {
-    [ORIGIN_KEY]: 'ciapp-test'
-  },
   isCiVisibility: true,
   flushInterval: isJestWorker ? 0 : 5000
 }

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -514,6 +514,11 @@ testFrameworks.forEach(({
         if (extraStdout) {
           assert.include(testOutput, extraStdout)
         }
+        // Can read DD_TAGS
+        testSpans.forEach(testSpan => {
+          assert.propertyVal(testSpan.meta, 'test.customtag', 'customvalue')
+          assert.propertyVal(testSpan.meta, 'test.customtag2', 'customvalue2')
+        })
 
         done()
       })
@@ -522,7 +527,8 @@ testFrameworks.forEach(({
         cwd,
         env: {
           DD_TRACE_AGENT_PORT: receiver.port,
-          NODE_OPTIONS: type === 'esm' ? `-r dd-trace/ci/init --loader=${hookFile}` : '-r dd-trace/ci/init'
+          NODE_OPTIONS: type === 'esm' ? `-r dd-trace/ci/init --loader=${hookFile}` : '-r dd-trace/ci/init',
+          DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2'
         },
         stdio: 'pipe'
       })

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -225,6 +225,9 @@ versions.forEach(version => {
                 assert.exists(testSuiteId)
                 assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
                 assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+                // Can read DD_TAGS
+                assert.propertyVal(meta, 'test.customtag', 'customvalue')
+                assert.propertyVal(meta, 'test.customtag2', 'customvalue2')
               })
 
               stepEvents.forEach(stepEvent => {
@@ -237,7 +240,10 @@ versions.forEach(version => {
               runTestsCommand,
               {
                 cwd,
-                env: envVars,
+                env: {
+                  ...envVars,
+                  DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2'
+                },
                 stdio: 'pipe'
               }
             )

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -282,6 +282,9 @@ moduleType.forEach(({
             assert.exists(testSuiteId)
             assert.equal(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
             assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+            // Can read DD_TAGS
+            assert.propertyVal(meta, 'test.customtag', 'customvalue')
+            assert.propertyVal(meta, 'test.customtag2', 'customvalue2')
           })
         }, 25000)
 
@@ -296,7 +299,8 @@ moduleType.forEach(({
           cwd,
           env: {
             ...restEnvVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2'
           },
           stdio: 'pipe'
         }

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -99,6 +99,9 @@ versions.forEach((version) => {
 
             testEvents.forEach(testEvent => {
               assert.exists(testEvent.content.metrics[TEST_SOURCE_START])
+              // Can read DD_TAGS
+              assert.propertyVal(testEvent.content.meta, 'test.customtag', 'customvalue')
+              assert.propertyVal(testEvent.content.meta, 'test.customtag2', 'customvalue2')
             })
 
             stepEvents.forEach(stepEvent => {
@@ -120,7 +123,8 @@ versions.forEach((version) => {
               cwd,
               env: {
                 ...envVars,
-                PW_BASE_URL: `http://localhost:${webAppPort}`
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2'
               },
               stdio: 'pipe'
             }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -13,6 +13,7 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('./plugins/util/tags')
 const { getGitMetadataFromGitProperties, removeUserSensitiveInfo } = require('./git_properties')
 const { updateConfig } = require('./telemetry')
 const { getIsGCPFunction, getIsAzureFunctionConsumptionPlan } = require('./serverless')
+const { ORIGIN_KEY } = require('./constants')
 
 const fromEntries = Object.fromEntries || (entries =>
   entries.reduce((obj, [k, v]) => Object.assign(obj, { [k]: v }), {}))
@@ -709,6 +710,12 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
       version: this.version,
       'runtime-id': uuid()
     })
+
+    if (this.isCiVisibility) {
+      tagger.add(this.tags, {
+        [ORIGIN_KEY]: 'ciapp-test'
+      })
+    }
 
     if (this.gitMetadataEnabled) {
       this.repositoryUrl = removeUserSensitiveInfo(


### PR DESCRIPTION
### What does this PR do?
* Stop using `tags` options in `ci/init`.
* Add `ORIGIN_KEY` key explicitly in `config.js`.
* This way, `DD_TAGS` is read correctly.
* Add e2e tests, so we avoid regressions in the future.

### Motivation
Fix `DD_TAGS` env var being ignored in CI Visibility. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

