### PR TITLE
[CI] Use system-tests reusable workflow for PARAMETRIC scenario

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -11,6 +11,19 @@ on:
     - cron:  '00 04 * * 2-6'
 
 jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dd-trace-js
+        uses: actions/checkout@v4
+        with:
+          path: dd-trace-js
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: system_tests_binaries
+          path: .
+
   get-essential-scenarios:
     runs-on: ubuntu-latest
     outputs:
@@ -71,31 +84,11 @@ jobs:
           path: artifact.tar.gz
 
   parametric:
-    runs-on: ubuntu-latest
-    env:
-      TEST_LIBRARY: nodejs
-    steps:
-      - name: Checkout system tests
-        uses: actions/checkout@v4
-        with:
-          repository: 'DataDog/system-tests'
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-      - name: Checkout dd-trace-js
-        uses: actions/checkout@v4
-        with:
-          path: 'binaries/dd-trace-js'
-      - name: Build
-        run: ./build.sh -i runner
-      - name: Run
-        run: ./run.sh PARAMETRIC
-      - name: Compress artifact
-        if: ${{ always() }}
-        run: tar -czvf artifact.tar.gz $(ls | grep logs)
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: logs_parametric
-          path: artifact.tar.gz
+    needs:
+      - build-artifacts
+    uses:  DataDog/system-tests/.github/workflows/system-tests.yml@main
+    secrets: inherit
+    with:
+      scenarios: PARAMETRIC
+      library: nodejs
+      binaries_artifact: system_tests_binaries


### PR DESCRIPTION
### What does this PR do?
Use official reusable workflow for system tests (definition [here](https://github.com/DataDog/system-tests/blob/main/.github/workflows/system-tests.yml))

### Motivation
Faster CI time

Ci time comparizon 

|what|before|after|
|-|-|-|
| Build artifact | N/A | [3s](https://github.com/DataDog/dd-trace-js/actions/runs/9665328177/job/26662155672?pr=4438) but in parallel with [get-essential-scenarios](https://github.com/DataDog/dd-trace-js/actions/runs/9665328177/job/26662151630?pr=4438), also 3s, so no extra time |
|get-parameters| N/A |  [7s](https://github.com/DataDog/dd-trace-js/actions/runs/9665328177/job/26662205899?pr=4438) |
|install runner| [62s](https://github.com/DataDog/dd-trace-js/actions/runs/9664843411/job/26660512724#step:5:10) | [3s](https://github.com/DataDog/dd-trace-js/actions/runs/9665328177/job/26662214848?pr=4438) |


==> gain = 52s


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


