### PR TITLE
[ci-visibility] Add back calculation of untested files when calculating total code coverage

### DIFF
--- a/integration-tests/ci-visibility/run-jest.js
+++ b/integration-tests/ci-visibility/run-jest.js
@@ -24,6 +24,10 @@ if (process.env.ENABLE_JSDOM) {
   options.testEnvironment = 'jsdom'
 }
 
+if (process.env.COLLECT_COVERAGE_FROM) {
+  options.collectCoverageFrom = process.env.COLLECT_COVERAGE_FROM.split(',')
+}
+
 jest.runCLI(
   options,
   options.projects

--- a/integration-tests/ci-visibility/test-total-code-coverage/test-run.js
+++ b/integration-tests/ci-visibility/test-total-code-coverage/test-run.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai')
+const sum = require('./used-dependency')
+
+describe('test-run', () => {
+  it('can report tests', () => {
+    expect(sum(1, 2)).to.equal(3)
+  })
+})

--- a/integration-tests/ci-visibility/test-total-code-coverage/test-skipped.js
+++ b/integration-tests/ci-visibility/test-total-code-coverage/test-skipped.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai')
+const sum = require('./unused-dependency')
+
+describe('test-skipped', () => {
+  it('can report tests', () => {
+    expect(sum(1, 2)).to.equal(3)
+  })
+})

--- a/integration-tests/ci-visibility/test-total-code-coverage/unused-dependency.js
+++ b/integration-tests/ci-visibility/test-total-code-coverage/unused-dependency.js
@@ -1,0 +1,3 @@
+module.exports = function (a, b) {
+  return a + b
+}

--- a/integration-tests/ci-visibility/test-total-code-coverage/used-dependency.js
+++ b/integration-tests/ci-visibility/test-total-code-coverage/used-dependency.js
@@ -1,0 +1,3 @@
+module.exports = function (a, b) {
+  return a + b
+}

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -592,7 +592,9 @@ function coverageReporterWrapper (coverageReporter) {
    * This calculation adds no value, so we'll skip it.
    */
   shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => async function () {
-    if (isSuitesSkippingEnabled) {
+    // If the user has added coverage manually, they're willing to pay the price of this execution, so
+    // we will not skip it
+    if (isSuitesSkippingEnabled && !isUserCodeCoverageEnabled) {
       return Promise.resolve()
     }
     return addUntestedFiles.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -589,11 +589,12 @@ function coverageReporterWrapper (coverageReporter) {
 
   /**
    * If ITR is active, we're running fewer tests, so of course the total code coverage is reduced.
-   * This calculation adds no value, so we'll skip it.
+   * This calculation adds no value, so we'll skip it, as long as the user has not manually opted in to code coverage,
+   * in which case we'll leave it.
    */
   shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => async function () {
     // If the user has added coverage manually, they're willing to pay the price of this execution, so
-    // we will not skip it
+    // we will not skip it.
     if (isSuitesSkippingEnabled && !isUserCodeCoverageEnabled) {
       return Promise.resolve()
     }


### PR DESCRIPTION
### What does this PR do?
Take into account `isUserCodeCoverageEnabled` when skipping the execution of `_addUntestedFiles`, which calculates the total executable lines of a project for those files which were not executed during a test session.

### Motivation

If a user has passed the `--coverage` flag, it means they're willing to pay the price of calculating executable lines (which means going through the whole repository to check untested files). Therefore, even if we've skipped suites, we should not interrupt the calculation of the total executable lines.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

