### PR TITLE
Update codeowners to include some more ci-visibility specific paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,10 @@
 /packages/datadog-plugin-cucumber/ @DataDog/ci-app-libraries
 /packages/datadog-plugin-cypress/ @DataDog/ci-app-libraries
 /packages/datadog-plugin-playwright/ @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/git.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/ci-visibility/ @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/git.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/ci-env/ @DataDog/ci-app-libraries
 
 /packages/datadog-instrumentations/src/jest.js @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/mocha.js @DataDog/ci-app-libraries


### PR DESCRIPTION
### What does this PR do?
Update `CODEOWNERS`

### Motivation
Assign correct owners to files

