### PR TITLE
Fix mongoose iast exec

### DIFF
--- a/packages/datadog-instrumentations/src/mongoose.js
+++ b/packages/datadog-instrumentations/src/mongoose.js
@@ -96,6 +96,7 @@ addHook({
             callbackWrapped = true
           }
         }
+
         wrapCallbackIfExist(arguments)
 
         return asyncResource.runInAsyncScope(() => {

--- a/packages/datadog-instrumentations/src/mongoose.js
+++ b/packages/datadog-instrumentations/src/mongoose.js
@@ -111,7 +111,9 @@ addHook({
           if (!callbackWrapped) {
             shimmer.wrap(res, 'exec', originalExec => {
               return function wrappedExec () {
-                wrapCallbackIfExist(arguments)
+                if (!callbackWrapped) {
+                  wrapCallbackIfExist(arguments)
+                }
 
                 const execResult = originalExec.apply(this, arguments)
 

--- a/packages/datadog-instrumentations/src/mongoose.js
+++ b/packages/datadog-instrumentations/src/mongoose.js
@@ -96,7 +96,6 @@ addHook({
             callbackWrapped = true
           }
         }
-        
         wrapCallbackIfExist(arguments)
 
         return asyncResource.runInAsyncScope(() => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -154,6 +154,28 @@ describe('nosql injection detection in mongodb - whole feature', () => {
                   res.end()
                 }
               }, 'NOSQL_MONGODB_INJECTION')
+
+              testThatRequestHasVulnerability({
+                fn: async (req, res) => {
+                  try {
+                    Test.find({
+                      name: req.query.key,
+                      value: [1, 2,
+                        'value',
+                        false, req.query.key]
+                    }).exec(() => {
+                      res.end()
+                    })
+                  } catch (e) {
+                    res.writeHead(500)
+                    res.end()
+                  }
+                },
+                vulnerability: 'NOSQL_MONGODB_INJECTION',
+                makeRequest: (done, config) => {
+                  axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
+                }
+              })
             })
           }
         })

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -173,6 +173,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
               }, 'NOSQL_MONGODB_INJECTION')
 
               testThatRequestHasVulnerability({
+                textDescription: 'should have NOSQL_MONGODB_INJECTION vulnerability using callback in exec',
                 fn: async (req, res) => {
                   try {
                     Test.find({
@@ -195,28 +196,21 @@ describe('nosql injection detection in mongodb - whole feature', () => {
               })
 
               testThatRequestHasVulnerability({
-                testDescription: 'this should fail',
+                textDescription: 'should have NOSQL_MONGODB_INJECTION vulnerability using callback in find',
                 fn: async (req, res) => {
-                  return new Promise((resolve) => {
-                    try {
-                      Test.find({
-                        name: req.query.key,
-                        value: [1, 2,
-                          'value',
-                          false, req.query.key]
-                      }, () => {
-                        console.log('first callback')
-                      }).exec(() => {
-                        console.log('whaaaaat')
-                        resolve()
-                      })
-                    } catch (e) {
-                      console.error(e)
-                      res.writeHead(500)
+                  try {
+                    Test.find({
+                      name: req.query.key,
+                      value: [1, 2,
+                        'value',
+                        false, req.query.key]
+                    }, () => {
                       res.end()
-                      resolve()
-                    }
-                  })
+                    })
+                  } catch (e) {
+                    res.writeHead(500)
+                    res.end()
+                  }
                 },
                 vulnerability: 'NOSQL_MONGODB_INJECTION',
                 makeRequest: (done, config) => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mongoose.plugin.spec.js
@@ -52,74 +52,15 @@ describe('nosql injection detection in mongodb - whole feature', () => {
 
       prepareTestServerForIastInExpress('Test with mongoose', expressVersion,
         (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
-          testThatRequestHasVulnerability({
-            fn: async (req, res) => {
-              Test.find({
-                name: req.query.key,
-                value: [1, 2,
-                  'value',
-                  false, req.query.key]
-              }).then(() => {
-                res.end()
-              })
-            },
-            vulnerability: 'NOSQL_MONGODB_INJECTION',
-            makeRequest: (done, config) => {
-              axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
-            }
-          })
-
-          testThatRequestHasVulnerability({
-            fn: async (req, res) => {
-              Test.find({
-                name: {
-                  child: [req.query.key]
-                }
-              }).then(() => {
-                res.end()
-              })
-            },
-            vulnerability: 'NOSQL_MONGODB_INJECTION',
-            makeRequest: (done, config) => {
-              axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
-            }
-          })
-
-          testThatRequestHasVulnerability({
-            testDescription: 'should have NOSQL_MONGODB_INJECTION vulnerability in correct file and line',
-            fn: async (req, res) => {
-              const filter = {
-                name: {
-                  child: [req.query.key]
-                }
-              }
-              require(tmpFilePath)(Test, filter, () => {
-                res.end()
-              })
-            },
-            vulnerability: 'NOSQL_MONGODB_INJECTION',
-            makeRequest: (done, config) => {
-              axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
-            },
-            occurrences: {
-              occurrences: 1,
-              location: {
-                path: vulnerableMethodFilename,
-                line: 4
-              }
-            }
-          })
-
-          if (semver.satisfies(specificMongooseVersion, '>=6')) {
-            testThatRequestHasNoVulnerability({
-              testDescription: 'should not have NOSQL_MONGODB_INJECTION vulnerability with mongoose.sanitizeFilter',
+          describe('using promises', () => {
+            testThatRequestHasVulnerability({
               fn: async (req, res) => {
-                const filter = mongoose.sanitizeFilter({
-                  name: {
-                    child: [req.query.key]
-                  }
-                })
-                Test.find(filter).then(() => {
+                Test.find({
+                  name: req.query.key,
+                  value: [1, 2,
+                    'value',
+                    false, req.query.key]
+                }).then(() => {
                   res.end()
                 })
               },
@@ -128,15 +69,93 @@ describe('nosql injection detection in mongodb - whole feature', () => {
                 axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
               }
             })
-          }
 
-          testThatRequestHasNoVulnerability(async (req, res) => {
-            Test.find({
-              name: 'test'
-            }).then(() => {
-              res.end()
+            testThatRequestHasVulnerability({
+              fn: async (req, res) => {
+                Test.find({
+                  name: {
+                    child: [req.query.key]
+                  }
+                }).then(() => {
+                  res.end()
+                })
+              },
+              vulnerability: 'NOSQL_MONGODB_INJECTION',
+              makeRequest: (done, config) => {
+                axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
+              }
             })
-          }, 'NOSQL_MONGODB_INJECTION')
+
+            testThatRequestHasVulnerability({
+              testDescription: 'should have NOSQL_MONGODB_INJECTION vulnerability in correct file and line',
+              fn: async (req, res) => {
+                const filter = {
+                  name: {
+                    child: [req.query.key]
+                  }
+                }
+                require(tmpFilePath)(Test, filter, () => {
+                  res.end()
+                })
+              },
+              vulnerability: 'NOSQL_MONGODB_INJECTION',
+              makeRequest: (done, config) => {
+                axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
+              },
+              occurrences: {
+                occurrences: 1,
+                location: {
+                  path: vulnerableMethodFilename,
+                  line: 4
+                }
+              }
+            })
+
+            if (semver.satisfies(specificMongooseVersion, '>=6')) {
+              testThatRequestHasNoVulnerability({
+                testDescription: 'should not have NOSQL_MONGODB_INJECTION vulnerability with mongoose.sanitizeFilter',
+                fn: async (req, res) => {
+                  const filter = mongoose.sanitizeFilter({
+                    name: {
+                      child: [req.query.key]
+                    }
+                  })
+                  Test.find(filter).then(() => {
+                    res.end()
+                  })
+                },
+                vulnerability: 'NOSQL_MONGODB_INJECTION',
+                makeRequest: (done, config) => {
+                  axios.get(`http://localhost:${config.port}/?key=value`).catch(done)
+                }
+              })
+            }
+
+            testThatRequestHasNoVulnerability(async (req, res) => {
+              Test.find({
+                name: 'test'
+              }).then(() => {
+                res.end()
+              })
+            }, 'NOSQL_MONGODB_INJECTION')
+          })
+
+          if (semver.satisfies(specificMongooseVersion, '^6.0.0')) {
+            describe('using callbacks', () => {
+              testThatRequestHasNoVulnerability(async (req, res) => {
+                try {
+                  Test.find({
+                    name: 'test'
+                  }).exec(() => {
+                    res.end()
+                  })
+                } catch (e) {
+                  res.writeHead(500)
+                  res.end()
+                }
+              }, 'NOSQL_MONGODB_INJECTION')
+            })
+          }
         })
     })
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix mongoose instrumentation when it is used with `.exec(callback)` function, like `Model.find(query).exec(cb)` instead of `Model.find(query).then(cb)` or `Model.find(query, cb)`.
### Motivation
<!-- What inspired you to submit this pull request? -->
Fix bug

### Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

