### PR TITLE
split couchbase tests by major version

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -365,7 +365,7 @@ jobs:
   couchbase:
     strategy:
       matrix:
-        range: ['2', '3', '>=4']
+        range: ['^2.6.12', '^3.0.7', '>=4']
     runs-on: ubuntu-latest
     services:
       couchbase:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -363,6 +363,9 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   couchbase:
+    strategy:
+      matrix:
+        range: ['2', '3', '>=4']
     runs-on: ubuntu-latest
     services:
       couchbase:
@@ -373,6 +376,7 @@ jobs:
     env:
       PLUGINS: couchbase
       SERVICES: couchbase
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -365,7 +365,7 @@ jobs:
   couchbase:
     strategy:
       matrix:
-        range: ['^2.6.12', '^3.0.7', '>=4']
+        range: ['^2.6.12', '^3.0.7', '>=4.2.0']
     runs-on: ubuntu-latest
     services:
       couchbase:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split couchbase tests by major version.

### Motivation
<!-- What inspired you to submit this pull request? -->

Couchbase takes a long time to build, and this is made even worse by building multiple versions sequentially.