### PR TITLE
amqplib: node>=v22.2.0 incompat amqplib<=v0.5.2

### DIFF
--- a/packages/datadog-instrumentations/src/amqplib.js
+++ b/packages/datadog-instrumentations/src/amqplib.js
@@ -8,13 +8,16 @@ const {
 const kebabCase = require('../../datadog-core/src/utils/src/kebabcase')
 const shimmer = require('../../datadog-shimmer')
 
+const { NODE_MAJOR, NODE_MINOR } = require('../../../version')
+const MIN_VERSION = ((NODE_MAJOR > 22) || (NODE_MAJOR === 22 && NODE_MINOR >= 2)) ? '>=0.5.3' : '>=0.5.0'
+
 const startCh = channel('apm:amqplib:command:start')
 const finishCh = channel('apm:amqplib:command:finish')
 const errorCh = channel('apm:amqplib:command:error')
 
 let methods = {}
 
-addHook({ name: 'amqplib', file: 'lib/defs.js', versions: ['>=0.5'] }, defs => {
+addHook({ name: 'amqplib', file: 'lib/defs.js', versions: [MIN_VERSION] }, defs => {
   methods = Object.keys(defs)
     .filter(key => Number.isInteger(defs[key]))
     .filter(key => isCamelCase(key))
@@ -22,7 +25,7 @@ addHook({ name: 'amqplib', file: 'lib/defs.js', versions: ['>=0.5'] }, defs => {
   return defs
 })
 
-addHook({ name: 'amqplib', file: 'lib/channel.js', versions: ['>=0.5'] }, channel => {
+addHook({ name: 'amqplib', file: 'lib/channel.js', versions: [MIN_VERSION] }, channel => {
   shimmer.wrap(channel.Channel.prototype, 'sendImmediately', sendImmediately => function (method, fields) {
     return instrument(sendImmediately, this, arguments, methods[method], fields)
   })


### PR DESCRIPTION
### What does this PR do?
- by changing the supported version of amqplib from 0.5.0 (8 years old) to 0.6.0 (4 years old) the tests pass
- 0.5.6 is ok
- 0.5.3 is always ok
  - OK https://github.com/DataDog/dd-trace-js/actions/runs/9134706614/job/25120800465?pr=4328
- 0.5.2 is mixed
  - mixed https://github.com/DataDog/dd-trace-js/actions/runs/9134728773/job/25120880692?pr=4328
    - 18.20 OK
    - 22.2 not ok
  - mixed https://github.com/DataDog/dd-trace-js/actions/runs/9134728773/job/25121082402?pr=4328
    - 18.20 OK
    - 22.2 not ok 
- 0.5.1 is mixed
  - ~~passed once then started failing? are the failures non-deterministic?~~ maybe I only looked at 18.20 and not 22.2
- haven't been able to find a commit where failure began
- v0.5.0 isn't all that popular
- the docker container is 5 years old https://hub.docker.com/_/rabbitmq/tags?page=&page_size=&ordering=&name=3.6
- no relevant recent commits in tracer, no changes to amqplib 0.5.0, no docker daemon changes either
- looks like node version is to blame
  - node 22.2.0 fails
    - https://github.com/DataDog/dd-trace-js/actions/runs/9129262696/job/25103424633?pr=4291
  - node 22.1.0 passes
    - https://github.com/DataDog/dd-trace-js/actions/runs/8969484146/job/24630988280?pr=4268
    - https://github.com/DataDog/dd-trace-js/actions/runs/9007508201/job/24747443728?pr=4288
  - node 22.0.0 passes
    - https://github.com/DataDog/dd-trace-js/actions/runs/8884062712/job/24392318158?pr=4272
  - yeah seems pretty certain that amqplib <= 0.5.3 is incompatible with Node.js >= 22.2.0
    - seems like a decent number of changes went into 0.5.3
    - https://diff.intrinsic.com/amqplib/0.5.2/0.5.3

### Motivation
- CI failures in master

### Version Popularity

- [0.8.0](https://www.npmjs.com/package/amqplib/v/0.8.0) 215,514 3 years ago
- [0.7.1](https://www.npmjs.com/package/amqplib/v/0.7.1) 23,462 3 years ago
- [0.7.0](https://www.npmjs.com/package/amqplib/v/0.7.0) 3,714 3 years ago
- [0.6.0](https://www.npmjs.com/package/amqplib/v/0.6.0) 15,927 4 years ago
- [0.5.6](https://www.npmjs.com/package/amqplib/v/0.5.6) 62,631 4 years ago
- [0.5.5](https://www.npmjs.com/package/amqplib/v/0.5.5) 14,058 5 years ago
- [0.5.3](https://www.npmjs.com/package/amqplib/v/0.5.3) 7,040 5 years ago
- [0.5.2](https://www.npmjs.com/package/amqplib/v/0.5.2) 35,826 7 years ago
- [0.5.1](https://www.npmjs.com/package/amqplib/v/0.5.1) 974 8 years ago
- [0.5.0](https://www.npmjs.com/package/amqplib/v/0.5.0) 158 8 years ago