### PR TITLE
Fix flaky kafkajs test

### DIFF
--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -273,8 +273,8 @@ describe('Plugin', () => {
             })
             afterStart.subscribe(spy)
 
-            consumer.run({
-              eachMessage: () => {
+            let eachMessage = async ({ topic, partition, message }) => {
+              try {
                 expect(spy).to.have.been.calledOnce
 
                 const channelMsg = spy.firstCall.args[0]
@@ -289,8 +289,15 @@ describe('Plugin', () => {
                 expect(name).to.eq(afterStart.name)
 
                 done()
+              } catch (e) {
+                done(e)
+              } finally {
+                eachMessage = () => {}
               }
-            }).then(() => sendMessages(kafka, testTopic, messages))
+            }
+
+            consumer.run({ eachMessage: (...args) => eachMessage(...args) })
+              .then(() => sendMessages(kafka, testTopic, messages))
           })
 
           it('should publish on beforeFinish channel', (done) => {
@@ -302,15 +309,22 @@ describe('Plugin', () => {
             })
             beforeFinish.subscribe(spy)
 
-            consumer.run({
-              eachMessage: () => {
-                setImmediate(() => {
+            let eachMessage = async ({ topic, partition, message }) => {
+              setImmediate(() => {
+                try {
                   expect(spy).to.have.been.calledOnceWith(undefined, beforeFinish.name)
 
                   done()
-                })
-              }
-            }).then(() => sendMessages(kafka, testTopic, messages))
+                } catch (e) {
+                  done(e)
+                } finally {
+                  eachMessage = () => {}
+                }
+              })
+            }
+
+            consumer.run({ eachMessage: (...args) => eachMessage(...args) })
+              .then(() => sendMessages(kafka, testTopic, messages))
           })
 
           withNamingSchema(

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -317,10 +317,10 @@ describe('Plugin', () => {
                   done()
                 } catch (e) {
                   done(e)
-                } finally {
-                  eachMessage = () => {}
                 }
               })
+
+              eachMessage = () => {}
             }
 
             consumer.run({ eachMessage: (...args) => eachMessage(...args) })


### PR DESCRIPTION
### What does this PR do?
Call done() only once

### Motivation
Flaky kafkajs test

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

