### PR TITLE
PROF-9979: use SIMPLE_HOST_AUTO_INJECTION_PROFILING target 

### DIFF
--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -55,7 +55,7 @@ onboarding_tests:
   parallel:
       matrix:
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs]
-          SCENARIO: [SIMPLE_HOST_AUTO_INJECTION]
+          SCENARIO: [SIMPLE_HOST_AUTO_INJECTION_PROFILING]
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-container]
           SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
   script:


### PR DESCRIPTION
For onboarding tests, use `SIMPLE_HOST_AUTO_INJECTION_PROFILING` target as that tests both tracing and profiling. 

### What does this PR do?
Changes the scenario used for SSI tests from `SIMPLE_HOST_AUTO_INJECTION` to `SIMPLE_HOST_AUTO_INJECTION_PROFILING`.

### Motivation
The new scenario tests tracing the same way as the old scenario did, but in addition it also tests profiling, specifically the scenario where profiling is manually enabled on a Node.js app into which the agent has injected the tracing library.

### Additional Notes
As soon as we have the container profiling scenario ready, we'll modify that too.


