### PR TITLE
Fix unhandled rejections in kafka instrumentation

### DIFF
--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -80,7 +80,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
             if (producerCommitCh.hasSubscribers) {
               producerCommitCh.publish(res)
             }
-          })
+          }, () => {})
 
           return result
         } catch (e) {


### PR DESCRIPTION
### What does this PR do?
Fixes #4039 by adding a no-op rejection handler.

### Motivation
Right now, we have to choose between disabling kafka instrumentation and suffering unhandled rejection events on our producer. Both aren't ideal, and this seems like a no-risk solution to me. Adding a no-op rejection handler here doesn't prevent the promise's rejection from being handled downstream.

### Additional Notes
I've tested using kafka instrumentation with this edit locally, but can't find any existing tests that cover this file.

### Security
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

