### PR TITLE
bump .eslintrc.json ecmaVersion to 2021

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2020
+    "ecmaVersion": 2021
   },
   "extends": [
     "eslint:recommended",


### PR DESCRIPTION
### What does this PR do?
Change the ecmaVersion value for ESLint from 2020 to 2021.

### Motivation
We dropped node 14 and I want to use `??=` and this is the min version it works.
