### PR TITLE
Only parse amqp message headers if defined

### DIFF
--- a/packages/datadog-plugin-amqplib/src/consumer.js
+++ b/packages/datadog-plugin-amqplib/src/consumer.js
@@ -28,7 +28,7 @@ class AmqplibConsumerPlugin extends ConsumerPlugin {
       }
     })
 
-    if (this.config.dsmEnabled && message) {
+    if (this.config.dsmEnabled && message && message.properties.headers) {
       const payloadSize = getAmqpMessageSize({ headers: message.properties.headers, content: message.content })
       const queue = fields.queue ?? fields.routingKey
       this.tracer.decodeDataStreamsContext(message.properties.headers[CONTEXT_PROPAGATION_KEY])


### PR DESCRIPTION
### What does this PR do?

We enabled DSM for RabbitMQ now that it's supported. We started to see crashes in our dev environment due to the amqp instrumentation expecting `message.properties.headers` to be defined.

An example stacktrace is as follows:

```
│ TypeError: Cannot read properties of undefined (reading 'dd-pathway-ctx')                                                                                                                                                                  │
│     at AmqplibConsumerPlugin.start (/app/src/node_modules/dd-trace/packages/datadog-plugin-amqplib/src/consumer.js:34:70)                                                                                                                  │
│     at /app/src/node_modules/dd-trace/packages/dd-trace/src/plugins/tracing.js:73:22                                                                                                                                                       │
│     at Subscription._handler (/app/src/node_modules/dd-trace/packages/dd-trace/src/plugins/plugin.js:14:9)                                                                                                                                 │
│     at Channel.publish (node:diagnostics_channel:142:9)                                                                                                                                                                                    │
│     at /app/src/node_modules/dd-trace/packages/datadog-instrumentations/src/amqplib.js:47:13                                                                                                                                               │
│     at AsyncResource.runInAsyncScope (node:async_hooks:206:9)                                                                                                                                                                              │
│     at instrument (/app/src/node_modules/dd-trace/packages/datadog-instrumentations/src/amqplib.js:46:24)                                                                                                                                  │
│     at Channel.dispatchMessage (/app/src/node_modules/dd-trace/packages/datadog-instrumentations/src/amqplib.js:35:12)                                                                                                                     │
│     at BaseChannel.handleDelivery (/app/src/node_modules/amqplib/lib/channel.js:492:15)                                                                                                                                                    │
│     at Channel.emit (node:events:518:28)                                                                                                                                                                                                   │
│     at Channel.emit (node:domain:488:12)                                                                                                                                                                                                   │
│     at /app/src/node_modules/amqplib/lib/channel.js:278:10                                                                                                                                                                                 │
│     at Channel.content (/app/src/node_modules/amqplib/lib/channel.js:331:9)                                                                                                                                                                │
│     at C.acceptMessageFrame (/app/src/node_modules/amqplib/lib/channel.js:246:31)                                                                                                                                                          │
│     at C.accept (/app/src/node_modules/amqplib/lib/channel.js:399:17)                                                                                                                                                                      │
│     at Connection.mainAccept [as accept] (/app/src/node_modules/amqplib/lib/connection.js:63:33)                                                                                                                                           │
│ {"level":"error","time":1708633634684,"pid":13,"name":"root","category":"PROCESS_EVENTS","dd":{"trace_id":"6366423218528967473","span_id":"6366423218528967473","service":"core-workers","version":"6b80d1835","env":"development"},"msg": │
│ make: *** [shared/make/production.mk:114: run-workers] Error 1                                                                                                                                                                             │
```

### Motivation

We'd like to use DSM without our application crashing.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

