### PR TITLE
fix(openai): handle `image_url` option on chat completion request gracefully

### DIFF
--- a/packages/datadog-plugin-openai/src/index.js
+++ b/packages/datadog-plugin-openai/src/index.js
@@ -330,9 +330,22 @@ function countPromptTokens (methodName, payload, model) {
     const messages = payload.messages
     for (const message of messages) {
       const content = message.content
-      const { tokens, estimated } = countTokens(content, model)
-      promptTokens += tokens
-      promptEstimated = estimated
+      if (typeof content === 'string') {
+        const { tokens, estimated } = countTokens(content, model)
+        promptTokens += tokens
+        promptEstimated = estimated
+      } else if (Array.isArray(content)) {
+        for (const c of content) {
+          if (c.type === 'text') {
+            const { tokens, estimated } = countTokens(c.text, model)
+            promptTokens += tokens
+            promptEstimated = estimated
+          }
+          // unsupported token computation for image_url
+          // as even though URL is a string, its true token count
+          // is based on the image itself, something onerous to do client-side
+        }
+      }
     }
   } else if (methodName === 'completions.create') {
     let prompt = payload.prompt

--- a/packages/datadog-plugin-openai/src/index.js
+++ b/packages/datadog-plugin-openai/src/index.js
@@ -780,25 +780,26 @@ function truncateText (text) {
   return text
 }
 
-function tagChatCompletionRequestContent (content, contentIdx, tags) {
-  if (typeof content === 'string') {
-    tags[`openai.request.messages.${contentIdx}.content`] = content
-  } else if (Array.isArray(content)) {
+function tagChatCompletionRequestContent (contents, messageIdx, tags) {
+  if (typeof contents === 'string') {
+    tags[`openai.request.messages.${messageIdx}.content`] = contents
+  } else if (Array.isArray(contents)) {
     // content can also be an array of objects
     // which represent text input or image url
-    for (const idx in content) {
-      const c = content[idx]
-      const type = c.type
-      tags[`openai.request.messages.${contentIdx}.content.${idx}.type`] = c.type
+    for (const contentIdx in contents) {
+      const content = contents[contentIdx]
+      const type = content.type
+      tags[`openai.request.messages.${messageIdx}.content.${contentIdx}.type`] = content.type
       if (type === 'text') {
-        tags[`openai.request.messages.${contentIdx}.content.${idx}.text`] = truncateText(c.text)
+        tags[`openai.request.messages.${messageIdx}.content.${contentIdx}.text`] = truncateText(content.text)
       } else if (type === 'image_url') {
-        tags[`openai.request.messages.${contentIdx}.content.${idx}.image_url.url`] = truncateText(c.image_url.url)
+        tags[`openai.request.messages.${messageIdx}.content.${contentIdx}.image_url.url`] =
+          truncateText(content.image_url.url)
       }
-      // unsupported type otherwise
+      // unsupported type otherwise, won't be tagged
     }
   }
-  // unsupported type otherwise
+  // unsupported type otherwise, won't be tagged
 }
 
 // The server almost always responds with JSON

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -2842,6 +2842,99 @@ describe('Plugin', () => {
           })
         })
 
+        describe('create chat completion with image_url in request', () => {
+          let scope
+
+          beforeEach(() => {
+            scope = nock('https://api.openai.com:443')
+              .post('/v1/chat/completions')
+              .reply(200, {
+                id: 'chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN',
+                object: 'chat.completion',
+                created: 1684188020,
+                model: 'gpt-4-visual-preview',
+                choices: [{
+                  message: {
+                    role: 'assistant',
+                    content: 'This is a picture of a bird.',
+                    name: 'hunter2'
+                  },
+                  finish_reason: 'length',
+                  index: 0
+                }]
+              }, [
+                'Date', 'Mon, 15 May 2023 22:00:21 GMT',
+                'Content-Type', 'application/json',
+                'Content-Length', '327',
+                'access-control-allow-origin', '*',
+                'openai-model', 'gpt-3.5-turbo-0301',
+                'openai-organization', 'kill-9',
+                'openai-processing-ms', '713',
+                'openai-version', '2020-10-01'
+              ])
+          })
+
+          afterEach(() => {
+            nock.removeInterceptor(scope)
+            scope.done()
+          })
+
+          it('should tag image_url', async () => {
+            const checkTraces = agent
+              .use(traces => {
+                const span = traces[0][0]
+                expect(span.meta).to.have.property('openai.request.messages.0.content.0.type', 'text')
+                expect(span.meta).to.have.property('openai.request.messages.0.content.0.text', 'Describe this picture')
+                expect(span.meta).to.have.property('openai.request.messages.0.content.1.type', 'image_url')
+                expect(span.meta).to.have.property(
+                  'openai.request.messages.0.content.1.image_url.url', 'dummy/url/pretty_bird.png'
+                )
+              })
+
+            const params = {
+              model: 'gpt-4-visual-preview',
+              messages: [
+                {
+                  role: 'user',
+                  name: 'hunter2',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Describe this picture'
+                    },
+                    {
+                      type: 'image_url',
+                      image_url: {
+                        url: 'dummy/url/pretty_bird.png'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+
+            if (semver.satisfies(realVersion, '>=4.0.0')) {
+              const result = await openai.chat.completions.create(params)
+
+              expect(result.id).to.eql('chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN')
+              expect(result.model).to.eql('gpt-4-visual-preview')
+              expect(result.choices[0].message.role).to.eql('assistant')
+              expect(result.choices[0].message.content).to.eql('This is a picture of a bird.')
+              expect(result.choices[0].finish_reason).to.eql('length')
+            } else {
+              const result = await openai.createChatCompletion(params)
+
+              expect(result.data.id).to.eql('chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN')
+              expect(result.data.model).to.eql('gpt-4-visual-preview')
+              expect(result.data.choices[0].message.role).to.eql('assistant')
+              expect(result.data.choices[0].message.content).to.eql('This is a picture of a bird.')
+              expect(result.data.choices[0].finish_reason).to.eql('length')
+            }
+
+            await checkTraces
+          })
+        })
+
         describe('create transcription', () => {
           let scope
 


### PR DESCRIPTION
### What does this PR do?
1. Properly tags the `image_url` option for a `chat.completions` call in the `openai` integration.
2. Excludes `image_url` from token counts in streamed responses, but ensures the `text` option is. This is because the token count that OpenAI computes for the image is based on the metadata of the image itself (size, etc.), and not the string URL. Since it's onerous on resources and HTTP calls (if it's not a local image), its computation for now is excluded from `tiktoken` calls or in-house estimations.
3. Additionally, adds some safeguards around tagging message content input in general. See [this section](https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages) of the OpenAI API documentation to learn more about `image_url` and where it falls within the request object structure. This PR follows those standards.

### Motivation
Previously, this would cause an error, where we try to call `replace` on an `object` that we assumed to be a string in `truncateText`. Not only does this change move to fix that error, but we want to tag it (not just ignore it), and add some additional safeguards to `tuncateText` so that it just returns on inputs that aren't strings. This way, it won't crash, and can be noted in missing input/output tags for OpenAI calls that it would need to be updated.

Example `image_url` usage that this PR fixes support for:

```javascript
const completion = openai.chat.completions.create({
  model: "gpt-4-vision-preview",
  messages: [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Describe this picture:"
        },
        {
          "type": "image_url",
          "image_url": {
            url: '/some/generic/url/to/an/image.png'
          }
        }
      ]
    }
  ],
})
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js