### PR TITLE
try supporting node 14 on v5

### DIFF
--- a/.github/actions/node/14/action.yml
+++ b/.github/actions/node/14/action.yml
@@ -2,6 +2,6 @@ name: Node 14
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '14'

--- a/.github/actions/node/16/action.yml
+++ b/.github/actions/node/16/action.yml
@@ -2,6 +2,6 @@ name: Node 16
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'

--- a/.github/actions/node/18/action.yml
+++ b/.github/actions/node/18/action.yml
@@ -2,6 +2,6 @@ name: Node 18
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '18'

--- a/.github/actions/node/20/action.yml
+++ b/.github/actions/node/20/action.yml
@@ -2,6 +2,6 @@ name: Node 20
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'

--- a/.github/actions/node/21/action.yml
+++ b/.github/actions/node/21/action.yml
@@ -2,6 +2,6 @@ name: Node 21
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '21'

--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -2,6 +2,6 @@ name: Node Latest
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 'latest'

--- a/.github/actions/node/oldest/action.yml
+++ b/.github/actions/node/oldest/action.yml
@@ -1,7 +1,7 @@
-name: Node 18
+name: Node 14
 runs:
   using: composite
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '14'

--- a/.github/actions/node/oldest/action.yml
+++ b/.github/actions/node/oldest/action.yml
@@ -2,6 +2,6 @@ name: Node 14
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '14'

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -2,7 +2,7 @@ name: Node Setup
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         cache: yarn
         node-version: '14'

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -5,4 +5,4 @@ runs:
     - uses: actions/setup-node@v3
       with:
         cache: yarn
-        node-version: '18'
+        node-version: '14'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   macos:
-    runs-on: macos-latest-large
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -210,7 +210,7 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
+      - uses: ./.github/actions/node/18
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/21
       - run: yarn test:appsec:plugins:ci

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:lambda:ci
+      - uses: ./.github/actions/node/16
+      - run: yarn test:lambda:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:lambda:ci
       - uses: ./.github/actions/node/20

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
       - run: yarn

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       # Needs to remain on v3 for now due to GLIBC version
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - id: pkg

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -959,7 +959,7 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
+      - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1002,7 +1002,7 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
+      - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1038,7 +1038,7 @@ jobs:
       DD_TEST_AGENT_URL: http://testagent:9126
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
           cache: yarn
           node-version: '16'

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -976,7 +976,7 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
+      - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       # Needs to remain on v3 for now due to GLIBC version
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '14'
       - id: pkg
@@ -136,7 +136,7 @@ jobs:
           majorVersion=$(echo "$version" | cut -d '.' -f 1)
           echo "Major Version: $majorVersion"
           echo "MAJOR_VERSION=$majorVersion" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies and run tests
@@ -1038,7 +1038,7 @@ jobs:
       DD_TEST_AGENT_URL: http://testagent:9126
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: yarn
           node-version: '16'

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -444,6 +444,10 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/16
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/20
@@ -630,6 +634,10 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/16
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/20
@@ -649,6 +657,10 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/16
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/20
@@ -923,6 +935,10 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:plugins:ci
+      - uses: ./.github/actions/node/16
+      - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/20

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -28,6 +28,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:profiler:ci
+      - run: yarn test:integration:profiler
+      - uses: ./.github/actions/node/16
+      - run: yarn test:profiler:ci
+      - run: yarn test:integration:profiler
       - uses: ./.github/actions/node/18
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   macos:
-    runs-on: macos-latest-large
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -86,7 +86,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
-      - uses: ./.github/actions/node/latest
       - run: yarn install --ignore-engines
       - uses: actions/setup-node@v4
         with:
@@ -110,8 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
-        with:
-          node-version: ${{ matrix.version }}
+      - uses: ./.github/actions/node/latest
       - run: yarn install
       - run: yarn type:test
       - run: yarn type:doc

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       # Disable core dumps since some integration tests intentionally abort and core dump generation takes around 5-10s
@@ -42,7 +42,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       - name: Install Google Chrome
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
       - run: yarn install --ignore-engines
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       - run: yarn config set ignore-engines true

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -86,6 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/latest
       - run: yarn install --ignore-engines
       - uses: actions/setup-node@v4
         with:
@@ -109,6 +110,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
+        with:
+          node-version: ${{ matrix.version }}
       - run: yarn install
       - run: yarn type:test
       - run: yarn type:doc

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,7 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [18, 20, latest]
+        version: [14, 16, 18, 20, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [18, latest]
+        version: [14, 16, 18, latest]
         framework: [cucumber, playwright, selenium]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -33,7 +33,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [14, 16, 18, latest]
+        version: [16, 18, 20, latest] # node 14 does not have experimental-fetch
         framework: [cucumber, playwright, selenium]
     runs-on: ubuntu-latest
     env:
@@ -75,7 +75,7 @@ jobs:
         # Important: This is outside the minimum supported version of dd-trace-js
         # Node > 16 does not work with Cypress@6.7.0 (not even without our plugin)
         # TODO: figure out what to do with this: we might have to deprecate support for cypress@6.7.0
-        version: [16, latest]
+        version: [16, 18, 20, latest]
         # 6.7.0 is the minimum version we support
         cypress-version: [6.7.0, latest]
     runs-on: ubuntu-latest

--- a/.github/workflows/release-3.yml
+++ b/.github/workflows/release-3.yml
@@ -20,7 +20,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --tag latest-node14 --provenance
@@ -37,7 +37,7 @@ jobs:
     needs: ['publish']
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Log in to the Container registry
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:

--- a/.github/workflows/release-4.yml
+++ b/.github/workflows/release-4.yml
@@ -20,7 +20,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --tag latest-node16 --provenance
@@ -37,7 +37,7 @@ jobs:
     needs: ['publish']
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Log in to the Container registry
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -16,7 +16,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install
@@ -36,7 +36,7 @@ jobs:
     needs: ['dev_release']
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Log in to the Container registry
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -22,7 +22,7 @@ jobs:
       pkgjson: ${{ steps.pkg.outputs.json }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --provenance
@@ -39,7 +39,7 @@ jobs:
     needs: ['publish']
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Log in to the Container registry
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:
@@ -62,7 +62,7 @@ jobs:
     needs: ['publish']
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - id: pkg
         run: |
           content=`cat ./package.json | tr '\n' ' '`

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - run: npm i -g @bengl/branch-diff
       - run: |
           mkdir -p ~/.config/changelog-maker

--- a/.github/workflows/serverless-integration-test.yml
+++ b/.github/workflows/serverless-integration-test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       - name: Authenticate to Google Cloud

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   macos:
-    runs-on: macos-latest-large
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
       - run: yarn install
+      - uses: ./.github/actions/node/14
+      - run: yarn test:trace:core:ci
+      - uses: ./.github/actions/node/16
+      - run: yarn test:trace:core:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:trace:core:ci
       - uses: ./.github/actions/node/20

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=14"
   },
   "dependencies": {
     "@datadog/native-appsec": "7.1.1",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds support for Node.js v14 to the master branch, with intent to add it to a 5.x (and even 4.x) release.

### Motivation
<!-- What inspired you to submit this pull request? -->
As we move toward automated installation methods, larger amounts of Node.js release history support are becoming necessary on the latest release line. For now, the easiest path foward is to ensure we support back to the earliest Node.js version we support on _any_ release line. In the near future, we'll work out a policy around this so that expectations are clear.

### Additional Notes
* Calling this semver minor since it _adds_ support for versions of Node.js that weren't already supported.
* There's a failing nextjs test that's also failing on master.

