### PR TITLE
[ci-visibility] Fix ITR when jest is using a custom test sequencer

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -544,6 +544,60 @@ testFrameworks.forEach(({
           testOutput += chunk.toString()
         })
       })
+      it('intelligent test runner can skip when using a custom test sequencer', (done) => {
+        receiver.setSettings({
+          itr_enabled: true,
+          tests_skipping: true
+        })
+        receiver.setSuitesToSkip([{
+          type: 'suite',
+          attributes: {
+            suite: 'ci-visibility/test/ci-visibility-test.js'
+          }
+        }])
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testEvents = events.filter(event => event.type === 'test')
+            // no tests end up running (suite is skipped)
+            assert.equal(testEvents.length, 0)
+
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.propertyVal(testSession.meta, TEST_ITR_TESTS_SKIPPED, 'true')
+
+            const skippedSuite = events.find(event =>
+              event.content.resource === 'test_suite.ci-visibility/test/ci-visibility-test.js'
+            ).content
+            assert.propertyVal(skippedSuite.meta, TEST_STATUS, 'skip')
+            assert.propertyVal(skippedSuite.meta, TEST_SKIPPED_BY_ITR, 'true')
+          })
+        childProcess = exec(
+          runTestsWithCoverageCommand,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              CUSTOM_TEST_SEQUENCER: './ci-visibility/jest-custom-test-sequencer.js',
+              TEST_SHARD: '2/2'
+            },
+            stdio: 'inherit'
+          }
+        )
+        childProcess.stdout.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+
+        childProcess.on('exit', () => {
+          assert.include(testOutput, 'Running shard with a custom sequencer')
+          eventsPromise.then(() => {
+            done()
+          }).catch(done)
+        })
+      })
     }
     const reportingOptions = ['agentless', 'evp proxy']
 

--- a/integration-tests/ci-visibility/jest-custom-test-sequencer.js
+++ b/integration-tests/ci-visibility/jest-custom-test-sequencer.js
@@ -1,0 +1,21 @@
+const Sequencer = require('@jest/test-sequencer').default
+
+// From example in https://jestjs.io/docs/configuration#testsequencer-string
+class CustomSequencer extends Sequencer {
+  shard (tests, { shardIndex, shardCount }) {
+    // Log used to show that the custom sequencer is being used
+    // eslint-disable-next-line
+    console.log('Running shard with a custom sequencer', shardIndex)
+    const shardSize = Math.ceil(tests.length / shardCount)
+    const shardStart = shardSize * (shardIndex - 1)
+    const shardEnd = shardSize * shardIndex
+
+    return [...tests].sort((a, b) => (a.path > b.path ? 1 : -1)).slice(shardStart, shardEnd)
+  }
+  sort (tests) {
+    const copyTests = [...tests]
+    return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1))
+  }
+}
+
+module.exports = CustomSequencer

--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -7,7 +7,8 @@ const options = {
   testRegex: process.env.TESTS_TO_RUN ? new RegExp(process.env.TESTS_TO_RUN) : /test\/ci-visibility-test/,
   coverage: !process.env.DISABLE_CODE_COVERAGE,
   runInBand: true,
-  shard: process.env.TEST_SHARD || undefined
+  shard: process.env.TEST_SHARD || undefined,
+  testSequencer: process.env.CUSTOM_TEST_SEQUENCER
 }
 
 if (process.env.RUN_IN_PARALLEL) {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -58,6 +58,7 @@ let hasUnskippableSuites = false
 let hasForcedToRunSuites = false
 let isEarlyFlakeDetectionEnabled = false
 let earlyFlakeDetectionNumRetries = 0
+let hasFilteredSkippableSuites = false
 
 const sessionAsyncResource = new AsyncResource('bound-anonymous-fn')
 


### PR DESCRIPTION
### What does this PR do?

Our skip logic was not kicking in when both `shard` and a customer jest sequencer is used.

This was because neither `@jest/core/build/SearchSource#getTestPaths` ([link to source](https://github.com/jestjs/jest/blob/5daab9075c66f5aae6d6adfd057ad49706cca771/packages/jest-core/src/SearchSource.ts#L322)) nor `@jest/test-sequencer/TestSequencer#shard` ([link to source](https://github.com/jestjs/jest/blob/5daab9075c66f5aae6d6adfd057ad49706cca771/packages/jest-test-sequencer/src/index.ts#L52C22-L52C35)) were applying the filtering logic. This was because `getTestPaths` bails out if there's a `shard` input and `TestSequencer#shard` was not called at all because there's a custom sequencer. 

What I've done to fix it is to find yet another extension point (`TestScheduler`) and apply the filtering logic there if it hasn't been applied in any of the two other options. 


### Motivation
Make sure ITR works when a using uses a customer sequencer, for example like follows:
```
jest --env=node --ci --silent --runInBand --logHeapUsage --testSequencer ./custom-sequencer.js --shard 1/2
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

