### PR TITLE
Fix graphql version reporting

### DIFF
--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -167,6 +167,82 @@ describe('Plugin', () => {
         })
       })
 
+      describe('graphql-yoga', () => {
+        withVersions(plugin, 'graphql-yoga', version => {
+          let graphqlYoga
+          let server
+          let port
+
+          before(() => {
+            tracer = require('../../dd-trace')
+            return agent.load('graphql')
+              .then(() => {
+                graphqlYoga = require(`../../../versions/graphql-yoga@${version}`).get()
+
+                const typeDefs = `
+                  type Query {
+                    hello(name: String): String
+                  }
+                `
+
+                const resolvers = {
+                  Query: {
+                    hello: (_, { name }) => {
+                      return `Hello, ${name || 'world'}!`
+                    }
+                  }
+                }
+
+                const schema = graphqlYoga.createSchema({
+                  typeDefs, resolvers
+                })
+
+                const yoga = graphqlYoga.createYoga({ schema })
+
+                server = http.createServer(yoga)
+
+                getPort().then(newPort => {
+                  port = newPort
+                  server.listen(port)
+                })
+              })
+          })
+
+          after(() => {
+            server.close()
+            return agent.close({ ritmReset: false })
+          })
+
+          it('should instrument graphql-yoga execution', done => {
+            agent
+              .use(traces => {
+                const spans = sort(traces[0])
+
+                expect(spans[0]).to.have.property('service', expectedSchema.server.serviceName)
+                expect(spans[0]).to.have.property('name', expectedSchema.server.opName)
+                expect(spans[0]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
+                expect(spans[0]).to.have.property('type', 'graphql')
+                expect(spans[0]).to.have.property('error', 0)
+                expect(spans[0].meta).to.not.have.property('graphql.source')
+                expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
+                expect(spans[0].meta).to.have.property('graphql.operation.name', 'MyQuery')
+                expect(spans[0].meta).to.have.property('component', 'graphql')
+              })
+              .then(done)
+
+            const query = `
+              query MyQuery {
+                hello(name: "world")
+              }
+            `
+
+            axios.post(`http://localhost:${port}/graphql`, {
+              query
+            }).catch(done)
+          })
+        })
+      })
+
       describe('without configuration', () => {
         before(() => {
           return agent.load('graphql')
@@ -1649,80 +1725,6 @@ describe('Plugin', () => {
             runQuery(params)
               .catch(done)
           })
-        })
-      })
-
-      withVersions(plugin, 'graphql-yoga', version => {
-        let graphqlYoga
-        let server
-        let port
-
-        before(() => {
-          tracer = require('../../dd-trace')
-          return agent.load('graphql')
-            .then(() => {
-              graphqlYoga = require(`../../../versions/graphql-yoga@${version}`).get()
-
-              const typeDefs = `
-                  type Query {
-                    hello(name: String): String
-                  }
-                `
-
-              const resolvers = {
-                Query: {
-                  hello: (_, { name }) => {
-                    return `Hello, ${name || 'world'}!`
-                  }
-                }
-              }
-
-              const schema = graphqlYoga.createSchema({
-                typeDefs, resolvers
-              })
-
-              const yoga = graphqlYoga.createYoga({ schema })
-
-              server = http.createServer(yoga)
-
-              getPort().then(newPort => {
-                port = newPort
-                server.listen(port)
-              })
-            })
-        })
-
-        after(() => {
-          server.close()
-          return agent.close({ ritmReset: false })
-        })
-
-        it('should instrument graphql-yoga execution', done => {
-          agent
-            .use(traces => {
-              const spans = sort(traces[0])
-
-              expect(spans[0]).to.have.property('service', expectedSchema.server.serviceName)
-              expect(spans[0]).to.have.property('name', expectedSchema.server.opName)
-              expect(spans[0]).to.have.property('resource', 'query MyQuery{hello(name:"")}')
-              expect(spans[0]).to.have.property('type', 'graphql')
-              expect(spans[0]).to.have.property('error', 0)
-              expect(spans[0].meta).to.not.have.property('graphql.source')
-              expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
-              expect(spans[0].meta).to.have.property('graphql.operation.name', 'MyQuery')
-              expect(spans[0].meta).to.have.property('component', 'graphql')
-            })
-            .then(done)
-
-          const query = `
-              query MyQuery {
-                hello(name: "world")
-              }
-            `
-
-          axios.post(`http://localhost:${port}/graphql`, {
-            query
-          }).catch(done)
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes the graphql test so that the nested tests do not collide with the root plugin test to ensure correct versions are being reported to the test agent

### Motivation
<!-- What inspired you to submit this pull request? -->

Part of a larger initiative to improve version reporting for the tracer

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

