### PR TITLE
feat: Check for LAMBDA_TASK_ROOT before patching

### DIFF
--- a/packages/dd-trace/src/lambda/runtime/ritm.js
+++ b/packages/dd-trace/src/lambda/runtime/ritm.js
@@ -87,7 +87,7 @@ const registerLambdaHook = () => {
   const lambdaTaskRoot = process.env.LAMBDA_TASK_ROOT
   const originalLambdaHandler = process.env.DD_LAMBDA_HANDLER
 
-  if (originalLambdaHandler !== undefined) {
+  if (originalLambdaHandler !== undefined && lambdaTaskRoot !== undefined) {
     const [moduleRoot, moduleAndHandler] = _extractModuleRootAndHandler(originalLambdaHandler)
     const [_module] = _extractModuleNameAndHandlerPath(moduleAndHandler)
 


### PR DESCRIPTION
### What does this PR do?
Our test actually specifies this: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/test/lambda/index.spec.js#L15

But a popular Lambda framework [sst](https://sst.dev/) sets `AWS_LAMBDA_FUNCTION_NAME` but not the task root, so this code fails with an error:
<img width="922" alt="image" src="https://github.com/DataDog/dd-trace-js/assets/1598537/d404bc13-246e-464f-a53a-3a0134254304">

This change won't make dd-trace work in SST's live lambda environment, but at least it won't error out.

### Motivation
Fix the bug

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

