### PR TITLE
[ci-visibility] Early flake detection for cypress

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -187,7 +187,7 @@ class FakeCiVisIntake extends FakeAgent {
       const data = JSON.stringify({
         data: {
           attributes: {
-            test_full_names: knownTests
+            tests: knownTests
           }
         }
       })

--- a/integration-tests/cypress-config.json
+++ b/integration-tests/cypress-config.json
@@ -5,5 +5,6 @@
   "supportFile": "cypress/support/e2e.js",
   "integrationFolder": "cypress/e2e",
   "defaultCommandTimeout": 100,
-  "nodeVersion": "system"
+  "nodeVersion": "system",
+  "testFiles": "cypress/e2e/**/*.cy.js"
 }

--- a/integration-tests/cypress-config.json
+++ b/integration-tests/cypress-config.json
@@ -5,6 +5,5 @@
   "supportFile": "cypress/support/e2e.js",
   "integrationFolder": "cypress/e2e",
   "defaultCommandTimeout": 100,
-  "nodeVersion": "system",
-  "testFiles": "cypress/e2e/**/*.cy.js"
+  "nodeVersion": "system"
 }

--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -15,7 +15,8 @@ async function runCypress () {
           import('dd-trace/ci/cypress/plugin').then(module => {
             module.default(on, config)
           })
-        }
+        },
+        specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js'
       },
       video: false,
       screenshotOnRunFailure: false

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -13,7 +13,8 @@ module.exports = {
           require('dd-trace/ci/cypress/after-run')(...args)
         })
       }
-    }
+    },
+    specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*'
   },
   video: false,
   screenshotOnRunFailure: false

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -14,7 +14,7 @@ module.exports = {
         })
       }
     },
-    specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*'
+    specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js'
   },
   video: false,
   screenshotOnRunFailure: false

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -43,7 +43,7 @@ const moduleType = [
   {
     type: 'commonJS',
     testCommand: function commandWithSuffic (version) {
-      const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json' : ''
+      const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json --spec "cypress/e2e/*.cy.js"' : ''
       return `./node_modules/.bin/cypress run ${commandSuffix}`
     }
   },

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -863,5 +863,71 @@ moduleType.forEach(({
         }).catch(done)
       })
     })
+
+    it.only('retries tests if early flake detection is enabled', (done) => {
+      const NUM_RETRIES_EFD = 3
+      receiver.setSettings({
+        itr_enabled: false,
+        code_coverage: false,
+        tests_skipping: false,
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': NUM_RETRIES_EFD
+          }
+        }
+      })
+
+      receiver.setKnownTests({
+        'cypress': {
+          'cypress/e2e/spec.cy.js': [
+            // This test will be considered new
+            // 'context passes',
+            'other context fails'
+          ]
+        }
+      })
+
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+          debugger
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSessionEvent = events.find(event => event.type === 'test_session_end')
+          assert.exists(testSessionEvent)
+          const testModuleEvent = events.find(event => event.type === 'test_module_end')
+          assert.exists(testModuleEvent)
+          const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
+          assert.equal(testSuiteEvents.length, 4)
+          const testEvents = events.filter(event => event.type === 'test')
+          assert.equal(testEvents.length, 9)
+        })
+
+      const {
+        NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+        ...restEnvVars
+      } = getCiVisEvpProxyConfig(receiver.port)
+
+      childProcess = exec(
+        testCommand,
+        {
+          cwd,
+          env: {
+            ...restEnvVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            SPEC_PATTERN: 'cypress/e2e/spec.cy.js'
+          },
+          stdio: 'pipe'
+        }
+      )
+
+      childProcess.stdout.pipe(process.stdout)
+      childProcess.stderr.pipe(process.stderr)
+
+      childProcess.on('exit', () => {
+        receiverPromise.then(() => {
+          done()
+        }).catch(done)
+      })
+    })
   })
 })

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -920,14 +920,16 @@ moduleType.forEach(({
           ...restEnvVars
         } = getCiVisEvpProxyConfig(receiver.port)
 
+        const specToRun = 'cypress/e2e/spec.cy.js'
+
         childProcess = exec(
-          testCommand,
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
           {
             cwd,
             env: {
               ...restEnvVars,
               CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-              SPEC_PATTERN: 'cypress/e2e/spec.cy.js'
+              SPEC_PATTERN: specToRun
             },
             stdio: 'pipe'
           }
@@ -979,14 +981,15 @@ moduleType.forEach(({
             assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED)
           })
 
+        const specToRun = 'cypress/e2e/spec.cy.js'
         childProcess = exec(
-          testCommand,
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
           {
             cwd,
             env: {
               ...restEnvVars,
               CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-              SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
+              SPEC_PATTERN: specToRun,
               DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false'
             },
             stdio: 'pipe'
@@ -1034,8 +1037,10 @@ moduleType.forEach(({
             assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED, 'true')
           })
 
+        const specToRun = 'cypress/e2e/skipped-test.js'
+
         childProcess = exec(
-          testCommand,
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
           {
             cwd,
             env: {

--- a/integration-tests/cypress/e2e/skipped-test.js
+++ b/integration-tests/cypress/e2e/skipped-test.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+describe('skipped', () => {
+  it.skip('skipped', () => {
+    cy.visit('/')
+      .get('.hello-world')
+      .should('have.text', 'Hello World')
+  })
+})

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -27,7 +27,8 @@ const {
   ITR_CORRELATION_ID,
   TEST_SOURCE_FILE,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY
+  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_EARLY_FLAKE_IS_ENABLED
 } = require('../../dd-trace/src/plugins/util/test')
 const { isMarkedAsUnskippable } = require('../../datadog-plugin-jest/src/util')
 const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
@@ -361,6 +362,10 @@ class CypressPlugin {
       getTestSessionCommonTags(this.command, this.frameworkVersion, TEST_FRAMEWORK_NAME)
     const testModuleSpanMetadata =
       getTestModuleCommonTags(this.command, this.frameworkVersion, TEST_FRAMEWORK_NAME)
+
+    if (this.isEarlyFlakeDetectionEnabled) {
+      testSessionSpanMetadata[TEST_EARLY_FLAKE_IS_ENABLED] = 'true'
+    }
 
     this.testSessionSpan = this.tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test_session`, {
       childOf,

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -198,6 +198,7 @@ class CypressPlugin {
     this.isSuitesSkippingEnabled = false
     this.isCodeCoverageEnabled = false
     this.isEarlyFlakeDetectionEnabled = false
+    this.earlyFlakeDetectionNumRetries = 0
     this.testsToSkip = []
     this.skippedTests = []
     this.hasForcedToRunSuites = false
@@ -295,10 +296,6 @@ class CypressPlugin {
     return !this.knownTestsByTestSuite?.[testSuite]?.includes(testName)
   }
 
-  async beforeSpec (spec) {
-    // console.log('spec', spec)
-  }
-
   async beforeRun (details) {
     this.command = getCypressCommand(details)
     this.frameworkVersion = getCypressVersion(details)
@@ -313,12 +310,14 @@ class CypressPlugin {
         libraryConfig: {
           isSuitesSkippingEnabled,
           isCodeCoverageEnabled,
-          isEarlyFlakeDetectionEnabled
+          isEarlyFlakeDetectionEnabled,
+          earlyFlakeDetectionNumRetries
         }
       } = libraryConfigurationResponse
       this.isSuitesSkippingEnabled = isSuitesSkippingEnabled
       this.isCodeCoverageEnabled = isCodeCoverageEnabled
       this.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
+      this.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
     }
 
     if (this.isEarlyFlakeDetectionEnabled) {
@@ -528,7 +527,8 @@ class CypressPlugin {
       'dd:testSuiteStart': (testSuite) => {
         const suitePayload = {
           isEarlyFlakeDetectionEnabled: this.isEarlyFlakeDetectionEnabled,
-          knownTestsForSuite: this.knownTestsByTestSuite?.[testSuite] || []
+          knownTestsForSuite: this.knownTestsByTestSuite?.[testSuite] || [],
+          earlyFlakeDetectionNumRetries: this.earlyFlakeDetectionNumRetries
         }
 
         if (this.testSuiteSpan) {

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -50,8 +50,10 @@ beforeEach(function () {
 
 before(function () {
   cy.task('dd:testSuiteStart', Cypress.mocha.getRootSuite().file).then((suiteConfig) => {
-    isEarlyFlakeDetectionEnabled = suiteConfig?.isEarlyFlakeDetectionEnabled
-    knownTestsForSuite = suiteConfig?.knownTestsForSuite
+    if (suiteConfig) {
+      isEarlyFlakeDetectionEnabled = suiteConfig.isEarlyFlakeDetectionEnabled
+      knownTestsForSuite = suiteConfig.knownTestsForSuite
+    }
   })
 })
 

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -11,11 +11,11 @@ function isNewTest (test) {
 function retryTest (test, earlyFlakeDetectionNumRetries = 3, suiteTests) {
   for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
     const clonedTest = test.clone()
-    // TODO: we'll have to somehow signal that this is a retry
+    // TODO: signal in framework logs that this is a retry
     suiteTests.unshift(clonedTest)
     clonedTest._ddIsNew = true
     clonedTest._ddIsEfdRetry = true
-    // TODO: these tests are allowed to fail. We'll have to change that
+    // TODO: Change it so these tests are allowed to fail.
   }
 }
 
@@ -50,8 +50,8 @@ beforeEach(function () {
 
 before(function () {
   cy.task('dd:testSuiteStart', Cypress.mocha.getRootSuite().file).then((suiteConfig) => {
-    isEarlyFlakeDetectionEnabled = suiteConfig.isEarlyFlakeDetectionEnabled
-    knownTestsForSuite = suiteConfig.knownTestsForSuite
+    isEarlyFlakeDetectionEnabled = suiteConfig?.isEarlyFlakeDetectionEnabled
+    knownTestsForSuite = suiteConfig?.knownTestsForSuite
   })
 })
 

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -1,9 +1,54 @@
 /* eslint-disable */
+const EFD_STRING = "Retried by Datadog's Early Flake Detection"
+
+let isEarlyFlakeDetectionEnabled = false
+let knownTestsForSuite = []
+
+debugger
+function addEfdStringToTestName (testName, numAttempt) {
+  return `${EFD_STRING} (#${numAttempt}): ${testName}`
+}
+
+function retryTest (test, earlyFlakeDetectionNumRetries = 3) {
+  const originalTestName = test.title
+  const suite = test.parent
+  for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
+    const clonedTest = test.clone()
+    clonedTest.title = addEfdStringToTestName(originalTestName, retryIndex + 1)
+    suite.addTest(clonedTest)
+    clonedTest._ddIsNew = true
+    clonedTest._ddIsEfdRetry = true
+  }
+}
+
+function isNewTest (test) {
+  return !knownTestsForSuite.includes(test.fullTitle())
+}
+// const oldIt = window.it
+
+debugger
+const oldRunTests = Cypress.mocha.getRunner().runTests
+
+Cypress.mocha.getRunner().runTests = function (suite) {
+  if (!isEarlyFlakeDetectionEnabled) {
+    return oldRunTests.apply(this, arguments)
+  }
+  suite.tests.forEach(test => {
+    debugger
+    if (!test._ddIsNew && !test.isPending() && isNewTest(test)) {
+      test._ddIsNew = true
+      retryTest(test)
+    }
+  })
+  return oldRunTests.apply(this, arguments)
+}
+
 beforeEach(function () {
   cy.task('dd:beforeEach', {
     testName: Cypress.mocha.getRunner().suite.ctx.currentTest.fullTitle(),
     testSuite: Cypress.mocha.getRootSuite().file
   }).then(({ traceId, shouldSkip }) => {
+    debugger
     Cypress.env('traceId', traceId)
     if (shouldSkip) {
       this.skip()
@@ -11,8 +56,12 @@ beforeEach(function () {
   })
 })
 
-before(() => {
-  cy.task('dd:testSuiteStart', Cypress.mocha.getRootSuite().file)
+before(function () {
+  cy.task('dd:testSuiteStart', Cypress.mocha.getRootSuite().file).then((suiteConfig) => {
+    debugger
+    isEarlyFlakeDetectionEnabled = suiteConfig.isEarlyFlakeDetectionEnabled
+    knownTestsForSuite = suiteConfig.knownTestsForSuite
+  })
 })
 
 after(() => {
@@ -32,6 +81,8 @@ afterEach(() => {
       testSuite: Cypress.mocha.getRootSuite().file,
       state: currentTest.state,
       error: currentTest.err,
+      isNew: currentTest._ddIsNew,
+      isEfdRetry: currentTest._ddIsEfdRetry
     }
     try {
       testInfo.testSourceLine = Cypress.mocha.getRunner().currentRunnable.invocationDetails.line

--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -70,7 +70,7 @@ function getKnownTests ({
       done(err)
     } else {
       try {
-        const { data: { attributes: { test_full_names: knownTests } } } = JSON.parse(res)
+        const { data: { attributes: { tests: knownTests } } } = JSON.parse(res)
         log.debug(() => `Number of received known tests: ${Object.keys(knownTests).length}`)
         done(null, knownTests)
       } catch (err) {

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -689,7 +689,12 @@ describe('CI Visibility Exporter', () => {
           .reply(200, JSON.stringify({
             data: {
               attributes: {
-                test_full_names: ['suite1.test1', 'suite2.test2']
+                tests: {
+                  'jest': {
+                    'suite1': ['test1'],
+                    'suite2': ['test2']
+                  }
+                }
               }
             }
           }))
@@ -700,7 +705,12 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter._libraryConfig = { isEarlyFlakeDetectionEnabled: true }
         ciVisibilityExporter.getKnownTests({}, (err, knownTests) => {
           expect(err).to.be.null
-          expect(knownTests).to.eql(['suite1.test1', 'suite2.test2'])
+          expect(knownTests).to.eql({
+            'jest': {
+              'suite1': ['test1'],
+              'suite2': ['test2']
+            }
+          })
           expect(scope.isDone()).to.be.true
           done()
         })
@@ -727,7 +737,16 @@ describe('CI Visibility Exporter', () => {
             requestHeaders = this.req.headers
 
             return zlib.gzipSync(JSON.stringify({
-              data: { attributes: { test_full_names: ['suite1.test1', 'suite2.test2'] } }
+              data: {
+                attributes: {
+                  tests: {
+                    'jest': {
+                      'suite1': ['test1'],
+                      'suite2': ['test2']
+                    }
+                  }
+                }
+              }
             }))
           }, {
             'content-encoding': 'gzip'
@@ -740,7 +759,12 @@ describe('CI Visibility Exporter', () => {
         ciVisibilityExporter._isGzipCompatible = true
         ciVisibilityExporter.getKnownTests({}, (err, knownTests) => {
           expect(err).to.be.null
-          expect(knownTests).to.eql(['suite1.test1', 'suite2.test2'])
+          expect(knownTests).to.eql({
+            'jest': {
+              'suite1': ['test1'],
+              'suite2': ['test2']
+            }
+          })
           expect(scope.isDone()).to.be.true
           expect(requestHeaders['accept-encoding']).to.equal('gzip')
           done()
@@ -754,7 +778,16 @@ describe('CI Visibility Exporter', () => {
             requestHeaders = this.req.headers
 
             return JSON.stringify({
-              data: { attributes: { test_full_names: ['suite1.test1', 'suite2.test2'] } }
+              data: {
+                attributes: {
+                  tests: {
+                    'jest': {
+                      'suite1': ['test1'],
+                      'suite2': ['test2']
+                    }
+                  }
+                }
+              }
             })
           })
 
@@ -767,7 +800,12 @@ describe('CI Visibility Exporter', () => {
 
         ciVisibilityExporter.getKnownTests({}, (err, knownTests) => {
           expect(err).to.be.null
-          expect(knownTests).to.eql(['suite1.test1', 'suite2.test2'])
+          expect(knownTests).to.eql({
+            'jest': {
+              'suite1': ['test1'],
+              'suite2': ['test2']
+            }
+          })
           expect(scope.isDone()).to.be.true
           expect(requestHeaders['accept-encoding']).not.to.equal('gzip')
           done()


### PR DESCRIPTION
### What does this PR do?
* Add early flake detection capability to cypress: if the feature is enabled, new tests will be retried automatically. 

### Motivation
Add support for early flake detection for cypress.

### Plugin Checklist

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

