### PR TITLE
Reduce object iterations in NoSQL vulnerabilities

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
@@ -12,7 +12,7 @@ const { HTTP_REQUEST_PARAMETER, HTTP_REQUEST_BODY } = require('../taint-tracking
 const EXCLUDED_PATHS_FROM_STACK = getNodeModulesPaths('mongodb', 'mongoose', 'mquery')
 const MONGODB_NOSQL_SECURE_MARK = getNextSecureMark()
 
-function iterateObjectStrings (target, fn, levelKeys = [], depth = 50, visited = new Set()) {
+function iterateObjectStrings (target, fn, levelKeys = [], depth = 20, visited = new Set()) {
   if (target && typeof target === 'object') {
     Object.keys(target).forEach((key) => {
       const nextLevelKeys = [...levelKeys, key]

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -13,15 +13,18 @@ const KEYS_REGEX_WITHOUT_SENSITIVE_RANGES = new RegExp(`"(${STRINGIFY_RANGE_KEY}
 
 const sensitiveValueRegex = new RegExp(DEFAULT_IAST_REDACTION_VALUE_PATTERN, 'gmi')
 
-function iterateObject (target, fn, levelKeys = [], depth = 50) {
+function iterateObject (target, fn, levelKeys = [], depth = 10, visited = new Set()) {
   Object.keys(target).forEach((key) => {
     const nextLevelKeys = [...levelKeys, key]
     const val = target[key]
 
-    fn(val, nextLevelKeys, target, key)
+    if (typeof val !== 'object' || !visited.has(val)) {
+      visited.add(val)
+      fn(val, nextLevelKeys, target, key)
 
-    if (val !== null && typeof val === 'object' && depth > 0) {
-      iterateObject(val, fn, nextLevelKeys, depth - 1)
+      if (val !== null && typeof val === 'object' && depth > 0) {
+        iterateObject(val, fn, nextLevelKeys, depth - 1, visited)
+      }
     }
   })
 }

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
@@ -133,11 +133,11 @@ describe('test vulnerabiilty-formatter utils', () => {
         const deepObject = [...Array(100).keys()]
           .reduce((obj) => ({ key: 'value', obj: obj || {} }), null)
 
-        const expectedObject = [...Array(50).keys()]
+        const expectedObject = [...Array(10).keys()]
           .reduce((obj) => ({ key: 'value', obj: obj || {} }), null)
 
         const iinfo = { type: 'TEST' }
-        const deepestKey = '0'.concat('.obj'.repeat(49)).concat('.key')
+        const deepestKey = '0'.concat('.obj'.repeat(9)).concat('.key')
         const objRanges = {
           [deepestKey]: [{ start: 0, end: 5, iinfo }]
         }
@@ -147,7 +147,7 @@ describe('test vulnerabiilty-formatter utils', () => {
         expect(value).to.be.equal(JSON.stringify([expectedObject], null, 2))
 
         expect(ranges).to.be.deep.equal([
-          { start: 6437, end: 6442, iinfo }
+          { start: 477, end: 482, iinfo }
         ])
       })
 
@@ -155,8 +155,7 @@ describe('test vulnerabiilty-formatter utils', () => {
         const circularObject = { key: 'value' }
         circularObject.obj = circularObject
 
-        const expectedObject = [...Array(50).keys()]
-          .reduce((obj) => ({ key: 'value', obj: obj || {} }), null)
+        const expectedObject = [{ key: 'value' }]
 
         const iinfo = { type: 'TEST' }
         const objRanges = {
@@ -165,7 +164,7 @@ describe('test vulnerabiilty-formatter utils', () => {
 
         const { value, ranges } = stringifyWithRanges([circularObject], objRanges)
 
-        expect(value).to.be.equal(JSON.stringify([expectedObject], null, 2))
+        expect(value).to.be.equal(JSON.stringify(expectedObject, null, 2))
 
         expect(ranges).to.be.deep.equal([
           { start: 18, end: 23, iinfo }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
When we format a mongodb injection vulnerability: 
- Reduce the depth from 50 to 10: Vulnerability is always in the first levels, we don't need to go too deep to send the vulnerability to backend.
- Prevent circular references: Ignore circular references when we are creating the vulnerability to save time and memory.

### Motivation
<!-- What inspired you to submit this pull request? -->
Improve memory footprint detected in some customers in this method.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

