### PR TITLE
fix: child_process: default to tracer service name

### DIFF
--- a/packages/datadog-plugin-child_process/src/index.js
+++ b/packages/datadog-plugin-child_process/src/index.js
@@ -54,7 +54,7 @@ class ChildProcessPlugin extends TracingPlugin {
     }
 
     this.startSpan('command_execution', {
-      service: this.config.service,
+      service: this.config.service || this._tracerConfig.service,
       resource: (shell === true) ? 'sh' : cmdFields[0],
       type: 'system',
       meta

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -34,6 +34,10 @@ describe('Child process plugin', () => {
       tracerStub = {
         startSpan: sinon.stub()
       }
+
+      configStub = {
+        service: 'test-service'
+      }
     })
 
     afterEach(() => {
@@ -52,7 +56,7 @@ describe('Child process plugin', () => {
             childOf: undefined,
             tags: {
               component: 'subprocess',
-              'service.name': undefined,
+              'service.name': 'test-service',
               'resource.name': 'ls',
               'span.kind': undefined,
               'span.type': 'system',
@@ -74,7 +78,7 @@ describe('Child process plugin', () => {
             childOf: undefined,
             tags: {
               component: 'subprocess',
-              'service.name': undefined,
+              'service.name': 'test-service',
               'resource.name': 'sh',
               'span.kind': undefined,
               'span.type': 'system',
@@ -98,7 +102,7 @@ describe('Child process plugin', () => {
             childOf: undefined,
             tags: {
               component: 'subprocess',
-              'service.name': undefined,
+              'service.name': 'test-service',
               'resource.name': 'echo',
               'span.kind': undefined,
               'span.type': 'system',
@@ -123,7 +127,7 @@ describe('Child process plugin', () => {
             childOf: undefined,
             tags: {
               component: 'subprocess',
-              'service.name': undefined,
+              'service.name': 'test-service',
               'resource.name': 'sh',
               'span.kind': undefined,
               'span.type': 'system',
@@ -149,7 +153,7 @@ describe('Child process plugin', () => {
             childOf: undefined,
             tags: {
               component: 'subprocess',
-              'service.name': undefined,
+              'service.name': 'test-service',
               'resource.name': 'ls',
               'span.kind': undefined,
               'span.type': 'system',
@@ -175,7 +179,7 @@ describe('Child process plugin', () => {
             childOf: undefined,
             tags: {
               component: 'subprocess',
-              'service.name': undefined,
+              'service.name': 'test-service',
               'resource.name': 'sh',
               'span.kind': undefined,
               'span.type': 'system',


### PR DESCRIPTION
### What does this PR do?
- defaults the service name of child process calls to the tracer's name

### Motivation
- see #3608
- a bunch of users are seeing `unnamed-service` entries for child processes