### PR TITLE
Replace `docker-compose` by `docker compose` in github actions

### DIFF
--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -12,7 +12,7 @@ runs:
         if [ -n "${{inputs.container-id}}" ]; then
           docker logs ${{inputs.container-id}}
         else
-          docker-compose logs testagent
+          docker compose logs testagent
         fi
       shell: bash
     - name: Get Tested Integrations from Test Agent

--- a/.github/actions/testagent/start/action.yml
+++ b/.github/actions/testagent/start/action.yml
@@ -4,5 +4,5 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-    - run: docker-compose up -d testagent
+    - run: docker compose up -d testagent
       shell: bash


### PR DESCRIPTION
### What does this PR do?
It's called `docker compose` now
