### PR TITLE
Re-enable telemetry logs

### DIFF
--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -6,6 +6,7 @@ const dependencies = require('./dependencies')
 const { sendData } = require('./send-data')
 const { errors } = require('../startup-log')
 const { manager: metricsManager } = require('./metrics')
+const logs = require('./logs')
 
 const telemetryStartChannel = dc.channel('datadog:telemetry:start')
 const telemetryStopChannel = dc.channel('datadog:telemetry:stop')
@@ -226,6 +227,7 @@ function createPayload (currReqType, currPayload = {}) {
 function heartbeat (config, application, host) {
   heartbeatTimeout = setTimeout(() => {
     metricsManager.send(config, application, host)
+    logs.send(config, application, host)
 
     const { reqType, payload } = createPayload('app-heartbeat')
     sendData(config, application, host, reqType, payload, updateRetryData)
@@ -259,6 +261,7 @@ function start (aConfig, thePluginManager) {
   integrations = getIntegrations()
 
   dependencies.start(config, application, host, getRetryData, updateRetryData)
+  logs.start(config)
 
   sendData(config, application, host, 'app-started', appStarted(config))
 

--- a/packages/dd-trace/src/telemetry/logs/index.js
+++ b/packages/dd-trace/src/telemetry/logs/index.js
@@ -52,9 +52,9 @@ function stop () {
 function send (config, application, host) {
   if (!enabled) return
 
-  const logs = { 'logs': logCollector.drain() }
+  const logs = logCollector.drain()
   if (logs) {
-    sendData(config, application, host, 'logs', logs)
+    sendData(config, application, host, 'logs', { logs })
   }
 }
 

--- a/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const dc = require('dc-polyfill')
+
+const telemetryLog = dc.channel('datadog:telemetry:log')
+
+describe('Telemetry logs', () => {
+  let telemetry
+  let clock
+  let start, send
+
+  before(() => {
+    clock = sinon.useFakeTimers()
+  })
+
+  after(() => {
+    clock.restore()
+    telemetry.stop()
+  })
+
+  it('should be started and send logs when log received via the datadog:telemetry:log channel', () => {
+    start = sinon.stub()
+    send = sinon.spy()
+
+    telemetry = proxyquire('../../../../src/telemetry', {
+      '../exporters/common/docker': {
+        id () {
+          return 'test docker id'
+        }
+      },
+      './logs': {
+        start,
+        send
+      }
+    })
+
+    const config = {
+      telemetry: { enabled: true, heartbeatInterval: 3000, logCollection: true },
+      version: '1.2.3-beta4',
+      appsec: { enabled: false },
+      profiling: { enabled: false },
+      env: 'preprod',
+      tags: {
+        'runtime-id': '1a2b3c'
+      }
+    }
+
+    telemetry.start(config, {
+      _pluginsByName: {}
+    })
+
+    telemetryLog.publish({ message: 'This is an Error', level: 'ERROR' })
+
+    clock.tick(3000)
+
+    expect(start).to.be.calledOnceWith(config)
+    expect(send).to.be.calledOnceWith(config)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Re-enable telemetry logs module used by the IAST

It includes a test in the IAST namespace so that the @DataDog/asm-js  team is notified if any modification of the expected behavior is made in the future.

### Motivation
The migration to telemetry v2 left out the telemetry logs module #3827.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

