### PR TITLE
add support for oracledb 6

### DIFF
--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -21,7 +21,7 @@ function finish (err) {
   finishChannel.publish(undefined)
 }
 
-addHook({ name: 'oracledb', versions: ['5'] }, oracledb => {
+addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
   shimmer.wrap(oracledb.Connection.prototype, 'execute', execute => {
     return function wrappedExecute (dbQuery, ...args) {
       if (!startChannel.hasSubscribers) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for oracledb 6.

### Motivation
<!-- What inspired you to submit this pull request? -->

Plugins shouldn't have an upper range.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The main changes in 6.0.0 are internal and don't affect our integration. They also dropped support for Node <14.6 but since our CI jobs run on the latest minor of each major that shouldn't cause any issue either even in v3.x.