### PR TITLE
[ci-visibility] Fix EFD with jest and jsdom

### DIFF
--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -20,6 +20,10 @@ if (process.env.OLD_RUNNER) {
   options.testRunner = 'jest-jasmine2'
 }
 
+if (process.env.ENABLE_JSDOM) {
+  options.testEnvironment = 'jsdom'
+}
+
 jest.runCLI(
   options,
   options.projects

--- a/integration-tests/ci-visibility/run-jest.mjs
+++ b/integration-tests/ci-visibility/run-jest.mjs
@@ -22,6 +22,10 @@ if (process.env.OLD_RUNNER) {
   options.testRunner = 'jest-jasmine2'
 }
 
+if (process.env.ENABLE_JSDOM) {
+  options.testEnvironment = 'jsdom'
+}
+
 jest.runCLI(
   options,
   options.projects

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -148,7 +148,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       }
       let hasSnapshotTests = true
       try {
-        const { _snapshotData } = this.context.expect.getState().snapshotState
+        const { _snapshotData } = this.getVmContext().expect.getState().snapshotState
         hasSnapshotTests = Object.keys(_snapshotData).length > 0
       } catch (e) {
         // if we can't be sure, we'll err on the side of caution and assume it has snapshots


### PR DESCRIPTION
### What does this PR do?
Fix EFD retry mechanism that was failing in jest when using `jsdom`. The problem: `this.context` is only defined for node jest environment, not jsdom. You need to use `getVmContext` instead. 

See how `this.context` is accessible in `jest-environment-node`: https://github.com/jestjs/jest/blob/559449e5a0a87210324720b56caa55b2e0ad3c94/packages/jest-environment-node/src/index.ts#L219

See how `this.context` is _not_ accessible in `jest-environment-jsdom`: 
https://github.com/jestjs/jest/blob/559449e5a0a87210324720b56caa55b2e0ad3c94/packages/jest-environment-jsdom-abstract/src/index.ts#L187

### Motivation
Fix retry mechanism in jest when using `jsdom`.

This was not caught earlier because we were not testing with `jsdom`. I've fixed that. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
