### PR TITLE
Fix Counter.dec in telemetry

### DIFF
--- a/packages/dd-trace/src/telemetry/metrics.js
+++ b/packages/dd-trace/src/telemetry/metrics.js
@@ -75,8 +75,8 @@ class CountMetric extends Metric {
     return this.track(value)
   }
 
-  dec (value = -1) {
-    return this.track(value)
+  dec (value = 1) {
+    return this.track(-value)
   }
 
   track (value = 1) {

--- a/packages/dd-trace/test/telemetry/metrics.spec.js
+++ b/packages/dd-trace/test/telemetry/metrics.spec.js
@@ -345,6 +345,23 @@ describe('metrics', () => {
       ])
     })
 
+    it('should decrement with explicit arg', () => {
+      const ns = new metrics.Namespace('tracers')
+      const metric = ns.count('name')
+
+      metric.inc(3)
+
+      metric.track = sinon.spy(metric.track)
+
+      metric.dec(2)
+
+      expect(metric.track).to.be.calledWith(-2)
+
+      expect(metric.points).to.deep.equal([
+        [now / 1e3, 1]
+      ])
+    })
+
     it('should retain timestamp of first change', () => {
       const ns = new metrics.Namespace('tracers')
       const metric = ns.count('name')


### PR DESCRIPTION
### What does this PR do?
Fixes `Counter.dec`. 

### Motivation
The implementation was broken. It worked the same way as increment when passed an explicit argument and only worked correctly when used without an argument.
