### PR TITLE
[ci-visibility] Fix playwright >=1.44.0

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -297,7 +297,12 @@ function dispatcherRunWrapper (run) {
 }
 
 function dispatcherRunWrapperNew (run) {
-  return function () {
+  return function (testGroups) {
+    if (!this._allTests) {
+      // Removed in https://github.com/microsoft/playwright/commit/1e52c37b254a441cccf332520f60225a5acc14c7
+      // Not available from >=1.44.0
+      this._allTests = testGroups.map(g => g.tests).flat()
+    }
     remainingTestsByFile = getTestsBySuiteFromTestGroups(arguments[0])
     return run.apply(this, arguments)
   }


### PR DESCRIPTION
### What does this PR do?
Fix playwright instrumentation. 

### Motivation
Playwright instrumentation is broken right now because of a change introduced in 1.44.0: https://github.com/microsoft/playwright/commit/1e52c37b254a441cccf332520f60225a5acc14c7. 

It removed an internal property we relied on.

### Plugin Checklist
No extra unit test needed. We just have to make sure that the playwright tests now pass.

