### PR TITLE
small telemetry fix

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -974,8 +974,8 @@ class Config {
     this._setTags(opts, 'tags', tags)
     this._setBoolean(opts, 'tracing', options.tracing_enabled)
     // ignore tags for now since rc sampling rule tags format is not supported
-    this._setSamplingRule(opts, 'sampler.rules', this._ignoreTags(options.tracing_sampling_rules))
     this._remoteUnprocessed['sampler.rules'] = options.tracing_sampling_rules
+    this._setSamplingRule(opts, 'sampler.rules', this._ignoreTags(options.tracing_sampling_rules))
   }
 
   _ignoreTags (samplingRules) {


### PR DESCRIPTION
### What does this PR do?
[_ignoreTags](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/config.js#L981) deletes tags in place, so telemetry is not able to send the original sampling rules set by the customer. This is a hacky fix because we want to support setting sampling rule tags through remote config soon, so we will be keeping the tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


