### PR TITLE
fix playwright test range for now

### DIFF
--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -26,7 +26,7 @@ const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
 const NUM_RETRIES_EFD = 3
 
-const versions = ['1.18.0', 'latest']
+const versions = ['1.18.0', '1.43.0']
 
 versions.forEach((version) => {
   describe(`playwright@${version}`, () => {

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -493,14 +493,14 @@ addHook({
 addHook({
   name: 'playwright',
   file: 'lib/runner/dispatcher.js',
-  versions: ['>=1.38.0']
+  versions: ['>=1.38.0 <=1.43.0']
 }, (dispatcher) => dispatcherHookNew(dispatcher, dispatcherRunWrapperNew))
 
 // Hook used for early flake detection. EFD only works from >=1.38.0
 addHook({
   name: 'playwright',
   file: 'lib/common/suiteUtils.js',
-  versions: [`>=${MINIMUM_SUPPORTED_VERSION_EFD}`]
+  versions: [`>=${MINIMUM_SUPPORTED_VERSION_EFD} <=1.43.0`]
 }, suiteUtilsPackage => {
   // We grab `applyRepeatEachIndex` to use it later
   // `applyRepeatEachIndex` needs to be applied to a cloned suite
@@ -512,7 +512,7 @@ addHook({
 addHook({
   name: 'playwright',
   file: 'lib/runner/loadUtils.js',
-  versions: [`>=${MINIMUM_SUPPORTED_VERSION_EFD}`]
+  versions: [`>=${MINIMUM_SUPPORTED_VERSION_EFD} <=1.43.0`]
 }, (loadUtilsPackage) => {
   const oldCreateRootSuite = loadUtilsPackage.createRootSuite
 


### PR DESCRIPTION
### What does this PR do?
Sets the top of the testing range for playwright to 1.43.0

### Motivation
The tests break on 1.44.0, so we can't properly support it (yet).


