### PR TITLE
exclude devflow from all-green

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: wechuli/allcheckspassed@v1
         with:
           retries: 20 # once per minute, some checks take up to 15 min
+          checks_exclude: devflow.*


### PR DESCRIPTION
### What does this PR do?
See title.

### Motivation
Devflow jobs have nothing to do with testing, and may fail to complete, or be cancelled, etc., without having any impact on the test results of the PR. It should be excluded, so that we don't have unmergeable PRs when devflow is cancelled.

