### PR TITLE
Add support for tracing in Deno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ typings/
 
 .next
 package-lock.json
+deno.lock
 out
 versions
 build

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type:test": "cd docs && yarn && yarn test",
     "lint": "node scripts/check_licenses.js && eslint . && yarn audit --groups dependencies",
     "services": "node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services",
-    "test": "SERVICES=* yarn services && mocha --colors --exit --expose-gc 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
+    "test": "SERVICES=* NODE_OPTIONS=--expose-gc DENO_V8_FLAGS=--expose-gc yarn services && mocha --colors --exit 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
     "test:appsec": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" \"packages/dd-trace/test/appsec/**/*.spec.js\"",
     "test:appsec:ci": "nyc --no-clean --include \"packages/dd-trace/src/appsec/**/*.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" -- npm run test:appsec",
     "test:appsec:plugins": "mocha --colors --exit -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/appsec/**/*.@($(echo $PLUGINS)).plugin.spec.js\"",

--- a/packages/datadog-core/src/storage/async_local_storage.js
+++ b/packages/datadog-core/src/storage/async_local_storage.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const { AsyncLocalStorage } = require('node:async_hooks')
+
+module.exports = AsyncLocalStorage

--- a/packages/datadog-core/src/storage/index.js
+++ b/packages/datadog-core/src/storage/index.js
@@ -7,7 +7,9 @@ const semver = require('semver')
 // https://github.com/nodejs/node/pull/33801
 const hasJavaScriptAsyncHooks = semver.satisfies(process.versions.node, '>=14.5')
 
-if (hasJavaScriptAsyncHooks) {
+if (typeof Deno !== 'undefined') {
+  module.exports = require('./async_local_storage')
+} else if (hasJavaScriptAsyncHooks) {
   module.exports = require('./async_resource')
 } else {
   module.exports = require('./async_hooks')

--- a/packages/dd-trace/test/setup/deno_adapter.ts
+++ b/packages/dd-trace/test/setup/deno_adapter.ts
@@ -1,0 +1,14 @@
+import process from 'node:process';
+import { createRequire } from 'node:module';
+
+process._getActiveHandles = () => [];
+process._getActiveRequests = () => [];
+process.execPath = `${process.argv[0]} run -A adapter.ts`;
+
+const require = createRequire(import.meta.url);
+
+if (Deno.args[0].startsWith('file:')) {
+  require(require('node:url').fileURLToPath(Deno.args[0]));
+} else {
+  require(require('path').resolve(Deno.args[0]));
+}


### PR DESCRIPTION
### What does this PR do?

Adds an `AsyncLocalStorage`-based storage implementation, and sets it to be used when loaded by Deno.

### Motivation

Deno does not implement async hooks, but it does implement AsyncLocalStorage. AsyncLocalStorage is enough to get reasonable traces out of Deno (and perhaps Node.js as well? I will leave it gated to just Deno for now...)

### Additional Notes

The performance overhead of ALS in deno is not fantastic, but we are planning to make improvements with v8's ContinuationPreservedEmbedderData API in the near future. (As is Node.js: https://github.com/nodejs/node/pull/48528)


`deno run -A npm:tap --node-arg=(realpath packages/dd-trace/test/setup/deno_adapter.ts)`


