### PR TITLE
[ci-visibility] Early flake detection for mocha 

### DIFF
--- a/integration-tests/ci-visibility/test-early-flake-detection/mocha-parameterized.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/mocha-parameterized.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai')
+const forEach = require('mocha-each')
+
+describe('parameterized', () => {
+  forEach(['parameter 1', 'parameter 2']).it('test %s', (value) => {
+    expect(value.startsWith('parameter')).to.be.true
+  })
+})

--- a/integration-tests/ci-visibility/test-early-flake-detection/skipped-and-todo-test.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/skipped-and-todo-test.js
@@ -4,7 +4,10 @@ describe('ci visibility', () => {
   it('can report tests', () => {
     expect(1 + 2).to.equal(3)
   })
-  it.todo('todo will not be retried')
+  // only run for jest tests
+  if (typeof jest !== 'undefined') {
+    it.todo('todo will not be retried')
+  }
   it.skip('skip will not be retried', () => {
     expect(1 + 2).to.equal(4)
   })

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -11,7 +11,8 @@ const {
   mergeCoverage,
   getTestSuitePath,
   fromCoverageMapToCoverage,
-  getCallSites
+  getCallSites,
+  addEfdStringToTestName
 } = require('../../dd-trace/src/plugins/util/test')
 
 const testStartCh = channel('ci:mocha:test:start')
@@ -56,6 +57,7 @@ const unskippableSuites = []
 let isForcedToRun = false
 let itrCorrelationId = ''
 let isEarlyFlakeDetectionEnabled = false
+let earlyFlakeDetectionNumRetries = 0
 let isSuitesSkippingEnabled = false
 let knownTests = []
 
@@ -102,6 +104,33 @@ function isNewTest (test) {
     .includes(`mocha.${getTestSuitePath(test.file, process.cwd())}.${test.fullTitle()}`)
 }
 
+function retryTest (test) {
+  const originalTestName = test.title
+  const suite = test.parent
+  for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
+    const clonedTest = test.clone()
+    clonedTest.title = addEfdStringToTestName(originalTestName, retryIndex + 1)
+    suite.addTest(clonedTest)
+    clonedTest._ddIsNew = true
+    clonedTest._ddIsEfdRetry = true
+  }
+}
+
+function getFailingNewTests (root) {
+  let failingTests = []
+  function getTests (suite) {
+    if (suite.tests?.length) {
+      failingTests = failingTests.concat(suite.tests.filter(test => test._ddIsNew && test.isFailed()))
+    }
+    suite.suites.forEach(suite => {
+      getTests(suite)
+    })
+  }
+  getTests(root)
+
+  return failingTests
+}
+
 function getTestAsyncResource (test) {
   if (!test.fn) {
     return testToAr.get(test)
@@ -132,6 +161,19 @@ function mochaHook (Runner) {
 
   patched.add(Runner)
 
+  shimmer.wrap(Runner.prototype, 'runTests', runTests => function (suite, fn) {
+    if (isEarlyFlakeDetectionEnabled) {
+      // by the time we reach `this.on('test')`, it is too late. We need to add retries here
+      suite.tests.forEach(test => {
+        if (isNewTest(test)) {
+          test._ddIsNew = true
+          retryTest(test)
+        }
+      })
+    }
+    return runTests.apply(this, arguments)
+  })
+
   shimmer.wrap(Runner.prototype, 'run', run => function () {
     if (!testStartCh.hasSubscribers || isWorker) {
       return run.apply(this, arguments)
@@ -151,6 +193,14 @@ function mochaHook (Runner) {
         }
       } else if (this.failures !== 0) {
         status = 'fail'
+      }
+
+      const failingNewTests = getFailingNewTests(this.suite)
+      if (failingNewTests.length) {
+        // If test is going through early flake detection and has failures, we don't
+        // want to fail the process
+        this.stats.failures -= failingNewTests.length
+        this.failures -= failingNewTests.length
       }
 
       if (status === 'fail') {
@@ -259,12 +309,10 @@ function mochaHook (Runner) {
       if (isRetry(test)) {
         return
       }
-      if (isEarlyFlakeDetectionEnabled && isNewTest(test)) {
-        debugger
-      }
       const testStartLine = testToStartLine.get(test)
       const asyncResource = new AsyncResource('bound-anonymous-fn')
       testToAr.set(test.fn, asyncResource)
+      // TODO: do not pass the "test" object but a normalized structure
       asyncResource.runInAsyncScope(() => {
         testStartCh.publish({ test, testStartLine })
       })
@@ -455,13 +503,13 @@ addHook({
     }
 
     const onReceivedConfiguration = ({ err, libraryConfig }) => {
-      debugger
       if (err || !skippableSuitesCh.hasSubscribers || !knownTestsCh.hasSubscribers) {
         return global.run()
       }
 
       isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
       isSuitesSkippingEnabled = libraryConfig.isSuitesSkippingEnabled
+      earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
 
       if (isEarlyFlakeDetectionEnabled) {
         knownTestsCh.publish({

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -121,22 +121,6 @@ function retryTest (test) {
   }
 }
 
-// Get the tests that are failing and are new
-function getFailingNewTests (root) {
-  let failingNewTests = []
-  function getTests (suite) {
-    if (suite.tests?.length) {
-      failingNewTests = failingNewTests.concat(suite.tests.filter(test => test._ddIsNew && test.isFailed()))
-    }
-    suite.suites.forEach(suite => {
-      getTests(suite)
-    })
-  }
-  getTests(root)
-
-  return failingNewTests
-}
-
 function getTestAsyncResource (test) {
   if (!test.fn) {
     return testToAr.get(test)

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -165,7 +165,7 @@ function mochaHook (Runner) {
     if (isEarlyFlakeDetectionEnabled) {
       // by the time we reach `this.on('test')`, it is too late. We need to add retries here
       suite.tests.forEach(test => {
-        if (isNewTest(test)) {
+        if (!test.isPending() && isNewTest(test)) {
           test._ddIsNew = true
           retryTest(test)
         }
@@ -227,7 +227,8 @@ function mochaHook (Runner) {
         numSkippedSuites: skippedSuites.length,
         hasForcedToRunSuites: isForcedToRun,
         hasUnskippableSuites: !!unskippableSuites.length,
-        error
+        error,
+        isEarlyFlakeDetectionEnabled
       })
     }))
 

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -19,7 +19,8 @@ const {
   TEST_SOURCE_FILE,
   removeEfdStringFromTestName,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY
+  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_EARLY_FLAKE_IS_ENABLED
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -193,7 +194,8 @@ class MochaPlugin extends CiPlugin {
       numSkippedSuites,
       hasForcedToRunSuites,
       hasUnskippableSuites,
-      error
+      error,
+      isEarlyFlakeDetectionEnabled
     }) => {
       if (this.testSessionSpan) {
         const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.libraryConfig || {}
@@ -219,6 +221,10 @@ class MochaPlugin extends CiPlugin {
             hasUnskippableSuites
           }
         )
+
+        if (isEarlyFlakeDetectionEnabled) {
+          this.testSessionSpan.setTag(TEST_EARLY_FLAKE_IS_ENABLED, 'true')
+        }
 
         this.testModuleSpan.finish()
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'module')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -43,7 +43,7 @@ class MochaPlugin extends CiPlugin {
     super(...args)
 
     this._testSuites = new Map()
-    this._testNameToParams = {}
+    this._testTitleToParams = {}
     this.sourceRoot = process.cwd()
 
     this.addSub('ci:mocha:test-suite:code-coverage', ({ coverageFiles, suiteFile }) => {
@@ -135,9 +135,9 @@ class MochaPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:mocha:test:start', ({ test, testStartLine }) => {
+    this.addSub('ci:mocha:test:start', (testInfo) => {
       const store = storage.getStore()
-      const span = this.startTestSpan(test, testStartLine)
+      const span = this.startTestSpan(testInfo)
 
       this.enter(span, store)
     })
@@ -160,12 +160,12 @@ class MochaPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:mocha:test:skip', (test) => {
+    this.addSub('ci:mocha:test:skip', (testInfo) => {
       const store = storage.getStore()
       // skipped through it.skip, so the span is not created yet
       // for this test
       if (!store) {
-        const testSpan = this.startTestSpan(test)
+        const testSpan = this.startTestSpan(testInfo)
         this.enter(testSpan, store)
       }
     })
@@ -183,8 +183,8 @@ class MochaPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:mocha:test:parameterize', ({ name, params }) => {
-      this._testNameToParams[name] = params
+    this.addSub('ci:mocha:test:parameterize', ({ title, params }) => {
+      this._testTitleToParams[title] = params
     })
 
     this.addSub('ci:mocha:session:finish', ({
@@ -237,12 +237,19 @@ class MochaPlugin extends CiPlugin {
     })
   }
 
-  startTestSpan (test, testStartLine) {
-    const testName = removeEfdStringFromTestName(test.fullTitle())
-    const { file: testSuiteAbsolutePath, title, _ddIsNew, _ddIsEfdRetry } = test
+  startTestSpan (testInfo) {
+    const {
+      testSuiteAbsolutePath,
+      title,
+      isNew,
+      isEfdRetry,
+      testStartLine
+    } = testInfo
+
+    const testName = removeEfdStringFromTestName(testInfo.testName)
 
     const extraTags = {}
-    const testParametersString = getTestParametersString(this._testNameToParams, title)
+    const testParametersString = getTestParametersString(this._testTitleToParams, title)
     if (testParametersString) {
       extraTags[TEST_PARAMETERS] = testParametersString
     }
@@ -254,17 +261,15 @@ class MochaPlugin extends CiPlugin {
     const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.sourceRoot)
     const testSuiteSpan = this._testSuites.get(testSuiteAbsolutePath)
 
-    const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
-
-    if (testSourceFile) {
-      extraTags[TEST_SOURCE_FILE] = testSourceFile
+    if (this.repositoryRoot !== this.sourceRoot && !!this.repositoryRoot) {
+      extraTags[TEST_SOURCE_FILE] = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
     } else {
       extraTags[TEST_SOURCE_FILE] = testSuite
     }
 
-    if (_ddIsNew) {
+    if (isNew) {
       extraTags[TEST_IS_NEW] = 'true'
-      if (_ddIsEfdRetry) {
+      if (isEfdRetry) {
         extraTags[TEST_EARLY_FLAKE_IS_RETRY] = 'true'
       }
     }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -51,7 +51,7 @@ module.exports = class CiPlugin extends Plugin {
     })
 
     this.addSub(`ci:${this.constructor.id}:test-suite:skippable`, ({ onDone }) => {
-      if (!this.tracer._exporter || !this.tracer._exporter.getSkippableSuites) {
+      if (!this.tracer._exporter?.getSkippableSuites) {
         return onDone({ err: new Error('CI Visibility was not initialized correctly') })
       }
       this.tracer._exporter.getSkippableSuites(this.testConfiguration, (err, skippableSuites, itrCorrelationId) => {

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -74,6 +74,10 @@ const TEST_CODE_COVERAGE_LINES_PCT = 'test.code_coverage.lines_pct'
 const JEST_WORKER_TRACE_PAYLOAD_CODE = 60
 const JEST_WORKER_COVERAGE_PAYLOAD_CODE = 61
 
+// Early flake detection util strings
+const EFD_STRING = "Retried by Datadog's Early Flake Detection"
+const EFD_TEST_NAME_REGEX = new RegExp(EFD_STRING + ' \\(#\\d+\\): ', 'g')
+
 module.exports = {
   TEST_CODE_OWNERS,
   TEST_FRAMEWORK,
@@ -131,7 +135,11 @@ module.exports = {
   getTestLineStart,
   getCallSites,
   removeInvalidMetadata,
-  parseAnnotations
+  parseAnnotations,
+  EFD_STRING,
+  EFD_TEST_NAME_REGEX,
+  removeEfdStringFromTestName,
+  addEfdStringToTestName
 }
 
 // Returns pkg manager and its version, separated by '-', e.g. npm-8.15.0 or yarn-1.22.19
@@ -551,4 +559,12 @@ function parseAnnotations (annotations) {
     }
     return tags
   }, {})
+}
+
+function addEfdStringToTestName (testName, numAttempt) {
+  return `${EFD_STRING} (#${numAttempt}): ${testName}`
+}
+
+function removeEfdStringFromTestName (testName) {
+  return testName.replace(EFD_TEST_NAME_REGEX, '')
 }


### PR DESCRIPTION
### What does this PR do?

* Fetch known tests from `mocha` 
* When tests are about to run in `Runner.prototype.runTests`, we check which ones are new and duplicate them. 
* If some of the attempts fail, we want _not_ to fail the test process (so long as at least a single attempt is passing):
  * If tests both pass and fail, they will be detected as flaky. The user will still be able to block PRs on flakiness. By not failing the process outright, we give them the option to decide. 
  
ℹ️ Most of the lines changed are because I moved tests around, but the actual tests look almost identical. 

### Motivation
Implement early flake detection for `mocha`.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

