### PR TITLE
instrumentation telemetry event app-extended-heartbeat update

### DIFF
--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -342,8 +342,6 @@ function updateConfig (changes, config) {
     const { reqType, payload } = createPayload('app-client-configuration-change', { configuration })
     sendData(config, application, host, reqType, payload, updateRetryData)
   }
-
-  return configWithOrigin // for testing using sinon
 }
 
 module.exports = {

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -311,10 +311,10 @@ function updateConfig (changes, config) {
     tags: 'DD_TAGS'
   }
 
-  const namesNeedFormatting = new Set(['DD_TAGS', 'peerServiceMapping', 'tags'])
+  const namesNeedFormatting = new Set(['DD_TAGS', 'peerServiceMapping'])
 
   const configuration = []
-  const names = []
+  const names = [] // list of config names whose values have been changed
 
   for (const change of changes) {
     const name = nameMapping[change.name] || change.name
@@ -336,6 +336,7 @@ function updateConfig (changes, config) {
   if (!configWithOrigin.length) {
     configWithOrigin = configuration
   } else {
+    // update configWithOrigin to contain up-to-date full list of config values for app-extended-heartbeat
     configWithOrigin = configWithOrigin.filter(isNotModified)
     configWithOrigin = configWithOrigin.concat(configuration)
     const { reqType, payload } = createPayload('app-client-configuration-change', { configuration })

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -280,16 +280,17 @@ describe('Telemetry extended heartbeat', () => {
   let pluginsByName
   let clock
 
-  before(() => {
+  beforeEach(() => {
     clock = sinon.useFakeTimers()
   })
 
-  after(() => {
+  afterEach(() => {
     clock.restore()
     telemetry.stop()
     traceAgent.close()
   })
-  it('extended beat', (done) => {
+
+  it('should be sent every 24 hours', (done) => {
     let extendedHeartbeatRequest
     let beats = 0 // to keep track of the amont of times extendedHeartbeat is called
     const sendDataRequest = {
@@ -335,6 +336,86 @@ describe('Telemetry extended heartbeat', () => {
     expect(beats).to.equal(1)
     clock.tick(86400000)
     expect(beats).to.equal(2)
+    done()
+  })
+
+  it('be sent with up-to-date configuration values', (done) => {
+    let configuration
+    const sendDataRequest = {
+      sendData: (config, application, host, reqType, payload, cb = () => {}) => {
+        if (reqType === 'app-extended-heartbeat') {
+          configuration = payload.configuration
+        }
+      }
+
+    }
+    telemetry = proxyquire('../../src/telemetry', {
+      '../exporters/common/docker': {
+        id () {
+          return 'test docker id'
+        }
+      },
+      './send-data': sendDataRequest
+    })
+
+    const config = {
+      telemetry: { enabled: true, heartbeatInterval: HEARTBEAT_INTERVAL },
+      hostname: 'localhost',
+      port: 0,
+      service: 'test service',
+      version: '1.2.3-beta4',
+      appsec: { enabled: true },
+      profiling: { enabled: true },
+      env: 'preprod',
+      tags: {
+        'runtime-id': '1a2b3c'
+      }
+    }
+
+    telemetry.start(config, { _pluginsByName: pluginsByName })
+
+    clock.tick(86400000)
+    expect(configuration).to.deep.equal([])
+
+    const changes = [
+      {
+        name: 'test',
+        value: true,
+        origin: 'code'
+      }
+    ]
+    telemetry.updateConfig(changes, config)
+    clock.tick(86400000)
+    expect(configuration).to.deep.equal(changes)
+
+    const updatedChanges = [
+      {
+        name: 'test',
+        value: false,
+        origin: 'code'
+      }
+    ]
+    telemetry.updateConfig(updatedChanges, config)
+    clock.tick(86400000)
+    expect(configuration).to.deep.equal(updatedChanges)
+
+    const changeNeedingNameRemapping = [
+      {
+        name: 'sampleRate', // one of the config names that require a remapping
+        value: 0,
+        origin: 'code'
+      }
+    ]
+    const expectedConfigList = [
+      updatedChanges[0],
+      {
+        ...changeNeedingNameRemapping[0],
+        name: 'DD_TRACE_SAMPLE_RATE' // remapped name
+      }
+    ]
+    telemetry.updateConfig(changeNeedingNameRemapping, config)
+    clock.tick(86400000)
+    expect(configuration).to.deep.equal(expectedConfigList)
     done()
   })
 })
@@ -715,71 +796,6 @@ describe('Telemetry retry', () => {
         { name: 'bar2', enabled: false, auto_enabled: true }
       ]
     })
-  })
-})
-
-describe('updateConfig', () => {
-  const config = {
-    service: 'node',
-    env: undefined,
-    version: '5.0.0',
-    telemetry: {
-      enabled: true
-    }
-  }
-  const sendDataStub = sinon.stub()
-
-  const { updateConfig } = proxyquire('../../src/telemetry', {
-    './send-data': {
-      sendData: sendDataStub
-    }
-  })
-
-  it('should return full list of configuration values on initial call', () => {
-    const initialChanges = [
-      {
-        name: 'test',
-        value: true,
-        origin: 'code'
-      }
-    ]
-    expect(updateConfig(initialChanges, config)).to.deep.equal(initialChanges)
-    expect(sendDataStub.called).to.be.false
-  })
-
-  it('should return updated list of configuration values after initial call', () => {
-    const changes = [
-      {
-        name: 'test',
-        value: false,
-        origin: 'code'
-      }
-    ]
-    expect(updateConfig(changes, config)).to.deep.equal(changes)
-    expect(sendDataStub).to.be.calledOnce
-  })
-
-  it('should return configuration list containing entry with modified name', () => {
-    const inputChanges = [
-      {
-        name: 'sampleRate', // one of the config names that require a remapping
-        value: 0,
-        origin: 'code'
-      }
-    ]
-    const expectedChanges = [
-      {
-        name: 'test',
-        value: false,
-        origin: 'code'
-      },
-      {
-        name: 'DD_TRACE_SAMPLE_RATE',
-        value: 0,
-        origin: 'code'
-      }
-    ]
-    expect(updateConfig(inputChanges, config)).to.deep.equal(expectedChanges)
   })
 })
 

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -735,7 +735,7 @@ describe('updateConfig', () => {
     }
   })
 
-  it('should set configWithOrigin on initial call', () => {
+  it('should return full list of configuration values on initial call', () => {
     const initialChanges = [
       {
         name: 'test',
@@ -747,7 +747,7 @@ describe('updateConfig', () => {
     expect(sendDataStub.called).to.be.false
   })
 
-  it('should modify configWithOrigin after initial call', () => {
+  it('should return updated list of configuration values after initial call', () => {
     const changes = [
       {
         name: 'test',
@@ -759,10 +759,10 @@ describe('updateConfig', () => {
     expect(sendDataStub).to.be.calledOnce
   })
 
-  it('should modify entry name', () => {
+  it('should return configuration list containing entry with modified name', () => {
     const inputChanges = [
       {
-        name: 'sampleRate',
+        name: 'sampleRate', // one of the config names that require a remapping
         value: 0,
         origin: 'code'
       }


### PR DESCRIPTION
### What does this PR do?
The `configuration` entry in app-extended-heartbeat used to contain exactly the same information as app-started, not taking into account that configuration values can change after app startup. This PR updates `configWithOrigin` whenever `updateConfig` is called, so that app-extended-heartbeat can send up-to-date configuration values.
This PR also contains unit tests for `updateConfig`

### Motivation
@CarlesDD asked about it

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

