### PR TITLE
[ci-visibility] Fix typo in `log.error`

### DIFF
--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -38,7 +38,7 @@ function getKnownTests ({
   } else {
     const apiKey = process.env.DATADOG_API_KEY || process.env.DD_API_KEY
     if (!apiKey) {
-      return done(new Error('Skippable suites were not fetched because Datadog API key is not defined.'))
+      return done(new Error('Known tests were not fetched because Datadog API key is not defined.'))
     }
 
     options.headers['dd-api-key'] = apiKey


### PR DESCRIPTION
### What does this PR do?
Fix typo in `log.error` if `getKnownTests` request fails.

### Motivation
Do not mislead the user.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

