### PR TITLE
[ci-visibility] Adapt early flake detection to new format

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -646,9 +646,11 @@ testFrameworks.forEach(({
             receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
           }
           // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
-          receiver.setKnownTests([
-            `${name}.ci-visibility/test/ci-visibility-test.js.ci visibility can report tests`
-          ])
+          receiver.setKnownTests({
+            [name]: {
+              'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests']
+            }
+          })
           const NUM_RETRIES_EFD = 3
           receiver.setSettings({
             itr_enabled: false,
@@ -728,9 +730,11 @@ testFrameworks.forEach(({
             receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
           }
           // Tests from ci-visibility/test-early-flake-detection/test-parameterized.js will be considered new
-          receiver.setKnownTests([
-            `${name}.ci-visibility/test-early-flake-detection/test.js.ci visibility can report tests`
-          ])
+          receiver.setKnownTests({
+            [name]: {
+              'ci-visibility/test-early-flake-detection/test.js': ['ci visibility can report tests']
+            }
+          })
           receiver.setSettings({
             itr_enabled: false,
             code_coverage: false,
@@ -811,9 +815,11 @@ testFrameworks.forEach(({
             receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
           }
           // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
-          receiver.setKnownTests([
-            `${name}.ci-visibility/test/ci-visibility-test.js.ci visibility can report tests`
-          ])
+          receiver.setKnownTests({
+            [name]: {
+              'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests']
+            }
+          })
           receiver.setSettings({
             itr_enabled: false,
             code_coverage: false,
@@ -873,7 +879,7 @@ testFrameworks.forEach(({
             receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
           }
           // Tests from ci-visibility/test/occasionally-failing-test will be considered new
-          receiver.setKnownTests([])
+          receiver.setKnownTests({})
 
           const NUM_RETRIES_EFD = 5
           receiver.setSettings({
@@ -945,7 +951,7 @@ testFrameworks.forEach(({
             receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
           }
           // Tests from ci-visibility/test/skipped-and-todo-test will be considered new
-          receiver.setKnownTests([])
+          receiver.setKnownTests({})
 
           const NUM_RETRIES_EFD = 5
           receiver.setSettings({

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -796,13 +796,14 @@ versions.forEach(version => {
                 }
               })
               // "cucumber.ci-visibility/features/farewell.feature.Say" whatever will be considered new
-              receiver.setKnownTests([
-                'cucumber.ci-visibility/features/farewell.feature.Say farewell',
-                'cucumber.ci-visibility/features/greetings.feature.Say greetings',
-                'cucumber.ci-visibility/features/greetings.feature.Say yeah',
-                'cucumber.ci-visibility/features/greetings.feature.Say yo',
-                'cucumber.ci-visibility/features/greetings.feature.Say skip'
-              ])
+              receiver.setKnownTests(
+                {
+                  cucumber: {
+                    'ci-visibility/features/farewell.feature': ['Say farewell'],
+                    'ci-visibility/features/greetings.feature': ['Say greetings', 'Say yeah', 'Say yo', 'Say skip']
+                  }
+                }
+              )
               const eventsPromise = receiver
                 .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
@@ -871,13 +872,12 @@ versions.forEach(version => {
                   assert.equal(newTests.length, 0)
                 })
               // cucumber.ci-visibility/features/farewell.feature.Say whatever will be considered new
-              receiver.setKnownTests([
-                'cucumber.ci-visibility/features/farewell.feature.Say farewell',
-                'cucumber.ci-visibility/features/greetings.feature.Say greetings',
-                'cucumber.ci-visibility/features/greetings.feature.Say yeah',
-                'cucumber.ci-visibility/features/greetings.feature.Say yo',
-                'cucumber.ci-visibility/features/greetings.feature.Say skip'
-              ])
+              receiver.setKnownTests({
+                cucumber: {
+                  'ci-visibility/features/farewell.feature': ['Say farewell'],
+                  'ci-visibility/features/greetings.feature': ['Say greetings', 'Say yeah', 'Say yo', 'Say skip']
+                }
+              })
 
               childProcess = exec(
                 runTestsCommand,
@@ -907,7 +907,7 @@ versions.forEach(version => {
                 }
               })
               // Tests in "cucumber.ci-visibility/features-flaky/flaky.feature" will be considered new
-              receiver.setKnownTests([])
+              receiver.setKnownTests({})
 
               const eventsPromise = receiver
                 .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
@@ -959,12 +959,12 @@ versions.forEach(version => {
               })
               // "cucumber.ci-visibility/features/farewell.feature.Say whatever" will be considered new
               // "cucumber.ci-visibility/features/greetings.feature.Say skip" will be considered new
-              receiver.setKnownTests([
-                'cucumber.ci-visibility/features/farewell.feature.Say farewell',
-                'cucumber.ci-visibility/features/greetings.feature.Say greetings',
-                'cucumber.ci-visibility/features/greetings.feature.Say yeah',
-                'cucumber.ci-visibility/features/greetings.feature.Say yo'
-              ])
+              receiver.setKnownTests({
+                cucumber: {
+                  'ci-visibility/features/farewell.feature': ['Say farewell'],
+                  'ci-visibility/features/greetings.feature': ['Say greetings', 'Say yeah', 'Say yo']
+                }
+              })
 
               const eventsPromise = receiver
                 .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -900,9 +900,6 @@ moduleType.forEach(({
         }
       )
 
-      childProcess.stdout.pipe(process.stdout)
-      childProcess.stderr.pipe(process.stderr)
-
       childProcess.on('exit', () => {
         receiverPromise.then(() => {
           done()

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -92,7 +92,8 @@ function getStatusFromResultLatest (result) {
 }
 
 function isNewTest (testSuite, testName) {
-  return !knownTests.includes(`cucumber.${testSuite}.${testName}`)
+  const testsForSuite = knownTests.cucumber?.[testSuite] || []
+  return !testsForSuite.includes(testName)
 }
 
 function getTestStatusFromRetries (testStatuses) {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -140,14 +140,16 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
     // Function that receives a list of known tests for a test service and
     // returns the ones that belong to the current suite
     getKnownTestsForSuite (knownTests) {
+      if (this.knownTestsForThisSuite) {
+        return this.knownTestsForThisSuite
+      }
       let knownTestsForSuite = knownTests
-      // If jest runs in band, the known tests are not serialized, so they're an array.
-      if (!Array.isArray(knownTests)) {
+      // If jest is using workers, known tests are serialized to json.
+      // If jest runs in band, they are not.
+      if (typeof knownTestsForSuite === 'string') {
         knownTestsForSuite = JSON.parse(knownTestsForSuite)
       }
-      return knownTestsForSuite
-        .filter(test => test.includes(this.testSuite))
-        .map(test => test.replace(`jest.${this.testSuite}.`, '').trim())
+      return knownTestsForSuite.jest?.[this.testSuite] || []
     }
 
     // Add the `add_test` event we don't have the test object yet, so

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -106,7 +106,10 @@ function getTestFullName (test) {
 }
 
 function isNewTest (test) {
-  return !knownTests.includes(getTestFullName(test))
+  const testSuite = getTestSuitePath(test.file, process.cwd())
+  const testName = removeEfdStringFromTestName(test.fullTitle())
+  const testsForSuite = knownTests.mocha?.[testSuite] || []
+  return !testsForSuite.includes(testName)
 }
 
 function retryTest (test) {

--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -1,6 +1,5 @@
 const request = require('../../exporters/common/request')
 const id = require('../../id')
-const log = require('../../log')
 
 function getKnownTests ({
   url,

--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -71,7 +71,6 @@ function getKnownTests ({
     } else {
       try {
         const { data: { attributes: { tests: knownTests } } } = JSON.parse(res)
-        log.debug(() => `Number of received known tests: ${Object.keys(knownTests).length}`)
         done(null, knownTests)
       } catch (err) {
         done(err)


### PR DESCRIPTION
### What does this PR do?
Adapt to the new format: instead of a flat list we now have a structured response: by framework and by suites. 

### Motivation
We've changed the format the API responds the known tests payload to make it more efficient to look for tests.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

