### PR TITLE
Replicate images even if other steps fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,7 @@ deploy_to_reliability_env:
 
 deploy_to_docker_registries:
   stage: deploy
+  needs: []
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/ || $CI_COMMIT_TAG == "dev"'
       when: on_success
@@ -80,6 +81,7 @@ deploy_to_docker_registries:
 
 deploy_latest_to_docker_registries:
   stage: deploy
+  needs: []
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Image replication for kubernetes injection is not run if package building for host/docker injection fails. This is because the package stage is before the deploy stage. This PR allows image replication to run regardless.

### Motivation
Kubernetes injection images are currently missing because of this failure

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

