### PR TITLE
fix trace sampling rate limit applying to individual rules

### DIFF
--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -266,6 +266,29 @@ describe('PrioritySampler', () => {
       expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_RULE)
     })
 
+    it('should support a global rate limit', () => {
+      prioritySampler = new PrioritySampler('test', {
+        sampleRate: 1,
+        rateLimit: 1,
+        rules: [{
+          service: 'test',
+          sampleRate: 1,
+          rateLimit: 1000
+        }]
+      })
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', USER_KEEP)
+      expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_RULE)
+
+      delete context._sampling.priority
+
+      prioritySampler.sample(context)
+
+      expect(context._sampling).to.have.property('priority', USER_REJECT)
+      expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_RULE)
+    })
+
     it('should support disabling the rate limit', () => {
       prioritySampler = new PrioritySampler('test', {
         sampleRate: 1,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix trace sampling rate limit applying to individual rules instead of globally.

### Motivation
<!-- What inspired you to submit this pull request? -->

The rate limit has always applied globally and not per rule. This was recently changed for span sampling, but it shouldn't also have been changed for trace sampling.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Regression introduced in #3904 