### PR TITLE
PROF-9248: Use underscore instead of comma for tag value

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -382,7 +382,7 @@ describe('profiler', () => {
 
       function checkTags (tags) {
         assert.include(tags, 'enablement_choice:manually_enabled')
-        assert.include(tags, 'heuristic_hypothetical_decision:no_span,short_lived')
+        assert.include(tags, 'heuristic_hypothetical_decision:no_span_short_lived')
         assert.include(tags, 'installation:ssi')
         // There's a race between metrics and on-shutdown profile, so tag value
         // can be either false or true but it must be present

--- a/packages/dd-trace/src/profiling/ssi-telemetry.js
+++ b/packages/dd-trace/src/profiling/ssi-telemetry.js
@@ -132,7 +132,7 @@ class SSITelemetry {
       'installation:ssi',
       `enablement_choice:${enablementChoiceToTagValue(this.enablementChoice)}`,
       `has_sent_profiles:${this.hasSentProfiles}`,
-      `heuristic_hypothetical_decision:${decision.join()}`
+      `heuristic_hypothetical_decision:${decision.join('_')}`
     ]
 
     this._profileCount = profilersNamespace.count('ssi_heuristic.number_of_profiles', tags)

--- a/packages/dd-trace/test/profiling/ssi-telemetry.spec.js
+++ b/packages/dd-trace/test/profiling/ssi-telemetry.spec.js
@@ -134,21 +134,21 @@ function testEnabledTelemetry (enablementChoice) {
 }
 
 function testNoOp (enablementChoice) {
-  executeTelemetryEnabledScenario(_ => {}, 0, false, enablementChoice, 'no_span,short_lived')
+  executeTelemetryEnabledScenario(_ => {}, 0, false, enablementChoice, 'no_span_short_lived')
 }
 
 function testProfilesSent (enablementChoice) {
   executeTelemetryEnabledScenario(_ => {
     dc.channel('datadog:profiling:profile-submitted').publish()
     dc.channel('datadog:profiling:profile-submitted').publish()
-  }, 2, true, enablementChoice, 'no_span,short_lived')
+  }, 2, true, enablementChoice, 'no_span_short_lived')
 }
 
 function testMockProfilesSent (enablementChoice) {
   executeTelemetryEnabledScenario(_ => {
     dc.channel('datadog:profiling:mock-profile-submitted').publish()
     dc.channel('datadog:profiling:mock-profile-submitted').publish()
-  }, 2, false, enablementChoice, 'no_span,short_lived')
+  }, 2, false, enablementChoice, 'no_span_short_lived')
 }
 
 function testSpan (enablementChoice) {


### PR DESCRIPTION
### What does this PR do?
Uses `_` instead of `,` in a telemetry tag value.

### Motivation
Commas are not valid characters in tag values and are normalized to underscores in various backend stages anyway. It's better to not even emit them to avoid any bugs.