### PR TITLE
docs: direct readers to the correct doc site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+Note: If you're viewing this `docs/` directory on GitHub
+you'll find that none of the links work and that most of
+the content is missing. This directory simply contains
+base files used to generate docs for the API docs site:
+
+[API Documentation](https://datadoghq.dev/dd-trace-js/)


### PR DESCRIPTION
### What does this PR do?
- displays a message in the `docs/` directory telling the user where to find docs
- it is not intended that anyone read the docs in this directory, it's really just doc build tooling

### Motivation
- both customers and employees have gotten lost in this directory