### PR TITLE
Improve lib-injection tagging script

### DIFF
--- a/.gitlab/build-lib-init.sh
+++ b/.gitlab/build-lib-init.sh
@@ -35,8 +35,8 @@ git fetch --tags
 # So we fetch all tags and sort them to find both the latest, and the latest in this major.
 # 'sort' technically gets prerelease versions in the wrong order here, but we explicitly
 # exclude them anyway, as they're ignored for the purposes of determining the 'latest' tags.
-LATEST_TAG="$(git tag | grep -v '-' | sort -V -r | head -n 1)"
-LATEST_MAJOR_TAG="$(git tag -l "$MAJOR_VERSION.*" | grep -v '-' | sort -V -r | head -n 1)"
+LATEST_TAG="$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r | head -n 1)"
+LATEST_MAJOR_TAG="$(git tag -l "$MAJOR_VERSION.*" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r | head -n 1)"
 echo "This tag: $CI_COMMIT_TAG"
 echo "Latest repository tag: $LATEST_TAG"
 echo "Latest repository tag for this major: $LATEST_MAJOR_TAG"


### PR DESCRIPTION
### What does this PR do?
Use a more restrictive regex when searching for tags for lib-injection

### Motivation
Suggested [here](https://github.com/DataDog/dd-trace-py/pull/9332#discussion_r1608980272) - dd-trace-js has some non-`vX.Y.Z-pre` tags, so the previous behavior wasn't ideal.

Replace `grep -v '-'` (i.e. reject any tags with a `-`) with `grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'` (explicit Regex)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

I re-ran all the checks on the .NET repo, and LGTM

