### PR TITLE
fix(openai): multiple choices on streamed requests are tagged properly

### DIFF
--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -155,6 +155,7 @@ function addStreamedChunkChoices (content, chunk) {
         oldChoice.finish_reason = choice.finish_reason
       }
 
+      // delta exists on chat completions
       const delta = choice.delta
 
       if (delta) {

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -3128,6 +3128,72 @@ describe('Plugin', () => {
             await checkTraces
           })
 
+          it.only('makes a successful chat completion call with multiple choices', async () => {
+            nock('https://api.openai.com:443')
+              .post('/v1/chat/completions')
+              .reply(200, function () {
+                return fs.createReadStream(Path.join(__dirname, 'streamed-responses/chat.completions.multiple.txt'))
+              }, {
+                'Content-Type': 'text/plain',
+                'openai-organization': 'kill-9'
+              })
+
+            const checkTraces = agent
+              .use(traces => {
+                const span = traces[0][0]
+                expect(span).to.have.property('name', 'openai.request')
+                expect(span).to.have.property('type', 'openai')
+                expect(span).to.have.property('error', 0)
+                expect(span.meta).to.have.property('openai.organization.name', 'kill-9')
+                expect(span.meta).to.have.property('openai.request.method', 'POST')
+                expect(span.meta).to.have.property('openai.request.endpoint', '/v1/chat/completions')
+                expect(span.meta).to.have.property('openai.request.model', 'gpt-4')
+                expect(span.meta).to.have.property('openai.request.messages.0.content', 'How are you?')
+                expect(span.meta).to.have.property('openai.request.messages.0.role', 'user')
+                expect(span.meta).to.have.property('openai.request.messages.0.name', 'hunter2')
+
+                // message 0
+                expect(span.meta).to.have.property('openai.response.choices.0.finish_reason', 'stop')
+                expect(span.meta).to.have.property('openai.response.choices.0.logprobs', 'returned')
+                expect(span.meta).to.have.property('openai.response.choices.0.message.role', 'assistant')
+                expect(span.meta).to.have.property('openai.response.choices.0.message.content',
+                  'As an AI, I don\'t have feelings, but I\'m here to assist you. How can I help you today?'
+                )
+
+                // message 1
+                expect(span.meta).to.have.property('openai.response.choices.1.finish_reason', 'stop')
+                expect(span.meta).to.have.property('openai.response.choices.1.logprobs', 'returned')
+                expect(span.meta).to.have.property('openai.response.choices.1.message.role', 'assistant')
+                expect(span.meta).to.have.property('openai.response.choices.1.message.content',
+                  'I\'m just a computer program so I don\'t have feelings, ' +
+                  'but I\'m here and ready to help you with anything you need. How can I assis...'
+                )
+
+                // message 2
+                expect(span.meta).to.have.property('openai.response.choices.2.finish_reason', 'stop')
+                expect(span.meta).to.have.property('openai.response.choices.2.logprobs', 'returned')
+                expect(span.meta).to.have.property('openai.response.choices.2.message.role', 'assistant')
+                expect(span.meta).to.have.property('openai.response.choices.2.message.content',
+                  'I\'m just a computer program, so I don\'t have feelings like humans do. ' +
+                  'I\'m here and ready to assist you with any questions or tas...'
+                )
+              })
+
+            const stream = await openai.chat.completions.create({
+              model: 'gpt-4',
+              messages: [{ role: 'user', content: 'How are you?', name: 'hunter2' }],
+              stream: true,
+              n: 3
+            })
+
+            for await (const part of stream) {
+              expect(part).to.have.property('choices')
+              expect(part.choices[0]).to.have.property('delta')
+            }
+
+            await checkTraces
+          })
+
           if (semver.intersects('>4.16.0', version)) {
             it('makes a successful chat completion call with tools', async () => {
               nock('https://api.openai.com:443')

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -3128,7 +3128,7 @@ describe('Plugin', () => {
             await checkTraces
           })
 
-          it.only('makes a successful chat completion call with multiple choices', async () => {
+          it('makes a successful chat completion call with multiple choices', async () => {
             nock('https://api.openai.com:443')
               .post('/v1/chat/completions')
               .reply(200, function () {

--- a/packages/datadog-plugin-openai/test/streamed-responses/chat.completions.multiple.txt
+++ b/packages/datadog-plugin-openai/test/streamed-responses/chat.completions.multiple.txt
@@ -1,0 +1,212 @@
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"As"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":"I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" an"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"'m"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":"'m"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" AI"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" just"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" just"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" a"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" a"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" computer"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" computer"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" don"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" program"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" program"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"'t"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" so"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" have"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" so"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" feelings"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" don"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" don"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" but"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"'t"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" have"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" feelings"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" but"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":"'t"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" have"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" feelings"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" like"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"'m"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" here"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" to"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" humans"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" do"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" assist"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"'m"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" here"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" How"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":"'m"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" can"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" ready"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" to"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" here"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" help"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" help"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" ready"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" with"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" to"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" anything"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" assist"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" today"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" need"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" with"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" any"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" How"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" questions"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" can"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" or"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" tasks"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" assist"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" have"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":" today"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" How"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" can"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" help"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":" today"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":1,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+data: {"id":"chatcmpl-9UI1IdBePvsMlmjSRj8LRojnwpm9f","object":"chat.completion.chunk","created":1717006136,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":2,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+data: [DONE]
+


### PR DESCRIPTION
### What does this PR do?
Makes sure tagging of OpenAI streamed response spans is done appropriately. 

**Notes for reviewers**: Most LOC are from adding a test fixture for a streamed response with 3 choices. If it's too noisy, I can replace it with one that uses 2 instead. Thought 3 would be a good balance for testing.

Previously, for `n: 3` for a generic prompt, it would look like:
<img width="745" alt="Screenshot 2024-05-29 at 3 49 18 PM" src="https://github.com/DataDog/dd-trace-js/assets/106700075/67e2610d-5ca8-4e1f-86ba-6bd418c080e1">

After this fix:
<img width="766" alt="Screenshot 2024-05-29 at 3 50 47 PM" src="https://github.com/DataDog/dd-trace-js/assets/106700075/e2e42459-728b-4376-9ca8-98d87b78595b">

Additionally, this also works for multiple prompts + multiple response choices:
<img width="525" alt="Screenshot 2024-05-30 at 11 06 50 AM" src="https://github.com/DataDog/dd-trace-js/assets/106700075/f21cad5f-cf11-454d-bb09-24fa5af8e9a2">


### Motivation
Fix support for OpenAI streamed responses for `chat.completions` and legacy `completions`, which was affecting both the `openai.response.choices.*.message` (or `openai.response.choices.*.text`) and `openai.response.choice_count` tags.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js