### PR TITLE
[ci-visibility] Fix issues with early flake detection in jest

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -1016,6 +1016,71 @@ testFrameworks.forEach(({
             }).catch(done)
           })
         })
+
+        it('handles spaces in test names', (done) => {
+          const envVars = reportingOption === 'agentless'
+            ? getCiVisAgentlessConfig(receiver.port)
+            : getCiVisEvpProxyConfig(receiver.port)
+          if (reportingOption === 'evp proxy') {
+            receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
+          }
+          // Tests from ci-visibility/test/skipped-and-todo-test will be considered new
+          receiver.setKnownTests({
+            [name]: {
+              'ci-visibility/test-early-flake-detection/weird-test-names.js': [
+                'no describe can do stuff',
+                'describe  trailing space '
+              ]
+            }
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.equal(tests.length, 2)
+
+              const resourceNames = tests.map(test => test.resource)
+
+              assert.includeMembers(resourceNames,
+                [
+                  'ci-visibility/test-early-flake-detection/weird-test-names.js.no describe can do stuff',
+                  'ci-visibility/test-early-flake-detection/weird-test-names.js.describe  trailing space '
+                ]
+              )
+
+              const newTests = tests.filter(
+                test => test.meta[TEST_IS_NEW] === 'true'
+              )
+              // no new tests
+              assert.equal(newTests.length, 0)
+            })
+
+          let TESTS_TO_RUN = 'test-early-flake-detection/weird-test-names'
+          if (name === 'mocha') {
+            TESTS_TO_RUN = JSON.stringify([
+              './test-early-flake-detection/weird-test-names.js'
+            ])
+          }
+
+          childProcess = exec(
+            runTestsWithCoverageCommand,
+            {
+              cwd,
+              env: {
+                ...envVars,
+                TESTS_TO_RUN
+              },
+              stdio: 'inherit'
+            }
+          )
+          childProcess.on('exit', () => {
+            eventsPromise.then(() => {
+              done()
+            }).catch(done)
+          })
+        })
       })
     })
 

--- a/integration-tests/ci-visibility/test-early-flake-detection/weird-test-names.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/weird-test-names.js
@@ -1,0 +1,11 @@
+const { expect } = require('chai')
+
+it('no describe can do stuff', () => {
+  expect(1).to.equal(1)
+})
+
+describe('describe ', () => {
+  it('trailing space ', () => {
+    expect(1).to.equal(1)
+  })
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -191,16 +191,12 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 
         if (this.isEarlyFlakeDetectionEnabled) {
           const originalTestName = removeEfdStringFromTestName(testName)
-          console.log(retriedTestsToNumAttempts)
           isNewTest = retriedTestsToNumAttempts.has(originalTestName)
           if (isNewTest) {
             numEfdRetry = retriedTestsToNumAttempts.get(originalTestName)
             retriedTestsToNumAttempts.set(originalTestName, numEfdRetry + 1)
           }
         }
-        const name = removeEfdStringFromTestName(testName)
-        console.log('isnewtest', {name, isNewTest})
-
         asyncResource.runInAsyncScope(() => {
           testStartCh.publish({
             name: removeEfdStringFromTestName(testName),

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -190,6 +190,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           const originalTestName = removeEfdStringFromTestName(testName)
           isNewTest = retriedTestsToNumAttempts.has(originalTestName)
           if (isNewTest) {
+            console.log('is new test test_start', testName)
+            console.log('this.knownTestsForThisSuite', this.knownTestsForThisSuite)
             numEfdRetry = retriedTestsToNumAttempts.get(originalTestName)
             retriedTestsToNumAttempts.set(originalTestName, numEfdRetry + 1)
           }
@@ -211,11 +213,16 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         })
       }
       if (event.name === 'add_test') {
+        if (this.testSuite.includes('ci-search-bar-new-suite.helpers.unit.ts')) {
+          console.log('this.knownTestsForThisSuite for helpers', this.knownTestsForThisSuite)
+        }
         if (this.isEarlyFlakeDetectionEnabled) {
           const testName = this.getTestNameFromAddTestEvent(event, state)
           const isNew = !this.knownTestsForThisSuite?.includes(testName)
           const isSkipped = event.mode === 'todo' || event.mode === 'skip'
           if (isNew && !isSkipped && !retriedTestsToNumAttempts.has(testName)) {
+            console.log('is new test add_test', testName)
+            console.log('this.knownTestsForThisSuite', this.knownTestsForThisSuite)
             retriedTestsToNumAttempts.set(testName, 0)
             for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
               if (this.global.test) {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -156,7 +156,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
     // we use its describe block to get the full name
     getTestNameFromAddTestEvent (event, state) {
       const describeSuffix = getJestTestName(state.currentDescribeBlock)
-      return removeEfdStringFromTestName(`${describeSuffix} ${event.testName}`).trim()
+      return removeEfdStringFromTestName(`${describeSuffix} ${event.testName}`)
     }
 
     async handleTestEvent (event, state) {
@@ -191,12 +191,15 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 
         if (this.isEarlyFlakeDetectionEnabled) {
           const originalTestName = removeEfdStringFromTestName(testName)
+          console.log(retriedTestsToNumAttempts)
           isNewTest = retriedTestsToNumAttempts.has(originalTestName)
           if (isNewTest) {
             numEfdRetry = retriedTestsToNumAttempts.get(originalTestName)
             retriedTestsToNumAttempts.set(originalTestName, numEfdRetry + 1)
           }
         }
+        const name = removeEfdStringFromTestName(testName)
+        console.log('isnewtest', {name, isNewTest})
 
         asyncResource.runInAsyncScope(() => {
           testStartCh.publish({

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -190,8 +190,6 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           const originalTestName = removeEfdStringFromTestName(testName)
           isNewTest = retriedTestsToNumAttempts.has(originalTestName)
           if (isNewTest) {
-            console.log('is new test test_start', `"${originalTestName}"`)
-            console.log('this.knownTestsForThisSuite', this.knownTestsForThisSuite)
             numEfdRetry = retriedTestsToNumAttempts.get(originalTestName)
             retriedTestsToNumAttempts.set(originalTestName, numEfdRetry + 1)
           }
@@ -218,8 +216,6 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           const isNew = !this.knownTestsForThisSuite?.includes(testName)
           const isSkipped = event.mode === 'todo' || event.mode === 'skip'
           if (isNew && !isSkipped && !retriedTestsToNumAttempts.has(testName)) {
-            console.log('is new test add_test', `"${testName}"`)
-            console.log('this.knownTestsForThisSuite', this.knownTestsForThisSuite)
             retriedTestsToNumAttempts.set(testName, 0)
             for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
               if (this.global.test) {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -152,7 +152,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
     // we use its describe block to get the full name
     getTestNameFromAddTestEvent (event, state) {
       const describeSuffix = getJestTestName(state.currentDescribeBlock)
-      return removeEfdStringFromTestName(`${describeSuffix} ${event.testName}`)
+      const fullTestName = describeSuffix ? `${describeSuffix} ${event.testName}` : event.testName
+      return removeEfdStringFromTestName(fullTestName)
     }
 
     async handleTestEvent (event, state) {
@@ -217,7 +218,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           const isNew = !this.knownTestsForThisSuite?.includes(testName)
           const isSkipped = event.mode === 'todo' || event.mode === 'skip'
           if (isNew && !isSkipped && !retriedTestsToNumAttempts.has(testName)) {
-            console.log('is new test test_start', `"${testName}"`)
+            console.log('is new test add_test', `"${testName}"`)
             console.log('this.knownTestsForThisSuite', this.knownTestsForThisSuite)
             retriedTestsToNumAttempts.set(testName, 0)
             for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -190,8 +190,6 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           const originalTestName = removeEfdStringFromTestName(testName)
           isNewTest = retriedTestsToNumAttempts.has(originalTestName)
           if (isNewTest) {
-            console.log('is new test test_start', testName)
-            console.log('this.knownTestsForThisSuite', this.knownTestsForThisSuite)
             numEfdRetry = retriedTestsToNumAttempts.get(originalTestName)
             retriedTestsToNumAttempts.set(originalTestName, numEfdRetry + 1)
           }
@@ -213,16 +211,11 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         })
       }
       if (event.name === 'add_test') {
-        if (this.testSuite.includes('ci-search-bar-new-suite.helpers.unit.ts')) {
-          console.log('this.knownTestsForThisSuite for helpers', this.knownTestsForThisSuite)
-        }
         if (this.isEarlyFlakeDetectionEnabled) {
           const testName = this.getTestNameFromAddTestEvent(event, state)
           const isNew = !this.knownTestsForThisSuite?.includes(testName)
           const isSkipped = event.mode === 'todo' || event.mode === 'skip'
           if (isNew && !isSkipped && !retriedTestsToNumAttempts.has(testName)) {
-            console.log('is new test add_test', testName)
-            console.log('this.knownTestsForThisSuite', this.knownTestsForThisSuite)
             retriedTestsToNumAttempts.set(testName, 0)
             for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
               if (this.global.test) {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -42,7 +42,7 @@ module.exports = class CiPlugin extends Plugin {
       }
       this.tracer._exporter.getLibraryConfiguration(this.testConfiguration, (err, libraryConfig) => {
         if (err) {
-          log.error(`Intelligent Test Runner configuration could not be fetched. ${err.message}`)
+          log.error(`Library configuration could not be fetched. ${err.message}`)
         } else {
           this.libraryConfig = libraryConfig
         }


### PR DESCRIPTION
### What does this PR do?
Remove the `.trim()` in [this line](https://github.com/DataDog/dd-trace-js/pull/4183/files#diff-74a96f6d5ac2137dcdae2e86565193c9f9a46b10276918a309dd19f974da1353L159), since it was buggy. It was there to remove leading empty spaces in the case where the test case had no `describe` clause:
```javascript
`${describeSuffix} ${event.testName}`
```

But this also modifies the test name, in case it includes a trailing empty space: 

```javascript
describe('context', () => {
  test('trailing space ', () => {...})
})
```

Which causes the early flake detection algorithm to fail. 

### Motivation
Fix early flake detection. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

