### PR TITLE
Do not require appsec modules when disabling appsec if they have not been required before

### DIFF
--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -8,7 +8,7 @@ const apiSecuritySampler = require('../api_security_sampler')
 
 let rc
 
-function enable (config) {
+function enable (config, tracer) {
   rc = new RemoteConfigManager(config)
   rc.updateCapabilities(RemoteConfigCapabilities.APM_TRACING_CUSTOM_TAGS, true)
   rc.updateCapabilities(RemoteConfigCapabilities.APM_TRACING_HTTP_HEADER_TAGS, true)
@@ -31,7 +31,7 @@ function enable (config) {
       if (!rcConfig) return
 
       if (activation === Activation.ONECLICK) {
-        enableOrDisableAppsec(action, rcConfig, config)
+        enableOrDisableAppsec(action, rcConfig, config, tracer)
       }
 
       apiSecuritySampler.setRequestSampling(rcConfig.api_security?.request_sample_rate)
@@ -41,7 +41,7 @@ function enable (config) {
   return rc
 }
 
-function enableOrDisableAppsec (action, rcConfig, config) {
+function enableOrDisableAppsec (action, rcConfig, config, tracer) {
   if (typeof rcConfig.asm?.enabled === 'boolean') {
     let shouldEnable
 
@@ -52,9 +52,9 @@ function enableOrDisableAppsec (action, rcConfig, config) {
     }
 
     if (shouldEnable) {
-      require('..').enable(config)
+      tracer._modules.appsec.enable(config)
     } else {
-      require('..').disable()
+      tracer._modules.appsec.disable()
     }
   }
 }

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -8,7 +8,7 @@ const apiSecuritySampler = require('../api_security_sampler')
 
 let rc
 
-function enable (config, tracer) {
+function enable (config, appsec) {
   rc = new RemoteConfigManager(config)
   rc.updateCapabilities(RemoteConfigCapabilities.APM_TRACING_CUSTOM_TAGS, true)
   rc.updateCapabilities(RemoteConfigCapabilities.APM_TRACING_HTTP_HEADER_TAGS, true)
@@ -31,7 +31,7 @@ function enable (config, tracer) {
       if (!rcConfig) return
 
       if (activation === Activation.ONECLICK) {
-        enableOrDisableAppsec(action, rcConfig, config, tracer)
+        enableOrDisableAppsec(action, rcConfig, config, appsec)
       }
 
       apiSecuritySampler.setRequestSampling(rcConfig.api_security?.request_sample_rate)
@@ -41,7 +41,7 @@ function enable (config, tracer) {
   return rc
 }
 
-function enableOrDisableAppsec (action, rcConfig, config, tracer) {
+function enableOrDisableAppsec (action, rcConfig, config, appsec) {
   if (typeof rcConfig.asm?.enabled === 'boolean') {
     let shouldEnable
 
@@ -52,9 +52,9 @@ function enableOrDisableAppsec (action, rcConfig, config, tracer) {
     }
 
     if (shouldEnable) {
-      tracer._modules.appsec.enable(config)
+      appsec.enable(config)
     } else {
-      tracer._modules.appsec.disable()
+      appsec.disable()
     }
   }
 }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -40,7 +40,7 @@ class Tracer extends NoopProxy {
     this.dogstatsd = new NoopDogStatsDClient()
     this._tracingInitialized = false
 
-    // this requires must work with esm bundler
+    // these requires must work with esm bundler
     this._modules = {
       appsec: new LazyModule(() => require('./appsec')),
       iast: new LazyModule(() => require('./appsec/iast'))

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -79,7 +79,7 @@ class Tracer extends NoopProxy {
       }
 
       if (config.remoteConfig.enabled && !config.isCiVisibility) {
-        const rc = remoteConfig.enable(config, this)
+        const rc = remoteConfig.enable(config, this._modules.appsec)
 
         rc.on('APM_TRACING', (action, conf) => {
           if (action === 'unapply') {

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -40,6 +40,7 @@ class Tracer extends NoopProxy {
     this.dogstatsd = new NoopDogStatsDClient()
     this._tracingInitialized = false
 
+    // this requires must work with esm bundler
     this._modules = {
       appsec: new TracerModule(() => require('./appsec')),
       iast: new TracerModule(() => require('./appsec/iast'))

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -79,7 +79,7 @@ class Tracer extends NoopProxy {
       }
 
       if (config.remoteConfig.enabled && !config.isCiVisibility) {
-        const rc = remoteConfig.enable(config)
+        const rc = remoteConfig.enable(config, this)
 
         rc.on('APM_TRACING', (action, conf) => {
           if (action === 'unapply') {

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -110,7 +110,11 @@ describe('Remote Config index', () => {
       beforeEach(() => {
         config.appsec = { enabled: undefined }
 
-        remoteConfig.enable(config)
+        remoteConfig.enable(config, {
+          _modules: {
+            appsec
+          }
+        })
 
         listener = rc.on.firstCall.args[1]
       })

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -110,11 +110,7 @@ describe('Remote Config index', () => {
       beforeEach(() => {
         config.appsec = { enabled: undefined }
 
-        remoteConfig.enable(config, {
-          _modules: {
-            appsec
-          }
-        })
+        remoteConfig.enable(config, appsec)
 
         listener = rc.on.firstCall.args[1]
       })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -274,6 +274,8 @@ describe('TracerProxy', () => {
         rc.emit('APM_TRACING', 'apply', { lib_config: conf })
         expect(DatadogTracer).to.have.been.calledOnce
         expect(AppsecSdk).to.have.been.calledOnce
+        expect(appsec.enable).to.not.have.been.called
+        expect(iast.enable).to.not.have.been.called
       })
 
       it('should support applying remote config (only call disable if enabled before)', () => {

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -262,6 +262,8 @@ describe('TracerProxy', () => {
         remoteConfigProxy.init()
         expect(DatadogTracer).to.have.been.calledOnce
         expect(AppsecSdk).to.have.been.calledOnce
+        expect(appsec.enable).to.not.have.been.called
+        expect(iast.enable).to.not.have.been.called
 
         let conf = { tracing_enabled: false }
         rc.emit('APM_TRACING', 'apply', { lib_config: conf })


### PR DESCRIPTION
### What does this PR do?
Use `LazyModule`s to handle how a module is loaded, enabled and disabled by the `Tracer`.
It takes into account ESM bundles keeping requires in place.
Also handles enablements/disablements via RC

### Motivation
do not require a module to disable it if it hasn't enabled before

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


