### PR TITLE
Remove last node 21 references in GH actions

### DIFF
--- a/.github/actions/node/21/action.yml
+++ b/.github/actions/node/21/action.yml
@@ -1,7 +1,0 @@
-name: Node 21
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '21'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -228,6 +228,6 @@ jobs:
       - run: yarn install
       - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/21
+      - uses: ./.github/actions/node/latest
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Set to latest node version appsec lodash tests and remove unused node 21 GH action

### Motivation
<!-- What inspired you to submit this pull request? -->
Execute test suites with expected node versions



