### PR TITLE
[ci-visibility] Cypress: do not lose all the trace if `testSuiteSpan` can't be created

### DIFF
--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -7,7 +7,12 @@ async function runCypress () {
       defaultCommandTimeout: 100,
       e2e: {
         setupNodeEvents (on, config) {
-          import('../ci/cypress/plugin.js').then(module => {
+          if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {
+            import('cypress-fail-fast/plugin').then(module => {
+              module.default(on, config)
+            })
+          }
+          import('dd-trace/ci/cypress/plugin').then(module => {
             module.default(on, config)
           })
         }

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -2,6 +2,9 @@ module.exports = {
   defaultCommandTimeout: 100,
   e2e: {
     setupNodeEvents (on, config) {
+      if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {
+        require('cypress-fail-fast/plugin')(on, config)
+      }
       require('dd-trace/ci/cypress/plugin')(on, config)
     }
   },

--- a/integration-tests/cypress/plugins-old/index.js
+++ b/integration-tests/cypress/plugins-old/index.js
@@ -1,3 +1,6 @@
 module.exports = (on, config) => {
+  if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {
+    require('cypress-fail-fast/plugin')(on, config)
+  }
   require('dd-trace/ci/cypress/plugin')(on, config)
 }

--- a/integration-tests/cypress/support/e2e.js
+++ b/integration-tests/cypress/support/e2e.js
@@ -1,1 +1,5 @@
-import 'dd-trace/ci/cypress/support'
+// eslint-disable-next-line
+if (Cypress.env('ENABLE_INCOMPATIBLE_PLUGIN')) {
+  require('cypress-fail-fast')
+}
+require('dd-trace/ci/cypress/support')


### PR DESCRIPTION
### What does this PR do?

Create a `testSuiteSpan` in `'after:spec'` event if it hadn't been created before.

### Motivation
This is an attempt to improve the fallback behavior of the cypress plugin if there are issues. `testSuiteSpan` being undefined could be a result of other plugins interacting with CI Visibility's plugin. If `testSuiteSpan` is undefined when a test span is created, that span will be invalid (no `test_suite_id`), resulting in the payload being dropped.

With this change, we have a more gracious degradation.

### Plugin Checklist

- [x] Unit tests.


### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

