### PR TITLE
deps: upgrade lru-cache@^7.14.0 -> ^10.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "koalas": "^1.0.2",
     "limiter": "1.1.5",
     "lodash.sortby": "^4.7.0",
-    "lru-cache": "^7.14.0",
+    "lru-cache": "^10.2.2",
     "module-details-from-path": "^1.0.3",
     "msgpack-lite": "^0.1.26",
     "opentracing": ">=0.12.1",

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const { MANUAL_KEEP } = require('../../../../../ext/tags')
-const LRU = require('lru-cache')
+const { LRUCache } = require('lru-cache')
 const vulnerabilitiesFormatter = require('./vulnerabilities-formatter')
 const { IAST_ENABLED_TAG_KEY, IAST_JSON_TAG_KEY } = require('./tags')
 const standalone = require('../standalone')
 
 const VULNERABILITIES_KEY = 'vulnerabilities'
 const VULNERABILITY_HASHES_MAX_SIZE = 1000
-const VULNERABILITY_HASHES = new LRU({ max: VULNERABILITY_HASHES_MAX_SIZE })
+const VULNERABILITY_HASHES = new LRUCache({ max: VULNERABILITY_HASHES_MAX_SIZE })
 const RESET_VULNERABILITY_CACHE_INTERVAL = 60 * 60 * 1000 // 1 hour
 
 let tracer

--- a/packages/dd-trace/src/datastreams/pathway.js
+++ b/packages/dd-trace/src/datastreams/pathway.js
@@ -3,7 +3,7 @@
 // this inconsistency is ok because hashes do not need to be consistent across services
 const crypto = require('crypto')
 const { encodeVarint, decodeVarint } = require('./encoding')
-const LRUCache = require('lru-cache')
+const { LRUCache } = require('lru-cache')
 
 const options = { max: 500 }
 const cache = new LRUCache(options)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,6 +3455,11 @@ loupe@^2.3.1:
   dependencies:
     get-func-name "^2.0.0"
 
+lru-cache@^10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
+  integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz"


### PR DESCRIPTION
### What does this PR do?
- upgrades lru-cache from ^7.14.0 to latest ^10.2.2

### Motivation
- newer is cooler