### PR TITLE
split parametric tests on multiple machines

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -84,6 +84,8 @@ jobs:
           path: artifact.tar.gz
 
   parametric:
+    needs:
+      - build-artifacts
     uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -84,7 +84,7 @@ jobs:
           path: artifact.tar.gz
 
   parametric:
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
     secrets: inherit
     with:
       library: nodejs

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -84,12 +84,10 @@ jobs:
           path: artifact.tar.gz
 
   parametric:
-    needs:
-      - build-artifacts
-    uses:  DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml
     secrets: inherit
     with:
-      scenarios: PARAMETRIC
       library: nodejs
       binaries_artifact: system_tests_binaries
-      _experimental_parametric_job_count: 8
+      _experimental_job_count: 8
+      _experimental_job_matrix: '[1,2,3,4,5,6,7,8]'

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -92,3 +92,4 @@ jobs:
       scenarios: PARAMETRIC
       library: nodejs
       binaries_artifact: system_tests_binaries
+      _experimental_parametric_job_count: 8


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split parametric tests on multiple machines.

### Motivation
<!-- What inspired you to submit this pull request? -->

Using xdist to split across cores doesn't improve performance all that much.