### PR TITLE
Fix iast metrics memory leak

### DIFF
--- a/packages/dd-trace/src/appsec/iast/telemetry/namespaces.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/namespaces.js
@@ -77,11 +77,12 @@ class IastNamespace extends Namespace {
     if (!metric) {
       metric = super[type](name, Array.isArray(tags) ? [...tags] : tags)
 
-      if (metrics.size < this.maxMetricTagsSize) {
-        metrics.set(tags, metric)
-      } else {
-        iastLog.debug(`Tags cache max size reached for metric ${name}`)
+      if (metrics.size === this.maxMetricTagsSize) {
+        metrics.clear()
+        iastLog.warnAndPublish(`Tags cache max size reached for metric ${name}`)
       }
+
+      metrics.set(tags, metric)
     }
 
     return metric

--- a/packages/dd-trace/src/appsec/iast/telemetry/namespaces.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/namespaces.js
@@ -44,7 +44,7 @@ function merge (metrics) {
     const { metric: metricName, type, tags, points } = metric
 
     if (points?.length && type === 'count') {
-      const gMetric = globalNamespace.count(metricName, getTagsObject(tags))
+      const gMetric = globalNamespace.getNamespaceMetric(metricName, getTagsObject(tags))
       points.forEach(point => gMetric.inc(point[1]))
     }
   })
@@ -73,12 +73,16 @@ class IastNamespace extends Namespace {
     return metrics
   }
 
+  getNamespaceMetric (name, tags, type = 'count') {
+    return super[type](name, tags)
+  }
+
   getMetric (name, tags, type = 'count') {
     const metrics = this.getIastMetrics(name)
 
     let metric = metrics.get(tags)
     if (!metric) {
-      metric = super[type](name, Array.isArray(tags) ? [...tags] : tags)
+      metric = this.getNamespaceMetric(name, Array.isArray(tags) ? [...tags] : tags, type)
       metrics.set(tags, metric)
     }
 

--- a/packages/dd-trace/src/appsec/iast/telemetry/span-tags.js
+++ b/packages/dd-trace/src/appsec/iast/telemetry/span-tags.js
@@ -40,7 +40,7 @@ function taggedMetricName (data) {
 }
 
 function filterTags (tags) {
-  return tags?.filter(tag => !tag.startsWith('lib_language') && !tag.startsWith('version'))
+  return tags?.filter(tag => !tag.startsWith('version'))
 }
 
 function processTagValue (tags) {

--- a/packages/dd-trace/test/appsec/iast/telemetry/namespaces.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/namespaces.spec.js
@@ -211,5 +211,18 @@ describe('IastNamespace', () => {
       expect(metric2).to.be.eq(metric)
       expect(metric2.points[0][1]).to.be.eq(42)
     })
+
+    it('should not cache more than max tags for same metric', () => {
+      const namespace = new IastNamespace(1)
+
+      namespace.getMetric('metric.name', ['key:tag1'])
+
+      namespace.getMetric('metric.name', ['key:tag2'])
+
+      namespace.getMetric('metric.name', ['key:tag3'])
+
+      expect(namespace.iastMetrics.size).to.be.eq(1)
+      expect(namespace.iastMetrics.get('metric.name').size).to.be.eq(1)
+    })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/telemetry/namespaces.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/namespaces.spec.js
@@ -47,7 +47,7 @@ describe('IAST metric namespaces', () => {
 
     const tag = rootSpan.addTags.getCalls()[0].args[0]
     expect(tag).to.has.property(`${TAG_PREFIX}.${REQUEST_TAINTED}`)
-    expect(tag[`${TAG_PREFIX}.${REQUEST_TAINTED}`]).to.be.eq(10)
+    expect(tag[`${TAG_PREFIX}.${REQUEST_TAINTED}`]).to.be.equal(10)
 
     expect(context[DD_IAST_METRICS_NAMESPACE]).to.be.undefined
   })
@@ -64,11 +64,11 @@ describe('IAST metric namespaces', () => {
     const calls = rootSpan.addTags.getCalls()
     const reqTaintedTag = calls[0].args[0]
     expect(reqTaintedTag).to.has.property(`${TAG_PREFIX}.${REQUEST_TAINTED}`)
-    expect(reqTaintedTag[`${TAG_PREFIX}.${REQUEST_TAINTED}`]).to.be.eq(15)
+    expect(reqTaintedTag[`${TAG_PREFIX}.${REQUEST_TAINTED}`]).to.be.equal(15)
 
     const execSinkTag = calls[1].args[0]
     expect(execSinkTag).to.has.property(`${TAG_PREFIX}.${EXECUTED_SINK}`)
-    expect(execSinkTag[`${TAG_PREFIX}.${EXECUTED_SINK}`]).to.be.eq(1)
+    expect(execSinkTag[`${TAG_PREFIX}.${EXECUTED_SINK}`]).to.be.equal(1)
   })
 
   it('should merge all kind of metrics in global Namespace as gauges', () => {
@@ -104,7 +104,7 @@ describe('IAST metric namespaces', () => {
 
     finalizeRequestNamespace(context3)
 
-    expect(globalNamespace.iastMetrics.size).to.be.eq(1)
+    expect(globalNamespace.iastMetrics.size).to.be.equal(1)
   })
 
   it('should clear metric and distribution collections and iast metrics cache', () => {
@@ -113,9 +113,9 @@ describe('IAST metric namespaces', () => {
 
     finalizeRequestNamespace(context)
 
-    expect(namespace.iastMetrics.size).to.be.eq(0)
-    expect(namespace.metrics.size).to.be.eq(0)
-    expect(namespace.distributions.size).to.be.eq(0)
+    expect(namespace.iastMetrics.size).to.be.equal(0)
+    expect(namespace.metrics.size).to.be.equal(0)
+    expect(namespace.distributions.size).to.be.equal(0)
   })
 })
 
@@ -133,7 +133,7 @@ describe('IastNamespace', () => {
     it('should reuse the same map if created before', () => {
       const namespace = new IastNamespace()
 
-      expect(namespace.getIastMetrics('metric.name')).to.be.eq(namespace.getIastMetrics('metric.name'))
+      expect(namespace.getIastMetrics('metric.name')).to.be.equal(namespace.getIastMetrics('metric.name'))
     })
   })
 
@@ -146,10 +146,10 @@ describe('IastNamespace', () => {
       const metric = namespace.getMetric('metric.name', ['key:tag1'])
 
       expect(metric).to.not.be.undefined
-      expect(metric.metric).to.be.eq('metric.name')
-      expect(metric.namespace).to.be.eq('iast')
-      expect(metric.type).to.be.eq('count')
-      expect(metric.tags).to.be.deep.eq(['key:tag1', `version:${process.version}`])
+      expect(metric.metric).to.be.equal('metric.name')
+      expect(metric.namespace).to.be.equal('iast')
+      expect(metric.type).to.be.equal('count')
+      expect(metric.tags).to.be.deep.equal(['key:tag1', `version:${process.version}`])
     })
 
     it('should register a new count type metric and store it in the map supporting non array tags', () => {
@@ -158,10 +158,10 @@ describe('IastNamespace', () => {
       const metric = namespace.getMetric('metric.name', { key: 'tag1' })
 
       expect(metric).to.not.be.undefined
-      expect(metric.metric).to.be.eq('metric.name')
-      expect(metric.namespace).to.be.eq('iast')
-      expect(metric.type).to.be.eq('count')
-      expect(metric.tags).to.be.deep.eq(['key:tag1', `version:${process.version}`])
+      expect(metric.metric).to.be.equal('metric.name')
+      expect(metric.namespace).to.be.equal('iast')
+      expect(metric.type).to.be.equal('count')
+      expect(metric.tags).to.be.deep.equal(['key:tag1', `version:${process.version}`])
     })
 
     it('should register a new distribution type metric and store it in the map', () => {
@@ -170,10 +170,10 @@ describe('IastNamespace', () => {
       const metric = namespace.getMetric('metric.name', ['key:tag1'], 'distribution')
 
       expect(metric).to.not.be.undefined
-      expect(metric.metric).to.be.eq('metric.name')
-      expect(metric.namespace).to.be.eq('iast')
-      expect(metric.type).to.be.eq('distribution')
-      expect(metric.tags).to.be.deep.eq(['key:tag1', `version:${process.version}`])
+      expect(metric.metric).to.be.equal('metric.name')
+      expect(metric.namespace).to.be.equal('iast')
+      expect(metric.type).to.be.equal('distribution')
+      expect(metric.tags).to.be.deep.equal(['key:tag1', `version:${process.version}`])
     })
 
     it('should not add the version tags to the tags array', () => {
@@ -182,8 +182,8 @@ describe('IastNamespace', () => {
       const tags = ['key:tag1']
       const metric = namespace.getMetric('metric.name', tags)
 
-      expect(tags).to.be.deep.eq(['key:tag1'])
-      expect(metric.tags).to.be.deep.eq(['key:tag1', `version:${process.version}`])
+      expect(tags).to.be.deep.equal(['key:tag1'])
+      expect(metric.tags).to.be.deep.equal(['key:tag1', `version:${process.version}`])
     })
 
     it('should not create a previously created metric', () => {
@@ -208,8 +208,8 @@ describe('IastNamespace', () => {
 
       const metric2 = namespace.getMetric('metric.name', ['key:tag1'])
 
-      expect(metric2).to.be.eq(metric)
-      expect(metric2.points[0][1]).to.be.eq(42)
+      expect(metric2).to.be.equal(metric)
+      expect(metric2.points[0][1]).to.be.equal(42)
     })
 
     it('should not cache more than max tags for same metric', () => {
@@ -221,8 +221,8 @@ describe('IastNamespace', () => {
 
       namespace.getMetric('metric.name', ['key:tag3'])
 
-      expect(namespace.iastMetrics.size).to.be.eq(1)
-      expect(namespace.iastMetrics.get('metric.name').size).to.be.eq(1)
+      expect(namespace.iastMetrics.size).to.be.equal(1)
+      expect(namespace.iastMetrics.get('metric.name').size).to.be.equal(1)
     })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/telemetry/namespaces.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/namespaces.spec.js
@@ -77,16 +77,16 @@ describe('IAST metric namespaces', () => {
     const metric = {
       inc: sinon.spy()
     }
-    sinon.stub(globalNamespace, 'getNamespaceMetric').returns(metric)
+    sinon.stub(globalNamespace, 'getNoCacheMetric').returns(metric)
 
     finalizeRequestNamespace(context, rootSpan)
 
-    expect(globalNamespace.getNamespaceMetric).to.be.calledTwice
-    expect(globalNamespace.getNamespaceMetric.firstCall.args).to.be.deep.equal([REQUEST_TAINTED, ['tag1:test']])
+    expect(globalNamespace.getNoCacheMetric).to.be.calledTwice
+    expect(globalNamespace.getNoCacheMetric.firstCall.args).to.be.deep.equal([REQUEST_TAINTED, ['tag1:test']])
     expect(metric.inc).to.be.calledTwice
     expect(metric.inc.firstCall.args[0]).to.equal(10)
 
-    expect(globalNamespace.getNamespaceMetric.secondCall.args).to.be.deep.equal([EXECUTED_SINK, []])
+    expect(globalNamespace.getNoCacheMetric.secondCall.args).to.be.deep.equal([EXECUTED_SINK, []])
     expect(metric.inc.secondCall.args[0]).to.equal(1)
   })
 
@@ -117,7 +117,7 @@ describe('IastNamespace', () => {
       const metrics = namespace.getIastMetrics('metric.name')
 
       expect(metrics).to.not.undefined
-      expect(metrics instanceof Map).to.be.true
+      expect(metrics instanceof WeakMap).to.be.true
     })
 
     it('should reuse the same map if created before', () => {
@@ -182,10 +182,11 @@ describe('IastNamespace', () => {
       const metric = {}
       const count = sinon.stub(Namespace.prototype, 'count').returns(metric)
 
-      namespace.getMetric('metric.name', 'key:tag1')
-      namespace.getMetric('metric.name', 'key:tag1')
+      const tags = ['key:tag1']
+      namespace.getMetric('metric.name', tags)
+      namespace.getMetric('metric.name', tags)
 
-      expect(count).to.be.calledOnceWith('metric.name', 'key:tag1')
+      expect(count).to.be.calledOnceWith('metric.name', tags)
     })
 
     it('should reuse a previously created metric', () => {


### PR DESCRIPTION
### What does this PR do?
Do not invoke `globalNamespace.count` when merging request metrics.

There are two kind of metrics collected by the iast: global and request metrics. In both cases `IastNamespace` is used.

`IastNamespace` overrides `Namespace.count` to cache metrics and uses the metric tags as the cache key. 
When finalizing the request, stored request metrics are merged into `globalNamespace` in order to be sent via telemetry.
And as `globalNamespace` never has a request metric cached it stores the metric automatically causing a leak.

### Motivation
Fix iast metrics memory leak introduced in #4017 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

