### PR TITLE
Support meta_struct in v0.4

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -287,7 +287,7 @@ class AgentEncoder {
     const validKeys = keys.filter(
       key =>
         typeof value[key] === 'string' || typeof value[key] === 'number' ||
-        (typeof value[key] === 'object' && !circularReferencesDetector.has(value[key])))
+        (value[key] !== null && typeof value[key] === 'object' && !circularReferencesDetector.has(value[key])))
 
     this._encodeMapPrefix(bytes, validKeys.length)
 
@@ -301,7 +301,7 @@ class AgentEncoder {
     const validValue = value.filter(
       item =>
         typeof item === 'string' || typeof item === 'number' ||
-        (typeof item === 'object' && !circularReferencesDetector.has(item)))
+        (item !== null && typeof item === 'object' && !circularReferencesDetector.has(item)))
 
     this._encodeArrayPrefix(bytes, validValue)
 

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -275,7 +275,7 @@ class AgentEncoder {
     circularReferencesDetector.add(value)
     if (Array.isArray(value)) {
       return this._encodeObjectAsArray(bytes, value, circularReferencesDetector)
-    } else if (typeof value === 'object') {
+    } else if (value !== null && typeof value === 'object') {
       return this._encodeObjectAsMap(bytes, value, circularReferencesDetector)
     } else if (typeof value === 'string' || typeof value === 'number') {
       this._encodeValue(bytes, value)
@@ -284,10 +284,10 @@ class AgentEncoder {
 
   _encodeObjectAsMap (bytes, value, circularReferencesDetector) {
     const keys = Object.keys(value)
-    const validKeys = keys.filter(
-      key =>
-        typeof value[key] === 'string' || typeof value[key] === 'number' ||
-        (value[key] !== null && typeof value[key] === 'object' && !circularReferencesDetector.has(value[key])))
+    const validKeys = keys.filter(key =>
+      typeof value[key] === 'string' ||
+      typeof value[key] === 'number' ||
+      (value[key] !== null && typeof value[key] === 'object' && !circularReferencesDetector.has(value[key])))
 
     this._encodeMapPrefix(bytes, validKeys.length)
 
@@ -298,10 +298,10 @@ class AgentEncoder {
   }
 
   _encodeObjectAsArray (bytes, value, circularReferencesDetector) {
-    const validValue = value.filter(
-      item =>
-        typeof item === 'string' || typeof item === 'number' ||
-        (item !== null && typeof item === 'object' && !circularReferencesDetector.has(item)))
+    const validValue = value.filter(item =>
+      typeof item === 'string' ||
+      typeof item === 'number' ||
+      (item !== null && typeof item === 'object' && !circularReferencesDetector.has(item)))
 
     this._encodeArrayPrefix(bytes, validValue)
 

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -293,7 +293,7 @@ class AgentEncoder {
 
     for (const key of validKeys) {
       this._encodeString(bytes, key)
-      this._encodeObject(bytes, value[key])
+      this._encodeObject(bytes, value[key], circularReferencesDetector)
     }
   }
 
@@ -306,7 +306,7 @@ class AgentEncoder {
     this._encodeArrayPrefix(bytes, validValue)
 
     for (const item of validValue) {
-      this._encodeObject(bytes, item)
+      this._encodeObject(bytes, item, circularReferencesDetector)
     }
   }
 

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -83,13 +83,17 @@ class AgentEncoder {
       span = formatSpan(span)
       bytes.reserve(1)
 
-      if (span.type) {
+      if (span.type && span.meta_struct) {
+        bytes.buffer[bytes.length++] = 0x8d
+      } else if (span.type || span.meta_struct) {
         bytes.buffer[bytes.length++] = 0x8c
-
-        this._encodeString(bytes, 'type')
-        this._encodeString(bytes, span.type)
       } else {
         bytes.buffer[bytes.length++] = 0x8b
+      }
+
+      if (span.type) {
+        this._encodeString(bytes, 'type')
+        this._encodeString(bytes, span.type)
       }
 
       this._encodeString(bytes, 'trace_id')
@@ -114,6 +118,10 @@ class AgentEncoder {
       this._encodeMap(bytes, span.meta)
       this._encodeString(bytes, 'metrics')
       this._encodeMap(bytes, span.metrics)
+      if (span.meta_struct) {
+        this._encodeString(bytes, 'meta_struct')
+        this._encodeObject(bytes, span.meta_struct)
+      }
     }
   }
 
@@ -260,6 +268,45 @@ class AgentEncoder {
       for (let i = 7; i >= 0; i--) {
         bytes.buffer[bytes.length - i - 1] = uInt8Float64Array[i]
       }
+    }
+  }
+
+  _encodeObject (bytes, value, circularReferencesDetector = new Set()) {
+    circularReferencesDetector.add(value)
+    if (Array.isArray(value)) {
+      return this._encodeObjectAsArray(bytes, value, circularReferencesDetector)
+    } else if (typeof value === 'object') {
+      return this._encodeObjectAsMap(bytes, value, circularReferencesDetector)
+    } else if (typeof value === 'string' || typeof value === 'number') {
+      this._encodeValue(bytes, value)
+    }
+  }
+
+  _encodeObjectAsMap (bytes, value, circularReferencesDetector) {
+    const keys = Object.keys(value)
+    const validKeys = keys.filter(
+      key =>
+        typeof value[key] === 'string' || typeof value[key] === 'number' ||
+        (typeof value[key] === 'object' && !circularReferencesDetector.has(value[key])))
+
+    this._encodeMapPrefix(bytes, validKeys.length)
+
+    for (const key of validKeys) {
+      this._encodeString(bytes, key)
+      this._encodeObject(bytes, value[key])
+    }
+  }
+
+  _encodeObjectAsArray (bytes, value, circularReferencesDetector) {
+    const validValue = value.filter(
+      item =>
+        typeof item === 'string' || typeof item === 'number' ||
+        (typeof item === 'object' && !circularReferencesDetector.has(item)))
+
+    this._encodeArrayPrefix(bytes, validValue)
+
+    for (const item of validValue) {
+      this._encodeObject(bytes, item)
     }
   }
 

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -400,5 +400,45 @@ describe('encode', () => {
       }
       expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
     })
+
+    it('should encode meta_struct ignoring undefined properties', () => {
+      const metaStruct = {
+        foo: 'bar',
+        undefinedProperty: undefined
+      }
+      data[0].meta_struct = metaStruct
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      const expectedMetaStruct = {
+        foo: 'bar'
+      }
+      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+    })
+
+    it('should encode meta_struct ignoring null properties', () => {
+      const metaStruct = {
+        foo: 'bar',
+        nullProperty: null
+      }
+      data[0].meta_struct = metaStruct
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      const expectedMetaStruct = {
+        foo: 'bar'
+      }
+      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+    })
   })
 })

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -290,7 +290,28 @@ describe('encode', () => {
                   id: 3333,
                   file: 'test.js',
                   line: 1,
-                  column: 12,
+                  column: 31,
+                  function: 'test'
+                },
+                {
+                  id: 444,
+                  file: 'test2.js',
+                  line: 54,
+                  column: 77,
+                  function: 'test'
+                },
+                {
+                  id: 55,
+                  file: 'test.js',
+                  line: 1245,
+                  column: 41,
+                  function: 'test'
+                },
+                {
+                  id: 6,
+                  file: 'test3.js',
+                  line: 2024,
+                  column: 32,
                   function: 'test'
                 }
               ]

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -276,7 +276,22 @@ describe('encode', () => {
       expect(trace[0].meta_struct).to.deep.equal(metaStruct)
     })
 
-    it('should encode meta_struct with complex object', () => {
+    it('should encode meta_struct with empty object and array', () => {
+      const metaStruct = {
+        foo: {},
+        bar: []
+      }
+      data[0].meta_struct = metaStruct
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+    })
+
+    it('should encode meta_struct with possible real use case', () => {
       const metaStruct = {
         '_dd.stack': {
           exploit: [
@@ -287,28 +302,28 @@ describe('encode', () => {
               message: 'Threat detected',
               frames: [
                 {
-                  id: 3333,
+                  id: 0,
                   file: 'test.js',
                   line: 1,
                   column: 31,
                   function: 'test'
                 },
                 {
-                  id: 444,
+                  id: 1,
                   file: 'test2.js',
                   line: 54,
                   column: 77,
                   function: 'test'
                 },
                 {
-                  id: 55,
+                  id: 2,
                   file: 'test.js',
                   line: 1245,
                   column: 41,
                   function: 'test'
                 },
                 {
-                  id: 6,
+                  id: 3,
                   file: 'test3.js',
                   line: 2024,
                   column: 32,

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// require('../setup/tap')
+require('../setup/tap')
 
 const { expect } = require('chai')
 const msgpack = require('msgpack-lite')

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -332,9 +332,12 @@ describe('encode', () => {
 
     it('should encode meta_struct ignoring circular references in objects', () => {
       const circular = {
-        bar: 'baz'
+        bar: 'baz',
+        deeper: {
+          foo: 'bar'
+        }
       }
-      circular.circular = circular
+      circular.deeper.circular = circular
       const metaStruct = {
         foo: circular
       }
@@ -349,7 +352,10 @@ describe('encode', () => {
 
       const expectedMetaStruct = {
         foo: {
-          bar: 'baz'
+          bar: 'baz',
+          deeper: {
+            foo: 'bar'
+          }
         }
       }
       expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-require('../setup/tap')
+// require('../setup/tap')
 
 const { expect } = require('chai')
 const msgpack = require('msgpack-lite')
@@ -439,6 +439,19 @@ describe('encode', () => {
         foo: 'bar'
       }
       expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+    })
+
+    it('should not encode null meta_struct', () => {
+      data[0].meta_struct = null
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      expect(trace[0].meta_struct).to.be.undefined
     })
   })
 })

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -189,4 +189,31 @@ describe('encode 0.5', () => {
     expect(payload[5]).to.equal(1)
     expect(payload[11]).to.equal(0)
   })
+
+  it('should ignore meta_struct property', () => {
+    data[0].meta_struct = { foo: 'bar' }
+
+    encoder.encode(data)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer, { codec })
+    const stringMap = decoded[0]
+    const trace = decoded[1][0]
+
+    expect(trace).to.be.instanceof(Array)
+    expect(trace[0]).to.be.instanceof(Array)
+    expect(stringMap[trace[0][0]]).to.equal(data[0].service)
+    expect(stringMap[trace[0][1]]).to.equal(data[0].name)
+    expect(stringMap[trace[0][2]]).to.equal(data[0].resource)
+    expect(trace[0][3].toString(16)).to.equal(data[0].trace_id.toString())
+    expect(trace[0][4].toString(16)).to.equal(data[0].span_id.toString())
+    expect(trace[0][5].toString(16)).to.equal(data[0].parent_id.toString())
+    expect(trace[0][6].toNumber()).to.equal(data[0].start)
+    expect(trace[0][7].toNumber()).to.equal(data[0].duration)
+    expect(trace[0][8]).to.equal(0)
+    expect(trace[0][9]).to.deep.equal({ [stringMap.indexOf('bar')]: stringMap.indexOf('baz') })
+    expect(trace[0][10]).to.deep.equal({ [stringMap.indexOf('example')]: 1 })
+    expect(stringMap[trace[0][11]]).to.equal('') // unset
+    expect(trace[0][12]).to.be.undefined // Everything works the same as without meta_struct, and nothing else is added
+  })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add support for `meta_struct` property in the spans for `v0.4` agent api.
`meta_struct` is expected to be an object with inner objects or arrays, not only `key: number|string` as we have in the current tags.

### Motivation
<!-- What inspired you to submit this pull request? -->
It will be used in the near future to send stack traces associated with detected threats.

### Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
[APPSEC-52970]




[APPSEC-52970]: https://datadoghq.atlassian.net/browse/APPSEC-52970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ