### PR TITLE
[ci-visibility] Remove usage of `.asyncResource` in mocha plugin

### DIFF
--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -23,7 +23,8 @@ const {
   getOnTestEndHandler,
   getOnHookEndHandler,
   getOnFailHandler,
-  getOnPendingHandler
+  getOnPendingHandler,
+  testFileToSuiteAr
 } = require('./utils')
 require('./common')
 
@@ -39,7 +40,6 @@ let isSuitesSkippingEnabled = false
 let earlyFlakeDetectionNumRetries = 0
 let knownTests = []
 let itrCorrelationId = ''
-const testFileToSuiteAr = new Map()
 let isForcedToRun = false
 
 // We'll preserve the original coverage here
@@ -469,7 +469,7 @@ addHook({
 // Used to start and finish test session and test module
 addHook({
   name: 'mocha',
-  versions: ['>=8.0.0'],
+  versions: ['>=5.2.0'],
   file: 'lib/nodejs/parallel-buffered-runner.js'
 }, (ParallelBufferedRunner, frameworkVersion) => {
   shimmer.wrap(ParallelBufferedRunner.prototype, 'run', run => function () {

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -142,6 +142,7 @@ describe('Plugin', () => {
         mocha.addFile(testFilePath)
         mocha.run()
       })
+
       it('works with failing tests', (done) => {
         const testFilePath = path.join(__dirname, 'mocha-test-fail.js')
         const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
@@ -178,6 +179,7 @@ describe('Plugin', () => {
         mocha.addFile(testFilePath)
         mocha.run()
       })
+
       it('works with skipping tests', (done) => {
         const testFilePath = path.join(__dirname, 'mocha-test-skip.js')
         const testNames = [

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -26,7 +26,11 @@ function loadInst (plugin) {
     loadInstFile(`${plugin}/server.js`, instrumentations)
     loadInstFile(`${plugin}/client.js`, instrumentations)
   } catch (e) {
-    loadInstFile(`${plugin}.js`, instrumentations)
+    try {
+      loadInstFile(`${plugin}/main.js`, instrumentations)
+    } catch (e) {
+      loadInstFile(`${plugin}.js`, instrumentations)
+    }
   }
 
   return instrumentations
@@ -143,10 +147,12 @@ function withNamingSchema (
 function withPeerService (tracer, pluginName, spanGenerationFn, service, serviceSource, opts = {}) {
   describe('peer service computation' + (opts.desc ? ` ${opts.desc}` : ''), () => {
     let computePeerServiceSpy
+
     beforeEach(() => {
       const plugin = tracer()._pluginManager._pluginsByName[pluginName]
       computePeerServiceSpy = sinon.stub(plugin._tracerConfig, 'spanComputePeerService').value(true)
     })
+
     afterEach(() => {
       computePeerServiceSpy.restore()
     })


### PR DESCRIPTION
### What does this PR do?
Remove the usage of `.asyncResource` to check if a function has been wrapped already. Now we'll use another `WeakSet` `wrappedFunctions` to check whether the function is wrapped. 

I've additionally fixed the plugin tests for mocha, which were not running since the merge of https://github.com/DataDog/dd-trace-js/pull/4314, as seen by this GHA: https://github.com/DataDog/dd-trace-js/actions/runs/9218422124/job/25361943902 

<img width="794" alt="Screenshot 2024-05-24 at 12 59 37" src="https://github.com/DataDog/dd-trace-js/assets/22798219/df131ed3-fad5-4bd9-b1ee-1e947f6f43a6">


It was not running because the instrumentation was split in three files and our test setup didn't allow for that. 

After this change, they're running: https://github.com/DataDog/dd-trace-js/actions/runs/9222873007/job/25374958036?pr=4348

### Motivation
It's deprecated: https://github.com/nodejs/node/pull/46432

### Plugin Checklist

No extra unit tests needed: just check that the ones we have are running and passing.

