### PR TITLE
Fix `describe.only` in `ci-visibility.spec.js`

### DIFF
--- a/integration-tests/ci-visibility.spec.js
+++ b/integration-tests/ci-visibility.spec.js
@@ -91,7 +91,7 @@ testFrameworks.forEach(({
   runTestsWithCoverageCommand,
   type
 }) => {
-  describe.only(`${name} ${type}`, () => {
+  describe(`${name} ${type}`, () => {
     let receiver
     let childProcess
     let sandbox


### PR DESCRIPTION
### What does this PR do?
Remove `describe.only`

### Motivation
This was an intended change in https://github.com/DataDog/dd-trace-js/pull/4314
