### PR TITLE
[ci-visibility] Add early flake detection to cucumber 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,7 @@
 /integration-tests/cucumber/ @DataDog/ci-app-libraries
 /integration-tests/cypress/ @DataDog/ci-app-libraries
 /integration-tests/playwright/ @DataDog/ci-app-libraries
-/integration-tests/ci-visibility-spec.js @DataDog/ci-app-libraries
+/integration-tests/ci-visibility.spec.js @DataDog/ci-app-libraries
 /integration-tests/test-api-manual.spec.js @DataDog/ci-app-libraries
 
 /packages/dd-trace/src/service-naming/ @Datadog/apm-framework-integrations-reviewers-js

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -744,7 +744,7 @@ testFrameworks.forEach(({
 
               const tests = events.filter(event => event.type === 'test').map(event => event.content)
               const newTests = tests.filter(test =>
-                test.meta[TEST_SUITE] === 'true'
+                test.meta[TEST_IS_NEW] === 'true'
               )
               // new tests are not detected
               assert.equal(newTests.length, 0)

--- a/integration-tests/ci-visibility/features-flaky/flaky.feature
+++ b/integration-tests/ci-visibility/features-flaky/flaky.feature
@@ -1,0 +1,4 @@
+Feature: Farewell
+  Scenario: Say flaky
+    When the greeter says flaky
+    Then I should have heard "flaky"

--- a/integration-tests/ci-visibility/features-flaky/support/steps.js
+++ b/integration-tests/ci-visibility/features-flaky/support/steps.js
@@ -1,0 +1,12 @@
+const assert = require('assert')
+const { When, Then } = require('@cucumber/cucumber')
+
+let globalCounter = 0
+
+Then('I should have heard {string}', function (expectedResponse) {
+  assert.equal(this.whatIHeard, expectedResponse)
+})
+
+When('the greeter says flaky', function () {
+  this.whatIHeard = globalCounter++ % 2 === 0 ? 'flaky' : 'not flaky'
+})

--- a/integration-tests/ci-visibility/features/farewell.feature
+++ b/integration-tests/ci-visibility/features/farewell.feature
@@ -2,3 +2,6 @@ Feature: Farewell
   Scenario: Say farewell
     When the greeter says farewell
     Then I should have heard "farewell"
+  Scenario: Say whatever
+    When the greeter says whatever
+    Then I should have heard "whatever"

--- a/integration-tests/ci-visibility/features/support/steps.js
+++ b/integration-tests/ci-visibility/features/support/steps.js
@@ -38,3 +38,7 @@ When('the greeter says yeah', function () {
 When('the greeter says greetings', function () {
   this.whatIHeard = new Greeter().sayGreetings()
 })
+
+When('the greeter says whatever', function () {
+  this.whatIHeard = 'whatever'
+})

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -893,6 +893,56 @@ versions.forEach(version => {
                 }).catch(done)
               })
             })
+            it('retries flaky tests', (done) => {
+              const NUM_RETRIES_EFD = 3
+              receiver.setSettings({
+                itr_enabled: false,
+                code_coverage: false,
+                tests_skipping: false,
+                early_flake_detection: {
+                  enabled: true,
+                  slow_test_retries: {
+                    '5s': NUM_RETRIES_EFD
+                  }
+                }
+              })
+              // Tests in "cucumber.ci-visibility/features-flaky/flaky.feature" will be considered new
+              receiver.setKnownTests([])
+
+              const eventsPromise = receiver
+                .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+                  const events = payloads.flatMap(({ payload }) => payload.events)
+
+                  const testSession = events.find(event => event.type === 'test_session_end').content
+                  assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED, 'true')
+                  const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+                  tests.forEach(test => {
+                    assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+                  })
+
+                  const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+                  const passedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
+
+                  // (1 original run + 3 retries) / 2
+                  assert.equal(failedAttempts.length, 2)
+                  assert.equal(passedAttempts.length, 2)
+                })
+
+              childProcess = exec(
+                './node_modules/.bin/cucumber-js ci-visibility/features-flaky/*.feature',
+                {
+                  cwd,
+                  env: envVars,
+                  stdio: 'pipe'
+                }
+              )
+              childProcess.on('exit', () => {
+                eventsPromise.then(() => {
+                  done()
+                }).catch(done)
+              })
+            })
             it('does not retry tests that are skipped', (done) => {
               const NUM_RETRIES_EFD = 3
               receiver.setSettings({

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -795,7 +795,7 @@ versions.forEach(version => {
                   }
                 }
               })
-              // cucumber.ci-visibility/features/farewell.feature.Say whatever will be considered new
+              // "cucumber.ci-visibility/features/farewell.feature.Say" whatever will be considered new
               receiver.setKnownTests([
                 'cucumber.ci-visibility/features/farewell.feature.Say farewell',
                 'cucumber.ci-visibility/features/greetings.feature.Say greetings',
@@ -803,32 +803,32 @@ versions.forEach(version => {
                 'cucumber.ci-visibility/features/greetings.feature.Say yo',
                 'cucumber.ci-visibility/features/greetings.feature.Say skip'
               ])
-              receiver.gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-                const events = payloads.flatMap(({ payload }) => payload.events)
+              const eventsPromise = receiver
+                .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+                  const events = payloads.flatMap(({ payload }) => payload.events)
 
-                const testSession = events.find(event => event.type === 'test_session_end').content
-                assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED, 'true')
-                const tests = events.filter(event => event.type === 'test').map(event => event.content)
+                  const testSession = events.find(event => event.type === 'test_session_end').content
+                  assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED, 'true')
+                  const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-                const newTests = tests.filter(test =>
-                  test.resource === 'ci-visibility/features/farewell.feature.Say whatever'
-                )
-                newTests.forEach(test => {
-                  assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+                  const newTests = tests.filter(test =>
+                    test.resource === 'ci-visibility/features/farewell.feature.Say whatever'
+                  )
+                  newTests.forEach(test => {
+                    assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+                  })
+                  const retriedTests = newTests.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true')
+                  // all but one has been retried
+                  assert.equal(
+                    newTests.length - 1,
+                    retriedTests.length
+                  )
+                  assert.equal(retriedTests.length, NUM_RETRIES_EFD)
+                  // Test name does not change
+                  newTests.forEach(test => {
+                    assert.equal(test.meta[TEST_NAME], 'Say whatever')
+                  })
                 })
-                const retriedTests = newTests.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true')
-                // all but one has been retried
-                assert.equal(
-                  newTests.length - 1,
-                  retriedTests.length
-                )
-                assert.equal(retriedTests.length, NUM_RETRIES_EFD)
-                // Test name does not change
-                newTests.forEach(test => {
-                  assert.equal(test.meta[TEST_NAME], 'Say whatever')
-                })
-                done()
-              })
               childProcess = exec(
                 runTestsCommand,
                 {
@@ -837,6 +837,112 @@ versions.forEach(version => {
                   stdio: 'pipe'
                 }
               )
+              childProcess.on('exit', () => {
+                eventsPromise.then(() => {
+                  done()
+                }).catch(done)
+              })
+            })
+            it('is disabled if DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED is false', (done) => {
+              const NUM_RETRIES_EFD = 3
+              receiver.setSettings({
+                itr_enabled: false,
+                code_coverage: false,
+                tests_skipping: false,
+                early_flake_detection: {
+                  enabled: true,
+                  slow_test_retries: {
+                    '5s': NUM_RETRIES_EFD
+                  }
+                }
+              })
+
+              const eventsPromise = receiver
+                .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+                  const events = payloads.flatMap(({ payload }) => payload.events)
+                  const testSession = events.find(event => event.type === 'test_session_end').content
+                  assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED)
+
+                  const tests = events.filter(event => event.type === 'test').map(event => event.content)
+                  const newTests = tests.filter(test =>
+                    test.meta[TEST_IS_NEW] === 'true'
+                  )
+                  // new tests are not detected
+                  assert.equal(newTests.length, 0)
+                })
+              // cucumber.ci-visibility/features/farewell.feature.Say whatever will be considered new
+              receiver.setKnownTests([
+                'cucumber.ci-visibility/features/farewell.feature.Say farewell',
+                'cucumber.ci-visibility/features/greetings.feature.Say greetings',
+                'cucumber.ci-visibility/features/greetings.feature.Say yeah',
+                'cucumber.ci-visibility/features/greetings.feature.Say yo',
+                'cucumber.ci-visibility/features/greetings.feature.Say skip'
+              ])
+
+              childProcess = exec(
+                runTestsCommand,
+                {
+                  cwd,
+                  env: { ...envVars, DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false' },
+                  stdio: 'pipe'
+                }
+              )
+              childProcess.on('exit', () => {
+                eventsPromise.then(() => {
+                  done()
+                }).catch(done)
+              })
+            })
+            it('does not retry tests that are skipped', (done) => {
+              const NUM_RETRIES_EFD = 3
+              receiver.setSettings({
+                itr_enabled: false,
+                code_coverage: false,
+                tests_skipping: false,
+                early_flake_detection: {
+                  enabled: true,
+                  slow_test_retries: {
+                    '5s': NUM_RETRIES_EFD
+                  }
+                }
+              })
+              // "cucumber.ci-visibility/features/farewell.feature.Say whatever" will be considered new
+              // "cucumber.ci-visibility/features/greetings.feature.Say skip" will be considered new
+              receiver.setKnownTests([
+                'cucumber.ci-visibility/features/farewell.feature.Say farewell',
+                'cucumber.ci-visibility/features/greetings.feature.Say greetings',
+                'cucumber.ci-visibility/features/greetings.feature.Say yeah',
+                'cucumber.ci-visibility/features/greetings.feature.Say yo'
+              ])
+
+              const eventsPromise = receiver
+                .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+                  const events = payloads.flatMap(({ payload }) => payload.events)
+
+                  const testSession = events.find(event => event.type === 'test_session_end').content
+                  assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED, 'true')
+                  const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+                  const skippedNewTest = tests.filter(test =>
+                    test.resource === 'ci-visibility/features/greetings.feature.Say skip'
+                  )
+                  // not retried
+                  assert.equal(skippedNewTest.length, 1)
+                })
+
+              childProcess = exec(
+                runTestsCommand,
+                {
+                  cwd,
+                  env: envVars,
+                  stdio: 'pipe'
+                }
+              )
+              childProcess.on('exit', () => {
+                eventsPromise.then(() => {
+                  done()
+                }).catch(done)
+              })
             })
           })
         })

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -893,7 +893,7 @@ versions.forEach(version => {
                 }).catch(done)
               })
             })
-            it('retries flaky tests', (done) => {
+            it('retries flaky tests and sets exit code to 0 as long as one attempt passes', (done) => {
               const NUM_RETRIES_EFD = 3
               receiver.setSettings({
                 itr_enabled: false,
@@ -937,7 +937,8 @@ versions.forEach(version => {
                   stdio: 'pipe'
                 }
               )
-              childProcess.on('exit', () => {
+              childProcess.on('exit', (exitCode) => {
+                assert.equal(exitCode, 0)
                 eventsPromise.then(() => {
                   done()
                 }).catch(done)

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -261,10 +261,6 @@ function getWrappedStart (start, frameworkVersion) {
 
     const configurationResponse = await configPromise
 
-    if (configurationResponse.err) {
-      return start.apply(this, arguments)
-    }
-
     isEarlyFlakeDetectionEnabled = configurationResponse.libraryConfig?.isEarlyFlakeDetectionEnabled
     earlyFlakeDetectionNumRetries = configurationResponse.libraryConfig?.earlyFlakeDetectionNumRetries
 


### PR DESCRIPTION
### What does this PR do?
Following https://github.com/DataDog/dd-trace-js/pull/3956 and https://github.com/DataDog/dd-trace-js/pull/4060, this PR implements early flake detection logic for cucumber.

### Motivation
Allow customers to detect their flaky tests before they're in the default branch.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

