### PR TITLE
remove `config.appsec.customRulesProvided`

### DIFF
--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -60,7 +60,7 @@ function enableOrDisableAppsec (action, rcConfig, config) {
 }
 
 function enableWafUpdate (appsecConfig) {
-  if (rc && appsecConfig && !appsecConfig.customRulesProvided) {
+  if (rc && appsecConfig && !appsecConfig.rules) {
     // dirty require to make startup faster for serverless
     const RuleManager = require('../rule_manager')
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -375,7 +375,6 @@ class Config {
 
     this._setValue(defaults, 'appsec.blockedTemplateHtml', undefined)
     this._setValue(defaults, 'appsec.blockedTemplateJson', undefined)
-    this._setValue(defaults, 'appsec.customRulesProvided', false)
     this._setValue(defaults, 'appsec.enabled', undefined)
     this._setValue(defaults, 'appsec.obfuscatorKeyRegex', defaultWafObfuscatorKeyRegex)
     this._setValue(defaults, 'appsec.obfuscatorValueRegex', defaultWafObfuscatorValueRegex)
@@ -539,7 +538,6 @@ class Config {
 
     this._setValue(env, 'appsec.blockedTemplateHtml', maybeFile(DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML))
     this._setValue(env, 'appsec.blockedTemplateJson', maybeFile(DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON))
-    if (DD_APPSEC_RULES) this._setBoolean(env, 'appsec.customRulesProvided', true)
     this._setBoolean(env, 'appsec.enabled', DD_APPSEC_ENABLED)
     this._setString(env, 'appsec.obfuscatorKeyRegex', DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP)
     this._setString(env, 'appsec.obfuscatorValueRegex', DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP)
@@ -633,7 +631,6 @@ class Config {
 
     this._setValue(opts, 'appsec.blockedTemplateHtml', maybeFile(options.appsec.blockedTemplateHtml))
     this._setValue(opts, 'appsec.blockedTemplateJson', maybeFile(options.appsec.blockedTemplateJson))
-    if (options.appsec.rules) this._setBoolean(opts, 'appsec.customRulesProvided', true)
     this._setBoolean(opts, 'appsec.enabled', options.appsec.enabled)
     this._setString(opts, 'appsec.obfuscatorKeyRegex', options.appsec.obfuscatorKeyRegex)
     this._setString(opts, 'appsec.obfuscatorValueRegex', options.appsec.obfuscatorValueRegex)

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -253,7 +253,7 @@ describe('Remote Config index', () => {
       })
 
       it('should not enable when custom appsec rules are provided', () => {
-        config.appsec = { enabled: true, rules: {}, customRulesProvided: true }
+        config.appsec = { enabled: true, rules: {} }
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 
@@ -262,7 +262,7 @@ describe('Remote Config index', () => {
       })
 
       it('should enable when using default rules', () => {
-        config.appsec = { enabled: true, rules: {}, customRulesProvided: false }
+        config.appsec = { enabled: true, rules: null }
         remoteConfig.enable(config)
         remoteConfig.enableWafUpdate(config.appsec)
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -108,7 +108,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.enableGetRumData', false)
     expect(config).to.have.nested.property('appsec.enabled', undefined)
     expect(config).to.have.nested.property('appsec.rules', undefined)
-    expect(config).to.have.nested.property('appsec.customRulesProvided', false)
     expect(config).to.have.nested.property('appsec.rateLimit', 100)
     expect(config).to.have.nested.property('appsec.wafTimeout', 5e3)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex').with.length(155)
@@ -180,7 +179,6 @@ describe('Config', () => {
       { name: 'tagsHeaderMaxLength', value: 512, origin: 'default' },
       { name: 'appsec.enabled', value: undefined, origin: 'default' },
       { name: 'appsec.rules', value: undefined, origin: 'default' },
-      { name: 'appsec.customRulesProvided', value: false, origin: 'default' },
       { name: 'appsec.rateLimit', value: 100, origin: 'default' },
       { name: 'appsec.wafTimeout', value: 5e3, origin: 'default' },
       { name: 'appsec.blockedTemplateHtml', value: undefined, origin: 'default' },
@@ -369,7 +367,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.enableGetRumData', true)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rules', RULES_JSON_PATH)
-    expect(config).to.have.nested.property('appsec.customRulesProvided', true)
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
@@ -428,7 +425,6 @@ describe('Config', () => {
       { name: 'experimental.enableGetRumData', value: true, origin: 'env_var' },
       { name: 'appsec.enabled', value: true, origin: 'env_var' },
       { name: 'appsec.rules', value: RULES_JSON_PATH, origin: 'env_var' },
-      { name: 'appsec.customRulesProvided', value: true, origin: 'env_var' },
       { name: 'appsec.rateLimit', value: 42, origin: 'env_var' },
       { name: 'appsec.wafTimeout', value: 42, origin: 'env_var' },
       { name: 'appsec.blockedTemplateHtml', value: BLOCKED_TEMPLATE_HTML, origin: 'env_var' },
@@ -966,7 +962,6 @@ describe('Config', () => {
     expect(config).to.have.nested.property('experimental.enableGetRumData', false)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rules', RULES_JSON_PATH)
-    expect(config).to.have.nested.property('appsec.customRulesProvided', true)
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.wafTimeout', 42)
     expect(config).to.have.nested.property('appsec.obfuscatorKeyRegex', '.*')
@@ -1034,7 +1029,6 @@ describe('Config', () => {
     expect(config).to.have.deep.property('appsec', {
       enabled: true,
       rules: undefined,
-      customRulesProvided: false,
       rateLimit: 42,
       wafTimeout: 42,
       obfuscatorKeyRegex: '.*',
@@ -1343,7 +1337,6 @@ describe('Config', () => {
 
     expect(config.appsec.enabled).to.be.true
     expect(config.appsec.rules).to.eq('path/to/rules.json')
-    expect(config.appsec.customRulesProvided).to.be.true
     expect(config.appsec.blockedTemplateHtml).to.be.undefined
     expect(config.appsec.blockedTemplateJson).to.be.undefined
     expect(config.appsec.blockedTemplateGraphql).to.be.undefined


### PR DESCRIPTION
### What does this PR do?
remove the `customRulesProvided` config entry.

### Motivation
It was used historically but is not needed anymore.