### PR TITLE
Updating next plugin to handle version change causing failure in tests

### DIFF
--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -6,7 +6,7 @@ const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const web = require('../../dd-trace/src/plugins/util/web')
 
-const errorPages = ['/404', '/500', '/_error', '/_not-found']
+const errorPages = ['/404', '/500', '/_error', '/_not-found', '/_not-found/page']
 
 class NextPlugin extends ServerPlugin {
   static get id () {
@@ -120,7 +120,6 @@ class NextPlugin extends ServerPlugin {
       'resource.name': `${req.method} ${page}`.trim(),
       'next.page': page
     })
-
     web.setRoute(req, page)
   }
 


### PR DESCRIPTION
### What does this PR do?
This is a PR to update the errorPages for NextJS plugin. For previous versions the error pages url was `/_not-found` and now includes page in the url such as `/_not-found/page`. Adding this to the array will continue the current workflow where this is bypassed and returns early. 

### Motivation
Failing CI tests for version 14.2.3 of NextJS.

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


