### PR TITLE
Check if prepareStackTrace has been wrapped before restore it

### DIFF
--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -21,7 +21,11 @@ const requestStart = dc.channel('dd-trace:incomingHttpRequestStart')
 const requestClose = dc.channel('dd-trace:incomingHttpRequestEnd')
 const iastResponseEnd = dc.channel('datadog:iast:response-end')
 
+let isEnabled = false
+
 function enable (config, _tracer) {
+  if (isEnabled) return
+
   iastTelemetry.configure(config, config.iast?.telemetryVerbosity)
   enableAllAnalyzers(config)
   enableTaintTracking(config.iast, iastTelemetry.verbosity)
@@ -30,9 +34,15 @@ function enable (config, _tracer) {
   overheadController.configure(config.iast)
   overheadController.startGlobalContext()
   vulnerabilityReporter.start(config, _tracer)
+
+  isEnabled = true
 }
 
 function disable () {
+  if (!isEnabled) return
+
+  isEnabled = false
+
   iastTelemetry.stop()
   disableAllAnalyzers()
   disableTaintTracking()

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -148,6 +148,19 @@ describe('IAST Index', () => {
         mockIast.disable()
         expect(mockOverheadController.finishGlobalContext).to.have.been.calledOnce
       })
+
+      it('should start global context only once when calling enable multiple times', () => {
+        mockIast.enable(config)
+        mockIast.enable(config)
+
+        expect(mockOverheadController.startGlobalContext).to.have.been.calledOnce
+      })
+
+      it('should not finish global context if not enabled before ', () => {
+        mockIast.disable(config)
+
+        expect(mockOverheadController.finishGlobalContext).to.have.been.not.called
+      })
     })
 
     describe('managing vulnerability reporter', () => {

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -143,6 +143,8 @@ describe('IAST Index', () => {
       })
 
       it('should finish global context refresher on iast disabled', () => {
+        mockIast.enable(config)
+
         mockIast.disable()
         expect(mockOverheadController.finishGlobalContext).to.have.been.calledOnce
       })
@@ -156,6 +158,8 @@ describe('IAST Index', () => {
       })
 
       it('should stop vulnerability reporter on iast disabled', () => {
+        mockIast.enable(config)
+
         mockIast.disable()
         expect(mockVulnerabilityReporter.stop).to.have.been.calledOnce
       })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -74,7 +74,7 @@ describe('IAST Rewriter', () => {
 
       rewriter.enableRewriter()
 
-      const testPrepareStackTrace = function (_, callsites) {
+      const testPrepareStackTrace = (_, callsites) => {
         // do nothing
       }
       Error.prepareStackTrace = testPrepareStackTrace
@@ -89,7 +89,7 @@ describe('IAST Rewriter', () => {
     it('Should keep original prepareStackTrace fn when calling disable only', () => {
       const orig = Error.prepareStackTrace
 
-      const testPrepareStackTrace = function (_, callsites) {
+      const testPrepareStackTrace = (_, callsites) => {
         // do nothing
       }
       Error.prepareStackTrace = testPrepareStackTrace

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -13,12 +13,7 @@ describe('IAST Rewriter', () => {
   })
 
   describe('Enabling rewriter', () => {
-    let rewriter, iastTelemetry
-
-    const shimmer = {
-      wrap: sinon.spy(),
-      unwrap: sinon.spy()
-    }
+    let rewriter, iastTelemetry, shimmer
 
     class Rewriter {
       rewrite (content, filename) {
@@ -35,27 +30,75 @@ describe('IAST Rewriter', () => {
       iastTelemetry = {
         add: sinon.spy()
       }
+
+      shimmer = {
+        wrap: sinon.spy(),
+        unwrap: sinon.spy()
+      }
+
       rewriter = proxyquire('../../../../src/appsec/iast/taint-tracking/rewriter', {
-        '@datadog/native-iast-rewriter': { Rewriter, getPrepareStackTrace: function () {} },
+        '@datadog/native-iast-rewriter': {
+          Rewriter,
+          getPrepareStackTrace: function (fn) {
+            return function testWrappedPrepareStackTrace (_, callsites) {
+              return fn(_, callsites)
+            }
+          }
+        },
         '../../../../../datadog-shimmer': shimmer,
         '../../telemetry': iastTelemetry
       })
     })
 
     afterEach(() => {
-      sinon.restore()
+      sinon.reset()
     })
 
     it('Should wrap module compile method on taint tracking enable', () => {
       rewriter.enableRewriter()
       expect(shimmer.wrap).to.be.calledOnce
       expect(shimmer.wrap.getCall(0).args[1]).eq('_compile')
+
+      rewriter.disableRewriter()
     })
 
     it('Should unwrap module compile method on taint tracking disable', () => {
       rewriter.disableRewriter()
+
       expect(shimmer.unwrap).to.be.calledOnce
       expect(shimmer.unwrap.getCall(0).args[1]).eq('_compile')
+    })
+
+    it('Should keep original prepareStackTrace fn when calling enable and then disable', () => {
+      const orig = Error.prepareStackTrace
+
+      rewriter.enableRewriter()
+
+      const testPrepareStackTrace = function (_, callsites) {
+        // do nothing
+      }
+      Error.prepareStackTrace = testPrepareStackTrace
+
+      rewriter.disableRewriter()
+
+      expect(Error.prepareStackTrace).to.be.eq(testPrepareStackTrace)
+
+      Error.prepareStackTrace = orig
+    })
+
+    it('Should keep original prepareStackTrace fn when calling disable only', () => {
+      const orig = Error.prepareStackTrace
+
+      const testPrepareStackTrace = function (_, callsites) {
+        // do nothing
+      }
+      Error.prepareStackTrace = testPrepareStackTrace
+
+      rewriter.disableRewriter()
+
+      expect(Error.prepareStackTrace).to.be.eq(testPrepareStackTrace)
+
+      Error.prepareStackTrace = orig
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
Check if `Error.prepareStackTrace` has been wrapped before restore it

### Motivation
Disabling IAST without having been enabled before can reset a possible `Error.prepareStackTrace` set by the app

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

