### PR TITLE
ASEC-131:Remove reference to SDG as the team no longer exists

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,10 +23,5 @@
 ### Additional Notes
 <!-- Anything else we should know when reviewing? -->
 
-### Security 
-Datadog employees:
-- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
-- [ ] This PR doesn't touch any of that.
-
 Unsure? Have a question? Request a review!
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,5 +23,4 @@
 ### Additional Notes
 <!-- Anything else we should know when reviewing? -->
 
-Unsure? Have a question? Request a review!
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removing reference of Security Design and Guidance team in PR review template as the team no longer exists. We will work with the trace team to understand the requirements of review.
