### PR TITLE
fix apollo request context error in some cases

### DIFF
--- a/packages/datadog-plugin-apollo/src/gateway/request.js
+++ b/packages/datadog-plugin-apollo/src/gateway/request.js
@@ -14,17 +14,6 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
     return 'tracing:apm:apollo:gateway:request'
   }
 
-  constructor (...args) {
-    super(...args)
-    this.addSub('apm:apollo:gateway:request:executor', (ctx) => {
-      if (ctx.requestContext || ctx.gateway) {
-        this.requestContext = ctx
-      } else {
-        this.requestContext = {}
-      }
-    })
-  }
-
   bindStart (ctx) {
     const store = storage.getStore()
     const childOf = store ? store.span : null
@@ -37,7 +26,7 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
       meta: {}
     }
 
-    const { requestContext, gateway } = this.requestContext
+    const { requestContext, gateway } = ctx
 
     if (requestContext?.operationName) {
       spanData.meta['graphql.operation.name'] = requestContext.operationName
@@ -75,10 +64,6 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
     }
     ctx.currentStore.span.finish()
     return ctx.parentStore
-  }
-
-  end () {
-    // do nothing to avoid ApolloBasePlugin's end method
   }
 }
 

--- a/packages/datadog-plugin-apollo/src/gateway/validate.js
+++ b/packages/datadog-plugin-apollo/src/gateway/validate.js
@@ -10,11 +10,15 @@ class ApolloGatewayValidatePlugin extends ApolloBasePlugin {
 
   end (ctx) {
     const result = ctx.result
+    const span = ctx.currentStore?.span
+
+    if (!span) return
+
     if (result instanceof Array &&
       result[result.length - 1] && result[result.length - 1].stack && result[result.length - 1].message) {
-      ctx.currentStore.span.setTag('error', result[result.length - 1])
+      span.setTag('error', result[result.length - 1])
     }
-    ctx.currentStore.span.finish()
+    span.finish()
   }
 }
 

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -25,8 +25,9 @@ class ApolloBasePlugin extends TracingPlugin {
   }
 
   end (ctx) {
+    // Only synchronous operations would have `result` or `error` on `end`.
     if (!ctx.hasOwnProperty('result') && !ctx.hasOwnProperty('error')) return
-    ctx?.currentStore?.span.finish()
+    ctx?.currentStore?.span?.finish()
   }
 
   asyncStart (ctx) {

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -25,6 +25,7 @@ class ApolloBasePlugin extends TracingPlugin {
   }
 
   end (ctx) {
+    if (!ctx.hasOwnProperty('result') && !ctx.hasOwnProperty('error')) return
     ctx?.currentStore?.span.finish()
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix apollo request context error in some cases. I also refactored the integration to not store the requestContext on the plugin and instead rely on the context on the store, and made the `end` handler generic.

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases, the executor can run in a way that doesn't seem to always go through the instrumentation. This makes `requestContext` unavailable to child handlers which resulted in errors. There might be an underlying problem that causes the request instrumentation to never run in which case that problem would still exist, but at least with this PR it will no longer crash.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

No test because I don't know how to reproduce this.