### PR TITLE
cache next apps

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -951,7 +951,19 @@ jobs:
           cache: yarn
           node-version: ${{ matrix.version }}
       - run: yarn install
+      - name: cache restore next-apps
+        id: cache-restore-next-apps
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/packages/datadog-plugin-next/test/next-apps
+          key: next-${{ matrix.version }}-${{ hashFiles('packages/datadog-plugin-next/test/*.js') }}
       - run: yarn test:plugins:ci
+      - name: cache save next-apps
+        if: steps.cache-restore-next-apps.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/packages/datadog-plugin-next/test/next-apps
+          key: next-${{ matrix.version }}-${{ hashFiles('packages/datadog-plugin-next/test/*.js') }}
       - if: always()
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ acmeair-nodejs
 packages/datadog-plugin-next/test/package.json
 packages/datadog-plugin-next/test/node_modules
 packages/datadog-plugin-next/test/yarn.lock
+packages/datadog-plugin-next/test/next-apps
 packages/dd-trace/test/appsec/next/*/package.json
 packages/dd-trace/test/appsec/next/*/node_modules
 packages/dd-trace/test/appsec/next/*/yarn.lock

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -110,14 +110,15 @@ describe('Plugin', function () {
         if (realVersion.startsWith('9')) pkg.resolutions = { webpack: '^5.0.0' }
 
         fs.mkdirSync(cwd, { recursive: true })
-        execSync(`cp -r ${path.join(__dirname)}/app "${cwd}/"`)
-        execSync(`cp -r ${path.join(__dirname)}/pages "${cwd}/"`)
-        execSync(`cp -r ${path.join(__dirname)}/public "${cwd}/"`)
-        execSync(`cp -r ${path.join(__dirname)}/datadog.js "${cwd}/"`)
-        execSync(`cp -r ${path.join(__dirname)}/middleware.js "${cwd}/"`)
-        execSync(`cp -r ${path.join(__dirname)}/naming.js "${cwd}/"`)
-        execSync(`cp -r ${path.join(__dirname)}/next.config.js "${cwd}/"`)
-        execSync(`cp -r ${path.join(__dirname)}/server.js "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/app "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/pages "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/public "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/datadog.js "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/middleware.js "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/naming.js "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/next.config.js "${cwd}/"`)
+        execSync(`cp -r ${__dirname}/server.js "${cwd}/"`)
+        execSync(`ln -s "${__dirname}/../../../versions/next@${version}/node_modules" "${cwd}/"`)
 
         writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, 2))
 

--- a/packages/datadog-plugin-next/test/pages/api/hello/[name].js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/[name].js
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  const tracer = require('../../../../../dd-trace')
+  const tracer = require('../../../../../../../dd-trace')
   const span = tracer.scope().active()
   const name = span && span.context()._name
 

--- a/packages/datadog-plugin-next/test/pages/api/hello/index.js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/index.js
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  const tracer = require('../../../../../dd-trace')
+  const tracer = require('../../../../../../../dd-trace')
   const span = tracer.scope().active()
   const name = span && span.context()._name
 

--- a/packages/datadog-plugin-next/test/pages/api/hello/other.js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/other.js
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  const tracer = require('../../../../../dd-trace')
+  const tracer = require('../../../../../../../dd-trace')
   const span = tracer.scope().active()
   const name = span && span.context()._name
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cache next apps generated for tests, only in CI. For now, only for the plugin tests, though this technique can be re-used in the future for integration tests.

### Motivation
The building of next apps takes a long time in CI. Not building them is a good thing.


### Numbers
Before (6m 13s) https://github.com/DataDog/dd-trace-js/actions/runs/9324282222/job/25669256544
After (4m 56s) https://github.com/DataDog/dd-trace-js/actions/runs/9352337264/job/25740495900

Okay, maybe this isn't as big a win?