### PR TITLE
Implement common taint tracking operations

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -217,3 +217,17 @@ jobs:
       - if: always()
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v3
+
+  propagation:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: lodash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/node/setup
+      - run: yarn install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: codecov/codecov-action@v3

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -218,7 +218,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v3
 
-  propagation:
+  lodash:
     runs-on: ubuntu-latest
     env:
       PLUGINS: lodash

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -228,6 +228,6 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@datadog/native-appsec": "7.1.1",
-    "@datadog/native-iast-rewriter": "2.3.0",
+    "@datadog/native-iast-rewriter": "2.3.1",
     "@datadog/native-iast-taint-tracking": "2.1.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.2.0",

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -66,6 +66,7 @@ module.exports = {
   kafkajs: () => require('../kafkajs'),
   ldapjs: () => require('../ldapjs'),
   'limitd-client': () => require('../limitd-client'),
+  lodash: () => require('../lodash'),
   mariadb: () => require('../mariadb'),
   memcached: () => require('../memcached'),
   'microgateway-core': () => require('../microgateway-core'),

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -5,88 +5,26 @@ const { channel, addHook } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
 addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
-  const trimCh = channel('datadog:lodash:trim')
-  const trimEndCh = channel('datadog:lodash:trimEnd')
-  const stringCaseCh = channel('datadog:lodash:stringCase')
-  const arrayJoinCh = channel('datadog:lodash:arrayJoin')
+  const lodashOperationCh = channel('datadog:lodash:operation')
 
-  shimmer.wrap(lodash, 'trim', trim => {
-    return function (string, chars, guard) {
-      if (!trimCh.hasSubscribers) {
-        return trim(arguments)
+  const instrumentedLodashFn = ['trim', 'trimStart', 'trimEnd', 'toLower', 'toUpper', 'join']
+
+  shimmer.massWrap(
+    lodash,
+    instrumentedLodashFn,
+    lodashFn => {
+      return function () {
+        if (!lodashOperationCh.hasSubscribers) {
+          return lodashFn(...arguments)
+        }
+
+        const result = lodashFn(...arguments)
+        lodashOperationCh.publish({ operation: lodashFn.name, arguments, result })
+
+        return result
       }
-
-      const result = trim(...arguments)
-      trimCh.publish({ arguments, result })
-
-      return result
     }
-  })
-
-  shimmer.wrap(lodash, 'trimStart', trimStart => {
-    return function (string, chars, guard) {
-      if (!trimCh.hasSubscribers) {
-        return trimStart(...arguments)
-      }
-
-      const result = trimStart(...arguments)
-      trimCh.publish({ arguments, result })
-
-      return result
-    }
-  })
-
-  shimmer.wrap(lodash, 'trimEnd', trimEnd => {
-    return function (string, chars, guard) {
-      if (!trimEndCh.hasSubscribers) {
-        return trimEnd(...arguments)
-      }
-
-      const result = trimEnd(...arguments)
-      trimEndCh.publish({ arguments, result })
-
-      return result
-    }
-  })
-
-  shimmer.wrap(lodash, 'toLower', toLower => {
-    return function (value) {
-      if (!stringCaseCh.hasSubscribers) {
-        return toLower(value)
-      }
-
-      const result = toLower(value)
-      stringCaseCh.publish({ value, result })
-
-      return result
-    }
-  })
-
-  shimmer.wrap(lodash, 'toUpper', toUpper => {
-    return function (value) {
-      if (!stringCaseCh.hasSubscribers) {
-        return toUpper(value)
-      }
-
-      const result = toUpper(value)
-      stringCaseCh.publish({ value, result })
-
-      return result
-    }
-  })
-
-  shimmer.wrap(lodash, 'join', join => {
-    return function (array, separator) {
-      if (!arrayJoinCh.hasSubscribers) {
-        return join(...arguments)
-      }
-
-      const result = join(...arguments)
-      arrayJoinCh.publish({ arguments, result })
-
-      return result
-    }
-  })
+  )
 
   return lodash
 })

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -5,7 +5,6 @@ const { channel, addHook } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
 addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
-
   const trimCh = channel('datadog:lodash:trim')
   const trimEndCh = channel('datadog:lodash:trimEnd')
 
@@ -16,7 +15,7 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
       }
 
       const result = trim(...arguments)
-      trimCh.publish({arguments, result})
+      trimCh.publish({ arguments, result })
 
       return result
     }
@@ -29,7 +28,7 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
       }
 
       const result = trimStart(...arguments)
-      trimCh.publish({arguments, result})
+      trimCh.publish({ arguments, result })
 
       return result
     }
@@ -42,7 +41,7 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
       }
 
       const result = trimEnd(...arguments)
-      trimEndCh.publish({arguments, result})
+      trimEndCh.publish({ arguments, result })
 
       return result
     }

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -15,10 +15,10 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
     lodashFn => {
       return function () {
         if (!lodashOperationCh.hasSubscribers) {
-          return lodashFn(...arguments)
+          return lodashFn.apply(this, arguments)
         }
 
-        const result = lodashFn(...arguments)
+        const result = lodashFn.apply(this, arguments)
         lodashOperationCh.publish({ operation: lodashFn.name, arguments, result })
 
         return result

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const { channel, addHook } = require('./helpers/instrument')
+
+const shimmer = require('../../datadog-shimmer')
+
+addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
+
+  const trimCh = channel('datadog:lodash:trim')
+  const trimEndCh = channel('datadog:lodash:trimEnd')
+
+  shimmer.wrap(lodash, 'trim', trim => {
+    return function (string, chars, guard) {
+      if (!trimCh.hasSubscribers) {
+        return trim(arguments)
+      }
+
+      const result = trim(...arguments)
+      trimCh.publish({arguments, result})
+
+      return result
+    }
+  })
+
+  shimmer.wrap(lodash, 'trimStart', trimStart => {
+    return function (string, chars, guard) {
+      if (!trimCh.hasSubscribers) {
+        return trimStart(...arguments)
+      }
+
+      const result = trimStart(...arguments)
+      trimCh.publish({arguments, result})
+
+      return result
+    }
+  })
+
+  shimmer.wrap(lodash, 'trimEnd', trimEnd => {
+    return function (string, chars, guard) {
+      if (!trimEndCh.hasSubscribers) {
+        return trimEnd(...arguments)
+      }
+
+      const result = trimEnd(...arguments)
+      trimEndCh.publish({arguments, result})
+
+      return result
+    }
+  })
+
+  return lodash
+})

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -19,9 +19,10 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
         }
 
         const result = lodashFn.apply(this, arguments)
-        lodashOperationCh.publish({ operation: lodashFn.name, arguments, result })
+        const message = { operation: lodashFn.name, arguments, result }
+        lodashOperationCh.publish(message)
 
-        return result
+        return message.result
       }
     }
   )

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -8,6 +8,7 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
   const trimCh = channel('datadog:lodash:trim')
   const trimEndCh = channel('datadog:lodash:trimEnd')
   const stringCaseCh = channel('datadog:lodash:stringCase')
+  const arrayJoinCh = channel('datadog:lodash:arrayJoin')
 
   shimmer.wrap(lodash, 'trim', trim => {
     return function (string, chars, guard) {
@@ -69,6 +70,19 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
 
       const result = toUpper(value)
       stringCaseCh.publish({ value, result })
+
+      return result
+    }
+  })
+
+  shimmer.wrap(lodash, 'join', join => {
+    return function (array, separator) {
+      if (!arrayJoinCh.hasSubscribers) {
+        return join(...arguments)
+      }
+
+      const result = join(...arguments)
+      arrayJoinCh.publish({ arguments, result })
 
       return result
     }

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -7,6 +7,7 @@ const shimmer = require('../../datadog-shimmer')
 addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
   const trimCh = channel('datadog:lodash:trim')
   const trimEndCh = channel('datadog:lodash:trimEnd')
+  const stringCaseCh = channel('datadog:lodash:stringCase')
 
   shimmer.wrap(lodash, 'trim', trim => {
     return function (string, chars, guard) {
@@ -42,6 +43,32 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
 
       const result = trimEnd(...arguments)
       trimEndCh.publish({ arguments, result })
+
+      return result
+    }
+  })
+
+  shimmer.wrap(lodash, 'toLower', toLower => {
+    return function (value) {
+      if (!stringCaseCh.hasSubscribers) {
+        return toLower(value)
+      }
+
+      const result = toLower(value)
+      stringCaseCh.publish({ value, result })
+
+      return result
+    }
+  })
+
+  shimmer.wrap(lodash, 'toUpper', toUpper => {
+    return function (value) {
+      if (!stringCaseCh.hasSubscribers) {
+        return toUpper(value)
+      }
+
+      const result = toUpper(value)
+      stringCaseCh.publish({ value, result })
 
       return result
     }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -2,6 +2,7 @@
 
 const csiMethods = [
   { src: 'concat' },
+  { src: 'join' },
   { src: 'parse' },
   { src: 'plusOperator', operator: true },
   { src: 'random' },

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -9,6 +9,8 @@ const csiMethods = [
   { src: 'slice' },
   { src: 'substr' },
   { src: 'substring' },
+  { src: 'toLowerCase', dst: 'stringCase' },
+  { src: 'toUpperCase', dst: 'stringCase' },
   { src: 'trim' },
   { src: 'trimEnd' },
   { src: 'trimStart', dst: 'trim' }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -9,12 +9,14 @@ const {
   getTaintTrackingImpl,
   getTaintTrackingNoop,
   lodashTrim,
-  lodashTrimEnd
+  lodashTrimEnd,
+  lodashStringCase
 } = require('./taint-tracking-impl')
 const { taintObject } = require('./operations-taint-object')
 
 const lodashTrimCh = dc.channel('datadog:lodash:trim')
 const lodashTrimEndCh = dc.channel('datadog:lodash:trimEnd')
+const lodashStringCaseCh = dc.channel('datadog:lodash:stringCase')
 
 function createTransaction (id, iastContext) {
   if (id && iastContext) {
@@ -109,6 +111,10 @@ function enableTaintOperations (telemetryVerbosity) {
   lodashTrimEndCh.subscribe(({ arguments: trimArgs, result }) => {
     const target = trimArgs[0]
     lodashTrimEnd(target, result)
+  })
+
+  lodashStringCaseCh.subscribe(({ value, result }) => {
+    lodashStringCase(value, result)
   })
 }
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -5,7 +5,12 @@ const { IAST_TRANSACTION_ID } = require('../iast-context')
 const iastTelemetry = require('../telemetry')
 const { REQUEST_TAINTED } = require('../telemetry/iast-metric')
 const { isInfoAllowed } = require('../telemetry/verbosity')
-const { getTaintTrackingImpl, getTaintTrackingNoop, lodashTrim, lodashTrimEnd} = require('./taint-tracking-impl')
+const {
+  getTaintTrackingImpl,
+  getTaintTrackingNoop,
+  lodashTrim,
+  lodashTrimEnd
+} = require('./taint-tracking-impl')
 const { taintObject } = require('./operations-taint-object')
 
 const lodashTrimCh = dc.channel('datadog:lodash:trim')
@@ -96,12 +101,12 @@ function enableTaintOperations (telemetryVerbosity) {
 
   global._ddiast = getTaintTrackingImpl(telemetryVerbosity)
 
-  lodashTrimCh.subscribe(({arguments: trimArgs, result}) => {
+  lodashTrimCh.subscribe(({ arguments: trimArgs, result }) => {
     const target = trimArgs[0]
     lodashTrim(target, result)
   })
 
-  lodashTrimEndCh.subscribe(({arguments: trimArgs, result}) => {
+  lodashTrimEndCh.subscribe(({ arguments: trimArgs, result }) => {
     const target = trimArgs[0]
     lodashTrimEnd(target, result)
   })

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -10,13 +10,15 @@ const {
   getTaintTrackingNoop,
   lodashTrim,
   lodashTrimEnd,
-  lodashStringCase
+  lodashStringCase,
+  lodashArrayJoin
 } = require('./taint-tracking-impl')
 const { taintObject } = require('./operations-taint-object')
 
 const lodashTrimCh = dc.channel('datadog:lodash:trim')
 const lodashTrimEndCh = dc.channel('datadog:lodash:trimEnd')
 const lodashStringCaseCh = dc.channel('datadog:lodash:stringCase')
+const lodashArrayJoinCh = dc.channel('datadog:lodash:arrayJoin')
 
 function createTransaction (id, iastContext) {
   if (id && iastContext) {
@@ -115,6 +117,12 @@ function enableTaintOperations (telemetryVerbosity) {
 
   lodashStringCaseCh.subscribe(({ value, result }) => {
     lodashStringCase(value, result)
+  })
+
+  lodashArrayJoinCh.subscribe(({ arguments: arrayJoinArgs, result }) => {
+    const target = arrayJoinArgs[0]
+    const separator = arrayJoinArgs[1]
+    lodashArrayJoin(target, result, separator)
   })
 }
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const dc = require('dc-polyfill')
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
 const { IAST_TRANSACTION_ID } = require('../iast-context')

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -192,7 +192,7 @@ function lodashTrim (target, result) {
       result = TaintedUtils.trim(transactionId, result, target)
     }
   } catch (e) {
-    iastLog.error(`Error invoking CSI lodash trim`)
+    iastLog.error('Error invoking CSI lodash trim')
       .errorAndPublish(e)
   }
 }
@@ -205,7 +205,7 @@ function lodashTrimEnd (target, result) {
       result = TaintedUtils.trimEnd(transactionId, result, target)
     }
   } catch (e) {
-    iastLog.error(`Error invoking CSI lodash trimEnd`)
+    iastLog.error('Error invoking CSI lodash trimEnd')
       .errorAndPublish(e)
   }
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -215,16 +215,16 @@ function getLodashTaintedUtilFn (lodashFn) {
   return lodashFns[lodashFn] || ((transactionId, result) => result)
 }
 
-function lodashTaintTrackingHandler ({ operation, arguments: lodashFnArguments, result }) {
+function lodashTaintTrackingHandler (message) {
   try {
-    if (!result) return
+    if (!message.result) return
     const context = getContextDefault()
     const transactionId = getTransactionId(context)
     if (transactionId) {
-      result = getLodashTaintedUtilFn(operation)(transactionId, result, ...lodashFnArguments)
+      message.result = getLodashTaintedUtilFn(message.operation)(transactionId, message.result, ...message.arguments)
     }
   } catch (e) {
-    iastLog.error(`Error invoking CSI lodash ${operation}`)
+    iastLog.error(`Error invoking CSI lodash ${message.operation}`)
       .errorAndPublish(e)
   }
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -217,6 +217,7 @@ function getLodashTaintedUtilFn (lodashFn) {
 
 function lodashTaintTrackingHandler ({ operation, arguments: lodashFnArguments, result }) {
   try {
+    if (!result) return
     const context = getContextDefault()
     const transactionId = getTransactionId(context)
     if (transactionId) {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -25,6 +25,7 @@ const TaintTrackingNoop = {
   slice: noop,
   substr: noop,
   substring: noop,
+  stringCase: noop,
   trim: noop,
   trimEnd: noop
 }
@@ -112,6 +113,13 @@ function csiMethodsOverrides (getContext) {
       }
       return res
     },
+
+    stringCase: getCsiFn(
+      (transactionId, res, target) => TaintedUtils.stringCase(transactionId, res, target),
+      getContext,
+      String.prototype.toLowerCase,
+      String.prototype.toUpperCase
+    ),
 
     trim: getCsiFn(
       (transactionId, res, target) => TaintedUtils.trim(transactionId, res, target),

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -17,6 +17,7 @@ function noop (res) { return res }
 // NOTE: methods of this object must be synchronized with csi-methods.js file definitions!
 // Otherwise you may end up rewriting a method and not providing its rewritten implementation
 const TaintTrackingNoop = {
+  join: noop,
   concat: noop,
   parse: noop,
   plusOperator: noop,
@@ -149,6 +150,22 @@ function csiMethodsOverrides (getContext) {
               const range = ranges.find(range => range.iinfo?.type)
               res = taintObject(iastContext, res, range?.iinfo.type || JSON_VALUE)
             }
+          }
+        } catch (e) {
+          iastLog.error(e)
+        }
+      }
+
+      return res
+    },
+
+    join: function (res, fn, target, separator) {
+      if (fn === Array.prototype.join) {
+        try {
+          const iastContext = getContext()
+          const transactionId = getTransactionId(iastContext)
+          if (transactionId) {
+            res = TaintedUtils.arrayJoin(transactionId, res, target, separator)
           }
         } catch (e) {
           iastLog.error(e)

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -176,7 +176,35 @@ function getTaintTrackingNoop () {
   return getTaintTrackingImpl(null, true)
 }
 
+function lodashTrim (target, result) {
+  try {
+    const context = getContextDefault()
+    const transactionId = getTransactionId(context)
+    if (transactionId) {
+      result = TaintedUtils.trim(transactionId, result, target)
+    }
+  } catch (e) {
+    iastLog.error(`Error invoking CSI lodash trim`)
+      .errorAndPublish(e)
+  }
+}
+
+function lodashTrimEnd (target, result) {
+  try {
+    const context = getContextDefault()
+    const transactionId = getTransactionId(context)
+    if (transactionId) {
+      result = TaintedUtils.trimEnd(transactionId, result, target)
+    }
+  } catch (e) {
+    iastLog.error(`Error invoking CSI lodash trimEnd`)
+      .errorAndPublish(e)
+  }
+}
+
 module.exports = {
   getTaintTrackingImpl,
-  getTaintTrackingNoop
+  getTaintTrackingNoop,
+  lodashTrim,
+  lodashTrimEnd
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -17,8 +17,8 @@ function noop (res) { return res }
 // NOTE: methods of this object must be synchronized with csi-methods.js file definitions!
 // Otherwise you may end up rewriting a method and not providing its rewritten implementation
 const TaintTrackingNoop = {
-  join: noop,
   concat: noop,
+  join: noop,
   parse: noop,
   plusOperator: noop,
   random: noop,
@@ -202,12 +202,13 @@ function getTaintTrackingNoop () {
 }
 
 const lodashFns = {
-  trim: TaintedUtils.trim,
-  trimStart: TaintedUtils.trim,
-  trimEnd: TaintedUtils.trimEnd,
+  join: TaintedUtils.arrayJoin,
   toLower: TaintedUtils.stringCase,
   toUpper: TaintedUtils.stringCase,
-  join: TaintedUtils.arrayJoin
+  trim: TaintedUtils.trim,
+  trimEnd: TaintedUtils.trimEnd,
+  trimStart: TaintedUtils.trim
+
 }
 
 function getLodashTaintedUtilFn (lodashFn) {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -227,9 +227,23 @@ function lodashTrimEnd (target, result) {
   }
 }
 
+function lodashStringCase (target, result) {
+  try {
+    const context = getContextDefault()
+    const transactionId = getTransactionId(context)
+    if (transactionId) {
+      result = TaintedUtils.stringCase(transactionId, result, target)
+    }
+  } catch (e) {
+    iastLog.error('Error invoking CSI lodash stringCase')
+      .errorAndPublish(e)
+  }
+}
+
 module.exports = {
   getTaintTrackingImpl,
   getTaintTrackingNoop,
   lodashTrim,
-  lodashTrimEnd
+  lodashTrimEnd,
+  lodashStringCase
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -240,10 +240,24 @@ function lodashStringCase (target, result) {
   }
 }
 
+function lodashArrayJoin (target, result, separator) {
+  try {
+    const context = getContextDefault()
+    const transactionId = getTransactionId(context)
+    if (transactionId) {
+      result = TaintedUtils.arrayJoin(transactionId, result, target, separator)
+    }
+  } catch (e) {
+    iastLog.error('Error invoking CSI lodash arrayJoin')
+      .errorAndPublish(e)
+  }
+}
+
 module.exports = {
   getTaintTrackingImpl,
   getTaintTrackingNoop,
   lodashTrim,
   lodashTrimEnd,
-  lodashStringCase
+  lodashStringCase,
+  lodashArrayJoin
 }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -212,11 +212,7 @@ const lodashFns = {
 }
 
 function getLodashTaintedUtilFn (lodashFn) {
-  if (!Object.keys(lodashFns).includes(lodashFn)) {
-    return (transactionId, result) => result
-  }
-
-  return lodashFns[lodashFn]
+  return lodashFns[lodashFn] || ((transactionId, result) => result)
 }
 
 function lodashTaintTrackingHandler ({ operation, arguments: lodashFnArguments, result }) {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -52,11 +52,11 @@ function sliceStr (str) {
   return str.slice(1, 4)
 }
 
-function toLowerCaseStr(str) {
+function toLowerCaseStr (str) {
   return str.toLowerCase()
 }
 
-function toUpperCaseStr(str) {
+function toUpperCaseStr (str) {
   return str.toUpperCase()
 }
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -72,7 +72,11 @@ function jsonParseStr (str) {
   return JSON.parse(str)
 }
 
-function arrayJoin (str) {
+function arrayJoin(str) {
+  return [str, str].join(str)
+}
+
+function arrayInVariableJoin (str) {
   const testArr = [str, str]
   return testArr.join(',')
 }
@@ -101,5 +105,6 @@ module.exports = {
   replaceRegexStr,
   jsonParseStr,
   arrayJoin,
-  arrayProtoJoin
+  arrayProtoJoin,
+  arrayInVariableJoin
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -72,7 +72,7 @@ function jsonParseStr (str) {
   return JSON.parse(str)
 }
 
-function arrayJoin(str) {
+function arrayJoin (str) {
   return [str, str].join(str)
 }
 
@@ -86,25 +86,25 @@ function arrayProtoJoin (str) {
 }
 
 module.exports = {
-  concatSuffix,
-  insertStr,
   appendStr,
-  trimStr,
-  trimStartStr,
-  trimEndStr,
-  trimProtoStr,
-  concatStr,
-  concatTaintedStr,
-  concatProtoStr,
-  substringStr,
-  substrStr,
-  sliceStr,
-  toLowerCaseStr,
-  toUpperCaseStr,
-  replaceStr,
-  replaceRegexStr,
-  jsonParseStr,
+  arrayInVariableJoin,
   arrayJoin,
   arrayProtoJoin,
-  arrayInVariableJoin
+  concatProtoStr,
+  concatStr,
+  concatSuffix,
+  concatTaintedStr,
+  insertStr,
+  jsonParseStr,
+  replaceRegexStr,
+  replaceStr,
+  sliceStr,
+  substrStr,
+  substringStr,
+  toLowerCaseStr,
+  toUpperCaseStr,
+  trimEndStr,
+  trimProtoStr,
+  trimStartStr,
+  trimStr
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -52,6 +52,14 @@ function sliceStr (str) {
   return str.slice(1, 4)
 }
 
+function toLowerCaseStr(str) {
+  return str.toLowerCase()
+}
+
+function toUpperCaseStr(str) {
+  return str.toUpperCase()
+}
+
 function replaceStr (str) {
   return str.replace('ls', 'sl')
 }
@@ -78,6 +86,8 @@ module.exports = {
   substringStr,
   substrStr,
   sliceStr,
+  toLowerCaseStr,
+  toUpperCaseStr,
   replaceStr,
   replaceRegexStr,
   jsonParseStr

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -72,6 +72,15 @@ function jsonParseStr (str) {
   return JSON.parse(str)
 }
 
+function arrayJoin (str) {
+  const testArr = [str, str]
+  return testArr.join(',')
+}
+
+function arrayProtoJoin (str) {
+  return Array.prototype.join.call([str, str], ',')
+}
+
 module.exports = {
   concatSuffix,
   insertStr,
@@ -90,5 +99,7 @@ module.exports = {
   toUpperCaseStr,
   replaceStr,
   replaceRegexStr,
-  jsonParseStr
+  jsonParseStr,
+  arrayJoin,
+  arrayProtoJoin
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
@@ -18,10 +18,20 @@ function toUpperLodash (_, str) {
   return _.toUpper(str)
 }
 
+function arrayJoinLodashWithoutSeparator (_, str) {
+  return _.join([str, str])
+}
+
+function arrayJoinLodashWithSeparator (_, str) {
+  return _.join([str, str], str)
+}
+
 module.exports = {
   trimLodash,
   trimStartLodash,
   trimEndLodash,
   toLowerLodash,
-  toUpperLodash
+  toUpperLodash,
+  arrayJoinLodashWithoutSeparator,
+  arrayJoinLodashWithSeparator
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
@@ -1,3 +1,5 @@
+'use strict'
+
 function trimLodash (_, str) {
   return _.trim(str)
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
@@ -1,0 +1,17 @@
+function trimLodash (_, str) {
+  return _.trim(str)
+}
+
+function trimStartLodash (_, str) {
+  return _.trimStart(str)
+}
+
+function trimEndLodash (_, str) {
+  return _.trimEnd(str)
+}
+
+module.exports = {
+  trimLodash,
+  trimStartLodash,
+  trimEndLodash
+}

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
@@ -10,8 +10,18 @@ function trimEndLodash (_, str) {
   return _.trimEnd(str)
 }
 
+function toLowerLodash (_, str) {
+  return _.toLower(str)
+}
+
+function toUpperLodash (_, str) {
+  return _.toUpper(str)
+}
+
 module.exports = {
   trimLodash,
   trimStartLodash,
-  trimEndLodash
+  trimEndLodash,
+  toLowerLodash,
+  toUpperLodash
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationLodashFunctions.js
@@ -26,12 +26,17 @@ function arrayJoinLodashWithSeparator (_, str) {
   return _.join([str, str], str)
 }
 
+function startCaseLodash (_, str) {
+  return _.startCase(str)
+}
+
 module.exports = {
-  trimLodash,
-  trimStartLodash,
-  trimEndLodash,
+  arrayJoinLodashWithoutSeparator,
+  arrayJoinLodashWithSeparator,
   toLowerLodash,
   toUpperLodash,
-  arrayJoinLodashWithoutSeparator,
-  arrayJoinLodashWithSeparator
+  startCaseLodash,
+  trimEndLodash,
+  trimLodash,
+  trimStartLodash
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -96,7 +96,6 @@ describe('TaintTracking lodash', () => {
       })
     })
   })
-
 })
 
 describe('TaintTracking', () => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -32,16 +32,6 @@ const propagationFns = [
   'replaceRegexStr'
 ]
 
-const propagationLodashFns = [
-  'toLowerLodash',
-  'toUpperLodash',
-  'trimLodash',
-  'trimStartLodash',
-  'trimEndLodash',
-  'arrayJoinLodashWithoutSeparator',
-  'arrayJoinLodashWithSeparator'
-]
-
 const commands = [
   '  ls -la  ',
   '  ls -la',
@@ -54,55 +44,6 @@ const commands = [
 
 const propagationFunctionsFile = path.join(__dirname, 'resources/propagationFunctions.js')
 const propagationFunctions = require(propagationFunctionsFile)
-
-const propagationLodashFunctionsFile = path.join(__dirname, 'resources/propagationLodashFunctions.js')
-const propagationLodashFunctions = require(propagationLodashFunctionsFile)
-
-describe('TaintTracking lodash', () => {
-  let instrumentedFunctionsFile
-
-  beforeEach(() => {
-    instrumentedFunctionsFile = copyFileToTmp(propagationLodashFunctionsFile)
-  })
-
-  afterEach(() => {
-    fs.unlinkSync(instrumentedFunctionsFile)
-    clearCache()
-  })
-
-  prepareTestServerForIast('should propagate strings with lodash', (testThatRequestHasVulnerability) => {
-    propagationLodashFns.forEach((propFn) => {
-      describe(`using ${propFn}()`, () => {
-        commands.forEach((command) => {
-          describe(`with command: '${command}'`, () => {
-            testThatRequestHasVulnerability(function () {
-              const _ = require('../../../../../../versions/lodash').get()
-              const store = storage.getStore()
-              const iastContext = iastContextFunctions.getIastContext(store)
-              const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
-
-              const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
-              const propFnOriginal = propagationLodashFunctions[propFn]
-
-              const commandResult = propFnInstrumented(_, commandTainted)
-              expect(isTainted(iastContext, commandResult)).to.be.true
-
-              const commandResultOrig = propFnOriginal(_, commandTainted)
-              expect(commandResult).eq(commandResultOrig)
-
-              try {
-                const childProcess = require('child_process')
-                childProcess.execSync(commandResult, { stdio: 'ignore' })
-              } catch (e) {
-                // do nothing
-              }
-            }, 'COMMAND_INJECTION')
-          })
-        })
-      })
-    })
-  })
-})
 
 describe('TaintTracking', () => {
   let instrumentedFunctionsFile

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -33,6 +33,8 @@ const propagationFns = [
 ]
 
 const propagationLodashFns = [
+  'toLowerLodash',
+  'toUpperLodash',
   'trimLodash',
   'trimStartLodash',
   'trimEndLodash'
@@ -83,7 +85,7 @@ describe('TaintTracking lodash', () => {
               const commandResult = propFnInstrumented(_, commandTainted)
               expect(isTainted(iastContext, commandResult)).to.be.true
 
-              const commandResultOrig = propFnOriginal(commandTainted)
+              const commandResultOrig = propFnOriginal(_, commandTainted)
               expect(commandResult).eq(commandResultOrig)
 
               try {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -37,7 +37,9 @@ const propagationLodashFns = [
   'toUpperLodash',
   'trimLodash',
   'trimStartLodash',
-  'trimEndLodash'
+  'trimEndLodash',
+  'arrayJoinLodashWithoutSeparator',
+  'arrayJoinLodashWithSeparator'
 ]
 
 const commands = [

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -28,6 +28,12 @@ const propagationFns = [
   'replaceRegexStr'
 ]
 
+const propagationLodashFns = [
+  'trimLodash',
+  'trimStartLodash',
+  'trimEndLodash'
+]
+
 const commands = [
   '  ls -la  ',
   '  ls -la',
@@ -40,6 +46,56 @@ const commands = [
 
 const propagationFunctionsFile = path.join(__dirname, 'resources/propagationFunctions.js')
 const propagationFunctions = require(propagationFunctionsFile)
+
+const propagationLodashFunctionsFile = path.join(__dirname, 'resources/propagationLodashFunctions.js')
+const propagationLodashFunctions = require(propagationLodashFunctionsFile)
+
+describe('TaintTracking lodash', () => {
+  let instrumentedFunctionsFile
+
+  beforeEach(() => {
+    instrumentedFunctionsFile = copyFileToTmp(propagationLodashFunctionsFile)
+  })
+
+  afterEach(() => {
+    fs.unlinkSync(instrumentedFunctionsFile)
+    clearCache()
+  })
+
+  prepareTestServerForIast('should propagate strings with lodash', (testThatRequestHasVulnerability) => {
+    propagationLodashFns.forEach((propFn) => {
+      describe(`using ${propFn}()`, () => {
+        commands.forEach((command) => {
+          describe(`with command: '${command}'`, () => {
+            testThatRequestHasVulnerability(function () {
+              const _ = require('../../../../../../versions/lodash').get()
+              const store = storage.getStore()
+              const iastContext = iastContextFunctions.getIastContext(store)
+              const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
+
+              const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
+              const propFnOriginal = propagationLodashFunctions[propFn]
+
+              const commandResult = propFnInstrumented(_, commandTainted)
+              expect(isTainted(iastContext, commandResult)).to.be.true
+
+              const commandResultOrig = propFnOriginal(commandTainted)
+              expect(commandResult).eq(commandResultOrig)
+
+              try {
+                const childProcess = require('child_process')
+                childProcess.execSync(commandResult, { stdio: 'ignore' })
+              } catch (e) {
+                // do nothing
+              }
+            }, 'COMMAND_INJECTION')
+          })
+        })
+      })
+    })
+  })
+
+})
 
 describe('TaintTracking', () => {
   let instrumentedFunctionsFile

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -11,26 +11,26 @@ const { clearCache } = require('../../../../src/appsec/iast/vulnerability-report
 const { expect } = require('chai')
 
 const propagationFns = [
-  'arrayProtoJoin',
-  'arrayJoin',
-  'arrayInVariableJoin',
-  'concatSuffix',
-  'insertStr',
   'appendStr',
-  'trimStr',
-  'trimStartStr',
-  'trimEndStr',
-  'trimProtoStr',
-  'concatStr',
-  'concatTaintedStr',
+  'arrayInVariableJoin',
+  'arrayJoin',
+  'arrayProtoJoin',
   'concatProtoStr',
-  'substringStr',
-  'substrStr',
+  'concatStr',
+  'concatSuffix',
+  'concatTaintedStr',
+  'insertStr',
+  'replaceRegexStr',
+  'replaceStr',
   'sliceStr',
+  'substrStr',
+  'substringStr',
   'toLowerCaseStr',
   'toUpperCaseStr',
-  'replaceStr',
-  'replaceRegexStr'
+  'trimEndStr',
+  'trimProtoStr',
+  'trimStartStr',
+  'trimStr'
 ]
 
 const commands = [

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -24,6 +24,8 @@ const propagationFns = [
   'substringStr',
   'substrStr',
   'sliceStr',
+  'toLowerCaseStr',
+  'toUpperCaseStr',
   'replaceStr',
   'replaceRegexStr'
 ]

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -13,6 +13,7 @@ const { expect } = require('chai')
 const propagationFns = [
   'arrayProtoJoin',
   'arrayJoin',
+  'arrayInVariableJoin',
   'concatSuffix',
   'insertStr',
   'appendStr',
@@ -128,6 +129,7 @@ describe('TaintTracking', () => {
   describe('should not catch original Error', () => {
     const filtered = [
       'appendStr',
+      'arrayInVariableJoin',
       'arrayJoin',
       'arrayProtoJoin',
       'concatSuffix',

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -11,6 +11,8 @@ const { clearCache } = require('../../../../src/appsec/iast/vulnerability-report
 const { expect } = require('chai')
 
 const propagationFns = [
+  'arrayProtoJoin',
+  'arrayJoin',
   'concatSuffix',
   'insertStr',
   'appendStr',
@@ -179,7 +181,14 @@ describe('TaintTracking', () => {
   })
 
   describe('should not catch original Error', () => {
-    const filtered = ['concatSuffix', 'insertStr', 'appendStr', 'concatTaintedStr']
+    const filtered = [
+      'appendStr',
+      'arrayJoin',
+      'arrayProtoJoin',
+      'concatSuffix',
+      'concatTaintedStr',
+      'insertStr'
+    ]
     propagationFns.forEach((propFn) => {
       if (filtered.includes(propFn)) return
       it(`invoking ${propFn} with null argument`, () => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
@@ -16,7 +16,9 @@ const commands = [
   'ls -la',
   ' ls -la  人 ',
   ' ls -la  𠆢𠆢𠆢 ',
-  ' ls -ls �'
+  ' ls -ls �',
+  ' w ',
+  'w'
 ]
 
 const propagationLodashFns = [

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
+const { storage } = require('../../../../../datadog-core')
+const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
+const { newTaintedString, isTainted } = require('../../../../src/appsec/iast/taint-tracking/operations')
+const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
+
+const commands = [
+  '  ls -la  ',
+  '  ls -la',
+  'ls -la  ',
+  'ls -la',
+  ' ls -la  人 ',
+  ' ls -la  𠆢𠆢𠆢 ',
+  ' ls -ls �'
+]
+
+const propagationLodashFns = [
+  'toLowerLodash',
+  'toUpperLodash',
+  'trimLodash',
+  'trimStartLodash',
+  'trimEndLodash',
+  'arrayJoinLodashWithoutSeparator',
+  'arrayJoinLodashWithSeparator'
+]
+
+const propagationLodashFunctionsFile = path.join(__dirname, 'resources/propagationLodashFunctions.js')
+const propagationLodashFunctions = require(propagationLodashFunctionsFile)
+
+describe('TaintTracking lodash', () => {
+  let instrumentedFunctionsFile
+
+  beforeEach(() => {
+    instrumentedFunctionsFile = copyFileToTmp(propagationLodashFunctionsFile)
+  })
+
+  afterEach(() => {
+    fs.unlinkSync(instrumentedFunctionsFile)
+    clearCache()
+  })
+
+  prepareTestServerForIast('should propagate strings with lodash', (testThatRequestHasVulnerability) => {
+    propagationLodashFns.forEach((propFn) => {
+      describe(`using ${propFn}()`, () => {
+        commands.forEach((command) => {
+          describe(`with command: '${command}'`, () => {
+            testThatRequestHasVulnerability(function () {
+              const _ = require('../../../../../../versions/lodash').get()
+              const store = storage.getStore()
+              const iastContext = iastContextFunctions.getIastContext(store)
+              const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
+
+              const propFnInstrumented = require(instrumentedFunctionsFile)[propFn]
+              const propFnOriginal = propagationLodashFunctions[propFn]
+
+              const commandResult = propFnInstrumented(_, commandTainted)
+              expect(isTainted(iastContext, commandResult)).to.be.true
+
+              const commandResultOrig = propFnOriginal(_, commandTainted)
+              expect(commandResult).eq(commandResultOrig)
+
+              try {
+                const childProcess = require('child_process')
+                childProcess.execSync(commandResult, { stdio: 'ignore' })
+              } catch (e) {
+                // do nothing
+              }
+            }, 'COMMAND_INJECTION')
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
@@ -76,4 +76,21 @@ describe('TaintTracking lodash', () => {
       })
     })
   })
+
+  describe('lodash method with no taint tracking', () => {
+    it('should return the original result', () => {
+      const _ = require('../../../../../../versions/lodash').get()
+      const store = storage.getStore()
+      const iastContext = iastContextFunctions.getIastContext(store)
+      const taintedValue = newTaintedString(iastContext, 'tainted', 'param', 'Request')
+
+      const propFnInstrumented = require(instrumentedFunctionsFile).startCaseLodash
+      const propFnOriginal = propagationLodashFunctions.startCaseLodash
+
+      const originalResult = propFnOriginal(_, taintedValue)
+      const instrumentedResult = propFnInstrumented(_, taintedValue)
+      expect(instrumentedResult).to.be.equal(originalResult)
+      expect(isTainted(iastContext, instrumentedResult)).to.be.false
+    })
+  })
 })

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -250,7 +250,7 @@
   "lodash": [
     {
       "name": "lodash",
-      "versions": [">=3"]
+      "versions": [">=4"]
     }
   ],
   "mariadb": [

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -247,6 +247,12 @@
       "versions": [">=2"]
     }
   ],
+  "lodash": [
+    {
+      "name": "lodash",
+      "versions": [">=3"]
+    }
+  ],
   "mariadb": [
     {
       "name": "mariadb",

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,10 +419,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.3.0.tgz#67abddc698504ad76736c0d49681bcf9e330e1bd"
-  integrity sha512-78ivSaaSXOaHn3VumF9kcSI443nbPfVAWsnDTH9X1ZbqXjHpSlHHTZgK9z/TNbkvuJarS/X1GBioPMcgea1Ejg==
+"@datadog/native-iast-rewriter@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.3.1.tgz#f9d6d858df88f7a8b6e38f0c07e46fca5394da72"
+  integrity sha512-3pmt5G1Ai/+MPyxP7wBerIu/zH/BnAHxEu/EAMr+77IMpK5m7THPDUoWrPRCWcgFBfn0pK5DR7gRItG0wX3e0g==
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"


### PR DESCRIPTION
### What does this PR do?
Implement taint tracking propagation for:
- String.prototype.toLowerCase
- String.prototype.toUpperCase
- Array.prototype.join
- Lodash.toLower
- Lodash.toUpper
- Lodash.join

### Motivation
Increase the propagation of tainted values, improving taint tracking.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

**For non-asm reviewers:**

Changes outside ASM scope are in instrumentations. A new [instrumentation for lodash](https://github.com/DataDog/dd-trace-js/pull/4239/files#diff-fb1da0991edbe303c32530f161600ed222f29aeaa0a401a4723e72d667612f6c) (>=4) has been implemented. It publishes a message when a lodash method is called, in order to propagate tainting values needed for IAST vulnerability detection.

<!-- Anything else we should know when reviewing? -->

[APPSEC-47443](https://datadoghq.atlassian.net/browse/APPSEC-47443)



[APPSEC-47443]: https://datadoghq.atlassian.net/browse/APPSEC-47443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ