### PR TITLE
decrease all green poll interval and timeout

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -12,5 +12,6 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@v1
         with:
-          retries: 20 # once per minute, some checks take up to 15 min
+          retries: 20 # ~3 times per minute, some checks take up to 5 min
+          polling_interval: '0.3'
           checks_exclude: devflow.*


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Decrease "All Green" poll interval to every 18 seconds and timeout to 6 minutes.

### Motivation
<!-- What inspired you to submit this pull request? -->

The tests were just made faster over the last few days, and there should be a check in place to make sure they don't become slow again.