### PR TITLE
aws-sdk: fix request_id tag for errors

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -126,8 +126,9 @@ class BaseAwsSdkPlugin extends ClientPlugin {
     if (err) {
       span.setTag('error', err)
 
-      if (err.requestId) {
-        span.addTags({ 'aws.response.request_id': err.requestId })
+      const requestId = err.RequestId || err.requestId
+      if (requestId) {
+        span.addTags({ 'aws.response.request_id': requestId })
       }
     }
 

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -122,7 +122,7 @@ describe('Plugin', () => {
 
             expect(span).to.include({
               name: 'aws.request',
-              resource: 'completeMultipartUpload',
+              resource: 'completeMultipartUpload my-bucket',
               service: 'test-aws-s3'
             })
 
@@ -132,9 +132,16 @@ describe('Plugin', () => {
               [ERROR_STACK]: error.stack,
               'component': 'aws-sdk'
             })
+            if (semver.intersects(version, '>=2.3.4')) {
+              expect(span.meta['aws.response.request_id']).to.match(/[\w]{8}(-[\w]{4}){3}-[\w]{12}/)
+            }
           }).then(done, done)
 
-          s3.completeMultipartUpload('invalid', e => {
+          s3.completeMultipartUpload({
+            Bucket: 'my-bucket',
+            Key: 'my-key',
+            UploadId: 'my-upload-id'
+          }, e => {
             error = e
           })
         })


### PR DESCRIPTION
### What does this PR do?

Correctly handle different error `requestId` and `RequestId` properties when tagging.

Fixes #4050

### Plugin Checklist

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
