### PR TITLE
PROF-9248: SSI profiler telemetry

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -33,6 +33,7 @@ const integrationCounters = {
   spans_finished: {}
 }
 
+const startCh = channel('dd-trace:span:start')
 const finishCh = channel('dd-trace:span:finish')
 
 function getIntegrationCounter (event, integration) {
@@ -96,6 +97,7 @@ class DatadogSpan {
       unfinishedRegistry.register(this, operationName, this)
     }
     spanleak.addSpan(this, operationName)
+    startCh.publish(this)
   }
 
   toString () {

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -4,6 +4,9 @@ const { EventEmitter } = require('events')
 const { Config } = require('./config')
 const { snapshotKinds } = require('./constants')
 const { threadNamePrefix } = require('./profilers/shared')
+const dc = require('dc-polyfill')
+
+const profileSubmittedChannel = dc.channel('datadog:profiling:profile-submitted')
 
 function maybeSourceMap (sourceMap, SourceMapper, debug) {
   if (!sourceMap) return
@@ -161,6 +164,7 @@ class Profiler extends EventEmitter {
         this._capture(this._timeoutInterval, endDate)
       }
       await this._submit(encodedProfiles, startDate, endDate, snapshotKind)
+      profileSubmittedChannel.publish()
       this._logger.debug('Submitted profiles')
     } catch (err) {
       this._logger.error(err)

--- a/packages/dd-trace/src/profiling/ssi-telemetry-mock-profiler.js
+++ b/packages/dd-trace/src/profiling/ssi-telemetry-mock-profiler.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const dc = require('dc-polyfill')
+const coalesce = require('koalas')
+const profileSubmittedChannel = dc.channel('datadog:profiling:mock-profile-submitted')
+const { DD_PROFILING_UPLOAD_PERIOD } = process.env
+
+let timerId
+
+module.exports = {
+  start: config => {
+    // Copied from packages/dd-trace/src/profiler.js
+    const flushInterval = coalesce(config.interval, Number(DD_PROFILING_UPLOAD_PERIOD) * 1000, 65 * 1000)
+
+    function scheduleProfileSubmit () {
+      timerId = setTimeout(emitProfileSubmit, flushInterval)
+    }
+
+    function emitProfileSubmit () {
+      profileSubmittedChannel.publish()
+      scheduleProfileSubmit()
+    }
+
+    scheduleProfileSubmit()
+  },
+
+  stop: () => {
+    if (timerId !== undefined) {
+      clearTimeout(timerId)
+      timerId = undefined
+    }
+  }
+}

--- a/packages/dd-trace/src/profiling/ssi-telemetry.js
+++ b/packages/dd-trace/src/profiling/ssi-telemetry.js
@@ -1,0 +1,146 @@
+'use strict'
+
+const telemetryMetrics = require('../telemetry/metrics')
+const profilersNamespace = telemetryMetrics.manager.namespace('profilers')
+const performance = require('perf_hooks').performance
+const dc = require('dc-polyfill')
+const { isTrue, isFalse } = require('../util')
+
+// If the process lived for less than 30 seconds, it's considered short-lived
+const DEFAULT_SHORT_LIVED_THRESHOLD = 30000
+
+const EnablementChoice = {
+  MANUALLY_ENABLED: Symbol('SSITelemetry.EnablementChoice.MANUALLY_ENABLED'),
+  SSI_ENABLED: Symbol('SSITelemetry.EnablementChoice.SSI_ENABLED'),
+  SSI_NOT_ENABLED: Symbol('SSITelemetry.EnablementChoice.SSI_NOT_ENABLED'),
+  DISABLED: Symbol('SSITelemetry.EnablementChoice.MANUALLY_DISABLED')
+}
+Object.freeze(EnablementChoice)
+
+function getEnablementChoiceFromEnv () {
+  const { DD_PROFILING_ENABLED, DD_INJECTION_ENABLED } = process.env
+  if (DD_INJECTION_ENABLED === undefined || isFalse(DD_PROFILING_ENABLED)) {
+    return EnablementChoice.DISABLED
+  } else if (DD_INJECTION_ENABLED.split(',').includes('profiling')) {
+    return EnablementChoice.SSI_ENABLED
+  } else if (isTrue(DD_PROFILING_ENABLED)) {
+    return EnablementChoice.MANUALLY_ENABLED
+  } else {
+    return EnablementChoice.SSI_NOT_ENABLED
+  }
+}
+
+function enablementChoiceToTagValue (enablementChoice) {
+  switch (enablementChoice) {
+    case EnablementChoice.MANUALLY_ENABLED:
+      return 'manually_enabled'
+    case EnablementChoice.SSI_ENABLED:
+      return 'ssi_enabled'
+    case EnablementChoice.SSI_NOT_ENABLED:
+      return 'not_enabled'
+    case EnablementChoice.MANUALLY_DISABLED:
+      // Can't emit this one as a tag
+      throw new Error('Invalid enablement choice')
+  }
+}
+
+/**
+ * This class emits telemetry metrics about the profiler behavior under SSI. It will only emit metrics
+ * when the application closes, and will emit the following metrics:
+ * - `number_of_profiles`: The number of profiles that were submitted
+ * - `number_of_runtime_id`: The number of runtime IDs in the app (always 1 for Node.js)
+ * It will also add tags describing the state of heuristics triggers, the enablement choice, and whether
+ * actual profiles were sent (as opposed to mock profiles). There is a mock profiler that is activated
+ * when the profiler is not enabled, and it will emit mock profile submission events at the same cadence
+ * the profiler would, providing insight into how many profiles would've been emitted if SSI enabled
+ * profiling. Note that telemetry is per tracer instance, and each worker thread will have its own instance.
+ */
+class SSITelemetry {
+  constructor ({
+    enablementChoice = getEnablementChoiceFromEnv(),
+    shortLivedThreshold = DEFAULT_SHORT_LIVED_THRESHOLD
+  } = {}) {
+    if (!Object.values(EnablementChoice).includes(enablementChoice)) {
+      throw new Error('Invalid enablement choice')
+    }
+    if (typeof shortLivedThreshold !== 'number' || shortLivedThreshold <= 0) {
+      throw new Error('Short-lived threshold must be a positive number')
+    }
+    this.enablementChoice = enablementChoice
+    this.shortLivedThreshold = shortLivedThreshold
+
+    this.profileCount = 0
+    this.hasSentProfiles = false
+    this.noSpan = true
+  }
+
+  enabled () {
+    return this.enablementChoice !== EnablementChoice.DISABLED
+  }
+
+  start () {
+    if (this.enabled()) {
+      // Used to determine short-livedness of the process. We could use the process start time as the
+      // reference point, but the tracer initialization point is more relevant, as we couldn't be
+      // collecting profiles earlier anyway. The difference is not particularly significant if the
+      // tracer is initialized early in the process lifetime.
+      this.startTime = performance.now()
+
+      this._onSpanCreated = this._onSpanCreated.bind(this)
+      this._onProfileSubmitted = this._onProfileSubmitted.bind(this)
+      this._onMockProfileSubmitted = this._onMockProfileSubmitted.bind(this)
+      this._onAppClosing = this._onAppClosing.bind(this)
+
+      dc.subscribe('dd-trace:span:start', this._onSpanCreated)
+      dc.subscribe('datadog:profiling:profile-submitted', this._onProfileSubmitted)
+      dc.subscribe('datadog:profiling:mock-profile-submitted', this._onMockProfileSubmitted)
+      dc.subscribe('datadog:telemetry:app-closing', this._onAppClosing)
+    }
+  }
+
+  _onSpanCreated () {
+    this.noSpan = false
+    dc.unsubscribe('dd-trace:span:start', this._onSpanCreated)
+  }
+
+  _onProfileSubmitted () {
+    this.profileCount++
+    this.hasSentProfiles = true
+  }
+
+  _onMockProfileSubmitted () {
+    this.profileCount++
+  }
+
+  _onAppClosing () {
+    const decision = []
+    if (this.noSpan) {
+      decision.push('no_span')
+    }
+    if (performance.now() - this.startTime < this.shortLivedThreshold) {
+      decision.push('short_lived')
+    }
+    if (decision.length === 0) {
+      decision.push('triggered')
+    }
+
+    const tags = [
+      'installation:ssi',
+      `enablement_choice:${enablementChoiceToTagValue(this.enablementChoice)}`,
+      `has_sent_profiles:${this.hasSentProfiles}`,
+      `heuristic_hypothetical_decision:${decision.join()}`
+    ]
+
+    profilersNamespace.count('ssi_heuristic.number_of_profiles', tags).inc(this.profileCount)
+    profilersNamespace.count('ssi_heuristic.number_of_runtime_id', tags).inc(1)
+
+    dc.unsubscribe('datadog:profiling:profile-submitted', this._onProfileSubmitted)
+    dc.unsubscribe('datadog:profiling:mock-profile-submitted', this._onMockProfileSubmitted)
+    dc.unsubscribe('datadog:telemetry:app-closing', this._onAppClosing)
+    if (this.noSpan) {
+      dc.unsubscribe('dd-trace:span:start', this._onSpanCreated)
+    }
+  }
+}
+
+module.exports = { SSITelemetry, EnablementChoice }

--- a/packages/dd-trace/src/profiling/ssi-telemetry.js
+++ b/packages/dd-trace/src/profiling/ssi-telemetry.js
@@ -138,7 +138,7 @@ class SSITelemetry {
     this._profileCount = profilersNamespace.count('ssi_heuristic.number_of_profiles', tags)
     this._runtimeIdCount = profilersNamespace.count('ssi_heuristic.number_of_runtime_id', tags)
 
-    if (decision.length === 0 && !this._emittedRuntimeId) {
+    if (!this._emittedRuntimeId && decision[0] === 'triggered') {
       // Tags won't change anymore, so we can emit the runtime ID metric now
       this._emittedRuntimeId = true
       this._runtimeIdCount.inc()

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -12,6 +12,7 @@ const remoteConfig = require('./appsec/remote_config')
 const AppsecSdk = require('./appsec/sdk')
 const dogstatsd = require('./dogstatsd')
 const spanleak = require('./spanleak')
+const { SSITelemetry } = require('./profiling/ssi-telemetry')
 
 class Tracer extends NoopProxy {
   constructor () {
@@ -72,6 +73,8 @@ class Tracer extends NoopProxy {
         require('./serverless').maybeStartServerlessMiniAgent(config)
       }
 
+      const ssiTelemetry = new SSITelemetry()
+      ssiTelemetry.start()
       if (config.profiling.enabled) {
         // do not stop tracer initialization if the profiler fails to be imported
         try {
@@ -80,6 +83,8 @@ class Tracer extends NoopProxy {
         } catch (e) {
           log.error(e)
         }
+      } else if (ssiTelemetry.enabled()) {
+        require('./profiling/ssi-telemetry-mock-profiler').start(config)
       }
       if (!this._profilerStarted) {
         this._profilerStarted = Promise.resolve(false)

--- a/packages/dd-trace/test/profiling/ssi-telemetry.spec.js
+++ b/packages/dd-trace/test/profiling/ssi-telemetry.spec.js
@@ -1,0 +1,174 @@
+'use strict'
+
+require('../setup/tap')
+
+const expect = require('chai').expect
+const sinon = require('sinon')
+
+const telemetryManagerNamespace = sinon.stub()
+telemetryManagerNamespace.returns()
+
+const dc = require('dc-polyfill')
+
+describe('SSI Telemetry', () => {
+  it('should be disabled without SSI even if the profiler is manually enabled', () => {
+    delete process.env.DD_INJECTION_ENABLED
+    process.env.DD_PROFILING_ENABLED = 'true'
+    testDisabledTelemetry()
+  })
+
+  it('should be disabled when SSI is present but the profiler is manually disabled', () => {
+    process.env.DD_INJECTION_ENABLED = 'tracing'
+    process.env.DD_PROFILING_ENABLED = 'false'
+    testDisabledTelemetry()
+  })
+
+  it('should be enabled when SSI is present', () => {
+    process.env.DD_INJECTION_ENABLED = 'tracing'
+    delete process.env.DD_PROFILING_ENABLED
+    testEnabledTelemetry('not_enabled')
+  })
+
+  it('should be enabled when SSI is present and profiling is manually enabled', () => {
+    process.env.DD_INJECTION_ENABLED = 'tracing'
+    process.env.DD_PROFILING_ENABLED = 'true'
+    testEnabledTelemetry('manually_enabled')
+  })
+})
+
+function setupHarness () {
+  const profileCountCount = {
+    inc: sinon.stub()
+  }
+  const runtimeIdCount = {
+    inc: sinon.stub()
+  }
+  const ssiMetricsNamespace = {
+    count: sinon.stub().callsFake((name, tags) => {
+      if (name === 'ssi_heuristic.number_of_profiles') {
+        return profileCountCount
+      } else if (name === 'ssi_heuristic.number_of_runtime_id') {
+        return runtimeIdCount
+      }
+    })
+  }
+
+  const namespaceFn = sinon.stub().returns(ssiMetricsNamespace)
+  const { SSITelemetry, EnablementChoice } = proxyquire('../src/profiling/ssi-telemetry', {
+    '../telemetry/metrics': {
+      manager: {
+        namespace: namespaceFn
+      }
+    }
+  })
+  expect(namespaceFn.calledOnceWithExactly('profilers')).to.equal(true)
+  const stubs = {
+    profileCountCountInc: profileCountCount.inc,
+    runtimeIdCountInc: runtimeIdCount.inc,
+    count: ssiMetricsNamespace.count
+  }
+  return { stubs, SSITelemetry, EnablementChoice }
+}
+
+function testDisabledTelemetry () {
+  const { stubs, SSITelemetry, EnablementChoice } = setupHarness()
+  const telemetry = new SSITelemetry()
+  telemetry.start()
+  dc.channel('dd-trace:span:start').publish()
+  dc.channel('datadog:profiling:profile-submitted').publish()
+  dc.channel('datadog:profiling:mock-profile-submitted').publish()
+  dc.channel('datadog:telemetry:app-closing').publish()
+  expect(telemetry.enablementChoice).to.equal(EnablementChoice.DISABLED)
+  expect(telemetry.enabled()).to.equal(false)
+  // When it is disabled, the telemetry should not subscribe to any channel
+  // so the preceding publishes should not have any effect.
+  expect(telemetry.profileCount).to.equal(0)
+  expect(telemetry.hasSentProfiles).to.equal(false)
+  expect(telemetry.noSpan).to.equal(true)
+  expect(stubs.count.notCalled).to.equal(true)
+}
+
+function executeTelemetryEnabledScenario (
+  scenario,
+  profileCount,
+  sentProfiles,
+  enablementChoice,
+  heuristicDecision,
+  longLived = false
+) {
+  const { stubs, SSITelemetry } = setupHarness()
+  const telemetry = longLived ? new SSITelemetry({ shortLivedThreshold: 2 }) : new SSITelemetry()
+  telemetry.start()
+  expect(telemetry.enabled()).to.equal(true)
+  if (longLived) {
+    for (const now = new Date().getTime(); new Date().getTime() - now < 3;);
+  }
+  scenario(telemetry)
+
+  createAndCheckMetrics(stubs, profileCount, sentProfiles, enablementChoice, heuristicDecision)
+}
+
+function createAndCheckMetrics (stubs, profileCount, sentProfiles, enablementChoice, heuristicDecision) {
+  // Trigger metrics creation
+  dc.channel('datadog:telemetry:app-closing').publish()
+
+  const tags = [
+    'installation:ssi',
+    `enablement_choice:${enablementChoice}`,
+    `has_sent_profiles:${sentProfiles}`,
+    `heuristic_hypothetical_decision:${heuristicDecision}`
+  ]
+  expect(stubs.count.calledWith('ssi_heuristic.number_of_profiles', tags)).to.equal(true)
+  expect(stubs.profileCountCountInc.calledWith(profileCount)).to.equal(true)
+  expect(stubs.count.calledWith('ssi_heuristic.number_of_runtime_id', tags)).to.equal(true)
+  expect(stubs.runtimeIdCountInc.calledWith(1)).to.equal(true)
+}
+
+function testEnabledTelemetry (enablementChoice) {
+  testNoOp(enablementChoice)
+  testProfilesSent(enablementChoice)
+  testMockProfilesSent(enablementChoice)
+  testSpan(enablementChoice)
+  testLongLived(enablementChoice)
+  testTriggered(enablementChoice)
+}
+
+function testNoOp (enablementChoice) {
+  executeTelemetryEnabledScenario(_ => {}, 0, false, enablementChoice, 'no_span,short_lived')
+}
+
+function testProfilesSent (enablementChoice) {
+  executeTelemetryEnabledScenario(_ => {
+    dc.channel('datadog:profiling:profile-submitted').publish()
+    dc.channel('datadog:profiling:profile-submitted').publish()
+  }, 2, true, enablementChoice, 'no_span,short_lived')
+}
+
+function testMockProfilesSent (enablementChoice) {
+  executeTelemetryEnabledScenario(_ => {
+    dc.channel('datadog:profiling:mock-profile-submitted').publish()
+    dc.channel('datadog:profiling:mock-profile-submitted').publish()
+  }, 2, false, enablementChoice, 'no_span,short_lived')
+}
+
+function testSpan (enablementChoice) {
+  executeTelemetryEnabledScenario(telemetry => {
+    dc.channel('dd-trace:span:start').publish()
+    expect(telemetry.noSpan).to.equal(false)
+    dc.channel('datadog:profiling:profile-submitted').publish()
+  }, 1, true, enablementChoice, 'short_lived')
+}
+
+function testLongLived (enablementChoice) {
+  executeTelemetryEnabledScenario(_ => {
+    dc.channel('datadog:profiling:profile-submitted').publish()
+  }, 1, true, enablementChoice, 'no_span', true)
+}
+
+function testTriggered (enablementChoice) {
+  executeTelemetryEnabledScenario(telemetry => {
+    dc.channel('dd-trace:span:start').publish()
+    expect(telemetry.noSpan).to.equal(false)
+    dc.channel('datadog:profiling:profile-submitted').publish()
+  }, 1, true, enablementChoice, 'triggered', true)
+}

--- a/packages/dd-trace/test/profiling/ssi-telemetry.spec.js
+++ b/packages/dd-trace/test/profiling/ssi-telemetry.spec.js
@@ -82,7 +82,7 @@ function testDisabledTelemetry () {
   expect(telemetry.enabled()).to.equal(false)
   // When it is disabled, the telemetry should not subscribe to any channel
   // so the preceding publishes should not have any effect.
-  expect(telemetry.profileCount).to.equal(0)
+  expect(telemetry._profileCount).to.equal(undefined)
   expect(telemetry.hasSentProfiles).to.equal(false)
   expect(telemetry.noSpan).to.equal(true)
   expect(stubs.count.notCalled).to.equal(true)
@@ -119,9 +119,9 @@ function createAndCheckMetrics (stubs, profileCount, sentProfiles, enablementCho
     `heuristic_hypothetical_decision:${heuristicDecision}`
   ]
   expect(stubs.count.calledWith('ssi_heuristic.number_of_profiles', tags)).to.equal(true)
-  expect(stubs.profileCountCountInc.calledWith(profileCount)).to.equal(true)
+  expect(stubs.profileCountCountInc.args.length).to.equal(profileCount + 1) // once at the end with 0
   expect(stubs.count.calledWith('ssi_heuristic.number_of_runtime_id', tags)).to.equal(true)
-  expect(stubs.runtimeIdCountInc.calledWith(1)).to.equal(true)
+  expect(stubs.runtimeIdCountInc.args.length).to.equal(1)
 }
 
 function testEnabledTelemetry (enablementChoice) {


### PR DESCRIPTION
### What does this PR do?
Adds telemetry we can use to track the impact of SSI on profiling for Node.js services.

### Motivation
Q1'24 OKR. We want to add the capability to turn profiling on through [Single Step Instrumentation ](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=linuxhostorvm). First step is to add telemetry to the profiler that'll help us assess how it would behave under SSI. It basically emits a metric for the number of profiles submitted (either actually submitted, or hypothetically submitted if SSI were on) and annotates the metric with tags showing the state affecting activation heuristics.