### PR TITLE
fix next node 18 flaky test by removing cache

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -946,10 +946,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start
-      - uses: actions/setup-node@v3
-        with:
-          cache: yarn
-          node-version: ${{ matrix.version }}
+      - uses: ./.github/actions/node/setup
       - run: yarn install
       - run: yarn test:plugins:ci
       - if: always()


### PR DESCRIPTION
### What does this PR do?
Remove cache for Next tests as they are causing flakiness when running in CI

### Motivation
Flakey CI tests timeout failures.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


