### PR TITLE
Add OCI package building

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,7 @@ oci-internal-test-ecr-publish:
     strategy: depend
   variables:
     IMG_SOURCES: registry.ddbuild.io/ci/remote-updates/datadog-apm-library-js:pipeline-${CI_PIPELINE_ID}-1
-    IMG_DESTINATIONS: apm-library-java-package:pipeline-${CI_PIPELINE_ID}
+    IMG_DESTINATIONS: apm-library-js-package:pipeline-${CI_PIPELINE_ID}
     IMG_REGISTRIES: agent-qa
 
 .release-package:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,12 @@ package-arm:
     - ../.gitlab/build-deb-rpm.sh
     - find . -iregex '.*\.\(deb\|rpm\)' -printf '%f\0' | xargs -0 dd-pkg lint
 
+package-oci:
+  extends: .package-oci
+  stage: package
+  script:
+    - ../.gitlab/build_oci_package.sh
+
 .release-package:
   stage: deploy
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,6 +91,29 @@ package-oci:
   script:
     - ../.gitlab/build_oci_package.sh
 
+oci-internal-publish:
+  extends: .oci-internal-publish
+  stage: package
+  needs: [ package-oci ]
+  rules:
+    - when: on_success
+  variables:
+    FLAVOR: datadog-apm-library-js
+
+oci-internal-test-ecr-publish:
+  stage: package
+  needs: [ oci-internal-publish ]
+  rules:
+    - when: on_success
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: registry.ddbuild.io/ci/remote-updates/datadog-apm-library-js:pipeline-${CI_PIPELINE_ID}-1
+    IMG_DESTINATIONS: apm-library-java-package:pipeline-${CI_PIPELINE_ID}
+    IMG_REGISTRIES: agent-qa
+
 .release-package:
   stage: deploy
   variables:

--- a/.gitlab/build_oci_package.sh
+++ b/.gitlab/build_oci_package.sh
@@ -6,7 +6,7 @@ cd ..
 
 npm pack
 
-cp dd-trace-js*.tar.gz packaging/dd-trace-js.tar.gz
+cp dd-trace-*.tgz packaging/dd-trace.tgz
 
 mkdir -p packaging/sources
 
@@ -14,7 +14,7 @@ jq --raw-output '.version' package.json > packaging/sources/version
 
 cd packaging
 
-npm install dd-trace-js.tar.gz
+npm install dd-trace.tgz
 
 cp -R node_modules sources/
 

--- a/.gitlab/build_oci_package.sh
+++ b/.gitlab/build_oci_package.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+cd ../dd-trace-js
+
+npm pack
+
+cp dd-trace-js*.tar.gz ../packaging/dd-trace-js.tar.gz
+
+mkdir -p ../packaging/sources
+
+jq --raw-output '.version' package.json > ../packaging/sources/version
+
+cd ../packaging
+
+npm install dd-trace-js.tar.gz
+
+cp -R node_modules sources/
+
+export VERSION=$(<sources/version)
+
+datadog-package create \
+  --version="$VERSION" \
+  --package="datadog-apm-library-js" \
+  --archive=true \
+  --archive-path="datadog-apm-library-$VERSION.tar" \
+  ./sources

--- a/.gitlab/build_oci_package.sh
+++ b/.gitlab/build_oci_package.sh
@@ -10,6 +10,8 @@ mkdir -p packaging/sources
 
 npm install --prefix ./packaging/sources/ dd-trace-*.tgz
 
+rm packaging/sources/*.json # package.json and package-lock.json are unneeded
+
 jq --raw-output '.version' package.json > packaging/sources/version
 
 cd packaging
@@ -20,5 +22,5 @@ datadog-package create \
   --version="$VERSION" \
   --package="datadog-apm-library-js" \
   --archive=true \
-  --archive-path="datadog-apm-library-$VERSION.tar" \
+  --archive-path="datadog-apm-library-js-$VERSION.tar" \
   ./sources

--- a/.gitlab/build_oci_package.sh
+++ b/.gitlab/build_oci_package.sh
@@ -2,17 +2,17 @@
 
 set -e
 
-cd ../dd-trace-js
+cd ..
 
 npm pack
 
-cp dd-trace-js*.tar.gz ../packaging/dd-trace-js.tar.gz
+cp dd-trace-js*.tar.gz packaging/dd-trace-js.tar.gz
 
-mkdir -p ../packaging/sources
+mkdir -p packaging/sources
 
-jq --raw-output '.version' package.json > ../packaging/sources/version
+jq --raw-output '.version' package.json > packaging/sources/version
 
-cd ../packaging
+cd packaging
 
 npm install dd-trace-js.tar.gz
 

--- a/.gitlab/build_oci_package.sh
+++ b/.gitlab/build_oci_package.sh
@@ -6,17 +6,13 @@ cd ..
 
 npm pack
 
-cp dd-trace-*.tgz packaging/dd-trace.tgz
-
 mkdir -p packaging/sources
+
+npm install --prefix ./packaging/sources/ dd-trace-*.tgz
 
 jq --raw-output '.version' package.json > packaging/sources/version
 
 cd packaging
-
-npm install dd-trace.tgz
-
-cp -R node_modules sources/
 
 export VERSION=$(<sources/version)
 


### PR DESCRIPTION
### What does this PR do?
Add packaging of dd-trace-js as an OCI package

### Motivation
It's need for the datadog installer and fleet automation

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


