### PR TITLE
Avoid run sequelize plugin test with non compatible mysql2

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -12,7 +12,7 @@ const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability
 
 describe('sql-injection-analyzer with sequelize', () => {
   withVersions('sequelize', 'sequelize', sequelizeVersion => {
-    const sequelizeSpecificVersion = require(`../../../../versions/sequelize@${sequelizeVersion}`).version()
+    const sequelizeSpecificVersion = require(`../../../../../../versions/sequelize@${sequelizeVersion}`).version()
     const compatibleMysql2VersionRange = semver.satisfies(sequelizeSpecificVersion, '>4') ? '>=1' : '>=1 <3.9.4'
     withVersions('mysql2', 'mysql2', compatibleMysql2VersionRange, () => {
       let sequelize

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -17,7 +17,7 @@ describe('sql-injection-analyzer with sequelize', () => {
      * Constraint the test combination of sequelize and mysql2 to force run mysql2 <3.9.4 with sequelize 4.x
      */
     const sequelizeSpecificVersion = require(`../../../../../../versions/sequelize@${sequelizeVersion}`).version()
-    const compatibleMysql2VersionRange = semver.satisfies(sequelizeSpecificVersion, '>4') ? '>=1' : '>=1 <3.9.4'
+    const compatibleMysql2VersionRange = semver.satisfies(sequelizeSpecificVersion, '>=5') ? '>=1' : '>=1 <3.9.4'
     withVersions('mysql2', 'mysql2', compatibleMysql2VersionRange, () => {
       let sequelize
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -12,6 +12,10 @@ const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability
 
 describe('sql-injection-analyzer with sequelize', () => {
   withVersions('sequelize', 'sequelize', sequelizeVersion => {
+    /**
+     * mysql2 3.9.4 causes an error when using it with sequelize 4.x, making sequelize plugin test to fail.
+     * Constraint the test combination of sequelize and mysql2 to force run mysql2 <3.9.4 with sequelize 4.x
+     */
     const sequelizeSpecificVersion = require(`../../../../../../versions/sequelize@${sequelizeVersion}`).version()
     const compatibleMysql2VersionRange = semver.satisfies(sequelizeSpecificVersion, '>4') ? '>=1' : '>=1 <3.9.4'
     withVersions('mysql2', 'mysql2', compatibleMysql2VersionRange, () => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -9,7 +9,6 @@ const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
-const semver = require("semver");
 
 describe('sql-injection-analyzer with sequelize', () => {
   withVersions('sequelize', 'sequelize', sequelizeVersion => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -3,15 +3,19 @@
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
+const semver = require('semver')
 const { prepareTestServerForIast } = require('../utils')
 const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
+const semver = require("semver");
 
 describe('sql-injection-analyzer with sequelize', () => {
   withVersions('sequelize', 'sequelize', sequelizeVersion => {
-    withVersions('mysql2', 'mysql2', (mysqlVersion) => {
+    const sequelizeSpecificVersion = require(`../../../../versions/sequelize@${sequelizeVersion}`).version()
+    const compatibleMysql2VersionRange = semver.satisfies(sequelizeSpecificVersion, '>4') ? '>=1' : '>=1 <3.9.4'
+    withVersions('mysql2', 'mysql2', compatibleMysql2VersionRange, () => {
       let sequelize
 
       prepareTestServerForIast('sequelize + mysql2',

--- a/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
@@ -3,16 +3,13 @@
 const path = require('path')
 const axios = require('axios')
 const getPort = require('get-port')
-const semver = require('semver')
 const agent = require('../plugins/agent')
 const appsec = require('../../src/appsec')
 const Config = require('../../src/config')
 
 describe('sequelize', () => {
   withVersions('sequelize', 'sequelize', sequelizeVersion => {
-    const sequelizeSpecificVersion = require(`../../../../versions/sequelize@${sequelizeVersion}`).version()
-    const compatibleMysql2VersionRange = semver.satisfies(sequelizeSpecificVersion, '>4') ? '>=1' : '>=1 <3.9.4'
-    withVersions('mysql2', 'mysql2', compatibleMysql2VersionRange, (mysql2Version) => {
+    withVersions('mysql2', 'mysql2', () => {
       withVersions('sequelize', 'express', (expressVersion) => {
         let sequelize, User, server, port
 

--- a/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
@@ -3,13 +3,16 @@
 const path = require('path')
 const axios = require('axios')
 const getPort = require('get-port')
+const semver = require('semver')
 const agent = require('../plugins/agent')
 const appsec = require('../../src/appsec')
 const Config = require('../../src/config')
 
 describe('sequelize', () => {
   withVersions('sequelize', 'sequelize', sequelizeVersion => {
-    withVersions('mysql2', 'mysql2', () => {
+    const sequelizeSpecificVersion = require(`../../../../versions/sequelize@${sequelizeVersion}`).version()
+    const compatibleMysql2VersionRange = semver.satisfies(sequelizeSpecificVersion, '>4') ? '>=1' : '>=1 <3.9.4'
+    withVersions('mysql2', 'mysql2', compatibleMysql2VersionRange, (mysql2Version) => {
       withVersions('sequelize', 'express', (expressVersion) => {
         let sequelize, User, server, port
 


### PR DESCRIPTION
### What does this PR do?
Avoid running IAST SQLi sequelize plugin tests with non compatible combo version `sequelize@4.x` - `mysql2@3.9.4`

### Motivation
Last release of mysql2 (3.9.4) causes an error when using sequelize 4, making sequelize plugin test to fail.

> Unhandled rejection TypeError: result.hasOwnProperty is not a function

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->