### PR TITLE
[ci-visibility] Fix ITR with multi project setup in jest

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -338,7 +338,7 @@ function applySuiteSkipping (originalTests, rootDir, frameworkVersion) {
   numSkippedSuites = jestSuitesToRun.skippedSuites.length
 
   itrSkippedSuitesCh.publish({ skippedSuites: jestSuitesToRun.skippedSuites, frameworkVersion })
-  skippableSuites = []
+
   return jestSuitesToRun.suitesToRun
 }
 


### PR DESCRIPTION
### What does this PR do?

For multi project setups, `applySuiteSkipping` (what we use to filter suites) is called once per project. If we set `skippableSuites` to `[]` after a single call, the following calls will see an empty array, resulting in suites not being skipped at all. 

### Motivation
Fix problem with ITR in "multi project" setup in jest: https://jestjs.io/docs/29.6/configuration#projects-arraystring--projectconfig

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
