### PR TITLE
Support ipv6 in profiler

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -10,6 +10,7 @@ const FormData = require('../../exporters/common/form-data')
 const { storage } = require('../../../../datadog-core')
 const version = require('../../../../../package.json').version
 const os = require('os')
+const { urlToHttpOptions } = require('url')
 const perf = require('perf_hooks').performance
 
 const containerId = docker.id()
@@ -177,9 +178,10 @@ class AgentExporter {
         if (this._url.protocol === 'unix:') {
           options.socketPath = this._url.pathname
         } else {
-          options.protocol = this._url.protocol
-          options.hostname = this._url.hostname
-          options.port = this._url.port
+          const httpOptions = urlToHttpOptions(this._url)
+          options.protocol = httpOptions.protocol
+          options.hostname = httpOptions.hostname
+          options.port = httpOptions.port
         }
 
         this._logger.debug(() => {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -355,6 +355,58 @@ describe('exporters/agent', function () {
     })
   })
 
+  describe('using ipv6', () => {
+    beforeEach(done => {
+      getPort().then(port => {
+        url = new URL(`http://[0:0:0:0:0:0:0:1]:${port}`)
+
+        listener = app.listen(port, '0:0:0:0:0:0:0:1', done)
+        listener.on('connection', socket => sockets.push(socket))
+        startSpan = sinon.spy(tracer._tracer, 'startSpan')
+      })
+    })
+
+    afterEach(done => {
+      listener.close(done)
+      sockets.forEach(socket => socket.end())
+      tracer._tracer.startSpan.restore()
+    })
+
+    it('should support ipv6 urls', async () => {
+      const exporter = newAgentExporter({ url, logger })
+      const start = new Date()
+      const end = new Date()
+      const tags = {
+        'runtime-id': RUNTIME_ID
+      }
+
+      const [ wall, space ] = await Promise.all([
+        createProfile(['wall', 'microseconds']),
+        createProfile(['space', 'bytes'])
+      ])
+
+      const profiles = {
+        wall,
+        space
+      }
+
+      await new Promise((resolve, reject) => {
+        app.post('/profiling/v1/input', upload.any(), (req, res) => {
+          try {
+            verifyRequest(req, profiles, start, end)
+            resolve()
+          } catch (e) {
+            reject(e)
+          }
+
+          res.send()
+        })
+
+        exporter.export({ profiles, start, end, tags }).catch(reject)
+      })
+    })
+  })
+
   describeOnUnix('using UDS', () => {
     let listener
 


### PR DESCRIPTION
### What does this PR do?
Fixes #3947

### Motivation
We run the profiler in an IPv6 EKS cluster and are maintaining a local patch to make it work.

### Plugin Checklist

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

I'm not sure if this counts as updating a plugin, but I did add a unit test!