### PR TITLE
[ci-visibility] Fix chrome installation for node 16

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install ChromeDriver
         run: |
           export CHROME_VERSION=$(google-chrome --version)
-          CHROME_DRIVER_DOWNLOAD_URL=$(node scripts/get-chrome-driver-download-url.js)
+          CHROME_DRIVER_DOWNLOAD_URL=$(node --experimental-fetch scripts/get-chrome-driver-download-url.js)
           wget -q "$CHROME_DRIVER_DOWNLOAD_URL"
           if [ $? -ne 0 ]; then echo "Failed to download ChromeDriver"; exit 1; fi
           unzip chromedriver-linux64.zip


### PR DESCRIPTION
### What does this PR do?
Pass `--experimental-fetch` flag to node, so that `fetch` is defined in node 16 too.

### Motivation
Selenium tests are failing for node 16: https://github.com/DataDog/dd-trace-js/actions/runs/8781974704/job/24095116325?pr=4253 in the 3.x and 4.x release proposal branches.

This is because `fetch` is not defined by default in node 16. 

