### PR TITLE
Disable crashing pugins

### DIFF
--- a/packages/dd-trace/test/plugins/plugin.spec.js
+++ b/packages/dd-trace/test/plugins/plugin.spec.js
@@ -1,0 +1,69 @@
+'use strict'
+
+require('../setup/tap')
+
+const Plugin = require('../../src/plugins/plugin')
+const plugins = require('../../src/plugins')
+const { channel } = require('dc-polyfill')
+
+describe('Plugin', () => {
+  class BadPlugin extends Plugin {
+    static get id () { return 'badPlugin' }
+
+    constructor () {
+      super()
+      this.addSub('apm:badPlugin:start', this.start)
+    }
+
+    start () {
+      throw new Error('this is one bad plugin')
+    }
+  }
+
+  class GoodPlugin extends Plugin {
+    static get id () { return 'goodPlugin' }
+
+    constructor () {
+      super()
+      this.addSub('apm:badPlugin:start', this.start)
+    }
+
+    start () {
+      //
+    }
+  }
+
+  const testPlugins = { badPlugin: BadPlugin, goodPlugin: GoodPlugin }
+  const loadChannel = channel('dd-trace:instrumentation:load')
+
+  before(() => {
+    for (const [name, cls] of Object.entries(testPlugins)) {
+      plugins[name] = cls
+      loadChannel.publish({ name })
+    }
+  })
+  after(() => { Object.keys(testPlugins).forEach(name => delete plugins[name]) })
+
+  it('should disable upon error', () => {
+
+    const plugin = new BadPlugin()
+    plugin.configure({ enabled: true })
+
+    expect(plugin._enabled).to.be.true
+
+    channel('apm:badPlugin:start').publish({ foo: 'bar' })
+
+    expect(plugin._enabled).to.be.false
+  })
+
+  it('should not disable with no error', () => {
+    const plugin = new GoodPlugin()
+    plugin.configure({ enabled: true })
+
+    expect(plugin._enabled).to.be.true
+
+    channel('apm:goodPlugin:start').publish({ foo: 'bar' })
+
+    expect(plugin._enabled).to.be.true
+  })
+})


### PR DESCRIPTION
### What does this PR do?

When one of the plugins subscriptions fails, catch it and disable the whole plugin.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

If we run into an unforeseen incompatibility on the Diagnostics Channel subscriber side, we don't want to crash user apps.


