### PR TITLE
Fix telemetry span type names

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -110,8 +110,8 @@ describe('opentelemetry', () => {
       const metrics = payload.payload
       assert.strictEqual(metrics.namespace, 'tracers')
 
-      const spanCreated = metrics.series.find(({ metric }) => metric === 'span_created')
-      const spanFinished = metrics.series.find(({ metric }) => metric === 'span_finished')
+      const spanCreated = metrics.series.find(({ metric }) => metric === 'spans_created')
+      const spanFinished = metrics.series.find(({ metric }) => metric === 'spans_finished')
 
       // Validate common fields between start and finish
       for (const series of [spanCreated, spanFinished]) {

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -29,8 +29,8 @@ const OTEL_ENABLED = !!process.env.DD_TRACE_OTEL_ENABLED
 const ALLOWED = ['string', 'number', 'boolean']
 
 const integrationCounters = {
-  span_created: {},
-  span_finished: {}
+  spans_created: {},
+  spans_finished: {}
 }
 
 const finishCh = channel('dd-trace:span:finish')
@@ -72,7 +72,7 @@ class DatadogSpan {
     this._name = operationName
     this._integrationName = fields.integrationName || 'opentracing'
 
-    getIntegrationCounter('span_created', this._integrationName).inc()
+    getIntegrationCounter('spans_created', this._integrationName).inc()
 
     this._spanContext = this._createContext(parent, fields)
     this._spanContext._name = operationName
@@ -172,7 +172,7 @@ class DatadogSpan {
       }
     }
 
-    getIntegrationCounter('span_finished', this._integrationName).inc()
+    getIntegrationCounter('spans_finished', this._integrationName).inc()
 
     if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.decrement('runtime.node.spans.unfinished')


### PR DESCRIPTION
### What does this PR do?

Fixes the naming of telemetry metrics for `spans_created` and `span_finished`.

### Motivation

The naming was incorrect so it was being discarded by the backend.

