### PR TITLE
[ci-visibility] Fix negative duration in playwright steps

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-error/before-all-timeout-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-error/before-all-timeout-test.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('@playwright/test')
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(process.env.PW_BASE_URL)
+})
+
+const waitFor = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+test.describe('playwright', () => {
+  test.beforeAll(async () => {
+    // timeout error
+    await waitFor(3100)
+  })
+  test('should work with passing tests', async ({ page }) => {
+    await expect(page.locator('.hello-world')).toHaveText([
+      'Hello World'
+    ])
+  })
+})

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -3,7 +3,8 @@ const { devices } = require('@playwright/test')
 
 module.exports = {
   baseURL: process.env.PW_BASE_URL,
-  testDir: './ci-visibility/playwright-tests',
+  testDir: process.env.TEST_DIR || './ci-visibility/playwright-tests',
+  timeout: Number(process.env.TEST_TIMEOUT) || 30000,
   reporter: 'line',
   /* Configure projects for major browsers */
   projects: [

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -77,6 +77,10 @@ versions.forEach((version) => {
             assert.equal(testModuleEvent.content.meta[TEST_STATUS], 'fail')
             assert.equal(testSessionEvent.content.meta[TEST_TYPE], 'browser')
             assert.equal(testModuleEvent.content.meta[TEST_TYPE], 'browser')
+
+            assert.exists(testSessionEvent.content.meta[ERROR_MESSAGE])
+            assert.exists(testModuleEvent.content.meta[ERROR_MESSAGE])
+
             assert.includeMembers(testSuiteEvents.map(suite => suite.content.resource), [
               'test_suite.todo-list-page-test.js',
               'test_suite.landing-page-test.js',
@@ -88,6 +92,12 @@ versions.forEach((version) => {
               'fail',
               'skip'
             ])
+
+            testSuiteEvents.forEach(testSuiteEvent => {
+              if (testSuiteEvent.content.meta[TEST_STATUS] === 'fail') {
+                assert.exists(testSuiteEvent.content.meta[ERROR_MESSAGE])
+              }
+            })
 
             assert.includeMembers(testEvents.map(test => test.content.resource), [
               'landing-page-test.js.should work with passing tests',

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -133,10 +133,10 @@ function formatTestHookError (error, hookType, isTimeout) {
 }
 
 function addErrorToTestSuite (testSuiteAbsolutePath, error) {
-  if (!testSuiteToErrors.has(testSuiteAbsolutePath)) {
-    testSuiteToErrors.set(testSuiteAbsolutePath, [error])
-  } else {
+  if (testSuiteToErrors.has(testSuiteAbsolutePath)) {
     testSuiteToErrors.get(testSuiteAbsolutePath).push(error)
+  } else {
+    testSuiteToErrors.set(testSuiteAbsolutePath, [error])
   }
 }
 

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -123,7 +123,6 @@ function getBrowserNameFromProjects (projects, test) {
 function formatTestHookError (error, hookType, isTimeout) {
   let hookError = error
   if (error) {
-    hookError = error
     hookError.message = `Error in ${hookType} hook: ${error.message}`
   }
   if (!hookError && isTimeout) {
@@ -202,10 +201,10 @@ function testEndHandler (test, annotations, testStatus, error, isTimeout) {
     testFinishCh.publish({ testStatus, steps: testResult.steps, error, extraTags: annotationTags })
   })
 
-  if (!testSuiteToTestStatuses.has(testSuiteAbsolutePath)) {
-    testSuiteToTestStatuses.set(testSuiteAbsolutePath, [testStatus])
-  } else {
+  if (testSuiteToTestStatuses.has(testSuiteAbsolutePath)) {
     testSuiteToTestStatuses.get(testSuiteAbsolutePath).push(testStatus)
+  } else {
+    testSuiteToTestStatuses.set(testSuiteAbsolutePath, [testStatus])
   }
 
   if (error) {

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -14,6 +14,7 @@ const testSuiteFinishCh = channel('ci:playwright:test-suite:finish')
 const testToAr = new WeakMap()
 const testSuiteToAr = new Map()
 const testSuiteToTestStatuses = new Map()
+const testSuiteToErrors = new Map()
 
 let startedSuites = []
 
@@ -81,7 +82,12 @@ function getRootDir (playwrightRunner) {
 
 function getProjectsFromRunner (runner) {
   const config = getPlaywrightConfig(runner)
-  return config.projects?.map(({ project }) => project)
+  return config.projects?.map((project) => {
+    if (project.project) {
+      return project.project
+    }
+    return project
+  })
 }
 
 function getProjectsFromDispatcher (dispatcher) {
@@ -93,13 +99,56 @@ function getProjectsFromDispatcher (dispatcher) {
   return dispatcher._loader?.fullConfig()?.projects
 }
 
-function getBrowserNameFromProjects (projects, projectId) {
-  if (!projects) {
+function getBrowserNameFromProjects (projects, test) {
+  if (!projects || !test) {
     return null
   }
-  return projects.find(project =>
-    project.__projectId === projectId || project._id === projectId
-  )?.name
+  const { _projectIndex, _projectId: testProjectId } = test
+
+  if (_projectIndex !== undefined) {
+    return projects[_projectIndex]?.name
+  }
+
+  return projects.find(({ __projectId, _id, name }) => {
+    if (__projectId !== undefined) {
+      return __projectId === testProjectId
+    }
+    if (_id !== undefined) {
+      return _id === testProjectId
+    }
+    return name === testProjectId
+  })?.name
+}
+
+function formatTestHookError (error, hookType, isTimeout) {
+  let hookError = error
+  if (error) {
+    hookError = error
+    hookError.message = `Error in ${hookType} hook: ${error.message}`
+  }
+  if (!hookError && isTimeout) {
+    hookError = new Error(`${hookType} hook timed out`)
+  }
+  return hookError
+}
+
+function addErrorToTestSuite (testSuiteAbsolutePath, error) {
+  if (!testSuiteToErrors.has(testSuiteAbsolutePath)) {
+    testSuiteToErrors.set(testSuiteAbsolutePath, [error])
+  } else {
+    testSuiteToErrors.get(testSuiteAbsolutePath).push(error)
+  }
+}
+
+function getTestSuiteError (testSuiteAbsolutePath) {
+  const errors = testSuiteToErrors.get(testSuiteAbsolutePath)
+  if (!errors) {
+    return null
+  }
+  if (errors.length === 1) {
+    return errors[0]
+  }
+  return new Error(`${errors.length} errors in this test suite:\n${errors.map(e => e.message).join('\n------\n')}`)
 }
 
 function testBeginHandler (test, browserName) {
@@ -131,7 +180,7 @@ function testBeginHandler (test, browserName) {
   })
 }
 
-function testEndHandler (test, annotations, testStatus, error) {
+function testEndHandler (test, annotations, testStatus, error, isTimeout) {
   let annotationTags
   if (annotations.length) {
     annotationTags = parseAnnotations(annotations)
@@ -139,6 +188,11 @@ function testEndHandler (test, annotations, testStatus, error) {
   const { _requireFile: testSuiteAbsolutePath, results, _type } = test
 
   if (_type === 'beforeAll' || _type === 'afterAll') {
+    const hookError = formatTestHookError(error, _type, isTimeout)
+
+    if (hookError) {
+      addErrorToTestSuite(testSuiteAbsolutePath, hookError)
+    }
     return
   }
 
@@ -154,9 +208,14 @@ function testEndHandler (test, annotations, testStatus, error) {
     testSuiteToTestStatuses.get(testSuiteAbsolutePath).push(testStatus)
   }
 
+  if (error) {
+    addErrorToTestSuite(testSuiteAbsolutePath, error)
+  }
+
   remainingTestsByFile[testSuiteAbsolutePath] = remainingTestsByFile[testSuiteAbsolutePath]
     .filter(currentTest => currentTest !== test)
 
+  // Last test, we finish the suite
   if (!remainingTestsByFile[testSuiteAbsolutePath].length) {
     const testStatuses = testSuiteToTestStatuses.get(testSuiteAbsolutePath)
 
@@ -167,9 +226,10 @@ function testEndHandler (test, annotations, testStatus, error) {
       testSuiteStatus = 'skip'
     }
 
+    const suiteError = getTestSuiteError(testSuiteAbsolutePath)
     const testSuiteAsyncResource = testSuiteToAr.get(testSuiteAbsolutePath)
     testSuiteAsyncResource.runInAsyncScope(() => {
-      testSuiteFinishCh.publish(testSuiteStatus)
+      testSuiteFinishCh.publish({ status: testSuiteStatus, error: suiteError })
     })
   }
 }
@@ -197,7 +257,7 @@ function dispatcherHook (dispatcherExport) {
       if (method === 'testBegin') {
         const { test } = dispatcher._testById.get(params.testId)
         const projects = getProjectsFromDispatcher(dispatcher)
-        const browser = getBrowserNameFromProjects(projects, test._projectId)
+        const browser = getBrowserNameFromProjects(projects, test)
         testBeginHandler(test, browser)
       } else if (method === 'testEnd') {
         const { test } = dispatcher._testById.get(params.testId)
@@ -205,7 +265,8 @@ function dispatcherHook (dispatcherExport) {
         const { results } = test
         const testResult = results[results.length - 1]
 
-        testEndHandler(test, params.annotations, STATUS_TO_TEST_STATUS[testResult.status], testResult.error)
+        const isTimeout = testResult.status === 'timedOut'
+        testEndHandler(test, params.annotations, STATUS_TO_TEST_STATUS[testResult.status], testResult.error, isTimeout)
       }
     })
 
@@ -232,13 +293,14 @@ function dispatcherHookNew (dispatcherExport, runWrapper) {
     worker.on('testBegin', ({ testId }) => {
       const test = getTestByTestId(dispatcher, testId)
       const projects = getProjectsFromDispatcher(dispatcher)
-      const browser = getBrowserNameFromProjects(projects, test._projectId)
+      const browser = getBrowserNameFromProjects(projects, test)
       testBeginHandler(test, browser)
     })
     worker.on('testEnd', ({ testId, status, errors, annotations }) => {
       const test = getTestByTestId(dispatcher, testId)
 
-      testEndHandler(test, annotations, STATUS_TO_TEST_STATUS[status], errors && errors[0])
+      const isTimeout = status === 'timedOut'
+      testEndHandler(test, annotations, STATUS_TO_TEST_STATUS[status], errors && errors[0], isTimeout)
     })
 
     return worker
@@ -265,7 +327,7 @@ function runnerHook (runnerExport, playwrightVersion) {
       // there were tests that did not go through `testBegin` or `testEnd`,
       // because they were skipped
       tests.forEach(test => {
-        const browser = getBrowserNameFromProjects(projects, test._projectId)
+        const browser = getBrowserNameFromProjects(projects, test)
         testBeginHandler(test, browser)
         testEndHandler(test, [], 'skip')
       })
@@ -327,6 +389,7 @@ addHook({
   file: 'lib/runner/runner.js',
   versions: ['>=1.38.0']
 }, runnerHook)
+
 addHook({
   name: 'playwright',
   file: 'lib/runner/dispatcher.js',

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -114,7 +114,11 @@ class PlaywrightPlugin extends CiPlugin {
         if (step.error) {
           stepSpan.setTag('error', step.error)
         }
-        stepSpan.finish(stepStartTime + step.duration)
+        let stepDuration = step.duration
+        if (stepDuration <= 0 || isNaN(stepDuration)) {
+          stepDuration = 0
+        }
+        stepSpan.finish(stepStartTime + stepDuration)
       })
 
       span.finish()


### PR DESCRIPTION
### What does this PR do?

* A playwright's step can have a negative duration (`step.duration`) if it's not executed, as a result of a failing hook. This results in our intake rejecting the whole payload.
* In addition to fixing this, I've improved the way we report test errors in suites and sessions in playwright:
  * If a test suite fails as a result of a `beforeAll` or `afterAll` test, it will report an error.
  * If a test suite fails as a result of any of its tests failing, it'll report the test errors. 
  * Sessions will include an error message with the number of failed suites and errors if they fail.

### Motivation
Fixes #4103

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

