### PR TITLE
Fix "directives is not iterable" error when directives is not defined in the document

### DIFF
--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -122,15 +122,17 @@ function getResolverInfo (info, args) {
     Object.assign(resolverVars, args)
   }
 
-  const directives = info.fieldNodes[0].directives
-  for (const directive of directives) {
-    const argList = {}
-    for (const argument of directive['arguments']) {
-      argList[argument.name.value] = argument.value.value
-    }
+  const directives = info.fieldNodes?.[0]?.directives
+  if (Array.isArray(directives)) {
+    for (const directive of directives) {
+      const argList = {}
+      for (const argument of directive['arguments']) {
+        argList[argument.name.value] = argument.value.value
+      }
 
-    if (Object.keys(argList).length) {
-      resolverVars[directive.name.value] = argList
+      if (Object.keys(argList).length) {
+        resolverVars[directive.name.value] = argList
+      }
     }
   }
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1002,7 +1002,6 @@ describe('Plugin', () => {
           delete document.definitions[0].selectionSet.selections[0].directives
 
           function noop () {}
-
           dc.channel('datadog:graphql:resolver:start').subscribe(noop)
 
           expect(() => {

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1004,11 +1004,13 @@ describe('Plugin', () => {
           function noop () {}
           dc.channel('datadog:graphql:resolver:start').subscribe(noop)
 
-          expect(() => {
-            graphql.execute({ schema, document })
-          }).to.not.throw()
-
-          dc.channel('datadog:graphql:resolver:start').unsubscribe(noop)
+          try {
+            expect(() => {
+              graphql.execute({ schema, document })
+            }).to.not.throw()
+          } finally {
+            dc.channel('datadog:graphql:resolver:start').unsubscribe(noop)
+          }
         })
 
         it('should support multiple validations on a pre-parsed document', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Check that directives property in a document is an array before the iteration.

### Motivation
<!-- What inspired you to submit this pull request? -->
#4097 issue: The graphql document is manually created in keystonejs instead of using `graphql.parse` method, and as they don't need directives, the directives property of the document is empty, and not `[]` as in the result of `graphql.parse` method. 
This is the reason why in the test, I'm just removing `directive` properties to check that it works without it.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Thanks to [mabilbao](https://github.com/mabilbao) for finding, sharing and proposing a solution for the error.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

[APPSEC-51949]




[APPSEC-51949]: https://datadoghq.atlassian.net/browse/APPSEC-51949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ