### PR TITLE
[ci-visibility] Early flake detection for playwright

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -229,16 +229,6 @@ class FakeCiVisIntake extends FakeAgent {
     return super.stop()
   }
 
-  getEventsFromPayloads (payloads) {
-    return payloads.flatMap(({ payload }) => payload.events)
-  }
-
-  getTestLevelEventsFromPayloads (payloads, testLevel = 'test') {
-    return this.getEventsFromPayloads(payloads)
-      .filter(event => event.type === testLevel)
-      .map(event => event.content)
-  }
-
   // Similar to gatherPayloads but resolves if enough payloads have been gathered
   // to make the assertions pass. It times out after maxGatheringTime so it should
   // always be faster or as fast as gatherPayloads
@@ -247,11 +237,7 @@ class FakeCiVisIntake extends FakeAgent {
     return new Promise((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         try {
-          onPayload(
-            payloads,
-            this.getEventsFromPayloads(payloads),
-            this.getTestLevelEventsFromPayloads(payloads, 'test')
-          )
+          onPayload(payloads)
           resolve()
         } catch (e) {
           reject(e)
@@ -263,11 +249,7 @@ class FakeCiVisIntake extends FakeAgent {
         if (!payloadMatch || payloadMatch(message)) {
           payloads.push(message)
           try {
-            onPayload(
-              payloads,
-              this.getEventsFromPayloads(payloads),
-              this.getTestLevelEventsFromPayloads(payloads, 'test')
-            )
+            onPayload(payloads)
             clearTimeout(timeoutId)
             this.off('message', messageHandler)
             resolve()

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -222,7 +222,7 @@ versions.forEach((version) => {
     })
 
     context('early flake detection', () => {
-      it.only('retries new tests', (done) => {
+      it('retries new tests', (done) => {
         receiver.setSettings({
           itr_enabled: false,
           code_coverage: false,
@@ -238,17 +238,17 @@ versions.forEach((version) => {
         receiver.setKnownTests(
           {
             playwright: {
-              'landing-page-tests.js': [
-                // 'playwright should work with passing tests', // it will be considered new
-                'playwright should work with skipped tests',
-                'playwright should work with fixme',
-                'playwright should work with annotated tests'
+              'landing-page-test.js': [
+                // 'should work with passing tests', // it will be considered new
+                'should work with skipped tests',
+                'should work with fixme',
+                'should work with annotated tests'
               ],
               'skipped-suite-test.js': [
                 'should work with fixme root'
               ],
               'todo-list-page-test.js': [
-                'playwright should work with failing tests',
+                'should work with failing tests',
                 'should work with fixme root'
               ]
             }
@@ -257,10 +257,9 @@ versions.forEach((version) => {
 
         const receiverPromise = receiver
           .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads, events, tests) => {
-            debugger
             const newTests = tests.filter(test =>
               test.resource ===
-                'landing-page-tests.js.playwright.should work with passing tests'
+                'landing-page-test.js.should work with passing tests'
             )
             newTests.forEach(test => {
               assert.propertyVal(test.meta, TEST_IS_NEW, 'true')

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -258,7 +258,10 @@ versions.forEach((version) => {
           )
 
           const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads, events, tests) => {
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
               const newTests = tests.filter(test =>
                 test.resource ===
                   'landing-page-test.js.should work with passing tests'
@@ -325,7 +328,10 @@ versions.forEach((version) => {
           )
 
           const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads, events, tests) => {
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
               const newTests = tests.filter(test =>
                 test.resource ===
                   'landing-page-test.js.should work with passing tests'
@@ -390,7 +396,10 @@ versions.forEach((version) => {
           )
 
           const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads, events, tests) => {
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
               const newTests = tests.filter(test =>
                 test.resource ===
                   'landing-page-test.js.should work with skipped tests' ||

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -19,7 +19,7 @@ const {
   TEST_SOURCE_FILE,
   TEST_CONFIGURATION_BROWSER_NAME,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY
+  TEST_IS_RETRY
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
@@ -267,7 +267,7 @@ versions.forEach((version) => {
                 assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
               })
 
-              const retriedTests = tests.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true')
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
 
               assert.equal(retriedTests.length, NUM_RETRIES_EFD)
 

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -38,6 +38,7 @@ let isEarlyFlakeDetectionEnabled = false
 let earlyFlakeDetectionNumRetries = 0
 let knownTests = []
 let rootDir = ''
+const MINIMUM_SUPPORTED_VERSION_EFD = '1.38.0'
 
 function isNewTest (test) {
   const testSuite = getTestSuitePath(test._requireFile, rootDir)
@@ -394,7 +395,7 @@ function runnerHook (runnerExport, playwrightVersion) {
       log.error(e)
     }
 
-    if (isEarlyFlakeDetectionEnabled && semver.gte(playwrightVersion, '1.38.0')) {
+    if (isEarlyFlakeDetectionEnabled && semver.gte(playwrightVersion, MINIMUM_SUPPORTED_VERSION_EFD)) {
       const knownTestsPromise = new Promise((resolve) => {
         onDone = resolve
       })
@@ -493,7 +494,7 @@ addHook({
 addHook({
   name: 'playwright',
   file: 'lib/common/suiteUtils.js',
-  versions: ['>=1.38.0']
+  versions: [`>=${MINIMUM_SUPPORTED_VERSION_EFD}`]
 }, suiteUtilsPackage => {
   // We grab `applyRepeatEachIndex` to use it later
   // `applyRepeatEachIndex` needs to be applied to a cloned suite
@@ -505,7 +506,7 @@ addHook({
 addHook({
   name: 'playwright',
   file: 'lib/runner/loadUtils.js',
-  versions: ['>=1.38.0']
+  versions: [`>=${MINIMUM_SUPPORTED_VERSION_EFD}`]
 }, (loadUtilsPackage) => {
   const oldCreateRootSuite = loadUtilsPackage.createRootSuite
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -13,7 +13,7 @@ const {
   TEST_SOURCE_FILE,
   TEST_CONFIGURATION_BROWSER_NAME,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY
+  TEST_IS_RETRY
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -127,7 +127,7 @@ class PlaywrightPlugin extends CiPlugin {
       if (isNew) {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
-          span.setTag(TEST_EARLY_FLAKE_IS_RETRY, 'true')
+          span.setTag(TEST_IS_RETRY, 'true')
         }
       }
 


### PR DESCRIPTION
### What does this PR do?
Add early flake detection feature to playwright test framework.

### Motivation
Allow playwright users to automatically retry new tests.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional notes
The support for EFD will be from >=1.38.0. Internal API changes are pretty common in playwright so attempting to support every version has proven almost impossible. 

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

