### PR TITLE
fix nomenclature file being loaded multiple times

### DIFF
--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -4,7 +4,6 @@ const { channel } = require('dc-polyfill')
 const { isFalse } = require('./util')
 const plugins = require('./plugins')
 const log = require('./log')
-const Nomenclature = require('./service-naming')
 
 const loadChannel = channel('dd-trace:instrumentation:load')
 
@@ -102,7 +101,7 @@ module.exports = class PluginManager {
   // like instrumenter.enable()
   configure (config = {}) {
     this._tracerConfig = config
-    Nomenclature.configure(config)
+    this._tracer._nomenclature.configure(config)
 
     for (const name in pluginClasses) {
       this.loadPlugin(name)

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -4,7 +4,6 @@ const Plugin = require('./plugin')
 const { storage } = require('../../../datadog-core')
 const analyticsSampler = require('../analytics_sampler')
 const { COMPONENT } = require('../constants')
-const Nomenclature = require('../service-naming')
 
 class TracingPlugin extends Plugin {
   constructor (...args) {
@@ -29,7 +28,7 @@ class TracingPlugin extends Plugin {
       kind = this.constructor.kind
     } = opts
 
-    return Nomenclature.serviceName(type, kind, id, opts)
+    return this._tracer._nomenclature.serviceName(type, kind, id, opts)
   }
 
   operationName (opts = {}) {
@@ -39,7 +38,7 @@ class TracingPlugin extends Plugin {
       kind = this.constructor.kind
     } = opts
 
-    return Nomenclature.opName(type, kind, id, opts)
+    return this._tracer._nomenclature.opName(type, kind, id, opts)
   }
 
   configure (config) {

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -6,6 +6,7 @@ const runtimeMetrics = require('./runtime_metrics')
 const log = require('./log')
 const { setStartupLogPluginManager } = require('./startup-log')
 const telemetry = require('./telemetry')
+const nomenclature = require('./service-naming')
 const PluginManager = require('./plugin_manager')
 const remoteConfig = require('./appsec/remote_config')
 const AppsecSdk = require('./appsec/sdk')
@@ -17,6 +18,7 @@ class Tracer extends NoopProxy {
     super()
 
     this._initialized = false
+    this._nomenclature = nomenclature
     this._pluginManager = new PluginManager(this)
     this.dogstatsd = new dogstatsd.NoopDogStatsDClient()
     this._tracingInitialized = false

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -6,7 +6,7 @@ const { channel } = require('dc-polyfill')
 const proxyquire = require('proxyquire')
 
 const loadChannel = channel('dd-trace:instrumentation:load')
-const Nomenclature = require('../../dd-trace/src/service-naming')
+const nomenclature = require('../../dd-trace/src/service-naming')
 
 describe('Plugin Manager', () => {
   let tracer
@@ -19,7 +19,9 @@ describe('Plugin Manager', () => {
   let pm
 
   beforeEach(() => {
-    tracer = {}
+    tracer = {
+      _nomenclature: nomenclature
+    }
     instantiated = []
     class FakePlugin {
       constructor (aTracer) {
@@ -249,7 +251,7 @@ describe('Plugin Manager', () => {
       let configureSpy
 
       beforeEach(() => {
-        configureSpy = sinon.spy(Nomenclature, 'configure')
+        configureSpy = sinon.spy(tracer._nomenclature, 'configure')
       })
 
       afterEach(() => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix nomenclature file being loaded multiple times and thus causing an invalid configuration to be loaded and by extension the wrong service name used on spans.

### Motivation
<!-- What inspired you to submit this pull request? -->

The nomenclature file was previously loaded multiple times in some cases because of a bug in `ritm` where it would be loaded once in the plugin manager, and then another time in the tracing plugin. This would result in 2 independent instances of the nomenclature, which could cause issues as one of the instances would never get its `configure` method called, which would ultimately result in the nomenclature not working to retrieve the service name. It's unclear if this only happens for Nest applications or for other types of applications as well.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The underlying issue was not fixed in this PR. Instead, the issue is worked around to ensure that the config is properly received. This is because there seems to be a bigger problem with `ritm` that causes this which would probably require a lot more investigation and potentially a refactor of the plugin system, so this PR focuses instead on fixing the immediate issue.

This is also why there is no test. This is a problem that only happens in edge cases that I was unable to reproduce in a test, and seems to depend on specific configuration of NestJS/Webpack.