### PR TITLE
test: enable an esbuild test for early node v16 versions

### DIFF
--- a/integration-tests/esbuild/basic-test.js
+++ b/integration-tests/esbuild/basic-test.js
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
 
-// TODO: add support for Node.js v14.17+ and v16.0+
-if (Number(process.versions.node.split('.')[0]) < 16) {
-  console.error(`Skip esbuild test for node@${process.version}`) // eslint-disable-line no-console
-  process.exit(0)
-}
-
 const tracer = require('../../').init() // dd-trace
 
 const assert = require('assert')


### PR DESCRIPTION
### What does this PR do?
- enables an esbuild test for early node 16 versions

### Motivation
- dc-polyfill fixed compat ages ago