### PR TITLE
Fix graphql.resolve span durations

### DIFF
--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -80,6 +80,11 @@ class GraphQLResolvePlugin extends TracingPlugin {
     // this will disable resolve subscribers if `config.depth` is set to 0
     super.configure(config.depth === 0 ? false : config)
   }
+
+  finish (finishTime) {
+    this.activeSpan.finish(finishTime)
+    super.finish()
+  }
 }
 
 // helpers

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -83,7 +83,6 @@ class GraphQLResolvePlugin extends TracingPlugin {
 
   finish (finishTime) {
     this.activeSpan.finish(finishTime)
-    super.finish()
   }
 }
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -439,13 +439,13 @@ describe('Plugin', () => {
                   }
 
                   if (span.resource === 'fastAsyncField:String') {
-                    expect(fastAsyncTime).to.be.below(slowAsyncTime)
+                    expect(fastAsyncTime).to.be.lessThan(slowAsyncTime)
                     foundFastFieldSpan = true
                   } else if (span.resource === 'slowAsyncField:String') {
-                    expect(slowAsyncTime).to.be.below(syncTime)
+                    expect(slowAsyncTime).to.be.lessThan(syncTime)
                     foundSlowFieldSpan = true
                   } else if (span.resource === 'syncField:String') {
-                    expect(syncTime).to.be.above(slowAsyncTime)
+                    expect(syncTime).to.be.greaterThan(slowAsyncTime)
                     foundSyncFieldSpan = true
                   }
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -86,11 +86,11 @@ describe('Plugin', () => {
         slowField: {
           type: graphql.GraphQLString,
           resolve (obj, args) {
-            return new Promise((r) => {
-              setTimeout(() => r('slow field'), SLOW_FIELD_RESOLVER_DELAY_MS)
+            return new Promise((resolve) => {
+              setTimeout(() => resolve('slow field'), SLOW_FIELD_RESOLVER_DELAY_MS)
             })
           }
-        },
+        }
       }
     })
 


### PR DESCRIPTION
### What does this PR do?
This pull request closes #3925 

### Motivation

From PR #3925:
What does this PR do?
Fix a bug in the graphql plugin that causes all graphql.resolve spans to have incorrect durations
Motivation
When looking at APM traces for graphql requests, we noticed that the graphql.resolve spans all seem to extend until the end of the parent graphql.execute span, rather than when that field resolver actually completes. This makes it hard to identify which specific field resolvers are performance bottlenecks of a graphql query.
Example 1 - note that all graphql.resolve spans extend to roughly the same end time, even for simple fields that should be trivially fast to resolve:

<img width="806" alt="2024-06-07_10-53-43" src="https://github.com/DataDog/dd-trace-js/assets/20286149/b9bf0077-639e-4cf3-a8d7-33eda2227523">


Example 2 - on another, much more complex graphql query, it's even more apparent that something is wrong and causing all spans to extend until the entire graphql.execute span finishes; I would expect most of the purple bars to end earlier, and only one or a few long-tail field resolver spans would extend till the end.
Screenshot 2024-01-03 at 11 58 34 PM

Additional Notes
I believe this was a regression introduced in PR https://github.com/DataDog/dd-trace-js/pull/3177, which refactored TracingPlugin subclasses to move the common span.finish() calls into the TracingPlugin base class.

However, the [change to the graphql plugin's resolve operation in that PR](https://github.com/DataDog/dd-trace-js/commit/4e46109e9975a57e0b30e5275451d28782715e6c#diff-796b4c9573e0971daf318484cdd9517eb62524e5dc46764d8342adaa5339c29a) stopped passing the finishTime argument from the finish method through to span.finish(); the base TracingPlugin.finish method [does not use/accept any arguments and calls span.finish() with no args](https://github.com/DataDog/dd-trace-js/blob/e581914099f97ceca0f07343a0c40f8dc8d8ffcc/packages/dd-trace/src/plugins/tracing.js#L57-L59). Due to this change, span.finish() is being called without a finish time argument, and thus falls back to using the current time as the finish time.

Why does this result in all resolve spans finishing at the end of the execute span? If I'm understanding the code correctly, it looks like the graphql plugin defers finishing the resolve operations until the entire execute operation has completed - [here](https://github.com/DataDog/dd-trace-js/blob/0ccbc344320f5e1882535bf310836cb795bc4620/packages/datadog-instrumentations/src/graphql.js#L354-L365). Although this code is still publishing the field's recorded finishTime to the finish channel, it is no longer being passed through to the span (as discussed above), so all the resolve spans are marked as finished at the current time, after the overall execute has completed.

Testing
The existing graphql plugin tests didn't appear to explicitly validate the span durations (other than a [basic greater-than-zero check](https://github.com/DataDog/dd-trace-js/blob/ed839d97ad53491c00655a892043243048bfd72c/packages/datadog-plugin-graphql/test/index.spec.js#L368)), so I made some guesses at how best to validate span durations within the existing test framework in order to add a unit test for this fix.

The new test introduces some new graphql field resolvers that intentionally take a while (via fake timers) to resolve:

2 async fields use setTimeout with different values to validate the duration recorded of concurrent graphql resolver promises
a 3rd new field directly ticks the clock as a synchronous resolver function to validate the duration recorded for a synchronous resolver
New test - fails as expected when run without the fix in resolve.js -- the faster async resolver's span is incorrectly recorded as taking 1234 milliseconds instead of the expected 100:
Screenshot 2024-01-05 at 10 38 37 PM

New test - passes with the changes to resolver.js:
Screenshot 2024-01-05 at 10 38 53 PM

### Plugin Checklist


- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


