### PR TITLE
user dockerhub image for elasticsearch instead of elastic's registry

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -458,7 +458,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+        image: elasticsearch:7.14.0
         env:
           discovery.type: single-node
         ports:


### PR DESCRIPTION
### What does this PR do?
See title
### Motivation
elastic's registry does not currently seem reliable


