### PR TITLE
Sum appsec waf.duration* metrics

### DIFF
--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -91,19 +91,20 @@ function reportWafInit (wafVersion, rulesVersion, diagnosticsRules = {}) {
   incrementWafInitMetric(wafVersion, rulesVersion)
 }
 
+function setOrAddTag (rootSpan, metricName, value) {
+  if (value) {
+    value += rootSpan.context()?._tags[metricName] || 0
+    rootSpan.setTag(metricName, value)
+  }
+}
+
 function reportMetrics (metrics) {
-  // TODO: metrics should be incremental, there already is an RFC to report metrics
   const store = storage.getStore()
   const rootSpan = store?.req && web.root(store.req)
   if (!rootSpan) return
 
-  if (metrics.duration) {
-    rootSpan.setTag('_dd.appsec.waf.duration', metrics.duration)
-  }
-
-  if (metrics.durationExt) {
-    rootSpan.setTag('_dd.appsec.waf.duration_ext', metrics.durationExt)
-  }
+  setOrAddTag(rootSpan, '_dd.appsec.waf.duration', metrics.duration)
+  setOrAddTag(rootSpan, '_dd.appsec.waf.duration_ext', metrics.durationExt)
 
   if (metrics.rulesVersion) {
     rootSpan.setTag('_dd.appsec.event_rules.version', metrics.rulesVersion)

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -8,7 +8,8 @@ const {
   incrementWafInitMetric,
   updateWafRequestsMetricTags,
   incrementWafUpdatesMetric,
-  incrementWafRequestsMetric
+  incrementWafRequestsMetric,
+  getRequestMetrics
 } = require('./telemetry')
 const zlib = require('zlib')
 
@@ -91,20 +92,10 @@ function reportWafInit (wafVersion, rulesVersion, diagnosticsRules = {}) {
   incrementWafInitMetric(wafVersion, rulesVersion)
 }
 
-function setOrAddTag (rootSpan, metricName, value) {
-  if (value) {
-    value += rootSpan.context()?._tags[metricName] || 0
-    rootSpan.setTag(metricName, value)
-  }
-}
-
 function reportMetrics (metrics) {
   const store = storage.getStore()
   const rootSpan = store?.req && web.root(store.req)
   if (!rootSpan) return
-
-  setOrAddTag(rootSpan, '_dd.appsec.waf.duration', metrics.duration)
-  setOrAddTag(rootSpan, '_dd.appsec.waf.duration_ext', metrics.durationExt)
 
   if (metrics.rulesVersion) {
     rootSpan.setTag('_dd.appsec.event_rules.version', metrics.rulesVersion)
@@ -178,6 +169,15 @@ function finishRequest (req, res) {
     rootSpan.addTags(Object.fromEntries(metricsQueue))
 
     metricsQueue.clear()
+  }
+
+  const metrics = getRequestMetrics(req)
+  if (metrics?.duration) {
+    rootSpan.setTag('_dd.appsec.waf.duration', metrics.duration)
+  }
+
+  if (metrics?.durationExt) {
+    rootSpan.setTag('_dd.appsec.waf.duration_ext', metrics.durationExt)
   }
 
   incrementWafRequestsMetric(req)

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -11,15 +11,12 @@ describe('reporter', () => {
   let telemetry
 
   beforeEach(() => {
-    const tags = {}
     span = {
       context: sinon.stub().returns({
-        _tags: tags
+        _tags: {}
       }),
       addTags: sinon.stub(),
-      setTag: sinon.stub().callsFake((tagName, value) => {
-        tags[tagName] = value
-      })
+      setTag: sinon.stub()
     }
 
     web = {

--- a/packages/dd-trace/test/appsec/telemetry.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry.spec.js
@@ -272,5 +272,24 @@ describe('Appsec Telemetry metrics', () => {
       expect(count).to.not.have.been.called
       expect(inc).to.not.have.been.called
     })
+
+    describe('updateWafRequestMetricTags', () => {
+      it('should sum waf.duration and waf.durationExt request metrics', () => {
+        appsecTelemetry.updateWafRequestsMetricTags({
+          duration: 42,
+          durationExt: 52
+        }, req)
+
+        appsecTelemetry.updateWafRequestsMetricTags({
+          duration: 24,
+          durationExt: 25
+        }, req)
+
+        const { duration, durationExt } = appsecTelemetry.getRequestMetrics(req)
+
+        expect(duration).to.be.eq(66)
+        expect(durationExt).to.be.eq(77)
+      })
+    })
   })
 })

--- a/packages/dd-trace/test/appsec/telemetry.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry.spec.js
@@ -142,6 +142,25 @@ describe('Appsec Telemetry metrics', () => {
 
         expect(track).to.have.been.calledTwice
       })
+
+      it('should sum waf.duration metrics', () => {
+        appsecTelemetry.updateWafRequestsMetricTags({
+          duration: 42,
+          durationExt: 52,
+          ...metrics
+        }, req)
+
+        appsecTelemetry.updateWafRequestsMetricTags({
+          duration: 24,
+          durationExt: 25,
+          ...metrics
+        }, req)
+
+        const { duration, durationExt } = appsecTelemetry.getRequestMetrics(req)
+
+        expect(duration).to.be.eq(66)
+        expect(durationExt).to.be.eq(77)
+      })
     })
 
     describe('incWafInitMetric', () => {

--- a/packages/dd-trace/test/appsec/telemetry.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry.spec.js
@@ -146,14 +146,12 @@ describe('Appsec Telemetry metrics', () => {
       it('should sum waf.duration metrics', () => {
         appsecTelemetry.updateWafRequestsMetricTags({
           duration: 42,
-          durationExt: 52,
-          ...metrics
+          durationExt: 52
         }, req)
 
         appsecTelemetry.updateWafRequestsMetricTags({
           duration: 24,
-          durationExt: 25,
-          ...metrics
+          durationExt: 25
         }, req)
 
         const { duration, durationExt } = appsecTelemetry.getRequestMetrics(req)
@@ -275,6 +273,33 @@ describe('Appsec Telemetry metrics', () => {
 
     describe('updateWafRequestMetricTags', () => {
       it('should sum waf.duration and waf.durationExt request metrics', () => {
+        appsecTelemetry.enable({
+          enabled: false,
+          metrics: true
+        })
+
+        appsecTelemetry.updateWafRequestsMetricTags({
+          duration: 42,
+          durationExt: 52
+        }, req)
+
+        appsecTelemetry.updateWafRequestsMetricTags({
+          duration: 24,
+          durationExt: 25
+        }, req)
+
+        const { duration, durationExt } = appsecTelemetry.getRequestMetrics(req)
+
+        expect(duration).to.be.eq(66)
+        expect(durationExt).to.be.eq(77)
+      })
+
+      it('should sum waf.duration and waf.durationExt with telemetry enabled and metrics disabled', () => {
+        appsecTelemetry.enable({
+          enabled: true,
+          metrics: false
+        })
+
         appsecTelemetry.updateWafRequestsMetricTags({
           duration: 42,
           durationExt: 52


### PR DESCRIPTION
### What does this PR do?
- no longer set `'_dd.appsec.waf.duration'` and `'_dd.appsec.waf.duration_ext'` tags in `reportMetrics()`
- rely on appsec telemetry module to store `waf.duration` and `waf.duration_ext` values so they can be updated (increased) multiple times in the same http request
- add `'_dd.appsec.waf.duration'` and `'_dd.appsec.waf.duration_ext'` tags at the end of the request in `finishRequest()` method using metrics stored in appsec telemetry

### Motivation
There can be multiple calls to the waf in the same http request so the metrics were incorrect because only the values of the last call were added to the `rootSpan`.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

