### PR TITLE
[ci-visibility] Fix selenium when run outside of a supported test framework

### DIFF
--- a/integration-tests/ci-visibility/test/selenium-no-framework.js
+++ b/integration-tests/ci-visibility/test/selenium-no-framework.js
@@ -1,0 +1,30 @@
+const { By, Builder } = require('selenium-webdriver')
+const chrome = require('selenium-webdriver/chrome')
+
+async function run () {
+  const options = new chrome.Options()
+  options.addArguments('--headless')
+  const build = new Builder().forBrowser('chrome').setChromeOptions(options)
+  const driver = await build.build()
+
+  await driver.get(process.env.WEB_APP_URL)
+
+  await driver.getTitle()
+
+  await driver.manage().setTimeouts({ implicit: 500 })
+
+  const helloWorld = await driver.findElement(By.className('hello-world'))
+
+  await helloWorld.getText()
+
+  return driver.quit()
+}
+
+run()
+  .then(() => {
+    process.exit(0)
+  }).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error(err)
+    process.exit(1)
+  })

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -113,5 +113,34 @@ versionRange.forEach(version => {
         })
       })
     })
+
+    it('does not crash when used outside a known test framework', (done) => {
+      let testOutput = ''
+      childProcess = exec(
+        'node ./ci-visibility/test/selenium-no-framework.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            WEB_APP_URL: `http://localhost:${webAppPort}`,
+            TESTS_TO_RUN: '**/ci-visibility/test/selenium-test*'
+          },
+          stdio: 'pipe'
+        }
+      )
+
+      childProcess.on('exit', (code) => {
+        assert.equal(code, 0)
+        assert.notInclude(testOutput, 'InvalidArgumentError')
+        done()
+      })
+
+      childProcess.stdout.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+    })
   })
 })

--- a/packages/datadog-instrumentations/src/selenium.js
+++ b/packages/datadog-instrumentations/src/selenium.js
@@ -43,7 +43,7 @@ addHook({
       isRumActive
     })
 
-    if (traceId) {
+    if (traceId && isRumActive) {
       await this.manage().addCookie({
         name: DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME,
         value: traceId
@@ -66,9 +66,8 @@ addHook({
           resolve()
         }, DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS)
       })
+      await this.manage().deleteCookie(DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME)
     }
-
-    await this.manage().deleteCookie(DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME)
 
     return quit.apply(this, arguments)
   })


### PR DESCRIPTION
### What does this PR do?

* Check whether `traceId` is defined before trying to set the cookie used by RUM: `traceId` will be undefined whenever selenium code is run outside of a test framework.
* Check whether there are listeners to `ciSeleniumDriverGetStartCh`: this is unrelated with the bug but it's good practice.

### Motivation
Fixes #4329 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

