### PR TITLE
[ci-visibility] Fix `cypress open` error when passing `experimentalInteractiveRunEvents`

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -30,7 +30,6 @@ const {
   TEST_SOURCE_FILE
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
-const semver = require('semver')
 const { NODE_MAJOR } = require('../../version')
 
 const version = process.env.CYPRESS_VERSION
@@ -55,7 +54,7 @@ moduleType.forEach(({
   testCommand
 }) => {
   // cypress only supports esm on versions >= 10.0.0
-  if (type === 'esm' && semver.satisfies(version, '<10.0.0')) {
+  if (type === 'esm' && version === '6.7.0') {
     return
   }
   if (version === '6.7.0' && NODE_MAJOR > 16) {

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -112,6 +112,9 @@ function getSessionStatus (summary) {
 }
 
 function getSuiteStatus (suiteStats) {
+  if (!suiteStats) {
+    return 'skip'
+  }
   if (suiteStats.failures !== undefined && suiteStats.failures > 0) {
     return 'fail'
   }
@@ -322,8 +325,9 @@ module.exports = (on, config) => {
             itrCorrelationId = correlationId
           }
 
+          // specs might be undefined if cypress is being run with "cypress open"
           // `details.specs` are test files
-          details.specs.forEach(({ absolute, relative }) => {
+          details.specs?.forEach(({ absolute, relative }) => {
             const isUnskippableSuite = isMarkedAsUnskippable({ path: absolute })
             if (isUnskippableSuite) {
               unskippableSuites.push(relative)
@@ -363,7 +367,9 @@ module.exports = (on, config) => {
         })
     })
   })
-  on('after:spec', (spec, { tests, stats }) => {
+  // results might be undefined if cypress is being run with "cypress open"
+  on('after:spec', (spec, results) => {
+    const { tests, stats } = results || {}
     const cypressTests = tests || []
     const finishedTests = finishedTestsByFile[spec.relative] || []
 


### PR DESCRIPTION
### What does this PR do?
Fix crash when using `cypress open` (interactive mode).

### Motivation
Fix customer issue. 

### Plugin Checklist
No tests, see additional notes.

### Additional Notes
⚠️ **Important**: no automated tests are possible in this case, since the error only happens with using the interactive mode `cypress open`, and there's no way to automate this. 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

