### PR TITLE
tracing(aws): add configuration option to inject all messages with trace context during SQS, SNS, and Kinesis batch send operations

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -227,6 +227,7 @@ const elasticsearchOptions: plugins.elasticsearch = {
 const awsSdkOptions: plugins.aws_sdk = {
   service: 'test',
   splitByAwsService: false,
+  batchPropagationEnabled: false,
   hooks: {
     request: (span?: Span, response?) => {},
   },

--- a/index.d.ts
+++ b/index.d.ts
@@ -1223,6 +1223,13 @@ declare namespace tracer {
       splitByAwsService?: boolean;
 
       /**
+       * Whether to inject all messages during batch AWS SQS, Kinesis, and SNS send operations. Normal
+       * behavior is to inject the first message in batch send operations.
+       * @default false
+       */
+      batchPropagationEnabled?: boolean;
+
+      /**
        * Hooks to run before spans are finished.
        */
       hooks?: {

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -20,7 +20,8 @@ function wrapRequest (send) {
 
     return innerAr.runInAsyncScope(() => {
       this.on('complete', innerAr.bind(response => {
-        channel(`apm:aws:request:complete:${channelSuffix}`).publish({ response })
+        const cbExists = typeof cb === 'function'
+        channel(`apm:aws:request:complete:${channelSuffix}`).publish({ response, cbExists })
       }))
 
       startCh.publish({

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -165,6 +165,7 @@ function normalizeConfig (config, serviceIdentifier) {
 
   return Object.assign({}, config, specificConfig, {
     splitByAwsService: config.splitByAwsService !== false,
+    batchPropagationEnabled: config.batchPropagationEnabled !== false,
     hooks
   })
 }

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -64,11 +64,17 @@ class BaseAwsSdkPlugin extends ClientPlugin {
       span.setTag('region', region)
     })
 
-    this.addSub(`apm:aws:request:complete:${this.serviceIdentifier}`, ({ response }) => {
+    this.addSub(`apm:aws:request:complete:${this.serviceIdentifier}`, ({ response, cbExists = false }) => {
       const store = storage.getStore()
       if (!store) return
       const { span } = store
       if (!span) return
+      // try to extract DSM context from response if no callback exists as extraction normally happens in CB
+      if (!cbExists && this.serviceIdentifier === 'sqs') {
+        const params = response.request.params
+        const operation = response.request.operation
+        this.responseExtractDSMContext(operation, params, response.data, span)
+      }
       this.addResponseTags(span, response)
       this.finish(span, response, response.error)
     })

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -52,7 +52,7 @@ class Kinesis extends BaseAwsSdkPlugin {
 
         // extract DSM context after as we might not have a parent-child but may have a DSM context
         this.responseExtractDSMContext(
-          request.operation, response, span || null, streamName
+          request.operation, response, span || null, { streamName }
         )
       }
     })
@@ -100,7 +100,8 @@ class Kinesis extends BaseAwsSdkPlugin {
     }
   }
 
-  responseExtractDSMContext (operation, response, span, streamName) {
+  responseExtractDSMContext (operation, params, response, span, kwargs = {}) {
+    const { streamName } = kwargs
     if (!this.config.dsmEnabled) return
     if (operation !== 'getRecords') return
     if (!response || !response.Records || !response.Records[0]) return

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -52,7 +52,7 @@ class Kinesis extends BaseAwsSdkPlugin {
 
         // extract DSM context after as we might not have a parent-child but may have a DSM context
         this.responseExtractDSMContext(
-          request.operation, response, span || null, { streamName }
+          request.operation, request.params, response, span || null, { streamName }
         )
       }
     })

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -152,7 +152,7 @@ class Kinesis extends BaseAwsSdkPlugin {
       case 'putRecords':
         stream = params.StreamArn ? params.StreamArn : (params.StreamName ? params.StreamName : '')
         for (let i = 0; i < params.Records.length; i++) {
-          this.injectToMessage(span, params.Records[i], stream, i === 0)
+          this.injectToMessage(span, params.Records[i], stream, i === 0 || this.config.batchPropagationEnabled)
         }
     }
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -152,7 +152,12 @@ class Kinesis extends BaseAwsSdkPlugin {
       case 'putRecords':
         stream = params.StreamArn ? params.StreamArn : (params.StreamName ? params.StreamName : '')
         for (let i = 0; i < params.Records.length; i++) {
-          this.injectToMessage(span, params.Records[i], stream, i === 0 || this.config.batchPropagationEnabled)
+          this.injectToMessage(
+            span,
+            params.Records[i],
+            stream,
+            i === 0 || (this.config.kinesis && this.config.kinesis.batchPropagationEnabled)
+          )
         }
     }
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -59,7 +59,9 @@ class Sns extends BaseAwsSdkPlugin {
         break
       case 'publishBatch':
         for (let i = 0; i < params.PublishBatchRequestEntries.length; i++) {
-          this.injectToMessage(span, params.PublishBatchRequestEntries[i], params.TopicArn, i === 0)
+          this.injectToMessage(
+            span, params.PublishBatchRequestEntries[i], params.TopicArn, i === 0 || this.config.batchPropagationEnabled
+          )
         }
         break
     }

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -60,7 +60,10 @@ class Sns extends BaseAwsSdkPlugin {
       case 'publishBatch':
         for (let i = 0; i < params.PublishBatchRequestEntries.length; i++) {
           this.injectToMessage(
-            span, params.PublishBatchRequestEntries[i], params.TopicArn, i === 0 || this.config.batchPropagationEnabled
+            span,
+            params.PublishBatchRequestEntries[i],
+            params.TopicArn,
+            i === 0 || (this.config.sns && this.config.sns.batchPropagationEnabled)
           )
         }
         break

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -218,7 +218,7 @@ class Sqs extends BaseAwsSdkPlugin {
         break
       case 'sendMessageBatch':
         for (let i = 0; i < params.Entries.length; i++) {
-          this.injectToMessage(span, params.Entries[i], params.QueueUrl, i === 0)
+          this.injectToMessage(span, params.Entries[i], params.QueueUrl, i === 0 || this.config.batchPropagationEnabled)
         }
         break
       case 'receiveMessage':

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -237,17 +237,6 @@ class Sqs extends BaseAwsSdkPlugin {
           params.MessageAttributeNames.push('_datadog')
         }
         break
-      case 'receiveMessage':
-        if (!params.MessageAttributeNames) {
-          params.MessageAttributeNames = ['_datadog']
-        } else if (
-          !params.MessageAttributeNames.includes('_datadog') &&
-          !params.MessageAttributeNames.includes('.*') &&
-          !params.MessageAttributeNames.includes('All')
-        ) {
-          params.MessageAttributeNames.push('_datadog')
-        }
-        break
     }
   }
 

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -218,7 +218,12 @@ class Sqs extends BaseAwsSdkPlugin {
         break
       case 'sendMessageBatch':
         for (let i = 0; i < params.Entries.length; i++) {
-          this.injectToMessage(span, params.Entries[i], params.QueueUrl, i === 0 || this.config.batchPropagationEnabled)
+          this.injectToMessage(
+            span,
+            params.Entries[i],
+            params.QueueUrl,
+            i === 0 || (this.config.sqs && this.config.sqs.batchPropagationEnabled)
+          )
         }
         break
       case 'receiveMessage':

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -23,7 +23,7 @@ class Sqs extends BaseAwsSdkPlugin {
       const plugin = this
       const contextExtraction = this.responseExtract(request.params, request.operation, response)
       let span
-      let parsedMessageAttributes
+      let parsedMessageAttributes = null
       if (contextExtraction && contextExtraction.datadogContext) {
         obj.needsFinish = true
         const options = {
@@ -39,8 +39,9 @@ class Sqs extends BaseAwsSdkPlugin {
         this.enter(span, store)
       }
       // extract DSM context after as we might not have a parent-child but may have a DSM context
+
       this.responseExtractDSMContext(
-        request.operation, request.params, response, span || null, parsedMessageAttributes || null
+        request.operation, request.params, response, span || null, { parsedMessageAttributes }
       )
     })
 

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -95,13 +95,13 @@ describe('Kinesis', function () {
         helpers.putTestRecords(kinesis, streamName, (err, data) => {
           if (err) return done(err)
 
-          helpers.getTestRecord(kinesis, streamName, data, (err, data) => {
+          helpers.getTestRecord(kinesis, streamName, data.Records[0], (err, data) => {
             if (err) return done(err)
 
             for (const record in data.Records) {
-              const data = Buffer.from(record.Data).toString()
-              expect(data).to.have.property('_datadog')
-              expect(data._datadog).to.have.property('x-datadog-trace-id')
+              const recordData = JSON.parse(Buffer.from(data.Records[record].Data).toString())
+              expect(recordData).to.have.property('_datadog')
+              expect(recordData._datadog).to.have.property('x-datadog-trace-id')
             }
 
             done()

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -52,7 +52,7 @@ describe('Kinesis', function () {
 
     describe('no configuration', () => {
       before(() => {
-        return agent.load('aws-sdk', { kinesis: { dsmEnabled: false } }, { dsmEnabled: true })
+        return agent.load('aws-sdk', { kinesis: { dsmEnabled: false, batchPropagationEnabled: true } }, { dsmEnabled: true })
       })
 
       before(done => {
@@ -85,6 +85,24 @@ describe('Kinesis', function () {
 
             expect(data).to.have.property('_datadog')
             expect(data._datadog).to.have.property('x-datadog-trace-id')
+
+            done()
+          })
+        })
+      })
+
+      it('injects trace context to each message during Kinesis putRecord and batchPropagationEnabled', done => {
+        helpers.putTestRecords(kinesis, streamName, (err, data) => {
+          if (err) return done(err)
+
+          helpers.getTestRecord(kinesis, streamName, data, (err, data) => {
+            if (err) return done(err)
+
+            for (const record in data.Records) {
+              const data = Buffer.from(record.Data).toString()
+              expect(data).to.have.property('_datadog')
+              expect(data._datadog).to.have.property('x-datadog-trace-id')
+            }
 
             done()
           })

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -8,7 +8,6 @@ const { setup } = require('./spec_helpers')
 const { rawExpectedSchema } = require('./sns-naming')
 
 describe('Sns', function () {
-  this.timeout(0)
   setup()
 
   withVersions('aws-sdk', ['aws-sdk', '@aws-sdk/smithy-client'], (version, moduleName) => {

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -23,7 +23,6 @@ const queueOptionsDsm = getQueueParams(queueNameDSM)
 
 describe('Plugin', () => {
   describe('aws-sdk (sqs)', function () {
-    this.timeout(10000)
     setup()
 
     withVersions('aws-sdk', ['aws-sdk', '@aws-sdk/smithy-client'], (version, moduleName) => {

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
+const semver = require('semver')
 const { rawExpectedSchema } = require('./sqs-naming')
 
 const queueName = 'SQS_QUEUE_NAME'
@@ -408,24 +409,33 @@ describe('Plugin', () => {
           })
         })
 
-        it('Should set pathway hash tag on a span when consuming and promise() was used over a callback',
-          async (done) => {
-            await sqs.sendMessage({ MessageBody: 'test DSM', QueueUrl: QueueUrlDsm }).promise()
-            await sqs.receiveMessage({ QueueUrl: QueueUrlDsm }).promise()
+        if (sqsClientName === 'aws-sdk' && semver.intersects(version, '>=2.3')) {
+          it('Should set pathway hash tag on a span when consuming and promise() was used over a callback',
+            async () => {
+              await sqs.sendMessage({ MessageBody: 'test DSM', QueueUrl: QueueUrlDsm })
+              await sqs.receiveMessage({ QueueUrl: QueueUrlDsm }).promise()
 
-            let consumeSpanMeta = {}
-            agent.use(traces => {
-              const span = traces[0][0]
+              let consumeSpanMeta = {}
+              return new Promise((resolve, reject) => {
+                agent.use(traces => {
+                  const span = traces[0][0]
 
-              if (span.name === 'aws.response') {
-                consumeSpanMeta = span.meta
-              }
+                  if (span.name === 'aws.request' && span.meta['aws.operation'] === 'receiveMessage') {
+                    consumeSpanMeta = span.meta
+                  }
 
-              expect(consumeSpanMeta).to.include({
-                'pathway.hash': expectedConsumerHash
+                  try {
+                    expect(consumeSpanMeta).to.include({
+                      'pathway.hash': expectedConsumerHash
+                    })
+                    resolve()
+                  } catch (error) {
+                    reject(error)
+                  }
+                })
               })
-            }).then(done, done)
-          })
+            })
+        }
 
         it('Should emit DSM stats to the agent when sending a message', done => {
           agent.expectPipelineStats(dsmStats => {

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -408,6 +408,25 @@ describe('Plugin', () => {
           })
         })
 
+        it('Should set pathway hash tag on a span when consuming and promise() was used over a callback',
+          async (done) => {
+            await sqs.sendMessage({ MessageBody: 'test DSM', QueueUrl: QueueUrlDsm }).promise()
+            await sqs.receiveMessage({ QueueUrl: QueueUrlDsm }).promise()
+
+            let consumeSpanMeta = {}
+            agent.use(traces => {
+              const span = traces[0][0]
+
+              if (span.name === 'aws.response') {
+                consumeSpanMeta = span.meta
+              }
+
+              expect(consumeSpanMeta).to.include({
+                'pathway.hash': expectedConsumerHash
+              })
+            }).then(done, done)
+          })
+
         it('Should emit DSM stats to the agent when sending a message', done => {
           agent.expectPipelineStats(dsmStats => {
             let statsPointsReceived = 0


### PR DESCRIPTION
### What does this PR do?
Adds an `aws-sdk` plugin config option to inject all AWS messages during batch send operations with trace context (SQS, SNS, Kinesis).
The config option can be enabled for all three services using the following:
`tracer.use('aws-sdk', { kinesis: { batchPropagationEnabled: true }, sns: { batchPropagationEnabled: true }, sqs: { batchPropagationEnabled: true } })`

### Motivation
Customer request

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


