### PR TITLE
Fix cassandra tests

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       cassandra:
-        image: cassandra:2.0.14
+        image: cassandra:2.2.4
         ports:
           - 9042:9042
     env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -327,9 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       cassandra:
-        image: spotify/cassandra
-        env:
-          CASSANDRA_TOKEN: '-9223372036854775808'
+        image: cassandra:2.0.14
         ports:
           - 9042:9042
     env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       cassandra:
-        image: cassandra:2.2.4
+        image: cassandra:3-focal
         ports:
           - 9042:9042
     env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     ports:
       - "11211:11211"
   cassandra:
-    image: cassandra:2.0.14
+    image: cassandra:3-focal
     ports:
       - "127.0.0.1:9042:9042"
   limitd:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,9 +70,7 @@ services:
     ports:
       - "11211:11211"
   cassandra:
-    image: spotify/cassandra
-    environment:
-      - CASSANDRA_TOKEN=-9223372036854775808
+    image: cassandra:2.0.14
     ports:
       - "127.0.0.1:9042:9042"
   limitd:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates cassandra container image used in the tests.
### Motivation
<!-- What inspired you to submit this pull request? -->
`spotify/cassandra` and old cassandra images are not compatibles with GHA anymore, the tests were failing because the container wasn't starting.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


