### PR TITLE
[ci-visibility] Early flake detection for jest: ignore retry failures

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -1149,12 +1149,9 @@ testFrameworks.forEach(({
           if (reportingOption === 'evp proxy') {
             receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
           }
-          // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
-          receiver.setKnownTests({
-            [name]: {
-              'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests']
-            }
-          })
+          // Tests from ci-visibility/test/occasionally-failing-test will be considered new
+          receiver.setKnownTests({})
+
           const NUM_RETRIES_EFD = 3
           receiver.setSettings({
             itr_enabled: false,
@@ -1167,6 +1164,34 @@ testFrameworks.forEach(({
               }
             }
           })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_IS_ENABLED, 'true')
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              // all but one has been retried
+              assert.equal(
+                tests.length - 1,
+                retriedTests.length
+              )
+              assert.equal(retriedTests.length, NUM_RETRIES_EFD)
+              // Out of NUM_RETRIES_EFD + 1 total runs, half will be passing and half will be failing,
+              // based on the global counter in the test file
+              const passingTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
+              const failingTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+              assert.equal(passingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+              assert.equal(failingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+              // Test name does not change
+              retriedTests.forEach(test => {
+                assert.equal(test.meta[TEST_NAME], 'fail occasionally fails')
+              })
+            })
 
           const command = name === 'jest'
             ? 'node ./node_modules/jest/bin/jest --config config-jest.js'
@@ -1199,7 +1224,9 @@ testFrameworks.forEach(({
               assert.include(testOutput, '2 failing')
             }
             assert.equal(exitCode, 0)
-            done()
+            eventsPromise.then(() => {
+              done()
+            }).catch(done)
           })
         })
       })

--- a/integration-tests/config-jest.js
+++ b/integration-tests/config-jest.js
@@ -3,6 +3,6 @@ module.exports = {
   testPathIgnorePatterns: ['/node_modules/'],
   cache: false,
   testMatch: [
-    '**/ci-visibility/test/ci-visibility-test*'
+    process.env.TESTS_TO_RUN || '**/ci-visibility/test/ci-visibility-test*'
   ]
 }

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -102,7 +102,6 @@ function getTestEnvironmentOptions (config) {
   return {}
 }
 
-// As long as one of the retries has passed, we will consider it passed
 function getEfdStats (testStatuses) {
   return testStatuses.reduce((acc, testStatus) => {
     acc[testStatus]++

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -73,6 +73,7 @@ const specStatusToTestStatus = {
 const asyncResources = new WeakMap()
 const originalTestFns = new WeakMap()
 const retriedTestsToNumAttempts = new Map()
+const newTestsTestStatuses = new Map()
 
 // based on https://github.com/facebook/jest/blob/main/packages/jest-circus/src/formatNodeAssertErrors.ts#L41
 function formatJestError (errors) {
@@ -99,6 +100,14 @@ function getTestEnvironmentOptions (config) {
     return config.testEnvironmentOptions
   }
   return {}
+}
+
+// As long as one of the retries has passed, we will consider it passed
+function getEfdStats (testStatuses) {
+  return testStatuses.reduce((acc, testStatus) => {
+    acc[testStatus]++
+    return acc
+  }, { pass: 0, fail: 0 })
 }
 
 function getWrappedEnvironment (BaseEnvironment, jestVersion) {
@@ -242,6 +251,19 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           })
           // restore in case it is retried
           event.test.fn = originalTestFns.get(event.test)
+          // We'll store the test statuses of the retries
+          if (this.isEarlyFlakeDetectionEnabled) {
+            const testName = getJestTestName(event.test)
+            const originalTestName = removeEfdStringFromTestName(testName)
+            const isNewTest = retriedTestsToNumAttempts.has(originalTestName)
+            if (isNewTest) {
+              if (newTestsTestStatuses.has(originalTestName)) {
+                newTestsTestStatuses.get(originalTestName).push(status)
+              } else {
+                newTestsTestStatuses.set(originalTestName, [status])
+              }
+            }
+          }
         })
       }
       if (event.name === 'test_skip' || event.name === 'test_todo') {
@@ -507,6 +529,28 @@ function cliWrapper (cli, jestVersion) {
     }
 
     numSkippedSuites = 0
+
+    /**
+     * If Early Flake Detection (EFD) is enabled the logic is as follows:
+     * - If all attempts for a test are failing, the test has failed and we will let the test process fail.
+     * - If just a single attempt passes, we will prevent the test process from failing.
+     * The rationale behind is the following: you may still be able to block your CI pipeline by gating
+     * on flakiness (the test will be considered flaky), but you may choose to unblock the pipeline too.
+     */
+
+    if (isEarlyFlakeDetectionEnabled) {
+      let numFailedTestsToIgnore = 0
+      for (const testStatuses of newTestsTestStatuses.values()) {
+        const { pass, fail } = getEfdStats(testStatuses)
+        if (pass > 0) { // as long as one passes, we'll consider the test passed
+          numFailedTestsToIgnore += fail
+        }
+      }
+      // If every test that failed was an EFD retry, we'll consider the suite passed
+      if (numFailedTestsToIgnore !== 0 && result.results.numFailedTests === numFailedTestsToIgnore) {
+        result.results.success = true
+      }
+    }
 
     return result
   })


### PR DESCRIPTION
### What does this PR do?
Whenever one of the attempts passes in an "early flake detected" new test we'll ignore errors.

### Motivation
This was missing from jest in EFD.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

