### PR TITLE
set an explicit version range for the @opentelemetry/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,10 @@ If you would like to trace your bundled application then please read this page o
 ## Security Vulnerabilities
 
 Please refer to the [SECURITY.md](https://github.com/DataDog/dd-trace-js/blob/master/SECURITY.md) document if you have found a security issue.
+
+## Datadog With OpenTelemetery
+
+Please refer to the [Node.js Custom Instrumentation using OpenTelemetry API](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/nodejs/otel/) document. It includes information on how to use the OpenTelemetry API with dd-trace-js
+
+Note that our internal implementation of the OpenTelemetry API is currently set within the version range `>=1.0.0 <1.9.0`. This range will be updated at a regular cadence therefore, we recommend updating your tracer to the latest release to ensure up to date support.
+

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.3.0",
     "@datadog/sketches-js": "^2.1.0",
-    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/core": "^1.14.0",
     "crypto-randomuuid": "^1.0.0",
     "dc-polyfill": "^0.1.4",


### PR DESCRIPTION
### What does this PR do?
sets an explicit version range for the @opentelemetry/api

### Motivation
https://github.com/DataDog/dd-trace-js/issues/3654

TLDR:

"Short version: an SDK implementation should expect that minor versions of the API may include new methods. Minor version stability is guaranteed for users but not implementers. The OpenTelemetry authors recommend the following: dd-trace should define not only a minimum API level but also a maximum"

the version maximum is set to <1.9.0 which is expected to break us:

https://github.com/open-telemetry/opentelemetry-js/pull/4677#issuecomment-2113002304

### Additional Notes
Should we take the approach of listing the supported version range as a "peerDependencies"? Although it will ensure that users install the supported versions of the @opentelemetry/api it will also force users not using the @opentelemetry/api to have to install it.


