### PR TITLE
fix node v14 compat for #4041 contribution

### DIFF
--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -33,7 +33,7 @@ describe('DataStreamWriter unix', () => {
   it("should call 'request' through flush with correct options", () => {
     writer = new DataStreamsWriter(unixConfig)
     writer.flush({})
-    const stubRequestCall = stubRequest.getCalls().at(0)
+    const stubRequestCall = stubRequest.getCalls()[0]
     const decodedPayload = msgpack.decode(stubRequestCall?.args[0], { codec })
     const requestOptions = stubRequestCall?.args[1]
     expect(decodedPayload).to.deep.equal({})


### PR DESCRIPTION
### What does this PR do?
- `Array#at()` isn't available on node v14

### Motivation
- fix the v3.x release https://github.com/DataDog/dd-trace-js/pull/4051