### PR TITLE
fixing the eu endpoint for agentless telemetry

### DIFF
--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -27,9 +27,6 @@ function getAgentlessTelemetryEndpoint (site) {
   if (site === 'datad0g.com') { // staging
     return 'https://all-http-intake.logs.datad0g.com'
   }
-  if (site === 'datadoghq.eu') {
-    return 'https://instrumentation-telemetry-intake.eu1.datadoghq.com'
-  }
   return `https://instrumentation-telemetry-intake.${site}`
 }
 

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -167,7 +167,7 @@ describe('sendData', () => {
       path: '/api/v2/apmtelemetry'
     })
     const { url } = options
-    expect(url).to.eql(new URL('https://instrumentation-telemetry-intake.eu1.datadoghq.com'))
+    expect(url).to.eql(new URL('https://instrumentation-telemetry-intake.datadoghq.eu'))
     delete process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED
   })
 })


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with dd-trace where the agentless-telemetry was not pointing to the correct domain for the eu site. 
currently it is pointing to https://instrumentation-telemetry-intake.eu1.datadoghq.com
it should be pointing to https://instrumentation-telemetry-intake.datadoghq.eu
I used the documentation here to address this issue:
https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/development.md#agentless

### Motivation
A trial customer was facing an issue implementing agentless telemetry in their application due to this issue. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->
I updated a unit test. 

- [X] Unit tests.
- [X] TypeScript [definitions][1].
- [X] TypeScript [tests][2].
- [X] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [X] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

