### PR TITLE
make the all-green job only run on PRs

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,0 +1,15 @@
+name: All Green
+on:
+  pull_request:
+
+jobs:
+
+  all-green:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    steps:
+      - uses: wechuli/allcheckspassed@v1
+        with:
+          retries: 20 # once per minute, some checks take up to 15 min

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -113,12 +113,3 @@ jobs:
       - run: yarn type:test
       - run: yarn type:doc
 
-  all-green:
-    runs-on: ubuntu-latest
-    permissions:
-      checks: read
-      contents: read
-    steps:
-      - uses: wechuli/allcheckspassed@v1
-        with:
-          retries: 20 # once per minute, some checks take up to 15 min


### PR DESCRIPTION
### What does this PR do?
See title. Also moves the job into its own workflow.

### Motivation
For non-PR builds, this check isn't useful, since it exists only to enforce an all-green policy on PRs. Moreover, we have jobs that may not complete on branches like master and release branches, which will trip up this job.



