### PR TITLE
[ci-visibility] Fix ci visibility tests

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -35,7 +35,7 @@ let gitUploadStatus = DEFAULT_GIT_UPLOAD_STATUS
 let infoResponse = DEFAULT_INFO_RESPONSE
 let correlationId = DEFAULT_CORRELATION_ID
 let knownTests = DEFAULT_KNOWN_TESTS
-let waitingTime = null
+let waitingTime = 0
 
 class FakeCiVisIntake extends FakeAgent {
   setKnownTests (newKnownTestsResponse) {
@@ -225,6 +225,7 @@ class FakeCiVisIntake extends FakeAgent {
     if (this.waitingTimeoutId) {
       clearTimeout(this.waitingTimeoutId)
     }
+    waitingTime = 0
     return super.stop()
   }
 

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -829,8 +829,8 @@ testFrameworks.forEach(({
         receiver.setWaitingTime(30000)
         const eventsPromise = receiver
           .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            assert.include(testOutput, "Jest's '--forceExit' flag has been passed")
-            assert.include(testOutput, 'Timeout waiting for the tracer to flush')
+            assert.include(testOutput, "Jest's '--forceExit' flag has been passed", `Actual test output: ${testOutput}`)
+            assert.include(testOutput, 'Timeout waiting for the tracer to flush', `Actual test output: ${testOutput}`)
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             assert.equal(events.length, 0)
@@ -850,7 +850,6 @@ testFrameworks.forEach(({
         )
         childProcess.on('exit', () => {
           eventsPromise.then(() => {
-            receiver.setWaitingTime(0)
             done()
           }).catch(done)
         })

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -827,14 +827,6 @@ testFrameworks.forEach(({
       it('does not hang if server is not available and logs an error', (done) => {
         // Very slow intake
         receiver.setWaitingTime(30000)
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            assert.include(testOutput, "Jest's '--forceExit' flag has been passed", `Actual test output: ${testOutput}`)
-            assert.include(testOutput, 'Timeout waiting for the tracer to flush', `Actual test output: ${testOutput}`)
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            assert.equal(events.length, 0)
-          }, 12000)
         // Needs to run with the CLI if we want --forceExit to work
         childProcess = exec(
           'node ./node_modules/jest/bin/jest --config config-jest.js --forceExit',
@@ -848,10 +840,20 @@ testFrameworks.forEach(({
             stdio: 'inherit'
           }
         )
+        const EXPECTED_FORCE_EXIT_LOG_MESSAGE = "Jest's '--forceExit' flag has been passed"
+        const EXPECTED_TIMEOUT_LOG_MESSAGE = 'Timeout waiting for the tracer to flush'
         childProcess.on('exit', () => {
-          eventsPromise.then(() => {
-            done()
-          }).catch(done)
+          assert.include(
+            testOutput,
+            EXPECTED_FORCE_EXIT_LOG_MESSAGE,
+            `"${EXPECTED_FORCE_EXIT_LOG_MESSAGE}" log message is not in test output: ${testOutput}`
+          )
+          assert.include(
+            testOutput,
+            EXPECTED_TIMEOUT_LOG_MESSAGE,
+            `"${EXPECTED_TIMEOUT_LOG_MESSAGE}" log message is not in the test output: ${testOutput}`
+          )
+          done()
         })
         childProcess.stdout.on('data', (chunk) => {
           testOutput += chunk.toString()


### PR DESCRIPTION
### What does this PR do?
It seems `does not hang if server is not available and logs an error` is flaky and when it fails it makes the rest of the tests fail. 

In this PR:
* I fix `waitingTime` not being set to `0` after the test fails, causing the rest of the tests to fail.
* I fix the race condition in the test.
* I add logs to the assertions that are failing to debug better in the future. 

### Motivation
Fix flakiness.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

