### PR TITLE
pin otel api version in integration test

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -56,7 +56,7 @@ describe('opentelemetry', () => {
 
   before(async () => {
     const dependencies = [
-      '@opentelemetry/api'
+      '@opentelemetry/api@1.8.0'
     ]
     if (satisfies(process.version.slice(1), '>=14')) {
       dependencies.push('@opentelemetry/sdk-node')


### PR DESCRIPTION
### What does this PR do?
Pin the version of Otel API used in integration test.
### Motivation

#4318 made the change elsewhere, but it needed to be reflected in the integration test.


