### PR TITLE
test: Lint produced deb and rpm packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ package:
     when: on_success
   script:
     - ../.gitlab/build-deb-rpm.sh
+    - find . -iregex '.*\.\(deb\|rpm\)' -printf '%f\0' | xargs -0 dd-pkg lint
 
 package-arm:
   extends: .package-arm
@@ -37,6 +38,7 @@ package-arm:
     when: on_success
   script:
     - ../.gitlab/build-deb-rpm.sh
+    - find . -iregex '.*\.\(deb\|rpm\)' -printf '%f\0' | xargs -0 dd-pkg lint
 
 .release-package:
   stage: deploy


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The latest stable version of the packaging template now includes a tool dd-pkg. This PR uses this tool to lint the produced DEB and RPM packages.

### Motivation
<!-- What inspired you to submit this pull request? -->

This lint has been run at the time of package promotion, this change moves this step to the left and lets teams identify issues before they're trying to release to production.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

[BARX-245](https://datadoghq.atlassian.net/browse/BARX-245)



[BARX-245]: https://datadoghq.atlassian.net/browse/BARX-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ