### PR TITLE
[ci-visibility] Add browser name as test configuration in playwright

### DIFF
--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -16,7 +16,8 @@ const {
   TEST_STATUS,
   TEST_SOURCE_START,
   TEST_TYPE,
-  TEST_SOURCE_FILE
+  TEST_SOURCE_FILE,
+  TEST_CONFIGURATION_BROWSER_NAME
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
 const versions = ['1.18.0', 'latest']
@@ -110,6 +111,8 @@ versions.forEach((version) => {
               // Can read DD_TAGS
               assert.propertyVal(testEvent.content.meta, 'test.customtag', 'customvalue')
               assert.propertyVal(testEvent.content.meta, 'test.customtag2', 'customvalue2')
+              // Adds the browser used
+              assert.propertyVal(testEvent.content.meta, TEST_CONFIGURATION_BROWSER_NAME, 'chromium')
             })
 
             stepEvents.forEach(stepEvent => {

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -10,7 +10,8 @@ const {
   getTestSuiteCommonTags,
   TEST_SOURCE_START,
   TEST_CODE_OWNERS,
-  TEST_SOURCE_FILE
+  TEST_SOURCE_FILE,
+  TEST_CONFIGURATION_BROWSER_NAME
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -77,11 +78,11 @@ class PlaywrightPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
     })
 
-    this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine }) => {
+    this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine, browserName }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
-      const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine)
+      const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine, browserName)
 
       this.enter(span, store)
     })
@@ -128,7 +129,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
   }
 
-  startTestSpan (testName, testSuite, testSourceFile, testSourceLine) {
+  startTestSpan (testName, testSuite, testSourceFile, testSourceLine, browserName) {
     const testSuiteSpan = this._testSuites.get(testSuite)
 
     const extraTags = {
@@ -136,6 +137,9 @@ class PlaywrightPlugin extends CiPlugin {
     }
     if (testSourceFile) {
       extraTags[TEST_SOURCE_FILE] = testSourceFile || testSuite
+    }
+    if (browserName) {
+      extraTags[TEST_CONFIGURATION_BROWSER_NAME] = browserName
     }
 
     return super.startTestSpan(testName, testSuite, testSuiteSpan, extraTags)

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -48,6 +48,9 @@ const TEST_MODULE_ID = 'test_module_id'
 const TEST_SUITE_ID = 'test_suite_id'
 const TEST_TOOLCHAIN = 'test.toolchain'
 const TEST_SKIPPED_BY_ITR = 'test.skipped_by_itr'
+// Browser used in browser test. Namespaced by test.configuration because it affects the fingerprint
+const TEST_CONFIGURATION_BROWSER_NAME = 'test.configuration.browser_name'
+// Early flake detection
 const TEST_IS_NEW = 'test.is_new'
 const TEST_EARLY_FLAKE_IS_RETRY = 'test.early_flake.is_retry'
 const TEST_EARLY_FLAKE_IS_ENABLED = 'test.early_flake.is_enabled'
@@ -90,6 +93,7 @@ module.exports = {
   JEST_WORKER_COVERAGE_PAYLOAD_CODE,
   TEST_SOURCE_START,
   TEST_SKIPPED_BY_ITR,
+  TEST_CONFIGURATION_BROWSER_NAME,
   TEST_IS_NEW,
   TEST_EARLY_FLAKE_IS_RETRY,
   TEST_EARLY_FLAKE_IS_ENABLED,


### PR DESCRIPTION
### What does this PR do?
Add the browser used by playwright as metadata in the test. 

### Motivation

Other than letting the user know what browser was used and allowing them to filter / query by it, it's important for our definition of test fingerprint: if we don't add this piece of metadata, the same test run for multiple browsers will not be distinguishable in our UI. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

