### PR TITLE
Use newer msgpack library to get rid of deprecation errors

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -21,7 +21,7 @@ require,lodash.sortby,MIT,Copyright JS Foundation and other contributors
 require,lru-cache,ISC,Copyright (c) 2010-2022 Isaac Z. Schlueter and Contributors
 require,methods,MIT,Copyright 2013-2014 TJ Holowaychuk
 require,module-details-from-path,MIT,Copyright 2016 Thomas Watson Steen
-require,msgpack-lite,MIT,Copyright 2015 Yusuke Kawasaki
+require,msgpack-long-lite,MIT,Copyright 2015,2017,2023 Yusuke Kawasaki and Patrick Schneider
 require,node-abort-controller,MIT,Copyright (c) 2019 Steve Faulkner
 require,opentracing,MIT,Copyright 2016 Resonance Labs Inc
 require,path-to-regexp,MIT,Copyright 2014 Blake Embrey

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const bodyParser = require('body-parser')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec({ int64: true })
 const http = require('http')
 const multer = require('multer')

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -3,7 +3,7 @@
 const { promisify } = require('util')
 const express = require('express')
 const bodyParser = require('body-parser')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec({ int64: true })
 const EventEmitter = require('events')
 const childProcess = require('child_process')

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lru-cache": "^7.14.0",
     "methods": "^1.1.2",
     "module-details-from-path": "^1.0.3",
-    "msgpack-lite": "^0.1.26",
+    "msgpack-long-lite": "^0.1.1",
     "node-abort-controller": "^3.1.1",
     "opentracing": ">=0.12.1",
     "path-to-regexp": "^0.1.2",

--- a/packages/dd-trace/src/datastreams/writer.js
+++ b/packages/dd-trace/src/datastreams/writer.js
@@ -2,7 +2,7 @@ const pkg = require('../../../../package.json')
 const log = require('../log')
 const request = require('../exporters/common/request')
 const { URL, format } = require('url')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const zlib = require('zlib')
 const codec = msgpack.createCodec({ int64: true })
 

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -15,7 +15,7 @@ let batch = 0
 // Internal representation of a trace or span ID.
 class Identifier {
   constructor (value, radix = 16) {
-    this._isUint64BE = true // msgpack-lite compatibility
+    this._isUint64BE = true // msgpack-long-lite compatibility
     this._buffer = radix === 16
       ? createBuffer(value)
       : fromString(value, radix)
@@ -31,7 +31,7 @@ class Identifier {
     return this._buffer
   }
 
-  // msgpack-lite compatibility
+  // msgpack-long-lite compatibility
   toArray () {
     if (this._buffer.length === 8) {
       return this._buffer

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -2,7 +2,7 @@
 require('../setup/tap')
 const pkg = require('../../../../package.json')
 const stubRequest = sinon.stub()
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec({ int64: true })
 
 const stubZlib = {

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -3,7 +3,7 @@
 require('../setup/tap')
 
 const { expect } = require('chai')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec({ int64: true })
 const id = require('../../src/id')
 

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -2,7 +2,7 @@
 
 require('../setup/tap')
 
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec({ int64: true })
 const id = require('../../src/id')
 

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -3,7 +3,7 @@
 require('../setup/tap')
 
 const { expect } = require('chai')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec({ int64: true })
 const id = require('../../src/id')
 const {

--- a/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js
@@ -3,7 +3,7 @@
 require('../setup/tap')
 
 const { expect } = require('chai')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 
 const id = require('../../src/id')
 

--- a/packages/dd-trace/test/encode/span-stats.spec.js
+++ b/packages/dd-trace/test/encode/span-stats.spec.js
@@ -3,7 +3,7 @@
 require('../setup/tap')
 
 const { expect } = require('chai')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec()
 
 const {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -2,7 +2,7 @@
 
 const http = require('http')
 const bodyParser = require('body-parser')
-const msgpack = require('msgpack-lite')
+const msgpack = require('msgpack-long-lite')
 const codec = msgpack.createCodec({ int64: true })
 const getPort = require('get-port')
 const express = require('express')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,10 +2247,10 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-event-lite@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/event-lite/-/event-lite-0.1.2.tgz"
-  integrity sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==
+event-lite@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.3.tgz#3dfe01144e808ac46448f0c19b4ab68e403a901d"
+  integrity sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw==
 
 events-to-array@^1.0.1:
   version "1.1.2"
@@ -2796,9 +2796,9 @@ ieee754@1.1.13:
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz"
   integrity "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q= sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 
-ieee754@^1.1.4, ieee754@^1.1.8:
+ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.1.1, ignore@^5.2.4:
@@ -3446,6 +3446,11 @@ long@^5.0.0:
   resolved "https://registry.npmjs.org/long/-/long-5.2.0.tgz"
   integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
 
+long@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
 loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
@@ -3649,15 +3654,15 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msgpack-lite@^0.1.26:
-  version "0.1.26"
-  resolved "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz"
-  integrity sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==
+msgpack-long-lite@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/msgpack-long-lite/-/msgpack-long-lite-0.1.1.tgz#77bd989eae7c87b690d7dbb2cf2ef72ad58c0cd2"
+  integrity sha512-1VyFwNwAtIILmgnDKdojdJt+KJWny1c/4DHk0zciRdcuO9klUUcE1YW4ST/Z7M58UV7EHbeukGRzu1sKucwoDQ==
   dependencies:
-    event-lite "^0.1.1"
-    ieee754 "^1.1.8"
-    int64-buffer "^0.1.9"
-    isarray "^1.0.0"
+    event-lite "^0.1.3"
+    ieee754 "^1.2.1"
+    isarray "^2.0.5"
+    long "^5.2.3"
 
 multer@^1.4.5-lts.1:
   version "1.4.5-lts.1"


### PR DESCRIPTION
### What does this PR do?
Using an updated lib for msgpack. msgpack-lite has not been maintained for more than 7 years.
msgpack-long-lite is a fork of msgpack-lite.

Solves issue: https://github.com/DataDog/dd-trace-js/issues/3546

### Motivation
Get rid of buffer deprecation warnings, because it uses [long.js](https://github.com/dcodeIO/long.js) to represent 64-bit integers instead of [int64-buffer](https://github.com/kawanet/int64-buffer)


