### PR TITLE
fix: clean /datadog-lib/node_modules before copying

### DIFF
--- a/lib-injection/copy-lib.sh
+++ b/lib-injection/copy-lib.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
+# Clean node_modules before writing in case we've been restarted
+rm -rf "$1/node_modules"
 cp -r node_modules "$1/node_modules"
 ls "$1"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Cleans the /datadog-lib/node_modules dir before it copies node_modules into it. 

### Motivation
<!-- What inspired you to submit this pull request? -->

We believe we found a bug in the copy-lib script where it isn't idempotent. This can happen when the init container running the script fails, in our case running OOM, and when re-ran copies the dir one layer too deep due to the node_modules dir already existing.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

There may be better ways to do this, but we just wanted to illustrate the bug.

If you'd like to reproduce this, run the below command twice, and you'll get a node_module dir within your node_module dir

`docker run -v ./test:/datadog-lib --rm --entrypoint "/bin/sh" gcr.io/datadoghq/dd-lib-js-init:v5.6.0 copy-lib.sh /datadog-lib`

Also note if the first invocation were to fail, the outer node_modules dir would be incomplete

### Security 
Datadog employees:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

