### PR TITLE
Fixed attempting to wrap undefined mongoose.Promise

### DIFF
--- a/packages/datadog-instrumentations/src/mongoose.js
+++ b/packages/datadog-instrumentations/src/mongoose.js
@@ -21,7 +21,8 @@ addHook({
   name: 'mongoose',
   versions: ['>=4.6.4 <5', '5', '6', '>=7']
 }, mongoose => {
-  if (mongoose.Promise !== global.Promise) {
+  // As of Mongoose 7, custom promise libraries are no longer supported and mongoose.Promise may be undefined
+  if (mongoose.Promise && mongoose.Promise !== global.Promise) {
     shimmer.wrap(mongoose.Promise.prototype, 'then', wrapThen)
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
As of Mongoose 7, custom promise libraries are no longer supported. The hook for Mongoose attempts to wrap `mongoose.Promise.prototype` if `mongoose.Promise !== global.Promise`, which is also true when `mongoose.Promise` is `undefined`, which is the case with modern versions of Mongoose. This just adds a simple check to make sure it doesn't attempt to wrap it when it doesn't exist.

### Motivation
<!-- What inspired you to submit this pull request? -->
I'd like to see the issue resolved so I can stop maintaining a patch for this.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

