### PR TITLE
move parametric tests to a 16 cores runner

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
 
   system-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     needs:
       - get-essential-scenarios
     strategy:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -71,7 +71,7 @@ jobs:
           path: artifact.tar.gz
 
   parametric:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     env:
       TEST_LIBRARY: nodejs
     steps:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Move parametric tests to a 16 cores runner.

### Motivation
<!-- What inspired you to submit this pull request? -->

These tests are slow, but they run in parallel so adding cores should mitigate their poor performance.