### PR TITLE
Improve weak hash detection accuracy for aws-sdk, keygrip, cookie-signature and google-gax

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
@@ -20,11 +20,15 @@ const EXCLUDED_LOCATIONS = getNodeModulesPaths(
   'pusher/lib/utils.js',
   'redlock/dist/cjs',
   'sqreen/lib/package-reader/index.js',
-  'ws/lib/websocket-server.js'
+  'ws/lib/websocket-server.js',
+  'google-gax/build/src/grpc.js',
+  'cookie-signature/index.js'
 )
 
 const EXCLUDED_PATHS_FROM_STACK = [
-  path.join('node_modules', 'object-hash', path.sep)
+  path.join('node_modules', 'object-hash', path.sep),
+  path.join('node_modules', 'aws-sdk', 'lib', 'util.js'),
+  path.join('node_modules', 'keygrip', path.sep)
 ]
 class WeakHashAnalyzer extends Analyzer {
   constructor () {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Ignore weak hash vulnerabilities to detected in cookie-signature and google-gax, as they are safe, and it's generating noise with false positives.
- Exclude `aws-sdk/lib/util.js` and `keygrip` from stack when the vulnerability is detected, as they are intermediate methods and the vulnerability should be in the method which is calling then.