### PR TITLE
[ci-visibility] Disable telemetry if you're inside a jest worker

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -209,10 +209,12 @@ class Config {
 
     const inServerlessEnvironment = inAWSLambda || isGCPFunction || isAzureFunctionConsumptionPlan
 
+    const isJestWorker = !!process.env.JEST_WORKER_ID
+
     const DD_INSTRUMENTATION_TELEMETRY_ENABLED = coalesce(
       process.env.DD_TRACE_TELEMETRY_ENABLED, // for backward compatibility
       process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED, // to comply with instrumentation telemetry specs
-      !inServerlessEnvironment
+      !(inServerlessEnvironment || isJestWorker)
     )
     const DD_TELEMETRY_HEARTBEAT_INTERVAL = process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL
       ? Math.floor(parseFloat(process.env.DD_TELEMETRY_HEARTBEAT_INTERVAL) * 1000)
@@ -611,7 +613,6 @@ ken|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)
     this.peerServiceMapping = DD_TRACE_PEER_SERVICE_MAPPING
     this.lookup = options.lookup
     this.startupLogs = isTrue(DD_TRACE_STARTUP_LOGS)
-    // Disabled for CI Visibility's agentless
     this.telemetry = {
       enabled: isTrue(DD_INSTRUMENTATION_TELEMETRY_ENABLED),
       heartbeatInterval: DD_TELEMETRY_HEARTBEAT_INTERVAL,

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1292,6 +1292,7 @@ describe('Config', () => {
       delete process.env.DD_CIVISIBILITY_GIT_UPLOAD_ENABLED
       delete process.env.DD_CIVISIBILITY_MANUAL_API_ENABLED
       delete process.env.DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED
+      delete process.env.JEST_WORKER_ID
       options = {}
     })
     context('ci visibility mode is enabled', () => {
@@ -1356,6 +1357,11 @@ describe('Config', () => {
         expect(config).to.have.property('isIntelligentTestRunnerEnabled', false)
         expect(config).to.have.property('isGitUploadEnabled', false)
       })
+    })
+    it('disables telemetry if inside a jest worker', () => {
+      process.env.JEST_WORKER_ID = '1'
+      const config = new Config(options)
+      expect(config.telemetry.enabled).to.be.false
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
Disable telemetry if `JEST_WORKER_ID` is defined, which means that you're inside a jest worker.

### Motivation
Jest workers are shut down ungracefully constantly. Making requests with them is going to be problematic. 

We'll have to figure out what to do with telemetry inside of jest workers, but for the moment let's just disable it altogether to avoid issues. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

