### PR TITLE
fix fetch error when request has already been sent

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/fetch.js
+++ b/packages/datadog-instrumentations/src/helpers/fetch.js
@@ -7,11 +7,16 @@ exports.createWrapFetch = function createWrapFetch (Request, ch) {
     return function (input, init) {
       if (!ch.start.hasSubscribers) return fetch.apply(this, arguments)
 
-      const req = new Request(input, init)
-      const headers = req.headers
-      const ctx = { req, headers }
+      if (input instanceof Request) {
+        const ctx = { req: input }
 
-      return ch.tracePromise(() => fetch.call(this, req, { headers: ctx.headers }), ctx)
+        return ch.tracePromise(() => fetch.call(this, input, init), ctx)
+      } else {
+        const req = new Request(input, init)
+        const ctx = { req }
+
+        return ch.tracePromise(() => fetch.call(this, req), ctx)
+      }
     }
   }
 }

--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -17,8 +17,11 @@ class FetchPlugin extends HttpClientPlugin {
 
     const store = super.bindStart(ctx)
 
-    ctx.headers = headers
-    ctx.req = new globalThis.Request(req, { headers })
+    for (const name in headers) {
+      if (!req.headers.has(name)) {
+        req.headers.set(name, headers[name])
+      }
+    }
 
     return store
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix fetch error when request has already been sent.

### Motivation
<!-- What inspired you to submit this pull request? -->

Creating `Request` objects when not necessary can result in errors if the request has already been sent. It also adds overhead and turned out not to be needed to update the headers which is what it was intended for when this was implemented, so it can just be removed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

For some reason I can't seem to reproduce this in tests even when resending a request, but the issue is clearly documented in https://github.com/DataDog/dd-trace-js/pull/4245#issuecomment-2072874739
