### PR TITLE
Avoid Max call stack size exceeded on vulnerability format

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -20,7 +20,7 @@ function iterateObject (target, fn, levelKeys = [], depth = 50) {
 
     fn(val, nextLevelKeys, target, key)
 
-    if (val !== null && typeof val === 'object') {
+    if (val !== null && typeof val === 'object' && depth > 0) {
       iterateObject(val, fn, nextLevelKeys, depth - 1)
     }
   })

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
@@ -156,7 +156,7 @@ describe('test vulnerabiilty-formatter utils', () => {
         circularObject.obj = circularObject
 
         const expectedObject = [...Array(50).keys()]
-          .reduce((obj, i) => ({ key: 'value', obj: obj || {} }), null)
+          .reduce((obj) => ({ key: 'value', obj: obj || {} }), null)
 
         const iinfo = { type: 'TEST' }
         const objRanges = {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
@@ -128,6 +128,49 @@ describe('test vulnerabiilty-formatter utils', () => {
           { start: 110, end: 112, iinfo }
         ])
       })
+
+      it('Very deep object', () => {
+        const deepObject = [...Array(100).keys()]
+          .reduce((obj) => ({ key: 'value', obj: obj || {} }), null)
+
+        const expectedObject = [...Array(50).keys()]
+          .reduce((obj) => ({ key: 'value', obj: obj || {} }), null)
+
+        const iinfo = { type: 'TEST' }
+        const deepestKey = '0'.concat('.obj'.repeat(49)).concat('.key')
+        const objRanges = {
+          [deepestKey]: [{ start: 0, end: 5, iinfo }]
+        }
+
+        const { value, ranges } = stringifyWithRanges([deepObject], objRanges)
+
+        expect(value).to.be.equal(JSON.stringify([expectedObject], null, 2))
+
+        expect(ranges).to.be.deep.equal([
+          { start: 6437, end: 6442, iinfo }
+        ])
+      })
+
+      it('Circular reference object', () => {
+        const circularObject = { key: 'value' }
+        circularObject.obj = circularObject
+
+        const expectedObject = [...Array(50).keys()]
+          .reduce((obj, i) => ({ key: 'value', obj: obj || {} }), null)
+
+        const iinfo = { type: 'TEST' }
+        const objRanges = {
+          '0.key': [{ start: 0, end: 5, iinfo }]
+        }
+
+        const { value, ranges } = stringifyWithRanges([circularObject], objRanges)
+
+        expect(value).to.be.equal(JSON.stringify([expectedObject], null, 2))
+
+        expect(ranges).to.be.deep.equal([
+          { start: 18, end: 23, iinfo }
+        ])
+      })
     })
 
     describe('loadSensitiveRanges = true', () => {


### PR DESCRIPTION
### What does this PR do?
Avoid `RangeError: Maximum call stack size exceeded` when formatting vulnerability 

### Motivation
Do not crash customer application.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!


[APPSEC-51769](https://datadoghq.atlassian.net/browse/APPSEC-51769)



[APPSEC-51769]: https://datadoghq.atlassian.net/browse/APPSEC-51769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ