### PR TITLE
fix(oci): Use same version as deb/rpms

### DIFF
--- a/.gitlab/build_oci_package.sh
+++ b/.gitlab/build_oci_package.sh
@@ -12,15 +12,19 @@ npm install --prefix ./packaging/sources/ dd-trace-*.tgz
 
 rm packaging/sources/*.json # package.json and package-lock.json are unneeded
 
-jq --raw-output '.version' package.json > packaging/sources/version
+if [ -n "$CI_COMMIT_TAG" ] && [ -z "$JS_PACKAGE_VERSION" ]; then
+  JS_PACKAGE_VERSION=${CI_COMMIT_TAG##v}
+elif [ -z "$CI_COMMIT_TAG" ] && [ -z "$JS_PACKAGE_VERSION" ]; then
+  JS_PACKAGE_VERSION="$(jq --raw-output '.version' package.json).pipeline.${CI_PIPELINE_ID}.beta.${CI_COMMIT_SHORT_SHA}"
+fi
+echo -n $JS_PACKAGE_VERSION > packaging/auto_inject-node.version
+echo -n $JS_PACKAGE_VERSION > packaging/sources/version
 
 cd packaging
 
-export VERSION=$(<sources/version)
-
 datadog-package create \
-  --version="$VERSION" \
+  --version="$JS_PACKAGE_VERSION" \
   --package="datadog-apm-library-js" \
   --archive=true \
-  --archive-path="datadog-apm-library-js-$VERSION.tar" \
+  --archive-path="datadog-apm-library-js-$JS_PACKAGE_VERSION.tar" \
   ./sources


### PR DESCRIPTION
### What does this PR do?
Fixes the versioning of OCI packaging to match our releasing process

### Motivation
Working OCI

### Plugin Checklist
- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


