### PR TITLE
[ci-visibility] Grab jest's `displayName` config for multi-project configs

### DIFF
--- a/integration-tests/config-jest-multiproject.js
+++ b/integration-tests/config-jest-multiproject.js
@@ -1,0 +1,20 @@
+module.exports = {
+  projects: [
+    {
+      displayName: 'standard',
+      testPathIgnorePatterns: ['/node_modules/'],
+      cache: false,
+      testMatch: [
+        '**/ci-visibility/test/ci-visibility-test*'
+      ]
+    },
+    {
+      displayName: 'node',
+      testPathIgnorePatterns: ['/node_modules/'],
+      cache: false,
+      testMatch: [
+        '**/ci-visibility/test/ci-visibility-test*'
+      ]
+    }
+  ]
+}

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -115,6 +115,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       this.nameToParams = {}
       this.global._ddtrace = global._ddtrace
 
+      this.displayName = config.projectConfig?.displayName?.name
       this.testEnvironmentOptions = getTestEnvironmentOptions(config)
 
       const repositoryRoot = this.testEnvironmentOptions._ddRepositoryRoot
@@ -201,6 +202,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             suite: this.testSuite,
             testSourceFile: this.testSourceFile,
             runner: 'jest-circus',
+            displayName: this.displayName,
             testParameters,
             frameworkVersion: jestVersion,
             isNew: isNewTest,
@@ -252,6 +254,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             suite: this.testSuite,
             testSourceFile: this.testSourceFile,
             runner: 'jest-circus',
+            displayName: this.displayName,
             frameworkVersion: jestVersion,
             testStartLine: getTestLineStart(event.test.asyncError, this.testSuite)
           })
@@ -559,6 +562,7 @@ function jestAdapterWrapper (jestAdapter, jestVersion) {
       testSuiteStartCh.publish({
         testSuite: environment.testSuite,
         testEnvironmentOptions: environment.testEnvironmentOptions,
+        displayName: environment.displayName,
         frameworkVersion: jestVersion
       })
       return adapter.apply(this, arguments).then(suiteResults => {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -18,7 +18,8 @@ const {
   TEST_SOURCE_FILE,
   TEST_IS_NEW,
   TEST_EARLY_FLAKE_IS_RETRY,
-  TEST_EARLY_FLAKE_IS_ENABLED
+  TEST_EARLY_FLAKE_IS_ENABLED,
+  JEST_DISPLAY_NAME
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -144,7 +145,7 @@ class JestPlugin extends CiPlugin {
       })
     })
 
-    this.addSub('ci:jest:test-suite:start', ({ testSuite, testEnvironmentOptions, frameworkVersion }) => {
+    this.addSub('ci:jest:test-suite:start', ({ testSuite, testEnvironmentOptions, frameworkVersion, displayName }) => {
       const {
         _ddTestSessionId: testSessionId,
         _ddTestCommand: testCommand,
@@ -178,6 +179,9 @@ class JestPlugin extends CiPlugin {
       }
       if (itrCorrelationId) {
         testSuiteMetadata[ITR_CORRELATION_ID] = itrCorrelationId
+      }
+      if (displayName) {
+        testSuiteMetadata[JEST_DISPLAY_NAME] = displayName
       }
 
       this.testSuiteSpan = this.tracer.startSpan('jest.test_suite', {
@@ -308,6 +312,7 @@ class JestPlugin extends CiPlugin {
       suite,
       name,
       runner,
+      displayName,
       testParameters,
       frameworkVersion,
       testStartLine,
@@ -326,6 +331,10 @@ class JestPlugin extends CiPlugin {
     }
     // If for whatever we don't have the source file, we'll fall back to the suite name
     extraTags[TEST_SOURCE_FILE] = testSourceFile || suite
+
+    if (displayName) {
+      extraTags[JEST_DISPLAY_NAME] = displayName
+    }
 
     if (isNew) {
       extraTags[TEST_IS_NEW] = 'true'

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -58,6 +58,7 @@ const TEST_EARLY_FLAKE_IS_ENABLED = 'test.early_flake.is_enabled'
 const CI_APP_ORIGIN = 'ciapp-test'
 
 const JEST_TEST_RUNNER = 'test.jest.test_runner'
+const JEST_DISPLAY_NAME = 'test.jest.display_name'
 
 const TEST_ITR_TESTS_SKIPPED = '_dd.ci.itr.tests_skipped'
 const TEST_ITR_SKIPPING_ENABLED = 'test.itr.tests_skipping.enabled'
@@ -83,6 +84,7 @@ module.exports = {
   TEST_FRAMEWORK,
   TEST_FRAMEWORK_VERSION,
   JEST_TEST_RUNNER,
+  JEST_DISPLAY_NAME,
   TEST_TYPE,
   TEST_NAME,
   TEST_SUITE,


### PR DESCRIPTION
### What does this PR do?
Jest can be configured to run different projects with different configs (see more in [jest docs](https://jestjs.io/docs/29.6/configuration#projects-arraystring--projectconfig)). We want a way to distinguish tests run for a different project configs and for that we can leverage the `displayName` config parameter. 

We grab this `displayName` and send it as `test.jest.display_name` tag in suites and tests.

### Motivation
Fixes #4121

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

