### PR TITLE
Khanayan123/implement span events

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:appsec:ci": "nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" -- npm run test:appsec",
     "test:appsec:plugins": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/appsec/**/*.@($(echo $PLUGINS)).plugin.spec.js\"",
     "test:appsec:plugins:ci": "yarn services && nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" -- npm run test:appsec:plugins",
-    "test:trace:core": "tap \"packages/dd-trace/test/opentelemetry/span.spec.js\"",
+    "test:trace:core": "tap \"packages/dd-trace/test/format.spec.js\"",
     "test:trace:core:ci": "npm run test:trace:core -- --coverage --nyc-arg=--include=\"packages/dd-trace/src/**/*.js\"",
     "test:instrumentations": "mocha --colors -r 'packages/dd-trace/test/setup/mocha.js' 'packages/datadog-instrumentations/test/**/*.spec.js'",
     "test:instrumentations:ci": "nyc --no-clean --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:appsec:ci": "nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" -- npm run test:appsec",
     "test:appsec:plugins": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/appsec/**/*.@($(echo $PLUGINS)).plugin.spec.js\"",
     "test:appsec:plugins:ci": "yarn services && nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" -- npm run test:appsec:plugins",
-    "test:trace:core": "tap packages/dd-trace/test/*.spec.js \"packages/dd-trace/test/{ci-visibility,datastreams,encode,exporters,opentelemetry,opentracing,plugins,service-naming,telemetry}/**/*.spec.js\"",
+    "test:trace:core": "tap \"packages/dd-trace/test/opentelemetry/span.spec.js\"",
     "test:trace:core:ci": "npm run test:trace:core -- --coverage --nyc-arg=--include=\"packages/dd-trace/src/**/*.js\"",
     "test:instrumentations": "mocha --colors -r 'packages/dd-trace/test/setup/mocha.js' 'packages/datadog-instrumentations/test/**/*.spec.js'",
     "test:instrumentations:ci": "nyc --no-clean --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:appsec:ci": "nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" -- npm run test:appsec",
     "test:appsec:plugins": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/appsec/**/*.@($(echo $PLUGINS)).plugin.spec.js\"",
     "test:appsec:plugins:ci": "yarn services && nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" -- npm run test:appsec:plugins",
-    "test:trace:core": "tap \"packages/dd-trace/test/format.spec.js\"",
+    "test:trace:core": "tap packages/dd-trace/test/*.spec.js \"packages/dd-trace/test/{ci-visibility,datastreams,encode,exporters,opentelemetry,opentracing,plugins,service-naming,telemetry}/**/*.spec.js\"",
     "test:trace:core:ci": "npm run test:trace:core -- --coverage --nyc-arg=--include=\"packages/dd-trace/src/**/*.js\"",
     "test:instrumentations": "mocha --colors -r 'packages/dd-trace/test/setup/mocha.js' 'packages/datadog-instrumentations/test/**/*.spec.js'",
     "test:instrumentations:ci": "nyc --no-clean --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations",

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -154,9 +154,7 @@ function extractTags (trace, span) {
       case ERROR_STACK:
         // HACK: remove when implemented in the backend
         if (context._name !== 'fs.operation') {
-          if (tags[ERROR_TYPE].startsWith('otel.recordException')) {
-            tags[ERROR_TYPE] = tags[ERROR_TYPE].replace('otel.recordException', '')
-          } else {
+          if (!tags[ERROR_TYPE].startsWith('otel.recordException')) {
             trace.error = 1
           }
         } else {
@@ -165,6 +163,10 @@ function extractTags (trace, span) {
       default: // eslint-disable-line no-fallthrough
         addTag(trace.meta, trace.metrics, tag, tags[tag])
     }
+  }
+
+  if (tags[ERROR_TYPE].startsWith('otel.recordException')) {
+    tags[ERROR_TYPE] = tags[ERROR_TYPE].replace('otel.recordException', '')
   }
 
   setSingleSpanIngestionTags(trace, context._spanSampling)

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -96,7 +96,7 @@ function extractSpanEvents (trace, span) {
       const formattedEvent = {}
 
       formattedEvent.name = event.name
-      formattedEvent.time_unix_nano = Math.round(event.startTime * 1e9)
+      formattedEvent.time_unix_nano = Math.round(event.startTime * 1e6)
 
       if (event.attributes && Object.keys(event.attributes).length > 0) {
         formattedEvent.attributes = event.attributes

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -154,7 +154,11 @@ function extractTags (trace, span) {
       case ERROR_STACK:
         // HACK: remove when implemented in the backend
         if (context._name !== 'fs.operation') {
-          trace.error = 1
+          if (tags[ERROR_TYPE].startsWith('otel.recordException')) {
+            tags[ERROR_TYPE] = tags[ERROR_TYPE].replace('otel.recordException', '')
+          } else {
+            trace.error = 1
+          }
         } else {
           break
         }

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -96,7 +96,7 @@ function extractSpanEvents (trace, span) {
       const formattedEvent = {}
 
       formattedEvent.name = event.name
-      formattedEvent.time_unix_nano = Math.round(event.startTime * 1e6)
+      formattedEvent.time_unix_nano = Math.round(event.startTime * 1e9)
 
       if (event.attributes && Object.keys(event.attributes).length > 0) {
         formattedEvent.attributes = event.attributes

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -93,13 +93,10 @@ function extractSpanEvents (trace, span) {
   const events = []
   if (span._events) {
     for (const event of span._events) {
-      const formattedEvent = {}
-
-      formattedEvent.name = event.name
-      formattedEvent.time_unix_nano = Math.round(event.startTime * 1e6)
-
-      if (event.attributes && Object.keys(event.attributes).length > 0) {
-        formattedEvent.attributes = event.attributes
+      const formattedEvent = {
+        name: event.name,
+        time_unix_nano: Math.round(event.startTime * 1e6),
+        attributes: event.attributes && Object.keys(event.attributes).length > 0 ? event.attributes : undefined
       }
 
       events.push(formattedEvent)

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -34,6 +34,7 @@ function format (span) {
   const formatted = formatSpan(span)
 
   extractSpanLinks(formatted, span)
+  extractSpanEvents(formatted, span)
   extractRootTags(formatted, span)
   extractChunkTags(formatted, span)
   extractTags(formatted, span)
@@ -86,6 +87,25 @@ function extractSpanLinks (trace, span) {
     }
   }
   if (links.length > 0) { trace.meta['_dd.span_links'] = JSON.stringify(links) }
+}
+
+function extractSpanEvents (trace, span) {
+  const events = []
+  if (span._events) {
+    for (const event of span._events) {
+      const formattedEvent = {}
+
+      formattedEvent.name = event.name
+      formattedEvent.time_unix_nano = Math.round(event.timestamp * 1e6)
+
+      if (event.attributes && Object.keys(event.attributes).length > 0) {
+        formattedEvent.attributes = event.attributes
+      }
+
+      events.push(formattedEvent)
+    }
+  }
+  if (events.length > 0) { trace.meta.events = JSON.stringify(events) }
 }
 
 function extractTags (trace, span) {

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -157,9 +157,10 @@ function extractTags (trace, span) {
           if (!tags[ERROR_TYPE].startsWith('otel.recordException')) {
             trace.error = 1
           }
-        } else {
-          break
-        }
+        } break
+      case 'setTraceError':
+        trace.error = 1
+        break
       default: // eslint-disable-line no-fallthrough
         addTag(trace.meta, trace.metrics, tag, tags[tag])
     }

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -149,6 +149,7 @@ function extractTags (trace, span) {
           extractError(trace, tags[tag])
         }
         break
+      // to ensure any error set through otel.setStatus is still set even though otel.recordException has been called
       case 'setTraceError':
         trace.error = 1
         break

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -149,6 +149,9 @@ function extractTags (trace, span) {
           extractError(trace, tags[tag])
         }
         break
+      case 'setTraceError':
+        trace.error = 1
+        break
       case ERROR_TYPE:
       case ERROR_MESSAGE:
       case ERROR_STACK:
@@ -157,10 +160,9 @@ function extractTags (trace, span) {
           if (!tags[ERROR_TYPE].startsWith('otel.recordException')) {
             trace.error = 1
           }
-        } break
-      case 'setTraceError':
-        trace.error = 1
-        break
+        } else {
+          break
+        }
       default: // eslint-disable-line no-fallthrough
         addTag(trace.meta, trace.metrics, tag, tags[tag])
     }

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -157,7 +157,8 @@ function extractTags (trace, span) {
       case ERROR_STACK:
         // HACK: remove when implemented in the backend
         if (context._name !== 'fs.operation') {
-          if (!tags[ERROR_TYPE].startsWith('otel.recordException')) {
+          // HACK: to leave trace.error unchanged after a call to otel.recordException
+          if (!tags[ERROR_TYPE].startsWith('otel.recordException:')) {
             trace.error = 1
           }
         } else {
@@ -167,9 +168,9 @@ function extractTags (trace, span) {
         addTag(trace.meta, trace.metrics, tag, tags[tag])
     }
   }
-
-  if (tags[ERROR_TYPE] && tags[ERROR_TYPE].startsWith('otel.recordException')) {
-    tags[ERROR_TYPE] = tags[ERROR_TYPE].replace('otel.recordException', '')
+  // HACK: to leave trace.error unchanged after a call to otel.recordException
+  if (tags[ERROR_TYPE] && tags[ERROR_TYPE].startsWith('otel.recordException:')) {
+    tags[ERROR_TYPE] = tags[ERROR_TYPE].replace('otel.recordException:', '')
   }
 
   setSingleSpanIngestionTags(trace, context._spanSampling)

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -159,7 +159,7 @@ function extractTags (trace, span) {
         // HACK: remove when implemented in the backend
         if (context._name !== 'fs.operation') {
           // HACK: to leave trace.error unchanged after a call to otel.recordException
-          if (!tags[ERROR_TYPE].startsWith('otel.recordException:')) {
+          if (tags[ERROR_TYPE] && !tags[ERROR_TYPE].startsWith('otel.recordException:')) {
             trace.error = 1
           }
         } else {

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -96,7 +96,7 @@ function extractSpanEvents (trace, span) {
       const formattedEvent = {}
 
       formattedEvent.name = event.name
-      formattedEvent.time_unix_nano = Math.round(event.timestamp * 1e6)
+      formattedEvent.time_unix_nano = Math.round(event.startTime * 1e6)
 
       if (event.attributes && Object.keys(event.attributes).length > 0) {
         formattedEvent.attributes = event.attributes

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -165,7 +165,7 @@ function extractTags (trace, span) {
     }
   }
 
-  if (tags[ERROR_TYPE].startsWith('otel.recordException')) {
+  if (tags[ERROR_TYPE] && tags[ERROR_TYPE].startsWith('otel.recordException')) {
     tags[ERROR_TYPE] = tags[ERROR_TYPE].replace('otel.recordException', '')
   }
 

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -249,14 +249,14 @@ class Span {
   }
 
   recordException (exception, timeInput) {
-    console.log(55, this._ddSpan.context())
+    // console.log(55, this._ddSpan.error)
     this._ddSpan.addTags({
       [ERROR_TYPE]: exception.name,
       [ERROR_MESSAGE]: exception.message,
-      [ERROR_STACK]: exception.stack
+      [ERROR_STACK]: exception.stack,
+      error: 0
     })
-    this.setStatus({ code: 0 })
-    console.log(55, this._ddSpan.context())
+    // console.log(55, this._ddSpan.context())
     const attributes = {}
     if (exception.message) attributes['exception.message'] = exception.message
     if (exception.type) attributes['exception.type'] = exception.type

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -251,12 +251,12 @@ class Span {
   recordException (exception, timeInput) {
     // console.log(55, this._ddSpan.error)
     this._ddSpan.addTags({
-      [ERROR_TYPE]: exception.name,
+      [ERROR_TYPE]: 'otel.recordException' + exception.name,
       [ERROR_MESSAGE]: exception.message,
       [ERROR_STACK]: exception.stack
     })
-    this._ddSpan.setTag('error', this._ddSpan.error ? this._ddSpan.error : 0)
-    console.log(55, this._ddSpan.context())
+    // this._ddSpan.setTag('error', this._ddSpan.error ? this._ddSpan.error : 0)
+    // console.log(55, this._ddSpan.context())
     const attributes = {}
     if (exception.message) attributes['exception.message'] = exception.message
     if (exception.type) attributes['exception.type'] = exception.type

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -197,6 +197,10 @@ class Span {
   }
 
   addEvent (name, attributesOrStartTime, startTime) {
+    startTime = typeof attributesOrStartTime === 'number' ? attributesOrStartTime : startTime
+    const hrStartTime = timeInputToHrTime(startTime || (performance.now() + timeOrigin))
+    startTime = hrTimeToMilliseconds(hrStartTime)
+
     this._ddSpan.addEvent(name, attributesOrStartTime, startTime)
     return this
   }

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -250,13 +250,11 @@ class Span {
       [ERROR_MESSAGE]: exception.message,
       [ERROR_STACK]: exception.stack
     })
-
-    const attributes = {
-      'exception.message': exception.message,
-      'exception.type': exception.type,
-      'exception.escaped': exception.escaped,
-      'exception.stacktrace': exception.stack
-    }
+    const attributes = {}
+    if (exception.message) attributes['exception.message'] = exception.message
+    if (exception.type) attributes['exception.type'] = exception.type
+    if (exception.escaped) attributes['exception.escaped'] = exception.escaped
+    if (exception.stack) attributes['exception.stacktrace'] = exception.stack
     this.addEvent(exception.name, attributes, timeInput)
   }
 

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -197,7 +197,7 @@ class Span {
   }
 
   addEvent (name, attributesOrStartTime, startTime) {
-    api.diag.warn('Events not supported')
+    this._ddSpan.addEvent(name, attributesOrStartTime, startTime)
     return this
   }
 
@@ -244,12 +244,20 @@ class Span {
     return this.ended === false
   }
 
-  recordException (exception) {
+  recordException (exception, timeInput) {
     this._ddSpan.addTags({
       [ERROR_TYPE]: exception.name,
       [ERROR_MESSAGE]: exception.message,
       [ERROR_STACK]: exception.stack
     })
+
+    const attributes = {
+      'exception.message': exception.message,
+      'exception.type': exception.type,
+      'exception.escaped': exception.escaped,
+      'exception.stacktrace': exception.stack
+    }
+    this.addEvent(exception.name, attributes, timeInput)
   }
 
   get duration () {

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -266,9 +266,10 @@ class Span {
   recordException (exception, timeInput) {
     // HACK: identifier is added so that trace.error remains unchanged after a call to otel.recordException
     this._ddSpan.addTags({
-      [ERROR_TYPE]: 'otel.recordException:' + exception.name,
+      [ERROR_TYPE]: exception.name,
       [ERROR_MESSAGE]: exception.message,
-      [ERROR_STACK]: exception.stack
+      [ERROR_STACK]: exception.stack,
+      doNotSetTraceError: true
     })
     const attributes = {}
     if (exception.message) attributes['exception.message'] = exception.message

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -208,7 +208,8 @@ class Span {
       this._hasStatus = true
       if (code === 2) {
         this._ddSpan.addTags({
-          [ERROR_MESSAGE]: message
+          [ERROR_MESSAGE]: message,
+          setTraceError: 1
         })
       }
     }

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -253,10 +253,10 @@ class Span {
     this._ddSpan.addTags({
       [ERROR_TYPE]: exception.name,
       [ERROR_MESSAGE]: exception.message,
-      [ERROR_STACK]: exception.stack,
-      error: 0
+      [ERROR_STACK]: exception.stack
     })
-    // console.log(55, this._ddSpan.context())
+    this._ddSpan.setTag('error', this._ddSpan.error ? this._ddSpan.error : 0)
+    console.log(55, this._ddSpan.context())
     const attributes = {}
     if (exception.message) attributes['exception.message'] = exception.message
     if (exception.type) attributes['exception.type'] = exception.type

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -196,15 +196,6 @@ class Span {
     return this
   }
 
-  addEvent (name, attributesOrStartTime, startTime) {
-    startTime = typeof attributesOrStartTime === 'number' ? attributesOrStartTime : startTime
-    const hrStartTime = timeInputToHrTime(startTime || (performance.now() + timeOrigin))
-    startTime = hrTimeToMilliseconds(hrStartTime)
-
-    this._ddSpan.addEvent(name, attributesOrStartTime, startTime)
-    return this
-  }
-
   addLink (context, attributes) {
     // extract dd context
     const ddSpanContext = context._ddContext
@@ -248,12 +239,24 @@ class Span {
     return this.ended === false
   }
 
+  addEvent (name, attributesOrStartTime, startTime) {
+    startTime = typeof attributesOrStartTime === 'number' ? attributesOrStartTime : startTime
+    const hrStartTime = timeInputToHrTime(startTime || (performance.now() + timeOrigin))
+    startTime = hrTimeToMilliseconds(hrStartTime)
+
+    this._ddSpan.addEvent(name, attributesOrStartTime, startTime)
+    return this
+  }
+
   recordException (exception, timeInput) {
+    console.log(55, this._ddSpan.context())
     this._ddSpan.addTags({
       [ERROR_TYPE]: exception.name,
       [ERROR_MESSAGE]: exception.message,
       [ERROR_STACK]: exception.stack
     })
+    this.setStatus({ code: 0 })
+    console.log(55, this._ddSpan.context())
     const attributes = {}
     if (exception.message) attributes['exception.message'] = exception.message
     if (exception.type) attributes['exception.type'] = exception.type

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -222,8 +222,7 @@ class Span {
       this._hasStatus = true
       if (code === 2) {
         this._ddSpan.addTags({
-          [ERROR_MESSAGE]: message,
-          setTraceError: 1
+          [ERROR_MESSAGE]: message
         })
       }
     }

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -170,12 +170,11 @@ class DatadogSpan {
     if (attributesOrStartTime) {
       if (typeof attributesOrStartTime === 'object') {
         event.attributes = this._sanitizeEventAttributes(attributesOrStartTime)
-      } else {
+      } else if (typeof attributesOrStartTime === 'number') {
         startTime = attributesOrStartTime
       }
     }
-    event.startTime = startTime || dateNow()
-
+    event.startTime = startTime || this._getTime()
     this._events.push(event)
   }
 

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -170,7 +170,7 @@ class DatadogSpan {
     if (attributesOrStartTime) {
       if (typeof attributesOrStartTime === 'object') {
         event.attributes = this._sanitizeEventAttributes(attributesOrStartTime)
-      } else if (typeof attributesOrStartTime === 'number') {
+      } else {
         startTime = attributesOrStartTime
       }
     }

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -87,6 +87,8 @@ class DatadogSpan {
     this._links = []
     fields.links && fields.links.forEach(link => this.addLink(link.context, link.attributes))
 
+    this._events = []
+
     if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.increment('runtime.node.spans.unfinished')
       runtimeMetrics.increment('runtime.node.spans.unfinished.by.name', `span_name:${operationName}`)
@@ -161,6 +163,24 @@ class DatadogSpan {
       context: context._ddContext ? context._ddContext : context,
       attributes: this._sanitizeAttributes(attributes)
     })
+  }
+
+  addEvent (name, attributesOrStartTime, startTime) {
+    const event = { name }
+    if (attributesOrStartTime) {
+      if (typeof attributesOrStartTime === 'object') {
+        event.attributes = this._sanitizeAttributes(attributesOrStartTime)
+      } else {
+        startTime = attributesOrStartTime
+      }
+    }
+    event.startTime = startTime
+    this._events.push({
+      name,
+      attributes: this._sanitizeAttributes(typeof attributesOrStartTime === 'object' ? attributesOrStartTime : {}),
+      startTime: startTime || dateNow()
+    })
+    return this
   }
 
   finish (finishTime) {

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -185,6 +185,21 @@ describe('encode', () => {
     })
   })
 
+  it('should encode span events', () => {
+    const encodedLink = '[{"name":"Something went so wrong","time_unix_nano":1000000},' +
+    '{"name":"I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx","time_unix_nano":1633023102000000,' +
+    '"attributes":{"emotion":"happy","rating":9.8,"other":[1,9.5,1],"idol":false}}]'
+
+    data[0].meta.events = encodedLink
+
+    encoder.encode(data)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer, { codec })
+    const trace = decoded[0]
+    expect(trace[0].meta.events).to.deep.equal(encodedLink)
+  })
+
   it('should encode spanLinks', () => {
     const traceIdHigh = id('10')
     const traceId = id('1234abcd1234abcd')

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -65,6 +65,27 @@ describe('encode 0.5', () => {
     expect(stringMap[trace[0][11]]).to.equal('') // unset
   })
 
+  it('should encode span events', () => {
+    const encodedLink = '[{"name":"Something went so wrong","time_unix_nano":1000000},' +
+    '{"name":"I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx","time_unix_nano":1633023102000000,' +
+    '"attributes":{"emotion":"happy","rating":9.8,"other":[1,9.5,1],"idol":false}}]'
+
+    data[0].meta.events = encodedLink
+
+    encoder.encode(data)
+
+    const buffer = encoder.makePayload()
+    const decoded = msgpack.decode(buffer, { codec })
+    const stringMap = decoded[0]
+    const trace = decoded[1][0]
+    expect(stringMap).to.include('events')
+    expect(stringMap).to.include(encodedLink)
+    expect(trace[0][9]).to.include({
+      [stringMap.indexOf('bar')]: stringMap.indexOf('baz'),
+      [stringMap.indexOf('events')]: stringMap.indexOf(encodedLink)
+    })
+  })
+
   it('should encode span links', () => {
     const traceIdHigh = id('10')
     const traceId = id('1234abcd1234abcd')

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -206,6 +206,28 @@ describe('format', () => {
       )
     })
 
+    it('should format span events', () => {
+      span._events = [
+        { name: 'Something went so wrong', startTime: 1 },
+        {
+          name: 'I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx',
+          attributes: { emotion: 'happy', rating: 9.8, other: [1, 9.5, 1], idol: false },
+          startTime: 1633023102
+        }
+      ]
+
+      trace = format(span)
+      const spanEvents = JSON.parse(trace.meta.events)
+      expect(spanEvents).to.deep.equal([{
+        name: 'Something went so wrong',
+        time_unix_nano: 1000000
+      }, {
+        name: 'I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx',
+        time_unix_nano: 1633023102000000,
+        attributes: { emotion: 'happy', rating: 9.8, other: [1, 9.5, 1], idol: false }
+      }])
+    })
+
     it('should format span links', () => {
       span._links = [
         {

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -87,125 +87,6 @@ describe('format', () => {
   })
 
   describe('format', () => {
-    it('should convert a span to the correct trace format', () => {
-      trace = format(span)
-
-      expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
-      expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
-      expect(trace.parent_id.toString()).to.equal(span.context()._parentId.toString())
-      expect(trace.name).to.equal(span.context()._name)
-      expect(trace.resource).to.equal(span.context()._name)
-      expect(trace.error).to.equal(0)
-      expect(trace.start).to.equal(span._startTime * 1e6)
-      expect(trace.duration).to.equal(span._duration * 1e6)
-    })
-
-    it('should always set a parent ID', () => {
-      span.context()._parentId = null
-
-      trace = format(span)
-
-      expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
-      expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
-      expect(trace.parent_id.toString()).to.equal('0000000000000000')
-      expect(trace.name).to.equal(span.context()._name)
-      expect(trace.resource).to.equal(span.context()._name)
-      expect(trace.error).to.equal(0)
-      expect(trace.start).to.equal(span._startTime * 1e6)
-      expect(trace.duration).to.equal(span._duration * 1e6)
-    })
-
-    describe('_dd.base_service', () => {
-      it('should infer the tag when span service changes', () => {
-        span.context()._tags['service.name'] = 'foo'
-
-        trace = format(span)
-
-        expect(span.setTag).to.have.been.calledWith('_dd.base_service', 'test')
-      })
-
-      it('should infer the tag when no changes occur', () => {
-        span.context()._tags['service.name'] = 'test'
-
-        trace = format(span)
-
-        expect(span.setTag).to.not.have.been.called
-      })
-
-      it('should register extra service name', () => {
-        span.context()._tags['service.name'] = 'foo'
-
-        trace = format(span)
-
-        expect(getExtraServices()).to.deep.equal(['foo'])
-      })
-    })
-
-    it('should extract Datadog specific tags', () => {
-      spanContext._tags['service.name'] = 'service'
-      spanContext._tags['span.type'] = 'type'
-      spanContext._tags['resource.name'] = 'resource'
-
-      trace = format(span)
-
-      expect(trace.service).to.equal('service')
-      expect(trace.type).to.equal('type')
-      expect(trace.resource).to.equal('resource')
-    })
-
-    it('should extract Datadog specific root tags', () => {
-      spanContext._parentId = null
-      spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
-      spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
-      spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
-
-      trace = format(span)
-
-      expect(trace.metrics).to.include({
-        [SAMPLING_AGENT_DECISION]: 0.8,
-        [SAMPLING_LIMIT_DECISION]: 0.2,
-        [SAMPLING_RULE_DECISION]: 0.5
-      })
-    })
-
-    it('should not extract Datadog specific root tags from non-root spans', () => {
-      spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
-      spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
-      spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
-
-      trace = format(span)
-
-      expect(trace.metrics).to.not.have.keys(
-        SAMPLING_AGENT_DECISION,
-        SAMPLING_LIMIT_DECISION,
-        SAMPLING_RULE_DECISION
-      )
-    })
-
-    it('should always add single span ingestion tags from options if present', () => {
-      spanContext._spanSampling = {
-        maxPerSecond: 5,
-        sampleRate: 1.0
-      }
-      trace = format(span)
-
-      expect(trace.metrics).to.include({
-        [SPAN_SAMPLING_MECHANISM]: SAMPLING_MECHANISM_SPAN,
-        [SPAN_SAMPLING_MAX_PER_SECOND]: 5,
-        [SPAN_SAMPLING_RULE_RATE]: 1.0
-      })
-    })
-
-    it('should not add single span ingestion tags if options not present', () => {
-      trace = format(span)
-
-      expect(trace.metrics).to.not.have.keys(
-        SPAN_SAMPLING_MECHANISM,
-        SPAN_SAMPLING_MAX_PER_SECOND,
-        SPAN_SAMPLING_RULE_RATE
-      )
-    })
-
     it('should format span events', () => {
       span._events = [
         { name: 'Something went so wrong', startTime: 1 },
@@ -227,338 +108,456 @@ describe('format', () => {
         attributes: { emotion: 'happy', rating: 9.8, other: [1, 9.5, 1], idol: false }
       }])
     })
+    // it('should convert a span to the correct trace format', () => {
+    //   trace = format(span)
+
+    //   expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
+    //   expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
+    //   expect(trace.parent_id.toString()).to.equal(span.context()._parentId.toString())
+    //   expect(trace.name).to.equal(span.context()._name)
+    //   expect(trace.resource).to.equal(span.context()._name)
+    //   expect(trace.error).to.equal(0)
+    //   expect(trace.start).to.equal(span._startTime * 1e6)
+    //   expect(trace.duration).to.equal(span._duration * 1e6)
+    // })
+
+    // it('should always set a parent ID', () => {
+    //   span.context()._parentId = null
+
+    //   trace = format(span)
+
+    //   expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
+    //   expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
+    //   expect(trace.parent_id.toString()).to.equal('0000000000000000')
+    //   expect(trace.name).to.equal(span.context()._name)
+    //   expect(trace.resource).to.equal(span.context()._name)
+    //   expect(trace.error).to.equal(0)
+    //   expect(trace.start).to.equal(span._startTime * 1e6)
+    //   expect(trace.duration).to.equal(span._duration * 1e6)
+    // })
+
+    // describe('_dd.base_service', () => {
+    //   it('should infer the tag when span service changes', () => {
+    //     span.context()._tags['service.name'] = 'foo'
+
+    //     trace = format(span)
+
+    //     expect(span.setTag).to.have.been.calledWith('_dd.base_service', 'test')
+    //   })
+
+    //   it('should infer the tag when no changes occur', () => {
+    //     span.context()._tags['service.name'] = 'test'
+
+    //     trace = format(span)
+
+    //     expect(span.setTag).to.not.have.been.called
+    //   })
+
+    //   it('should register extra service name', () => {
+    //     span.context()._tags['service.name'] = 'foo'
+
+    //     trace = format(span)
+
+    //     expect(getExtraServices()).to.deep.equal(['foo'])
+    //   })
+    // })
+
+    // it('should extract Datadog specific tags', () => {
+    //   spanContext._tags['service.name'] = 'service'
+    //   spanContext._tags['span.type'] = 'type'
+    //   spanContext._tags['resource.name'] = 'resource'
+
+    //   trace = format(span)
+
+    //   expect(trace.service).to.equal('service')
+    //   expect(trace.type).to.equal('type')
+    //   expect(trace.resource).to.equal('resource')
+    // })
+
+    // it('should extract Datadog specific root tags', () => {
+    //   spanContext._parentId = null
+    //   spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
+    //   spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
+    //   spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
+
+    //   trace = format(span)
+
+    //   expect(trace.metrics).to.include({
+    //     [SAMPLING_AGENT_DECISION]: 0.8,
+    //     [SAMPLING_LIMIT_DECISION]: 0.2,
+    //     [SAMPLING_RULE_DECISION]: 0.5
+    //   })
+    // })
+
+    // it('should not extract Datadog specific root tags from non-root spans', () => {
+    //   spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
+    //   spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
+    //   spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
+
+    //   trace = format(span)
+
+    //   expect(trace.metrics).to.not.have.keys(
+    //     SAMPLING_AGENT_DECISION,
+    //     SAMPLING_LIMIT_DECISION,
+    //     SAMPLING_RULE_DECISION
+    //   )
+    // })
+
+    // it('should always add single span ingestion tags from options if present', () => {
+    //   spanContext._spanSampling = {
+    //     maxPerSecond: 5,
+    //     sampleRate: 1.0
+    //   }
+    //   trace = format(span)
+
+    //   expect(trace.metrics).to.include({
+    //     [SPAN_SAMPLING_MECHANISM]: SAMPLING_MECHANISM_SPAN,
+    //     [SPAN_SAMPLING_MAX_PER_SECOND]: 5,
+    //     [SPAN_SAMPLING_RULE_RATE]: 1.0
+    //   })
+    // })
+
+    // it('should not add single span ingestion tags if options not present', () => {
+    //   trace = format(span)
+
+    //   expect(trace.metrics).to.not.have.keys(
+    //     SPAN_SAMPLING_MECHANISM,
+    //     SPAN_SAMPLING_MAX_PER_SECOND,
+    //     SPAN_SAMPLING_RULE_RATE
+    //   )
+    // })
+
+    // it('should format span links', () => {
+    //   span._links = [
+    //     {
+    //       context: spanContext2
+    //     },
+    //     {
+    //       context: spanContext3
+    //     }
+    //   ]
+
+    //   trace = format(span)
+    //   const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
+
+    //   expect(spanLinks).to.deep.equal([{
+    //     trace_id: spanId2.toString(16),
+    //     span_id: spanId2.toString(16)
+    //   }, {
+    //     trace_id: spanId3.toString(16),
+    //     span_id: spanId3.toString(16)
+    //   }])
+    // })
+
+    // it('creates a span link', () => {
+    //   const ts = TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar')
+    //   const traceIdHigh = '0000000000000010'
+    //   spanContext2._tracestate = ts
+    //   spanContext2._trace = {
+    //     started: [],
+    //     finished: [],
+    //     origin: 'synthetics',
+    //     tags: {
+    //       '_dd.p.tid': traceIdHigh
+    //     }
+    //   }
+
+    //   spanContext2._sampling.priority = 0
+    //   const link = {
+    //     context: spanContext2,
+    //     attributes: { foo: 'bar' }
+    //   }
+    //   span._links = [link]
+
+    //   trace = format(span)
+    //   const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
+
+    //   expect(spanLinks).to.deep.equal([{
+    //     trace_id: spanId2.toString(16),
+    //     span_id: spanId2.toString(16),
+    //     attributes: { foo: 'bar' },
+    //     tracestate: ts.toString(),
+    //     flags: 0
+    //   }])
+    // })
+
+    // it('should extract trace chunk tags', () => {
+    //   spanContext._trace.tags = {
+    //     chunk: 'test',
+    //     count: 1
+    //   }
+
+    //   trace = format(span)
+
+    //   expect(trace.meta).to.include({
+    //     chunk: 'test'
+    //   })
+
+    //   expect(trace.metrics).to.include({
+    //     count: 1
+    //   })
+    // })
+
+    // it('should discard user-defined tags with name HOSTNAME_KEY by default', () => {
+    //   spanContext._tags[HOSTNAME_KEY] = 'some_hostname'
+
+    //   trace = format(span)
+
+    //   expect(trace.meta[HOSTNAME_KEY]).to.be.undefined
+    // })
+
+    // it('should include the real hostname of the system if reportHostname is true', () => {
+    //   spanContext._hostname = 'my_hostname'
+    //   trace = format(span)
+
+    //   expect(trace.meta[HOSTNAME_KEY]).to.equal('my_hostname')
+    // })
 
-    it('should format span links', () => {
-      span._links = [
-        {
-          context: spanContext2
-        },
-        {
-          context: spanContext3
-        }
-      ]
-
-      trace = format(span)
-      const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
-
-      expect(spanLinks).to.deep.equal([{
-        trace_id: spanId2.toString(16),
-        span_id: spanId2.toString(16)
-      }, {
-        trace_id: spanId3.toString(16),
-        span_id: spanId3.toString(16)
-      }])
-    })
-
-    it('creates a span link', () => {
-      const ts = TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar')
-      const traceIdHigh = '0000000000000010'
-      spanContext2._tracestate = ts
-      spanContext2._trace = {
-        started: [],
-        finished: [],
-        origin: 'synthetics',
-        tags: {
-          '_dd.p.tid': traceIdHigh
-        }
-      }
-
-      spanContext2._sampling.priority = 0
-      const link = {
-        context: spanContext2,
-        attributes: { foo: 'bar' }
-      }
-      span._links = [link]
-
-      trace = format(span)
-      const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
-
-      expect(spanLinks).to.deep.equal([{
-        trace_id: spanId2.toString(16),
-        span_id: spanId2.toString(16),
-        attributes: { foo: 'bar' },
-        tracestate: ts.toString(),
-        flags: 0
-      }])
-    })
-
-    it('should extract trace chunk tags', () => {
-      spanContext._trace.tags = {
-        chunk: 'test',
-        count: 1
-      }
-
-      trace = format(span)
-
-      expect(trace.meta).to.include({
-        chunk: 'test'
-      })
-
-      expect(trace.metrics).to.include({
-        count: 1
-      })
-    })
-
-    it('should discard user-defined tags with name HOSTNAME_KEY by default', () => {
-      spanContext._tags[HOSTNAME_KEY] = 'some_hostname'
-
-      trace = format(span)
+    // it('should only extract tags that are not Datadog specific to meta', () => {
+    //   spanContext._tags['service.name'] = 'service'
+    //   spanContext._tags['span.type'] = 'type'
+    //   spanContext._tags['resource.name'] = 'resource'
+    //   spanContext._tags['foo.bar'] = 'foobar'
 
-      expect(trace.meta[HOSTNAME_KEY]).to.be.undefined
-    })
+    //   trace = format(span)
 
-    it('should include the real hostname of the system if reportHostname is true', () => {
-      spanContext._hostname = 'my_hostname'
-      trace = format(span)
+    //   expect(trace.meta['service.name']).to.be.undefined
+    //   expect(trace.meta['span.type']).to.be.undefined
+    //   expect(trace.meta['resource.name']).to.be.undefined
+    //   expect(trace.meta['foo.bar']).to.equal('foobar')
+    // })
 
-      expect(trace.meta[HOSTNAME_KEY]).to.equal('my_hostname')
-    })
+    // it('should extract numeric tags as metrics', () => {
+    //   spanContext._tags = { metric: 50 }
 
-    it('should only extract tags that are not Datadog specific to meta', () => {
-      spanContext._tags['service.name'] = 'service'
-      spanContext._tags['span.type'] = 'type'
-      spanContext._tags['resource.name'] = 'resource'
-      spanContext._tags['foo.bar'] = 'foobar'
+    //   trace = format(span)
 
-      trace = format(span)
+    //   expect(trace.metrics).to.have.property('metric', 50)
+    // })
 
-      expect(trace.meta['service.name']).to.be.undefined
-      expect(trace.meta['span.type']).to.be.undefined
-      expect(trace.meta['resource.name']).to.be.undefined
-      expect(trace.meta['foo.bar']).to.equal('foobar')
-    })
+    // it('should extract boolean tags as metrics', () => {
+    //   spanContext._tags = { yes: true, no: false }
 
-    it('should extract numeric tags as metrics', () => {
-      spanContext._tags = { metric: 50 }
+    //   trace = format(span)
 
-      trace = format(span)
+    //   expect(trace.metrics).to.have.property('yes', 1)
+    //   expect(trace.metrics).to.have.property('no', 0)
+    // })
 
-      expect(trace.metrics).to.have.property('metric', 50)
-    })
+    // it('should ignore metrics with invalid type', () => {
+    //   spanContext._metrics = { metric: 'test' }
 
-    it('should extract boolean tags as metrics', () => {
-      spanContext._tags = { yes: true, no: false }
+    //   trace = format(span)
 
-      trace = format(span)
+    //   expect(trace.metrics).to.not.have.property('metric')
+    // })
 
-      expect(trace.metrics).to.have.property('yes', 1)
-      expect(trace.metrics).to.have.property('no', 0)
-    })
+    // it('should ignore metrics that are not a number', () => {
+    //   spanContext._metrics = { metric: NaN }
 
-    it('should ignore metrics with invalid type', () => {
-      spanContext._metrics = { metric: 'test' }
+    //   trace = format(span)
 
-      trace = format(span)
+    //   expect(trace.metrics).to.not.have.property('metric')
+    // })
 
-      expect(trace.metrics).to.not.have.property('metric')
-    })
+    // it('should extract errors', () => {
+    //   const error = new Error('boom')
 
-    it('should ignore metrics that are not a number', () => {
-      spanContext._metrics = { metric: NaN }
+    //   spanContext._tags.error = error
+    //   trace = format(span)
 
-      trace = format(span)
+    //   expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
+    //   expect(trace.meta[ERROR_TYPE]).to.equal(error.name)
+    //   expect(trace.meta[ERROR_STACK]).to.equal(error.stack)
+    // })
 
-      expect(trace.metrics).to.not.have.property('metric')
-    })
+    // it('should skip error properties without a value', () => {
+    //   const error = new Error('boom')
 
-    it('should extract errors', () => {
-      const error = new Error('boom')
-
-      spanContext._tags.error = error
-      trace = format(span)
-
-      expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
-      expect(trace.meta[ERROR_TYPE]).to.equal(error.name)
-      expect(trace.meta[ERROR_STACK]).to.equal(error.stack)
-    })
-
-    it('should skip error properties without a value', () => {
-      const error = new Error('boom')
-
-      error.name = null
-      error.stack = null
-      spanContext._tags.error = error
-      trace = format(span)
-
-      expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
-      expect(trace.meta).to.not.have.property(ERROR_TYPE)
-      expect(trace.meta).to.not.have.property(ERROR_STACK)
-    })
-
-    it('should extract the origin', () => {
-      spanContext._trace.origin = 'synthetics'
-
-      trace = format(span)
-
-      expect(trace.meta[ORIGIN_KEY]).to.equal('synthetics')
-    })
-
-    it('should add the language tag for a basic span', () => {
-      trace = format(span)
-
-      expect(trace.meta.language).to.equal('javascript')
-    })
-
-    describe('when there is an `error` tag ', () => {
-      it('should set the error flag when error tag is true', () => {
-        spanContext._tags.error = true
-
-        trace = format(span)
-
-        expect(trace.error).to.equal(1)
-      })
-
-      it('should not set the error flag when error is false', () => {
-        spanContext._tags.error = false
-
-        trace = format(span)
-
-        expect(trace.error).to.equal(0)
-      })
-
-      it('should not extract error to meta', () => {
-        spanContext._tags.error = true
-
-        trace = format(span)
-
-        expect(trace.meta.error).to.be.undefined
-      })
-    })
-
-    it('should set the error flag when there is an error-related tag', () => {
-      spanContext._tags[ERROR_TYPE] = 'Error'
-      spanContext._tags[ERROR_MESSAGE] = 'boom'
-      spanContext._tags[ERROR_STACK] = ''
-
-      trace = format(span)
-
-      expect(trace.error).to.equal(1)
-    })
-
-    it('should not set the error flag for internal spans with error tags', () => {
-      spanContext._tags[ERROR_TYPE] = 'Error'
-      spanContext._tags[ERROR_MESSAGE] = 'boom'
-      spanContext._tags[ERROR_STACK] = ''
-      spanContext._name = 'fs.operation'
-
-      trace = format(span)
-
-      expect(trace.error).to.equal(0)
-    })
-
-    it('should not set the error flag for internal spans with error tag', () => {
-      spanContext._tags.error = new Error('boom')
-      spanContext._name = 'fs.operation'
-
-      trace = format(span)
-
-      expect(trace.error).to.equal(0)
-    })
-
-    it('should sanitize the input', () => {
-      spanContext._name = null
-      spanContext._tags = {
-        'foo.bar': null,
-        'baz.qux': undefined
-      }
-      span._startTime = NaN
-      span._duration = NaN
-
-      trace = format(span)
-
-      expect(trace.name).to.equal('null')
-      expect(trace.resource).to.equal('null')
-      expect(trace.meta).to.not.have.property('foo.bar')
-      expect(trace.meta).to.not.have.property('baz.qux')
-      expect(trace.start).to.be.a('number')
-      expect(trace.duration).to.be.a('number')
-    })
-
-    it('should include the sampling priority', () => {
-      spanContext._sampling.priority = 0
-      trace = format(span)
-      expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
-    })
-
-    it('should support only the first level of depth for objects', () => {
-      const tag = {
-        A: {
-          B: {},
-          num: '2'
-        },
-        num: '1'
-      }
-
-      spanContext._tags.nested = tag
-      trace = format(span)
-
-      expect(trace.meta['nested.num']).to.equal('1')
-      expect(trace.meta['nested.A']).to.be.undefined
-      expect(trace.meta['nested.A.B']).to.be.undefined
-      expect(trace.meta['nested.A.num']).to.be.undefined
-    })
-
-    it('should accept a boolean for measured', () => {
-      spanContext._tags[MEASURED] = true
-      trace = format(span)
-      expect(trace.metrics[MEASURED]).to.equal(1)
-    })
-
-    it('should accept a numeric value for measured', () => {
-      spanContext._tags[MEASURED] = 0
-      trace = format(span)
-      expect(trace.metrics[MEASURED]).to.equal(0)
-    })
-
-    it('should accept undefined for measured', () => {
-      spanContext._tags[MEASURED] = undefined
-      trace = format(span)
-      expect(trace.metrics[MEASURED]).to.equal(1)
-    })
-
-    it('should not measure internal spans', () => {
-      spanContext._tags['span.kind'] = 'internal'
-      trace = format(span)
-      expect(trace.metrics).to.not.have.property(MEASURED)
-    })
-
-    it('should not measure unknown spans', () => {
-      trace = format(span)
-      expect(trace.metrics).to.not.have.property(MEASURED)
-    })
-
-    it('should measure non-internal spans', () => {
-      spanContext._tags['span.kind'] = 'server'
-      trace = format(span)
-      expect(trace.metrics[MEASURED]).to.equal(1)
-    })
-
-    it('should not override explicit measure decision', () => {
-      spanContext._tags[MEASURED] = 0
-      spanContext._tags['span.kind'] = 'server'
-      trace = format(span)
-      expect(trace.metrics[MEASURED]).to.equal(0)
-    })
-
-    it('should possess a process_id tag', () => {
-      trace = format(span)
-      expect(trace.metrics[PROCESS_ID]).to.equal(process.pid)
-    })
-
-    it('should not crash on prototype-free tags objects when nesting', () => {
-      const tags = Object.create(null)
-      tags.nested = { foo: 'bar' }
-      spanContext._tags.nested = tags
-
-      format(span)
-    })
-
-    it('should capture analytics.event', () => {
-      spanContext._tags['analytics.event'] = 1
-
-      trace = format(span)
-
-      expect(trace.metrics).to.have.property('_dd1.sr.eausr', 1)
-    })
+    //   error.name = null
+    //   error.stack = null
+    //   spanContext._tags.error = error
+    //   trace = format(span)
+
+    //   expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
+    //   expect(trace.meta).to.not.have.property(ERROR_TYPE)
+    //   expect(trace.meta).to.not.have.property(ERROR_STACK)
+    // })
+
+    // it('should extract the origin', () => {
+    //   spanContext._trace.origin = 'synthetics'
+
+    //   trace = format(span)
+
+    //   expect(trace.meta[ORIGIN_KEY]).to.equal('synthetics')
+    // })
+
+    // it('should add the language tag for a basic span', () => {
+    //   trace = format(span)
+
+    //   expect(trace.meta.language).to.equal('javascript')
+    // })
+
+    // describe('when there is an `error` tag ', () => {
+    //   it('should set the error flag when error tag is true', () => {
+    //     spanContext._tags.error = true
+
+    //     trace = format(span)
+
+    //     expect(trace.error).to.equal(1)
+    //   })
+
+    //   it('should not set the error flag when error is false', () => {
+    //     spanContext._tags.error = false
+
+    //     trace = format(span)
+
+    //     expect(trace.error).to.equal(0)
+    //   })
+
+    //   it('should not extract error to meta', () => {
+    //     spanContext._tags.error = true
+
+    //     trace = format(span)
+
+    //     expect(trace.meta.error).to.be.undefined
+    //   })
+    // })
+
+    // it('should set the error flag when there is an error-related tag', () => {
+    //   spanContext._tags[ERROR_TYPE] = 'Error'
+    //   spanContext._tags[ERROR_MESSAGE] = 'boom'
+    //   spanContext._tags[ERROR_STACK] = ''
+
+    //   trace = format(span)
+
+    //   expect(trace.error).to.equal(1)
+    // })
+
+    // it('should not set the error flag for internal spans with error tags', () => {
+    //   spanContext._tags[ERROR_TYPE] = 'Error'
+    //   spanContext._tags[ERROR_MESSAGE] = 'boom'
+    //   spanContext._tags[ERROR_STACK] = ''
+    //   spanContext._name = 'fs.operation'
+
+    //   trace = format(span)
+
+    //   expect(trace.error).to.equal(0)
+    // })
+
+    // it('should not set the error flag for internal spans with error tag', () => {
+    //   spanContext._tags.error = new Error('boom')
+    //   spanContext._name = 'fs.operation'
+
+    //   trace = format(span)
+
+    //   expect(trace.error).to.equal(0)
+    // })
+
+    // it('should sanitize the input', () => {
+    //   spanContext._name = null
+    //   spanContext._tags = {
+    //     'foo.bar': null,
+    //     'baz.qux': undefined
+    //   }
+    //   span._startTime = NaN
+    //   span._duration = NaN
+
+    //   trace = format(span)
+
+    //   expect(trace.name).to.equal('null')
+    //   expect(trace.resource).to.equal('null')
+    //   expect(trace.meta).to.not.have.property('foo.bar')
+    //   expect(trace.meta).to.not.have.property('baz.qux')
+    //   expect(trace.start).to.be.a('number')
+    //   expect(trace.duration).to.be.a('number')
+    // })
+
+    // it('should include the sampling priority', () => {
+    //   spanContext._sampling.priority = 0
+    //   trace = format(span)
+    //   expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
+    // })
+
+    // it('should support only the first level of depth for objects', () => {
+    //   const tag = {
+    //     A: {
+    //       B: {},
+    //       num: '2'
+    //     },
+    //     num: '1'
+    //   }
+
+    //   spanContext._tags.nested = tag
+    //   trace = format(span)
+
+    //   expect(trace.meta['nested.num']).to.equal('1')
+    //   expect(trace.meta['nested.A']).to.be.undefined
+    //   expect(trace.meta['nested.A.B']).to.be.undefined
+    //   expect(trace.meta['nested.A.num']).to.be.undefined
+    // })
+
+    // it('should accept a boolean for measured', () => {
+    //   spanContext._tags[MEASURED] = true
+    //   trace = format(span)
+    //   expect(trace.metrics[MEASURED]).to.equal(1)
+    // })
+
+    // it('should accept a numeric value for measured', () => {
+    //   spanContext._tags[MEASURED] = 0
+    //   trace = format(span)
+    //   expect(trace.metrics[MEASURED]).to.equal(0)
+    // })
+
+    // it('should accept undefined for measured', () => {
+    //   spanContext._tags[MEASURED] = undefined
+    //   trace = format(span)
+    //   expect(trace.metrics[MEASURED]).to.equal(1)
+    // })
+
+    // it('should not measure internal spans', () => {
+    //   spanContext._tags['span.kind'] = 'internal'
+    //   trace = format(span)
+    //   expect(trace.metrics).to.not.have.property(MEASURED)
+    // })
+
+    // it('should not measure unknown spans', () => {
+    //   trace = format(span)
+    //   expect(trace.metrics).to.not.have.property(MEASURED)
+    // })
+
+    // it('should measure non-internal spans', () => {
+    //   spanContext._tags['span.kind'] = 'server'
+    //   trace = format(span)
+    //   expect(trace.metrics[MEASURED]).to.equal(1)
+    // })
+
+    // it('should not override explicit measure decision', () => {
+    //   spanContext._tags[MEASURED] = 0
+    //   spanContext._tags['span.kind'] = 'server'
+    //   trace = format(span)
+    //   expect(trace.metrics[MEASURED]).to.equal(0)
+    // })
+
+    // it('should possess a process_id tag', () => {
+    //   trace = format(span)
+    //   expect(trace.metrics[PROCESS_ID]).to.equal(process.pid)
+    // })
+
+    // it('should not crash on prototype-free tags objects when nesting', () => {
+    //   const tags = Object.create(null)
+    //   tags.nested = { foo: 'bar' }
+    //   spanContext._tags.nested = tags
+
+    //   format(span)
+    // })
+
+    // it('should capture analytics.event', () => {
+    //   spanContext._tags['analytics.event'] = 1
+
+    //   trace = format(span)
+
+    //   expect(trace.metrics).to.have.property('_dd1.sr.eausr', 1)
+    // })
   })
 })

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -424,12 +424,29 @@ describe('format', () => {
       })
     })
 
-    it('should set the error flag when there is an error-related tag', () => {
+    it('should not set the error flag when there is an error-related tag without a set trace tag', () => {
       spanContext._tags[ERROR_TYPE] = 'Error'
       spanContext._tags[ERROR_MESSAGE] = 'boom'
       spanContext._tags[ERROR_STACK] = ''
 
       trace = format(span)
+
+      expect(trace.error).to.equal(0)
+    })
+
+    it('should set the error flag when there is an error-related tag with should setTrace', () => {
+      spanContext._tags[ERROR_TYPE] = 'Error'
+      spanContext._tags[ERROR_MESSAGE] = 'boom'
+      spanContext._tags[ERROR_STACK] = ''
+      spanContext._tags.setTraceError = 1
+
+      trace = format(span)
+
+      expect(trace.error).to.equal(1)
+
+      spanContext._tags[ERROR_TYPE] = 'foo'
+      spanContext._tags[ERROR_MESSAGE] = 'foo'
+      spanContext._tags[ERROR_STACK] = 'foo'
 
       expect(trace.error).to.equal(1)
     })

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -108,456 +108,456 @@ describe('format', () => {
         attributes: { emotion: 'happy', rating: 9.8, other: [1, 9.5, 1], idol: false }
       }])
     })
-    // it('should convert a span to the correct trace format', () => {
-    //   trace = format(span)
-
-    //   expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
-    //   expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
-    //   expect(trace.parent_id.toString()).to.equal(span.context()._parentId.toString())
-    //   expect(trace.name).to.equal(span.context()._name)
-    //   expect(trace.resource).to.equal(span.context()._name)
-    //   expect(trace.error).to.equal(0)
-    //   expect(trace.start).to.equal(span._startTime * 1e6)
-    //   expect(trace.duration).to.equal(span._duration * 1e6)
-    // })
-
-    // it('should always set a parent ID', () => {
-    //   span.context()._parentId = null
-
-    //   trace = format(span)
-
-    //   expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
-    //   expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
-    //   expect(trace.parent_id.toString()).to.equal('0000000000000000')
-    //   expect(trace.name).to.equal(span.context()._name)
-    //   expect(trace.resource).to.equal(span.context()._name)
-    //   expect(trace.error).to.equal(0)
-    //   expect(trace.start).to.equal(span._startTime * 1e6)
-    //   expect(trace.duration).to.equal(span._duration * 1e6)
-    // })
-
-    // describe('_dd.base_service', () => {
-    //   it('should infer the tag when span service changes', () => {
-    //     span.context()._tags['service.name'] = 'foo'
-
-    //     trace = format(span)
-
-    //     expect(span.setTag).to.have.been.calledWith('_dd.base_service', 'test')
-    //   })
-
-    //   it('should infer the tag when no changes occur', () => {
-    //     span.context()._tags['service.name'] = 'test'
-
-    //     trace = format(span)
-
-    //     expect(span.setTag).to.not.have.been.called
-    //   })
-
-    //   it('should register extra service name', () => {
-    //     span.context()._tags['service.name'] = 'foo'
-
-    //     trace = format(span)
-
-    //     expect(getExtraServices()).to.deep.equal(['foo'])
-    //   })
-    // })
-
-    // it('should extract Datadog specific tags', () => {
-    //   spanContext._tags['service.name'] = 'service'
-    //   spanContext._tags['span.type'] = 'type'
-    //   spanContext._tags['resource.name'] = 'resource'
-
-    //   trace = format(span)
-
-    //   expect(trace.service).to.equal('service')
-    //   expect(trace.type).to.equal('type')
-    //   expect(trace.resource).to.equal('resource')
-    // })
-
-    // it('should extract Datadog specific root tags', () => {
-    //   spanContext._parentId = null
-    //   spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
-    //   spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
-    //   spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
-
-    //   trace = format(span)
-
-    //   expect(trace.metrics).to.include({
-    //     [SAMPLING_AGENT_DECISION]: 0.8,
-    //     [SAMPLING_LIMIT_DECISION]: 0.2,
-    //     [SAMPLING_RULE_DECISION]: 0.5
-    //   })
-    // })
-
-    // it('should not extract Datadog specific root tags from non-root spans', () => {
-    //   spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
-    //   spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
-    //   spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
-
-    //   trace = format(span)
-
-    //   expect(trace.metrics).to.not.have.keys(
-    //     SAMPLING_AGENT_DECISION,
-    //     SAMPLING_LIMIT_DECISION,
-    //     SAMPLING_RULE_DECISION
-    //   )
-    // })
-
-    // it('should always add single span ingestion tags from options if present', () => {
-    //   spanContext._spanSampling = {
-    //     maxPerSecond: 5,
-    //     sampleRate: 1.0
-    //   }
-    //   trace = format(span)
-
-    //   expect(trace.metrics).to.include({
-    //     [SPAN_SAMPLING_MECHANISM]: SAMPLING_MECHANISM_SPAN,
-    //     [SPAN_SAMPLING_MAX_PER_SECOND]: 5,
-    //     [SPAN_SAMPLING_RULE_RATE]: 1.0
-    //   })
-    // })
-
-    // it('should not add single span ingestion tags if options not present', () => {
-    //   trace = format(span)
-
-    //   expect(trace.metrics).to.not.have.keys(
-    //     SPAN_SAMPLING_MECHANISM,
-    //     SPAN_SAMPLING_MAX_PER_SECOND,
-    //     SPAN_SAMPLING_RULE_RATE
-    //   )
-    // })
-
-    // it('should format span links', () => {
-    //   span._links = [
-    //     {
-    //       context: spanContext2
-    //     },
-    //     {
-    //       context: spanContext3
-    //     }
-    //   ]
-
-    //   trace = format(span)
-    //   const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
-
-    //   expect(spanLinks).to.deep.equal([{
-    //     trace_id: spanId2.toString(16),
-    //     span_id: spanId2.toString(16)
-    //   }, {
-    //     trace_id: spanId3.toString(16),
-    //     span_id: spanId3.toString(16)
-    //   }])
-    // })
-
-    // it('creates a span link', () => {
-    //   const ts = TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar')
-    //   const traceIdHigh = '0000000000000010'
-    //   spanContext2._tracestate = ts
-    //   spanContext2._trace = {
-    //     started: [],
-    //     finished: [],
-    //     origin: 'synthetics',
-    //     tags: {
-    //       '_dd.p.tid': traceIdHigh
-    //     }
-    //   }
-
-    //   spanContext2._sampling.priority = 0
-    //   const link = {
-    //     context: spanContext2,
-    //     attributes: { foo: 'bar' }
-    //   }
-    //   span._links = [link]
-
-    //   trace = format(span)
-    //   const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
-
-    //   expect(spanLinks).to.deep.equal([{
-    //     trace_id: spanId2.toString(16),
-    //     span_id: spanId2.toString(16),
-    //     attributes: { foo: 'bar' },
-    //     tracestate: ts.toString(),
-    //     flags: 0
-    //   }])
-    // })
-
-    // it('should extract trace chunk tags', () => {
-    //   spanContext._trace.tags = {
-    //     chunk: 'test',
-    //     count: 1
-    //   }
-
-    //   trace = format(span)
-
-    //   expect(trace.meta).to.include({
-    //     chunk: 'test'
-    //   })
-
-    //   expect(trace.metrics).to.include({
-    //     count: 1
-    //   })
-    // })
-
-    // it('should discard user-defined tags with name HOSTNAME_KEY by default', () => {
-    //   spanContext._tags[HOSTNAME_KEY] = 'some_hostname'
-
-    //   trace = format(span)
-
-    //   expect(trace.meta[HOSTNAME_KEY]).to.be.undefined
-    // })
-
-    // it('should include the real hostname of the system if reportHostname is true', () => {
-    //   spanContext._hostname = 'my_hostname'
-    //   trace = format(span)
-
-    //   expect(trace.meta[HOSTNAME_KEY]).to.equal('my_hostname')
-    // })
+    it('should convert a span to the correct trace format', () => {
+      trace = format(span)
+
+      expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
+      expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
+      expect(trace.parent_id.toString()).to.equal(span.context()._parentId.toString())
+      expect(trace.name).to.equal(span.context()._name)
+      expect(trace.resource).to.equal(span.context()._name)
+      expect(trace.error).to.equal(0)
+      expect(trace.start).to.equal(span._startTime * 1e6)
+      expect(trace.duration).to.equal(span._duration * 1e6)
+    })
+
+    it('should always set a parent ID', () => {
+      span.context()._parentId = null
+
+      trace = format(span)
+
+      expect(trace.trace_id.toString()).to.equal(span.context()._traceId.toString())
+      expect(trace.span_id.toString()).to.equal(span.context()._spanId.toString())
+      expect(trace.parent_id.toString()).to.equal('0000000000000000')
+      expect(trace.name).to.equal(span.context()._name)
+      expect(trace.resource).to.equal(span.context()._name)
+      expect(trace.error).to.equal(0)
+      expect(trace.start).to.equal(span._startTime * 1e6)
+      expect(trace.duration).to.equal(span._duration * 1e6)
+    })
+
+    describe('_dd.base_service', () => {
+      it('should infer the tag when span service changes', () => {
+        span.context()._tags['service.name'] = 'foo'
+
+        trace = format(span)
+
+        expect(span.setTag).to.have.been.calledWith('_dd.base_service', 'test')
+      })
+
+      it('should infer the tag when no changes occur', () => {
+        span.context()._tags['service.name'] = 'test'
+
+        trace = format(span)
+
+        expect(span.setTag).to.not.have.been.called
+      })
+
+      it('should register extra service name', () => {
+        span.context()._tags['service.name'] = 'foo'
+
+        trace = format(span)
+
+        expect(getExtraServices()).to.deep.equal(['foo'])
+      })
+    })
+
+    it('should extract Datadog specific tags', () => {
+      spanContext._tags['service.name'] = 'service'
+      spanContext._tags['span.type'] = 'type'
+      spanContext._tags['resource.name'] = 'resource'
+
+      trace = format(span)
+
+      expect(trace.service).to.equal('service')
+      expect(trace.type).to.equal('type')
+      expect(trace.resource).to.equal('resource')
+    })
+
+    it('should extract Datadog specific root tags', () => {
+      spanContext._parentId = null
+      spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
+      spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
+      spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
+
+      trace = format(span)
+
+      expect(trace.metrics).to.include({
+        [SAMPLING_AGENT_DECISION]: 0.8,
+        [SAMPLING_LIMIT_DECISION]: 0.2,
+        [SAMPLING_RULE_DECISION]: 0.5
+      })
+    })
+
+    it('should not extract Datadog specific root tags from non-root spans', () => {
+      spanContext._trace[SAMPLING_AGENT_DECISION] = 0.8
+      spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
+      spanContext._trace[SAMPLING_RULE_DECISION] = 0.5
+
+      trace = format(span)
+
+      expect(trace.metrics).to.not.have.keys(
+        SAMPLING_AGENT_DECISION,
+        SAMPLING_LIMIT_DECISION,
+        SAMPLING_RULE_DECISION
+      )
+    })
+
+    it('should always add single span ingestion tags from options if present', () => {
+      spanContext._spanSampling = {
+        maxPerSecond: 5,
+        sampleRate: 1.0
+      }
+      trace = format(span)
+
+      expect(trace.metrics).to.include({
+        [SPAN_SAMPLING_MECHANISM]: SAMPLING_MECHANISM_SPAN,
+        [SPAN_SAMPLING_MAX_PER_SECOND]: 5,
+        [SPAN_SAMPLING_RULE_RATE]: 1.0
+      })
+    })
+
+    it('should not add single span ingestion tags if options not present', () => {
+      trace = format(span)
+
+      expect(trace.metrics).to.not.have.keys(
+        SPAN_SAMPLING_MECHANISM,
+        SPAN_SAMPLING_MAX_PER_SECOND,
+        SPAN_SAMPLING_RULE_RATE
+      )
+    })
+
+    it('should format span links', () => {
+      span._links = [
+        {
+          context: spanContext2
+        },
+        {
+          context: spanContext3
+        }
+      ]
+
+      trace = format(span)
+      const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
+
+      expect(spanLinks).to.deep.equal([{
+        trace_id: spanId2.toString(16),
+        span_id: spanId2.toString(16)
+      }, {
+        trace_id: spanId3.toString(16),
+        span_id: spanId3.toString(16)
+      }])
+    })
+
+    it('creates a span link', () => {
+      const ts = TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar')
+      const traceIdHigh = '0000000000000010'
+      spanContext2._tracestate = ts
+      spanContext2._trace = {
+        started: [],
+        finished: [],
+        origin: 'synthetics',
+        tags: {
+          '_dd.p.tid': traceIdHigh
+        }
+      }
+
+      spanContext2._sampling.priority = 0
+      const link = {
+        context: spanContext2,
+        attributes: { foo: 'bar' }
+      }
+      span._links = [link]
+
+      trace = format(span)
+      const spanLinks = JSON.parse(trace.meta['_dd.span_links'])
+
+      expect(spanLinks).to.deep.equal([{
+        trace_id: spanId2.toString(16),
+        span_id: spanId2.toString(16),
+        attributes: { foo: 'bar' },
+        tracestate: ts.toString(),
+        flags: 0
+      }])
+    })
+
+    it('should extract trace chunk tags', () => {
+      spanContext._trace.tags = {
+        chunk: 'test',
+        count: 1
+      }
+
+      trace = format(span)
+
+      expect(trace.meta).to.include({
+        chunk: 'test'
+      })
+
+      expect(trace.metrics).to.include({
+        count: 1
+      })
+    })
+
+    it('should discard user-defined tags with name HOSTNAME_KEY by default', () => {
+      spanContext._tags[HOSTNAME_KEY] = 'some_hostname'
+
+      trace = format(span)
+
+      expect(trace.meta[HOSTNAME_KEY]).to.be.undefined
+    })
+
+    it('should include the real hostname of the system if reportHostname is true', () => {
+      spanContext._hostname = 'my_hostname'
+      trace = format(span)
+
+      expect(trace.meta[HOSTNAME_KEY]).to.equal('my_hostname')
+    })
 
-    // it('should only extract tags that are not Datadog specific to meta', () => {
-    //   spanContext._tags['service.name'] = 'service'
-    //   spanContext._tags['span.type'] = 'type'
-    //   spanContext._tags['resource.name'] = 'resource'
-    //   spanContext._tags['foo.bar'] = 'foobar'
+    it('should only extract tags that are not Datadog specific to meta', () => {
+      spanContext._tags['service.name'] = 'service'
+      spanContext._tags['span.type'] = 'type'
+      spanContext._tags['resource.name'] = 'resource'
+      spanContext._tags['foo.bar'] = 'foobar'
 
-    //   trace = format(span)
+      trace = format(span)
 
-    //   expect(trace.meta['service.name']).to.be.undefined
-    //   expect(trace.meta['span.type']).to.be.undefined
-    //   expect(trace.meta['resource.name']).to.be.undefined
-    //   expect(trace.meta['foo.bar']).to.equal('foobar')
-    // })
+      expect(trace.meta['service.name']).to.be.undefined
+      expect(trace.meta['span.type']).to.be.undefined
+      expect(trace.meta['resource.name']).to.be.undefined
+      expect(trace.meta['foo.bar']).to.equal('foobar')
+    })
 
-    // it('should extract numeric tags as metrics', () => {
-    //   spanContext._tags = { metric: 50 }
+    it('should extract numeric tags as metrics', () => {
+      spanContext._tags = { metric: 50 }
 
-    //   trace = format(span)
+      trace = format(span)
 
-    //   expect(trace.metrics).to.have.property('metric', 50)
-    // })
+      expect(trace.metrics).to.have.property('metric', 50)
+    })
 
-    // it('should extract boolean tags as metrics', () => {
-    //   spanContext._tags = { yes: true, no: false }
+    it('should extract boolean tags as metrics', () => {
+      spanContext._tags = { yes: true, no: false }
 
-    //   trace = format(span)
+      trace = format(span)
 
-    //   expect(trace.metrics).to.have.property('yes', 1)
-    //   expect(trace.metrics).to.have.property('no', 0)
-    // })
+      expect(trace.metrics).to.have.property('yes', 1)
+      expect(trace.metrics).to.have.property('no', 0)
+    })
 
-    // it('should ignore metrics with invalid type', () => {
-    //   spanContext._metrics = { metric: 'test' }
+    it('should ignore metrics with invalid type', () => {
+      spanContext._metrics = { metric: 'test' }
 
-    //   trace = format(span)
+      trace = format(span)
 
-    //   expect(trace.metrics).to.not.have.property('metric')
-    // })
+      expect(trace.metrics).to.not.have.property('metric')
+    })
 
-    // it('should ignore metrics that are not a number', () => {
-    //   spanContext._metrics = { metric: NaN }
+    it('should ignore metrics that are not a number', () => {
+      spanContext._metrics = { metric: NaN }
 
-    //   trace = format(span)
+      trace = format(span)
 
-    //   expect(trace.metrics).to.not.have.property('metric')
-    // })
+      expect(trace.metrics).to.not.have.property('metric')
+    })
 
-    // it('should extract errors', () => {
-    //   const error = new Error('boom')
+    it('should extract errors', () => {
+      const error = new Error('boom')
 
-    //   spanContext._tags.error = error
-    //   trace = format(span)
+      spanContext._tags.error = error
+      trace = format(span)
 
-    //   expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
-    //   expect(trace.meta[ERROR_TYPE]).to.equal(error.name)
-    //   expect(trace.meta[ERROR_STACK]).to.equal(error.stack)
-    // })
+      expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
+      expect(trace.meta[ERROR_TYPE]).to.equal(error.name)
+      expect(trace.meta[ERROR_STACK]).to.equal(error.stack)
+    })
 
-    // it('should skip error properties without a value', () => {
-    //   const error = new Error('boom')
+    it('should skip error properties without a value', () => {
+      const error = new Error('boom')
 
-    //   error.name = null
-    //   error.stack = null
-    //   spanContext._tags.error = error
-    //   trace = format(span)
-
-    //   expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
-    //   expect(trace.meta).to.not.have.property(ERROR_TYPE)
-    //   expect(trace.meta).to.not.have.property(ERROR_STACK)
-    // })
-
-    // it('should extract the origin', () => {
-    //   spanContext._trace.origin = 'synthetics'
-
-    //   trace = format(span)
-
-    //   expect(trace.meta[ORIGIN_KEY]).to.equal('synthetics')
-    // })
-
-    // it('should add the language tag for a basic span', () => {
-    //   trace = format(span)
-
-    //   expect(trace.meta.language).to.equal('javascript')
-    // })
-
-    // describe('when there is an `error` tag ', () => {
-    //   it('should set the error flag when error tag is true', () => {
-    //     spanContext._tags.error = true
-
-    //     trace = format(span)
-
-    //     expect(trace.error).to.equal(1)
-    //   })
-
-    //   it('should not set the error flag when error is false', () => {
-    //     spanContext._tags.error = false
-
-    //     trace = format(span)
-
-    //     expect(trace.error).to.equal(0)
-    //   })
-
-    //   it('should not extract error to meta', () => {
-    //     spanContext._tags.error = true
-
-    //     trace = format(span)
-
-    //     expect(trace.meta.error).to.be.undefined
-    //   })
-    // })
-
-    // it('should set the error flag when there is an error-related tag', () => {
-    //   spanContext._tags[ERROR_TYPE] = 'Error'
-    //   spanContext._tags[ERROR_MESSAGE] = 'boom'
-    //   spanContext._tags[ERROR_STACK] = ''
-
-    //   trace = format(span)
-
-    //   expect(trace.error).to.equal(1)
-    // })
-
-    // it('should not set the error flag for internal spans with error tags', () => {
-    //   spanContext._tags[ERROR_TYPE] = 'Error'
-    //   spanContext._tags[ERROR_MESSAGE] = 'boom'
-    //   spanContext._tags[ERROR_STACK] = ''
-    //   spanContext._name = 'fs.operation'
-
-    //   trace = format(span)
-
-    //   expect(trace.error).to.equal(0)
-    // })
-
-    // it('should not set the error flag for internal spans with error tag', () => {
-    //   spanContext._tags.error = new Error('boom')
-    //   spanContext._name = 'fs.operation'
-
-    //   trace = format(span)
-
-    //   expect(trace.error).to.equal(0)
-    // })
-
-    // it('should sanitize the input', () => {
-    //   spanContext._name = null
-    //   spanContext._tags = {
-    //     'foo.bar': null,
-    //     'baz.qux': undefined
-    //   }
-    //   span._startTime = NaN
-    //   span._duration = NaN
-
-    //   trace = format(span)
-
-    //   expect(trace.name).to.equal('null')
-    //   expect(trace.resource).to.equal('null')
-    //   expect(trace.meta).to.not.have.property('foo.bar')
-    //   expect(trace.meta).to.not.have.property('baz.qux')
-    //   expect(trace.start).to.be.a('number')
-    //   expect(trace.duration).to.be.a('number')
-    // })
-
-    // it('should include the sampling priority', () => {
-    //   spanContext._sampling.priority = 0
-    //   trace = format(span)
-    //   expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
-    // })
-
-    // it('should support only the first level of depth for objects', () => {
-    //   const tag = {
-    //     A: {
-    //       B: {},
-    //       num: '2'
-    //     },
-    //     num: '1'
-    //   }
-
-    //   spanContext._tags.nested = tag
-    //   trace = format(span)
-
-    //   expect(trace.meta['nested.num']).to.equal('1')
-    //   expect(trace.meta['nested.A']).to.be.undefined
-    //   expect(trace.meta['nested.A.B']).to.be.undefined
-    //   expect(trace.meta['nested.A.num']).to.be.undefined
-    // })
-
-    // it('should accept a boolean for measured', () => {
-    //   spanContext._tags[MEASURED] = true
-    //   trace = format(span)
-    //   expect(trace.metrics[MEASURED]).to.equal(1)
-    // })
-
-    // it('should accept a numeric value for measured', () => {
-    //   spanContext._tags[MEASURED] = 0
-    //   trace = format(span)
-    //   expect(trace.metrics[MEASURED]).to.equal(0)
-    // })
-
-    // it('should accept undefined for measured', () => {
-    //   spanContext._tags[MEASURED] = undefined
-    //   trace = format(span)
-    //   expect(trace.metrics[MEASURED]).to.equal(1)
-    // })
-
-    // it('should not measure internal spans', () => {
-    //   spanContext._tags['span.kind'] = 'internal'
-    //   trace = format(span)
-    //   expect(trace.metrics).to.not.have.property(MEASURED)
-    // })
-
-    // it('should not measure unknown spans', () => {
-    //   trace = format(span)
-    //   expect(trace.metrics).to.not.have.property(MEASURED)
-    // })
-
-    // it('should measure non-internal spans', () => {
-    //   spanContext._tags['span.kind'] = 'server'
-    //   trace = format(span)
-    //   expect(trace.metrics[MEASURED]).to.equal(1)
-    // })
-
-    // it('should not override explicit measure decision', () => {
-    //   spanContext._tags[MEASURED] = 0
-    //   spanContext._tags['span.kind'] = 'server'
-    //   trace = format(span)
-    //   expect(trace.metrics[MEASURED]).to.equal(0)
-    // })
-
-    // it('should possess a process_id tag', () => {
-    //   trace = format(span)
-    //   expect(trace.metrics[PROCESS_ID]).to.equal(process.pid)
-    // })
-
-    // it('should not crash on prototype-free tags objects when nesting', () => {
-    //   const tags = Object.create(null)
-    //   tags.nested = { foo: 'bar' }
-    //   spanContext._tags.nested = tags
-
-    //   format(span)
-    // })
-
-    // it('should capture analytics.event', () => {
-    //   spanContext._tags['analytics.event'] = 1
-
-    //   trace = format(span)
-
-    //   expect(trace.metrics).to.have.property('_dd1.sr.eausr', 1)
-    // })
+      error.name = null
+      error.stack = null
+      spanContext._tags.error = error
+      trace = format(span)
+
+      expect(trace.meta[ERROR_MESSAGE]).to.equal(error.message)
+      expect(trace.meta).to.not.have.property(ERROR_TYPE)
+      expect(trace.meta).to.not.have.property(ERROR_STACK)
+    })
+
+    it('should extract the origin', () => {
+      spanContext._trace.origin = 'synthetics'
+
+      trace = format(span)
+
+      expect(trace.meta[ORIGIN_KEY]).to.equal('synthetics')
+    })
+
+    it('should add the language tag for a basic span', () => {
+      trace = format(span)
+
+      expect(trace.meta.language).to.equal('javascript')
+    })
+
+    describe('when there is an `error` tag ', () => {
+      it('should set the error flag when error tag is true', () => {
+        spanContext._tags.error = true
+
+        trace = format(span)
+
+        expect(trace.error).to.equal(1)
+      })
+
+      it('should not set the error flag when error is false', () => {
+        spanContext._tags.error = false
+
+        trace = format(span)
+
+        expect(trace.error).to.equal(0)
+      })
+
+      it('should not extract error to meta', () => {
+        spanContext._tags.error = true
+
+        trace = format(span)
+
+        expect(trace.meta.error).to.be.undefined
+      })
+    })
+
+    it('should set the error flag when there is an error-related tag', () => {
+      spanContext._tags[ERROR_TYPE] = 'Error'
+      spanContext._tags[ERROR_MESSAGE] = 'boom'
+      spanContext._tags[ERROR_STACK] = ''
+
+      trace = format(span)
+
+      expect(trace.error).to.equal(1)
+    })
+
+    it('should not set the error flag for internal spans with error tags', () => {
+      spanContext._tags[ERROR_TYPE] = 'Error'
+      spanContext._tags[ERROR_MESSAGE] = 'boom'
+      spanContext._tags[ERROR_STACK] = ''
+      spanContext._name = 'fs.operation'
+
+      trace = format(span)
+
+      expect(trace.error).to.equal(0)
+    })
+
+    it('should not set the error flag for internal spans with error tag', () => {
+      spanContext._tags.error = new Error('boom')
+      spanContext._name = 'fs.operation'
+
+      trace = format(span)
+
+      expect(trace.error).to.equal(0)
+    })
+
+    it('should sanitize the input', () => {
+      spanContext._name = null
+      spanContext._tags = {
+        'foo.bar': null,
+        'baz.qux': undefined
+      }
+      span._startTime = NaN
+      span._duration = NaN
+
+      trace = format(span)
+
+      expect(trace.name).to.equal('null')
+      expect(trace.resource).to.equal('null')
+      expect(trace.meta).to.not.have.property('foo.bar')
+      expect(trace.meta).to.not.have.property('baz.qux')
+      expect(trace.start).to.be.a('number')
+      expect(trace.duration).to.be.a('number')
+    })
+
+    it('should include the sampling priority', () => {
+      spanContext._sampling.priority = 0
+      trace = format(span)
+      expect(trace.metrics[SAMPLING_PRIORITY_KEY]).to.equal(0)
+    })
+
+    it('should support only the first level of depth for objects', () => {
+      const tag = {
+        A: {
+          B: {},
+          num: '2'
+        },
+        num: '1'
+      }
+
+      spanContext._tags.nested = tag
+      trace = format(span)
+
+      expect(trace.meta['nested.num']).to.equal('1')
+      expect(trace.meta['nested.A']).to.be.undefined
+      expect(trace.meta['nested.A.B']).to.be.undefined
+      expect(trace.meta['nested.A.num']).to.be.undefined
+    })
+
+    it('should accept a boolean for measured', () => {
+      spanContext._tags[MEASURED] = true
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(1)
+    })
+
+    it('should accept a numeric value for measured', () => {
+      spanContext._tags[MEASURED] = 0
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(0)
+    })
+
+    it('should accept undefined for measured', () => {
+      spanContext._tags[MEASURED] = undefined
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(1)
+    })
+
+    it('should not measure internal spans', () => {
+      spanContext._tags['span.kind'] = 'internal'
+      trace = format(span)
+      expect(trace.metrics).to.not.have.property(MEASURED)
+    })
+
+    it('should not measure unknown spans', () => {
+      trace = format(span)
+      expect(trace.metrics).to.not.have.property(MEASURED)
+    })
+
+    it('should measure non-internal spans', () => {
+      spanContext._tags['span.kind'] = 'server'
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(1)
+    })
+
+    it('should not override explicit measure decision', () => {
+      spanContext._tags[MEASURED] = 0
+      spanContext._tags['span.kind'] = 'server'
+      trace = format(span)
+      expect(trace.metrics[MEASURED]).to.equal(0)
+    })
+
+    it('should possess a process_id tag', () => {
+      trace = format(span)
+      expect(trace.metrics[PROCESS_ID]).to.equal(process.pid)
+    })
+
+    it('should not crash on prototype-free tags objects when nesting', () => {
+      const tags = Object.create(null)
+      tags.nested = { foo: 'bar' }
+      spanContext._tags.nested = tags
+
+      format(span)
+    })
+
+    it('should capture analytics.event', () => {
+      spanContext._tags['analytics.event'] = 1
+
+      trace = format(span)
+
+      expect(trace.metrics).to.have.property('_dd1.sr.eausr', 1)
+    })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -352,7 +352,7 @@ describe('OTel Span', () => {
     span.recordException(error, datenow)
 
     const { _tags } = span._ddSpan.context()
-    expect(_tags).to.have.property(ERROR_TYPE, 'otel.recordException:' + error.name)
+    expect(_tags).to.have.property(ERROR_TYPE, error.name)
     expect(_tags).to.have.property(ERROR_MESSAGE, error.message)
     expect(_tags).to.have.property(ERROR_STACK, error.stack)
 

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -10,7 +10,6 @@ const api = require('@opentelemetry/api')
 const TracerProvider = require('../../src/opentelemetry/tracer_provider')
 const SpanContext = require('../../src/opentelemetry/span_context')
 const { NoopSpanProcessor } = require('../../src/opentelemetry/span_processor')
-const { timeInputToHrTime } = require('@opentelemetry/core')
 
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../src/constants')
 const { SERVICE_NAME, RESOURCE_NAME } = require('../../../../ext/tags')
@@ -338,27 +337,7 @@ describe('OTel Span', () => {
     error.setStatus({ code: 2, message: 'error' })
     expect(errorCtx._tags).to.have.property(ERROR_MESSAGE, 'error')
   })
-  // it('should use user set time in span events', () => {
-  //   const hrnow = process.hrtime()
-  //   const perfnow = performance.now()
-  //   const datenow = Date.now()
 
-  //   const checks = [
-  //     // hrtime
-  //     [hrnow, hrnow],
-  //     // performance.now()
-  //     [perfnow, hrTime(perfnow)],
-  //     // Date.now()
-  //     [datenow, timeInputToHrTime(datenow)]
-  //   ]
-
-  //   for (const [input, output] of checks) {
-  //     const span = otelTracer.startSpan('name', {
-  //       startTime: input
-  //     })
-  //     expect(span.startTime).to.eql(output)
-  //   }
-  // })
   it('should record exceptions', () => {
     const span = makeSpan('name')
 
@@ -373,7 +352,7 @@ describe('OTel Span', () => {
     span.recordException(error, datenow)
 
     const { _tags } = span._ddSpan.context()
-    expect(_tags).to.have.property(ERROR_TYPE, 'otel.recordException' + error.name)
+    expect(_tags).to.have.property(ERROR_TYPE, 'otel.recordException:' + error.name)
     expect(_tags).to.have.property(ERROR_MESSAGE, error.message)
     expect(_tags).to.have.property(ERROR_STACK, error.stack)
 

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -373,7 +373,7 @@ describe('OTel Span', () => {
     span.recordException(error, datenow)
 
     const { _tags } = span._ddSpan.context()
-    expect(_tags).to.have.property(ERROR_TYPE, error.name)
+    expect(_tags).to.have.property(ERROR_TYPE, 'otel.recordException' + error.name)
     expect(_tags).to.have.property(ERROR_MESSAGE, error.message)
     expect(_tags).to.have.property(ERROR_STACK, error.stack)
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -279,6 +279,43 @@ describe('Span', () => {
     })
   })
 
+  describe('events', () => {
+    it('should add span events', () => {
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      span.addEvent('Web page unresponsive',
+        { 'error.code': '403', 'unknown values': [1, ['h', 'a', [false]]] }, 1714536311886)
+      span.addEvent('Web page loaded')
+      span.addEvent('Button changed color', { colors: [112, 215, 70], 'response.time': 134.3, success: true })
+
+      const events = span._events
+      const expectedEvents = [
+        {
+          name: 'Web page unresponsive',
+          startTime: 1714536311886,
+          attributes: {
+            'error.code': '403',
+            'unknown values': [1]
+          }
+        },
+        {
+          name: 'Web page loaded',
+          startTime: 1500000000000
+        },
+        {
+          name: 'Button changed color',
+          attributes: {
+            colors: [112, 215, 70],
+            'response.time': 134.3,
+            success: true
+          },
+          startTime: 1500000000000
+        }
+      ]
+      expect(events).to.deep.equal(expectedEvents)
+    })
+  })
+
   describe('getBaggageItem', () => {
     it('should get a baggage item', () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })

--- a/packages/dd-trace/test/tagger.spec.js
+++ b/packages/dd-trace/test/tagger.spec.js
@@ -54,19 +54,19 @@ describe('tagger', () => {
     tagger.add(carrier, {
       [ERROR_TYPE]: 'foo',
       [ERROR_MESSAGE]: 'foo',
-      [ERROR_STACK]: 'foo'
+      [ERROR_STACK]: 'foo',
+      doNotSetTraceError: true
     })
 
     expect(carrier).to.have.property(ERROR_TYPE, 'foo')
     expect(carrier).to.have.property(ERROR_MESSAGE, 'foo')
     expect(carrier).to.have.property(ERROR_STACK, 'foo')
-    expect(carrier).to.have.property('setTraceError', true)
+    expect(carrier).to.not.have.property('setTraceError')
 
     tagger.add(carrier, {
       [ERROR_TYPE]: 'foo',
       [ERROR_MESSAGE]: 'foo',
-      [ERROR_STACK]: 'foo',
-      doNotSetTraceError: true
+      [ERROR_STACK]: 'foo'
     })
 
     expect(carrier).to.have.property(ERROR_TYPE, 'foo')

--- a/packages/dd-trace/test/tagger.spec.js
+++ b/packages/dd-trace/test/tagger.spec.js
@@ -1,6 +1,10 @@
 'use strict'
 
+const constants = require('../src/constants')
 require('./setup/tap')
+const ERROR_MESSAGE = constants.ERROR_MESSAGE
+const ERROR_STACK = constants.ERROR_STACK
+const ERROR_TYPE = constants.ERROR_TYPE
 
 describe('tagger', () => {
   let carrier
@@ -44,5 +48,30 @@ describe('tagger', () => {
 
   it('should handle missing carrier', () => {
     expect(() => tagger.add()).not.to.throw()
+  })
+
+  it('should set trace error', () => {
+    tagger.add(carrier, {
+      [ERROR_TYPE]: 'foo',
+      [ERROR_MESSAGE]: 'foo',
+      [ERROR_STACK]: 'foo'
+    })
+
+    expect(carrier).to.have.property(ERROR_TYPE, 'foo')
+    expect(carrier).to.have.property(ERROR_MESSAGE, 'foo')
+    expect(carrier).to.have.property(ERROR_STACK, 'foo')
+    expect(carrier).to.have.property('setTraceError', true)
+
+    tagger.add(carrier, {
+      [ERROR_TYPE]: 'foo',
+      [ERROR_MESSAGE]: 'foo',
+      [ERROR_STACK]: 'foo',
+      doNotSetTraceError: true
+    })
+
+    expect(carrier).to.have.property(ERROR_TYPE, 'foo')
+    expect(carrier).to.have.property(ERROR_MESSAGE, 'foo')
+    expect(carrier).to.have.property(ERROR_STACK, 'foo')
+    expect(carrier).to.have.property('setTraceError', true)
   })
 })


### PR DESCRIPTION
### What does this PR do?
implements otel span events & recordException api as according to the [RFC](https://docs.google.com/document/d/1b8GLnbC4oPrHoksmUOhy66iEJto1FjnVivr_jsZlSNw/edit#heading=h.z8rsw69ccced)

### Motivation
adding support for otel addEvent and recordException api

### Notes
Tested against span events and recordException system tests on this branch
https://github.com/DataDog/system-tests/pull/2539

There is a hack implemented in the tagger and formatter to ensure that the setting of error tags from the recordException api does not influence the setting of the trace.error bit
