### PR TITLE
Do not start verdaccio, npm pack and run fpm with the just packed .tgz

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ package-snapshot:
       when: never
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: never
-    - if: $CI_COMMIT_BRANCH == 'master'
+    - if: $CI_COMMIT_BRANCH == 'robertomonteromiguel/add_onboarding_tests__using_pack'
       when: on_success
       allow_failure: true
     - when: manual
@@ -72,7 +72,7 @@ package-snapshot-arm:
       when: never
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: never
-    - if: $CI_COMMIT_BRANCH == 'master'
+    - if: $CI_COMMIT_BRANCH == 'robertomonteromiguel/add_onboarding_tests__using_pack'
       when: on_success
       allow_failure: true
     - when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ package-snapshot:
       when: never
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: never
-    - if: $CI_COMMIT_BRANCH == 'robertomonteromiguel/add_onboarding_tests__using_pack'
+    - if: $CI_COMMIT_BRANCH == 'master'
       when: on_success
       allow_failure: true
     - when: manual
@@ -72,7 +72,7 @@ package-snapshot-arm:
       when: never
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: never
-    - if: $CI_COMMIT_BRANCH == 'robertomonteromiguel/add_onboarding_tests__using_pack'
+    - if: $CI_COMMIT_BRANCH == 'master'
       when: on_success
       allow_failure: true
     - when: manual

--- a/.gitlab/build-deb-rpm-snapshot.sh
+++ b/.gitlab/build-deb-rpm-snapshot.sh
@@ -4,8 +4,6 @@
 #We build the npm package setting the snapshot version and then we publish it to the local registry
 #Use local registry  to build the deb and rpm packages
 
-verdaccio &
-sleep 5
 npm install -g npm-cli-adduser
 npm-cli-adduser -u test -p test -e email@email.com -r http://localhost:4873
 yarn install
@@ -14,7 +12,7 @@ current_version=$(jq '.version' <<< "$content" )
 current_version=$(echo "$current_version" | tr -d '"')
 current_version+="$CI_VERSION_SUFFIX"
 npm version --no-git-tag-version $current_version
-npm publish --tag dev --registry http://localhost:4873
+npm pack
 export JS_PACKAGE_VERSION=$current_version
 
 echo "Generating Version: $JS_PACKAGE_VERSION"
@@ -26,11 +24,9 @@ source common_build_functions.sh
 # Extract package to a dir to make changes
 fpm --input-type npm \
   --npm-package-name-prefix "" \
-  --npm-registry http://localhost:4873 \
   --output-type dir --prefix "" \
-  --version "$JS_PACKAGE_VERSION" \
   --verbose \
-  --name dd-trace dd-trace
+  --name dd-trace ./dd-trace-$JS_PACKAGE_VERSION.tgz
 
 cp auto_inject-node.version dd-trace.dir/lib/version
 

--- a/.gitlab/build-deb-rpm-snapshot.sh
+++ b/.gitlab/build-deb-rpm-snapshot.sh
@@ -14,7 +14,7 @@ current_version+="$CI_VERSION_SUFFIX"
 npm version --no-git-tag-version $current_version
 npm pack
 export JS_PACKAGE_VERSION=$current_version
-
+cp dd-trace-$JS_PACKAGE_VERSION.tgz packaging/dd-trace-$JS_PACKAGE_VERSION.tgz
 echo "Generating Version: $JS_PACKAGE_VERSION"
 cd packaging
 echo -n $JS_PACKAGE_VERSION > auto_inject-node.version


### PR DESCRIPTION
### What does this PR do?
Modifies #4226 to pack the npm tgz locally and thus eliminate the need to use verdaccio.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


