### PR TITLE
Activate AVM OSS via environment variable

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -447,7 +447,7 @@ class Config {
     this._setValue(defaults, 'appsec.rateLimit', 100)
     this._setValue(defaults, 'appsec.rules', undefined)
     this._setValue(defaults, 'appsec.wafTimeout', 5e3) // µs
-    this._setValue(defaults, 'appsec.sca.enabled', undefined)
+    this._setValue(defaults, 'appsec.sca.enabled', null)
     this._setValue(defaults, 'clientIpEnabled', false)
     this._setValue(defaults, 'clientIpHeader', null)
     this._setValue(defaults, 'dbmPropagationMode', 'disabled')

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -495,6 +495,7 @@ class Config {
     this._setValue(defaults, 'runtimeMetrics', false)
     this._setValue(defaults, 'sampleRate', undefined)
     this._setValue(defaults, 'sampler.rateLimit', undefined)
+    this._setValue(defaults, 'sca.enabled', false)
     this._setValue(defaults, 'scope', undefined)
     this._setValue(defaults, 'service', service)
     this._setValue(defaults, 'site', 'datadoghq.com')
@@ -528,6 +529,7 @@ class Config {
       DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP,
       DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP,
       DD_APPSEC_RULES,
+      DD_APPSEC_SCA_ENABLED,
       DD_APPSEC_TRACE_RATE_LIMIT,
       DD_APPSEC_WAF_TIMEOUT,
       DD_DATA_STREAMS_ENABLED,
@@ -680,6 +682,7 @@ class Config {
     }
     this._setUnit(env, 'sampleRate', DD_TRACE_SAMPLE_RATE || OTEL_TRACES_SAMPLER_MAPPING[OTEL_TRACES_SAMPLER])
     this._setValue(env, 'sampler.rateLimit', DD_TRACE_RATE_LIMIT)
+    this._setBoolean(env, 'sca.enabled', DD_APPSEC_SCA_ENABLED)
     this._setString(env, 'scope', DD_TRACE_SCOPE)
     this._setString(env, 'service', DD_SERVICE || DD_SERVICE_NAME || tags.service || OTEL_SERVICE_NAME)
     this._setString(env, 'site', DD_SITE)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -446,8 +446,8 @@ class Config {
     this._setValue(defaults, 'appsec.obfuscatorValueRegex', defaultWafObfuscatorValueRegex)
     this._setValue(defaults, 'appsec.rateLimit', 100)
     this._setValue(defaults, 'appsec.rules', undefined)
-    this._setValue(defaults, 'appsec.wafTimeout', 5e3) // µs
     this._setValue(defaults, 'appsec.sca.enabled', null)
+    this._setValue(defaults, 'appsec.wafTimeout', 5e3) // µs
     this._setValue(defaults, 'clientIpEnabled', false)
     this._setValue(defaults, 'clientIpHeader', null)
     this._setValue(defaults, 'dbmPropagationMode', 'disabled')
@@ -617,9 +617,9 @@ class Config {
     this._setString(env, 'appsec.obfuscatorValueRegex', DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP)
     this._setValue(env, 'appsec.rateLimit', maybeInt(DD_APPSEC_TRACE_RATE_LIMIT))
     this._setString(env, 'appsec.rules', DD_APPSEC_RULES)
-    this._setValue(env, 'appsec.wafTimeout', maybeInt(DD_APPSEC_WAF_TIMEOUT))
     // DD_APPSEC_SCA_ENABLED is never used locally, but only sent to the backend
     this._setBoolean(env, 'appsec.sca.enabled', DD_APPSEC_SCA_ENABLED)
+    this._setValue(env, 'appsec.wafTimeout', maybeInt(DD_APPSEC_WAF_TIMEOUT))
     this._setBoolean(env, 'clientIpEnabled', DD_TRACE_CLIENT_IP_ENABLED)
     this._setString(env, 'clientIpHeader', DD_TRACE_CLIENT_IP_HEADER)
     this._setString(env, 'dbmPropagationMode', DD_DBM_PROPAGATION_MODE)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -447,6 +447,7 @@ class Config {
     this._setValue(defaults, 'appsec.rateLimit', 100)
     this._setValue(defaults, 'appsec.rules', undefined)
     this._setValue(defaults, 'appsec.wafTimeout', 5e3) // µs
+    this._setValue(defaults, 'appsec.sca.enabled', undefined)
     this._setValue(defaults, 'clientIpEnabled', false)
     this._setValue(defaults, 'clientIpHeader', null)
     this._setValue(defaults, 'dbmPropagationMode', 'disabled')
@@ -495,7 +496,6 @@ class Config {
     this._setValue(defaults, 'runtimeMetrics', false)
     this._setValue(defaults, 'sampleRate', undefined)
     this._setValue(defaults, 'sampler.rateLimit', undefined)
-    this._setValue(defaults, 'sca.enabled', undefined)
     this._setValue(defaults, 'scope', undefined)
     this._setValue(defaults, 'service', service)
     this._setValue(defaults, 'site', 'datadoghq.com')
@@ -618,6 +618,8 @@ class Config {
     this._setValue(env, 'appsec.rateLimit', maybeInt(DD_APPSEC_TRACE_RATE_LIMIT))
     this._setString(env, 'appsec.rules', DD_APPSEC_RULES)
     this._setValue(env, 'appsec.wafTimeout', maybeInt(DD_APPSEC_WAF_TIMEOUT))
+    // DD_APPSEC_SCA_ENABLED is never used locally, but only sent to the backend
+    this._setBoolean(env, 'appsec.sca.enabled', DD_APPSEC_SCA_ENABLED)
     this._setBoolean(env, 'clientIpEnabled', DD_TRACE_CLIENT_IP_ENABLED)
     this._setString(env, 'clientIpHeader', DD_TRACE_CLIENT_IP_HEADER)
     this._setString(env, 'dbmPropagationMode', DD_DBM_PROPAGATION_MODE)
@@ -682,8 +684,6 @@ class Config {
     }
     this._setUnit(env, 'sampleRate', DD_TRACE_SAMPLE_RATE || OTEL_TRACES_SAMPLER_MAPPING[OTEL_TRACES_SAMPLER])
     this._setValue(env, 'sampler.rateLimit', DD_TRACE_RATE_LIMIT)
-    // DD_APPSEC_SCA_ENABLED is never used locally, but only sent to the backend
-    this._setBoolean(env, 'sca.enabled', DD_APPSEC_SCA_ENABLED)
     this._setString(env, 'scope', DD_TRACE_SCOPE)
     this._setString(env, 'service', DD_SERVICE || DD_SERVICE_NAME || tags.service || OTEL_SERVICE_NAME)
     this._setString(env, 'site', DD_SITE)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -495,7 +495,7 @@ class Config {
     this._setValue(defaults, 'runtimeMetrics', false)
     this._setValue(defaults, 'sampleRate', undefined)
     this._setValue(defaults, 'sampler.rateLimit', undefined)
-    this._setValue(defaults, 'sca.enabled', false)
+    this._setValue(defaults, 'sca.enabled', undefined)
     this._setValue(defaults, 'scope', undefined)
     this._setValue(defaults, 'service', service)
     this._setValue(defaults, 'site', 'datadoghq.com')

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -682,6 +682,7 @@ class Config {
     }
     this._setUnit(env, 'sampleRate', DD_TRACE_SAMPLE_RATE || OTEL_TRACES_SAMPLER_MAPPING[OTEL_TRACES_SAMPLER])
     this._setValue(env, 'sampler.rateLimit', DD_TRACE_RATE_LIMIT)
+    // DD_APPSEC_SCA_ENABLED is never used locally, but only sent to the backend
     this._setBoolean(env, 'sca.enabled', DD_APPSEC_SCA_ENABLED)
     this._setString(env, 'scope', DD_TRACE_SCOPE)
     this._setString(env, 'service', DD_SERVICE || DD_SERVICE_NAME || tags.service || OTEL_SERVICE_NAME)

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -7,6 +7,7 @@ const { sendData } = require('./send-data')
 const { errors } = require('../startup-log')
 const { manager: metricsManager } = require('./metrics')
 const logs = require('./logs')
+const log = require('../log')
 
 const telemetryStartChannel = dc.channel('datadog:telemetry:start')
 const telemetryStopChannel = dc.channel('datadog:telemetry:stop')
@@ -235,6 +236,10 @@ function extendedHeartbeat (config) {
 
 function start (aConfig, thePluginManager) {
   if (!aConfig.telemetry.enabled) {
+    if (aConfig.sca?.enabled) {
+      log.warn('DD_APPSEC_SCA_ENABLED requires enabling telemetry to work.')
+    }
+
     return
   }
   config = aConfig

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -6,8 +6,8 @@ const dependencies = require('./dependencies')
 const { sendData } = require('./send-data')
 const { errors } = require('../startup-log')
 const { manager: metricsManager } = require('./metrics')
-const logs = require('./logs')
-const log = require('../log')
+const telemetryLogger = require('./logs')
+const logger = require('../log')
 
 const telemetryStartChannel = dc.channel('datadog:telemetry:start')
 const telemetryStopChannel = dc.channel('datadog:telemetry:stop')
@@ -212,7 +212,7 @@ function createPayload (currReqType, currPayload = {}) {
 function heartbeat (config, application, host) {
   heartbeatTimeout = setTimeout(() => {
     metricsManager.send(config, application, host)
-    logs.send(config, application, host)
+    telemetryLogger.send(config, application, host)
 
     const { reqType, payload } = createPayload('app-heartbeat')
     sendData(config, application, host, reqType, payload, updateRetryData)
@@ -237,7 +237,7 @@ function extendedHeartbeat (config) {
 function start (aConfig, thePluginManager) {
   if (!aConfig.telemetry.enabled) {
     if (aConfig.sca?.enabled) {
-      log.warn('DD_APPSEC_SCA_ENABLED requires enabling telemetry to work.')
+      logger.warn('DD_APPSEC_SCA_ENABLED requires enabling telemetry to work.')
     }
 
     return
@@ -250,7 +250,7 @@ function start (aConfig, thePluginManager) {
   integrations = getIntegrations()
 
   dependencies.start(config, application, host, getRetryData, updateRetryData)
-  logs.start(config)
+  telemetryLogger.start(config)
 
   sendData(config, application, host, 'app-started', appStarted(config))
 

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -317,12 +317,18 @@ function updateConfig (changes, config) {
   }
 
   const namesNeedFormatting = new Set(['DD_TAGS', 'peerServiceMapping'])
+  const entriesNotSentOnUndefinedDefault = new Set(['appsec.sca.enabled'])
 
   const configuration = []
   const names = [] // list of config names whose values have been changed
 
   for (const change of changes) {
     const name = nameMapping[change.name] || change.name
+
+    if (entriesNotSentOnUndefinedDefault.has(name) && change.origin === 'default' && change.value === undefined) {
+      continue
+    }
+
     names.push(name)
     const { origin, value } = change
     const entry = { name, value, origin }

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -317,17 +317,12 @@ function updateConfig (changes, config) {
   }
 
   const namesNeedFormatting = new Set(['DD_TAGS', 'peerServiceMapping'])
-  const entriesNotSentOnUndefinedDefault = new Set(['appsec.sca.enabled'])
 
   const configuration = []
   const names = [] // list of config names whose values have been changed
 
   for (const change of changes) {
     const name = nameMapping[change.name] || change.name
-
-    if (entriesNotSentOnUndefinedDefault.has(name) && change.origin === 'default' && change.value === undefined) {
-      continue
-    }
 
     names.push(name)
     const { origin, value } = change

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -295,7 +295,7 @@ describe('Config', () => {
         value: '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\\s*=[^;]|"\\s*:\\s*"[^"]+")|bearer\\s+[a-z0-9\\._\\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\\w=-]+\\.ey[I-L][\\w=-]+(?:\\.[\\w.+\\/=-]+)?|[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}[^\\-]+[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY|ssh-rsa\\s*[a-z0-9\\/\\.+]{100,}',
         origin: 'default'
       },
-      { name: 'appsec.sca.enabled', value: undefined, origin: 'default' },
+      { name: 'appsec.sca.enabled', value: null, origin: 'default' },
       { name: 'remoteConfig.enabled', value: true, origin: 'env_var' },
       { name: 'remoteConfig.pollInterval', value: 5, origin: 'default' },
       { name: 'iast.enabled', value: false, origin: 'default' },

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -228,7 +228,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('installSignature.id', null)
     expect(config).to.have.nested.property('installSignature.time', null)
     expect(config).to.have.nested.property('installSignature.type', null)
-    expect(config).to.have.nested.property('sca.enabled', false)
+    expect(config).to.have.nested.property('sca.enabled', undefined)
 
     expect(updateConfig).to.be.calledOnce
 
@@ -325,7 +325,7 @@ describe('Config', () => {
       { name: 'spanComputePeerService', value: false, origin: 'calculated' },
       { name: 'stats.enabled', value: false, origin: 'calculated' },
       { name: 'version', value: '', origin: 'default' },
-      { name: 'sca.enabled', value: false, origin: 'default' }
+      { name: 'sca.enabled', value: undefined, origin: 'default' }
     ])
   })
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -228,6 +228,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('installSignature.id', null)
     expect(config).to.have.nested.property('installSignature.time', null)
     expect(config).to.have.nested.property('installSignature.type', null)
+    expect(config).to.have.nested.property('sca.enabled', false)
 
     expect(updateConfig).to.be.calledOnce
 
@@ -323,7 +324,8 @@ describe('Config', () => {
       { name: 'sampler.rateLimit', value: undefined, origin: 'default' },
       { name: 'spanComputePeerService', value: false, origin: 'calculated' },
       { name: 'stats.enabled', value: false, origin: 'calculated' },
-      { name: 'version', value: '', origin: 'default' }
+      { name: 'version', value: '', origin: 'default' },
+      { name: 'sca.enabled', value: false, origin: 'default' }
     ])
   })
 
@@ -417,6 +419,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON = BLOCKED_TEMPLATE_JSON_PATH
     process.env.DD_APPSEC_GRAPHQL_BLOCKED_TEMPLATE_JSON = BLOCKED_TEMPLATE_GRAPHQL_PATH
     process.env.DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING = 'extended'
+    process.env.DD_APPSEC_SCA_ENABLED = true
     process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = '42'
     process.env.DD_IAST_ENABLED = 'true'
@@ -519,6 +522,7 @@ describe('Config', () => {
       type: 'k8s_single_step',
       time: '1703188212'
     })
+    expect(config).to.have.nested.property('sca.enabled', true)
 
     expect(updateConfig).to.be.calledOnce
 
@@ -569,7 +573,8 @@ describe('Config', () => {
       { name: 'iast.redactionValuePattern', value: 'REDACTION_VALUE_PATTERN', origin: 'env_var' },
       { name: 'iast.telemetryVerbosity', value: 'DEBUG', origin: 'env_var' },
       { name: 'isGCPFunction', value: false, origin: 'env_var' },
-      { name: 'queryStringObfuscation', value: '.*', origin: 'env_var' }
+      { name: 'queryStringObfuscation', value: '.*', origin: 'env_var' },
+      { name: 'sca.enabled', value: true, origin: 'env_var' }
     ])
   })
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -218,6 +218,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.eventTracking.mode', 'safe')
     expect(config).to.have.nested.property('appsec.apiSecurity.enabled', true)
     expect(config).to.have.nested.property('appsec.apiSecurity.requestSampling', 0.1)
+    expect(config).to.have.nested.property('appsec.sca.enabled', undefined)
     expect(config).to.have.nested.property('remoteConfig.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 5)
     expect(config).to.have.nested.property('iast.enabled', false)
@@ -228,7 +229,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('installSignature.id', null)
     expect(config).to.have.nested.property('installSignature.time', null)
     expect(config).to.have.nested.property('installSignature.type', null)
-    expect(config).to.have.nested.property('sca.enabled', undefined)
 
     expect(updateConfig).to.be.calledOnce
 
@@ -295,6 +295,7 @@ describe('Config', () => {
         value: '(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\\s*=[^;]|"\\s*:\\s*"[^"]+")|bearer\\s+[a-z0-9\\._\\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\\w=-]+\\.ey[I-L][\\w=-]+(?:\\.[\\w.+\\/=-]+)?|[\\-]{5}BEGIN[a-z\\s]+PRIVATE\\sKEY[\\-]{5}[^\\-]+[\\-]{5}END[a-z\\s]+PRIVATE\\sKEY|ssh-rsa\\s*[a-z0-9\\/\\.+]{100,}',
         origin: 'default'
       },
+      { name: 'appsec.sca.enabled', value: undefined, origin: 'default' },
       { name: 'remoteConfig.enabled', value: true, origin: 'env_var' },
       { name: 'remoteConfig.pollInterval', value: 5, origin: 'default' },
       { name: 'iast.enabled', value: false, origin: 'default' },
@@ -324,8 +325,7 @@ describe('Config', () => {
       { name: 'sampler.rateLimit', value: undefined, origin: 'default' },
       { name: 'spanComputePeerService', value: false, origin: 'calculated' },
       { name: 'stats.enabled', value: false, origin: 'calculated' },
-      { name: 'version', value: '', origin: 'default' },
-      { name: 'sca.enabled', value: undefined, origin: 'default' }
+      { name: 'version', value: '', origin: 'default' }
     ])
   })
 
@@ -506,6 +506,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.eventTracking.mode', 'extended')
     expect(config).to.have.nested.property('appsec.apiSecurity.enabled', true)
     expect(config).to.have.nested.property('appsec.apiSecurity.requestSampling', 1)
+    expect(config).to.have.nested.property('appsec.sca.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.enabled', false)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
@@ -522,7 +523,6 @@ describe('Config', () => {
       type: 'k8s_single_step',
       time: '1703188212'
     })
-    expect(config).to.have.nested.property('sca.enabled', true)
 
     expect(updateConfig).to.be.calledOnce
 
@@ -561,6 +561,7 @@ describe('Config', () => {
       { name: 'appsec.blockedTemplateJson', value: BLOCKED_TEMPLATE_JSON, origin: 'env_var' },
       { name: 'appsec.obfuscatorKeyRegex', value: '.*', origin: 'env_var' },
       { name: 'appsec.obfuscatorValueRegex', value: '.*', origin: 'env_var' },
+      { name: 'appsec.sca.enabled', value: true, origin: 'env_var' },
       { name: 'remoteConfig.enabled', value: false, origin: 'env_var' },
       { name: 'remoteConfig.pollInterval', value: 42, origin: 'env_var' },
       { name: 'iast.enabled', value: true, origin: 'env_var' },
@@ -573,8 +574,7 @@ describe('Config', () => {
       { name: 'iast.redactionValuePattern', value: 'REDACTION_VALUE_PATTERN', origin: 'env_var' },
       { name: 'iast.telemetryVerbosity', value: 'DEBUG', origin: 'env_var' },
       { name: 'isGCPFunction', value: false, origin: 'env_var' },
-      { name: 'queryStringObfuscation', value: '.*', origin: 'env_var' },
-      { name: 'sca.enabled', value: true, origin: 'env_var' }
+      { name: 'queryStringObfuscation', value: '.*', origin: 'env_var' }
     ])
   })
 
@@ -1181,6 +1181,9 @@ describe('Config', () => {
       apiSecurity: {
         enabled: true,
         requestSampling: 1.0
+      },
+      sca: {
+        enabled: undefined
       }
     })
   })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -218,7 +218,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.eventTracking.mode', 'safe')
     expect(config).to.have.nested.property('appsec.apiSecurity.enabled', true)
     expect(config).to.have.nested.property('appsec.apiSecurity.requestSampling', 0.1)
-    expect(config).to.have.nested.property('appsec.sca.enabled', undefined)
+    expect(config).to.have.nested.property('appsec.sca.enabled', null)
     expect(config).to.have.nested.property('remoteConfig.enabled', true)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 5)
     expect(config).to.have.nested.property('iast.enabled', false)
@@ -1183,7 +1183,7 @@ describe('Config', () => {
         requestSampling: 1.0
       },
       sca: {
-        enabled: undefined
+        enabled: null
       }
     })
   })

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -812,7 +812,7 @@ describe('AVM OSS', () => {
       }
 
       telemetry.updateConfig(
-        [{ name: 'sca.enabled', value: false, origin: 'default' }],
+        [{ name: 'sca.enabled', value: true, origin: 'env_var' }],
         telemetryConfig
       )
 
@@ -828,18 +828,6 @@ describe('AVM OSS', () => {
     it('in app-started message', () => {
       return testSeq(1, 'app-started', payload => {
         expect(payload).to.have.property('configuration').that.deep.equal([
-          { name: 'sca.enabled', value: false, origin: 'default' }
-        ])
-      }, true)
-    })
-
-    it('in app-client-configuration-change message', () => {
-      telemetry.updateConfig(
-        [{ name: 'sca.enabled', value: true, origin: 'env_var' }],
-        telemetryConfig
-      )
-      return testSeq(2, 'app-client-configuration-change', payload => {
-        expect(payload).to.have.property('configuration').that.deep.equal([
           { name: 'sca.enabled', value: true, origin: 'env_var' }
         ])
       }, true)
@@ -848,9 +836,9 @@ describe('AVM OSS', () => {
     it('in app-extended-heartbeat message', () => {
       // Skip a full day
       clock.tick(86400000)
-      return testSeq(3, 'app-extended-heartbeat', payload => {
+      return testSeq(2, 'app-extended-heartbeat', payload => {
         expect(payload).to.have.property('configuration').that.deep.equal([
-          { name: 'sca.enabled', value: false, origin: 'default' }
+          { name: 'sca.enabled', value: true, origin: 'env_var' }
         ])
       }, true)
     })

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -792,7 +792,7 @@ describe('AVM OSS', () => {
       }
     ]
 
-    function expectScaValue(payload, scaValue) {
+    function expectScaValue (payload, scaValue) {
       if (scaValue === undefined) {
         expect(payload.configuration.filter(c => c.name === 'sca.enabled')).is.empty
       } else {
@@ -802,7 +802,7 @@ describe('AVM OSS', () => {
       }
     }
 
-    suite.forEach(({scaValue, testDescription}) => {
+    suite.forEach(({ scaValue, testDescription }) => {
       describe(testDescription, () => {
         before((done) => {
           clock = sinon.useFakeTimers()

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -789,21 +789,11 @@ describe('AVM OSS', () => {
         testDescription: 'should send when env var is false'
       },
       {
-        scaValue: undefined,
+        scaValue: null,
         scaValueOrigin: 'default',
-        testDescription: 'should not send when no env var is informed'
+        testDescription: 'should send null (default) when no env var is set'
       }
     ]
-
-    function expectScaValue (payload, scaValue) {
-      if (scaValue === undefined) {
-        expect(payload.configuration.filter(c => c.name === 'appsec.sca.enabled')).is.empty
-      } else {
-        expect(payload).to.have.property('configuration').that.deep.equal([
-          { name: 'appsec.sca.enabled', value: scaValue, origin: 'env_var' }
-        ])
-      }
-    }
 
     suite.forEach(({ scaValue, scaValueOrigin, testDescription }) => {
       describe(testDescription, () => {
@@ -860,7 +850,9 @@ describe('AVM OSS', () => {
 
         it('in app-started message', () => {
           return testSeq(1, 'app-started', payload => {
-            expectScaValue(payload, scaValue)
+            expect(payload).to.have.property('configuration').that.deep.equal([
+              { name: 'appsec.sca.enabled', value: scaValue, origin: scaValueOrigin }
+            ])
           }, true)
         })
 
@@ -868,7 +860,9 @@ describe('AVM OSS', () => {
           // Skip a full day
           clock.tick(86400000)
           return testSeq(2, 'app-extended-heartbeat', payload => {
-            expectScaValue(payload, scaValue)
+            expect(payload).to.have.property('configuration').that.deep.equal([
+              { name: 'appsec.sca.enabled', value: scaValue, origin: scaValueOrigin }
+            ])
           }, true)
         })
       })

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -779,30 +779,33 @@ describe('AVM OSS', () => {
 
     const suite = [
       {
-        scaValue: undefined,
-        testDescription: 'should not send when no env var is informed'
-      },
-      {
         scaValue: true,
+        scaValueOrigin: 'env_var',
         testDescription: 'should send when env var is true'
       },
       {
         scaValue: false,
+        scaValueOrigin: 'env_var',
         testDescription: 'should send when env var is false'
+      },
+      {
+        scaValue: undefined,
+        scaValueOrigin: 'default',
+        testDescription: 'should not send when no env var is informed'
       }
     ]
 
     function expectScaValue (payload, scaValue) {
       if (scaValue === undefined) {
-        expect(payload.configuration.filter(c => c.name === 'sca.enabled')).is.empty
+        expect(payload.configuration.filter(c => c.name === 'appsec.sca.enabled')).is.empty
       } else {
         expect(payload).to.have.property('configuration').that.deep.equal([
-          { name: 'sca.enabled', value: scaValue, origin: 'env_var' }
+          { name: 'appsec.sca.enabled', value: scaValue, origin: 'env_var' }
         ])
       }
     }
 
-    suite.forEach(({ scaValue, testDescription }) => {
+    suite.forEach(({ scaValue, scaValueOrigin, testDescription }) => {
       describe(testDescription, () => {
         before((done) => {
           clock = sinon.useFakeTimers()
@@ -842,12 +845,10 @@ describe('AVM OSS', () => {
         })
 
         before(() => {
-          if (scaValue !== undefined) {
-            telemetry.updateConfig(
-              [{ name: 'sca.enabled', value: scaValue, origin: 'env_var' }],
-              telemetryConfig
-            )
-          }
+          telemetry.updateConfig(
+            [{ name: 'appsec.sca.enabled', value: scaValue, origin: scaValueOrigin }],
+            telemetryConfig
+          )
           telemetry.start(telemetryConfig, { _pluginsByName: {} })
         })
 


### PR DESCRIPTION
### What does this PR do?
Adds a new configuration `DD_APPSEC_SCA_ENABLED`, used to enable AVM OSS.
The value of this new configuration is sent via telemetry to the backend in the `configuration` payload for the following telemetry messages: `app-started`, `app-extended-heartbeat` and `app-client-configuration-change`.
If `DD_APPSEC_SCA_ENABLED` is not set explicitly, then the value is not sent in telemetry messages.

### Motivation
Customers need a way to enable AVM OSS via an environment variable, just as they enable APM or other products or features, instead of having to do it exclusively through the UI.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
[System Test PR](https://github.com/DataDog/system-tests/pull/2372)

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

[APPSEC-17141](https://datadoghq.atlassian.net/browse/APPSEC-17141)

[APPSEC-17141]: https://datadoghq.atlassian.net/browse/APPSEC-17141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ