### PR TITLE
Don't Run OpenAI v4 Tests Against Node 14

### DIFF
--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -12,6 +12,7 @@ const agent = require('../../dd-trace/test/plugins/agent')
 const { DogStatsDClient } = require('../../dd-trace/src/dogstatsd')
 const { NoopExternalLogger } = require('../../dd-trace/src/external-logger/src')
 const Sampler = require('../../dd-trace/src/sampler')
+const { DD_MAJOR } = require('../../../version')
 
 const tracerRequirePath = '../../dd-trace'
 
@@ -23,7 +24,9 @@ describe('Plugin', () => {
   let realVersion
 
   describe('openai', () => {
-    withVersions('openai', 'openai', version => {
+    // don't run tests when DD_MAJOR < 4
+    // passing 'true' to withVersions will skip the test suite
+    withVersions('openai', 'openai', DD_MAJOR < 4, version => {
       const moduleRequirePath = `../../../versions/openai@${version}`
 
       beforeEach(() => {

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -16,6 +16,8 @@ const { DD_MAJOR } = require('../../../version')
 
 const tracerRequirePath = '../../dd-trace'
 
+const VERSIONS_TO_TEST = DD_MAJOR >= 4 ? '>=3' : '>=3 <4'
+
 describe('Plugin', () => {
   let openai
   let clock
@@ -24,9 +26,7 @@ describe('Plugin', () => {
   let realVersion
 
   describe('openai', () => {
-    // don't run tests when DD_MAJOR < 4
-    // passing 'true' to withVersions will skip the test suite
-    withVersions('openai', 'openai', DD_MAJOR < 4, version => {
+    withVersions('openai', 'openai', VERSIONS_TO_TEST, version => {
       const moduleRequirePath = `../../../versions/openai@${version}`
 
       beforeEach(() => {


### PR DESCRIPTION
### What does this PR do?
Limits testing to OpenAI unit testing to `>=3 <4` the v3 release line due to incompatibility issues with OpenAI v4 and node 14.

### Motivation
Let CI pass for v3 release line


