### PR TITLE
[ci-visibility] Disable EFD is there's an error in known tests request

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -23,6 +23,7 @@ const DEFAULT_SETTINGS = {
 
 const DEFAULT_SUITES_TO_SKIP = []
 const DEFAULT_GIT_UPLOAD_STATUS = 200
+const DEFAULT_KNOWN_TESTS_UPLOAD_STATUS = 200
 const DEFAULT_INFO_RESPONSE = {
   endpoints: ['/evp_proxy/v2']
 }
@@ -35,9 +36,14 @@ let gitUploadStatus = DEFAULT_GIT_UPLOAD_STATUS
 let infoResponse = DEFAULT_INFO_RESPONSE
 let correlationId = DEFAULT_CORRELATION_ID
 let knownTests = DEFAULT_KNOWN_TESTS
+let knownTestsStatusCode = DEFAULT_KNOWN_TESTS_UPLOAD_STATUS
 let waitingTime = 0
 
 class FakeCiVisIntake extends FakeAgent {
+  setKnownTestsResponseCode (statusCode) {
+    knownTestsStatusCode = statusCode
+  }
+
   setKnownTests (newKnownTestsResponse) {
     knownTests = newKnownTestsResponse
   }
@@ -195,7 +201,7 @@ class FakeCiVisIntake extends FakeAgent {
       if (isGzip) {
         res.setHeader('content-encoding', 'gzip')
       }
-      res.status(200).send(isGzip ? zlib.gzipSync(data) : data)
+      res.status(knownTestsStatusCode).send(isGzip ? zlib.gzipSync(data) : data)
       this.emit('message', {
         headers: req.headers,
         url: req.url
@@ -220,6 +226,7 @@ class FakeCiVisIntake extends FakeAgent {
     settings = DEFAULT_SETTINGS
     suitesToSkip = DEFAULT_SUITES_TO_SKIP
     gitUploadStatus = DEFAULT_GIT_UPLOAD_STATUS
+    knownTestsStatusCode = DEFAULT_KNOWN_TESTS_UPLOAD_STATUS
     infoResponse = DEFAULT_INFO_RESPONSE
     this.removeAllListeners()
     if (this.waitingTimeoutId) {

--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -1016,6 +1016,70 @@ testFrameworks.forEach(({
             }).catch(done)
           })
         })
+        it('handles spaces in test names', (done) => {
+          const envVars = reportingOption === 'agentless'
+            ? getCiVisAgentlessConfig(receiver.port)
+            : getCiVisEvpProxyConfig(receiver.port)
+          if (reportingOption === 'evp proxy') {
+            receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
+          }
+          // Tests from ci-visibility/test/skipped-and-todo-test will be considered new
+          receiver.setKnownTests({
+            [name]: {
+              'ci-visibility/test-early-flake-detection/weird-test-names.js': [
+                'no describe can do stuff',
+                'describe  trailing space '
+              ]
+            }
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.equal(tests.length, 2)
+
+              const resourceNames = tests.map(test => test.resource)
+
+              assert.includeMembers(resourceNames,
+                [
+                  'ci-visibility/test-early-flake-detection/weird-test-names.js.no describe can do stuff',
+                  'ci-visibility/test-early-flake-detection/weird-test-names.js.describe  trailing space '
+                ]
+              )
+
+              const newTests = tests.filter(
+                test => test.meta[TEST_IS_NEW] === 'true'
+              )
+              // no new tests
+              assert.equal(newTests.length, 0)
+            })
+
+          let TESTS_TO_RUN = 'test-early-flake-detection/weird-test-names'
+          if (name === 'mocha') {
+            TESTS_TO_RUN = JSON.stringify([
+              './test-early-flake-detection/weird-test-names.js'
+            ])
+          }
+
+          childProcess = exec(
+            runTestsWithCoverageCommand,
+            {
+              cwd,
+              env: {
+                ...envVars,
+                TESTS_TO_RUN
+              },
+              stdio: 'inherit'
+            }
+          )
+          childProcess.on('exit', () => {
+            eventsPromise.then(() => {
+              done()
+            }).catch(done)
+          })
+        })
         it('does not run EFD if the known tests request fails', (done) => {
           const envVars = reportingOption === 'agentless'
             ? getCiVisAgentlessConfig(receiver.port)
@@ -1075,9 +1139,7 @@ testFrameworks.forEach(({
           )
 
           childProcess.on('exit', () => {
-            eventsPromise.then(() => {
-              done()
-            }).catch(done)
+            eventsPromise.then(() => done()).catch(done)
           })
         })
       })

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1097,6 +1097,61 @@ moduleType.forEach(({
           }).catch(done)
         })
       })
+      it('does not run EFD if the known tests request fails', (done) => {
+        receiver.setSettings({
+          itr_enabled: false,
+          code_coverage: false,
+          tests_skipping: false,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD
+            }
+          }
+        })
+
+        receiver.setKnownTestsResponseCode(500)
+        receiver.setKnownTests({})
+
+        const {
+          NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+          ...restEnvVars
+        } = getCiVisEvpProxyConfig(receiver.port)
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED)
+
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            assert.equal(tests.length, 2)
+
+            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+            assert.equal(newTests.length, 0)
+          })
+
+        const specToRun = 'cypress/e2e/spec.cy.js'
+
+        childProcess = exec(
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+          {
+            cwd,
+            env: {
+              ...restEnvVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              SPEC_PATTERN: specToRun
+            },
+            stdio: 'pipe'
+          }
+        )
+
+        childProcess.on('exit', () => {
+          receiverPromise.then(() => {
+            done()
+          }).catch(done)
+        })
+      })
     })
   })
 })

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -292,6 +292,8 @@ function getWrappedStart (start, frameworkVersion) {
       const knownTestsResponse = await knownTestsPromise
       if (!knownTestsResponse.err) {
         knownTests = knownTestsResponse.knownTests
+      } else {
+        isEarlyFlakeDetectionEnabled = false
       }
     }
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -405,6 +405,9 @@ function cliWrapper (cli, jestVersion) {
         const { err, knownTests: receivedKnownTests } = await knownTestsPromise
         if (!err) {
           knownTests = receivedKnownTests
+        } else {
+          // We disable EFD if there has been an error in the known tests request
+          isEarlyFlakeDetectionEnabled = false
         }
       } catch (err) {
         log.error(err)

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -436,7 +436,11 @@ function runnerHook (runnerExport, playwrightVersion) {
       onDone = resolve
     })
     testSessionAsyncResource.runInAsyncScope(() => {
-      testSessionFinishCh.publish({ status: STATUS_TO_TEST_STATUS[sessionStatus], onDone })
+      testSessionFinishCh.publish({
+        status: STATUS_TO_TEST_STATUS[sessionStatus],
+        isEarlyFlakeDetectionEnabled,
+        onDone
+      })
     })
     await flushWait
 

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -36,7 +36,7 @@ const STATUS_TO_TEST_STATUS = {
 let remainingTestsByFile = {}
 let isEarlyFlakeDetectionEnabled = false
 let earlyFlakeDetectionNumRetries = 0
-let knownTests = []
+let knownTests = {}
 let rootDir = ''
 const MINIMUM_SUPPORTED_VERSION_EFD = '1.38.0'
 
@@ -407,6 +407,8 @@ function runnerHook (runnerExport, playwrightVersion) {
         const { err, knownTests: receivedKnownTests } = await knownTestsPromise
         if (!err) {
           knownTests = receivedKnownTests
+        } else {
+          isEarlyFlakeDetectionEnabled = false
         }
       } catch (err) {
         log.error(err)

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -327,6 +327,7 @@ class CypressPlugin {
       )
       if (knownTestsResponse.err) {
         log.error(knownTestsResponse.err)
+        this.isEarlyFlakeDetectionEnabled = false
       } else {
         // We use TEST_FRAMEWORK_NAME for the name of the module
         this.knownTestsByTestSuite = knownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -13,7 +13,8 @@ const {
   TEST_SOURCE_FILE,
   TEST_CONFIGURATION_BROWSER_NAME,
   TEST_IS_NEW,
-  TEST_IS_RETRY
+  TEST_IS_RETRY,
+  TEST_EARLY_FLAKE_IS_ENABLED
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -35,9 +36,13 @@ class PlaywrightPlugin extends CiPlugin {
     this.numFailedTests = 0
     this.numFailedSuites = 0
 
-    this.addSub('ci:playwright:session:finish', ({ status, onDone }) => {
+    this.addSub('ci:playwright:session:finish', ({ status, isEarlyFlakeDetectionEnabled, onDone }) => {
       this.testModuleSpan.setTag(TEST_STATUS, status)
       this.testSessionSpan.setTag(TEST_STATUS, status)
+
+      if (isEarlyFlakeDetectionEnabled) {
+        this.testSessionSpan.setTag(TEST_EARLY_FLAKE_IS_ENABLED, 'true')
+      }
 
       if (this.numFailedSuites > 0) {
         let errorMessage = `Test suites failed: ${this.numFailedSuites}.`

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -123,6 +123,7 @@ module.exports = class CiPlugin extends Plugin {
       this.tracer._exporter.getKnownTests(this.testConfiguration, (err, knownTests) => {
         if (err) {
           log.error(`Known tests could not be fetched. ${err.message}`)
+          this.libraryConfig.isEarlyFlakeDetectionEnabled = false
         }
         onDone({ err, knownTests })
       })


### PR DESCRIPTION
### What does this PR do?
Disable EFD if there's an error in the known tests request.

### Motivation
Make sure we don't assume known tests to be empty if there has been an error in the request (which would result in every test being considered new).

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

