### PR TITLE
remove most get-port usage in appsec tests

### DIFF
--- a/packages/dd-trace/test/appsec/graphql.apollo-server-express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.apollo-server-express.plugin.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const agent = require('../plugins/agent')
 const {
   schema,
@@ -41,10 +40,9 @@ withVersions('apollo-server-core', 'express', '>=4', expressVersion => {
 
       server.applyMiddleware({ app })
 
-      config.port = await getPort()
-
       return new Promise(resolve => {
         expressServer = app.listen({ port: config.port }, () => {
+          config.port = expressServer.address().port
           resolve()
         })
       })

--- a/packages/dd-trace/test/appsec/graphql.apollo-server-fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.apollo-server-fastify.plugin.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const agent = require('../plugins/agent')
 const {
   schema,
@@ -41,10 +40,9 @@ withVersions('apollo-server-core', 'fastify', '3', fastifyVersion => {
 
       app.register(server.createHandler())
 
-      config.port = await getPort()
-
       return new Promise(resolve => {
-        app.listen({ port: config.port }, (data) => {
+        const server = app.listen({ port: config.port }, (data) => {
+          config.port = server.address().port
           resolve()
         })
       })

--- a/packages/dd-trace/test/appsec/graphql.apollo-server-fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.apollo-server-fastify.plugin.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const http = require('http')
 const agent = require('../plugins/agent')
 const {
   schema,
@@ -28,17 +27,7 @@ withVersions('apollo-server-core', 'fastify', '3', fastifyVersion => {
     })
 
     before(async () => {
-      let appListener
-
-      const serverFactory = (handler, opts) => {
-        appListener = http.createServer((req, res) => {
-          handler(req, res)
-        })
-
-        return appListener
-      }
-
-      app = fastify({ serverFactory })
+      app = fastify()
 
       const typeDefs = gql(schema)
 
@@ -53,7 +42,7 @@ withVersions('apollo-server-core', 'fastify', '3', fastifyVersion => {
 
       return new Promise(resolve => {
         app.listen({ port: config.port }, (data) => {
-          config.port = appListener.address().port
+          config.port = app.listener.address().port
           resolve()
         })
       })

--- a/packages/dd-trace/test/appsec/graphql.apollo-server-fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.apollo-server-fastify.plugin.spec.js
@@ -42,7 +42,7 @@ withVersions('apollo-server-core', 'fastify', '3', fastifyVersion => {
 
       return new Promise(resolve => {
         app.listen({ port: config.port }, (data) => {
-          config.port = app.listener.address().port
+          config.port = app.server.address().port
           resolve()
         })
       })

--- a/packages/dd-trace/test/appsec/graphql.apollo-server.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.apollo-server.plugin.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const path = require('path')
 const agent = require('../plugins/agent')
 const {
@@ -31,9 +30,9 @@ withVersions('apollo-server', '@apollo/server', apolloServerVersion => {
       resolvers
     })
 
-    config.port = await getPort()
+    const { url } = await startStandaloneServer(server, { listen: { port: 0 } })
 
-    await startStandaloneServer(server, { listen: { port: config.port } })
+    config.port = new URL(url).port
   })
 
   after(async () => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/plugin.apollo-server-express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/plugin.apollo-server-express.plugin.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const agent = require('../../../../plugins/agent')
 const {
   schema,
@@ -41,10 +40,9 @@ withVersions('graphql', 'express', '>=4', expressVersion => {
 
       server.applyMiddleware({ app })
 
-      config.port = await getPort()
-
       return new Promise(resolve => {
         expressServer = app.listen({ port: config.port }, () => {
+          config.port = expressServer.address().port
           resolve()
         })
       })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/plugin.apollo-server.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/plugin.apollo-server.plugin.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const path = require('path')
 const agent = require('../../../../plugins/agent')
 const {
@@ -31,9 +30,9 @@ withVersions('apollo-server', '@apollo/server', apolloServerVersion => {
       resolvers
     })
 
-    config.port = await getPort()
+    const { url } = await startStandaloneServer(server, { listen: { port: config.port } })
 
-    await startStandaloneServer(server, { listen: { port: config.port } })
+    config.port = new URL(url).port
   })
 
   after(async () => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
@@ -171,7 +171,9 @@ describe('Path params sourcing with express', () => {
 
       app.use('/:parameterParent', nestedRouter)
 
-      appListener = app.listen(0, 'localhost', port => {
+      appListener = app.listen(0, 'localhost', () => {
+        const port = appListener.address().port
+
         axios
           .get(`http://localhost:${port}/tainted1/tainted2`)
           .then(() => done())
@@ -189,7 +191,9 @@ describe('Path params sourcing with express', () => {
       app.param('parameter1', checkParamIsTaintedAndNext)
       app.param('parameter2', checkParamIsTaintedAndNext)
 
-      appListener = app.listen(0, 'localhost', port => {
+      appListener = app.listen(0, 'localhost', () => {
+        const port = appListener.address().port
+
         axios
           .get(`http://localhost:${port}/tainted1/tainted2`)
           .then(() => done())
@@ -211,7 +215,9 @@ describe('Path params sourcing with express', () => {
       app.param('parameter1')
       app.param('parameter2')
 
-      appListener = app.listen(0, 'localhost', port => {
+      appListener = app.listen(0, 'localhost', () => {
+        const port = appListener.address().port
+
         axios
           .get(`http://localhost:${port}/tainted1/tainted2`)
           .then(() => done())

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const axios = require('axios')
-const getPort = require('get-port')
 const semver = require('semver')
 const agent = require('../../../../plugins/agent')
 const Config = require('../../../../../src/config')
@@ -59,13 +58,13 @@ describe('URI sourcing with express', () => {
         res.status(200).send()
       })
 
-      getPort().then(port => {
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}/path/vulnerable`)
-            .then(() => done())
-            .catch(done)
-        })
+      appListener = app.listen(0, 'localhost', () => {
+        const port = appListener.address().port
+
+        axios
+          .get(`http://localhost:${port}/path/vulnerable`)
+          .then(() => done())
+          .catch(done)
       })
     })
   })
@@ -137,13 +136,13 @@ describe('Path params sourcing with express', () => {
         res.status(200).send()
       })
 
-      getPort().then(port => {
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}/tainted1/tainted2`)
-            .then(() => done())
-            .catch(done)
-        })
+      appListener = app.listen(0, 'localhost', () => {
+        const port = appListener.address().port
+
+        axios
+          .get(`http://localhost:${port}/tainted1/tainted2`)
+          .then(() => done())
+          .catch(done)
       })
     })
 
@@ -172,13 +171,11 @@ describe('Path params sourcing with express', () => {
 
       app.use('/:parameterParent', nestedRouter)
 
-      getPort().then(port => {
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}/tainted1/tainted2`)
-            .then(() => done())
-            .catch(done)
-        })
+      appListener = app.listen(0, 'localhost', port => {
+        axios
+          .get(`http://localhost:${port}/tainted1/tainted2`)
+          .then(() => done())
+          .catch(done)
       })
     })
 
@@ -192,13 +189,11 @@ describe('Path params sourcing with express', () => {
       app.param('parameter1', checkParamIsTaintedAndNext)
       app.param('parameter2', checkParamIsTaintedAndNext)
 
-      getPort().then(port => {
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}/tainted1/tainted2`)
-            .then(() => done())
-            .catch(done)
-        })
+      appListener = app.listen(0, 'localhost', port => {
+        axios
+          .get(`http://localhost:${port}/tainted1/tainted2`)
+          .then(() => done())
+          .catch(done)
       })
     })
 
@@ -216,13 +211,11 @@ describe('Path params sourcing with express', () => {
       app.param('parameter1')
       app.param('parameter2')
 
-      getPort().then(port => {
-        appListener = app.listen(port, 'localhost', () => {
-          axios
-            .get(`http://localhost:${port}/tainted1/tainted2`)
-            .then(() => done())
-            .catch(done)
-        })
+      appListener = app.listen(0, 'localhost', port => {
+        axios
+          .get(`http://localhost:${port}/tainted1/tainted2`)
+          .then(() => done())
+          .catch(done)
       })
     })
   })

--- a/packages/dd-trace/test/appsec/index.body-parser.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.body-parser.plugin.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const axios = require('axios')
-const getPort = require('get-port')
 const path = require('path')
 const agent = require('../plugins/agent')
 const appsec = require('../../src/appsec')
@@ -27,11 +26,9 @@ withVersions('body-parser', 'body-parser', version => {
         res.end('DONE')
       })
 
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(port, () => {
+        port = server.address().port
+        done()
       })
     })
 

--- a/packages/dd-trace/test/appsec/index.cookie-parser.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.cookie-parser.plugin.spec.js
@@ -2,7 +2,6 @@
 
 const { assert } = require('chai')
 const axios = require('axios')
-const getPort = require('get-port')
 const path = require('path')
 const agent = require('../plugins/agent')
 const appsec = require('../../src/appsec')
@@ -28,11 +27,9 @@ withVersions('cookie-parser', 'cookie-parser', version => {
         res.end('DONE')
       })
 
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(port, () => {
+        port = server.address().port
+        done()
       })
     })
 

--- a/packages/dd-trace/test/appsec/index.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.express.plugin.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const axios = require('axios')
-const getPort = require('get-port')
 const path = require('path')
 const agent = require('../plugins/agent')
 const appsec = require('../../src/appsec')
@@ -45,11 +44,9 @@ withVersions('express', 'express', version => {
         res.jsonp({ jsonResKey: 'jsonResValue' })
       })
 
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(port, () => {
+        port = server.address().port
+        done()
       })
     })
 

--- a/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 const axios = require('axios')
-const getPort = require('get-port')
 const agent = require('../plugins/agent')
 const appsec = require('../../src/appsec')
 const Config = require('../../src/config')
@@ -69,11 +68,9 @@ describe('sequelize', () => {
             res.json(users)
           })
 
-          getPort().then(newPort => {
-            port = newPort
-            server = app.listen(newPort, () => {
-              done()
-            })
+          server = app.listen(0, () => {
+            port = server.address().port
+            done()
           })
         })
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -19,7 +19,6 @@ const Reporter = require('../../src/appsec/reporter')
 const agent = require('../plugins/agent')
 const Config = require('../../src/config')
 const axios = require('axios')
-const getPort = require('get-port')
 const blockedTemplate = require('../../src/appsec/blocked_templates')
 const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../../src/telemetry/metrics')
@@ -1005,11 +1004,6 @@ describe('IP blocking', function () {
 
   let http, appListener, port
   before(() => {
-    return getPort().then(newPort => {
-      port = newPort
-    })
-  })
-  before(() => {
     return agent.load('http')
       .then(() => {
         http = require('http')
@@ -1021,7 +1015,10 @@ describe('IP blocking', function () {
       res.end(JSON.stringify({ message: 'OK' }))
     })
     appListener = server
-      .listen(port, 'localhost', () => done())
+      .listen(0, 'localhost', () => {
+        port = appListener.address().port
+        done()
+      })
   })
 
   beforeEach(() => {

--- a/packages/dd-trace/test/appsec/rasp.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp.express.plugin.spec.js
@@ -2,7 +2,6 @@
 
 const Axios = require('axios')
 const agent = require('../plugins/agent')
-const getPort = require('get-port')
 const appsec = require('../../src/appsec')
 const Config = require('../../src/config')
 const path = require('path')
@@ -10,7 +9,7 @@ const { assert } = require('chai')
 
 withVersions('express', 'express', expressVersion => {
   describe('RASP', () => {
-    let app, server, port, axios
+    let app, server, axios
 
     before(() => {
       return agent.load(['http'], { client: false })
@@ -32,14 +31,12 @@ withVersions('express', 'express', expressVersion => {
         }
       }))
 
-      getPort().then(newPort => {
-        port = newPort
+      server = expressApp.listen(0, () => {
+        const port = server.address().port
         axios = Axios.create({
           baseURL: `http://localhost:${port}`
         })
-        server = expressApp.listen(port, () => {
-          done()
-        })
+        done()
       })
     })
 

--- a/packages/dd-trace/test/appsec/sdk/set_user.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/set_user.spec.js
@@ -3,7 +3,6 @@
 const proxyquire = require('proxyquire')
 const agent = require('../../plugins/agent')
 const tracer = require('../../../../../index')
-const getPort = require('get-port')
 const axios = require('axios')
 
 describe('set_user', () => {
@@ -83,7 +82,6 @@ describe('set_user', () => {
     }
 
     before(async () => {
-      port = await getPort()
       await agent.load('http')
       http = require('http')
     })
@@ -91,7 +89,10 @@ describe('set_user', () => {
     before(done => {
       const server = new http.Server(listener)
       appListener = server
-        .listen(port, 'localhost', () => done())
+        .listen(port, 'localhost', () => {
+          port = appListener.address().port
+          done()
+        })
     })
 
     after(() => {

--- a/packages/dd-trace/test/appsec/sdk/track_event.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event.spec.js
@@ -2,7 +2,6 @@
 
 const proxyquire = require('proxyquire')
 const agent = require('../../plugins/agent')
-const getPort = require('get-port')
 const axios = require('axios')
 const tracer = require('../../../../../index')
 
@@ -281,7 +280,6 @@ describe('track_event', () => {
     }
 
     before(async () => {
-      port = await getPort()
       await agent.load('http')
       http = require('http')
     })
@@ -289,7 +287,10 @@ describe('track_event', () => {
     before(done => {
       const server = new http.Server(listener)
       appListener = server
-        .listen(port, 'localhost', () => done())
+        .listen(port, 'localhost', () => {
+          port = appListener.address().port
+          done()
+        })
     })
 
     after(() => {

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -5,7 +5,6 @@ const agent = require('../../plugins/agent')
 const tracer = require('../../../../../index')
 const appsec = require('../../../src/appsec')
 const Config = require('../../../src/config')
-const getPort = require('get-port')
 const axios = require('axios')
 const path = require('path')
 const waf = require('../../../src/appsec/waf')
@@ -166,7 +165,6 @@ describe('user_blocking', () => {
     }
 
     before(async () => {
-      port = await getPort()
       await agent.load('http')
       http = require('http')
     })
@@ -174,7 +172,10 @@ describe('user_blocking', () => {
     before(done => {
       const server = new http.Server(listener)
       appListener = server
-        .listen(port, 'localhost', () => done())
+        .listen(port, 'localhost', () => {
+          port = appListener.address().port
+          done()
+        })
 
       appsec.enable(config)
     })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove most get-port usage in AppSec tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Follow-up of #4426

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The only usage left is in Next plugin test because it sends the port to an external process. If that test could be refactored to avoid doing this, then AppSec tests could be completely free of get-port.