### PR TITLE
remove get-port usage from http tests and test agent

### DIFF
--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios')
 const { incomingHttpRequestStart } = require('../../dd-trace/src/appsec/channels')
@@ -23,12 +22,6 @@ describe('Plugin', () => {
           res.writeHead(200)
           res.end()
         }
-      })
-
-      beforeEach(() => {
-        return getPort().then(newPort => {
-          port = newPort
-        })
       })
 
       afterEach(() => {
@@ -58,7 +51,10 @@ describe('Plugin', () => {
         beforeEach(done => {
           const server = new http.Server(listener)
           appListener = server
-            .listen(port, 'localhost', () => done())
+            .listen(0, 'localhost', () => {
+              port = appListener.address().port
+              done()
+            })
         })
 
         it('should send traces to agent', (done) => {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -4,7 +4,6 @@ const http = require('http')
 const bodyParser = require('body-parser')
 const msgpack = require('msgpack-lite')
 const codec = msgpack.createCodec({ int64: true })
-const getPort = require('get-port')
 const express = require('express')
 const path = require('path')
 const ritm = require('../../src/ritm')
@@ -270,8 +269,6 @@ module.exports = {
       res.status(200).send()
     })
 
-    const port = await getPort()
-
     const server = this.server = http.createServer(agent)
     const emit = server.emit
 
@@ -283,7 +280,11 @@ module.exports = {
     server.on('connection', socket => sockets.push(socket))
 
     const promise = new Promise((resolve, reject) => {
-      listener = server.listen(port, () => resolve())
+      listener = server.listen(0, () => {
+        const port = listener.address().port
+        tracer.setUrl(`http://127.0.0.1:${port}`)
+        resolve()
+      })
     })
 
     pluginName = [].concat(pluginName)
@@ -298,12 +299,9 @@ module.exports = {
     tracer.init(Object.assign({}, {
       service: 'test',
       env: 'tester',
-      port,
       flushInterval: 0,
       plugins: false
     }, tracerConfig))
-
-    tracer.setUrl(`http://127.0.0.1:${port}`)
 
     for (let i = 0, l = pluginName.length; i < l; i++) {
       tracer.use(pluginName[i], config[i])

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -282,7 +282,21 @@ module.exports = {
     const promise = new Promise((resolve, reject) => {
       listener = server.listen(0, () => {
         const port = listener.address().port
+
+        tracer.init(Object.assign({}, {
+          service: 'test',
+          env: 'tester',
+          port,
+          flushInterval: 0,
+          plugins: false
+        }, tracerConfig))
+
         tracer.setUrl(`http://127.0.0.1:${port}`)
+
+        for (let i = 0, l = pluginName.length; i < l; i++) {
+          tracer.use(pluginName[i], config[i])
+        }
+
         resolve()
       })
     })
@@ -295,17 +309,6 @@ module.exports = {
       tracer = null
       dsmStats = []
     })
-
-    tracer.init(Object.assign({}, {
-      service: 'test',
-      env: 'tester',
-      flushInterval: 0,
-      plugins: false
-    }, tracerConfig))
-
-    for (let i = 0, l = pluginName.length; i < l; i++) {
-      tracer.use(pluginName[i], config[i])
-    }
 
     return promise
   },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove get-port usage from http tests and test agent.

### Motivation
<!-- What inspired you to submit this pull request? -->

We often see flakiness from race conditions between getting and using available ports. Node can do this for us, so when possible we should rely on `server.listen` to do both steps at the same time for us, removing the possibility of a race condition. This should alleviate most of the seemingly random `EADDRINUSE` errors in tests.

### Additional Notes

Since get-port is used in many other places, it's possible that we still get the issue, at which point it should also be removed from any other problematic tests.
