### PR TITLE
Fix flaky kafkajs test

### DIFF
--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -269,6 +269,7 @@ describe('Plugin', () => {
 
             const spy = sinon.spy(() => {
               expect(tracer.scope().active()).to.not.be.null
+              afterStart.unsubscribe(spy)
             })
             afterStart.subscribe(spy)
 
@@ -287,8 +288,6 @@ describe('Plugin', () => {
                 const name = spy.firstCall.args[1]
                 expect(name).to.eq(afterStart.name)
 
-                afterStart.unsubscribe(spy)
-
                 done()
               }
             }).then(() => sendMessages(kafka, testTopic, messages))
@@ -299,6 +298,7 @@ describe('Plugin', () => {
 
             const spy = sinon.spy(() => {
               expect(tracer.scope().active()).to.not.be.null
+              beforeFinish.unsubscribe(spy)
             })
             beforeFinish.subscribe(spy)
 
@@ -306,8 +306,6 @@ describe('Plugin', () => {
               eachMessage: () => {
                 setImmediate(() => {
                   expect(spy).to.have.been.calledOnceWith(undefined, beforeFinish.name)
-
-                  beforeFinish.unsubscribe(spy)
 
                   done()
                 })


### PR DESCRIPTION
### What does this PR do?
Unsubscribe from the channel at first attempt so the spy is called only once.

### Motivation
Try to fix flaky kafkajs test

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

