### PR TITLE
[ci-visibility] Fix selenium tests in node@16

### DIFF
--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -16,6 +16,9 @@ const {
   TEST_IS_RUM_ACTIVE,
   TEST_TYPE
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { NODE_MAJOR } = require('../../version')
+
+const cucumberVersion = NODE_MAJOR <= 16 ? '9' : 'latest'
 
 const webAppServer = require('../ci-visibility/web-app-server')
 
@@ -30,7 +33,13 @@ versionRange.forEach(version => {
     let webAppPort
 
     before(async function () {
-      sandbox = await createSandbox(['mocha', 'jest', '@cucumber/cucumber', 'chai@v4', `selenium-webdriver@${version}`])
+      sandbox = await createSandbox([
+        'mocha',
+        'jest',
+        `@cucumber/cucumber@${cucumberVersion}`,
+        'chai@v4',
+        `selenium-webdriver@${version}`
+      ])
       cwd = sandbox.folder
 
       webAppPort = await getPort()


### PR DESCRIPTION
### What does this PR do?
The latest version of cucumber does not work with node@16, so we need to use an old version for the tests in node@16.

### Motivation
Fix release proposal branches: https://github.com/DataDog/dd-trace-js/actions/runs/8782925371/job/24098071180?pr=4253

