### PR TITLE
Add prerequisite requirements to testing docs in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ $ yarn
 Before running _plugin_ tests, the data stores need to be running. And for that to work you first need to authenticate Docker against the GitHub Container Registry.
 
 1. [Create a new classic GitHub Personal Access Token (PAT)](https://github.com/settings/tokens/new) with `read:packages` permissions.
-2. [Authorise the new PAT with the Datadog org](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on).
+2. [Authorise the new PAT with the Datadog org](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on) (required only if you want to pull the `couchbase-server-sandbox` package).
 3. Configure Docker to log in using this new PAT:
    ```sh
    # Ensure you have the PAT in the clipboard, then run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,14 +86,22 @@ $ yarn
 
 ## Testing
 
-Before running _plugin_ tests, the data stores need to be running.
-The easiest way to start all of them is to use the provided
-docker-compose configuration:
+### Prerequisites
 
-```sh
-$ docker-compose up -d -V --remove-orphans --force-recreate
-$ yarn services
-```
+Before running _plugin_ tests, the data stores need to be running. And for that to work you first need to authenticate Docker against the GitHub Container Registry.
+
+1. [Create a new classic GitHub Personal Access Token (PAT)](https://github.com/settings/tokens/new) with `read:packages` permissions.
+2. [Authorise the new PAT with the Datadog org](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on).
+3. Configure Docker to log in using this new PAT:
+   ```sh
+   # Ensure you have the PAT in the clipboard, then run:
+   $ pbpaste | docker login ghcr.io -u <github-username> --password-stdin
+   ```
+4. The easiest way to start all of them is to use the provided docker compose configuration:
+   ```sh
+   $ docker compose up -d -V --remove-orphans --force-recreate
+   $ yarn services
+   ```
 
 > **Note**
 > The `couchbase`, `grpc` and `oracledb` instrumentations rely on native modules


### PR DESCRIPTION
### What does this PR do?

Add prerequisite documentation to the testing section, documenting how to authenticate Docker in order to download packages from the GitHub Container Registry.

### Motivation

Without this change, it's not possible to run `docker compose up`.

### Additional Notes

There's still some issues running `docker compose up` with the current `docker-compose.yml` file when on an `arm64` architecture. This PR doesn't attempt to fix that, but should probably be addressed separately to make onboarding easier.

