### PR TITLE
V4.38.0 proposal

### DIFF
--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: ./.github/actions/node/20
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
-      - uses: ./.github/actions/node/21
+      - uses: ./.github/actions/node/latest
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -33,7 +33,7 @@ jobs:
       - run: yarn test:trace:core:ci
       - uses: ./.github/actions/node/20
       - run: yarn test:trace:core:ci
-      - uses: ./.github/actions/node/21
+      - uses: ./.github/actions/node/latest
       - run: yarn test:trace:core:ci
       - uses: codecov/codecov-action@v3
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,10 @@ If you would like to trace your bundled application then please read this page o
 ## Security Vulnerabilities
 
 Please refer to the [SECURITY.md](https://github.com/DataDog/dd-trace-js/blob/master/SECURITY.md) document if you have found a security issue.
+
+## Datadog With OpenTelemetery
+
+Please refer to the [Node.js Custom Instrumentation using OpenTelemetry API](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/nodejs/otel/) document. It includes information on how to use the OpenTelemetry API with dd-trace-js
+
+Note that our internal implementation of the OpenTelemetry API is currently set within the version range `>=1.0.0 <1.9.0`. This range will be updated at a regular cadence therefore, we recommend updating your tracer to the latest release to ensure up to date support.
+

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -260,6 +260,7 @@ tracer.use('aws-sdk', awsSdkOptions);
 tracer.use('bunyan');
 tracer.use('couchbase');
 tracer.use('cassandra-driver');
+tracer.use('child_process');
 tracer.use('connect');
 tracer.use('connect', httpServerOptions);
 tracer.use('cypress');

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,6 +144,7 @@ interface Plugins {
   "aws-sdk": tracer.plugins.aws_sdk;
   "bunyan": tracer.plugins.bunyan;
   "cassandra-driver": tracer.plugins.cassandra_driver;
+  "child_process": tracer.plugins.child_process;
   "connect": tracer.plugins.connect;
   "couchbase": tracer.plugins.couchbase;
   "cucumber": tracer.plugins.cucumber;
@@ -1206,6 +1207,12 @@ declare namespace tracer {
      * [cassandra-driver](https://github.com/datastax/nodejs-driver) module.
      */
     interface cassandra_driver extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
+     * [child_process](https://nodejs.org/api/child_process.html) module.
+     */
+    interface child_process extends Instrumentation {}
 
     /**
      * This plugin automatically instruments the

--- a/init.js
+++ b/init.js
@@ -1,7 +1,31 @@
 'use strict'
 
-const tracer = require('.')
+const path = require('path')
+const Module = require('module')
 
-tracer.init()
+let initBailout = false
 
-module.exports = tracer
+if (process.env.DD_INJECTION_ENABLED) {
+  // If we're running via single-step install, and we're not in the app's
+  // node_modules, then we should not initialize the tracer. This prevents
+  // single-step-installed tracer from clobbering the manually-installed tracer.
+  let resolvedInApp
+  const entrypoint = process.argv[1]
+  try {
+    resolvedInApp = Module.createRequire(entrypoint).resolve('dd-trace')
+  } catch (e) {
+    // Ignore. If we can't resolve the module, we assume it's not in the app.
+  }
+  if (resolvedInApp) {
+    const ourselves = path.join(__dirname, 'index.js')
+    if (ourselves !== resolvedInApp) {
+      initBailout = true
+    }
+  }
+}
+
+if (!initBailout) {
+  const tracer = require('.')
+  tracer.init()
+  module.exports = tracer
+}

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -1,0 +1,57 @@
+const {
+  createSandbox,
+  spawnProc
+} = require('./helpers')
+const { assert } = require('chai')
+const path = require('path')
+
+const DD_INJECTION_ENABLED = 'tracing'
+
+describe('init.js', () => {
+  let cwd, proc, sandbox
+
+  async function runTest (cwd, env, expected) {
+    return new Promise((resolve, reject) => {
+      spawnProc(path.join(cwd, 'init/index.js'), { cwd, env }, data => {
+        try {
+          assert.strictEqual(data.toString(), expected)
+          resolve()
+        } catch (e) {
+          reject(e)
+        }
+      }).then(subproc => {
+        proc = subproc
+      })
+    })
+  }
+
+  before(async () => {
+    sandbox = await createSandbox()
+    cwd = sandbox.folder
+  })
+  afterEach(() => {
+    proc && proc.kill()
+  })
+  after(() => {
+    return sandbox.remove()
+  })
+
+  context('when dd-trace is not in the app dir', () => {
+    const NODE_OPTIONS = `--require ${path.join(__dirname, '..', 'init.js')}`
+    it('should initialize the tracer, if no DD_INJECTION_ENABLED', () => {
+      return runTest(cwd, { NODE_OPTIONS }, 'true\n')
+    })
+    it('should not initialize the tracer, if DD_INJECTION_ENABLED', () => {
+      return runTest(cwd, { NODE_OPTIONS, DD_INJECTION_ENABLED }, 'false\n')
+    })
+  })
+  context('when dd-trace in the app dir', () => {
+    const NODE_OPTIONS = '--require dd-trace/init.js'
+    it('should initialize the tracer, if no DD_INJECTION_ENABLED', () => {
+      return runTest(cwd, { NODE_OPTIONS }, 'true\n')
+    })
+    it('should initialize the tracer, if DD_INJECTION_ENABLED', () => {
+      return runTest(cwd, { NODE_OPTIONS, DD_INJECTION_ENABLED }, 'true\n')
+    })
+  })
+})

--- a/integration-tests/init/index.js
+++ b/integration-tests/init/index.js
@@ -1,0 +1,3 @@
+// eslint-disable-next-line no-console
+console.log(!!global._ddtrace)
+process.exit()

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@datadog/native-iast-rewriter": "2.3.1",
     "@datadog/native-iast-taint-tracking": "2.1.0",
     "@datadog/native-metrics": "^2.0.0",
-    "@datadog/pprof": "5.2.0",
+    "@datadog/pprof": "5.3.0",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "4.37.0",
+  "version": "4.38.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.3.0",
     "@datadog/sketches-js": "^2.1.0",
-    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/core": "^1.14.0",
     "crypto-randomuuid": "^1.0.0",
     "dc-polyfill": "^0.1.4",

--- a/packages/dd-trace/src/appsec/iast/iast-log.js
+++ b/packages/dd-trace/src/appsec/iast/iast-log.js
@@ -2,34 +2,8 @@
 
 const dc = require('dc-polyfill')
 const log = require('../../log')
-const { calculateDDBasePath } = require('../../util')
 
 const telemetryLog = dc.channel('datadog:telemetry:log')
-
-const ddBasePath = calculateDDBasePath(__dirname)
-const EOL = '\n'
-const STACK_FRAME_LINE_REGEX = /^\s*at\s/gm
-
-function sanitize (logEntry, stack) {
-  if (!stack) return logEntry
-
-  let stackLines = stack.split(EOL)
-
-  const firstIndex = stackLines.findIndex(l => l.match(STACK_FRAME_LINE_REGEX))
-
-  const isDDCode = firstIndex > -1 && stackLines[firstIndex].includes(ddBasePath)
-  stackLines = stackLines
-    .filter((line, index) => (isDDCode && index < firstIndex) || line.includes(ddBasePath))
-    .map(line => line.replace(ddBasePath, ''))
-
-  logEntry.stack_trace = stackLines.join(EOL)
-
-  if (!isDDCode) {
-    logEntry.message = 'omitted'
-  }
-
-  return logEntry
-}
 
 function getTelemetryLog (data, level) {
   try {
@@ -42,18 +16,13 @@ function getTelemetryLog (data, level) {
       message = String(data.message || data)
     }
 
-    let logEntry = {
+    const logEntry = {
       message,
       level
     }
-
     if (data.stack) {
-      logEntry = sanitize(logEntry, data.stack)
-      if (logEntry.stack_trace === '') {
-        return
-      }
+      logEntry.stack_trace = data.stack
     }
-
     return logEntry
   } catch (e) {
     log.error(e)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -16,7 +16,7 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('./plugins/util/tags')
 const { getGitMetadataFromGitProperties, removeUserSensitiveInfo } = require('./git_properties')
 const { updateConfig } = require('./telemetry')
 const telemetryMetrics = require('./telemetry/metrics')
-const { getIsGCPFunction, getIsAzureFunctionConsumptionPlan } = require('./serverless')
+const { getIsGCPFunction, getIsAzureFunction } = require('./serverless')
 const { ORIGIN_KEY } = require('./constants')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
@@ -339,7 +339,7 @@ class Config {
 
     // Requires an accompanying DD_APM_OBFUSCATION_MEMCACHED_KEEP_COMMAND=true in the agent
     this.memcachedCommandEnabled = isTrue(DD_TRACE_MEMCACHED_COMMAND_ENABLED)
-    this.isAzureFunctionConsumptionPlan = getIsAzureFunctionConsumptionPlan()
+    this.isAzureFunction = getIsAzureFunction()
     this.spanLeakDebug = Number(DD_TRACE_SPAN_LEAK_DEBUG)
     this.installSignature = {
       id: DD_INSTRUMENTATION_INSTALL_ID,
@@ -417,8 +417,8 @@ class Config {
   _isInServerlessEnvironment () {
     const inAWSLambda = process.env.AWS_LAMBDA_FUNCTION_NAME !== undefined
     const isGCPFunction = getIsGCPFunction()
-    const isAzureFunctionConsumptionPlan = getIsAzureFunctionConsumptionPlan()
-    return inAWSLambda || isGCPFunction || isAzureFunctionConsumptionPlan
+    const isAzureFunction = getIsAzureFunction()
+    return inAWSLambda || isGCPFunction || isAzureFunction
   }
 
   // for _merge to work, every config value must have a default value
@@ -877,7 +877,7 @@ class Config {
     return coalesce(
       this.options.stats,
       process.env.DD_TRACE_STATS_COMPUTATION_ENABLED,
-      getIsGCPFunction() || getIsAzureFunctionConsumptionPlan()
+      getIsGCPFunction() || getIsAzureFunction()
     )
   }
 

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -5,6 +5,7 @@ const { Config } = require('./config')
 const { snapshotKinds } = require('./constants')
 const { threadNamePrefix } = require('./profilers/shared')
 const dc = require('dc-polyfill')
+const telemetryLog = dc.channel('datadog:telemetry:log')
 
 const profileSubmittedChannel = dc.channel('datadog:profiling:profile-submitted')
 
@@ -13,6 +14,19 @@ function maybeSourceMap (sourceMap, SourceMapper, debug) {
   return SourceMapper.create([
     process.cwd()
   ], debug)
+}
+
+function logError (logger, err) {
+  if (logger) {
+    logger.error(err)
+  }
+  if (telemetryLog.hasSubscribers) {
+    telemetryLog.publish({
+      message: err.message,
+      level: 'ERROR',
+      stack_trace: err.stack
+    })
+  }
 }
 
 class Profiler extends EventEmitter {
@@ -28,11 +42,13 @@ class Profiler extends EventEmitter {
 
   start (options) {
     return this._start(options).catch((err) => {
-      if (options.logger) {
-        options.logger.error(err)
-      }
+      logError(options.logger, err)
       return false
     })
+  }
+
+  _logError (err) {
+    logError(this._logger, err)
   }
 
   async _start (options) {
@@ -61,7 +77,7 @@ class Profiler extends EventEmitter {
         })
       }
     } catch (err) {
-      this._logger.error(err)
+      this._logError(err)
     }
 
     try {
@@ -78,7 +94,7 @@ class Profiler extends EventEmitter {
       this._capture(this._timeoutInterval, start)
       return true
     } catch (e) {
-      this._logger.error(e)
+      this._logError(e)
       this._stop()
       return false
     }
@@ -167,7 +183,7 @@ class Profiler extends EventEmitter {
       profileSubmittedChannel.publish()
       this._logger.debug('Submitted profiles')
     } catch (err) {
-      this._logger.error(err)
+      this._logError(err)
       this._stop()
     }
   }
@@ -182,7 +198,7 @@ class Profiler extends EventEmitter {
     tags.snapshot = snapshotKind
     for (const exporter of this._config.exporters) {
       const task = exporter.export({ profiles, start, end, tags })
-        .catch(err => this._logger.error(err))
+        .catch(err => this._logError(err))
 
       tasks.push(task)
     }

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -92,7 +92,7 @@ class Tracer extends NoopProxy {
         })
       }
 
-      if (config.isGCPFunction || config.isAzureFunctionConsumptionPlan) {
+      if (config.isGCPFunction || config.isAzureFunction) {
         require('./serverless').maybeStartServerlessMiniAgent(config)
       }
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -14,6 +14,7 @@ const dogstatsd = require('./dogstatsd')
 const NoopDogStatsDClient = require('./noop/dogstatsd')
 const spanleak = require('./spanleak')
 const { SSITelemetry } = require('./profiling/ssi-telemetry')
+const telemetryLog = require('dc-polyfill').channel('datadog:telemetry:log')
 
 class LazyModule {
   constructor (provider) {
@@ -104,6 +105,11 @@ class Tracer extends NoopProxy {
           this._profilerStarted = profiler.start(config)
         } catch (e) {
           log.error(e)
+          telemetryLog.publish({
+            message: e.message,
+            level: 'ERROR',
+            stack_trace: e.stack
+          })
         }
       } else if (ssiTelemetry.enabled()) {
         require('./profiling/ssi-telemetry-mock-profiler').start(config)

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -53,18 +53,16 @@ function getIsGCPFunction () {
   return isDeprecatedGCPFunction || isNewerGCPFunction
 }
 
-function getIsAzureFunctionConsumptionPlan () {
+function getIsAzureFunction () {
   const isAzureFunction =
     process.env.FUNCTIONS_EXTENSION_VERSION !== undefined && process.env.FUNCTIONS_WORKER_RUNTIME !== undefined
-  const azureWebsiteSKU = process.env.WEBSITE_SKU
-  const isConsumptionPlan = azureWebsiteSKU === undefined || azureWebsiteSKU === 'Dynamic'
 
-  return isAzureFunction && isConsumptionPlan
+  return isAzureFunction
 }
 
 module.exports = {
   maybeStartServerlessMiniAgent,
   getIsGCPFunction,
-  getIsAzureFunctionConsumptionPlan,
+  getIsAzureFunction,
   getRustBinaryPath
 }

--- a/packages/dd-trace/src/telemetry/logs/log-collector.js
+++ b/packages/dd-trace/src/telemetry/logs/log-collector.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const log = require('../../log')
+const { calculateDDBasePath } = require('../../util')
 
 const logs = new Map()
 
@@ -29,6 +30,37 @@ function isValid (logEntry) {
   return logEntry?.level && logEntry.message
 }
 
+const ddBasePath = calculateDDBasePath(__dirname)
+const EOL = '\n'
+const STACK_FRAME_LINE_REGEX = /^\s*at\s/gm
+
+function sanitize (logEntry) {
+  const stack = logEntry.stack_trace
+  if (!stack) return logEntry
+
+  let stackLines = stack.split(EOL)
+
+  const firstIndex = stackLines.findIndex(l => l.match(STACK_FRAME_LINE_REGEX))
+
+  const isDDCode = firstIndex > -1 && stackLines[firstIndex].includes(ddBasePath)
+  stackLines = stackLines
+    .filter((line, index) => (isDDCode && index < firstIndex) || line.includes(ddBasePath))
+    .map(line => line.replace(ddBasePath, ''))
+
+  logEntry.stack_trace = stackLines.join(EOL)
+  if (logEntry.stack_trace === '') {
+    // If entire stack was removed, we'd just have a message saying "omitted"
+    // in which case we'd rather not log it at all.
+    return null
+  }
+
+  if (!isDDCode) {
+    logEntry.message = 'omitted'
+  }
+
+  return logEntry
+}
+
 const logCollector = {
   add (logEntry) {
     try {
@@ -37,9 +69,13 @@ const logCollector = {
       // NOTE: should errors have higher priority? and discard log entries with lower priority?
       if (logs.size >= maxEntries) {
         overflowedCount++
-        return
+        return false
       }
 
+      logEntry = sanitize(logEntry)
+      if (!logEntry) {
+        return false
+      }
       const hash = createHash(logEntry)
       if (!logs.has(hash)) {
         logs.set(hash, logEntry)
@@ -49,6 +85,11 @@ const logCollector = {
       log.error(`Unable to add log to logCollector: ${e.message}`)
     }
     return false
+  },
+
+  // Used for testing
+  hasEntry (logEntry) {
+    return logs.has(createHash(logEntry))
   },
 
   drain () {

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -235,4 +235,223 @@ describe('encode', () => {
     expect(trace[0].meta).to.deep.equal({ bar: 'baz', '_dd.span_links': encodedLink })
     expect(trace[0].metrics).to.deep.equal({ example: 1 })
   })
+
+  describe('meta_struct', () => {
+    it('should encode meta_struct with simple key value object', () => {
+      const metaStruct = {
+        foo: 'bar',
+        baz: 123
+      }
+      data[0].meta_struct = metaStruct
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+    })
+
+    it('should encode meta_struct with simple array of simple values', () => {
+      const metaStruct = ['one', 2, 'three', 4, 5, 'six']
+      data[0].meta_struct = metaStruct
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+    })
+
+    it('should encode meta_struct with array of objects', () => {
+      const metaStruct = [{ foo: 'bar' }, { baz: 123 }]
+      data[0].meta_struct = metaStruct
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+    })
+
+    it('should encode meta_struct with empty object and array', () => {
+      const metaStruct = {
+        foo: {},
+        bar: []
+      }
+      data[0].meta_struct = metaStruct
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+    })
+
+    it('should encode meta_struct with possible real use case', () => {
+      const metaStruct = {
+        '_dd.stack': {
+          exploit: [
+            {
+              type: 'test',
+              language: 'nodejs',
+              id: 'someuuid',
+              message: 'Threat detected',
+              frames: [
+                {
+                  id: 0,
+                  file: 'test.js',
+                  line: 1,
+                  column: 31,
+                  function: 'test'
+                },
+                {
+                  id: 1,
+                  file: 'test2.js',
+                  line: 54,
+                  column: 77,
+                  function: 'test'
+                },
+                {
+                  id: 2,
+                  file: 'test.js',
+                  line: 1245,
+                  column: 41,
+                  function: 'test'
+                },
+                {
+                  id: 3,
+                  file: 'test3.js',
+                  line: 2024,
+                  column: 32,
+                  function: 'test'
+                }
+              ]
+            }
+          ]
+        }
+      }
+      data[0].meta_struct = metaStruct
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+    })
+
+    it('should encode meta_struct ignoring circular references in objects', () => {
+      const circular = {
+        bar: 'baz',
+        deeper: {
+          foo: 'bar'
+        }
+      }
+      circular.deeper.circular = circular
+      const metaStruct = {
+        foo: circular
+      }
+      data[0].meta_struct = metaStruct
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      const expectedMetaStruct = {
+        foo: {
+          bar: 'baz',
+          deeper: {
+            foo: 'bar'
+          }
+        }
+      }
+      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+    })
+
+    it('should encode meta_struct ignoring circular references in arrays', () => {
+      const circular = [{
+        bar: 'baz'
+      }]
+      circular.push(circular)
+      const metaStruct = {
+        foo: circular
+      }
+      data[0].meta_struct = metaStruct
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      const expectedMetaStruct = {
+        foo: [{
+          bar: 'baz'
+        }]
+      }
+      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+    })
+
+    it('should encode meta_struct ignoring undefined properties', () => {
+      const metaStruct = {
+        foo: 'bar',
+        undefinedProperty: undefined
+      }
+      data[0].meta_struct = metaStruct
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      const expectedMetaStruct = {
+        foo: 'bar'
+      }
+      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+    })
+
+    it('should encode meta_struct ignoring null properties', () => {
+      const metaStruct = {
+        foo: 'bar',
+        nullProperty: null
+      }
+      data[0].meta_struct = metaStruct
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      const expectedMetaStruct = {
+        foo: 'bar'
+      }
+      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+    })
+
+    it('should not encode null meta_struct', () => {
+      data[0].meta_struct = null
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+
+      const decoded = msgpack.decode(buffer, { codec })
+      const trace = decoded[0]
+
+      expect(trace[0].meta_struct).to.be.undefined
+    })
+  })
 })

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -189,4 +189,31 @@ describe('encode 0.5', () => {
     expect(payload[5]).to.equal(1)
     expect(payload[11]).to.equal(0)
   })
+
+  it('should ignore meta_struct property', () => {
+    data[0].meta_struct = { foo: 'bar' }
+
+    encoder.encode(data)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer, { codec })
+    const stringMap = decoded[0]
+    const trace = decoded[1][0]
+
+    expect(trace).to.be.instanceof(Array)
+    expect(trace[0]).to.be.instanceof(Array)
+    expect(stringMap[trace[0][0]]).to.equal(data[0].service)
+    expect(stringMap[trace[0][1]]).to.equal(data[0].name)
+    expect(stringMap[trace[0][2]]).to.equal(data[0].resource)
+    expect(trace[0][3].toString(16)).to.equal(data[0].trace_id.toString())
+    expect(trace[0][4].toString(16)).to.equal(data[0].span_id.toString())
+    expect(trace[0][5].toString(16)).to.equal(data[0].parent_id.toString())
+    expect(trace[0][6].toNumber()).to.equal(data[0].start)
+    expect(trace[0][7].toNumber()).to.equal(data[0].duration)
+    expect(trace[0][8]).to.equal(0)
+    expect(trace[0][9]).to.deep.equal({ [stringMap.indexOf('bar')]: stringMap.indexOf('baz') })
+    expect(trace[0][10]).to.deep.equal({ [stringMap.indexOf('example')]: 1 })
+    expect(stringMap[trace[0][11]]).to.equal('') // unset
+    expect(trace[0][12]).to.be.undefined // Everything works the same as without meta_struct, and nothing else is added
+  })
 })

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -54,33 +54,13 @@ describe('Serverless', () => {
     expect(spawnStub).to.have.been.calledOnce
   })
 
-  it('should spawn mini agent when FUNCTIONS_WORKER_RUNTIME, FUNCTIONS_EXTENSION_VERSION env vars are defined', () => {
+  it('should spawn mini agent when Azure env vars are defined', () => {
     process.env.FUNCTIONS_WORKER_RUNTIME = 'node'
     process.env.FUNCTIONS_EXTENSION_VERSION = '4'
 
     proxy.init()
 
     expect(spawnStub).to.have.been.calledOnce
-  })
-
-  it('should spawn mini agent when Azure Function env vars are defined and SKU is dynamic', () => {
-    process.env.FUNCTIONS_WORKER_RUNTIME = 'node'
-    process.env.FUNCTIONS_EXTENSION_VERSION = '4'
-    process.env.WEBSITE_SKU = 'Dynamic'
-
-    proxy.init()
-
-    expect(spawnStub).to.have.been.calledOnce
-  })
-
-  it('should NOT spawn mini agent when Azure Function env vars are defined but SKU is NOT dynamic', () => {
-    process.env.FUNCTIONS_WORKER_RUNTIME = 'node'
-    process.env.FUNCTIONS_EXTENSION_VERSION = '4'
-    process.env.WEBSITE_SKU = 'Basic'
-
-    proxy.init()
-
-    expect(spawnStub).to.not.have.been.called
   })
 
   it('should log error if mini agent binary path is invalid', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,10 +442,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.2.0.tgz#a6c2779335b4f0fd51754e4de193e98591de387e"
-  integrity sha512-pSwLARpNLAIV1JttxXOBRKTn/NQYXDy1PJaV458YFDdAYxnBqpsYTat3/nX+8V5GoN4SfdHDci3zqXM+Ym66gQ==
+"@datadog/pprof@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.3.0.tgz#c2f58d328ecced7f99887f1a559d7fe3aecb9219"
+  integrity sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### Improvements

- **core:** Add child_process plugin to typings (#4306)
- **asm:** Add support for meta_struct property in the spans for v0.4 agent api (#4287)
- **serverless:** Enable Serverless Mini Agent for Azure Functions on All Plans (#4304)
- **core:** stop clobbering manually-installed tracer with Single Step Instrumentation (#4300)
- **core:** define an explicit version range of support for the @opentelemetry/api (#4318)

### Features

- **profiling:** Add profiler support for node 22 (#4312)


