### PR TITLE
Update types

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "main": "typedoc.js",
   "scripts": {
-    "build": "typedoc",
+    "build": "typedoc ../index.d.ts",
     "pretest": "tsc -p . && tsc test",
     "test": "node test"
   },
   "license": "BSD-3-Clause",
   "private": true,
   "devDependencies": {
-    "typedoc": "^0.17.3",
+    "typedoc": "^0.25.8",
     "typescript": "^4.6"
   }
 }

--- a/docs/typedoc.js
+++ b/docs/typedoc.js
@@ -4,8 +4,8 @@ module.exports = {
   excludeExternals: true,
   excludePrivate: true,
   excludeProtected: true,
-  includeDeclarations: true,
-  mode: 'file',
+  // includeDeclarations: true,
+  // mode: 'file',
   name: 'dd-trace',
   out: 'out',
   readme: 'API.md'

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2,249 +2,76 @@
 # yarn lockfile v1
 
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
   dependencies:
     balanced-match "^1.0.0"
-    concat-map "0.0.1"
 
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+jsonc-parser@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz#031904571ccf929d7670ee8c547545081cb37f1a"
+  integrity sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==
 
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-function-bind@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
-  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
-glob@^7.0.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
-  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
-
-handlebars@^4.7.6:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
-  dependencies:
-    minimist "^1.2.5"
-    neo-async "^2.6.2"
-    source-map "^0.6.1"
-    wordwrap "^1.0.0"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-hasown@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
-  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
-  dependencies:
-    function-bind "^1.1.2"
-
-highlight.js@^10.0.0:
-  version "10.7.3"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
-  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
-
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-interpret@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
-  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
-
-is-core-module@^2.13.0:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
-  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
-  dependencies:
-    hasown "^2.0.0"
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-lodash@^4.17.15:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lunr@^2.3.8:
+lunr@^2.3.9:
   version "2.3.9"
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
-marked@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
-  integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
-minimatch@^3.0.0, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
   dependencies:
-    brace-expansion "^1.1.7"
+    brace-expansion "^2.0.1"
 
-minimist@^1.2.5:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
-  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-neo-async@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
-  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+shiki@^0.14.7:
+  version "0.14.7"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.7.tgz#c3c9e1853e9737845f1d2ef81b31bcfb07056d4e"
+  integrity sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==
   dependencies:
-    wrappy "1"
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
 
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
-
-path-parse@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
-  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
-
-progress@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+typedoc@^0.25.8:
+  version "0.25.8"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.8.tgz#7d0e1bf12d23bf1c459fd4893c82cb855911ff12"
+  integrity sha512-mh8oLW66nwmeB9uTa0Bdcjfis+48bAjSH3uqdzSuSawfduROQLlXw//WSNZLYDdhmMVB7YcYZicq6e8T0d271A==
   dependencies:
-    resolve "^1.1.6"
-
-resolve@^1.1.6:
-  version "1.22.8"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
-  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
-  dependencies:
-    is-core-module "^2.13.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-shelljs@^0.8.4:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
-  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-source-map@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-supports-preserve-symlinks-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
-  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-typedoc-default-themes@^0.10.2:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz#743380a80afe62c5ef92ca1bd4abe2ac596be4d2"
-  integrity sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==
-  dependencies:
-    lunr "^2.3.8"
-
-typedoc@^0.17.3:
-  version "0.17.8"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.17.8.tgz#96b67e9454aa7853bfc4dc9a55c8a07adfd5478e"
-  integrity sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==
-  dependencies:
-    fs-extra "^8.1.0"
-    handlebars "^4.7.6"
-    highlight.js "^10.0.0"
-    lodash "^4.17.15"
-    lunr "^2.3.8"
-    marked "1.0.0"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    shelljs "^0.8.4"
-    typedoc-default-themes "^0.10.2"
+    lunr "^2.3.9"
+    marked "^4.3.0"
+    minimatch "^9.0.3"
+    shiki "^0.14.7"
 
 typescript@^4.6:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-uglify-js@^3.1.4:
-  version "3.17.4"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
-  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-wordwrap@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
-
-wrappy@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==

--- a/index.d.ts
+++ b/index.d.ts
@@ -891,7 +891,7 @@ declare namespace tracer {
     /**
      * Binds a target to the provided span, or the active span if omitted.
      *
-     * @param {Function|Promise} target Target that will have the span activated on its scope.
+     * @param {Function|Promise} fn Target that will have the span activated on its scope.
      * @param {Span} [span=scope.active()] The span to activate.
      * @returns The bound target.
      */
@@ -1741,15 +1741,12 @@ declare namespace tracer {
        * Returns a Tracer, creating one if one with the given name and version is
        * not already created.
        *
-       * This function may return different Tracer types (e.g.
-       * {@link NoopTracerProvider} vs. a functional tracer).
-       *
        * @param name The name of the tracer or instrumentation library.
        * @param version The version of the tracer or instrumentation library.
        * @param options The options of the tracer or instrumentation library.
        * @returns Tracer A Tracer with the given name and version
        */
-      getTracer(name: string, version?: string): Tracer;
+      getTracer(name: string, version?: string, options?: any): Tracer;
 
       /**
        * Register this tracer provider with @opentelemetry/api
@@ -1821,9 +1818,9 @@ declare namespace tracer {
        *     do some more work
        *     span.end();
        */
-      startActiveSpan<F extends (span: Span) => unknown>(name: string, fn: F): ReturnType<F>;
-      startActiveSpan<F extends (span: Span) => unknown>(name: string, options: SpanOptions, fn: F): ReturnType<F>;
       startActiveSpan<F extends (span: Span) => unknown>(name: string, options: SpanOptions, context: otel.Context, fn: F): ReturnType<F>;
+      startActiveSpan<F extends (span: Span) => unknown>(name: string, options: SpanOptions, fn: F): ReturnType<F>;
+      startActiveSpan<F extends (span: Span) => unknown>(name: string, fn: F): ReturnType<F>;
     }
 
     /**
@@ -1873,14 +1870,14 @@ declare namespace tracer {
        * @param name the name of the event.
        * @param [attributesOrStartTime] the attributes that will be added; these are
        *     associated with this event. Can be also a start time
-       *     if type is {@type TimeInput} and 3rd param is undefined
+       *     if type is {@link TimeInput} and 3rd param is undefined
        * @param [startTime] start time of the event.
        */
       addEvent(name: string, attributesOrStartTime?: SpanAttributes | TimeInput, startTime?: TimeInput): this;
 
       /**
        * Sets a status to the span. If used, this will override the default Span
-       * status. Default is {@link SpanStatusCode.UNSET}. SetStatus overrides the value
+       * status. Default is {@link otel.SpanStatusCode.UNSET}. SetStatus overrides the value
        * of previous calls to SetStatus on the Span.
        *
        * @param status the SpanStatus to set.
@@ -1940,7 +1937,7 @@ declare namespace tracer {
 
     /**
      * A SpanContext represents the portion of a {@link Span} which must be
-     * serialized and propagated along side of a {@link Baggage}.
+     * serialized and propagated along side of a {@link otel.Baggage}.
      */
     export interface SpanContext extends otel.SpanContext {
       /**
@@ -1971,7 +1968,7 @@ declare namespace tracer {
        * caller may have recorded trace data. A caller who does not record trace
        * data out-of-band leaves this flag unset.
        *
-       * see {@link TraceFlags} for valid flag values.
+       * see {@link otel.TraceFlags} for valid flag values.
        */
       traceFlags: number;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,29 @@
 import { ClientRequest, IncomingMessage, OutgoingMessage, ServerResponse } from "http";
 import { LookupFunction } from 'net';
 import * as opentracing from "opentracing";
-import { SpanOptions } from "opentracing/lib/tracer";
 import * as otel from "@opentelemetry/api";
-
-export { SpanOptions };
 
 /**
  * Tracer is the entry-point of the Datadog tracing implementation.
  */
-export declare interface Tracer extends opentracing.Tracer {
+interface Tracer extends opentracing.Tracer {
+  /**
+   * Add tracer as a named export
+   */
+  tracer: Tracer;
+
+  /**
+   * For compatibility with NodeNext + esModuleInterop: false
+   */
+  default: Tracer;
+
   /**
    * Starts and returns a new Span representing a logical unit of work.
    * @param {string} name The name of the operation.
-   * @param {SpanOptions} [options] Options for the newly created span.
+   * @param {tracer.SpanOptions} [options] Options for the newly created span.
    * @returns {Span} A new Span object.
    */
-  startSpan (name: string, options?: SpanOptions): Span;
+  startSpan (name: string, options?: tracer.SpanOptions): tracer.Span;
 
   /**
    * Injects the given SpanContext instance for cross-process propagation
@@ -28,7 +35,7 @@ export declare interface Tracer extends opentracing.Tracer {
    * @param  {string} format The format of the carrier.
    * @param  {any} carrier The carrier object.
    */
-  inject (spanContext: SpanContext | Span, format: string, carrier: any): void;
+  inject (spanContext: tracer.SpanContext | tracer.Span, format: string, carrier: any): void;
 
   /**
    * Returns a SpanContext instance extracted from `carrier` in the given
@@ -39,12 +46,12 @@ export declare interface Tracer extends opentracing.Tracer {
    *         The extracted SpanContext, or null if no such SpanContext could
    *         be found in `carrier`
    */
-  extract (format: string, carrier: any): SpanContext | null;
+  extract (format: string, carrier: any): tracer.SpanContext | null;
 
   /**
    * Initializes the tracer. This should be called before importing other libraries.
    */
-  init (options?: TracerOptions): this;
+  init (options?: tracer.TracerOptions): this;
 
   /**
    * Sets the URL for the trace agent. This should only be called _after_
@@ -63,7 +70,7 @@ export declare interface Tracer extends opentracing.Tracer {
   /**
    * Returns a reference to the current scope.
    */
-  scope (): Scope;
+  scope (): tracer.Scope;
 
   /**
    * Instruments a function by automatically creating a span activated on its
@@ -83,9 +90,9 @@ export declare interface Tracer extends opentracing.Tracer {
    * unless there is already an active span or `childOf` option. Note that this
    * option is deprecated and has been removed in version 4.0.
    */
-  trace<T> (name: string, fn: (span: Span) => T): T;
-  trace<T> (name: string, fn: (span: Span, done: (error?: Error) => void) => T): T;
-  trace<T> (name: string, options: TraceOptions & SpanOptions, fn: (span?: Span, done?: (error?: Error) => void) => T): T;
+  trace<T> (name: string, fn: (span: tracer.Span) => T): T;
+  trace<T> (name: string, fn: (span: tracer.Span, done: (error?: Error) => void) => T): T;
+  trace<T> (name: string, options: tracer.TraceOptions & tracer.SpanOptions, fn: (span?: tracer.Span, done?: (error?: Error) => void) => T): T;
 
   /**
    * Wrap a function to automatically create a span activated on its
@@ -102,8 +109,8 @@ export declare interface Tracer extends opentracing.Tracer {
    * which case the span will finish at the end of the function execution.
    */
   wrap<T = (...args: any[]) => any> (name: string, fn: T): T;
-  wrap<T = (...args: any[]) => any> (name: string, options: TraceOptions & SpanOptions, fn: T): T;
-  wrap<T = (...args: any[]) => any> (name: string, options: (...args: any[]) => TraceOptions & SpanOptions, fn: T): T;
+  wrap<T = (...args: any[]) => any> (name: string, options: tracer.TraceOptions & tracer.SpanOptions, fn: T): T;
+  wrap<T = (...args: any[]) => any> (name: string, options: (...args: any[]) => tracer.TraceOptions & tracer.SpanOptions, fn: T): T;
 
   /**
    * Create and return a string that can be included in the <head> of a
@@ -117,1879 +124,1885 @@ export declare interface Tracer extends opentracing.Tracer {
    * @param {User} user Properties of the authenticated user. Accepts custom fields.
    * @returns {Tracer} The Tracer instance for chaining.
    */
-  setUser (user: User): Tracer;
+  setUser (user: tracer.User): Tracer;
 
-  appsec: Appsec;
+  appsec: tracer.Appsec;
 
-  TracerProvider: opentelemetry.TracerProvider;
+  TracerProvider: tracer.opentelemetry.TracerProvider;
 
-  dogstatsd: DogStatsD;
+  dogstatsd: tracer.DogStatsD;
 }
 
-export declare interface TraceOptions extends Analyzable {
-  /**
-   * The resource you are tracing. The resource name must not be longer than
-   * 5000 characters.
-   */
-  resource?: string,
-
-  /**
-   * The service you are tracing. The service name must not be longer than
-   * 100 characters.
-   */
-  service?: string,
-
-  /**
-   * The type of request.
-   */
-  type?: string
-
-  /**
-   * An array of span links
-   */
-  links?: Array<{ context: SpanContext, attributes?: Object }>
+// left out of the namespace, so it
+// is doesn't need to be exported for Tracer
+/** @hidden */
+interface Plugins {
+  "amqp10": tracer.plugins.amqp10;
+  "amqplib": tracer.plugins.amqplib;
+  "aws-sdk": tracer.plugins.aws_sdk;
+  "bunyan": tracer.plugins.bunyan;
+  "cassandra-driver": tracer.plugins.cassandra_driver;
+  "connect": tracer.plugins.connect;
+  "couchbase": tracer.plugins.couchbase;
+  "cucumber": tracer.plugins.cucumber;
+  "cypress": tracer.plugins.cypress;
+  "dns": tracer.plugins.dns;
+  "elasticsearch": tracer.plugins.elasticsearch;
+  "express": tracer.plugins.express;
+  "fastify": tracer.plugins.fastify;
+  "fetch": tracer.plugins.fetch;
+  "generic-pool": tracer.plugins.generic_pool;
+  "google-cloud-pubsub": tracer.plugins.google_cloud_pubsub;
+  "graphql": tracer.plugins.graphql;
+  "grpc": tracer.plugins.grpc;
+  "hapi": tracer.plugins.hapi;
+  "http": tracer.plugins.http;
+  "http2": tracer.plugins.http2;
+  "ioredis": tracer.plugins.ioredis;
+  "jest": tracer.plugins.jest;
+  "kafkajs": tracer.plugins.kafkajs
+  "knex": tracer.plugins.knex;
+  "koa": tracer.plugins.koa;
+  "mariadb": tracer.plugins.mariadb;
+  "memcached": tracer.plugins.memcached;
+  "microgateway-core": tracer.plugins.microgateway_core;
+  "mocha": tracer.plugins.mocha;
+  "moleculer": tracer.plugins.moleculer;
+  "mongodb-core": tracer.plugins.mongodb_core;
+  "mongoose": tracer.plugins.mongoose;
+  "mysql": tracer.plugins.mysql;
+  "mysql2": tracer.plugins.mysql2;
+  "net": tracer.plugins.net;
+  "next": tracer.plugins.next;
+  "openai": tracer.plugins.openai;
+  "opensearch": tracer.plugins.opensearch;
+  "oracledb": tracer.plugins.oracledb;
+  "paperplane": tracer.plugins.paperplane;
+  "playwright": tracer.plugins.playwright;
+  "pg": tracer.plugins.pg;
+  "pino": tracer.plugins.pino;
+  "redis": tracer.plugins.redis;
+  "restify": tracer.plugins.restify;
+  "rhea": tracer.plugins.rhea;
+  "router": tracer.plugins.router;
+  "sharedb": tracer.plugins.sharedb;
+  "tedious": tracer.plugins.tedious;
+  "winston": tracer.plugins.winston;
 }
 
-/**
- * Span represents a logical unit of work as part of a broader Trace.
- * Examples of span might include remote procedure calls or a in-process
- * function calls to sub-components. A Trace has a single, top-level "root"
- * Span that in turn may have zero or more child Spans, which in turn may
- * have children.
- */
-export declare interface Span extends opentracing.Span {
-  context (): SpanContext;
+declare namespace tracer {
+  export type SpanOptions = opentracing.SpanOptions;
+  export { Tracer };
 
-  /**
-   * Causally links another span to the current span
-   * @param {SpanContext} context The context of the span to link to.
-   * @param {Object} attributes An optional key value pair of arbitrary values.
-   * @returns {void}
-   */
-  addLink (context: SpanContext, attributes?: Object): void;
-}
-
-/**
- * SpanContext represents Span state that must propagate to descendant Spans
- * and across process boundaries.
- *
- * SpanContext is logically divided into two pieces: the user-level "Baggage"
- * (see setBaggageItem and getBaggageItem) that propagates across Span
- * boundaries and any Tracer-implementation-specific fields that are needed to
- * identify or otherwise contextualize the associated Span instance (e.g., a
- * <trace_id, span_id, sampled> tuple).
- */
-export declare interface SpanContext extends opentracing.SpanContext {
-  /**
-   * Returns the string representation of the internal trace ID.
-   */
-  toTraceId (): string;
-
-  /**
-   * Returns the string representation of the internal span ID.
-   */
-  toSpanId (): string;
-
-  /**
-   * Returns the string representation used for DBM integration.
-   */
-  toTraceparent (): string;
-}
-
-/**
- * Sampling rule to configure on the priority sampler.
- */
-export declare interface SamplingRule {
-  /**
-   * Sampling rate for this rule.
-   */
-  sampleRate: number
-
-  /**
-   * Service on which to apply this rule. The rule will apply to all services if not provided.
-   */
-  service?: string | RegExp
-
-  /**
-   * Operation name on which to apply this rule. The rule will apply to all operation names if not provided.
-   */
-  name?: string | RegExp
-}
-
-/**
- * Span sampling rules to ingest single spans where the enclosing trace is dropped
- */
-export declare interface SpanSamplingRule {
-  /**
-   * Sampling rate for this rule. Will default to 1.0 (always) if not provided.
-   */
-  sampleRate?: number
-
-  /**
-   * Maximum number of spans matching a span sampling rule to be allowed per second.
-   */
-  maxPerSecond?: number
-
-  /**
-   * Service name or pattern on which to apply this rule. The rule will apply to all services if not provided.
-   */
-  service?: string
-
-  /**
-   * Operation name or pattern on which to apply this rule. The rule will apply to all operation names if not provided.
-   */
-  name?: string
-}
-
-/**
- * Selection and priority order of context propagation injection and extraction mechanisms.
- */
-export declare interface PropagationStyle {
-  /**
-   * Selection of context propagation injection mechanisms.
-   */
-  inject: string[],
-
-  /**
-   * Selection and priority order of context propagation extraction mechanisms.
-   */
-  extract: string[]
-}
-
-/**
- * List of options available to the tracer.
- */
-export declare interface TracerOptions {
-  /**
-   * Whether to enable trace ID injection in log records to be able to correlate
-   * traces with logs.
-   * @default false
-   */
-  logInjection?: boolean,
-
-  /**
-   * Whether to enable startup logs.
-   * @default true
-   */
-  startupLogs?: boolean,
-
-  /**
-   * The service name to be used for this program. If not set, the service name
-   * will attempted to be inferred from package.json
-   */
-  service?: string;
-
-  /**
-   * Provide service name mappings for each plugin.
-   */
-  serviceMapping?: { [key: string]: string };
-
-  /**
-   * The url of the trace agent that the tracer will submit to.
-   * Takes priority over hostname and port, if set.
-   */
-  url?: string;
-
-  /**
-   * The address of the trace agent that the tracer will submit to.
-   * @default 'localhost'
-   */
-  hostname?: string;
-
-  /**
-   * The port of the trace agent that the tracer will submit to.
-   * @default 8126
-   */
-  port?: number | string;
-
-  /**
-   * Whether to enable profiling.
-   */
-  profiling?: boolean
-
-  /**
-   * Options specific for the Dogstatsd agent.
-   */
-  dogstatsd?: {
+  export interface TraceOptions extends Analyzable {
     /**
-     * The hostname of the Dogstatsd agent that the metrics will submitted to.
+     * The resource you are tracing. The resource name must not be longer than
+     * 5000 characters.
      */
-    hostname?: string
+    resource?: string,
 
     /**
-     * The port of the Dogstatsd agent that the metrics will submitted to.
-     * @default 8125
+     * The service you are tracing. The service name must not be longer than
+     * 100 characters.
      */
-    port?: number
-  };
+    service?: string,
+
+    /**
+     * The type of request.
+     */
+    type?: string
+
+    /**
+     * An array of span links
+     */
+    links?: Array<{ context: SpanContext, attributes?: Object }>
+  }
 
   /**
-   * Set an application’s environment e.g. prod, pre-prod, stage.
+   * Span represents a logical unit of work as part of a broader Trace.
+   * Examples of span might include remote procedure calls or a in-process
+   * function calls to sub-components. A Trace has a single, top-level "root"
+   * Span that in turn may have zero or more child Spans, which in turn may
+   * have children.
    */
-  env?: string;
+  export interface Span extends opentracing.Span {
+    context (): SpanContext;
+
+    /**
+     * Causally links another span to the current span
+     * @param {SpanContext} context The context of the span to link to.
+     * @param {Object} attributes An optional key value pair of arbitrary values.
+     * @returns {void}
+     */
+    addLink (context: SpanContext, attributes?: Object): void;
+  }
 
   /**
-   * The version number of the application. If not set, the version
-   * will attempted to be inferred from package.json.
-   */
-  version?: string;
-
-  /**
-   * Controls the ingestion sample rate (between 0 and 1) between the agent and the backend.
-   */
-  sampleRate?: number;
-
-  /**
-   * Global rate limit that is applied on the global sample rate and all rules,
-   * and controls the ingestion rate limit between the agent and the backend.
-   * Defaults to deferring the decision to the agent.
-   */
-  rateLimit?: number,
-
-  /**
-   * Sampling rules to apply to priority samplin. Each rule is a JSON,
-   * consisting of `service` and `name`, which are regexes to match against
-   * a trace's `service` and `name`, and a corresponding `sampleRate`. If not
-   * specified, will defer to global sampling rate for all spans.
-   * @default []
-   */
-  samplingRules?: SamplingRule[]
-
-  /**
-   * Span sampling rules that take effect when the enclosing trace is dropped, to ingest single spans
-   * @default []
-   */
-  spanSamplingRules?: SpanSamplingRule[]
-
-  /**
-   * Interval in milliseconds at which the tracer will submit traces to the agent.
-   * @default 2000
-   */
-  flushInterval?: number;
-
-  /**
-   *  Number of spans before partially exporting a trace. This prevents keeping all the spans in memory for very large traces.
-   * @default 1000
-   */
-  flushMinSpans?: number;
-
-  /**
-   * Whether to enable runtime metrics.
-   * @default false
-   */
-  runtimeMetrics?: boolean
-
-  /**
-   * Custom function for DNS lookups when sending requests to the agent.
-   * @default dns.lookup()
-   */
-  lookup?: LookupFunction
-
-  /**
-   * Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped.
-   * @default 0.4
-   */
-  protocolVersion?: string
-
-  /**
-   * Deprecated in favor of the global versions of the variables provided under this option
+   * SpanContext represents Span state that must propagate to descendant Spans
+   * and across process boundaries.
    *
-   * @deprecated
-   * @hidden
+   * SpanContext is logically divided into two pieces: the user-level "Baggage"
+   * (see setBaggageItem and getBaggageItem) that propagates across Span
+   * boundaries and any Tracer-implementation-specific fields that are needed to
+   * identify or otherwise contextualize the associated Span instance (e.g., a
+   * <trace_id, span_id, sampled> tuple).
    */
-  ingestion?: {
+  export interface SpanContext extends opentracing.SpanContext {
     /**
-     * Controls the ingestion sample rate (between 0 and 1) between the agent and the backend.
+     * Returns the string representation of the internal trace ID.
+     */
+    toTraceId (): string;
+
+    /**
+     * Returns the string representation of the internal span ID.
+     */
+    toSpanId (): string;
+
+    /**
+     * Returns the string representation used for DBM integration.
+     */
+    toTraceparent (): string;
+  }
+
+  /**
+   * Sampling rule to configure on the priority sampler.
+   */
+  export interface SamplingRule {
+    /**
+     * Sampling rate for this rule.
+     */
+    sampleRate: number
+
+    /**
+     * Service on which to apply this rule. The rule will apply to all services if not provided.
+     */
+    service?: string | RegExp
+
+    /**
+     * Operation name on which to apply this rule. The rule will apply to all operation names if not provided.
+     */
+    name?: string | RegExp
+  }
+
+  /**
+   * Span sampling rules to ingest single spans where the enclosing trace is dropped
+   */
+  export interface SpanSamplingRule {
+    /**
+     * Sampling rate for this rule. Will default to 1.0 (always) if not provided.
      */
     sampleRate?: number
 
     /**
-     * Controls the ingestion rate limit between the agent and the backend. Defaults to deferring the decision to the agent.
+     * Maximum number of spans matching a span sampling rule to be allowed per second.
      */
-    rateLimit?: number
-  };
-
-  /**
-   * Experimental features can be enabled individually using key / value pairs.
-   * @default {}
-   */
-  experimental?: {
-    b3?: boolean
-    traceparent?: boolean
+    maxPerSecond?: number
 
     /**
-     * Whether to add an auto-generated `runtime-id` tag to metrics.
+     * Service name or pattern on which to apply this rule. The rule will apply to all services if not provided.
+     */
+    service?: string
+
+    /**
+     * Operation name or pattern on which to apply this rule. The rule will apply to all operation names if not provided.
+     */
+    name?: string
+  }
+
+  /**
+   * Selection and priority order of context propagation injection and extraction mechanisms.
+   */
+  export interface PropagationStyle {
+    /**
+     * Selection of context propagation injection mechanisms.
+     */
+    inject: string[],
+
+    /**
+     * Selection and priority order of context propagation extraction mechanisms.
+     */
+    extract: string[]
+  }
+
+  /**
+   * List of options available to the tracer.
+   */
+  export interface TracerOptions {
+    /**
+     * Whether to enable trace ID injection in log records to be able to correlate
+     * traces with logs.
      * @default false
      */
-    runtimeId?: boolean
+    logInjection?: boolean,
 
     /**
-     * Whether to write traces to log output or agentless, rather than send to an agent
-     * @default false
+     * Whether to enable startup logs.
+     * @default true
      */
-    exporter?: 'log' | 'agent' | 'datadog'
+    startupLogs?: boolean,
 
     /**
-     * Whether to enable the experimental `getRumData` method.
-     * @default false
+     * The service name to be used for this program. If not set, the service name
+     * will attempted to be inferred from package.json
      */
-    enableGetRumData?: boolean
+    service?: string;
 
     /**
-     * Configuration of the IAST. Can be a boolean as an alias to `iast.enabled`.
+     * Provide service name mappings for each plugin.
      */
-    iast?: boolean | {
-      /**
-       * Whether to enable IAST.
-       * @default false
-       */
-      enabled?: boolean,
-      /**
-       * Controls the percentage of requests that iast will analyze
-       * @default 30
-       */
-      requestSampling?: number,
-      /**
-       * Controls how many request can be analyzing code vulnerabilities at the same time
-       * @default 2
-       */
-      maxConcurrentRequests?: number,
-      /**
-       * Controls how many code vulnerabilities can be detected in the same request
-       * @default 2
-       */
-      maxContextOperations?: number,
-      /**
-       * Whether to enable vulnerability deduplication
-       */
-      deduplicationEnabled?: boolean
-      /**
-       * Whether to enable vulnerability redaction
-       * @default true
-       */
-      redactionEnabled?: boolean,
-      /**
-       * Specifies a regex that will redact sensitive source names in vulnerability reports.
-       */
-      redactionNamePattern?: string,
-      /**
-       * Specifies a regex that will redact sensitive source values in vulnerability reports.
-       */
-      redactionValuePattern?: string
-    }
-  };
+    serviceMapping?: { [key: string]: string };
 
-  /**
-   * Whether to load all built-in plugins.
-   * @default true
-   */
-  plugins?: boolean;
-
-  /**
-   * Custom logger to be used by the tracer (if debug = true),
-   * should support error(), warn(), info(), and debug() methods
-   * see https://datadog.github.io/dd-trace-js/#custom-logging
-   */
-  logger?: {
-    error: (err: Error | string) => void;
-    warn: (message: string) => void;
-    info: (message: string) => void;
-    debug: (message: string) => void;
-  };
-
-  /**
-   * Global tags that should be assigned to every span.
-   */
-  tags?: { [key: string]: any };
-
-  /**
-   * Specifies which scope implementation to use. The default is to use the best
-   * implementation for the runtime. Only change this if you know what you are
-   * doing.
-   */
-  scope?: 'async_hooks' | 'async_local_storage' | 'async_resource' | 'sync' | 'noop'
-
-  /**
-   * Whether to report the hostname of the service host. This is used when the agent is deployed on a different host and cannot determine the hostname automatically.
-   * @default false
-   */
-  reportHostname?: boolean
-
-  /**
-   * A string representing the minimum tracer log level to use when debug logging is enabled
-   * @default 'debug'
-   */
-  logLevel?: 'error' | 'debug'
-
-  /**
-   * If false, require a parent in order to trace.
-   * @default true
-   * @deprecated since version 4.0
-   */
-  orphanable?: boolean
-
-  /**
-   * Enables DBM to APM link using tag injection.
-   * @default 'disabled'
-   */
-  dbmPropagationMode?: 'disabled' | 'service' | 'full'
-
-  /**
-   * Configuration of the AppSec protection. Can be a boolean as an alias to `appsec.enabled`.
-   */
-  appsec?: boolean | {
     /**
-     * Whether to enable AppSec.
-     * @default false
+     * The url of the trace agent that the tracer will submit to.
+     * Takes priority over hostname and port, if set.
      */
-    enabled?: boolean,
+    url?: string;
 
     /**
-     * Specifies a path to a custom rules file.
+     * The address of the trace agent that the tracer will submit to.
+     * @default 'localhost'
      */
-    rules?: string,
+    hostname?: string;
 
     /**
-     * Controls the maximum amount of traces sampled by AppSec attacks, per second.
-     * @default 100
+     * The port of the trace agent that the tracer will submit to.
+     * @default 8126
+     */
+    port?: number | string;
+
+    /**
+     * Whether to enable profiling.
+     */
+    profiling?: boolean
+
+    /**
+     * Options specific for the Dogstatsd agent.
+     */
+    dogstatsd?: {
+      /**
+       * The hostname of the Dogstatsd agent that the metrics will submitted to.
+       */
+      hostname?: string
+
+      /**
+       * The port of the Dogstatsd agent that the metrics will submitted to.
+       * @default 8125
+       */
+      port?: number
+    };
+
+    /**
+     * Set an application’s environment e.g. prod, pre-prod, stage.
+     */
+    env?: string;
+
+    /**
+     * The version number of the application. If not set, the version
+     * will attempted to be inferred from package.json.
+     */
+    version?: string;
+
+    /**
+     * Controls the ingestion sample rate (between 0 and 1) between the agent and the backend.
+     */
+    sampleRate?: number;
+
+    /**
+     * Global rate limit that is applied on the global sample rate and all rules,
+     * and controls the ingestion rate limit between the agent and the backend.
+     * Defaults to deferring the decision to the agent.
      */
     rateLimit?: number,
 
     /**
-     * Controls the maximum amount of time in microseconds the WAF is allowed to run synchronously for.
-     * @default 5000
+     * Sampling rules to apply to priority samplin. Each rule is a JSON,
+     * consisting of `service` and `name`, which are regexes to match against
+     * a trace's `service` and `name`, and a corresponding `sampleRate`. If not
+     * specified, will defer to global sampling rate for all spans.
+     * @default []
      */
-    wafTimeout?: number,
+    samplingRules?: SamplingRule[]
 
     /**
-     * Specifies a regex that will redact sensitive data by its key in attack reports.
+     * Span sampling rules that take effect when the enclosing trace is dropped, to ingest single spans
+     * @default []
      */
-    obfuscatorKeyRegex?: string,
+    spanSamplingRules?: SpanSamplingRule[]
 
     /**
-     * Specifies a regex that will redact sensitive data by its value in attack reports.
+     * Interval in milliseconds at which the tracer will submit traces to the agent.
+     * @default 2000
      */
-    obfuscatorValueRegex?: string,
+    flushInterval?: number;
 
     /**
-     * Specifies a path to a custom blocking template html file.
+     *  Number of spans before partially exporting a trace. This prevents keeping all the spans in memory for very large traces.
+     * @default 1000
      */
-    blockedTemplateHtml?: string,
+    flushMinSpans?: number;
 
     /**
-     * Specifies a path to a custom blocking template json file.
+     * Whether to enable runtime metrics.
+     * @default false
      */
-    blockedTemplateJson?: string,
+    runtimeMetrics?: boolean
 
     /**
-     * Specifies a path to a custom blocking template json file for graphql requests
+     * Custom function for DNS lookups when sending requests to the agent.
+     * @default dns.lookup()
      */
-    blockedTemplateGraphql?: string,
+    lookup?: LookupFunction
 
     /**
-     * Controls the automated user event tracking configuration
+     * Protocol version to use for requests to the agent. The version configured must be supported by the agent version installed or all traces will be dropped.
+     * @default 0.4
      */
-    eventTracking?: {
+    protocolVersion?: string
+
+    /**
+     * Deprecated in favor of the global versions of the variables provided under this option
+     *
+     * @deprecated
+     * @hidden
+     */
+    ingestion?: {
       /**
-       * Controls the automated user event tracking mode. Possible values are disabled, safe and extended.
-       * On safe mode, any detected Personally Identifiable Information (PII) about the user will be redacted from the event.
-       * On extended mode, no redaction will take place.
-       * @default 'safe'
+       * Controls the ingestion sample rate (between 0 and 1) between the agent and the backend.
        */
-      mode?: 'safe' | 'extended' | 'disabled'
-    },
+      sampleRate?: number
+
+      /**
+       * Controls the ingestion rate limit between the agent and the backend. Defaults to deferring the decision to the agent.
+       */
+      rateLimit?: number
+    };
 
     /**
-     * Configuration for Api Security sampling
+     * Experimental features can be enabled individually using key / value pairs.
+     * @default {}
      */
-    apiSecurity?: {
-      /** Whether to enable Api Security.
+    experimental?: {
+      b3?: boolean
+      traceparent?: boolean
+
+      /**
+       * Whether to add an auto-generated `runtime-id` tag to metrics.
+       * @default false
+       */
+      runtimeId?: boolean
+
+      /**
+       * Whether to write traces to log output or agentless, rather than send to an agent
+       * @default false
+       */
+      exporter?: 'log' | 'agent' | 'datadog'
+
+      /**
+       * Whether to enable the experimental `getRumData` method.
+       * @default false
+       */
+      enableGetRumData?: boolean
+
+      /**
+       * Configuration of the IAST. Can be a boolean as an alias to `iast.enabled`.
+       */
+      iast?: boolean | {
+        /**
+         * Whether to enable IAST.
+         * @default false
+         */
+        enabled?: boolean,
+        /**
+         * Controls the percentage of requests that iast will analyze
+         * @default 30
+         */
+        requestSampling?: number,
+        /**
+         * Controls how many request can be analyzing code vulnerabilities at the same time
+         * @default 2
+         */
+        maxConcurrentRequests?: number,
+        /**
+         * Controls how many code vulnerabilities can be detected in the same request
+         * @default 2
+         */
+        maxContextOperations?: number,
+        /**
+         * Whether to enable vulnerability deduplication
+         */
+        deduplicationEnabled?: boolean,
+        /**
+         * Whether to enable vulnerability redaction
+         * @default true
+         */
+        redactionEnabled?: boolean,
+        /**
+         * Specifies a regex that will redact sensitive source names in vulnerability reports.
+         */
+        redactionNamePattern?: string,
+        /**
+         * Specifies a regex that will redact sensitive source values in vulnerability reports.
+         */
+        redactionValuePattern?: string
+      }
+    };
+
+    /**
+     * Whether to load all built-in plugins.
+     * @default true
+     */
+    plugins?: boolean;
+
+    /**
+     * Custom logger to be used by the tracer (if debug = true),
+     * should support error(), warn(), info(), and debug() methods
+     * see https://datadog.github.io/dd-trace-js/#custom-logging
+     */
+    logger?: {
+      error: (err: Error | string) => void;
+      warn: (message: string) => void;
+      info: (message: string) => void;
+      debug: (message: string) => void;
+    };
+
+    /**
+     * Global tags that should be assigned to every span.
+     */
+    tags?: { [key: string]: any };
+
+    /**
+     * Specifies which scope implementation to use. The default is to use the best
+     * implementation for the runtime. Only change this if you know what you are
+     * doing.
+     */
+    scope?: 'async_hooks' | 'async_local_storage' | 'async_resource' | 'sync' | 'noop'
+
+    /**
+     * Whether to report the hostname of the service host. This is used when the agent is deployed on a different host and cannot determine the hostname automatically.
+     * @default false
+     */
+    reportHostname?: boolean
+
+    /**
+     * A string representing the minimum tracer log level to use when debug logging is enabled
+     * @default 'debug'
+     */
+    logLevel?: 'error' | 'debug'
+
+    /**
+     * If false, require a parent in order to trace.
+     * @default true
+     * @deprecated since version 4.0
+     */
+    orphanable?: boolean
+
+    /**
+     * Enables DBM to APM link using tag injection.
+     * @default 'disabled'
+     */
+    dbmPropagationMode?: 'disabled' | 'service' | 'full'
+
+    /**
+     * Configuration of the AppSec protection. Can be a boolean as an alias to `appsec.enabled`.
+     */
+    appsec?: boolean | {
+      /**
+       * Whether to enable AppSec.
        * @default false
        */
       enabled?: boolean,
 
-      /** Controls the request sampling rate (between 0 and 1) in which Api Security is triggered.
-       * The value will be coerced back if it's outside of the 0-1 range.
-       * @default 0.1
+      /**
+       * Specifies a path to a custom rules file.
        */
-      requestSampling?: number
+      rules?: string,
+
+      /**
+       * Controls the maximum amount of traces sampled by AppSec attacks, per second.
+       * @default 100
+       */
+      rateLimit?: number,
+
+      /**
+       * Controls the maximum amount of time in microseconds the WAF is allowed to run synchronously for.
+       * @default 5000
+       */
+      wafTimeout?: number,
+
+      /**
+       * Specifies a regex that will redact sensitive data by its key in attack reports.
+       */
+      obfuscatorKeyRegex?: string,
+
+      /**
+       * Specifies a regex that will redact sensitive data by its value in attack reports.
+       */
+      obfuscatorValueRegex?: string,
+
+      /**
+       * Specifies a path to a custom blocking template html file.
+       */
+      blockedTemplateHtml?: string,
+
+      /**
+       * Specifies a path to a custom blocking template json file.
+       */
+      blockedTemplateJson?: string,
+
+      /**
+       * Specifies a path to a custom blocking template json file for graphql requests
+       */
+      blockedTemplateGraphql?: string,
+
+      /**
+       * Controls the automated user event tracking configuration
+       */
+      eventTracking?: {
+        /**
+         * Controls the automated user event tracking mode. Possible values are disabled, safe and extended.
+         * On safe mode, any detected Personally Identifiable Information (PII) about the user will be redacted from the event.
+         * On extended mode, no redaction will take place.
+         * @default 'safe'
+         */
+        mode?: 'safe' | 'extended' | 'disabled'
+      },
+      /**
+       * Configuration for Api Security sampling
+       */
+      apiSecurity?: {
+        /** Whether to enable Api Security.
+         * @default false
+         */
+        enabled?: boolean,
+
+        /** Controls the request sampling rate (between 0 and 1) in which Api Security is triggered.
+         * The value will be coerced back if it's outside of the 0-1 range.
+         * @default 0.1
+         */
+        requestSampling?: number
+      }
+    };
+
+    /**
+     * Configuration of ASM Remote Configuration
+     */
+    remoteConfig?: {
+      /**
+       * Specifies the remote configuration polling interval in seconds
+       * @default 5
+       */
+      pollInterval?: number,
     }
+
+    /**
+     * Whether to enable client IP collection from relevant IP headers
+     * @default false
+     */
+    clientIpEnabled?: boolean
+
+    /**
+     * Custom header name to source the http.client_ip tag from.
+     */
+    clientIpHeader?: string,
+
+    /**
+     * The selection and priority order of context propagation injection and extraction mechanisms.
+     */
+    propagationStyle?: string[] | PropagationStyle
+  }
+
+  /**
+   * User object that can be passed to `tracer.setUser()`.
+   */
+  export interface User {
+    /**
+     * Unique identifier of the user.
+     * Mandatory.
+     */
+    id: string,
+
+    /**
+     * Email of the user.
+     */
+    email?: string,
+
+    /**
+     * User-friendly name of the user.
+     */
+    name?: string,
+
+    /**
+     * Session ID of the user.
+     */
+    session_id?: string,
+
+    /**
+     * Role the user is making the request under.
+     */
+    role?: string,
+
+    /**
+     * Scopes or granted authorizations the user currently possesses.
+     * The value could come from the scope associated with an OAuth2
+     * Access Token or an attribute value in a SAML 2 Assertion.
+     */
+    scope?: string,
+
+    /**
+     * Custom fields to attach to the user (RBAC, Oauth, etc…).
+     */
+    [key: string]: string | undefined
+  }
+
+  export interface DogStatsD {
+    /**
+     * Increments a metric by the specified value, optionally specifying tags.
+     * @param {string} stat The dot-separated metric name.
+     * @param {number} value The amount to increment the stat by.
+     * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
+     */
+    increment(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
+
+    /**
+     * Decrements a metric by the specified value, optionally specifying tags.
+     * @param {string} stat The dot-separated metric name.
+     * @param {number} value The amount to decrement the stat by.
+     * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
+     */
+    decrement(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
+
+    /**
+     * Sets a distribution value, optionally specifying tags.
+     * @param {string} stat The dot-separated metric name.
+     * @param {number} value The amount to increment the stat by.
+     * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
+     */
+    distribution(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
+
+    /**
+     * Sets a gauge value, optionally specifying tags.
+     * @param {string} stat The dot-separated metric name.
+     * @param {number} value The amount to increment the stat by.
+     * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
+     */
+    gauge(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
+
+    /**
+     * Forces any unsent metrics to be sent
+     *
+     * @beta This method is experimental and could be removed in future versions.
+     */
+    flush(): void
+  }
+
+  export interface Appsec {
+    /**
+     * Links a successful login event to the current trace. Will link the passed user to the current trace with Appsec.setUser() internally.
+     * @param {User} user Properties of the authenticated user. Accepts custom fields.
+     * @param {[key: string]: string} metadata Custom fields to link to the login success event.
+     *
+     * @beta This method is in beta and could change in future versions.
+     */
+    trackUserLoginSuccessEvent(user: User, metadata?: { [key: string]: string }): void
+
+    /**
+     * Links a failed login event to the current trace.
+     * @param {string} userId The user id of the attemped login.
+     * @param {boolean} exists If the user id exists.
+     * @param {[key: string]: string} metadata Custom fields to link to the login failure event.
+     *
+     * @beta This method is in beta and could change in future versions.
+     */
+    trackUserLoginFailureEvent(userId: string, exists: boolean, metadata?: { [key: string]: string }): void
+
+    /**
+     * Links a custom event to the current trace.
+     * @param {string} eventName The name of the event.
+     * @param {[key: string]: string} metadata Custom fields to link to the event.
+     *
+     * @beta This method is in beta and could change in future versions.
+     */
+    trackCustomEvent(eventName: string, metadata?: { [key: string]: string }): void
+
+    /**
+     * Checks if the passed user should be blocked according to AppSec rules.
+     * If no user is linked to the current trace, will link the passed user to it.
+     * @param {User} user Properties of the authenticated user. Accepts custom fields.
+     * @return {boolean} Indicates whether the user should be blocked.
+     *
+     * @beta This method is in beta and could change in the future
+     */
+    isUserBlocked(user: User): boolean
+
+    /**
+     * Sends a "blocked" template response based on the request accept header and ends the response.
+     * **You should stop processing the request after calling this function!**
+     * @param {IncomingMessage} req Can be passed to force which request to act on. Optional.
+     * @param {OutgoingMessage} res Can be passed to force which response to act on. Optional.
+     * @return {boolean} Indicates if the action was successful.
+     *
+     * @beta This method is in beta and could change in the future
+     */
+    blockRequest(req?: IncomingMessage, res?: OutgoingMessage): boolean
+
+    /**
+     * Links an authenticated user to the current trace.
+     * @param {User} user Properties of the authenticated user. Accepts custom fields.
+     *
+     * @beta This method is in beta and could change in the future
+     */
+    setUser(user: User): void
+  }
+
+  /** @hidden */
+  type anyObject = {
+    [key: string]: any;
   };
 
-  /**
-   * Configuration of ASM Remote Configuration
-   */
-  remoteConfig?: {
-    /**
-     * Specifies the remote configuration polling interval in seconds
-     * @default 5
-     */
-    pollInterval?: number,
+  /** @hidden */
+  interface TransportRequestParams {
+    method: string;
+    path: string;
+    body?: anyObject;
+    bulkBody?: anyObject;
+    querystring?: anyObject;
   }
 
   /**
-   * Whether to enable client IP collection from relevant IP headers
-   * @default false
+   * The Datadog Scope Manager. This is used for context propagation.
    */
-  clientIpEnabled?: boolean
-
-  /**
-   * Custom header name to source the http.client_ip tag from.
-   */
-  clientIpHeader?: string,
-
-  /**
-   * The selection and priority order of context propagation injection and extraction mechanisms.
-   */
-  propagationStyle?: string[] | PropagationStyle
-}
-
-/**
- * User object that can be passed to `tracer.setUser()`.
- */
-export declare interface User {
-  /**
-   * Unique identifier of the user.
-   * Mandatory.
-   */
-  id: string,
-
-  /**
-   * Email of the user.
-   */
-  email?: string,
-
-  /**
-   * User-friendly name of the user.
-   */
-  name?: string,
-
-  /**
-   * Session ID of the user.
-   */
-  session_id?: string,
-
-  /**
-   * Role the user is making the request under.
-   */
-  role?: string,
-
-  /**
-   * Scopes or granted authorizations the user currently possesses.
-   * The value could come from the scope associated with an OAuth2
-   * Access Token or an attribute value in a SAML 2 Assertion.
-   */
-  scope?: string,
-
-  /**
-   * Custom fields to attach to the user (RBAC, Oauth, etc…).
-   */
-  [key: string]: string | undefined
-}
-
-export declare interface DogStatsD {
-  /**
-   * Increments a metric by the specified value, optionally specifying tags.
-   * @param {string} stat The dot-separated metric name.
-   * @param {number} value The amount to increment the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
-   */
-  increment(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
-
-  /**
-   * Decrements a metric by the specified value, optionally specifying tags.
-   * @param {string} stat The dot-separated metric name.
-   * @param {number} value The amount to decrement the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
-   */
-  decrement(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
-
-  /**
-   * Sets a distribution value, optionally specifying tags.
-   * @param {string} stat The dot-separated metric name.
-   * @param {number} value The amount to increment the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
-   */
-  distribution(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
-
-  /**
-   * Sets a gauge value, optionally specifying tags.
-   * @param {string} stat The dot-separated metric name.
-   * @param {number} value The amount to increment the stat by.
-   * @param {[tag:string]:string|number} tags Tags to pass along, such as `{ foo: 'bar' }`. Values are combined with config.tags.
-   */
-  gauge(stat: string, value?: number, tags?: { [tag: string]: string|number }): void
-
-  /**
-   * Forces any unsent metrics to be sent
-   *
-   * @beta This method is experimental and could be removed in future versions.
-   */
-  flush(): void
-}
-
-export declare interface Appsec {
-  /**
-   * Links a successful login event to the current trace. Will link the passed user to the current trace with Appsec.setUser() internally.
-   * @param {User} user Properties of the authenticated user. Accepts custom fields.
-   * @param {[key: string]: string} metadata Custom fields to link to the login success event.
-   *
-   * @beta This method is in beta and could change in future versions.
-   */
-  trackUserLoginSuccessEvent(user: User, metadata?: { [key: string]: string }): void
-
-  /**
-   * Links a failed login event to the current trace.
-   * @param {string} userId The user id of the attemped login.
-   * @param {boolean} exists If the user id exists.
-   * @param {[key: string]: string} metadata Custom fields to link to the login failure event.
-   *
-   * @beta This method is in beta and could change in future versions.
-   */
-  trackUserLoginFailureEvent(userId: string, exists: boolean, metadata?: { [key: string]: string }): void
-
-  /**
-   * Links a custom event to the current trace.
-   * @param {string} eventName The name of the event.
-   * @param {[key: string]: string} metadata Custom fields to link to the event.
-   *
-   * @beta This method is in beta and could change in future versions.
-   */
-  trackCustomEvent(eventName: string, metadata?: { [key: string]: string }): void
-
-  /**
-   * Checks if the passed user should be blocked according to AppSec rules.
-   * If no user is linked to the current trace, will link the passed user to it.
-   * @param {User} user Properties of the authenticated user. Accepts custom fields.
-   * @return {boolean} Indicates whether the user should be blocked.
-   *
-   * @beta This method is in beta and could change in the future
-   */
-  isUserBlocked(user: User): boolean
-
-  /**
-   * Sends a "blocked" template response based on the request accept header and ends the response.
-   * **You should stop processing the request after calling this function!**
-   * @param {IncomingMessage} req Can be passed to force which request to act on. Optional.
-   * @param {OutgoingMessage} res Can be passed to force which response to act on. Optional.
-   * @return {boolean} Indicates if the action was successful.
-   *
-   * @beta This method is in beta and could change in the future
-   */
-  blockRequest(req?: IncomingMessage, res?: OutgoingMessage): boolean
-
-  /**
-   * Links an authenticated user to the current trace.
-   * @param {User} user Properties of the authenticated user. Accepts custom fields.
-   *
-   * @beta This method is in beta and could change in the future
-   */
-  setUser(user: User): void
-}
-
-/** @hidden */
-declare type anyObject = {
-  [key: string]: any;
-};
-
-/** @hidden */
-interface TransportRequestParams {
-  method: string;
-  path: string;
-  body?: anyObject;
-  bulkBody?: anyObject;
-  querystring?: anyObject;
-}
-
-/**
- * The Datadog Scope Manager. This is used for context propagation.
- */
-export declare interface Scope {
-  /**
-   * Get the current active span or null if there is none.
-   *
-   * @returns {Span} The active span.
-   */
-  active (): Span | null;
-
-  /**
-   * Activate a span in the scope of a function.
-   *
-   * @param {Span} span The span to activate.
-   * @param {Function} fn Function that will have the span activated on its scope.
-   * @returns The return value of the provided function.
-   */
-  activate<T> (span: Span, fn: ((...args: any[]) => T)): T;
-
-  /**
-   * Binds a target to the provided span, or the active span if omitted.
-   *
-   * @param {Function|Promise} target Target that will have the span activated on its scope.
-   * @param {Span} [span=scope.active()] The span to activate.
-   * @returns The bound target.
-   */
-  bind<T extends (...args: any[]) => void> (fn: T, span?: Span | null): T;
-  bind<V, T extends (...args: any[]) => V> (fn: T, span?: Span | null): T;
-  bind<T> (fn: Promise<T>, span?: Span | null): Promise<T>;
-}
-
-/** @hidden */
-interface Plugins {
-  "amqp10": plugins.amqp10;
-  "amqplib": plugins.amqplib;
-  "aws-sdk": plugins.aws_sdk;
-  "bunyan": plugins.bunyan;
-  "cassandra-driver": plugins.cassandra_driver;
-  "connect": plugins.connect;
-  "couchbase": plugins.couchbase;
-  "cucumber": plugins.cucumber;
-  "cypress": plugins.cypress;
-  "dns": plugins.dns;
-  "elasticsearch": plugins.elasticsearch;
-  "express": plugins.express;
-  "fastify": plugins.fastify;
-  "fetch": plugins.fetch;
-  "generic-pool": plugins.generic_pool;
-  "google-cloud-pubsub": plugins.google_cloud_pubsub;
-  "graphql": plugins.graphql;
-  "grpc": plugins.grpc;
-  "hapi": plugins.hapi;
-  "http": plugins.http;
-  "http2": plugins.http2;
-  "ioredis": plugins.ioredis;
-  "jest": plugins.jest;
-  "kafkajs": plugins.kafkajs
-  "knex": plugins.knex;
-  "koa": plugins.koa;
-  "mariadb": plugins.mariadb;
-  "memcached": plugins.memcached;
-  "microgateway-core": plugins.microgateway_core;
-  "mocha": plugins.mocha;
-  "moleculer": plugins.moleculer;
-  "mongodb-core": plugins.mongodb_core;
-  "mongoose": plugins.mongoose;
-  "mysql": plugins.mysql;
-  "mysql2": plugins.mysql2;
-  "net": plugins.net;
-  "next": plugins.next;
-  "openai": plugins.openai;
-  "opensearch": plugins.opensearch;
-  "oracledb": plugins.oracledb;
-  "paperplane": plugins.paperplane;
-  "playwright": plugins.playwright;
-  "pg": plugins.pg;
-  "pino": plugins.pino;
-  "redis": plugins.redis;
-  "restify": plugins.restify;
-  "rhea": plugins.rhea;
-  "router": plugins.router;
-  "sharedb": plugins.sharedb;
-  "tedious": plugins.tedious;
-  "winston": plugins.winston;
-}
-
-/** @hidden */
-interface Analyzable {
-  /**
-   * Whether to measure the span. Can also be set to a key-value pair with span
-   * names as keys and booleans as values for more granular control.
-   */
-  measured?: boolean | { [key: string]: boolean };
-}
-
-export declare namespace plugins {
-  /** @hidden */
-  interface Integration {
+  export interface Scope {
     /**
-     * The service name to be used for this plugin.
+     * Get the current active span or null if there is none.
+     *
+     * @returns {Span} The active span.
      */
-    service?: string | any;
+    active (): Span | null;
 
-    /** Whether to enable the plugin.
-     * @default true
+    /**
+     * Activate a span in the scope of a function.
+     *
+     * @param {Span} span The span to activate.
+     * @param {Function} fn Function that will have the span activated on its scope.
+     * @returns The return value of the provided function.
      */
-    enabled?: boolean;
+    activate<T> (span: Span, fn: ((...args: any[]) => T)): T;
+
+    /**
+     * Binds a target to the provided span, or the active span if omitted.
+     *
+     * @param {Function|Promise} target Target that will have the span activated on its scope.
+     * @param {Span} [span=scope.active()] The span to activate.
+     * @returns The bound target.
+     */
+    bind<T extends (...args: any[]) => void> (fn: T, span?: Span | null): T;
+    bind<V, T extends (...args: any[]) => V> (fn: T, span?: Span | null): T;
+    bind<T> (fn: Promise<T>, span?: Span | null): Promise<T>;
   }
 
   /** @hidden */
-  interface Instrumentation extends Integration, Analyzable {}
-
-  /** @hidden */
-  interface Http extends Instrumentation {
+  interface Analyzable {
     /**
-     * List of URLs that should be instrumented.
-     *
-     * @default /^.*$/
+     * Whether to measure the span. Can also be set to a key-value pair with span
+     * names as keys and booleans as values for more granular control.
      */
-    allowlist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
-
-    /**
-     * Deprecated in favor of `allowlist`.
-     *
-     * @deprecated
-     * @hidden
-     */
-    whitelist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
-
-    /**
-     * List of URLs that should not be instrumented. Takes precedence over
-     * allowlist if a URL matches an entry in both.
-     *
-     * @default []
-     */
-    blocklist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
-
-    /**
-     * Deprecated in favor of `blocklist`.
-     *
-     * @deprecated
-     * @hidden
-     */
-    blacklist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
-
-    /**
-     * An array of headers to include in the span metadata.
-     *
-     * @default []
-     */
-    headers?: string[];
-
-    /**
-     * Callback function to determine if there was an error. It should take a
-     * status code as its only parameter and return `true` for success or `false`
-     * for errors.
-     *
-     * @default code => code < 500
-     */
-    validateStatus?: (code: number) => boolean;
-
-    /**
-     * Enable injection of tracing headers into requests signed with AWS IAM headers.
-     * Disable this if you get AWS signature errors (HTTP 403).
-     *
-     * @default false
-     */
-    enablePropagationWithAmazonHeaders?: boolean;
+    measured?: boolean | { [key: string]: boolean };
   }
 
-  /** @hidden */
-  interface HttpServer extends Http {
-    /**
-     * Callback function to determine if there was an error. It should take a
-     * status code as its only parameter and return `true` for success or `false`
-     * for errors.
-     *
-     * @default code => code < 500
-     */
-    validateStatus?: (code: number) => boolean;
-
-    /**
-     * Hooks to run before spans are finished.
-     */
-    hooks?: {
+  export namespace plugins {
+    /** @hidden */
+    interface Integration {
       /**
-       * Hook to execute just before the request span finishes.
+       * The service name to be used for this plugin.
        */
-      request?: (span?: Span, req?: IncomingMessage, res?: ServerResponse) => any;
-    };
+      service?: string | any;
 
-    /**
-     * Whether to enable instrumentation of <plugin>.middleware spans
-     *
-     * @default true
-     */
-    middleware?: boolean;
-  }
-
-  /** @hidden */
-  interface HttpClient extends Http {
-    /**
-     * Use the remote endpoint host as the service name instead of the default.
-     *
-     * @default false
-     */
-    splitByDomain?: boolean;
-
-    /**
-     * Callback function to determine if there was an error. It should take a
-     * status code as its only parameter and return `true` for success or `false`
-     * for errors.
-     *
-     * @default code => code < 400 || code >= 500
-     */
-    validateStatus?: (code: number) => boolean;
-
-    /**
-     * Hooks to run before spans are finished.
-     */
-    hooks?: {
-      /**
-       * Hook to execute just before the request span finishes.
+      /** Whether to enable the plugin.
+       * @default true
        */
-      request?: (span?: Span, req?: ClientRequest, res?: IncomingMessage) => any;
-    };
-
-    /**
-     * List of urls to which propagation headers should not be injected
-     */
-    propagationBlocklist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
-  }
-
-  /** @hidden */
-  interface Http2Client extends Http {
-    /**
-     * Use the remote endpoint host as the service name instead of the default.
-     *
-     * @default false
-     */
-    splitByDomain?: boolean;
-
-    /**
-     * Callback function to determine if there was an error. It should take a
-     * status code as its only parameter and return `true` for success or `false`
-     * for errors.
-     *
-     * @default code => code < 400 || code >= 500
-     */
-    validateStatus?: (code: number) => boolean;
-  }
-
-  /** @hidden */
-  interface Http2Server extends Http {
-    /**
-     * Callback function to determine if there was an error. It should take a
-     * status code as its only parameter and return `true` for success or `false`
-     * for errors.
-     *
-     * @default code => code < 500
-     */
-    validateStatus?: (code: number) => boolean;
-  }
-
-  /** @hidden */
-  interface Grpc extends Instrumentation {
-    /**
-     * An array of metadata entries to record. Can also be a callback that returns
-     * the key/value pairs to record. For example, using
-     * `variables => variables` would record all variables.
-     */
-    metadata?: string[] | ((variables: { [key: string]: any }) => { [key: string]: any });
-  }
-
-  /** @hidden */
-  interface Moleculer extends Instrumentation {
-    /**
-     * Whether to include context meta as tags.
-     *
-     * @default false
-     */
-    meta?: boolean;
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [amqp10](https://github.com/noodlefrenzy/node-amqp10) module.
-   */
-  interface amqp10 extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [amqplib](https://github.com/squaremo/amqp.node) module.
-   */
-  interface amqplib extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [aws-sdk](https://github.com/aws/aws-sdk-js) module.
-   */
-  interface aws_sdk extends Instrumentation {
-    /**
-     * Whether to add a suffix to the service name so that each AWS service has its own service name.
-     * @default true
-     */
-    splitByAwsService?: boolean;
-
-    /**
-     * Hooks to run before spans are finished.
-     */
-    hooks?: {
-      /**
-       * Hook to execute just before the aws span finishes.
-       */
-      request?: (span?: Span, response?: anyObject) => any;
-    };
-
-    /**
-     * Configuration for individual services to enable/disable them. Message
-     * queue services can also configure the producer and consumer individually
-     * by passing an object with a `producer` and `consumer` properties. The
-     * list of valid service keys is in the service-specific section of
-     * https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html
-     */
-    [key: string]: boolean | Object | undefined;
-  }
-
-  /**
-   * This plugin patches the [bunyan](https://github.com/trentm/node-bunyan)
-   * to automatically inject trace identifiers in log records when the
-   * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
-   * on the tracer.
-   */
-  interface bunyan extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [cassandra-driver](https://github.com/datastax/nodejs-driver) module.
-   */
-  interface cassandra_driver extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [connect](https://github.com/senchalabs/connect) module.
-   */
-  interface connect extends HttpServer {}
-
-  /**
-   * This plugin automatically instruments the
-   * [couchbase](https://www.npmjs.com/package/couchbase) module.
-   */
-  interface couchbase extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [cucumber](https://www.npmjs.com/package/@cucumber/cucumber) module.
-   */
-  interface cucumber extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [cypress](https://github.com/cypress-io/cypress) module.
-   */
-  interface cypress extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [dns](https://nodejs.org/api/dns.html) module.
-   */
-  interface dns extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [elasticsearch](https://github.com/elastic/elasticsearch-js) module.
-   */
-  interface elasticsearch extends Instrumentation {
-    /**
-     * Hooks to run before spans are finished.
-     */
-    hooks?: {
-      /**
-       * Hook to execute just before the query span finishes.
-       */
-      query?: (span?: Span, params?: TransportRequestParams) => any;
-    };
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [express](http://expressjs.com/) module.
-   */
-  interface express extends HttpServer {}
-
-  /**
-   * This plugin automatically instruments the
-   * [fastify](https://www.fastify.io/) module.
-   */
-  interface fastify extends HttpServer {}
-
-  /**
-   * This plugin automatically instruments the
-   * [fetch](https://nodejs.org/api/globals.html#fetch) global.
-   */
-  interface fetch extends HttpClient {}
-
-  /**
-   * This plugin patches the [generic-pool](https://github.com/coopernurse/node-pool)
-   * module to bind the callbacks the the caller context.
-   */
-  interface generic_pool extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [@google-cloud/pubsub](https://github.com/googleapis/nodejs-pubsub) module.
-   */
-  interface google_cloud_pubsub extends Integration {}
-
-  /** @hidden */
-  interface ExecutionArgs {
-    schema: any,
-    document: any,
-    rootValue?: any,
-    contextValue?: any,
-    variableValues?: any,
-    operationName?: string,
-    fieldResolver?: any,
-    typeResolver?: any,
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [graphql](https://github.com/graphql/graphql-js) module.
-   *
-   * The `graphql` integration uses the operation name as the span resource name.
-   * If no operation name is set, the resource name will always be just `query`,
-   * `mutation` or `subscription`.
-   *
-   * For example:
-   *
-   * ```graphql
-   * # good, the resource name will be `query HelloWorld`
-   * query HelloWorld {
-   *   hello
-   *   world
-   * }
-   *
-   * # bad, the resource name will be `query`
-   * {
-   *   hello
-   *   world
-   * }
-   * ```
-   */
-  interface graphql extends Instrumentation {
-    /**
-     * The maximum depth of fields/resolvers to instrument. Set to `0` to only
-     * instrument the operation or to `-1` to instrument all fields/resolvers.
-     *
-     * @default -1
-     */
-    depth?: number;
-
-    /**
-     * Whether to include the source of the operation within the query as a tag
-     * on every span. This may contain sensitive information and sould only be
-     * enabled if sensitive data is always sent as variables and not in the
-     * query text.
-     *
-     * @default false
-     */
-    source?: boolean;
-
-    /**
-     * An array of variable names to record. Can also be a callback that returns
-     * the key/value pairs to record. For example, using
-     * `variables => variables` would record all variables.
-     */
-    variables?: string[] | ((variables: { [key: string]: any }) => { [key: string]: any });
-
-    /**
-     * Whether to collapse list items into a single element. (i.e. single
-     * `users.*.name` span instead of `users.0.name`, `users.1.name`, etc)
-     *
-     * @default true
-     */
-    collapse?: boolean;
-
-    /**
-     * Whether to enable signature calculation for the resource name. This can
-     * be disabled if your GraphQL operations always have a name. Note that when
-     * disabled all queries will need to be named for this to work properly.
-     *
-     * @default true
-     */
-    signature?: boolean;
-
-    /**
-     * An object of optional callbacks to be executed during the respective
-     * phase of a GraphQL operation. Undefined callbacks default to a noop
-     * function.
-     *
-     * @default {}
-     */
-    hooks?: {
-      execute?: (span?: Span, args?: ExecutionArgs, res?: any) => void;
-      validate?: (span?: Span, document?: any, errors?: any) => void;
-      parse?: (span?: Span, source?: any, document?: any) => void;
+      enabled?: boolean;
     }
-  }
 
-  /**
-   * This plugin automatically instruments the
-   * [grpc](https://github.com/grpc/grpc-node) module.
-   */
-  interface grpc extends Grpc {
-    /**
-     * Configuration for gRPC clients.
-     */
-    client?: Grpc,
+    /** @hidden */
+    interface Instrumentation extends Integration, Analyzable {}
 
-    /**
-     * Configuration for gRPC servers.
-     */
-    server?: Grpc
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [hapi](https://hapijs.com/) module.
-   */
-  interface hapi extends HttpServer {}
-
-  /**
-   * This plugin automatically instruments the
-   * [http](https://nodejs.org/api/http.html) module.
-   *
-   * By default any option set at the root will apply to both clients and
-   * servers. To configure only one or the other, use the `client` and `server`
-   * options.
-   */
-  interface http extends HttpClient, HttpServer {
-    /**
-     * Configuration for HTTP clients.
-     */
-    client?: HttpClient | boolean,
-
-    /**
-     * Configuration for HTTP servers.
-     */
-    server?: HttpServer | boolean
-
-    /**
-     * Hooks to run before spans are finished.
-     */
-    hooks?: {
+    /** @hidden */
+    interface Http extends Instrumentation {
       /**
-       * Hook to execute just before the request span finishes.
+       * List of URLs that should be instrumented.
+       *
+       * @default /^.*$/
        */
-      request?: (
-        span?: Span,
-        req?: IncomingMessage | ClientRequest,
-        res?: ServerResponse | IncomingMessage
-      ) => any;
-    };
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [http2](https://nodejs.org/api/http2.html) module.
-   *
-   * By default any option set at the root will apply to both clients and
-   * servers. To configure only one or the other, use the `client` and `server`
-   * options.
-   */
-  interface http2 extends Http2Client, Http2Server {
-    /**
-     * Configuration for HTTP clients.
-     */
-    client?: Http2Client | boolean,
-
-    /**
-     * Configuration for HTTP servers.
-     */
-    server?: Http2Server | boolean
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [ioredis](https://github.com/luin/ioredis) module.
-   */
-  interface ioredis extends Instrumentation {
-    /**
-     * List of commands that should be instrumented. Commands must be in
-     * lowercase for example 'xread'.
-     *
-     * @default /^.*$/
-     */
-    allowlist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-
-    /**
-     * Deprecated in favor of `allowlist`.
-     *
-     * @deprecated
-     * @hidden
-     */
-    whitelist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-
-    /**
-     * List of commands that should not be instrumented. Takes precedence over
-     * allowlist if a command matches an entry in both. Commands must be in
-     * lowercase for example 'xread'.
-     *
-     * @default []
-     */
-    blocklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-
-    /**
-     * Deprecated in favor of `blocklist`.
-     *
-     * @deprecated
-     * @hidden
-     */
-    blacklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-
-    /**
-     * Whether to use a different service name for each Redis instance based
-     * on the configured connection name of the client.
-     *
-     * @default false
-     */
-    splitByInstance?: boolean;
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [jest](https://github.com/facebook/jest) module.
-   */
-  interface jest extends Integration {}
-
-  /**
-   * This plugin patches the [knex](https://knexjs.org/)
-   * module to bind the promise callback the the caller context.
-   */
-  interface knex extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [koa](https://koajs.com/) module.
-   */
-  interface koa extends HttpServer {}
-
-  /**
-   * This plugin automatically instruments the
-   * [kafkajs](https://kafka.js.org/) module.
-   */
-  interface kafkajs extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [ldapjs](https://github.com/ldapjs/node-ldapjs/) module.
-   */
-  interface ldapjs extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [mariadb](https://github.com/mariadb-corporation/mariadb-connector-nodejs) module.
-   */
-  interface mariadb extends mysql {}
-
-  /**
-   * This plugin automatically instruments the
-   * [memcached](https://github.com/3rd-Eden/memcached) module.
-   */
-  interface memcached extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [microgateway-core](https://github.com/apigee/microgateway-core) module.
-   */
-  interface microgateway_core extends HttpServer {}
-
-  /**
-   * This plugin automatically instruments the
-   * [mocha](https://mochajs.org/) module.
-   */
-  interface mocha extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [moleculer](https://moleculer.services/) module.
-   */
-  interface moleculer extends Moleculer {
-    /**
-     * Configuration for Moleculer clients. Set to false to disable client
-     * instrumentation.
-     */
-    client?: boolean | Moleculer;
-
-    /**
-     * Configuration for Moleculer servers. Set to false to disable server
-     * instrumentation.
-     */
-    server?: boolean | Moleculer;
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [mongodb-core](https://github.com/mongodb-js/mongodb-core) module.
-   */
-  interface mongodb_core extends Instrumentation {
-    /**
-     * Whether to include the query contents in the resource name.
-     */
-    queryInResourceName?: boolean;
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [mongoose](https://mongoosejs.com/) module.
-   */
-  interface mongoose extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [mysql](https://github.com/mysqljs/mysql) module.
-   */
-  interface mysql extends Instrumentation {
-    service?: string | ((params: any) => string);
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [mysql2](https://github.com/sidorares/node-mysql2) module.
-   */
-  interface mysql2 extends mysql {}
-
-  /**
-   * This plugin automatically instruments the
-   * [net](https://nodejs.org/api/net.html) module.
-   */
-  interface net extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [next](https://nextjs.org/) module.
-   */
-  interface next extends Instrumentation {
-    /**
-     * Hooks to run before spans are finished.
-     */
-    hooks?: {
-      /**
-       * Hook to execute just before the request span finishes.
-       */
-      request?: (span?: Span, req?: IncomingMessage, res?: ServerResponse) => any;
-    };
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [openai](https://platform.openai.com/docs/api-reference?lang=node.js) module.
-   *
-   * Note that for logs to work you'll need to set the `DD_API_KEY` environment variable.
-   * You'll also need to adjust any firewall settings to allow the tracer to communicate
-   * with `http-intake.logs.datadoghq.com`.
-   *
-   * Note that for metrics to work you'll need to enable
-   * [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent#setup)
-   * in the agent.
-   */
-  interface openai extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [opensearch](https://github.com/opensearch-project/opensearch-js) module.
-   */
-  interface opensearch extends elasticsearch {}
-
-  /**
-   * This plugin automatically instruments the
-   * [oracledb](https://github.com/oracle/node-oracledb) module.
-   */
-  interface oracledb extends Instrumentation {
-    /**
-     * The service name to be used for this plugin. If a function is used, it will be passed the connection parameters and its return value will be used as the service name.
-     */
-    service?: string | ((params: any) => string);
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [paperplane](https://github.com/articulate/paperplane) module.
-   */
-  interface paperplane extends HttpServer {}
-
-  /**
-  * This plugin automatically instruments the
-  * [playwright](https://github.com/microsoft/playwright) module.
-  */
-  interface playwright extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [pg](https://node-postgres.com/) module.
-   */
-  interface pg extends Instrumentation {
-    /**
-     * The service name to be used for this plugin. If a function is used, it will be passed the connection parameters and its return value will be used as the service name.
-     */
-    service?: string | ((params: any) => string);
-  }
-
-  /**
-   * This plugin patches the [pino](http://getpino.io)
-   * to automatically inject trace identifiers in log records when the
-   * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
-   * on the tracer.
-   */
-  interface pino extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [redis](https://github.com/NodeRedis/node_redis) module.
-   */
-  interface redis extends Instrumentation {
-    /**
-     * List of commands that should be instrumented.
-     *
-     * @default /^.*$/
-     */
-    allowlist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-
-    /**
-     * Deprecated in favor of `allowlist`.
-     *
-     * deprecated
-     * @hidden
-     */
-    whitelist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-
-    /**
-     * List of commands that should not be instrumented. Takes precedence over
-     * allowlist if a command matches an entry in both.
-     *
-     * @default []
-     */
-    blocklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-
-    /**
-     * Deprecated in favor of `blocklist`.
-     *
-     * @deprecated
-     * @hidden
-     */
-    blacklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
-  }
-
-  /**
-   * This plugin automatically instruments the
-   * [restify](http://restify.com/) module.
-   */
-  interface restify extends HttpServer {}
-
-  /**
-   * This plugin automatically instruments the
-   * [rhea](https://github.com/amqp/rhea) module.
-   */
-  interface rhea extends Instrumentation {}
-
-  /**
-   * This plugin automatically instruments the
-   * [router](https://github.com/pillarjs/router) module.
-   */
-  interface router extends Integration {}
-
-  /**
-   * This plugin automatically instruments the
-   * [sharedb](https://github.com/share/sharedb) module.
-   */
-  interface sharedb extends Integration {
-    /**
-     * Hooks to run before spans are finished.
-     */
-    hooks?: {
-      /**
-       * Hook to execute just when the span is created.
-       */
-      receive?: (span?: Span, request?: any) => any;
+      allowlist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
 
       /**
-       * Hook to execute just when the span is finished.
+       * Deprecated in favor of `allowlist`.
+       *
+       * @deprecated
+       * @hidden
        */
-      reply?: (span?: Span, request?: any, response?: any) => any;
-    };
+      whitelist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
+
+      /**
+       * List of URLs that should not be instrumented. Takes precedence over
+       * allowlist if a URL matches an entry in both.
+       *
+       * @default []
+       */
+      blocklist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
+
+      /**
+       * Deprecated in favor of `blocklist`.
+       *
+       * @deprecated
+       * @hidden
+       */
+      blacklist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
+
+      /**
+       * An array of headers to include in the span metadata.
+       *
+       * @default []
+       */
+      headers?: string[];
+
+      /**
+       * Callback function to determine if there was an error. It should take a
+       * status code as its only parameter and return `true` for success or `false`
+       * for errors.
+       *
+       * @default code => code < 500
+       */
+      validateStatus?: (code: number) => boolean;
+
+      /**
+       * Enable injection of tracing headers into requests signed with AWS IAM headers.
+       * Disable this if you get AWS signature errors (HTTP 403).
+       *
+       * @default false
+       */
+      enablePropagationWithAmazonHeaders?: boolean;
+    }
+
+    /** @hidden */
+    interface HttpServer extends Http {
+      /**
+       * Callback function to determine if there was an error. It should take a
+       * status code as its only parameter and return `true` for success or `false`
+       * for errors.
+       *
+       * @default code => code < 500
+       */
+      validateStatus?: (code: number) => boolean;
+
+      /**
+       * Hooks to run before spans are finished.
+       */
+      hooks?: {
+        /**
+         * Hook to execute just before the request span finishes.
+         */
+        request?: (span?: Span, req?: IncomingMessage, res?: ServerResponse) => any;
+      };
+
+      /**
+       * Whether to enable instrumentation of <plugin>.middleware spans
+       *
+       * @default true
+       */
+      middleware?: boolean;
+    }
+
+    /** @hidden */
+    interface HttpClient extends Http {
+      /**
+       * Use the remote endpoint host as the service name instead of the default.
+       *
+       * @default false
+       */
+      splitByDomain?: boolean;
+
+      /**
+       * Callback function to determine if there was an error. It should take a
+       * status code as its only parameter and return `true` for success or `false`
+       * for errors.
+       *
+       * @default code => code < 400 || code >= 500
+       */
+      validateStatus?: (code: number) => boolean;
+
+      /**
+       * Hooks to run before spans are finished.
+       */
+      hooks?: {
+        /**
+         * Hook to execute just before the request span finishes.
+         */
+        request?: (span?: Span, req?: ClientRequest, res?: IncomingMessage) => any;
+      };
+
+      /**
+       * List of urls to which propagation headers should not be injected
+       */
+      propagationBlocklist?: string | RegExp | ((url: string) => boolean) | (string | RegExp | ((url: string) => boolean))[];
+    }
+
+    /** @hidden */
+    interface Http2Client extends Http {
+      /**
+       * Use the remote endpoint host as the service name instead of the default.
+       *
+       * @default false
+       */
+      splitByDomain?: boolean;
+
+      /**
+       * Callback function to determine if there was an error. It should take a
+       * status code as its only parameter and return `true` for success or `false`
+       * for errors.
+       *
+       * @default code => code < 400 || code >= 500
+       */
+      validateStatus?: (code: number) => boolean;
+    }
+
+    /** @hidden */
+    interface Http2Server extends Http {
+      /**
+       * Callback function to determine if there was an error. It should take a
+       * status code as its only parameter and return `true` for success or `false`
+       * for errors.
+       *
+       * @default code => code < 500
+       */
+      validateStatus?: (code: number) => boolean;
+    }
+
+    /** @hidden */
+    interface Grpc extends Instrumentation {
+      /**
+       * An array of metadata entries to record. Can also be a callback that returns
+       * the key/value pairs to record. For example, using
+       * `variables => variables` would record all variables.
+       */
+      metadata?: string[] | ((variables: { [key: string]: any }) => { [key: string]: any });
+    }
+
+    /** @hidden */
+    interface Moleculer extends Instrumentation {
+      /**
+       * Whether to include context meta as tags.
+       *
+       * @default false
+       */
+      meta?: boolean;
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [amqp10](https://github.com/noodlefrenzy/node-amqp10) module.
+     */
+    interface amqp10 extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [amqplib](https://github.com/squaremo/amqp.node) module.
+     */
+    interface amqplib extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [aws-sdk](https://github.com/aws/aws-sdk-js) module.
+     */
+    interface aws_sdk extends Instrumentation {
+      /**
+       * Whether to add a suffix to the service name so that each AWS service has its own service name.
+       * @default true
+       */
+      splitByAwsService?: boolean;
+
+      /**
+       * Hooks to run before spans are finished.
+       */
+      hooks?: {
+        /**
+         * Hook to execute just before the aws span finishes.
+         */
+        request?: (span?: Span, response?: anyObject) => any;
+      };
+
+      /**
+       * Configuration for individual services to enable/disable them. Message
+       * queue services can also configure the producer and consumer individually
+       * by passing an object with a `producer` and `consumer` properties. The
+       * list of valid service keys is in the service-specific section of
+       * https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html
+       */
+      [key: string]: boolean | Object | undefined;
+    }
+
+    /**
+     * This plugin patches the [bunyan](https://github.com/trentm/node-bunyan)
+     * to automatically inject trace identifiers in log records when the
+     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+     * on the tracer.
+     */
+    interface bunyan extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [cassandra-driver](https://github.com/datastax/nodejs-driver) module.
+     */
+    interface cassandra_driver extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [connect](https://github.com/senchalabs/connect) module.
+     */
+    interface connect extends HttpServer {}
+
+    /**
+     * This plugin automatically instruments the
+     * [couchbase](https://www.npmjs.com/package/couchbase) module.
+     */
+    interface couchbase extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [cucumber](https://www.npmjs.com/package/@cucumber/cucumber) module.
+     */
+    interface cucumber extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [cypress](https://github.com/cypress-io/cypress) module.
+     */
+    interface cypress extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [dns](https://nodejs.org/api/dns.html) module.
+     */
+    interface dns extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [elasticsearch](https://github.com/elastic/elasticsearch-js) module.
+     */
+    interface elasticsearch extends Instrumentation {
+      /**
+       * Hooks to run before spans are finished.
+       */
+      hooks?: {
+        /**
+         * Hook to execute just before the query span finishes.
+         */
+        query?: (span?: Span, params?: TransportRequestParams) => any;
+      };
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [express](http://expressjs.com/) module.
+     */
+    interface express extends HttpServer {}
+
+    /**
+     * This plugin automatically instruments the
+     * [fastify](https://www.fastify.io/) module.
+     */
+    interface fastify extends HttpServer {}
+
+    /**
+     * This plugin automatically instruments the
+     * [fetch](https://nodejs.org/api/globals.html#fetch) global.
+     */
+    interface fetch extends HttpClient {}
+
+    /**
+     * This plugin patches the [generic-pool](https://github.com/coopernurse/node-pool)
+     * module to bind the callbacks the the caller context.
+     */
+    interface generic_pool extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [@google-cloud/pubsub](https://github.com/googleapis/nodejs-pubsub) module.
+     */
+    interface google_cloud_pubsub extends Integration {}
+
+    /** @hidden */
+    interface ExecutionArgs {
+      schema: any,
+      document: any,
+      rootValue?: any,
+      contextValue?: any,
+      variableValues?: any,
+      operationName?: string,
+      fieldResolver?: any,
+      typeResolver?: any,
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [graphql](https://github.com/graphql/graphql-js) module.
+     *
+     * The `graphql` integration uses the operation name as the span resource name.
+     * If no operation name is set, the resource name will always be just `query`,
+     * `mutation` or `subscription`.
+     *
+     * For example:
+     *
+     * ```graphql
+     * # good, the resource name will be `query HelloWorld`
+     * query HelloWorld {
+     *   hello
+     *   world
+     * }
+     *
+     * # bad, the resource name will be `query`
+     * {
+     *   hello
+     *   world
+     * }
+     * ```
+     */
+    interface graphql extends Instrumentation {
+      /**
+       * The maximum depth of fields/resolvers to instrument. Set to `0` to only
+       * instrument the operation or to `-1` to instrument all fields/resolvers.
+       *
+       * @default -1
+       */
+      depth?: number;
+
+      /**
+       * Whether to include the source of the operation within the query as a tag
+       * on every span. This may contain sensitive information and sould only be
+       * enabled if sensitive data is always sent as variables and not in the
+       * query text.
+       *
+       * @default false
+       */
+      source?: boolean;
+
+      /**
+       * An array of variable names to record. Can also be a callback that returns
+       * the key/value pairs to record. For example, using
+       * `variables => variables` would record all variables.
+       */
+      variables?: string[] | ((variables: { [key: string]: any }) => { [key: string]: any });
+
+      /**
+       * Whether to collapse list items into a single element. (i.e. single
+       * `users.*.name` span instead of `users.0.name`, `users.1.name`, etc)
+       *
+       * @default true
+       */
+      collapse?: boolean;
+
+      /**
+       * Whether to enable signature calculation for the resource name. This can
+       * be disabled if your GraphQL operations always have a name. Note that when
+       * disabled all queries will need to be named for this to work properly.
+       *
+       * @default true
+       */
+      signature?: boolean;
+
+      /**
+       * An object of optional callbacks to be executed during the respective
+       * phase of a GraphQL operation. Undefined callbacks default to a noop
+       * function.
+       *
+       * @default {}
+       */
+      hooks?: {
+        execute?: (span?: Span, args?: ExecutionArgs, res?: any) => void;
+        validate?: (span?: Span, document?: any, errors?: any) => void;
+        parse?: (span?: Span, source?: any, document?: any) => void;
+      }
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [grpc](https://github.com/grpc/grpc-node) module.
+     */
+    interface grpc extends Grpc {
+      /**
+       * Configuration for gRPC clients.
+       */
+      client?: Grpc,
+
+      /**
+       * Configuration for gRPC servers.
+       */
+      server?: Grpc
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [hapi](https://hapijs.com/) module.
+     */
+    interface hapi extends HttpServer {}
+
+    /**
+     * This plugin automatically instruments the
+     * [http](https://nodejs.org/api/http.html) module.
+     *
+     * By default any option set at the root will apply to both clients and
+     * servers. To configure only one or the other, use the `client` and `server`
+     * options.
+     */
+    interface http extends HttpClient, HttpServer {
+      /**
+       * Configuration for HTTP clients.
+       */
+      client?: HttpClient | boolean,
+
+      /**
+       * Configuration for HTTP servers.
+       */
+      server?: HttpServer | boolean
+
+      /**
+       * Hooks to run before spans are finished.
+       */
+      hooks?: {
+        /**
+         * Hook to execute just before the request span finishes.
+         */
+        request?: (
+          span?: Span,
+          req?: IncomingMessage | ClientRequest,
+          res?: ServerResponse | IncomingMessage
+        ) => any;
+      };
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [http2](https://nodejs.org/api/http2.html) module.
+     *
+     * By default any option set at the root will apply to both clients and
+     * servers. To configure only one or the other, use the `client` and `server`
+     * options.
+     */
+    interface http2 extends Http2Client, Http2Server {
+      /**
+       * Configuration for HTTP clients.
+       */
+      client?: Http2Client | boolean,
+
+      /**
+       * Configuration for HTTP servers.
+       */
+      server?: Http2Server | boolean
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [ioredis](https://github.com/luin/ioredis) module.
+     */
+    interface ioredis extends Instrumentation {
+      /**
+       * List of commands that should be instrumented. Commands must be in
+       * lowercase for example 'xread'.
+       *
+       * @default /^.*$/
+       */
+      allowlist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+      /**
+       * Deprecated in favor of `allowlist`.
+       *
+       * @deprecated
+       * @hidden
+       */
+      whitelist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+      /**
+       * List of commands that should not be instrumented. Takes precedence over
+       * allowlist if a command matches an entry in both. Commands must be in
+       * lowercase for example 'xread'.
+       *
+       * @default []
+       */
+      blocklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+      /**
+       * Deprecated in favor of `blocklist`.
+       *
+       * @deprecated
+       * @hidden
+       */
+      blacklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+      /**
+       * Whether to use a different service name for each Redis instance based
+       * on the configured connection name of the client.
+       *
+       * @default false
+       */
+      splitByInstance?: boolean;
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [jest](https://github.com/facebook/jest) module.
+     */
+    interface jest extends Integration {}
+
+    /**
+     * This plugin patches the [knex](https://knexjs.org/)
+     * module to bind the promise callback the the caller context.
+     */
+    interface knex extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [koa](https://koajs.com/) module.
+     */
+    interface koa extends HttpServer {}
+
+    /**
+     * This plugin automatically instruments the
+     * [kafkajs](https://kafka.js.org/) module.
+     */
+    interface kafkajs extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [ldapjs](https://github.com/ldapjs/node-ldapjs/) module.
+     */
+    interface ldapjs extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [mariadb](https://github.com/mariadb-corporation/mariadb-connector-nodejs) module.
+     */
+    interface mariadb extends mysql {}
+
+    /**
+     * This plugin automatically instruments the
+     * [memcached](https://github.com/3rd-Eden/memcached) module.
+     */
+    interface memcached extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [microgateway-core](https://github.com/apigee/microgateway-core) module.
+     */
+    interface microgateway_core extends HttpServer {}
+
+    /**
+     * This plugin automatically instruments the
+     * [mocha](https://mochajs.org/) module.
+     */
+    interface mocha extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [moleculer](https://moleculer.services/) module.
+     */
+    interface moleculer extends Moleculer {
+      /**
+       * Configuration for Moleculer clients. Set to false to disable client
+       * instrumentation.
+       */
+      client?: boolean | Moleculer;
+
+      /**
+       * Configuration for Moleculer servers. Set to false to disable server
+       * instrumentation.
+       */
+      server?: boolean | Moleculer;
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [mongodb-core](https://github.com/mongodb-js/mongodb-core) module.
+     */
+    interface mongodb_core extends Instrumentation {
+      /**
+       * Whether to include the query contents in the resource name.
+       */
+      queryInResourceName?: boolean;
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [mongoose](https://mongoosejs.com/) module.
+     */
+    interface mongoose extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [mysql](https://github.com/mysqljs/mysql) module.
+     */
+    interface mysql extends Instrumentation {
+      service?: string | ((params: any) => string);
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [mysql2](https://github.com/sidorares/node-mysql2) module.
+     */
+    interface mysql2 extends mysql {}
+
+    /**
+     * This plugin automatically instruments the
+     * [net](https://nodejs.org/api/net.html) module.
+     */
+    interface net extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [next](https://nextjs.org/) module.
+     */
+    interface next extends Instrumentation {
+      /**
+       * Hooks to run before spans are finished.
+       */
+      hooks?: {
+        /**
+         * Hook to execute just before the request span finishes.
+         */
+        request?: (span?: Span, req?: IncomingMessage, res?: ServerResponse) => any;
+      };
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [openai](https://platform.openai.com/docs/api-reference?lang=node.js) module.
+     *
+     * Note that for logs to work you'll need to set the `DD_API_KEY` environment variable.
+     * You'll also need to adjust any firewall settings to allow the tracer to communicate
+     * with `http-intake.logs.datadoghq.com`.
+     *
+     * Note that for metrics to work you'll need to enable
+     * [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent#setup)
+     * in the agent.
+     */
+    interface openai extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [opensearch](https://github.com/opensearch-project/opensearch-js) module.
+     */
+    interface opensearch extends elasticsearch {}
+
+    /**
+     * This plugin automatically instruments the
+     * [oracledb](https://github.com/oracle/node-oracledb) module.
+     */
+    interface oracledb extends Instrumentation {
+      /**
+       * The service name to be used for this plugin. If a function is used, it will be passed the connection parameters and its return value will be used as the service name.
+       */
+      service?: string | ((params: any) => string);
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [paperplane](https://github.com/articulate/paperplane) module.
+     */
+    interface paperplane extends HttpServer {}
+
+    /**
+    * This plugin automatically instruments the
+    * [playwright](https://github.com/microsoft/playwright) module.
+    */
+    interface playwright extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [pg](https://node-postgres.com/) module.
+     */
+    interface pg extends Instrumentation {
+      /**
+       * The service name to be used for this plugin. If a function is used, it will be passed the connection parameters and its return value will be used as the service name.
+       */
+      service?: string | ((params: any) => string);
+    }
+
+    /**
+     * This plugin patches the [pino](http://getpino.io)
+     * to automatically inject trace identifiers in log records when the
+     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+     * on the tracer.
+     */
+    interface pino extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [redis](https://github.com/NodeRedis/node_redis) module.
+     */
+    interface redis extends Instrumentation {
+      /**
+       * List of commands that should be instrumented.
+       *
+       * @default /^.*$/
+       */
+      allowlist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+      /**
+       * Deprecated in favor of `allowlist`.
+       *
+       * deprecated
+       * @hidden
+       */
+      whitelist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+      /**
+       * List of commands that should not be instrumented. Takes precedence over
+       * allowlist if a command matches an entry in both.
+       *
+       * @default []
+       */
+      blocklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+
+      /**
+       * Deprecated in favor of `blocklist`.
+       *
+       * @deprecated
+       * @hidden
+       */
+      blacklist?: string | RegExp | ((command: string) => boolean) | (string | RegExp | ((command: string) => boolean))[];
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [restify](http://restify.com/) module.
+     */
+    interface restify extends HttpServer {}
+
+    /**
+     * This plugin automatically instruments the
+     * [rhea](https://github.com/amqp/rhea) module.
+     */
+    interface rhea extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [router](https://github.com/pillarjs/router) module.
+     */
+    interface router extends Integration {}
+
+    /**
+     * This plugin automatically instruments the
+     * [sharedb](https://github.com/share/sharedb) module.
+     */
+    interface sharedb extends Integration {
+      /**
+       * Hooks to run before spans are finished.
+       */
+      hooks?: {
+        /**
+         * Hook to execute just when the span is created.
+         */
+        receive?: (span?: Span, request?: any) => any;
+
+        /**
+         * Hook to execute just when the span is finished.
+         */
+        reply?: (span?: Span, request?: any, response?: any) => any;
+      };
+    }
+
+    /**
+     * This plugin automatically instruments the
+     * [tedious](https://github.com/tediousjs/tedious/) module.
+     */
+    interface tedious extends Instrumentation {}
+
+    /**
+     * This plugin patches the [winston](https://github.com/winstonjs/winston)
+     * to automatically inject trace identifiers in log records when the
+     * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
+     * on the tracer.
+     */
+    interface winston extends Integration {}
   }
 
-  /**
-   * This plugin automatically instruments the
-   * [tedious](https://github.com/tediousjs/tedious/) module.
-   */
-  interface tedious extends Instrumentation {}
-
-  /**
-   * This plugin patches the [winston](https://github.com/winstonjs/winston)
-   * to automatically inject trace identifiers in log records when the
-   * [logInjection](interfaces/traceroptions.html#logInjection) option is enabled
-   * on the tracer.
-   */
-  interface winston extends Integration {}
-}
-
-export namespace opentelemetry {
-  /**
-   * A registry for creating named {@link Tracer}s.
-   */
-  export interface TracerProvider extends otel.TracerProvider {
+  export namespace opentelemetry {
     /**
-     * Construct a new TracerProvider to register with @opentelemetry/api
-     *
-     * @returns TracerProvider A TracerProvider instance
+     * A registry for creating named {@link Tracer}s.
      */
-    new(): TracerProvider;
+    export interface TracerProvider extends otel.TracerProvider {
+      /**
+       * Construct a new TracerProvider to register with @opentelemetry/api
+       *
+       * @returns TracerProvider A TracerProvider instance
+       */
+      new(): TracerProvider;
 
-    /**
-     * Returns a Tracer, creating one if one with the given name and version is
-     * not already created.
-     *
-     * This function may return different Tracer types (e.g.
-     * {@link NoopTracerProvider} vs. a functional tracer).
-     *
-     * @param name The name of the tracer or instrumentation library.
-     * @param version The version of the tracer or instrumentation library.
-     * @param options The options of the tracer or instrumentation library.
-     * @returns Tracer A Tracer with the given name and version
-     */
-    getTracer(name: string, version?: string): Tracer;
+      /**
+       * Returns a Tracer, creating one if one with the given name and version is
+       * not already created.
+       *
+       * This function may return different Tracer types (e.g.
+       * {@link NoopTracerProvider} vs. a functional tracer).
+       *
+       * @param name The name of the tracer or instrumentation library.
+       * @param version The version of the tracer or instrumentation library.
+       * @param options The options of the tracer or instrumentation library.
+       * @returns Tracer A Tracer with the given name and version
+       */
+      getTracer(name: string, version?: string): Tracer;
+
+      /**
+       * Register this tracer provider with @opentelemetry/api
+       */
+      register(): void;
+    }
 
     /**
-     * Register this tracer provider with @opentelemetry/api
+     * Tracer provides an interface for creating {@link Span}s.
      */
-    register(): void;
+    export interface Tracer extends otel.Tracer {
+      /**
+       * Starts a new {@link Span}. Start the span without setting it on context.
+       *
+       * This method do NOT modify the current Context.
+       *
+       * @param name The name of the span
+       * @param [options] SpanOptions used for span creation
+       * @param [context] Context to use to extract parent
+       * @returns Span The newly created span
+       * @example
+       *     const span = tracer.startSpan('op');
+       *     span.setAttribute('key', 'value');
+       *     span.end();
+       */
+      startSpan(name: string, options?: SpanOptions, context?: Context): Span;
+
+      /**
+       * Starts a new {@link Span} and calls the given function passing it the
+       * created span as first argument.
+       * Additionally the new span gets set in context and this context is activated
+       * for the duration of the function call.
+       *
+       * @param name The name of the span
+       * @param [options] SpanOptions used for span creation
+       * @param [context] Context to use to extract parent
+       * @param fn function called in the context of the span and receives the newly created span as an argument
+       * @returns return value of fn
+       * @example
+       *     const something = tracer.startActiveSpan('op', span => {
+       *       try {
+       *         do some work
+       *         span.setStatus({code: SpanStatusCode.OK});
+       *         return something;
+       *       } catch (err) {
+       *         span.setStatus({
+       *           code: SpanStatusCode.ERROR,
+       *           message: err.message,
+       *         });
+       *         throw err;
+       *       } finally {
+       *         span.end();
+       *       }
+       *     });
+       *
+       * @example
+       *     const span = tracer.startActiveSpan('op', span => {
+       *       try {
+       *         do some work
+       *         return span;
+       *       } catch (err) {
+       *         span.setStatus({
+       *           code: SpanStatusCode.ERROR,
+       *           message: err.message,
+       *         });
+       *         throw err;
+       *       }
+       *     });
+       *     do some more work
+       *     span.end();
+       */
+      startActiveSpan<F extends (span: Span) => unknown>(name: string, fn: F): ReturnType<F>;
+      startActiveSpan<F extends (span: Span) => unknown>(name: string, options: SpanOptions, fn: F): ReturnType<F>;
+      startActiveSpan<F extends (span: Span) => unknown>(name: string, options: SpanOptions, context: otel.Context, fn: F): ReturnType<F>;
+    }
+
+    /**
+     * An interface that represents a span. A span represents a single operation
+     * within a trace. Examples of span might include remote procedure calls or a
+     * in-process function calls to sub-components. A Trace has a single, top-level
+     * "root" Span that in turn may have zero or more child Spans, which in turn
+     * may have children.
+     *
+     * Spans are created by the {@link Tracer.startSpan} method.
+     */
+    export interface Span extends otel.Span {
+      /**
+       * Returns the {@link SpanContext} object associated with this Span.
+       *
+       * Get an immutable, serializable identifier for this span that can be used
+       * to create new child spans. Returned SpanContext is usable even after the
+       * span ends.
+       *
+       * @returns the SpanContext object associated with this Span.
+       */
+      spanContext(): SpanContext;
+
+      /**
+       * Sets an attribute to the span.
+       *
+       * Sets a single Attribute with the key and value passed as arguments.
+       *
+       * @param key the key for this attribute.
+       * @param value the value for this attribute. Setting a value null or
+       *              undefined is invalid and will result in undefined behavior.
+       */
+      setAttribute(key: string, value: SpanAttributeValue): this;
+
+      /**
+       * Sets attributes to the span.
+       *
+       * @param attributes the attributes that will be added.
+       *                   null or undefined attribute values
+       *                   are invalid and will result in undefined behavior.
+       */
+      setAttributes(attributes: SpanAttributes): this;
+
+      /**
+       * Adds an event to the Span.
+       *
+       * @param name the name of the event.
+       * @param [attributesOrStartTime] the attributes that will be added; these are
+       *     associated with this event. Can be also a start time
+       *     if type is {@type TimeInput} and 3rd param is undefined
+       * @param [startTime] start time of the event.
+       */
+      addEvent(name: string, attributesOrStartTime?: SpanAttributes | TimeInput, startTime?: TimeInput): this;
+
+      /**
+       * Sets a status to the span. If used, this will override the default Span
+       * status. Default is {@link SpanStatusCode.UNSET}. SetStatus overrides the value
+       * of previous calls to SetStatus on the Span.
+       *
+       * @param status the SpanStatus to set.
+       */
+      setStatus(status: SpanStatus): this;
+
+      /**
+       * Updates the Span name.
+       *
+       * This will override the name provided via {@link Tracer.startSpan}.
+       *
+       * Upon this update, any sampling behavior based on Span name will depend on
+       * the implementation.
+       *
+       * @param name the Span name.
+       */
+      updateName(name: string): this;
+
+      /**
+       * Marks the end of Span execution.
+       *
+       * Call to End of a Span MUST not have any effects on child spans. Those may
+       * still be running and can be ended later.
+       *
+       * Do not return `this`. The Span generally should not be used after it
+       * is ended so chaining is not desired in this context.
+       *
+       * @param [endTime] the time to set as Span's end time. If not provided,
+       *     use the current time as the span's end time.
+       */
+      end(endTime?: TimeInput): void;
+
+      /**
+       * Returns the flag whether this span will be recorded.
+       *
+       * @returns true if this Span is active and recording information like events
+       *     with the `AddEvent` operation and attributes using `setAttributes`.
+       */
+      isRecording(): boolean;
+
+      /**
+       * Sets exception as a span event
+       * @param exception the exception the only accepted values are string or Error
+       * @param [time] the time to set as Span's event time. If not provided,
+       *     use the current time.
+       */
+      recordException(exception: Exception, time?: TimeInput): void;
+
+      /**
+       * Causally links another span to the current span
+       * @param {otel.SpanContext} context The context of the span to link to.
+       * @param {SpanAttributes} attributes An optional key value pair of arbitrary values.
+       * @returns {void}
+       */
+      addLink(context: otel.SpanContext, attributes?: SpanAttributes): void;
+    }
+
+    /**
+     * A SpanContext represents the portion of a {@link Span} which must be
+     * serialized and propagated along side of a {@link Baggage}.
+     */
+    export interface SpanContext extends otel.SpanContext {
+      /**
+       * The ID of the trace that this span belongs to. It is worldwide unique
+       * with practically sufficient probability by being made as 16 randomly
+       * generated bytes, encoded as a 32 lowercase hex characters corresponding to
+       * 128 bits.
+       */
+      traceId: string;
+
+      /**
+       * The ID of the Span. It is globally unique with practically sufficient
+       * probability by being made as 8 randomly generated bytes, encoded as a 16
+       * lowercase hex characters corresponding to 64 bits.
+       */
+      spanId: string;
+
+      /**
+       * Only true if the SpanContext was propagated from a remote parent.
+       */
+      isRemote?: boolean;
+
+      /**
+       * Trace flags to propagate.
+       *
+       * It is represented as 1 byte (bitmap). Bit to represent whether trace is
+       * sampled or not. When set, the least significant bit documents that the
+       * caller may have recorded trace data. A caller who does not record trace
+       * data out-of-band leaves this flag unset.
+       *
+       * see {@link TraceFlags} for valid flag values.
+       */
+      traceFlags: number;
+
+      /**
+       * Tracing-system-specific info to propagate.
+       *
+       * The tracestate field value is a `list` as defined below. The `list` is a
+       * series of `list-members` separated by commas `,`, and a list-member is a
+       * key/value pair separated by an equals sign `=`. Spaces and horizontal tabs
+       * surrounding `list-members` are ignored. There can be a maximum of 32
+       * `list-members` in a `list`.
+       * More Info: https://www.w3.org/TR/trace-context/#tracestate-field
+       *
+       * Examples:
+       *     Single tracing system (generic format):
+       *         tracestate: rojo=00f067aa0ba902b7
+       *     Multiple tracing systems (with different formatting):
+       *         tracestate: rojo=00f067aa0ba902b7,congo=t61rcWkgMzE
+       */
+      traceState?: TraceState;
+    }
+
+    export type Context = otel.Context;
+    export type Exception = otel.Exception;
+    export type SpanAttributes = otel.SpanAttributes;
+    export type SpanAttributeValue = otel.SpanAttributeValue;
+    export type SpanOptions = otel.SpanOptions;
+    export type SpanStatus = otel.SpanStatus;
+    export type TimeInput = otel.TimeInput;
+    export type TraceState = otel.TraceState;
   }
-
-  /**
-   * Tracer provides an interface for creating {@link Span}s.
-   */
-  export interface Tracer extends otel.Tracer {
-    /**
-     * Starts a new {@link Span}. Start the span without setting it on context.
-     *
-     * This method do NOT modify the current Context.
-     *
-     * @param name The name of the span
-     * @param [options] SpanOptions used for span creation
-     * @param [context] Context to use to extract parent
-     * @returns Span The newly created span
-     * @example
-     *     const span = tracer.startSpan('op');
-     *     span.setAttribute('key', 'value');
-     *     span.end();
-     */
-    startSpan(name: string, options?: SpanOptions, context?: Context): Span;
-
-    /**
-     * Starts a new {@link Span} and calls the given function passing it the
-     * created span as first argument.
-     * Additionally the new span gets set in context and this context is activated
-     * for the duration of the function call.
-     *
-     * @param name The name of the span
-     * @param [options] SpanOptions used for span creation
-     * @param [context] Context to use to extract parent
-     * @param fn function called in the context of the span and receives the newly created span as an argument
-     * @returns return value of fn
-     * @example
-     *     const something = tracer.startActiveSpan('op', span => {
-     *       try {
-     *         do some work
-     *         span.setStatus({code: SpanStatusCode.OK});
-     *         return something;
-     *       } catch (err) {
-     *         span.setStatus({
-     *           code: SpanStatusCode.ERROR,
-     *           message: err.message,
-     *         });
-     *         throw err;
-     *       } finally {
-     *         span.end();
-     *       }
-     *     });
-     *
-     * @example
-     *     const span = tracer.startActiveSpan('op', span => {
-     *       try {
-     *         do some work
-     *         return span;
-     *       } catch (err) {
-     *         span.setStatus({
-     *           code: SpanStatusCode.ERROR,
-     *           message: err.message,
-     *         });
-     *         throw err;
-     *       }
-     *     });
-     *     do some more work
-     *     span.end();
-     */
-    startActiveSpan<F extends (span: Span) => unknown>(name: string, fn: F): ReturnType<F>;
-    startActiveSpan<F extends (span: Span) => unknown>(name: string, options: SpanOptions, fn: F): ReturnType<F>;
-    startActiveSpan<F extends (span: Span) => unknown>(name: string, options: SpanOptions, context: otel.Context, fn: F): ReturnType<F>;
-  }
-
-  /**
-   * An interface that represents a span. A span represents a single operation
-   * within a trace. Examples of span might include remote procedure calls or a
-   * in-process function calls to sub-components. A Trace has a single, top-level
-   * "root" Span that in turn may have zero or more child Spans, which in turn
-   * may have children.
-   *
-   * Spans are created by the {@link Tracer.startSpan} method.
-   */
-  export interface Span extends otel.Span {
-    /**
-     * Returns the {@link SpanContext} object associated with this Span.
-     *
-     * Get an immutable, serializable identifier for this span that can be used
-     * to create new child spans. Returned SpanContext is usable even after the
-     * span ends.
-     *
-     * @returns the SpanContext object associated with this Span.
-     */
-    spanContext(): SpanContext;
-
-    /**
-     * Sets an attribute to the span.
-     *
-     * Sets a single Attribute with the key and value passed as arguments.
-     *
-     * @param key the key for this attribute.
-     * @param value the value for this attribute. Setting a value null or
-     *              undefined is invalid and will result in undefined behavior.
-     */
-    setAttribute(key: string, value: SpanAttributeValue): this;
-
-    /**
-     * Sets attributes to the span.
-     *
-     * @param attributes the attributes that will be added.
-     *                   null or undefined attribute values
-     *                   are invalid and will result in undefined behavior.
-     */
-    setAttributes(attributes: SpanAttributes): this;
-
-    /**
-     * Adds an event to the Span.
-     *
-     * @param name the name of the event.
-     * @param [attributesOrStartTime] the attributes that will be added; these are
-     *     associated with this event. Can be also a start time
-     *     if type is {@type TimeInput} and 3rd param is undefined
-     * @param [startTime] start time of the event.
-     */
-    addEvent(name: string, attributesOrStartTime?: SpanAttributes | TimeInput, startTime?: TimeInput): this;
-
-    /**
-     * Sets a status to the span. If used, this will override the default Span
-     * status. Default is {@link SpanStatusCode.UNSET}. SetStatus overrides the value
-     * of previous calls to SetStatus on the Span.
-     *
-     * @param status the SpanStatus to set.
-     */
-    setStatus(status: SpanStatus): this;
-
-    /**
-     * Updates the Span name.
-     *
-     * This will override the name provided via {@link Tracer.startSpan}.
-     *
-     * Upon this update, any sampling behavior based on Span name will depend on
-     * the implementation.
-     *
-     * @param name the Span name.
-     */
-    updateName(name: string): this;
-
-    /**
-     * Marks the end of Span execution.
-     *
-     * Call to End of a Span MUST not have any effects on child spans. Those may
-     * still be running and can be ended later.
-     *
-     * Do not return `this`. The Span generally should not be used after it
-     * is ended so chaining is not desired in this context.
-     *
-     * @param [endTime] the time to set as Span's end time. If not provided,
-     *     use the current time as the span's end time.
-     */
-    end(endTime?: TimeInput): void;
-
-    /**
-     * Returns the flag whether this span will be recorded.
-     *
-     * @returns true if this Span is active and recording information like events
-     *     with the `AddEvent` operation and attributes using `setAttributes`.
-     */
-    isRecording(): boolean;
-
-    /**
-     * Sets exception as a span event
-     * @param exception the exception the only accepted values are string or Error
-     * @param [time] the time to set as Span's event time. If not provided,
-     *     use the current time.
-     */
-    recordException(exception: Exception, time?: TimeInput): void;
-
-    /**
-     * Causally links another span to the current span
-     * @param {otel.SpanContext} context The context of the span to link to.
-     * @param {SpanAttributes} attributes An optional key value pair of arbitrary values.
-     * @returns {void}
-     */
-    addLink (context: otel.SpanContext, attributes?: SpanAttributes): void;
-  }
-
-  /**
-   * A SpanContext represents the portion of a {@link Span} which must be
-   * serialized and propagated along side of a {@link Baggage}.
-   */
-  export interface SpanContext extends otel.SpanContext {
-    /**
-     * The ID of the trace that this span belongs to. It is worldwide unique
-     * with practically sufficient probability by being made as 16 randomly
-     * generated bytes, encoded as a 32 lowercase hex characters corresponding to
-     * 128 bits.
-     */
-    traceId: string;
-
-    /**
-     * The ID of the Span. It is globally unique with practically sufficient
-     * probability by being made as 8 randomly generated bytes, encoded as a 16
-     * lowercase hex characters corresponding to 64 bits.
-     */
-    spanId: string;
-
-    /**
-     * Only true if the SpanContext was propagated from a remote parent.
-     */
-    isRemote?: boolean;
-
-    /**
-     * Trace flags to propagate.
-     *
-     * It is represented as 1 byte (bitmap). Bit to represent whether trace is
-     * sampled or not. When set, the least significant bit documents that the
-     * caller may have recorded trace data. A caller who does not record trace
-     * data out-of-band leaves this flag unset.
-     *
-     * see {@link TraceFlags} for valid flag values.
-     */
-    traceFlags: number;
-
-    /**
-     * Tracing-system-specific info to propagate.
-     *
-     * The tracestate field value is a `list` as defined below. The `list` is a
-     * series of `list-members` separated by commas `,`, and a list-member is a
-     * key/value pair separated by an equals sign `=`. Spaces and horizontal tabs
-     * surrounding `list-members` are ignored. There can be a maximum of 32
-     * `list-members` in a `list`.
-     * More Info: https://www.w3.org/TR/trace-context/#tracestate-field
-     *
-     * Examples:
-     *     Single tracing system (generic format):
-     *         tracestate: rojo=00f067aa0ba902b7
-     *     Multiple tracing systems (with different formatting):
-     *         tracestate: rojo=00f067aa0ba902b7,congo=t61rcWkgMzE
-     */
-    traceState?: TraceState;
-  }
-
-  export type Context = otel.Context;
-  export type Exception = otel.Exception;
-  export type SpanAttributes = otel.SpanAttributes;
-  export type SpanAttributeValue = otel.SpanAttributeValue;
-  export type SpanOptions = otel.SpanOptions;
-  export type SpanStatus = otel.SpanStatus;
-  export type TimeInput = otel.TimeInput;
-  export type TraceState = otel.TraceState;
 }
 
 /**
@@ -1997,6 +2010,6 @@ export namespace opentelemetry {
  * start tracing. If not initialized, or initialized and disabled, it will use
  * a no-op implementation.
  */
-export declare const tracer: Tracer;
+declare const tracer: Tracer;
 
-export default tracer;
+export = tracer;


### PR DESCRIPTION
### What does this PR do?

Fixes #3937
Fixes #4035

Updates TypeScript type definitions to properly support NodeNext module resolution and ESM. It also updates typedoc to silence some low priority vuln warnings. (This is dev dependency only, so would never be installed or used in user environments.)

### Motivation

Better support TypeScript and ESM crowd while also appeasing security scanners.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

