### PR TITLE
SQS span extraction - fallback on AttributeValue if Value is undefined

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -157,8 +157,9 @@ class Sqs extends BaseAwsSdkPlugin {
         const textMap = attributes.StringValue
         return JSON.parse(textMap)
       } else if (attributes.Type === 'Binary') {
-        const buffer = Buffer.from(attributes.Value, 'base64')
-        return JSON.parse(buffer)
+        const binaryMap = attributes.Value ? attributes.Value : attributes.BinaryValue;
+        const buffer = Buffer.from(binaryMap, 'base64');
+        return JSON.parse(buffer.toString());
       }
     } catch (e) {
       log.error(e)


### PR DESCRIPTION
### What does this PR do?
this attempts to fix trace propagation between an SNS producer and SQS consumer. Since the sns plugin is setting the `_datadog` attribute with a `BinaryValue` property [here](https://github.com/DataDog/dd-trace-js/blob/f4adddc8086e628753fc3499c8b5faf104966b34/packages/datadog-plugin-aws-sdk/src/services/sns.js#L79-L94), it seems good to check for this property on the `sqs` side.

### Motivation
trace propagation not working for me when publishing with `sns` and consumer is `sqs`.

as a workaround, I am currently doing this to propagate between `sns` and `sqs`

```ts
const datadogAttribute = message.MessageAttributes._datadog
const buffer = Buffer.from(datadogAttribute.BinaryValue, 'base64')
const parsedAttributes = JSON.parse(buffer)
tracer.extract('text_map', parsedAttributes)
```

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
no additional notes


