### PR TITLE
allow reconfiguration via init()

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -714,7 +714,7 @@ class Config {
     const opts = this._options = this._options || {}
     const tags = {}
 
-    options = this.options = Object.assign({ ingestion: {} }, options, opts)
+    options = this.options = Object.assign({ ingestion: {}, appsec: {} }, options, opts)
 
     tagger.add(tags, options.tags)
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -48,7 +48,15 @@ class Tracer extends NoopProxy {
   }
 
   init (options) {
-    if (this._initialized) return this
+    if (this._initialized) {
+      if (options) {
+        if (this._tracingInitialized) {
+          this._tracer._config.configure(options)
+        }
+        this._enableOrDisableTracing(this._tracer._config)
+      }
+      return this
+    }
 
     this._initialized = true
 
@@ -134,7 +142,7 @@ class Tracer extends NoopProxy {
 
   _enableOrDisableTracing (config) {
     if (config.tracing !== false) {
-      if (config.appsec.enabled) {
+      if (config.appsec && config.appsec.enabled) {
         this._modules.appsec.enable(config)
       }
       if (!this._tracingInitialized) {
@@ -142,7 +150,7 @@ class Tracer extends NoopProxy {
         this.appsec = new AppsecSdk(this._tracer, config)
         this._tracingInitialized = true
       }
-      if (config.iast.enabled) {
+      if (config.iast && config.iast.enabled) {
         this._modules.iast.enable(config, this._tracer)
       }
     } else if (this._tracingInitialized) {


### PR DESCRIPTION
### What does this PR do?

Every time init() is called, pass the options object to .configure(), allowing for config to be changed at any time (as it already can be with remote config).

### Motivation
<!-- What inspired you to submit this pull request? -->
This allows programmatic config to apply even if `-r dd-trace/init` was used.


