### PR TITLE
[ci-visibility] Expose cypress' `after:spec` handler 

### DIFF
--- a/ci/cypress/after-spec.js
+++ b/ci/cypress/after-spec.js
@@ -1,0 +1,1 @@
+module.exports = require('../../packages/datadog-plugin-cypress/src/after-spec')

--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -15,6 +15,24 @@ async function runCypress () {
           import('dd-trace/ci/cypress/plugin').then(module => {
             module.default(on, config)
           })
+          if (process.env.CYPRESS_ENABLE_AFTER_RUN_CUSTOM) {
+            on('after:run', (...args) => {
+              // do custom stuff
+              // and call after-run at the end
+              return import('dd-trace/ci/cypress/after-run').then(module => {
+                module.default(...args)
+              })
+            })
+          }
+          if (process.env.CYPRESS_ENABLE_AFTER_SPEC_CUSTOM) {
+            on('after:spec', (...args) => {
+              // do custom stuff
+              // and call after-spec at the end
+              return import('dd-trace/ci/cypress/after-spec').then(module => {
+                module.default(...args)
+              })
+            })
+          }
         }
       },
       video: false,

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -1,16 +1,28 @@
+const ddAfterRun = require('dd-trace/ci/cypress/after-run')
+const ddAfterSpec = require('dd-trace/ci/cypress/after-spec')
+const cypressFailFast = require('cypress-fail-fast/plugin')
+const ddTracePlugin = require('dd-trace/ci/cypress/plugin')
+
 module.exports = {
   defaultCommandTimeout: 100,
   e2e: {
     setupNodeEvents (on, config) {
       if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {
-        require('cypress-fail-fast/plugin')(on, config)
+        cypressFailFast(on, config)
       }
-      require('dd-trace/ci/cypress/plugin')(on, config)
+      ddTracePlugin(on, config)
       if (process.env.CYPRESS_ENABLE_AFTER_RUN_CUSTOM) {
         on('after:run', (...args) => {
           // do custom stuff
           // and call after-run at the end
-          require('dd-trace/ci/cypress/after-run')(...args)
+          return ddAfterRun(...args)
+        })
+      }
+      if (process.env.CYPRESS_ENABLE_AFTER_SPEC_CUSTOM) {
+        on('after:spec', (...args) => {
+          // do custom stuff
+          // and call after-spec at the end
+          return ddAfterSpec(...args)
         })
       }
     }

--- a/packages/datadog-plugin-cypress/src/after-spec.js
+++ b/packages/datadog-plugin-cypress/src/after-spec.js
@@ -1,0 +1,3 @@
+const cypressPlugin = require('./cypress-plugin')
+
+module.exports = cypressPlugin.afterSpec.bind(cypressPlugin)


### PR DESCRIPTION
### What does this PR do?

Some plugins make use of `after:spec` handler. By exposing this handler to users we give more flexibility to use multiple cypress plugins.

The user will now be able to do:
```javascript
setupNodeEvents (on, config) {
  require('dd-trace/ci/cypress/plugin')(on, config)
  // Using after:spec directly is now an option
  on('after:spec', (...args) => {
    // do custom stuff
    // and call after-spec at the end
    return require('dd-trace/ci/cypress/after-spec')(...args)
  })
}
```

### Motivation
Fixes #4099 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

