### PR TITLE
[ci-visibility] Rename early flake detection retry tag

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -27,7 +27,7 @@ const {
   TEST_ITR_FORCED_RUN,
   TEST_SOURCE_FILE,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_IS_RETRY,
   TEST_EARLY_FLAKE_IS_ENABLED,
   TEST_NAME,
   JEST_DISPLAY_NAME
@@ -688,7 +688,7 @@ testFrameworks.forEach(({
               newTests.forEach(test => {
                 assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
               })
-              const retriedTests = newTests.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true')
+              const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
               // all but one has been retried
               assert.equal(
                 newTests.length - 1,
@@ -777,12 +777,12 @@ testFrameworks.forEach(({
               // all but one have been retried
               assert.equal(
                 testsForFirstParameter.length - 1,
-                testsForFirstParameter.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true').length
+                testsForFirstParameter.filter(test => test.meta[TEST_IS_RETRY] === 'true').length
               )
 
               assert.equal(
                 testsForSecondParameter.length - 1,
-                testsForSecondParameter.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true').length
+                testsForSecondParameter.filter(test => test.meta[TEST_IS_RETRY] === 'true').length
               )
             })
 
@@ -903,7 +903,7 @@ testFrameworks.forEach(({
 
               const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-              const retriedTests = tests.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true')
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
               // all but one has been retried
               assert.equal(
                 tests.length - 1,
@@ -979,14 +979,14 @@ testFrameworks.forEach(({
                 test => test.meta[TEST_NAME] === 'ci visibility skip will not be retried'
               )
               assert.equal(newSkippedTests.length, 1)
-              assert.notProperty(newSkippedTests[0].meta, TEST_EARLY_FLAKE_IS_RETRY)
+              assert.notProperty(newSkippedTests[0].meta, TEST_IS_RETRY)
 
               if (name === 'jest') {
                 const newTodoTests = tests.filter(
                   test => test.meta[TEST_NAME] === 'ci visibility todo will not be retried'
                 )
                 assert.equal(newTodoTests.length, 1)
-                assert.notProperty(newTodoTests[0].meta, TEST_EARLY_FLAKE_IS_RETRY)
+                assert.notProperty(newTodoTests[0].meta, TEST_IS_RETRY)
               }
             })
 

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -29,7 +29,7 @@ const {
   TEST_SOURCE_FILE,
   TEST_EARLY_FLAKE_IS_ENABLED,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_IS_RETRY,
   TEST_NAME
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
@@ -818,7 +818,7 @@ versions.forEach(version => {
                   newTests.forEach(test => {
                     assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
                   })
-                  const retriedTests = newTests.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true')
+                  const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
                   // all but one has been retried
                   assert.equal(
                     newTests.length - 1,

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -29,7 +29,7 @@ const {
   TEST_ITR_FORCED_RUN,
   TEST_SOURCE_FILE,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_IS_RETRY,
   TEST_EARLY_FLAKE_IS_ENABLED
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -939,7 +939,7 @@ moduleType.forEach(({
             const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
             assert.equal(newTests.length, NUM_RETRIES_EFD + 1)
 
-            const retriedTests = tests.filter(test => test.meta[TEST_EARLY_FLAKE_IS_RETRY] === 'true')
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
             assert.equal(retriedTests.length, NUM_RETRIES_EFD)
 
             newTests.forEach(newTest => {

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -18,7 +18,7 @@ const {
   TEST_SOURCE_FILE,
   TEST_EARLY_FLAKE_IS_ENABLED,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY
+  TEST_IS_RETRY
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -181,7 +181,7 @@ class CucumberPlugin extends CiPlugin {
       if (isNew) {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
-          span.setTag(TEST_EARLY_FLAKE_IS_RETRY, 'true')
+          span.setTag(TEST_IS_RETRY, 'true')
         }
       }
 

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -27,7 +27,7 @@ const {
   ITR_CORRELATION_ID,
   TEST_SOURCE_FILE,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_IS_RETRY,
   TEST_EARLY_FLAKE_IS_ENABLED
 } = require('../../dd-trace/src/plugins/util/test')
 const { isMarkedAsUnskippable } = require('../../datadog-plugin-jest/src/util')
@@ -592,7 +592,7 @@ class CypressPlugin {
           if (isNew) {
             this.activeTestSpan.setTag(TEST_IS_NEW, 'true')
             if (isEfdRetry) {
-              this.activeTestSpan.setTag(TEST_EARLY_FLAKE_IS_RETRY, 'true')
+              this.activeTestSpan.setTag(TEST_IS_RETRY, 'true')
             }
           }
           const finishedTest = {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -17,7 +17,7 @@ const {
   ITR_CORRELATION_ID,
   TEST_SOURCE_FILE,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_IS_RETRY,
   TEST_EARLY_FLAKE_IS_ENABLED,
   JEST_DISPLAY_NAME
 } = require('../../dd-trace/src/plugins/util/test')
@@ -339,7 +339,7 @@ class JestPlugin extends CiPlugin {
     if (isNew) {
       extraTags[TEST_IS_NEW] = 'true'
       if (isEfdRetry) {
-        extraTags[TEST_EARLY_FLAKE_IS_RETRY] = 'true'
+        extraTags[TEST_IS_RETRY] = 'true'
       }
     }
 

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -19,7 +19,7 @@ const {
   TEST_SOURCE_FILE,
   removeEfdStringFromTestName,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_IS_RETRY,
   TEST_EARLY_FLAKE_IS_ENABLED
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -270,7 +270,7 @@ class MochaPlugin extends CiPlugin {
     if (isNew) {
       extraTags[TEST_IS_NEW] = 'true'
       if (isEfdRetry) {
-        extraTags[TEST_EARLY_FLAKE_IS_RETRY] = 'true'
+        extraTags[TEST_IS_RETRY] = 'true'
       }
     }
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -52,7 +52,7 @@ const TEST_SKIPPED_BY_ITR = 'test.skipped_by_itr'
 const TEST_CONFIGURATION_BROWSER_NAME = 'test.configuration.browser_name'
 // Early flake detection
 const TEST_IS_NEW = 'test.is_new'
-const TEST_EARLY_FLAKE_IS_RETRY = 'test.early_flake.is_retry'
+const TEST_IS_RETRY = 'test.is_retry'
 const TEST_EARLY_FLAKE_IS_ENABLED = 'test.early_flake.is_enabled'
 
 const CI_APP_ORIGIN = 'ciapp-test'
@@ -101,7 +101,7 @@ module.exports = {
   TEST_SKIPPED_BY_ITR,
   TEST_CONFIGURATION_BROWSER_NAME,
   TEST_IS_NEW,
-  TEST_EARLY_FLAKE_IS_RETRY,
+  TEST_IS_RETRY,
   TEST_EARLY_FLAKE_IS_ENABLED,
   getTestEnvironmentMetadata,
   getTestParametersString,


### PR DESCRIPTION
### What does this PR do?
Rename `test.early_flake.is_retry` to `test.is_retry`

### Motivation
We don't want to namespace the `is_retry` tag since we'll use it for other features.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

