### PR TITLE
APM uninstrumentation: small fix to preserve original behaviour

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -118,8 +118,10 @@ class Tracer extends NoopProxy {
         require('./appsec/iast').enable(config, this._tracer)
       }
     } else {
-      require('./appsec').disable()
-      require('./appsec/iast').disable()
+      if (this._tracingInitialized) {
+        require('./appsec').disable()
+        require('./appsec/iast').disable()
+      }
     }
     if (this._tracingInitialized) {
       this._tracer.configure(config)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -117,12 +117,11 @@ class Tracer extends NoopProxy {
       if (config.iast.enabled) {
         require('./appsec/iast').enable(config, this._tracer)
       }
-    } else {
-      if (this._tracingInitialized) {
-        require('./appsec').disable()
-        require('./appsec/iast').disable()
-      }
+    } else if (this._tracingInitialized) {
+      require('./appsec').disable()
+      require('./appsec/iast').disable()
     }
+
     if (this._tracingInitialized) {
       this._tracer.configure(config)
       this._pluginManager.configure(config)


### PR DESCRIPTION
### What does this PR do?
We do not want to require appsec and iast when trying to disable them, if they haven't already been required.

### Motivation
`_enableOrDisableTracing` was written to extend remote config support for DD_TRACING_ENABLED. Other than adding the capability to toggle tracing_enabled dynamically, we want to preserve the original behaviour of proxy.js. This PR was made to ensure we are not adding requires at the places we didn't used to.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

