### PR TITLE
Send meta_struct properties as byte array

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -272,16 +272,19 @@ class AgentEncoder {
   }
 
   _encodeMetaStruct (bytes, value) {
-    const entries = Array.isArray(value) ? [] : Object.entries(value)
-    const validEntries = entries.filter(([_, v]) =>
-      typeof v === 'string' ||
-      typeof v === 'number' ||
-      (v !== null && typeof v === 'object'))
+    const keys = Array.isArray(value) ? [] : Object.keys(value)
+    const validKeys = keys.filter(key => {
+      const v = value[key]
+      return typeof v === 'string' ||
+        typeof v === 'number' ||
+        (v !== null && typeof v === 'object')
+    })
 
-    this._encodeMapPrefix(bytes, validEntries.length)
+    this._encodeMapPrefix(bytes, validKeys.length)
 
-    for (const [k, v] of validEntries) {
-      this._encodeString(bytes, k)
+    for (const key of validKeys) {
+      const v = value[key]
+      this._encodeString(bytes, key)
       this._encodeObjectAsByteArray(bytes, v)
     }
   }
@@ -316,16 +319,19 @@ class AgentEncoder {
   }
 
   _encodeObjectAsMap (bytes, value, circularReferencesDetector) {
-    const entries = Object.entries(value)
-    const validEntries = entries.filter(([_, v]) =>
-      typeof v === 'string' ||
-      typeof v === 'number' ||
-      (v !== null && typeof v === 'object' && !circularReferencesDetector.has(v)))
+    const keys = Object.keys(value)
+    const validKeys = keys.filter(key => {
+      const v = value[key]
+      return typeof v === 'string' ||
+        typeof v === 'number' ||
+        (v !== null && typeof v === 'object' && !circularReferencesDetector.has(v))
+    })
 
-    this._encodeMapPrefix(bytes, validEntries.length)
+    this._encodeMapPrefix(bytes, validKeys.length)
 
-    for (const [k, v] of validEntries) {
-      this._encodeString(bytes, k)
+    for (const key of validKeys) {
+      const v = value[key]
+      this._encodeString(bytes, key)
       this._encodeObject(bytes, v, circularReferencesDetector)
     }
   }

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -272,17 +272,17 @@ class AgentEncoder {
   }
 
   _encodeMetaStruct (bytes, value) {
-    const keys = Array.isArray(value) ? [] : Object.keys(value)
-    const validKeys = keys.filter(key =>
-      typeof value[key] === 'string' ||
-      typeof value[key] === 'number' ||
-      (value[key] !== null && typeof value[key] === 'object'))
+    const entries = Array.isArray(value) ? [] : Object.entries(value)
+    const validEntries = entries.filter(([_, v]) =>
+      typeof v === 'string' ||
+      typeof v === 'number' ||
+      (v !== null && typeof v === 'object'))
 
-    this._encodeMapPrefix(bytes, validKeys.length)
+    this._encodeMapPrefix(bytes, validEntries.length)
 
-    for (const key of validKeys) {
-      this._encodeString(bytes, key)
-      this._encodeObjectAsByteArray(bytes, value[key])
+    for (const [k, v] of validEntries) {
+      this._encodeString(bytes, k)
+      this._encodeObjectAsByteArray(bytes, v)
     }
   }
 
@@ -316,17 +316,17 @@ class AgentEncoder {
   }
 
   _encodeObjectAsMap (bytes, value, circularReferencesDetector) {
-    const keys = Object.keys(value)
-    const validKeys = keys.filter(key =>
-      typeof value[key] === 'string' ||
-      typeof value[key] === 'number' ||
-      (value[key] !== null && typeof value[key] === 'object' && !circularReferencesDetector.has(value[key])))
+    const entries = Object.entries(value)
+    const validEntries = entries.filter(([_, v]) =>
+      typeof v === 'string' ||
+      typeof v === 'number' ||
+      (v !== null && typeof v === 'object' && !circularReferencesDetector.has(v)))
 
-    this._encodeMapPrefix(bytes, validKeys.length)
+    this._encodeMapPrefix(bytes, validEntries.length)
 
-    for (const key of validKeys) {
-      this._encodeString(bytes, key)
-      this._encodeObject(bytes, value[key], circularReferencesDetector)
+    for (const [k, v] of validEntries) {
+      this._encodeString(bytes, k)
+      this._encodeObject(bytes, v, circularReferencesDetector)
     }
   }
 

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -249,10 +249,12 @@ describe('encode', () => {
 
       const decoded = msgpack.decode(buffer, { codec })
       const trace = decoded[0]
-      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+
+      expect(msgpack.decode(trace[0].meta_struct.foo)).to.be.equal(metaStruct.foo)
+      expect(msgpack.decode(trace[0].meta_struct.baz)).to.be.equal(metaStruct.baz)
     })
 
-    it('should encode meta_struct with simple array of simple values', () => {
+    it('should ignore array in meta_struct', () => {
       const metaStruct = ['one', 2, 'three', 4, 5, 'six']
       data[0].meta_struct = metaStruct
       encoder.encode(data)
@@ -261,19 +263,7 @@ describe('encode', () => {
 
       const decoded = msgpack.decode(buffer, { codec })
       const trace = decoded[0]
-      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
-    })
-
-    it('should encode meta_struct with array of objects', () => {
-      const metaStruct = [{ foo: 'bar' }, { baz: 123 }]
-      data[0].meta_struct = metaStruct
-      encoder.encode(data)
-
-      const buffer = encoder.makePayload()
-
-      const decoded = msgpack.decode(buffer, { codec })
-      const trace = decoded[0]
-      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+      expect(trace[0].meta_struct).to.deep.equal({})
     })
 
     it('should encode meta_struct with empty object and array', () => {
@@ -288,7 +278,8 @@ describe('encode', () => {
 
       const decoded = msgpack.decode(buffer, { codec })
       const trace = decoded[0]
-      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+      expect(msgpack.decode(trace[0].meta_struct.foo)).to.deep.equal(metaStruct.foo)
+      expect(msgpack.decode(trace[0].meta_struct.bar)).to.deep.equal(metaStruct.bar)
     })
 
     it('should encode meta_struct with possible real use case', () => {
@@ -342,7 +333,7 @@ describe('encode', () => {
 
       const decoded = msgpack.decode(buffer, { codec })
       const trace = decoded[0]
-      expect(trace[0].meta_struct).to.deep.equal(metaStruct)
+      expect(msgpack.decode(trace[0].meta_struct['_dd.stack'])).to.deep.equal(metaStruct['_dd.stack'])
     })
 
     it('should encode meta_struct ignoring circular references in objects', () => {
@@ -373,7 +364,7 @@ describe('encode', () => {
           }
         }
       }
-      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+      expect(msgpack.decode(trace[0].meta_struct.foo)).to.deep.equal(expectedMetaStruct.foo)
     })
 
     it('should encode meta_struct ignoring circular references in arrays', () => {
@@ -398,7 +389,7 @@ describe('encode', () => {
           bar: 'baz'
         }]
       }
-      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+      expect(msgpack.decode(trace[0].meta_struct.foo)).to.deep.equal(expectedMetaStruct.foo)
     })
 
     it('should encode meta_struct ignoring undefined properties', () => {
@@ -418,7 +409,8 @@ describe('encode', () => {
       const expectedMetaStruct = {
         foo: 'bar'
       }
-      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+      expect(msgpack.decode(trace[0].meta_struct.foo)).to.deep.equal(expectedMetaStruct.foo)
+      expect(trace[0].meta_struct.undefinedProperty).to.be.undefined
     })
 
     it('should encode meta_struct ignoring null properties', () => {
@@ -438,7 +430,8 @@ describe('encode', () => {
       const expectedMetaStruct = {
         foo: 'bar'
       }
-      expect(trace[0].meta_struct).to.deep.equal(expectedMetaStruct)
+      expect(msgpack.decode(trace[0].meta_struct.foo)).to.deep.equal(expectedMetaStruct.foo)
+      expect(trace[0].meta_struct.nullProperty).to.be.undefined
     })
 
     it('should not encode null meta_struct', () => {


### PR DESCRIPTION
### What does this PR do?
Sends meta_struct data as byte array instead of as object. 

### Motivation
<!-- What inspired you to submit this pull request? -->
It was expected to be a byte array and I misunderstood the spec it in the first implementation.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.


