### PR TITLE
remove most usage of get-port for plugin tests

### DIFF
--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -22,11 +21,9 @@ withVersions('body-parser', 'body-parser', version => {
         middlewareProcessBodyStub()
         res.end('DONE')
       })
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(0, () => {
+        port = server.address().port
+        done()
       })
     })
     beforeEach(async () => {

--- a/packages/datadog-instrumentations/test/cookie-parser.spec.js
+++ b/packages/datadog-instrumentations/test/cookie-parser.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { assert } = require('chai')
-const getPort = require('get-port')
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -23,11 +22,9 @@ withVersions('cookie-parser', 'cookie-parser', version => {
         middlewareProcessCookieStub()
         res.end('DONE')
       })
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(0, () => {
+        port = server.address().port
+        done()
       })
     })
     beforeEach(async () => {

--- a/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
+++ b/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const getPort = require('get-port')
 const { channel } = require('dc-polyfill')
 const axios = require('axios')
 describe('express-mongo-sanitize', () => {
@@ -25,11 +24,9 @@ describe('express-mongo-sanitize', () => {
           res.end()
         })
 
-        getPort().then(newPort => {
-          port = newPort
-          server = app.listen(port, () => {
-            done()
-          })
+        server = app.listen(0, () => {
+          port = server.address().port
+          done()
         })
       })
 

--- a/packages/datadog-instrumentations/test/express.spec.js
+++ b/packages/datadog-instrumentations/test/express.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const getPort = require('get-port')
 const axios = require('axios')
 const dc = require('dc-polyfill')
 
@@ -20,11 +19,9 @@ withVersions('express', 'express', version => {
         requestBody()
         res.end('DONE')
       })
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(0, () => {
+        port = server.address().port
+        done()
       })
     })
     beforeEach(async () => {

--- a/packages/datadog-instrumentations/test/passport-http.spec.js
+++ b/packages/datadog-instrumentations/test/passport-http.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const getPort = require('get-port')
 const axios = require('axios')
 const dc = require('dc-polyfill')
 
@@ -70,11 +69,9 @@ withVersions('passport-http', 'passport-http', version => {
         subscriberStub(arguments[0])
       })
 
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(0, () => {
+        port = server.address().port
+        done()
       })
     })
     beforeEach(() => {

--- a/packages/datadog-instrumentations/test/passport-local.spec.js
+++ b/packages/datadog-instrumentations/test/passport-local.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const getPort = require('get-port')
 const axios = require('axios')
 const dc = require('dc-polyfill')
 
@@ -71,11 +70,9 @@ withVersions('passport-local', 'passport-local', version => {
         subscriberStub(arguments[0])
       })
 
-      getPort().then(newPort => {
-        port = newPort
-        server = app.listen(port, () => {
-          done()
-        })
+      server = app.listen(0, () => {
+        port = server.address().port
+        done()
       })
     })
     beforeEach(() => {

--- a/packages/datadog-plugin-apollo/test/index.spec.js
+++ b/packages/datadog-plugin-apollo/test/index.spec.js
@@ -5,7 +5,6 @@ const agent = require('../../dd-trace/test/plugins/agent.js')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants.js')
 const { expectedSchema, rawExpectedSchema } = require('./naming.js')
 const axios = require('axios')
-const getPort = require('get-port')
 
 const accounts = require('./fixtures.js')
 
@@ -86,13 +85,15 @@ describe('Plugin', () => {
             gateway: setupGateway(),
             subscriptions: false // Disable subscriptions (not supported with Apollo Gateway)
           })
-          getPort().then(newPort => {
-            port = newPort
-            startStandaloneServer(server, {
-              listen: { port }
-            }).then(() => {})
-          })
 
+          return startStandaloneServer(server, {
+            listen: { port: 0 }
+          }).then(({ url }) => {
+            port = new URL(url).port
+          })
+        })
+
+        before(() => {
           return agent.load('apollo')
         })
 

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -2,7 +2,6 @@
 
 const axios = require('axios')
 const http = require('http')
-const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { AsyncLocalStorage } = require('async_hooks')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
@@ -45,7 +44,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -62,11 +63,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -76,7 +75,9 @@ describe('Plugin', () => {
           app.use(function named (req, res, next) { next() })
           app.use('/app/user', (req, res) => res.end())
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -94,11 +95,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -109,7 +108,9 @@ describe('Plugin', () => {
           app.use('/foo/bar', (req, res, next) => next())
           app.use('/foo', (req, res) => res.end())
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -119,11 +120,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/foo/bar`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/foo/bar`)
+              .catch(done)
           })
         })
 
@@ -137,7 +136,9 @@ describe('Plugin', () => {
 
           app.use('/parent', childApp)
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -148,11 +149,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/parent/child`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/parent/child`)
+              .catch(done)
           })
         })
 
@@ -175,12 +174,12 @@ describe('Plugin', () => {
             done()
           })
 
-          getPort().then(port => {
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -196,7 +195,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -206,11 +207,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -239,12 +238,12 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -253,7 +252,9 @@ describe('Plugin', () => {
 
           app.use((req, res, next) => res.end())
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -263,11 +264,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -293,11 +292,11 @@ describe('Plugin', () => {
             }
           })
 
-          getPort().then(port => {
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios.get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -308,7 +307,9 @@ describe('Plugin', () => {
           app.use('/app', (req, res) => res.end())
           app.use('/bar', (req, res, next) => next())
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -318,10 +319,8 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/app/user/123`)
-                .catch(done)
-            })
+            axios.get(`http://localhost:${port}/app/user/123`)
+              .catch(done)
           })
         })
 
@@ -332,7 +331,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -342,17 +343,15 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  headers: {
-                    'x-datadog-trace-id': '1234',
-                    'x-datadog-parent-id': '5678',
-                    'ot-baggage-foo': 'bar'
-                  }
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                headers: {
+                  'x-datadog-trace-id': '1234',
+                  'x-datadog-parent-id': '5678',
+                  'ot-baggage-foo': 'bar'
+                }
+              })
+              .catch(done)
           })
         })
 
@@ -368,7 +367,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -381,13 +382,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -403,7 +402,9 @@ describe('Plugin', () => {
             throw new Error('boom')
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -416,13 +417,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 400
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 400
+              })
+              .catch(done)
           })
         })
 
@@ -432,7 +431,9 @@ describe('Plugin', () => {
 
           app.use(() => { throw error })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -447,13 +448,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -477,12 +476,12 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -497,7 +496,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -516,13 +517,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
       })
@@ -551,7 +550,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -561,11 +562,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -577,7 +576,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -587,13 +588,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 400
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 400
+              })
+              .catch(done)
           })
         })
 
@@ -604,7 +603,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -614,13 +615,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  headers: { 'User-Agent': 'test' }
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                headers: { 'User-Agent': 'test' }
+              })
+              .catch(done)
           })
         })
 
@@ -632,7 +631,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -649,11 +650,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -668,7 +667,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -687,13 +688,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -703,7 +702,9 @@ describe('Plugin', () => {
 
           app.use(() => { throw error })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -718,13 +719,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
       })
@@ -750,7 +749,9 @@ describe('Plugin', () => {
           app.use(function named (req, res, next) { next() })
           app.use('/app/user', (req, res) => res.end())
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -762,11 +763,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -791,11 +790,11 @@ describe('Plugin', () => {
             }
           })
 
-          getPort().then(port => {
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios.get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -810,7 +809,9 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -825,13 +826,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -841,7 +840,9 @@ describe('Plugin', () => {
 
           app.use(() => { throw error })
 
-          getPort().then(port => {
+          appListener = http.createServer(app).listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -856,13 +857,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = http.createServer(app).listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
       })

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -1,5 +1,4 @@
 'use strict'
-const getPort = require('get-port')
 const { expect } = require('chai')
 const semver = require('semver')
 
@@ -31,15 +30,16 @@ describe('Plugin', function () {
   let agentListenPort
   this.retries(2)
   withVersions('cypress', 'cypress', (version, moduleName) => {
-    beforeEach(function () {
+    beforeEach(() => {
+      return agent.load()
+    })
+    beforeEach(function (done) {
       this.timeout(10000)
-      return agent.load().then(() => {
-        agentListenPort = agent.server.address().port
-        cypressExecutable = require(`../../../versions/cypress@${version}`).get()
-        return getPort().then(port => {
-          appPort = port
-          appServer.listen(appPort)
-        })
+      agentListenPort = agent.server.address().port
+      cypressExecutable = require(`../../../versions/cypress@${version}`).get()
+      appServer.listen(0, () => {
+        appPort = appServer.address().port
+        done()
       })
     })
     afterEach(() => agent.close({ ritmReset: false }))

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1279,7 +1279,9 @@ describe('Plugin', () => {
             res.status(200).send('hi')
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -1292,13 +1294,11 @@ describe('Plugin', () => {
               done()
             })
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/does-not-exist`, {
-                  validateStatus: status => status === 404
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/does-not-exist`, {
+                validateStatus: status => status === 404
+              })
+              .catch(done)
           })
         })
 

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -2,7 +2,6 @@
 
 const { AsyncLocalStorage } = require('async_hooks')
 const axios = require('axios')
-const getPort = require('get-port')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
@@ -45,7 +44,8 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
             const timer = setTimeout(done, 100)
 
             agent.use(() => {
@@ -53,11 +53,9 @@ describe('Plugin', () => {
               done(new Error('Agent received an unexpected trace.'))
             })
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -70,13 +68,13 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .then(() => done())
-                .catch(done)
-            })
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/user`)
+              .then(() => done())
+              .catch(done)
           })
         })
       })
@@ -101,7 +99,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -119,11 +119,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -137,7 +135,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -154,11 +154,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -174,7 +172,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -191,11 +191,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -210,7 +208,9 @@ describe('Plugin', () => {
           app.use(function named (req, res, next) { next() })
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -246,11 +246,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -272,7 +270,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -287,11 +287,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/1`)
+              .catch(done)
           })
         })
 
@@ -317,7 +315,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -331,11 +331,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/1`)
+              .catch(done)
           })
         })
 
@@ -349,7 +347,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -359,11 +359,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -377,7 +375,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -387,11 +387,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -411,7 +409,9 @@ describe('Plugin', () => {
           app.use('/foo/bar', (req, res, next) => next())
           app.use('/foo', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -421,11 +421,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/foo/bar`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/foo/bar`)
+              .catch(done)
           })
         })
 
@@ -439,7 +437,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -449,11 +449,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -468,7 +466,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -478,11 +478,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -496,7 +494,9 @@ describe('Plugin', () => {
 
           app.use('/parent', childApp)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -508,11 +508,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/parent/child`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/parent/child`)
+              .catch(done)
           })
         })
 
@@ -535,12 +533,12 @@ describe('Plugin', () => {
             done()
           })
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/1`)
-                .catch(done)
-            })
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/app/user/1`)
+              .catch(done)
           })
         })
 
@@ -564,7 +562,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -574,11 +574,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/123`)
+              .catch(done)
           })
         })
 
@@ -596,7 +594,9 @@ describe('Plugin', () => {
 
           app.use('/app', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -606,11 +606,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app/user/123`)
+              .catch(done)
           })
         })
 
@@ -625,7 +623,9 @@ describe('Plugin', () => {
             res.status(200).send(error.message)
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -635,11 +635,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -660,7 +658,9 @@ describe('Plugin', () => {
           app.use('/v1', routerA)
           app.use('/v1', routerB)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -670,11 +670,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/v1/a`)
-                .catch(() => {})
-            })
+            axios
+              .get(`http://localhost:${port}/v1/a`)
+              .catch(() => {})
           })
         })
 
@@ -690,7 +688,9 @@ describe('Plugin', () => {
             res.status(200).send(req.body)
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -700,11 +700,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -726,7 +724,9 @@ describe('Plugin', () => {
             res.status(200).send('')
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -736,11 +736,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/foo/bar`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/foo/bar`)
+              .catch(done)
           })
         })
 
@@ -762,7 +760,9 @@ describe('Plugin', () => {
             res.status(200).send('')
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -772,11 +772,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/foo/bar`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/foo/bar`)
+              .catch(done)
           })
         })
 
@@ -800,7 +798,9 @@ describe('Plugin', () => {
             res.status(200).send('')
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -810,11 +810,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/foo/bar`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/foo/bar`)
+              .catch(done)
           })
         })
 
@@ -831,7 +829,9 @@ describe('Plugin', () => {
 
           app.use('/v1', router)
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -841,11 +841,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/v1/a`)
-                .catch(() => {})
-            })
+            axios
+              .get(`http://localhost:${port}/v1/a`)
+              .catch(() => {})
           })
         })
 
@@ -874,12 +872,12 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -888,7 +886,9 @@ describe('Plugin', () => {
 
           app.use((req, res, next) => res.status(200).send())
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -898,11 +898,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -928,11 +926,11 @@ describe('Plugin', () => {
             }
           })
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios.get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -958,11 +956,11 @@ describe('Plugin', () => {
             }
           )
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios.get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -980,7 +978,9 @@ describe('Plugin', () => {
           app.use('/app', router)
           app.use('/bar', (req, res, next) => next())
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -990,10 +990,8 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/app/user/123`)
-                .catch(done)
-            })
+            axios.get(`http://localhost:${port}/app/user/123`)
+              .catch(done)
           })
         })
 
@@ -1004,7 +1002,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -1014,17 +1014,15 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  headers: {
-                    'x-datadog-trace-id': '1234',
-                    'x-datadog-parent-id': '5678',
-                    'ot-baggage-foo': 'bar'
-                  }
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                headers: {
+                  'x-datadog-trace-id': '1234',
+                  'x-datadog-parent-id': '5678',
+                  'ot-baggage-foo': 'bar'
+                }
+              })
+              .catch(done)
           })
         })
 
@@ -1039,7 +1037,9 @@ describe('Plugin', () => {
             res.status(500).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -1051,13 +1051,11 @@ describe('Plugin', () => {
               done()
             })
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -1073,7 +1071,9 @@ describe('Plugin', () => {
             throw new Error('boom')
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -1085,13 +1085,11 @@ describe('Plugin', () => {
               done()
             })
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 400
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 400
+              })
+              .catch(done)
           })
         })
 
@@ -1101,7 +1099,9 @@ describe('Plugin', () => {
 
           app.use(() => { throw error })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1116,13 +1116,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -1134,7 +1132,9 @@ describe('Plugin', () => {
           // eslint-disable-next-line n/handle-callback-err
           app.use((error, req, res, next) => res.status(500).send())
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1153,13 +1153,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -1171,7 +1169,9 @@ describe('Plugin', () => {
           // eslint-disable-next-line n/handle-callback-err
           app.use((error, req, res, next) => res.status(500).send())
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1190,13 +1190,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -1207,7 +1205,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1218,11 +1218,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -1261,12 +1259,12 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -1320,7 +1318,9 @@ describe('Plugin', () => {
               res.status(200).send()
             })
 
-            getPort().then(port => {
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
               agent
                 .use(traces => {
                   const spans = sort(traces[0])
@@ -1337,10 +1337,8 @@ describe('Plugin', () => {
                 .then(done)
                 .catch(done)
 
-              appListener = app.listen(port, 'localhost', () => {
-                axios.get(`http://localhost:${port}/dd`)
-                  .catch(done)
-              })
+              axios.get(`http://localhost:${port}/dd`)
+                .catch(done)
             })
           })
 
@@ -1355,7 +1353,9 @@ describe('Plugin', () => {
               res.status(200).send()
             })
 
-            getPort().then(port => {
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
               agent
                 .use(traces => {
                   const spans = sort(traces[0])
@@ -1367,10 +1367,8 @@ describe('Plugin', () => {
                 .then(done)
                 .catch(done)
 
-              appListener = app.listen(port, 'localhost', () => {
-                axios.get(`http://localhost:${port}/dd`)
-                  .catch(done)
-              })
+              axios.get(`http://localhost:${port}/dd`)
+                .catch(done)
             })
           })
         })
@@ -1401,7 +1399,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1411,11 +1411,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -1426,7 +1424,9 @@ describe('Plugin', () => {
             res.status(400).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1436,13 +1436,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 400
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 400
+              })
+              .catch(done)
           })
         })
 
@@ -1453,7 +1451,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1463,13 +1463,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  headers: { 'User-Agent': 'test' }
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                headers: { 'User-Agent': 'test' }
+              })
+              .catch(done)
           })
         })
 
@@ -1480,7 +1478,8 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
             const spy = sinon.spy()
 
             agent
@@ -1496,11 +1495,9 @@ describe('Plugin', () => {
               }
             }, 100)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/health`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/health`)
+              .catch(done)
           })
         })
       })
@@ -1540,11 +1537,11 @@ describe('Plugin', () => {
             }
           })
 
-          getPort().then(port => {
-            appListener = app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios.get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -1559,7 +1556,9 @@ describe('Plugin', () => {
             res.status(200).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1570,10 +1569,8 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios.get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -1588,7 +1585,9 @@ describe('Plugin', () => {
             res.status(500).send()
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -1600,13 +1599,11 @@ describe('Plugin', () => {
               done()
             })
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -1622,7 +1619,9 @@ describe('Plugin', () => {
             throw new Error('boom')
           })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1635,13 +1634,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 400
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 400
+              })
+              .catch(done)
           })
         })
 
@@ -1653,7 +1650,9 @@ describe('Plugin', () => {
           // eslint-disable-next-line n/handle-callback-err
           app.use((error, req, res, next) => res.status(500).send())
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1667,13 +1666,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -1683,7 +1680,9 @@ describe('Plugin', () => {
 
           app.use(() => { throw error })
 
-          getPort().then(port => {
+          appListener = app.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -1698,13 +1697,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = app.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
       })

--- a/packages/datadog-plugin-express/test/leak.js
+++ b/packages/datadog-plugin-express/test/leak.js
@@ -7,23 +7,22 @@ require('../../dd-trace')
 const test = require('tape')
 const express = require('../../../versions/express').get()
 const axios = require('axios')
-const getPort = require('get-port')
 const profile = require('../../dd-trace/test/profile')
 
 test('express plugin should not leak', t => {
-  getPort().then(port => {
-    const app = express()
+  const app = express()
 
-    app.use((req, res) => {
-      res.status(200).send()
-    })
+  app.use((req, res) => {
+    res.status(200).send()
+  })
 
-    const listener = app.listen(port, '127.0.0.1', () => {
-      profile(t, operation).then(() => listener.close())
+  const listener = app.listen(0, '127.0.0.1', () => {
+    const port = listener.address().port
 
-      function operation (done) {
-        axios.get(`http://localhost:${port}`).then(done)
-      }
-    })
+    profile(t, operation).then(() => listener.close())
+
+    function operation (done) {
+      axios.get(`http://localhost:${port}`).then(done)
+    }
   })
 })

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -2,7 +2,6 @@
 
 const { AsyncLocalStorage } = require('async_hooks')
 const axios = require('axios')
-const getPort = require('get-port')
 const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -48,7 +47,9 @@ describe('Plugin', () => {
               reply.send()
             })
 
-            getPort().then(port => {
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
               agent
                 .use(traces => {
                   const spans = traces[0]
@@ -66,11 +67,9 @@ describe('Plugin', () => {
                 .then(done)
                 .catch(done)
 
-              app.listen({ host, port }, () => {
-                axios
-                  .get(`http://localhost:${port}/user`)
-                  .catch(done)
-              })
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(done)
             })
           })
 
@@ -83,7 +82,9 @@ describe('Plugin', () => {
               }
             })
 
-            getPort().then(port => {
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
               agent
                 .use(traces => {
                   const spans = traces[0]
@@ -101,11 +102,9 @@ describe('Plugin', () => {
                 .then(done)
                 .catch(done)
 
-              app.listen({ host, port }, () => {
-                axios
-                  .get(`http://localhost:${port}/user/123`)
-                  .catch(done)
-              })
+              axios
+                .get(`http://localhost:${port}/user/123`)
+                .catch(done)
             })
           })
 
@@ -117,7 +116,9 @@ describe('Plugin', () => {
                 }
               })
 
-              getPort().then(port => {
+              app.listen({ host, port: 0 }, () => {
+                const port = app.server.address().port
+
                 agent
                   .use(traces => {
                     const spans = traces[0]
@@ -135,11 +136,9 @@ describe('Plugin', () => {
                   .then(done)
                   .catch(done)
 
-                app.listen({ host, port }, () => {
-                  axios
-                    .get(`http://localhost:${port}/user/123`)
-                    .catch(done)
-                })
+                axios
+                  .get(`http://localhost:${port}/user/123`)
+                  .catch(done)
               })
             })
           }
@@ -155,12 +154,12 @@ describe('Plugin', () => {
               reply.send()
             })
 
-            getPort().then(port => {
-              app.listen({ host, port }, () => {
-                axios.get(`http://localhost:${port}/user`)
-                  .then(() => done())
-                  .catch(done)
-              })
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
+              axios.get(`http://localhost:${port}/user`)
+                .then(() => done())
+                .catch(done)
             })
           })
 
@@ -172,12 +171,12 @@ describe('Plugin', () => {
 
             app.get('/user', (request, reply) => reply.send())
 
-            getPort().then(port => {
-              app.listen({ host, port }, () => {
-                axios.get(`http://localhost:${port}/user`)
-                  .then(() => done())
-                  .catch(done)
-              })
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
+              axios.get(`http://localhost:${port}/user`)
+                .then(() => done())
+                .catch(done)
             })
           })
 
@@ -187,12 +186,12 @@ describe('Plugin', () => {
               reply.send()
             })
 
-            getPort().then(port => {
-              app.listen({ host, port }, () => {
-                axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
-                  .then(() => done())
-                  .catch(done)
-              })
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
+              axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
+                .then(() => done())
+                .catch(done)
             })
           })
 
@@ -211,12 +210,12 @@ describe('Plugin', () => {
               }
             })
 
-            getPort().then(port => {
-              app.listen({ host, port }, () => {
-                axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
-                  .then(() => done())
-                  .catch(done)
-              })
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
+              axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
+                .then(() => done())
+                .catch(done)
             })
           })
 
@@ -248,12 +247,12 @@ describe('Plugin', () => {
               }
             })
 
-            getPort().then(port => {
-              app.listen({ host, port }, () => {
-                axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
-                  .then(() => done())
-                  .catch(done)
-              })
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
+              axios.post(`http://localhost:${port}/user`, { foo: 'bar' })
+                .then(() => done())
+                .catch(done)
             })
           })
 
@@ -264,7 +263,9 @@ describe('Plugin', () => {
               reply.send(error = new Error('boom'))
             })
 
-            getPort().then(port => {
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
               agent
                 .use(traces => {
                   const spans = traces[0]
@@ -279,11 +280,9 @@ describe('Plugin', () => {
                 .then(done)
                 .catch(done)
 
-              app.listen({ host, port }, () => {
-                axios
-                  .get(`http://localhost:${port}/user`)
-                  .catch(() => {})
-              })
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(() => {})
             })
           })
 
@@ -295,11 +294,11 @@ describe('Plugin', () => {
               reply.send()
             })
 
-            getPort().then(port => {
-              app.listen({ host, port }, async () => {
-                await axios.get(`http://localhost:${port}/user`)
-                done()
-              })
+            app.listen({ host, port: 0 }, async () => {
+              const port = app.server.address().port
+
+              await axios.get(`http://localhost:${port}/user`)
+              done()
             })
           })
 
@@ -324,11 +323,11 @@ describe('Plugin', () => {
               reply.send()
             })
 
-            getPort().then(port => {
-              app.listen({ host, port }, () => {
-                axios.get(`http://localhost:${port}/user`)
-                  .catch(done)
-              })
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
+              axios.get(`http://localhost:${port}/user`)
+                .catch(done)
             })
           })
 
@@ -343,7 +342,9 @@ describe('Plugin', () => {
               reply.send()
             })
 
-            getPort().then(port => {
+            app.listen({ host, port: 0 }, () => {
+              const port = app.server.address().port
+
               agent
                 .use(traces => {
                   const spans = traces[0]
@@ -359,11 +360,9 @@ describe('Plugin', () => {
                 .then(done)
                 .catch(done)
 
-              app.listen({ host, port }, () => {
-                axios
-                  .get(`http://localhost:${port}/user`)
-                  .catch(() => {})
-              })
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(() => {})
             })
           })
 
@@ -376,7 +375,9 @@ describe('Plugin', () => {
                 reply.send()
               })
 
-              getPort().then(port => {
+              app.listen({ host, port: 0 }, () => {
+                const port = app.server.address().port
+
                 agent
                   .use(traces => {
                     const spans = traces[0]
@@ -389,11 +390,9 @@ describe('Plugin', () => {
                   .then(done)
                   .catch(done)
 
-                app.listen({ host, port }, () => {
-                  axios
-                    .get(`http://localhost:${port}/user`)
-                    .catch(() => {})
-                })
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
               })
             })
           }
@@ -407,7 +406,9 @@ describe('Plugin', () => {
                 return Promise.reject(error = new Error('boom'))
               })
 
-              getPort().then(port => {
+              app.listen({ host, port: 0 }, () => {
+                const port = app.server.address().port
+
                 agent
                   .use(traces => {
                     const spans = traces[0]
@@ -422,11 +423,9 @@ describe('Plugin', () => {
                   .then(done)
                   .catch(done)
 
-                app.listen({ host, port }, () => {
-                  axios
-                    .get(`http://localhost:${port}/user`)
-                    .catch(() => {})
-                })
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
               })
             })
 
@@ -442,7 +441,9 @@ describe('Plugin', () => {
                 throw (error = new Error('boom'))
               })
 
-              getPort().then(port => {
+              app.listen({ host, port: 0 }, () => {
+                const port = app.server.address().port
+
                 agent
                   .use(traces => {
                     const spans = traces[0]
@@ -458,11 +459,9 @@ describe('Plugin', () => {
                   .then(done)
                   .catch(done)
 
-                app.listen({ host, port }, () => {
-                  axios
-                    .get(`http://localhost:${port}/user`)
-                    .catch(() => {})
-                })
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
               })
             })
 
@@ -476,7 +475,9 @@ describe('Plugin', () => {
                 throw new Error('boom')
               })
 
-              getPort().then(port => {
+              app.listen({ host, port: 0 }, () => {
+                const port = app.server.address().port
+
                 agent
                   .use(traces => {
                     const spans = traces[0]
@@ -492,11 +493,9 @@ describe('Plugin', () => {
                   .then(done)
                   .catch(done)
 
-                app.listen({ host, port }, () => {
-                  axios
-                    .get(`http://localhost:${port}/user`)
-                    .catch(() => {})
-                })
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
               })
             })
           }
@@ -515,7 +514,9 @@ describe('Plugin', () => {
                 reply.send()
               })
 
-              getPort().then(port => {
+              app.listen({ host, port: 0 }, () => {
+                const port = app.server.address().port
+
                 agent
                   .use(traces => {
                     const spans = traces[0]
@@ -531,11 +532,9 @@ describe('Plugin', () => {
                   .then(done)
                   .catch(done)
 
-                app.listen({ host, port }, () => {
-                  axios
-                    .get(`http://localhost:${port}/user`)
-                    .catch(() => {})
-                })
+                axios
+                  .get(`http://localhost:${port}/user`)
+                  .catch(() => {})
               })
             })
           }

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -7,7 +7,6 @@ const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/c
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 const axios = require('axios')
 const http = require('http')
-const getPort = require('get-port')
 const dc = require('dc-polyfill')
 const plugin = require('../src')
 
@@ -231,12 +230,14 @@ describe('Plugin', () => {
                 const yoga = graphqlYoga.createYoga({ schema })
 
                 server = http.createServer(yoga)
-
-                getPort().then(newPort => {
-                  port = newPort
-                  server.listen(port)
-                })
               })
+          })
+
+          before(done => {
+            server.listen(0, () => {
+              port = server.address().port
+              done()
+            })
           })
 
           after(() => {

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
 const fs = require('fs')
 const path = require('path')
@@ -24,7 +23,7 @@ describe('Plugin', () => {
     const protocol = pluginToBeLoaded.split(':')[1] || pluginToBeLoaded
     const loadPlugin = pluginToBeLoaded.includes('node:') ? 'node:http2' : 'http2'
     describe(`http2/client, protocol ${pluginToBeLoaded}`, () => {
-      function server (app, port, listener) {
+      function server (app, listener) {
         let server
         if (pluginToBeLoaded === 'https' || pluginToBeLoaded === 'node:https') {
           process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
@@ -33,7 +32,7 @@ describe('Plugin', () => {
           server = require(loadPlugin).createServer()
         }
         server.on('stream', app)
-        server.listen(port, 'localhost', listener)
+        server.listen(0, 'localhost', () => listener(server.address().port))
         return server
       }
 
@@ -58,23 +57,22 @@ describe('Plugin', () => {
         })
 
         const spanProducerFn = (done) => {
-          getPort().then(port => {
-            const app = (stream, headers) => {
-              stream.respond({
-                ':status': 200
-              })
-              stream.end()
-            }
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
-
-              const req = client.request({ ':path': '/user', ':method': 'GET' })
-              req.on('error', done)
-
-              req.end()
+          const app = (stream, headers) => {
+            stream.respond({
+              ':status': 200
             })
+            stream.end()
+          }
+
+          appListener = server(app, port => {
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
+
+            const req = client.request({ ':path': '/user', ':method': 'GET' })
+            req.on('error', done)
+
+            req.end()
           })
         }
 
@@ -99,7 +97,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
@@ -116,16 +114,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/user', ':method': 'GET' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/user', ':method': 'GET' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -137,7 +133,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('span.kind', 'client')
@@ -146,16 +142,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({})
-                .on('error', done)
+            const req = client.request({})
+              .on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -167,7 +161,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
@@ -181,16 +175,14 @@ describe('Plugin', () => {
               port
             }
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(uri)
-                .on('error', done)
+            const client = http2
+              .connect(uri)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/user' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/user' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -202,7 +194,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
@@ -210,16 +202,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/user?foo=bar' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/user?foo=bar' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -232,7 +222,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
@@ -252,21 +242,19 @@ describe('Plugin', () => {
               port: 1337
             }
 
-            appListener = server(app, port, () => {
-              let client
-              if (protocol === 'https') {
-                client = http2.connect(incorrectConfig, correctConfig)
-              } else {
-                client = http2.connect(correctConfig, incorrectConfig)
-              }
+            let client
+            if (protocol === 'https') {
+              client = http2.connect(incorrectConfig, correctConfig)
+            } else {
+              client = http2.connect(correctConfig, incorrectConfig)
+            }
 
-              client.on('error', done)
+            client.on('error', done)
 
-              const req = client.request({ ':path': '/user' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/user' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -279,7 +267,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
@@ -299,21 +287,19 @@ describe('Plugin', () => {
               port: 1337
             }
 
-            appListener = server(app, port, () => {
-              let client
-              if (protocol === 'https') {
-                client = http2.connect(`${protocol}://remotehost:1337`, correctConfig)
-              } else {
-                client = http2.connect(`${protocol}://localhost:${port}`, incorrectConfig)
-              }
+            let client
+            if (protocol === 'https') {
+              client = http2.connect(`${protocol}://remotehost:1337`, correctConfig)
+            } else {
+              client = http2.connect(`${protocol}://localhost:${port}`, incorrectConfig)
+            }
 
-              client.on('error', done)
+            client.on('error', done)
 
-              const req = client.request({ ':path': '/user' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/user' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -325,7 +311,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/`)
@@ -338,16 +324,14 @@ describe('Plugin', () => {
               port
             }
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(uri)
-                .on('error', done)
+            const client = http2
+              .connect(uri)
+              .on('error', done)
 
-              const req = client.request({})
-              req.on('error', done)
+            const req = client.request({})
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -362,7 +346,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
@@ -370,16 +354,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({})
-              req.on('error', done)
+            const req = client.request({})
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -400,20 +382,18 @@ describe('Plugin', () => {
             }
           }
 
-          getPort().then(port => {
-            appListener = server(app, port, () => {
-              const headers = {
-                Authorization: 'AWS4-HMAC-SHA256 ...'
-              }
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+          appListener = server(app, port => {
+            const headers = {
+              Authorization: 'AWS4-HMAC-SHA256 ...'
+            }
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request(headers)
-              req.on('error', done)
+            const req = client.request(headers)
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -434,20 +414,18 @@ describe('Plugin', () => {
             }
           }
 
-          getPort().then(port => {
-            appListener = server(app, port, () => {
-              const headers = {
-                Authorization: ['AWS4-HMAC-SHA256 ...']
-              }
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+          appListener = server(app, port => {
+            const headers = {
+              Authorization: ['AWS4-HMAC-SHA256 ...']
+            }
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request(headers)
-              req.on('error', done)
+            const req = client.request(headers)
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -468,20 +446,18 @@ describe('Plugin', () => {
             }
           }
 
-          getPort().then(port => {
-            appListener = server(app, port, () => {
-              const headers = {
-                'X-Amz-Signature': 'abc123'
-              }
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+          appListener = server(app, port => {
+            const headers = {
+              'X-Amz-Signature': 'abc123'
+            }
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request(headers)
-              req.on('error', done)
+            const req = client.request(headers)
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -502,17 +478,15 @@ describe('Plugin', () => {
             }
           }
 
-          getPort().then(port => {
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+          appListener = server(app, port => {
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/?X-Amz-Signature=abc123' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/?X-Amz-Signature=abc123' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -524,53 +498,49 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+          appListener = server(app, port => {
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const span = {}
+            const span = {}
 
-              tracer.scope().activate(span, () => {
-                const req = client.request({ ':path': '/user' })
-                req.on('response', (headers, flags) => {
-                  expect(tracer.scope().active()).to.equal(span)
-                  done()
-                })
-
-                req.on('error', done)
-
-                req.end()
+            tracer.scope().activate(span, () => {
+              const req = client.request({ ':path': '/user' })
+              req.on('response', (headers, flags) => {
+                expect(tracer.scope().active()).to.equal(span)
+                done()
               })
+
+              req.on('error', done)
+
+              req.end()
             })
           })
         })
 
         it('should handle connection errors', done => {
-          getPort().then(port => {
-            let error
+          let error
 
-            agent
-              .use(traces => {
-                expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
-                expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
-                expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
-                expect(traces[0][0].meta).to.have.property('component', 'http2')
-                expect(traces[0][0].metrics).to.have.property('network.destination.port', port)
-              })
-              .then(done)
-              .catch(done)
+          agent
+            .use(traces => {
+              expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
+              expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
+              expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
+              expect(traces[0][0].meta).to.have.property('component', 'http2')
+              expect(traces[0][0].metrics).to.have.property('network.destination.port', 7357)
+            })
+            .then(done)
+            .catch(done)
 
-            const client = http2.connect(`${protocol}://localhost:${port}`)
-              // eslint-disable-next-line n/handle-callback-err
-              .on('error', (err) => {})
+          const client = http2.connect(`${protocol}://localhost:7357`)
+            // eslint-disable-next-line n/handle-callback-err
+            .on('error', (err) => {})
 
-            const req = client.request({ ':path': '/user' })
-              .on('error', (err) => { error = err })
+          const req = client.request({ ':path': '/user' })
+            .on('error', (err) => { error = err })
 
-            req.end()
-          })
+          req.end()
         })
 
         it('should not record HTTP 5XX responses as errors by default', done => {
@@ -581,7 +551,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('error', 0)
@@ -589,16 +559,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -610,7 +578,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('error', 1)
@@ -618,16 +586,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
 
@@ -640,7 +606,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 const spans = traces[0]
@@ -649,24 +615,22 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              // Activate a new parent span so we capture any double counting that may happen, otherwise double-counts
-              // would be siblings and our test would only capture 1 as a false positive.
-              const span = tracer.startSpan('http-test')
-              tracer.scope().activate(span, () => {
-                const client = http2.connect(`${protocol}://localhost:${port}`)
-                  .on('error', done)
+            // Activate a new parent span so we capture any double counting that may happen, otherwise double-counts
+            // would be siblings and our test would only capture 1 as a false positive.
+            const span = tracer.startSpan('http-test')
+            tracer.scope().activate(span, () => {
+              const client = http2.connect(`${protocol}://localhost:${port}`)
+                .on('error', done)
 
-                client.request({ ':path': '/test-1' })
-                  .on('error', done)
-                  .end()
+              client.request({ ':path': '/test-1' })
+                .on('error', done)
+                .end()
 
-                client.request({ ':path': '/user?test=2' })
-                  .on('error', done)
-                  .end()
+              client.request({ ':path': '/user?test=2' })
+                .on('error', done)
+                .end()
 
-                span.finish()
-              })
+              span.finish()
             })
           })
         })
@@ -697,7 +661,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('service', 'custom')
@@ -705,16 +669,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/user' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/user' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
       })
@@ -744,7 +706,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('error', 1)
@@ -752,16 +714,14 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2
-                .connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              const req = client.request({ ':path': '/user' })
-              req.on('error', done)
+            const req = client.request({ ':path': '/user' })
+            req.on('error', done)
 
-              req.end()
-            })
+            req.end()
           })
         })
       })
@@ -786,24 +746,23 @@ describe('Plugin', () => {
 
         withNamingSchema(
           (done) => {
-            getPort().then(port => {
-              serverPort = port
-              const app = (stream, headers) => {
-                stream.respond({
-                  ':status': 200
-                })
-                stream.end()
-              }
-              appListener = server(app, port, () => {
-                const client = http2
-                  .connect(`${protocol}://localhost:${port}`)
-                  .on('error', done)
-
-                const req = client.request({ ':path': '/user', ':method': 'GET' })
-                req.on('error', done)
-
-                req.end()
+            const app = (stream, headers) => {
+              stream.respond({
+                ':status': 200
               })
+              stream.end()
+            }
+            appListener = server(app, port => {
+              serverPort = port
+
+              const client = http2
+                .connect(`${protocol}://localhost:${port}`)
+                .on('error', done)
+
+              const req = client.request({ ':path': '/user', ':method': 'GET' })
+              req.on('error', done)
+
+              req.end()
             })
           },
           {
@@ -826,7 +785,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('service', `localhost:${port}`)
@@ -834,14 +793,12 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2.connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2.connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              client.request({ ':path': '/user' })
-                .on('error', done)
-                .end()
-            })
+            client.request({ ':path': '/user' })
+              .on('error', done)
+              .end()
           })
         })
       })
@@ -872,7 +829,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             agent
               .use(traces => {
                 const meta = traces[0][0].meta
@@ -883,14 +840,12 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2.connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2.connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              client.request({ ':path': '/user' })
-                .on('error', done)
-                .end()
-            })
+            client.request({ ':path': '/user' })
+              .on('error', done)
+              .end()
           })
         })
       })
@@ -920,7 +875,7 @@ describe('Plugin', () => {
             stream.end()
           }
 
-          getPort().then(port => {
+          appListener = server(app, port => {
             const timer = setTimeout(done, 100)
 
             agent
@@ -930,14 +885,12 @@ describe('Plugin', () => {
               })
               .catch(done)
 
-            appListener = server(app, port, () => {
-              const client = http2.connect(`${protocol}://localhost:${port}`)
-                .on('error', done)
+            const client = http2.connect(`${protocol}://localhost:${port}`)
+              .on('error', done)
 
-              client.request({ ':path': '/user' })
-                .on('error', done)
-                .end()
-            })
+            client.request({ ':path': '/user' })
+              .on('error', done)
+              .end()
           })
         })
       })

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { EventEmitter } = require('events')
-const getPort = require('get-port')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { rawExpectedSchema } = require('./naming')
 
@@ -63,12 +62,6 @@ describe('Plugin', () => {
         }
       })
 
-      beforeEach(() => {
-        return getPort().then(newPort => {
-          port = newPort
-        })
-      })
-
       afterEach(() => {
         appListener && appListener.close()
         app = null
@@ -96,7 +89,10 @@ describe('Plugin', () => {
         beforeEach(done => {
           const server = http2.createServer(listener)
           appListener = server
-            .listen(port, 'localhost', () => done())
+            .listen(0, 'localhost', () => {
+              port = appListener.address().port
+              done()
+            })
         })
 
         it('should send traces to agent', (done) => {

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const getPort = require('get-port')
 const dns = require('dns')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
@@ -36,11 +35,7 @@ describe('Plugin', () => {
             tracer = require('../../dd-trace')
             parent = tracer.startSpan('parent')
             parent.finish()
-
-            return getPort()
           }).then(_port => {
-            port = _port
-
             return new Promise(resolve => setImmediate(resolve))
           })
       })
@@ -49,7 +44,10 @@ describe('Plugin', () => {
         tcp = new net.Server(socket => {
           socket.write('')
         })
-        tcp.listen(port, () => done())
+        tcp.listen(0, () => {
+          port = tcp.address().port
+          done()
+        })
       })
 
       beforeEach(done => {

--- a/packages/datadog-plugin-paperplane/test/index.spec.js
+++ b/packages/datadog-plugin-paperplane/test/index.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const axios = require('axios')
-const getPort = require('get-port')
 const semver = require('semver')
 
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -76,7 +75,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -94,11 +95,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -113,7 +112,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -123,11 +124,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/1`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/1`)
+              .catch(done)
           })
         })
 
@@ -155,7 +154,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -165,11 +166,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/123`)
+              .catch(done)
           })
         })
 
@@ -191,7 +190,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -201,11 +202,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/123`)
+              .catch(done)
           })
         })
 
@@ -220,7 +219,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -230,13 +231,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -247,7 +246,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -257,11 +258,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/app`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/app`)
+              .catch(done)
           })
         })
 
@@ -280,7 +279,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -290,10 +291,8 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios.get(`http://localhost:${port}/app/user/123`)
-                .catch(done)
-            })
+            axios.get(`http://localhost:${port}/app/user/123`)
+              .catch(done)
           })
         })
 
@@ -308,7 +307,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -318,17 +319,15 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  headers: {
-                    'x-datadog-trace-id': '1234',
-                    'x-datadog-parent-id': '5678',
-                    'ot-baggage-foo': 'bar'
-                  }
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                headers: {
+                  'x-datadog-trace-id': '1234',
+                  'x-datadog-parent-id': '5678',
+                  'ot-baggage-foo': 'bar'
+                }
+              })
+              .catch(done)
           })
         })
 
@@ -343,7 +342,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -355,13 +356,11 @@ describe('Plugin', () => {
               done()
             })
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -376,7 +375,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent.use(traces => {
               const spans = sort(traces[0])
 
@@ -388,13 +389,11 @@ describe('Plugin', () => {
               done()
             })
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 400
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 400
+              })
+              .catch(done)
           })
         })
 
@@ -405,7 +404,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -417,13 +418,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 500
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 500
+              })
+              .catch(done)
           })
         })
 
@@ -477,7 +476,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -487,11 +488,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -506,7 +505,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -516,13 +517,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  validateStatus: status => status === 400
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                validateStatus: status => status === 400
+              })
+              .catch(done)
           })
         })
 
@@ -537,7 +536,9 @@ describe('Plugin', () => {
 
           server = http.createServer(mount({ app, cry, logger }))
 
-          getPort().then(port => {
+          server.listen(0, 'localhost', () => {
+            const port = server.address().port
+
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -547,13 +548,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`, {
-                  headers: { 'User-Agent': 'test' }
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user`, {
+                headers: { 'User-Agent': 'test' }
+              })
+              .catch(done)
           })
         })
 

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -2,7 +2,6 @@
 
 const { AsyncLocalStorage } = require('async_hooks')
 const axios = require('axios')
-const getPort = require('get-port')
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -35,7 +34,9 @@ describe('Plugin', () => {
         it('should do automatic instrumentation', done => {
           const server = restify.createServer()
 
-          getPort().then(port => {
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'restify.request')
@@ -51,11 +52,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(() => {})
-            })
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(() => {})
           })
         })
 
@@ -67,7 +66,9 @@ describe('Plugin', () => {
             return next()
           })
 
-          getPort().then(port => {
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
@@ -77,11 +78,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/123`)
+              .catch(done)
           })
         })
 
@@ -96,7 +95,9 @@ describe('Plugin', () => {
             }
           )
 
-          getPort().then(port => {
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
@@ -106,11 +107,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/123`)
+              .catch(done)
           })
         })
 
@@ -135,7 +134,9 @@ describe('Plugin', () => {
             }
           )
 
-          getPort().then(port => {
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 expect(warningSpy).to.not.have.been.called
@@ -143,11 +144,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/123`)
+              .catch(done)
           })
         })
 
@@ -184,12 +183,12 @@ describe('Plugin', () => {
             next()
           })
 
-          getPort().then(port => {
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -201,7 +200,9 @@ describe('Plugin', () => {
             return next()
           }])
 
-          getPort().then(port => {
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
@@ -211,11 +212,9 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user/123`)
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/user/123`)
+              .catch(done)
           })
         })
 
@@ -239,12 +238,12 @@ describe('Plugin', () => {
             res.end()
           })
 
-          getPort().then(port => {
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
+            axios
+              .get(`http://localhost:${port}/user`)
+              .catch(done)
           })
         })
 
@@ -264,7 +263,9 @@ describe('Plugin', () => {
             throw new Error('uncaught')
           }])
 
-          getPort().then(port => {
+          appListener = server.listen(0, 'localhost', () => {
+            const port = appListener.address().port
+
             agent
               .use(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /error')
@@ -276,13 +277,11 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            appListener = server.listen(port, 'localhost', () => {
-              axios
-                .get(`http://localhost:${port}/error`, {
-                  validateStatus: status => status === 599
-                })
-                .catch(done)
-            })
+            axios
+              .get(`http://localhost:${port}/error`, {
+                validateStatus: status => status === 599
+              })
+              .catch(done)
           })
         })
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove most get-port usage in plugin tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Follow-up of #4426