### PR TITLE
Enable Serverless Mini Agent for Azure Functions on All Plans

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -16,7 +16,7 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('./plugins/util/tags')
 const { getGitMetadataFromGitProperties, removeUserSensitiveInfo } = require('./git_properties')
 const { updateConfig } = require('./telemetry')
 const telemetryMetrics = require('./telemetry/metrics')
-const { getIsGCPFunction, getIsAzureFunctionConsumptionPlan } = require('./serverless')
+const { getIsGCPFunction, getIsAzureFunction } = require('./serverless')
 const { ORIGIN_KEY } = require('./constants')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
@@ -339,7 +339,7 @@ class Config {
 
     // Requires an accompanying DD_APM_OBFUSCATION_MEMCACHED_KEEP_COMMAND=true in the agent
     this.memcachedCommandEnabled = isTrue(DD_TRACE_MEMCACHED_COMMAND_ENABLED)
-    this.isAzureFunctionConsumptionPlan = getIsAzureFunctionConsumptionPlan()
+    this.isAzureFunction = getIsAzureFunction()
     this.spanLeakDebug = Number(DD_TRACE_SPAN_LEAK_DEBUG)
     this.installSignature = {
       id: DD_INSTRUMENTATION_INSTALL_ID,
@@ -417,8 +417,8 @@ class Config {
   _isInServerlessEnvironment () {
     const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
     const isGCPFunction = getIsGCPFunction()
-    const isAzureFunctionConsumptionPlan = getIsAzureFunctionConsumptionPlan()
-    return inAWSLambda || isGCPFunction || isAzureFunctionConsumptionPlan
+    const isAzureFunction = getIsAzureFunction()
+    return inAWSLambda || isGCPFunction || isAzureFunction
   }
 
   // for _merge to work, every config value must have a default value
@@ -867,7 +867,7 @@ class Config {
     return coalesce(
       this.options.stats,
       process.env.DD_TRACE_STATS_COMPUTATION_ENABLED,
-      getIsGCPFunction() || getIsAzureFunctionConsumptionPlan()
+      getIsGCPFunction() || getIsAzureFunction()
     )
   }
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -91,7 +91,7 @@ class Tracer extends NoopProxy {
         })
       }
 
-      if (config.isGCPFunction || config.isAzureFunctionConsumptionPlan) {
+      if (config.isGCPFunction || config.isAzureFunction) {
         require('./serverless').maybeStartServerlessMiniAgent(config)
       }
 

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -53,18 +53,16 @@ function getIsGCPFunction () {
   return isDeprecatedGCPFunction || isNewerGCPFunction
 }
 
-function getIsAzureFunctionConsumptionPlan () {
+function getIsAzureFunction () {
   const isAzureFunction =
     process.env.FUNCTIONS_EXTENSION_VERSION !== undefined && process.env.FUNCTIONS_WORKER_RUNTIME !== undefined
-  const azureWebsiteSKU = process.env.WEBSITE_SKU
-  const isConsumptionPlan = azureWebsiteSKU === undefined || azureWebsiteSKU === 'Dynamic'
 
-  return isAzureFunction && isConsumptionPlan
+  return isAzureFunction
 }
 
 module.exports = {
   maybeStartServerlessMiniAgent,
   getIsGCPFunction,
-  getIsAzureFunctionConsumptionPlan,
+  getIsAzureFunction,
   getRustBinaryPath
 }

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -54,7 +54,7 @@ describe('Serverless', () => {
     expect(spawnStub).to.have.been.calledOnce
   })
 
-  it('should spawn mini agent when Azure FUNCTIONS_WORKER_RUNTIME, FUNCTIONS_EXTENSION_VERSION env vars are defined', () => {
+  it('should spawn mini agent when Azure env vars are defined', () => {
     process.env.FUNCTIONS_WORKER_RUNTIME = 'node'
     process.env.FUNCTIONS_EXTENSION_VERSION = '4'
 

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -54,33 +54,13 @@ describe('Serverless', () => {
     expect(spawnStub).to.have.been.calledOnce
   })
 
-  it('should spawn mini agent when FUNCTIONS_WORKER_RUNTIME, FUNCTIONS_EXTENSION_VERSION env vars are defined', () => {
+  it('should spawn mini agent when Azure FUNCTIONS_WORKER_RUNTIME, FUNCTIONS_EXTENSION_VERSION env vars are defined', () => {
     process.env.FUNCTIONS_WORKER_RUNTIME = 'node'
     process.env.FUNCTIONS_EXTENSION_VERSION = '4'
 
     proxy.init()
 
     expect(spawnStub).to.have.been.calledOnce
-  })
-
-  it('should spawn mini agent when Azure Function env vars are defined and SKU is dynamic', () => {
-    process.env.FUNCTIONS_WORKER_RUNTIME = 'node'
-    process.env.FUNCTIONS_EXTENSION_VERSION = '4'
-    process.env.WEBSITE_SKU = 'Dynamic'
-
-    proxy.init()
-
-    expect(spawnStub).to.have.been.calledOnce
-  })
-
-  it('should NOT spawn mini agent when Azure Function env vars are defined but SKU is NOT dynamic', () => {
-    process.env.FUNCTIONS_WORKER_RUNTIME = 'node'
-    process.env.FUNCTIONS_EXTENSION_VERSION = '4'
-    process.env.WEBSITE_SKU = 'Basic'
-
-    proxy.init()
-
-    expect(spawnStub).to.not.have.been.called
   })
 
   it('should log error if mini agent binary path is invalid', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Run Serverless Mini Agent for Azure Functions on all consumption plans.

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/SVLS-4805

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


