### PR TITLE
Remap `http.response.status_code` to `http.status_code` for otel spans

### DIFF
--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -179,11 +179,19 @@ class Span {
   }
 
   setAttribute (key, value) {
+    if (key === 'http.response.status_code') {
+      this._ddSpan.setTag('http.status_code', value.toString())
+    }
+
     this._ddSpan.setTag(key, value)
     return this
   }
 
   setAttributes (attributes) {
+    if ('http.response.status_code' in attributes) {
+      attributes['http.status_code'] = attributes['http.response.status_code'].toString()
+    }
+
     this._ddSpan.addTags(attributes)
     return this
   }

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -287,6 +287,26 @@ describe('OTel Span', () => {
     expect(_tags).to.have.property('baz', 'buz')
   })
 
+  describe('should remap http.response.status_code', () => {
+    it('should remap when setting attributes', () => {
+      const span = makeSpan('name')
+
+      const { _tags } = span._ddSpan.context()
+
+      span.setAttributes({ 'http.response.status_code': 200 })
+      expect(_tags).to.have.property('http.status_code', '200')
+    })
+
+    it('should remap when setting singular attribute', () => {
+      const span = makeSpan('name')
+
+      const { _tags } = span._ddSpan.context()
+
+      span.setAttribute('http.response.status_code', 200)
+      expect(_tags).to.have.property('http.status_code', '200')
+    })
+  })
+
   it('should set span links', () => {
     const span = makeSpan('name')
     const span2 = makeSpan('name2')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remap `http.response.status_code` to `http.status_code`

### Motivation
<!-- What inspired you to submit this pull request? -->
To make otel spans compliant with trace metrics



