### PR TITLE
Fix patching behavior for require-in-the-middle

### DIFF
--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -35,9 +35,7 @@ function Hook (modules, options, onrequire) {
   this.modules = modules
   this.options = options
   this.onrequire = onrequire
-  this._origRequire = Module.prototype.require
-
-  const self = this
+  const _origRequire = Module.prototype.require
 
   if (Array.isArray(modules)) {
     for (const mod of modules) {
@@ -63,7 +61,7 @@ function Hook (modules, options, onrequire) {
     try {
       filename = Module._resolveFilename(request, this)
     } catch (resolveErr) {
-      return self._origRequire.apply(this, arguments)
+      return _origRequire.apply(this, arguments)
     }
 
     const core = filename.indexOf(path.sep) === -1

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -35,7 +35,6 @@ function Hook (modules, options, onrequire) {
   this.modules = modules
   this.options = options
   this.onrequire = onrequire
-  const _origRequire = Module.prototype.require
 
   if (Array.isArray(modules)) {
     for (const mod of modules) {
@@ -51,6 +50,7 @@ function Hook (modules, options, onrequire) {
 
   if (patchedRequire) return
 
+  const _origRequire = Module.prototype.require
   patchedRequire = Module.prototype.require = function (request) {
     /*
     If resolving the filename for a `require(...)` fails, defer to the wrapped

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -5,8 +5,6 @@ const Module = require('module')
 const parse = require('module-details-from-path')
 const dc = require('dc-polyfill')
 
-const origRequire = Module.prototype.require
-
 // derived from require-in-the-middle@3 with tweaks
 
 module.exports = Hook
@@ -35,7 +33,9 @@ function Hook (modules, options, onrequire) {
   this.modules = modules
   this.options = options
   this.onrequire = onrequire
-  const _origRequire = Module.prototype.require
+  this.origRequire = Module.prototype.require
+
+  const self = this
 
   if (Array.isArray(modules)) {
     for (const mod of modules) {
@@ -61,7 +61,7 @@ function Hook (modules, options, onrequire) {
     try {
       filename = Module._resolveFilename(request, this)
     } catch (resolveErr) {
-      return _origRequire.apply(this, arguments)
+      return self.origRequire.apply(this, arguments)
     }
 
     const core = filename.indexOf(path.sep) === -1
@@ -81,7 +81,7 @@ function Hook (modules, options, onrequire) {
     const patched = patching[filename]
     if (patched) {
       // If it's already patched, just return it as-is.
-      return origRequire.apply(this, arguments)
+      return self.origRequire.apply(this, arguments)
     } else {
       patching[filename] = true
     }
@@ -94,7 +94,7 @@ function Hook (modules, options, onrequire) {
     if (moduleLoadStartChannel.hasSubscribers) {
       moduleLoadStartChannel.publish(payload)
     }
-    const exports = origRequire.apply(this, arguments)
+    const exports = self.origRequire.apply(this, arguments)
     payload.module = exports
     if (moduleLoadEndChannel.hasSubscribers) {
       moduleLoadEndChannel.publish(payload)
@@ -159,7 +159,7 @@ function Hook (modules, options, onrequire) {
 }
 
 Hook.reset = function () {
-  Module.prototype.require = origRequire
+  Module.prototype.require = this.origRequire
   patchedRequire = null
   patching = Object.create(null)
   cache = Object.create(null)

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -51,7 +51,12 @@ function Hook (modules, options, onrequire) {
   if (patchedRequire) return
 
   patchedRequire = Module.prototype.require = function (request) {
-    const filename = Module._resolveFilename(request, this)
+    let filename
+    try {
+      filename = Module._resolveFilename(request, this)
+    } catch (resolveErr) {
+      return origRequire.apply(this, arguments)
+    }
     const core = filename.indexOf(path.sep) === -1
     let name, basedir, hooks
     // return known patched modules immediately

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -10,7 +10,6 @@ const Hook = require('../src/ritm')
 describe('Ritm', () => {
   let moduleLoadStartChannel, moduleLoadEndChannel, startListener, endListener
   let utilHook, aHook, bHook, httpHook
-  const origRequire = Module.prototype.require
 
   before(() => {
     moduleLoadStartChannel = dc.channel('dd-trace:moduleLoadStart')
@@ -51,7 +50,6 @@ describe('Ritm', () => {
     aHook.unhook()
     bHook.unhook()
     httpHook.unhook()
-    Module.prototype.require = origRequire
   })
 
   it('should shim util', () => {

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -41,7 +41,7 @@ describe('Ritm', () => {
 
   it('should fall back to monkey patched module', () => {
     Module.prototype.require = new Proxy(Module.prototype.require, {
-      apply(target, thisArg, argArray) {
+      apply (target, thisArg, argArray) {
         if (argArray[0] === '@azure/functions-core') {
           return {
             version: '1.0.0',
@@ -53,7 +53,7 @@ describe('Ritm', () => {
       }
     })
 
-    const httpHook = new Hook(['http'], function onRequire(exports, name, basedir) {
+    const httpHook = new Hook(['http'], function onRequire (exports, name, basedir) {
       exports.foo = 1
       return exports
     })

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -4,6 +4,7 @@ require('./setup/tap')
 
 const dc = require('dc-polyfill')
 const { assert } = require('chai')
+const Module = require('module')
 const Hook = require('../src/ritm')
 
 const moduleLoadStartChannel = dc.channel('dd-trace:moduleLoadStart')
@@ -36,5 +37,39 @@ describe('Ritm', () => {
     assert.equal(startListener.callCount, 2)
     assert.equal(endListener.callCount, 2)
     assert.equal(a(), 'Called by AJ')
+  })
+
+  it('should fall back to monkey patched module', () => {
+    Module.prototype.require = new Proxy(Module.prototype.require, {
+      apply(target, thisArg, argArray) {
+        if (argArray[0] === '@azure/functions-core') {
+          return {
+            version: '1.0.0',
+            registerHook: () => { }
+          }
+        } else {
+          return Reflect.apply(target, thisArg, argArray)
+        }
+      }
+    })
+
+    const httpHook = new Hook(['http'], function onRequire(exports, name, basedir) {
+      exports.foo = 1
+      return exports
+    })
+    assert.equal(require('http').foo, 1, 'normal hooking still works')
+
+    const fnCore = require('@azure/functions-core')
+    assert.ok(fnCore, 'requiring monkey patched in module works')
+    assert.equal(fnCore.version, '1.0.0')
+    assert.equal(typeof fnCore.registerHook, 'function')
+
+    assert.throws(
+      () => require('package-does-not-exist'),
+      'Cannot find module \'package-does-not-exist\'',
+      'a failing `require(...)` can still throw as expected'
+    )
+
+    httpHook.unhook()
   })
 })

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -10,6 +10,7 @@ const Hook = require('../src/ritm')
 describe('Ritm', () => {
   let moduleLoadStartChannel, moduleLoadEndChannel, startListener, endListener
   let utilHook, aHook, bHook, httpHook
+  const origRequire = Module.prototype.require
 
   before(() => {
     moduleLoadStartChannel = dc.channel('dd-trace:moduleLoadStart')
@@ -50,6 +51,7 @@ describe('Ritm', () => {
     aHook.unhook()
     bHook.unhook()
     httpHook.unhook()
+    Module.prototype.require = origRequire
   })
 
   it('should shim util', () => {

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -17,11 +17,13 @@ describe('Ritm', () => {
 
     moduleLoadStartChannel.subscribe(startListener)
     moduleLoadEndChannel.subscribe(endListener)
-    Hook('util')
+    const utilHook = Hook('util')
     require('util')
 
     assert.equal(startListener.callCount, 1)
     assert.equal(endListener.callCount, 1)
+
+    utilHook.unhook()
   })
 
   it('should handle module load cycles', () => {
@@ -30,13 +32,16 @@ describe('Ritm', () => {
 
     moduleLoadStartChannel.subscribe(startListener)
     moduleLoadEndChannel.subscribe(endListener)
-    Hook('module-a')
-    Hook('module-b')
+    const aHook = Hook('module-a')
+    const bHook = Hook('module-b')
     const { a } = require('./ritm-tests/module-a')
 
     assert.equal(startListener.callCount, 2)
     assert.equal(endListener.callCount, 2)
     assert.equal(a(), 'Called by AJ')
+
+    aHook.unhook()
+    bHook.unhook()
   })
 
   it('should fall back to monkey patched module', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Applies a fix made to the `require-in-the-middle` package so monkey patched modules can be required correctly.

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/SVLS-4805

This is needed to use `require-in-the-middle` with `azure-functions-nodejs-worker`, which patches `require` to support `require('@azure/functions-core')`. `@azure/functions` adds these modules that otherwise would not be handled by require. So from `dd-trace`'s perspective these modules don't exist and it errors out when trying to require them.

* PR with fix to `require-in-the-middle`: https://github.com/elastic/require-in-the-middle/pull/59
* Relevant code: https://github.com/elastic/require-in-the-middle/blob/826dbde2898ef4a3a4ddb0fe6d44287694238b5b/index.js#L155-L168

<img width="703" alt="Screenshot 2024-05-13 at 4 23 17 PM" src="https://github.com/DataDog/dd-trace-js/assets/35278470/30a0a658-9134-466a-bd87-ec60a75df0e7">

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Confirmed unit tests fails before fix to `ritm.js` is added.

```
  Ritm
    ✓ should shim util
    ✓ should handle module load cycles
    ✓ should fall back to monkey patched module


  3 passing (140.468ms)
```

Mimic `require-in-the-middle` by setting `_origRequire` inside the `Hook` function. Our version of ritm sets `origRequire` outside of `Hook` and prevented the unit test from passing. I tried refactoring all of the references to `origRequire` but it resulted in unit tests in other packages failing. I took this approach to prevent regressions.

https://github.com/elastic/require-in-the-middle/blob/826dbde2898ef4a3a4ddb0fe6d44287694238b5b/index.js#L124
