### PR TITLE
Fix issue with graphql.execute span naming

### DIFF
--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -108,7 +108,6 @@ function extractTags (trace, span) {
 
   for (const tag in tags) {
     switch (tag) {
-      case 'operation.name':
       case 'service.name':
       case 'span.type':
       case 'resource.name':

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -142,14 +142,12 @@ describe('format', () => {
     })
 
     it('should extract Datadog specific tags', () => {
-      spanContext._tags['operation.name'] = 'name'
       spanContext._tags['service.name'] = 'service'
       spanContext._tags['span.type'] = 'type'
       spanContext._tags['resource.name'] = 'resource'
 
       trace = format(span)
 
-      expect(trace.name).to.equal('name')
       expect(trace.service).to.equal('service')
       expect(trace.type).to.equal('type')
       expect(trace.resource).to.equal('resource')


### PR DESCRIPTION
### What does this PR do?

Fixes #3862

### Motivation

There was a bug caused by an incorrect change to the format logic which raised the `operation.name` field when it should not have.

