### PR TITLE
Check if Error.prepareStackTrace has been wrapped by iast

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@datadog/native-appsec": "7.1.0",
-    "@datadog/native-iast-rewriter": "2.2.3",
+    "@datadog/native-iast-rewriter": "2.3.0",
     "@datadog/native-iast-taint-tracking": "1.7.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.1.0",

--- a/packages/dd-trace/src/appsec/iast/path-line.js
+++ b/packages/dd-trace/src/appsec/iast/path-line.js
@@ -29,13 +29,16 @@ function getCallSiteInfo () {
   const previousStackTraceLimit = Error.stackTraceLimit
   let callsiteList
   Error.stackTraceLimit = 100
-  Error.prepareStackTrace = function (_, callsites) {
-    callsiteList = callsites
+  try {
+    Error.prepareStackTrace = function (_, callsites) {
+      callsiteList = callsites
+    }
+    const e = new Error()
+    e.stack
+  } finally {
+    Error.prepareStackTrace = previousPrepareStackTrace
+    Error.stackTraceLimit = previousStackTraceLimit
   }
-  const e = new Error()
-  e.stack
-  Error.prepareStackTrace = previousPrepareStackTrace
-  Error.stackTraceLimit = previousStackTraceLimit
   return callsiteList
 }
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -12,6 +12,7 @@ const dc = require('dc-polyfill')
 const hardcodedSecretCh = dc.channel('datadog:secrets:result')
 let rewriter
 let getPrepareStackTrace
+let kSymbolPrepareStackTrace
 
 let getRewriterOriginalPathAndLineFromSourceMap = function (path, line, column) {
   return { path, line, column }
@@ -44,6 +45,7 @@ function getRewriter (telemetryVerbosity) {
       const iastRewriter = require('@datadog/native-iast-rewriter')
       const Rewriter = iastRewriter.Rewriter
       getPrepareStackTrace = iastRewriter.getPrepareStackTrace
+      kSymbolPrepareStackTrace = iastRewriter.kSymbolPrepareStackTrace
 
       const chainSourceMap = isFlagPresent('--enable-source-maps')
       const getOriginalPathAndLineFromSourceMap = iastRewriter.getOriginalPathAndLineFromSourceMap
@@ -124,7 +126,7 @@ function enableRewriter (telemetryVerbosity) {
 function disableRewriter () {
   shimmer.unwrap(Module.prototype, '_compile')
 
-  if (!actualPrepareStackTrace) return
+  if (!actualPrepareStackTrace || !actualPrepareStackTrace[kSymbolPrepareStackTrace]) return
 
   try {
     delete Error.prepareStackTrace

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -68,17 +68,16 @@ function getRewriter (telemetryVerbosity) {
 }
 
 let originalPrepareStackTrace
-let actualPrepareStackTrace
 function getPrepareStackTraceAccessor () {
   originalPrepareStackTrace = Error.prepareStackTrace
-  actualPrepareStackTrace = getPrepareStackTrace(originalPrepareStackTrace)
+  let actual = getPrepareStackTrace(originalPrepareStackTrace)
   return {
     configurable: true,
     get () {
-      return actualPrepareStackTrace
+      return actual
     },
     set (value) {
-      actualPrepareStackTrace = getPrepareStackTrace(value)
+      actual = getPrepareStackTrace(value)
       originalPrepareStackTrace = value
     }
   }
@@ -126,14 +125,12 @@ function enableRewriter (telemetryVerbosity) {
 function disableRewriter () {
   shimmer.unwrap(Module.prototype, '_compile')
 
-  if (!actualPrepareStackTrace || !actualPrepareStackTrace[kSymbolPrepareStackTrace]) return
+  if (!Error.prepareStackTrace?.[kSymbolPrepareStackTrace]) return
 
   try {
     delete Error.prepareStackTrace
 
     Error.prepareStackTrace = originalPrepareStackTrace
-
-    actualPrepareStackTrace = undefined
   } catch (e) {
     iastLog.warn(e)
   }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -36,14 +36,21 @@ describe('IAST Rewriter', () => {
         unwrap: sinon.spy()
       }
 
+      const kSymbolPrepareStackTrace = Symbol('kTestSymbolPrepareStackTrace')
+
       rewriter = proxyquire('../../../../src/appsec/iast/taint-tracking/rewriter', {
         '@datadog/native-iast-rewriter': {
           Rewriter,
           getPrepareStackTrace: function (fn) {
-            return function testWrappedPrepareStackTrace (_, callsites) {
+            const testWrap = function testWrappedPrepareStackTrace (_, callsites) {
               return fn(_, callsites)
             }
-          }
+            Object.defineProperty(testWrap, kSymbolPrepareStackTrace, {
+              value: true
+            })
+            return testWrap
+          },
+          kSymbolPrepareStackTrace
         },
         '../../../../../datadog-shimmer': shimmer,
         '../../telemetry': iastTelemetry

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -107,6 +107,26 @@ describe('IAST Rewriter', () => {
 
       Error.prepareStackTrace = orig
     })
+
+    it('Should keep original prepareStackTrace fn when calling disable if not marked with the Symbol', () => {
+      const orig = Error.prepareStackTrace
+
+      rewriter.enableRewriter()
+
+      // remove iast property to avoid wrapping the new testPrepareStackTrace fn
+      delete Error.prepareStackTrace
+
+      const testPrepareStackTrace = (_, callsites) => {
+        // do nothing
+      }
+      Error.prepareStackTrace = testPrepareStackTrace
+
+      rewriter.disableRewriter()
+
+      expect(Error.prepareStackTrace).to.be.eq(testPrepareStackTrace)
+
+      Error.prepareStackTrace = orig
+    })
   })
 
   describe('getOriginalPathAndLineFromSourceMap', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,10 +419,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.3.tgz#7d512abdb03dcc238825e8d6c90cebf782686db3"
-  integrity sha512-RCbflf8BJ++h99I7iA4NxTA1lx7YqB+sPQkJNSZKxXyEXtWl9J4XsDV9C/sB9iGbf1PVY77tFvoGm5/WpUV4IA==
+"@datadog/native-iast-rewriter@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.3.0.tgz#67abddc698504ad76736c0d49681bcf9e330e1bd"
+  integrity sha512-78ivSaaSXOaHn3VumF9kcSI443nbPfVAWsnDTH9X1ZbqXjHpSlHHTZgK9z/TNbkvuJarS/X1GBioPMcgea1Ejg==
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"


### PR DESCRIPTION
### What does this PR do?
- Use `kSymbolPrepareStackTrace` symbol exported by iast rewriter to check if `Error.prepareStackTrace` has been wrapped by iast before resetting it.
- When a vulnerability is found, ensure original `Error.prepareStackTrace` fn is reset when obtaining stacktrace frames for the vulnerability.

### Motivation
When disabling iast, avoid resetting `Error.prepareStackTrace` if it is not the iast prepareStackTrace wrapper.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

