### PR TITLE
Cache appsec metrics

### DIFF
--- a/packages/dd-trace/src/appsec/telemetry/cache.js
+++ b/packages/dd-trace/src/appsec/telemetry/cache.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const telemetryMetrics = require('../../telemetry/metrics')
+const { REQUEST_BLOCKED, RULE_TRIGGERED, WAF_TIMEOUT, EVENT_RULES_VERSION } = require('./tags')
+
+const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
+
+const cacheKeyProvider = {
+  'waf.requests': (metricTags) => {
+    let key
+    if (metricTags[REQUEST_BLOCKED]) {
+      key = 'waf.requests-blocked'
+    } else if (metricTags[RULE_TRIGGERED]) {
+      key = 'waf.requests-rule-triggered'
+    } else {
+      key = 'waf.requests-normal'
+    }
+
+    if (metricTags[WAF_TIMEOUT]) {
+      key += '-timeout'
+    }
+
+    return key
+  }
+}
+
+const metricsCache = new Map()
+
+let currentRulesVersion
+
+function getMetricKey (name, tags) {
+  return cacheKeyProvider[name] ? cacheKeyProvider[name](tags) : name
+}
+
+function getMetric (metricName, metricTags = {}, type = 'count') {
+  const rulesVersion = metricTags[EVENT_RULES_VERSION]
+  if (!rulesVersion) return
+
+  if (rulesVersion !== currentRulesVersion) {
+    metricsCache.clear()
+    currentRulesVersion = rulesVersion
+  }
+
+  const metricKey = getMetricKey(metricName, metricTags)
+
+  let metric = metricsCache.get(metricKey)
+  if (!metric) {
+    metric = appsecMetrics[type](metricName, metricTags)
+    metricsCache.set(metricKey, metric)
+  }
+
+  return metric
+}
+
+function clearCache () {
+  metricsCache.clear()
+}
+
+module.exports = {
+  getMetric,
+  clearCache
+}

--- a/packages/dd-trace/src/appsec/telemetry/tags.js
+++ b/packages/dd-trace/src/appsec/telemetry/tags.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = {
+  REQUEST_BLOCKED: 'request_blocked',
+  RULE_TRIGGERED: 'rule_triggered',
+  WAF_TIMEOUT: 'waf_timeout',
+  WAF_VERSION: 'waf_version',
+  EVENT_RULES_VERSION: 'event_rules_version'
+}

--- a/packages/dd-trace/test/appsec/telemetry/cache.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/cache.spec.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const telemetryMetrics = require('../../../src/telemetry/metrics')
+const cache = require('../../../src/appsec/telemetry/cache')
+const {
+  EVENT_RULES_VERSION,
+  REQUEST_BLOCKED,
+  RULE_TRIGGERED,
+  WAF_TIMEOUT
+} = require('../../../src/appsec/telemetry/tags')
+
+const appsecNamespace = telemetryMetrics.manager.namespace('appsec')
+
+describe('Appsec Telemetry metrics cache', () => {
+  let tags, count, distribution
+
+  beforeEach(() => {
+    tags = { [EVENT_RULES_VERSION]: '0.0.1' }
+
+    count = sinon.stub(appsecNamespace, 'count').callThrough()
+    distribution = sinon.stub(appsecNamespace, 'distribution').callThrough()
+
+    appsecNamespace.metrics.clear()
+    appsecNamespace.distributions.clear()
+  })
+
+  afterEach(() => {
+    cache.clearCache()
+    sinon.restore()
+  })
+
+  describe('getMetric', () => {
+    it('should do nothing if EVENT_RULES_VERSION tag is not provided', () => {
+      expect(cache.getMetric('metric.name')).to.be.undefined
+    })
+
+    it('should return a metric of count type by default', () => {
+      cache.getMetric('metric.name', tags)
+      expect(count).to.be.calledOnceWith('metric.name')
+    })
+
+    it('should return a a metric of distribution type if specified', () => {
+      cache.getMetric('metric.name', tags, 'distribution')
+      expect(distribution).to.be.calledOnceWith('metric.name')
+    })
+
+    it('should use the cache to store created metrics', () => {
+      const metric1 = cache.getMetric('metric.name', tags)
+      const metric2 = cache.getMetric('metric.name', tags)
+
+      expect(count).to.be.calledOnceWith('metric.name')
+      expect(metric1).to.be.eq(metric2)
+    })
+
+    it('should clear the cache if new EVENT_RULES_VERSION tag is provided', () => {
+      const metric1 = cache.getMetric('metric.name', tags)
+
+      const metric2 = cache.getMetric('metric.name', { [EVENT_RULES_VERSION]: '0.0.2' })
+
+      expect(count).to.be.calledTwice
+      expect(metric1).to.not.eq(metric2)
+    })
+
+    describe('with waf.requests', () => {
+      it('should use the same cached metric for same tags', () => {
+        const metric1 = cache.getMetric('waf.requests', { [WAF_TIMEOUT]: false, ...tags })
+
+        const metric2 = cache.getMetric('waf.requests', { [WAF_TIMEOUT]: false, ...tags })
+
+        expect(metric1).to.be.eq(metric2)
+      })
+
+      it('should use different cached metrics for different tags', () => {
+        const metric1 = cache.getMetric('waf.requests', { [REQUEST_BLOCKED]: true, ...tags })
+
+        const metric2 = cache.getMetric('waf.requests', { [RULE_TRIGGERED]: true, ...tags })
+
+        expect(metric1).to.be.not.eq(metric2)
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/telemetry/index.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/index.spec.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const telemetryMetrics = require('../../src/telemetry/metrics')
+const telemetryMetrics = require('../../../src/telemetry/metrics')
 const appsecNamespace = telemetryMetrics.manager.namespace('appsec')
 
-const appsecTelemetry = require('../../src/appsec/telemetry')
+const appsecTelemetry = require('../../../src/appsec/telemetry')
 
 describe('Appsec Telemetry metrics', () => {
   const wafVersion = '0.0.1'
@@ -27,7 +27,10 @@ describe('Appsec Telemetry metrics', () => {
     appsecNamespace.distributions.clear()
   })
 
-  afterEach(sinon.restore)
+  afterEach(() => {
+    sinon.restore()
+    appsecTelemetry.disable()
+  })
 
   describe('if enabled', () => {
     beforeEach(() => {


### PR DESCRIPTION
### What does this PR do?
Cache appsec metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

