### PR TITLE
fix mongodb instrumentation re-throwing promises

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   aerospike:
     image: aerospike:ce-6.4.0.3
-    ports: 
+    ports:
       - "127.0.0.1:3000-3002:3000-3002"
   couchbase:
     image: ghcr.io/datadog/couchbase-server-sandbox:latest
@@ -38,6 +38,7 @@ services:
       - "127.0.0.1:6379:6379"
   mongo:
     image: circleci/mongo:3.6
+    platform: linux/amd64
     ports:
       - "127.0.0.1:27017:27017"
   oracledb:

--- a/packages/datadog-instrumentations/src/mongodb-core.js
+++ b/packages/datadog-instrumentations/src/mongodb-core.js
@@ -197,7 +197,7 @@ function instrumentPromise (operation, command, ctx, args, server, ns, ops, opti
 
     const promise = command.apply(ctx, args)
 
-    promise.then(function (res) {
+    return promise.then(function (res) {
       finishCh.publish()
       return res
     }, function (err) {
@@ -206,7 +206,5 @@ function instrumentPromise (operation, command, ctx, args, server, ns, ops, opti
 
       return Promise.reject(err)
     })
-
-    return promise
   })
 }

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -62,7 +62,7 @@ describe('Plugin', () => {
           const Server = getServer()
 
           server = new Server({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 27017,
             reconnect: false
           })
@@ -86,7 +86,7 @@ describe('Plugin', () => {
                 expect(span).to.have.property('type', 'mongodb')
                 expect(span.meta).to.have.property('span.kind', 'client')
                 expect(span.meta).to.have.property('db.name', `test.${collection}`)
-                expect(span.meta).to.have.property('out.host', 'localhost')
+                expect(span.meta).to.have.property('out.host', '127.0.0.1')
                 expect(span.meta).to.have.property('component', 'mongodb')
               })
               .then(done)
@@ -360,7 +360,7 @@ describe('Plugin', () => {
           const Server = getServer()
 
           server = new Server({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 27017,
             reconnect: false
           })

--- a/packages/dd-trace/test/setup/services/mongo.js
+++ b/packages/dd-trace/test/setup/services/mongo.js
@@ -9,7 +9,7 @@ function waitForMongo () {
 
     operation.attempt(currentAttempt => {
       const server = new mongo.Server({
-        host: 'localhost',
+        host: '127.0.0.1',
         port: 27017,
         reconnect: false
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix mongodb instrumentation re-throwing promises.

### Motivation
<!-- What inspired you to submit this pull request? -->

Calling `promise.then()` in the way it was done previously had 2 issues:

1) It swallows any errors on the returned promises, since as soon as a promise has been chained, its error is considered handled if a rejection handler was executed.
2) Any chained rejection handler that returns an error without returning the new promise ends up re-throwing globally resulting in an uncaught exception.

Fixes #4154

### Additional Notes

I didn't add a test because I don't know how to cause the issue on purpose.