### PR TITLE
Force node21 in test suites with native modules

### DIFF
--- a/.github/actions/node/21/action.yml
+++ b/.github/actions/node/21/action.yml
@@ -1,0 +1,7 @@
+name: Node 21
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '21'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -31,7 +31,7 @@ jobs:
       - run: yarn test:appsec:ci
       - uses: ./.github/actions/node/20
       - run: yarn test:appsec:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:ci
       - uses: codecov/codecov-action@v3
 
@@ -65,7 +65,7 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -127,7 +127,7 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -141,7 +141,7 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -161,7 +161,7 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -181,7 +181,7 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -197,7 +197,7 @@ jobs:
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/20
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -212,7 +212,7 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: ./.github/actions/node/20
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -31,7 +31,7 @@ jobs:
       - run: yarn test:trace:core:ci
       - uses: ./.github/actions/node/20
       - run: yarn test:trace:core:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/21
       - run: yarn test:trace:core:ci
       - uses: codecov/codecov-action@v3
 

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -133,7 +133,7 @@ describe('Plugin', () => {
               } else { // pino <7
                 expect(record).to.have.property('msg', error.message)
                 // ** TODO ** add this back once we fix it
-                if (NODE_MAJOR !== 21) {
+                if (NODE_MAJOR < 21) {
                   expect(record).to.have.property('type', 'Error')
                   expect(record).to.have.property('stack', error.stack)
                 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Executes with node21 tests suites with native modules that are not ready yet to be executed in node 22. (Profiling and iast taint tracking module)

- appsec and profiling tests changed to run with node21
- tracer ubuntu tests changed to run with node 21 because there is a test checking that profiling.run method is executed, and it is not executed if node is 22
- pino test updated, because it had a check `NODE_MAJOR != 21` instead of `NODE_MAJOR < 21`

### Motivation
<!-- What inspired you to submit this pull request? -->
Unblock release without node 22 compatible native modules


