### PR TITLE
Support mongodb 6.4.0 which uses Promises instead of callbacks in connection method

### DIFF
--- a/packages/datadog-instrumentations/src/mongodb-core.js
+++ b/packages/datadog-instrumentations/src/mongodb-core.js
@@ -32,9 +32,15 @@ addHook({ name: 'mongodb', versions: ['>=4 <4.6.0'], file: 'lib/cmap/connection.
   return Connection
 })
 
-addHook({ name: 'mongodb', versions: ['>=4.6.0'], file: 'lib/cmap/connection.js' }, Connection => {
+addHook({ name: 'mongodb', versions: ['>=4.6.0 <6.4.0'], file: 'lib/cmap/connection.js' }, Connection => {
   const proto = Connection.Connection.prototype
   shimmer.wrap(proto, 'command', command => wrapConnectionCommand(command, 'command'))
+  return Connection
+})
+
+addHook({ name: 'mongodb', versions: ['>=6.4.0'], file: 'lib/cmap/connection.js' }, Connection => {
+  const proto = Connection.Connection.prototype
+  shimmer.wrap(proto, 'command', command => wrapConnectionCommand(command, 'command', undefined, true))
   return Connection
 })
 
@@ -89,7 +95,7 @@ function wrapUnifiedCommand (command, operation, name) {
   return shimmer.wrap(command, wrapped)
 }
 
-function wrapConnectionCommand (command, operation, name) {
+function wrapConnectionCommand (command, operation, name, isPromise = false) {
   const wrapped = function (ns, ops) {
     if (!startCh.hasSubscribers) {
       return command.apply(this, arguments)
@@ -101,7 +107,11 @@ function wrapConnectionCommand (command, operation, name) {
     const topology = { s: { options } }
 
     ns = `${ns.db}.${ns.collection}`
-    return instrument(operation, command, this, arguments, topology, ns, ops, { name })
+    if (isPromise) {
+      return instrumentPromise(operation, command, this, arguments, topology, ns, ops, { name })
+    } else {
+      return instrument(operation, command, this, arguments, topology, ns, ops, { name })
+    }
   }
   return shimmer.wrap(command, wrapped)
 }
@@ -177,5 +187,30 @@ function instrument (operation, command, ctx, args, server, ns, ops, options = {
 
       throw err
     }
+  })
+}
+
+function instrumentPromise (operation, command, ctx, args, server, ns, ops, options = {}) {
+  const name = options.name || (ops && Object.keys(ops)[0])
+
+  const serverInfo = server && server.s && server.s.options
+  const asyncResource = new AsyncResource('bound-anonymous-fn')
+
+  return asyncResource.runInAsyncScope(() => {
+    startCh.publish({ ns, ops, options: serverInfo, name })
+
+    const promise = command.apply(ctx, args)
+
+    promise.then(function (res) {
+      finishCh.publish()
+      return res
+    }, function (err) {
+      errorCh.publish(err)
+      finishCh.publish()
+
+      return Promise.reject(err)
+    })
+
+    return promise
   })
 }

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -251,6 +251,10 @@
     {
       "name": "bson",
       "versions": ["4.0.0"]
+    },
+    {
+      "name": "mongodb",
+      "versions": ["6.3.0"]
     }
   ],
   "mongoose": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Creates new instrumentPromise method in mongodb instrumentation to support 6.4.0 version

Added 6.3.0 in externals.json to force test running in that version.

### Motivation
<!-- What inspired you to submit this pull request? -->
Test failing since Friday when mongodb 6.4.0 was released.

### Additional Notes
https://github.com/mongodb/node-mongodb-native/compare/v6.3.0...v6.4.0#diff-7cc25e5d3247913cdf1fe1e7788e951e4435bb1091d6b8aef135c4b171c7c997R39
![Screenshot 2024-03-04 at 11 52 10](https://github.com/DataDog/dd-trace-js/assets/1437996/f79ef6f4-e099-4d28-a2b0-eecdd9709d4d)


### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

