### PR TITLE
Reduce need for async functions in profiler integration tests

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -29,8 +29,7 @@ async function checkProfiles (agent, proc, timeout,
     }
   }, timeout, multiplicity)
 
-  await processExitPromise(proc, timeout, expectBadExit)
-  return resultPromise
+  await Promise.all([processExitPromise(proc, timeout, expectBadExit), resultPromise])
 }
 
 function processExitPromise (proc, timeout, expectBadExit = false) {

--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -15,7 +15,7 @@ const zlib = require('zlib')
 const { Profile } = require('pprof-format')
 const semver = require('semver')
 
-async function checkProfiles (agent, proc, timeout,
+function checkProfiles (agent, proc, timeout,
   expectedProfileTypes = ['wall', 'space'], expectBadExit = false, multiplicity = 1) {
   const fileNames = expectedProfileTypes.map(type => `${type}.pprof`)
   const resultPromise = agent.assertMessageReceived(({ headers, payload, files }) => {
@@ -29,7 +29,7 @@ async function checkProfiles (agent, proc, timeout,
     }
   }, timeout, multiplicity)
 
-  await Promise.all([processExitPromise(proc, timeout, expectBadExit), resultPromise])
+  return Promise.all([processExitPromise(proc, timeout, expectBadExit), resultPromise])
 }
 
 function processExitPromise (proc, timeout, expectBadExit = false) {
@@ -342,7 +342,7 @@ describe('profiler', () => {
       await agent.stop()
     })
 
-    it('records profile on process exit', async () => {
+    it('records profile on process exit', () => {
       proc = fork(profilerTestFile, {
         cwd,
         env: {
@@ -354,7 +354,7 @@ describe('profiler', () => {
     })
 
     if (process.platform !== 'win32') { // PROF-8905
-      it('sends a heap profile on OOM with external process', async () => {
+      it('sends a heap profile on OOM with external process', () => {
         proc = fork(oomTestFile, {
           cwd,
           execArgv: oomExecArgv,
@@ -363,7 +363,7 @@ describe('profiler', () => {
         return checkProfiles(agent, proc, timeout, ['space'], true)
       })
 
-      it('sends a heap profile on OOM with external process and exits successfully', async () => {
+      it('sends a heap profile on OOM with external process and exits successfully', () => {
         proc = fork(oomTestFile, {
           cwd,
           execArgv: oomExecArgv,
@@ -376,7 +376,7 @@ describe('profiler', () => {
         return checkProfiles(agent, proc, timeout, ['space'], false, 2)
       })
 
-      it('sends a heap profile on OOM with async callback', async () => {
+      it('sends a heap profile on OOM with async callback', () => {
         proc = fork(oomTestFile, {
           cwd,
           execArgv: oomExecArgv,
@@ -390,7 +390,7 @@ describe('profiler', () => {
         return checkProfiles(agent, proc, timeout, ['space'], true)
       })
 
-      it('sends heap profiles on OOM with multiple strategies', async () => {
+      it('sends heap profiles on OOM with multiple strategies', () => {
         proc = fork(oomTestFile, {
           cwd,
           execArgv: oomExecArgv,
@@ -404,7 +404,7 @@ describe('profiler', () => {
         return checkProfiles(agent, proc, timeout, ['space'], true, 2)
       })
 
-      it('sends a heap profile on OOM in worker thread and exits successfully', async () => {
+      it('sends a heap profile on OOM in worker thread and exits successfully', () => {
         proc = fork(oomTestFile, [1, 50], {
           cwd,
           env: { ...oomEnv, DD_PROFILING_WALLTIME_ENABLED: 0 }


### PR DESCRIPTION
### What does this PR do?
Improves profiler integration tests to return promises and avoid the need for many `async` keywords. Promises returned from tests will be awaited by the test framework.

### Motivation
Cleaner implementation.

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
