### PR TITLE
[appsec] do not ping `ifconfig.pro` in RASP tests

### DIFF
--- a/packages/dd-trace/test/appsec/rasp.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp.express.plugin.spec.js
@@ -108,7 +108,7 @@ withVersions('express', 'express', expressVersion => {
               res.end('end')
             }
 
-            axios.get('/?host=ifconfig.pro')
+            axios.get('/?host=localhost/ifconfig.pro')
 
             await agent.use((traces) => {
               const span = getWebSpan(traces)

--- a/packages/dd-trace/test/appsec/rasp.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp.express.plugin.spec.js
@@ -85,7 +85,7 @@ withVersions('express', 'express', expressVersion => {
               res.end('end')
             }
 
-            axios.get('/?host=ifconfig.pro')
+            axios.get('/?host=localhost/ifconfig.pro')
 
             await agent.use((traces) => {
               const span = getWebSpan(traces)


### PR DESCRIPTION
Pinging an actual domain in tests is not sparking joy.