### PR TITLE
debug: warn if loaded with conflicting packages

### DIFF
--- a/packages/datadog-instrumentations/src/check_require_cache.js
+++ b/packages/datadog-instrumentations/src/check_require_cache.js
@@ -15,13 +15,13 @@ const potentialConflicts = new Set([
   '@instana/azure-container-services',
   '@instana/collector',
   '@instana/google-cloud-run',
-  '@opentelemetry/sdk-node',
   '@sentry/node',
   'appoptics-apm',
   'atatus-nodejs',
   'elastic-apm-node',
   'newrelic',
-  'stackify-node-apm'
+  'stackify-node-apm',
+  'sqreen'
 ])
 
 const extractPackageAndModulePath = require('./utils/src/extract-package-and-module-path')
@@ -53,13 +53,13 @@ module.exports.checkForRequiredModules = function () {
     if (naughties.has(pkg)) continue
     if (!(pkg in packages)) continue
 
-    console.error(`Warning: Package '${pkg}' was loaded before dd-trace! This may break instrumentation.`)
+    console.warn(`Warning: Package '${pkg}' was loaded before dd-trace! This may break instrumentation.`)
 
     naughties.add(pkg)
     didWarn = true
   }
 
-  if (didWarn) console.error('Warning: Please ensure dd-trace is loaded before other modules.')
+  if (didWarn) console.warn('Warning: Please ensure dd-trace is loaded before other modules.')
 }
 
 /**
@@ -85,11 +85,11 @@ module.exports.checkForPotentialConflicts = function () {
     if (naughties.has(pkg)) continue
     if (!potentialConflicts.has(pkg)) continue
 
-    console.error(`Warning: Package '${pkg}' may cause conflicts with dd-trace.`)
+    console.warn(`Warning: Package '${pkg}' may cause conflicts with dd-trace.`)
 
     naughties.add(pkg)
     didWarn = true
   }
 
-  if (didWarn) console.error('Warning: Packages were loaded that may conflict with dd-trace.')
+  if (didWarn) console.warn('Warning: Packages were loaded that may conflict with dd-trace.')
 }

--- a/packages/datadog-instrumentations/src/check_require_cache.js
+++ b/packages/datadog-instrumentations/src/check_require_cache.js
@@ -2,6 +2,28 @@
 
 /* eslint-disable no-console */
 
+/**
+ * Here we maintain a list of packages that an application
+ * may have installed which could potentially conflict with
+ */
+const potentialConflicts = new Set([
+  '@appsignal/javascript',
+  '@appsignal/nodejs',
+  '@dynatrace/oneagent',
+  '@instana/aws-fargate',
+  '@instana/aws-lambda',
+  '@instana/azure-container-services',
+  '@instana/collector',
+  '@instana/google-cloud-run',
+  '@opentelemetry/sdk-node',
+  '@sentry/node',
+  'appoptics-apm',
+  'atatus-nodejs',
+  'elastic-apm-node',
+  'newrelic',
+  'stackify-node-apm'
+])
+
 const extractPackageAndModulePath = require('./utils/src/extract-package-and-module-path')
 
 /**
@@ -13,14 +35,14 @@ const extractPackageAndModulePath = require('./utils/src/extract-package-and-mod
  *
  * Note that this only going to work for modules within npm
  * packages, like `express`, and not internal modules, like
- * `http`.
+ * `http`. It also only works with CJS, not with ESM imports.
  *
  * The output isn't necessarily 100% perfect. For example if the
  * app loads a package we instrument but outside of an
  * unsupported version then a warning would still be displayed.
  * This is OK as the tracer should be loaded earlier anyway.
  */
-module.exports = function () {
+module.exports.checkForRequiredModules = function () {
   const packages = require('../../datadog-instrumentations/src/helpers/hooks')
   const naughties = new Set()
   let didWarn = false
@@ -38,4 +60,36 @@ module.exports = function () {
   }
 
   if (didWarn) console.error('Warning: Please ensure dd-trace is loaded before other modules.')
+}
+
+/**
+ * APM tools, and some other packages in the community, work
+ * by monkey-patching internal modules and possibly some
+ * globals. Usually this is done in a conflict-free way by
+ * wrapping an existing method with a new method that still
+ * calls the original method. Unfortunately it's possible
+ * that some of these packages (dd-trace included) may
+ * wrap methods in a way that make it unsafe for the methods
+ * to be wrapped again by another library.
+ *
+ * When encountered, and when debug mode is on, a warning is
+ * printed if such a package is discovered. This can help
+ * when debugging a faulty installation.
+ */
+module.exports.checkForPotentialConflicts = function () {
+  const naughties = new Set()
+  let didWarn = false
+
+  for (const pathToModule of Object.keys(require.cache)) {
+    const { pkg } = extractPackageAndModulePath(pathToModule)
+    if (naughties.has(pkg)) continue
+    if (!potentialConflicts.has(pkg)) continue
+
+    console.error(`Warning: Package '${pkg}' may cause conflicts with dd-trace.`)
+
+    naughties.add(pkg)
+    didWarn = true
+  }
+
+  if (didWarn) console.error('Warning: Packages were loaded that may conflict with dd-trace.')
 }

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -29,10 +29,13 @@ if (!disabledInstrumentations.has('fetch')) {
 }
 
 const HOOK_SYMBOL = Symbol('hookExportsMap')
+
+if (DD_TRACE_DEBUG && DD_TRACE_DEBUG.toLowerCase() !== 'false') {
+  checkRequireCache.checkForRequiredModules()
+  setImmediate(checkRequireCache.checkForPotentialConflicts)
+}
+
 // TODO: make this more efficient
-
-if (DD_TRACE_DEBUG && DD_TRACE_DEBUG.toLowerCase() !== 'false') checkRequireCache()
-
 for (const packageName of names) {
   if (disabledInstrumentations.has(packageName)) continue
 

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -11,6 +11,8 @@ const { DataStreamsProcessor } = require('./datastreams/processor')
 const { DsmPathwayCodec } = require('./datastreams/pathway')
 const { DD_MAJOR } = require('../../../version')
 const DataStreamsContext = require('./data_streams_context')
+const { flushStartupLogs } = require('../../datadog-instrumentations/src/check_require_cache')
+const log = require('./log/writer')
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
@@ -23,6 +25,7 @@ class DatadogTracer extends Tracer {
     this._dataStreamsProcessor = new DataStreamsProcessor(config)
     this._scope = new Scope()
     setStartupLogConfig(config)
+    flushStartupLogs(log)
   }
 
   configure ({ env, sampler }) {


### PR DESCRIPTION
### What does this PR do?
- displays a warning if a potentially conflicting package is loaded into the same application as dd-trace
- only runs in debug mode
- caveat: doesn't work with ESM imports
- caveat: doesn't work if package is loaded later than the first stack of the process

```
$ cat app.js
require('redis')
require('dd-trace')
require('@sentry/node')

$ DD_TRACE_DEBUG=true node app.js
Warning: Package 'redis' was loaded before dd-trace! This may break instrumentation.
Warning: Package '@redis/client' was loaded before dd-trace! This may break instrumentation.
Warning: Package 'generic-pool' was loaded before dd-trace! This may break instrumentation.
Warning: Please ensure dd-trace is loaded before other modules.
Warning: Package '@sentry/node' may cause conflicts with dd-trace.
Warning: Packages were loaded that may conflict with dd-trace.
```

### Motivation
- should help debug faulty installations
- It doesn't look like the `packages/dd-trace/src/log/index.js` logger is initialized at this point
  - makes sense since the tracer hasn't gone through `.init()` yet and no log level has been determined
