### PR TITLE
split nextjs tests by major versions

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -938,9 +938,11 @@ jobs:
         version:
           - 18
           - latest
+        range: ['>=9.5 <11.1', '>=11.1 <13.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: next
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -938,7 +938,7 @@ jobs:
         version:
           - 18
           - latest
-        range: ['>=9.5 <11.1', '>=11.1 <13.2']
+        range: ['>=9.5 <11.1', '>=11.1 <13.2', '>=13.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: next

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -80,7 +80,7 @@ async function assertVersions () {
 }
 
 async function assertInstrumentation (instrumentation, external) {
-  const versions = process.env.PACKAGE_VERSION_RANGE
+  const versions = process.env.PACKAGE_VERSION_RANGE && !external
     ? [process.env.PACKAGE_VERSION_RANGE]
     : [].concat(instrumentation.versions || [])
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split Next.js tests by major version.

### Motivation
<!-- What inspired you to submit this pull request? -->

Next.js takes a long time to build, and this is made even worse by building multiple versions sequentially.