### PR TITLE
[ci-visibility] Always request library config, regardless of `DD_CIVISIBILITY_ITR_ENABLED`

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -88,10 +88,6 @@ class CiVisibilityExporter extends AgentInfoExporter {
     )
   }
 
-  shouldRequestLibraryConfiguration () {
-    return this._config.isIntelligentTestRunnerEnabled
-  }
-
   canReportSessionTraces () {
     return this._canUseCiVisProtocol
   }
@@ -141,9 +137,6 @@ class CiVisibilityExporter extends AgentInfoExporter {
   getLibraryConfiguration (testConfiguration, callback) {
     const { repositoryUrl } = testConfiguration
     this.sendGitMetadata(repositoryUrl)
-    if (!this.shouldRequestLibraryConfiguration()) {
-      return callback(null, {})
-    }
     this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {
       if (!canUseCiVisProtocol) {
         return callback(null, {})

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -231,7 +231,6 @@ describe('CI Visibility Exporter', () => {
           port, isIntelligentTestRunnerEnabled: true
         })
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        expect(ciVisibilityExporter.shouldRequestLibraryConfiguration()).to.be.true
         ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
           expect(scope.isDone()).to.be.true
           expect(err).to.be.null
@@ -273,7 +272,6 @@ describe('CI Visibility Exporter', () => {
           port, isIntelligentTestRunnerEnabled: true
         })
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        expect(ciVisibilityExporter.shouldRequestLibraryConfiguration()).to.be.true
         ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
           expect(scope.isDone()).to.be.true
           expect(err).to.be.null


### PR DESCRIPTION
### What does this PR do?
Do not affect the library config request if `DD_CIVISIBILITY_ITR_ENABLED=false`

### Motivation
`DD_CIVISIBILITY_ITR_ENABLED=false` is used as a kill switch for ITR, but it shouldn't affect other features.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

