### PR TITLE
Fix stack trace collection for appsec events

### DIFF
--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -31,15 +31,13 @@ function filterOutFramesFromLibrary (callSiteList) {
 }
 
 function getFramesForMetaStruct (callSiteList, maxDepth = 32) {
-  const maxCallSite = maxDepth < 1 ? Infinity : maxDepth
-
   const filteredFrames = filterOutFramesFromLibrary(callSiteList)
 
-  const half = filteredFrames.length > maxCallSite ? Math.round(maxCallSite / 2) : Infinity
+  const half = filteredFrames.length > maxDepth ? Math.round(maxDepth / 2) : Infinity
 
   const indexedFrames = []
-  for (let i = 0; i < Math.min(filteredFrames.length, maxCallSite); i++) {
-    const index = i < half ? i : i + filteredFrames.length - maxCallSite
+  for (let i = 0; i < Math.min(filteredFrames.length, maxDepth); i++) {
+    const index = i < half ? i : i + filteredFrames.length - maxDepth
     const callSite = filteredFrames[index]
     indexedFrames.push({
       id: index,
@@ -60,8 +58,8 @@ function reportStackTrace (rootSpan, stackId, maxDepth, maxStackTraces, callSite
   if (maxStackTraces < 1 || (rootSpan.meta_struct?.['_dd.stack']?.exploit?.length ?? 0) < maxStackTraces) {
     // Since some frames will be discarded because they come from tracer codebase, a buffer is added
     // to the limit in order to get as close as `maxDepth` number of frames.
-    const stackTraceLimit = maxDepth < 1 ? Infinity : maxDepth + LIBRARY_FRAMES_BUFFER
-    const callSiteList = callSiteListGetter(stackTraceLimit)
+    if (maxDepth < 1) maxDepth = Infinity
+    const callSiteList = callSiteListGetter(maxDepth  + LIBRARY_FRAMES_BUFFER)
     if (!Array.isArray(callSiteList)) return
 
     if (!rootSpan.meta_struct) {

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -57,23 +57,25 @@ function getFramesForMetaStruct (callSiteList, maxDepth = 32) {
 function reportStackTrace (rootSpan, stackId, maxDepth, maxStackTraces, callSiteListGetter = getCallSiteList) {
   if (!rootSpan) return
 
-  if (!rootSpan.meta_struct) {
-    rootSpan.meta_struct = {}
-  }
-
-  if (!rootSpan.meta_struct['_dd.stack']) {
-    rootSpan.meta_struct['_dd.stack'] = {}
-  }
-
-  if (!rootSpan.meta_struct['_dd.stack'].exploit) {
-    rootSpan.meta_struct['_dd.stack'].exploit = []
-  }
-
-  if (maxStackTraces < 1 || rootSpan.meta_struct['_dd.stack'].exploit.length < maxStackTraces) {
+  if (maxStackTraces < 1 || (rootSpan.meta_struct?.['_dd.stack']?.exploit?.length ?? 0) < maxStackTraces) {
     // Since some frames will be discarded because they come from tracer codebase, a buffer is added
     // to the limit in order to get as close as `maxDepth` number of frames.
     const stackTraceLimit = maxDepth < 1 ? Infinity : maxDepth + LIBRARY_FRAMES_BUFFER
     const callSiteList = callSiteListGetter(stackTraceLimit)
+    if (!Array.isArray(callSiteList)) return
+
+    if (!rootSpan.meta_struct) {
+      rootSpan.meta_struct = {}
+    }
+
+    if (!rootSpan.meta_struct['_dd.stack']) {
+      rootSpan.meta_struct['_dd.stack'] = {}
+    }
+
+    if (!rootSpan.meta_struct['_dd.stack'].exploit) {
+      rootSpan.meta_struct['_dd.stack'].exploit = []
+    }
+
     const frames = getFramesForMetaStruct(callSiteList, maxDepth)
 
     rootSpan.meta_struct['_dd.stack'].exploit.push({
@@ -86,6 +88,5 @@ function reportStackTrace (rootSpan, stackId, maxDepth, maxStackTraces, callSite
 
 module.exports = {
   getCallSiteList,
-  filterOutFramesFromLibrary,
   reportStackTrace
 }

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -59,7 +59,7 @@ function reportStackTrace (rootSpan, stackId, maxDepth, maxStackTraces, callSite
     // Since some frames will be discarded because they come from tracer codebase, a buffer is added
     // to the limit in order to get as close as `maxDepth` number of frames.
     if (maxDepth < 1) maxDepth = Infinity
-    const callSiteList = callSiteListGetter(maxDepth  + LIBRARY_FRAMES_BUFFER)
+    const callSiteList = callSiteListGetter(maxDepth + LIBRARY_FRAMES_BUFFER)
     if (!Array.isArray(callSiteList)) return
 
     if (!rootSpan.meta_struct) {

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -27,7 +27,7 @@ function getCallSiteList (maxDepth = 100) {
 }
 
 function filterOutFramesFromLibrary (callSiteList) {
-  return callSiteList.filter(callSite => !callSite.getFileName()?.includes(ddBasePath))
+  return callSiteList.filter(callSite => !callSite.getFileName()?.startsWith(ddBasePath))
 }
 
 function getFramesForMetaStruct (callSiteList, maxDepth = 32) {

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -27,7 +27,7 @@ function getCallSiteList (maxDepth = 100) {
 }
 
 function filterOutFramesFromLibrary (callSiteList) {
-  return callSiteList.filter(callSite => !callSite.getFileName().includes(ddBasePath))
+  return callSiteList.filter(callSite => !callSite.getFileName()?.includes(ddBasePath))
 }
 
 function getFramesForMetaStruct (callSiteList, maxDepth = 32) {

--- a/packages/dd-trace/test/appsec/stack_trace.spec.js
+++ b/packages/dd-trace/test/appsec/stack_trace.spec.js
@@ -29,7 +29,14 @@ describe('Stack trace reporter', () => {
               getFunctionName: () => `function${i}`
             }
           ))
-        )
+        ).concat([
+          {
+            getFileName: () => null,
+            getLineNumber: () => null,
+            getColumnNumber: () => null,
+            getFunctionName: () => null
+          }
+        ])
 
       const expectedFrames = [...Array(10).keys()].map(i => (
         {
@@ -39,6 +46,14 @@ describe('Stack trace reporter', () => {
           function: `function${i}`
         }
       ))
+        .concat([
+          {
+            file: null,
+            line: null,
+            column: null,
+            function: null
+          }
+        ])
 
       const filteredFrames = filterOutFramesFromLibrary(callSiteList).map(frame => (
         {

--- a/packages/dd-trace/test/appsec/stack_trace.spec.js
+++ b/packages/dd-trace/test/appsec/stack_trace.spec.js
@@ -9,7 +9,7 @@ describe('Stack trace reporter', () => {
   describe('frame filtering', () => {
     it('should filer out frames from library', () => {
       const callSiteList =
-         Array(10).fill().map((_,i) => (
+        Array(10).fill().map((_, i) => (
           {
             getFileName: () => path.join(__dirname, `file${i}`),
             getLineNumber: () => i,
@@ -17,9 +17,8 @@ describe('Stack trace reporter', () => {
             getFunctionName: () => `libraryFunction${i}`,
             getTypeName: () => `LibraryClass${i}`
           }
-        )
-        ).concat(
-           Array(10).fill().map((_,i) => (
+        )).concat(
+          Array(10).fill().map((_, i) => (
             {
               getFileName: () => `file${i}`,
               getLineNumber: () => i,
@@ -38,7 +37,7 @@ describe('Stack trace reporter', () => {
           }
         ])
 
-      const expectedFrames =  Array(10).fill().map((_,i) => (
+      const expectedFrames = Array(10).fill().map((_, i) => (
         {
           id: i,
           file: `file${i}`,
@@ -70,7 +69,7 @@ describe('Stack trace reporter', () => {
   })
 
   describe('report stack traces', () => {
-    const callSiteList =  Array(20).fill().map((_,i) => (
+    const callSiteList = Array(20).fill().map((_, i) => (
       {
         getFileName: () => `file${i}`,
         getLineNumber: () => i,
@@ -95,7 +94,7 @@ describe('Stack trace reporter', () => {
       const rootSpan = {}
       const stackId = 'test_stack_id'
       const maxDepth = 32
-      const expectedFrames =  Array(20).fill().map((_,i) => (
+      const expectedFrames = Array(20).fill().map((_, i) => (
         {
           id: i,
           file: `file${i}`,
@@ -121,7 +120,7 @@ describe('Stack trace reporter', () => {
       }
       const stackId = 'test_stack_id'
       const maxDepth = 32
-      const expectedFrames =  Array(20).fill().map((_,i) => (
+      const expectedFrames = Array(20).fill().map((_, i) => (
         {
           id: i,
           file: `file${i}`,
@@ -151,7 +150,7 @@ describe('Stack trace reporter', () => {
       }
       const stackId = 'test_stack_id'
       const maxDepth = 32
-      const expectedFrames =  Array(20).fill().map((_,i) => (
+      const expectedFrames = Array(20).fill().map((_, i) => (
         {
           id: i,
           file: `file${i}`,
@@ -240,7 +239,7 @@ describe('Stack trace reporter', () => {
   })
 
   describe('limit stack traces frames', () => {
-    const callSiteList =  Array(120).fill().map((_,i) => (
+    const callSiteList = Array(120).fill().map((_, i) => (
       {
         getFileName: () => `file${i}`,
         getLineNumber: () => i,
@@ -282,7 +281,7 @@ describe('Stack trace reporter', () => {
           getFunctionName: () => 'libraryFunction',
           getTypeName: () => 'libraryType'
         }
-      ].concat( Array(120).fill().map((_,i) => (
+      ].concat(Array(120).fill().map((_, i) => (
         {
           getFileName: () => `file${i}`,
           getLineNumber: () => i,
@@ -319,7 +318,7 @@ describe('Stack trace reporter', () => {
       const rootSpan = {}
       const stackId = 'test_stack_id'
       const maxDepth = 0
-      const expectedFrames =  Array(120).fill().map((_,i) => (
+      const expectedFrames = Array(120).fill().map((_, i) => (
         {
           id: i,
           file: `file${i}`,
@@ -339,7 +338,7 @@ describe('Stack trace reporter', () => {
       const rootSpan = {}
       const stackId = 'test_stack_id'
       const maxDepth = -1
-      const expectedFrames =  Array(120).fill().map((_,i) => (
+      const expectedFrames = Array(120).fill().map((_, i) => (
         {
           id: i,
           file: `file${i}`,

--- a/packages/dd-trace/test/appsec/stack_trace.spec.js
+++ b/packages/dd-trace/test/appsec/stack_trace.spec.js
@@ -3,13 +3,10 @@
 const { assert } = require('chai')
 const path = require('path')
 
-const {
-  filterOutFramesFromLibrary,
-  reportStackTrace
-} = require('../../src/appsec/stack_trace')
+const { reportStackTrace } = require('../../src/appsec/stack_trace')
 
 describe('Stack trace reporter', () => {
-  describe('filterOutFramesFromLibrary', () => {
+  describe('frame filtering', () => {
     it('should filer out frames from library', () => {
       const callSiteList =
         [...Array(10).keys()].map(i => (
@@ -17,7 +14,8 @@ describe('Stack trace reporter', () => {
             getFileName: () => path.join(__dirname, `file${i}`),
             getLineNumber: () => i,
             getColumnNumber: () => i,
-            getFunctionName: () => `function${i}`
+            getFunctionName: () => `libraryFunction${i}`,
+            getTypeName: () => `LibraryClass${i}`
           }
         )
         ).concat(
@@ -26,7 +24,8 @@ describe('Stack trace reporter', () => {
               getFileName: () => `file${i}`,
               getLineNumber: () => i,
               getColumnNumber: () => i,
-              getFunctionName: () => `function${i}`
+              getFunctionName: () => `function${i}`,
+              getTypeName: () => `Class${i}`
             }
           ))
         ).concat([
@@ -34,199 +33,251 @@ describe('Stack trace reporter', () => {
             getFileName: () => null,
             getLineNumber: () => null,
             getColumnNumber: () => null,
-            getFunctionName: () => null
+            getFunctionName: () => null,
+            getTypeName: () => null
           }
         ])
 
       const expectedFrames = [...Array(10).keys()].map(i => (
         {
+          id: i,
           file: `file${i}`,
           line: i,
           column: i,
-          function: `function${i}`
+          function: `function${i}`,
+          class_name: `Class${i}`
         }
       ))
         .concat([
           {
+            id: 10,
             file: null,
             line: null,
             column: null,
-            function: null
+            function: null,
+            class_name: null
           }
         ])
 
-      const filteredFrames = filterOutFramesFromLibrary(callSiteList).map(frame => (
-        {
-          file: frame.getFileName(),
-          line: frame.getLineNumber(),
-          column: frame.getColumnNumber(),
-          function: frame.getFunctionName()
-        }
-      ))
+      const rootSpan = {}
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+      const maxStackTraces = 2
+      reportStackTrace(rootSpan, stackId, maxDepth, maxStackTraces, () => callSiteList)
 
-      assert.deepEqual(filteredFrames, expectedFrames)
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
     })
   })
 
-  describe('reportStackTrace', () => {
-    describe('report stack traces', () => {
-      const callSiteList = [...Array(20).keys()].map(i => (
-        {
-          getFileName: () => `file${i}`,
-          getLineNumber: () => i,
-          getColumnNumber: () => i,
-          getFunctionName: () => `function${i}`,
-          getTypeName: () => `type${i}`
-        }
-      ))
+  describe('report stack traces', () => {
+    const callSiteList = [...Array(20).keys()].map(i => (
+      {
+        getFileName: () => `file${i}`,
+        getLineNumber: () => i,
+        getColumnNumber: () => i,
+        getFunctionName: () => `function${i}`,
+        getTypeName: () => `type${i}`
+      }
+    ))
 
-      it('should not fail if no root span is passed', () => {
-        const rootSpan = undefined
-        const stackId = 'test_stack_id'
-        const maxDepth = 32
-        try {
-          reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
-        } catch (e) {
-          assert.fail()
-        }
-      })
-
-      it('should add stack trace to rootSpan when meta_struct is not present', () => {
-        const rootSpan = {}
-        const stackId = 'test_stack_id'
-        const maxDepth = 32
-        const expectedFrames = [...Array(20).keys()].map(i => (
-          {
-            id: i,
-            file: `file${i}`,
-            line: i,
-            column: i,
-            function: `function${i}`,
-            class_name: `type${i}`
-          }
-        ))
-
+    it('should not fail if no root span is passed', () => {
+      const rootSpan = undefined
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+      try {
         reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
-
-        assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].id, stackId)
-        assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].language, 'nodejs')
-        assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-      })
-
-      it('should add stack trace to rootSpan when meta_struct is already present', () => {
-        const rootSpan = {
-          meta_struct: {
-            another_tag: []
-          }
-        }
-        const stackId = 'test_stack_id'
-        const maxDepth = 32
-        const expectedFrames = [...Array(20).keys()].map(i => (
-          {
-            id: i,
-            file: `file${i}`,
-            line: i,
-            column: i,
-            function: `function${i}`,
-            class_name: `type${i}`
-          }
-        ))
-
-        reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
-
-        assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].id, stackId)
-        assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].language, 'nodejs')
-        assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-        assert.property(rootSpan.meta_struct, 'another_tag')
-      })
-
-      it('should add stack trace to rootSpan when meta_struct is already present and contains another stack', () => {
-        const rootSpan = {
-          meta_struct: {
-            another_tag: [],
-            '_dd.stack': {
-              exploit: [callSiteList]
-            }
-          }
-        }
-        const stackId = 'test_stack_id'
-        const maxDepth = 32
-        const expectedFrames = [...Array(20).keys()].map(i => (
-          {
-            id: i,
-            file: `file${i}`,
-            line: i,
-            column: i,
-            function: `function${i}`,
-            class_name: `type${i}`
-          }
-        ))
-
-        reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
-
-        assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].id, stackId)
-        assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].language, 'nodejs')
-        assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].frames, expectedFrames)
-        assert.property(rootSpan.meta_struct, 'another_tag')
-      })
-
-      it('should not report stack trace when the maximum has been reached', () => {
-        const rootSpan = {
-          meta_struct: {
-            '_dd.stack': {
-              exploit: [callSiteList, callSiteList]
-            },
-            another_tag: []
-          }
-        }
-        const stackId = 'test_stack_id'
-        const maxDepth = 32
-
-        reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
-
-        assert.equal(rootSpan.meta_struct['_dd.stack'].exploit.length, 2)
-        assert.property(rootSpan.meta_struct, 'another_tag')
-      })
-
-      it('should add stack trace when the max stack trace is 0', () => {
-        const rootSpan = {
-          meta_struct: {
-            '_dd.stack': {
-              exploit: [callSiteList, callSiteList]
-            },
-            another_tag: []
-          }
-        }
-        const stackId = 'test_stack_id'
-        const maxDepth = 32
-
-        reportStackTrace(rootSpan, stackId, maxDepth, 0, () => callSiteList)
-
-        assert.equal(rootSpan.meta_struct['_dd.stack'].exploit.length, 3)
-        assert.property(rootSpan.meta_struct, 'another_tag')
-      })
-
-      it('should add stack trace when the max stack trace is negative', () => {
-        const rootSpan = {
-          meta_struct: {
-            '_dd.stack': {
-              exploit: [callSiteList, callSiteList]
-            },
-            another_tag: []
-          }
-        }
-        const stackId = 'test_stack_id'
-        const maxDepth = 32
-
-        reportStackTrace(rootSpan, stackId, maxDepth, -1, () => callSiteList)
-
-        assert.equal(rootSpan.meta_struct['_dd.stack'].exploit.length, 3)
-        assert.property(rootSpan.meta_struct, 'another_tag')
-      })
+      } catch (e) {
+        assert.fail()
+      }
     })
 
-    describe('limit stack traces frames', () => {
-      const callSiteList = [...Array(120).keys()].map(i => (
+    it('should add stack trace to rootSpan when meta_struct is not present', () => {
+      const rootSpan = {}
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+      const expectedFrames = [...Array(20).keys()].map(i => (
+        {
+          id: i,
+          file: `file${i}`,
+          line: i,
+          column: i,
+          function: `function${i}`,
+          class_name: `type${i}`
+        }
+      ))
+
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
+
+      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].id, stackId)
+      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].language, 'nodejs')
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+    })
+
+    it('should add stack trace to rootSpan when meta_struct is already present', () => {
+      const rootSpan = {
+        meta_struct: {
+          another_tag: []
+        }
+      }
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+      const expectedFrames = [...Array(20).keys()].map(i => (
+        {
+          id: i,
+          file: `file${i}`,
+          line: i,
+          column: i,
+          function: `function${i}`,
+          class_name: `type${i}`
+        }
+      ))
+
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
+
+      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].id, stackId)
+      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].language, 'nodejs')
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+      assert.property(rootSpan.meta_struct, 'another_tag')
+    })
+
+    it('should add stack trace to rootSpan when meta_struct is already present and contains another stack', () => {
+      const rootSpan = {
+        meta_struct: {
+          another_tag: [],
+          '_dd.stack': {
+            exploit: [callSiteList]
+          }
+        }
+      }
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+      const expectedFrames = [...Array(20).keys()].map(i => (
+        {
+          id: i,
+          file: `file${i}`,
+          line: i,
+          column: i,
+          function: `function${i}`,
+          class_name: `type${i}`
+        }
+      ))
+
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
+
+      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].id, stackId)
+      assert.strictEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].language, 'nodejs')
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[1].frames, expectedFrames)
+      assert.property(rootSpan.meta_struct, 'another_tag')
+    })
+
+    it('should not report stack trace when the maximum has been reached', () => {
+      const rootSpan = {
+        meta_struct: {
+          '_dd.stack': {
+            exploit: [callSiteList, callSiteList]
+          },
+          another_tag: []
+        }
+      }
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
+
+      assert.equal(rootSpan.meta_struct['_dd.stack'].exploit.length, 2)
+      assert.property(rootSpan.meta_struct, 'another_tag')
+    })
+
+    it('should add stack trace when the max stack trace is 0', () => {
+      const rootSpan = {
+        meta_struct: {
+          '_dd.stack': {
+            exploit: [callSiteList, callSiteList]
+          },
+          another_tag: []
+        }
+      }
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+
+      reportStackTrace(rootSpan, stackId, maxDepth, 0, () => callSiteList)
+
+      assert.equal(rootSpan.meta_struct['_dd.stack'].exploit.length, 3)
+      assert.property(rootSpan.meta_struct, 'another_tag')
+    })
+
+    it('should add stack trace when the max stack trace is negative', () => {
+      const rootSpan = {
+        meta_struct: {
+          '_dd.stack': {
+            exploit: [callSiteList, callSiteList]
+          },
+          another_tag: []
+        }
+      }
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+
+      reportStackTrace(rootSpan, stackId, maxDepth, -1, () => callSiteList)
+
+      assert.equal(rootSpan.meta_struct['_dd.stack'].exploit.length, 3)
+      assert.property(rootSpan.meta_struct, 'another_tag')
+    })
+
+    it('should not report stackTraces if callSiteList is undefined', () => {
+      const rootSpan = {}
+      const stackId = 'test_stack_id'
+      const maxDepth = 32
+      const maxStackTraces = 2
+      reportStackTrace(rootSpan, stackId, maxDepth, maxStackTraces, () => undefined)
+      assert.deepEqual(rootSpan, {})
+    })
+  })
+
+  describe('limit stack traces frames', () => {
+    const callSiteList = [...Array(120).keys()].map(i => (
+      {
+        getFileName: () => `file${i}`,
+        getLineNumber: () => i,
+        getColumnNumber: () => i,
+        getFunctionName: () => `function${i}`,
+        getTypeName: () => `type${i}`
+      }
+    ))
+
+    it('limit frames to max depth', () => {
+      const rootSpan = {}
+      const stackId = 'test_stack_id'
+      const maxDepth = 5
+      const expectedFrames = [0, 1, 2, 118, 119].map(i => (
+        {
+          id: i,
+          file: `file${i}`,
+          line: i,
+          column: i,
+          function: `function${i}`,
+          class_name: `type${i}`
+        }
+      ))
+
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
+
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+    })
+
+    it('limit frames to max depth with filtered frames', () => {
+      const rootSpan = {}
+      const stackId = 'test_stack_id'
+      const maxDepth = 5
+      const callSiteListWithLibraryFrames = [
+        {
+          getFileName: () => path.join(__dirname, 'firstFrame'),
+          getLineNumber: () => 314,
+          getColumnNumber: () => 271,
+          getFunctionName: () => 'libraryFunction',
+          getTypeName: () => 'libraryType'
+        }
+      ].concat([...Array(120).keys()].map(i => (
         {
           getFileName: () => `file${i}`,
           getLineNumber: () => i,
@@ -234,112 +285,69 @@ describe('Stack trace reporter', () => {
           getFunctionName: () => `function${i}`,
           getTypeName: () => `type${i}`
         }
+      )).concat([
+        {
+          getFileName: () => path.join(__dirname, 'lastFrame'),
+          getLineNumber: () => 271,
+          getColumnNumber: () => 314,
+          getFunctionName: () => 'libraryFunction',
+          getTypeName: () => 'libraryType'
+        }
+      ]))
+      const expectedFrames = [0, 1, 2, 118, 119].map(i => (
+        {
+          id: i,
+          file: `file${i}`,
+          line: i,
+          column: i,
+          function: `function${i}`,
+          class_name: `type${i}`
+        }
       ))
 
-      it('limit frames to max depth', () => {
-        const rootSpan = {}
-        const stackId = 'test_stack_id'
-        const maxDepth = 5
-        const expectedFrames = [0, 1, 2, 118, 119].map(i => (
-          {
-            id: i,
-            file: `file${i}`,
-            line: i,
-            column: i,
-            function: `function${i}`,
-            class_name: `type${i}`
-          }
-        ))
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteListWithLibraryFrames)
 
-        reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+    })
 
-        assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-      })
+    it('no limit if maxDepth is 0', () => {
+      const rootSpan = {}
+      const stackId = 'test_stack_id'
+      const maxDepth = 0
+      const expectedFrames = [...Array(120).keys()].map(i => (
+        {
+          id: i,
+          file: `file${i}`,
+          line: i,
+          column: i,
+          function: `function${i}`,
+          class_name: `type${i}`
+        }
+      ))
 
-      it('limit frames to max depth with filtered frames', () => {
-        const rootSpan = {}
-        const stackId = 'test_stack_id'
-        const maxDepth = 5
-        const callSiteListWithLibraryFrames = [
-          {
-            getFileName: () => path.join(__dirname, 'firstFrame'),
-            getLineNumber: () => 314,
-            getColumnNumber: () => 271,
-            getFunctionName: () => 'libraryFunction',
-            getTypeName: () => 'libraryType'
-          }
-        ].concat([...Array(120).keys()].map(i => (
-          {
-            getFileName: () => `file${i}`,
-            getLineNumber: () => i,
-            getColumnNumber: () => i,
-            getFunctionName: () => `function${i}`,
-            getTypeName: () => `type${i}`
-          }
-        )).concat([
-          {
-            getFileName: () => path.join(__dirname, 'lastFrame'),
-            getLineNumber: () => 271,
-            getColumnNumber: () => 314,
-            getFunctionName: () => 'libraryFunction',
-            getTypeName: () => 'libraryType'
-          }
-        ]))
-        const expectedFrames = [0, 1, 2, 118, 119].map(i => (
-          {
-            id: i,
-            file: `file${i}`,
-            line: i,
-            column: i,
-            function: `function${i}`,
-            class_name: `type${i}`
-          }
-        ))
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
 
-        reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteListWithLibraryFrames)
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
+    })
 
-        assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-      })
+    it('no limit if maxDepth is negative', () => {
+      const rootSpan = {}
+      const stackId = 'test_stack_id'
+      const maxDepth = -1
+      const expectedFrames = [...Array(120).keys()].map(i => (
+        {
+          id: i,
+          file: `file${i}`,
+          line: i,
+          column: i,
+          function: `function${i}`,
+          class_name: `type${i}`
+        }
+      ))
 
-      it('no limit if maxDepth is 0', () => {
-        const rootSpan = {}
-        const stackId = 'test_stack_id'
-        const maxDepth = 0
-        const expectedFrames = [...Array(120).keys()].map(i => (
-          {
-            id: i,
-            file: `file${i}`,
-            line: i,
-            column: i,
-            function: `function${i}`,
-            class_name: `type${i}`
-          }
-        ))
+      reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
 
-        reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
-
-        assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-      })
-
-      it('no limit if maxDepth is negative', () => {
-        const rootSpan = {}
-        const stackId = 'test_stack_id'
-        const maxDepth = -1
-        const expectedFrames = [...Array(120).keys()].map(i => (
-          {
-            id: i,
-            file: `file${i}`,
-            line: i,
-            column: i,
-            function: `function${i}`,
-            class_name: `type${i}`
-          }
-        ))
-
-        reportStackTrace(rootSpan, stackId, maxDepth, 2, () => callSiteList)
-
-        assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
-      })
+      assert.deepEqual(rootSpan.meta_struct['_dd.stack'].exploit[0].frames, expectedFrames)
     })
   })
 })

--- a/packages/dd-trace/test/appsec/stack_trace.spec.js
+++ b/packages/dd-trace/test/appsec/stack_trace.spec.js
@@ -9,7 +9,7 @@ describe('Stack trace reporter', () => {
   describe('frame filtering', () => {
     it('should filer out frames from library', () => {
       const callSiteList =
-        [...Array(10).keys()].map(i => (
+         Array(10).fill().map((_,i) => (
           {
             getFileName: () => path.join(__dirname, `file${i}`),
             getLineNumber: () => i,
@@ -19,7 +19,7 @@ describe('Stack trace reporter', () => {
           }
         )
         ).concat(
-          [...Array(10).keys()].map(i => (
+           Array(10).fill().map((_,i) => (
             {
               getFileName: () => `file${i}`,
               getLineNumber: () => i,
@@ -38,7 +38,7 @@ describe('Stack trace reporter', () => {
           }
         ])
 
-      const expectedFrames = [...Array(10).keys()].map(i => (
+      const expectedFrames =  Array(10).fill().map((_,i) => (
         {
           id: i,
           file: `file${i}`,
@@ -70,7 +70,7 @@ describe('Stack trace reporter', () => {
   })
 
   describe('report stack traces', () => {
-    const callSiteList = [...Array(20).keys()].map(i => (
+    const callSiteList =  Array(20).fill().map((_,i) => (
       {
         getFileName: () => `file${i}`,
         getLineNumber: () => i,
@@ -95,7 +95,7 @@ describe('Stack trace reporter', () => {
       const rootSpan = {}
       const stackId = 'test_stack_id'
       const maxDepth = 32
-      const expectedFrames = [...Array(20).keys()].map(i => (
+      const expectedFrames =  Array(20).fill().map((_,i) => (
         {
           id: i,
           file: `file${i}`,
@@ -121,7 +121,7 @@ describe('Stack trace reporter', () => {
       }
       const stackId = 'test_stack_id'
       const maxDepth = 32
-      const expectedFrames = [...Array(20).keys()].map(i => (
+      const expectedFrames =  Array(20).fill().map((_,i) => (
         {
           id: i,
           file: `file${i}`,
@@ -151,7 +151,7 @@ describe('Stack trace reporter', () => {
       }
       const stackId = 'test_stack_id'
       const maxDepth = 32
-      const expectedFrames = [...Array(20).keys()].map(i => (
+      const expectedFrames =  Array(20).fill().map((_,i) => (
         {
           id: i,
           file: `file${i}`,
@@ -225,17 +225,22 @@ describe('Stack trace reporter', () => {
     })
 
     it('should not report stackTraces if callSiteList is undefined', () => {
-      const rootSpan = {}
+      const rootSpan = {
+        meta_struct: {
+          another_tag: []
+        }
+      }
       const stackId = 'test_stack_id'
       const maxDepth = 32
       const maxStackTraces = 2
       reportStackTrace(rootSpan, stackId, maxDepth, maxStackTraces, () => undefined)
-      assert.deepEqual(rootSpan, {})
+      assert.property(rootSpan.meta_struct, 'another_tag')
+      assert.notProperty(rootSpan.meta_struct, '_dd.stack')
     })
   })
 
   describe('limit stack traces frames', () => {
-    const callSiteList = [...Array(120).keys()].map(i => (
+    const callSiteList =  Array(120).fill().map((_,i) => (
       {
         getFileName: () => `file${i}`,
         getLineNumber: () => i,
@@ -277,7 +282,7 @@ describe('Stack trace reporter', () => {
           getFunctionName: () => 'libraryFunction',
           getTypeName: () => 'libraryType'
         }
-      ].concat([...Array(120).keys()].map(i => (
+      ].concat( Array(120).fill().map((_,i) => (
         {
           getFileName: () => `file${i}`,
           getLineNumber: () => i,
@@ -314,7 +319,7 @@ describe('Stack trace reporter', () => {
       const rootSpan = {}
       const stackId = 'test_stack_id'
       const maxDepth = 0
-      const expectedFrames = [...Array(120).keys()].map(i => (
+      const expectedFrames =  Array(120).fill().map((_,i) => (
         {
           id: i,
           file: `file${i}`,
@@ -334,7 +339,7 @@ describe('Stack trace reporter', () => {
       const rootSpan = {}
       const stackId = 'test_stack_id'
       const maxDepth = -1
-      const expectedFrames = [...Array(120).keys()].map(i => (
+      const expectedFrames =  Array(120).fill().map((_,i) => (
         {
           id: i,
           file: `file${i}`,


### PR DESCRIPTION
### What does this PR do?
Fix and address some issues with stack trace collection.

- Improve testing
- Avoid failing when frame has no filename
- Handle non-array CallsiteList

### Motivation
Have a more robust stack trace collection
