### PR TITLE
PR to address APMS-11815

### DIFF
--- a/lib-injection/copy-lib.sh
+++ b/lib-injection/copy-lib.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-cp -r node_modules "$1/node_modules"
+
+mkdir -p "$1/node_modules"
+cp -r node_modules/* "$1/node_modules/"
 ls "$1"


### PR DESCRIPTION
### What does this PR do?
Avoids creating `node_modules` subdirectory under `node_modules` possibly due to race condition

### Motivation
[APMS-11815](https://datadoghq.atlassian.net/browse/APMS-11815)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->




[APMS-11815]: https://datadoghq.atlassian.net/browse/APMS-11815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ