### PR TITLE
[ci-visibility] Fix v3 evp proxy version

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -38,9 +38,14 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
 
     this.getAgentInfo((err, agentInfo) => {
       this._isInitialized = true
-      const latestEvpProxyVersion = getLatestEvpProxyVersion(err, agentInfo)
+      let latestEvpProxyVersion = getLatestEvpProxyVersion(err, agentInfo)
       const isEvpCompatible = latestEvpProxyVersion >= 2
       const isGzipCompatible = latestEvpProxyVersion >= 4
+
+      // v3 does not work well citestcycle, so we downgrade to v2
+      if (latestEvpProxyVersion === 3) {
+        latestEvpProxyVersion = 2
+      }
 
       const evpProxyPrefix = `${AGENT_EVP_PROXY_PATH_PREFIX}${latestEvpProxyVersion}`
       if (isEvpCompatible) {

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -285,4 +285,39 @@ describe('AgentProxyCiVisibilityExporter', () => {
       expect(scope.isDone()).to.be.true
     })
   })
+
+  describe('evpProxyPrefix', () => {
+    it('should set evpProxyPrefix to v2 if the newest version is v3', async () => {
+      const scope = nock('http://localhost:8126')
+        .get('/info')
+        .reply(200, JSON.stringify({
+          endpoints: ['/evp_proxy/v2', '/evp_proxy/v3']
+        }))
+
+      const agentProxyCiVisibilityExporter = new AgentProxyCiVisibilityExporter({ port, tags })
+
+      expect(agentProxyCiVisibilityExporter).not.to.be.null
+
+      await agentProxyCiVisibilityExporter._canUseCiVisProtocolPromise
+
+      expect(agentProxyCiVisibilityExporter.evpProxyPrefix).to.equal('/evp_proxy/v2')
+      expect(scope.isDone()).to.be.true
+    })
+    it('should set evpProxyPrefix to v4 if the newest version is v4', async () => {
+      const scope = nock('http://localhost:8126')
+        .get('/info')
+        .reply(200, JSON.stringify({
+          endpoints: ['/evp_proxy/v2', '/evp_proxy/v3', '/evp_proxy/v4/']
+        }))
+
+      const agentProxyCiVisibilityExporter = new AgentProxyCiVisibilityExporter({ port, tags })
+
+      expect(agentProxyCiVisibilityExporter).not.to.be.null
+
+      await agentProxyCiVisibilityExporter._canUseCiVisProtocolPromise
+
+      expect(agentProxyCiVisibilityExporter.evpProxyPrefix).to.equal('/evp_proxy/v4')
+      expect(scope.isDone()).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Avoid using evp_proxy v3 endpoint in the agent.

### Motivation
`evp_proxy/v3` is not working well for citestcycle. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

