### PR TITLE
[test visibility] Add automatic flaky test retries to Mocha

### DIFF
--- a/integration-tests/ci-visibility/test-flaky-test-retries/eventually-passing-test.js
+++ b/integration-tests/ci-visibility/test-flaky-test-retries/eventually-passing-test.js
@@ -1,0 +1,9 @@
+const { expect } = require('chai')
+
+let counter = 0
+
+describe('test-flaky-test-retries', () => {
+  it('can retry failed tests', () => {
+    expect(++counter).to.equal(3)
+  })
+})

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1589,7 +1589,12 @@ describe('mocha CommonJS', function () {
           const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
           assert.equal(failedAttempts.length, 2)
 
-          // TODO: maybe the passed should have retry and the first attempt (if failed), should not
+          // The first attempt is not marked as a retry
+          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          assert.equal(retriedFailure.length, 1)
+
+          const passedAttempt = tests.find(test => test.meta[TEST_STATUS] === 'pass')
+          assert.equal(passedAttempt.meta[TEST_IS_RETRY], 'true')
         })
 
       childProcess.on('exit', () => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1552,4 +1552,51 @@ describe('mocha CommonJS', function () {
       })
     })
   })
+
+  context('flaky test retries', () => {
+    it('retries failed tests automatically', (done) => {
+      receiver.setSettings({
+        itr_enabled: false,
+        code_coverage: false,
+        tests_skipping: false,
+        flaky_test_retries_enabled: true,
+        early_flake_detection: {
+          enabled: false
+        }
+      })
+
+      childProcess = exec(
+        runTestsWithCoverageCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: JSON.stringify([
+              './test-flaky-test-retries/eventually-passing-test.js'
+            ])
+          },
+          stdio: 'inherit'
+        }
+      )
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+          assert.equal(tests.length, 3) // two failed retries and then the pass
+
+          const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+          assert.equal(failedAttempts.length, 2)
+
+          // TODO: maybe the passed should have retry and the first attempt (if failed), should not
+        })
+
+      childProcess.on('exit', () => {
+        eventsPromise.then(() => {
+          done()
+        }).catch(done)
+      })
+    })
+  })
 })

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -43,7 +43,7 @@ let earlyFlakeDetectionNumRetries = 0
 let knownTests = []
 let itrCorrelationId = ''
 let isForcedToRun = false
-let config = {}
+const config = {}
 
 // We'll preserve the original coverage here
 const originalCoverageMap = createCoverageMap()
@@ -232,7 +232,6 @@ addHook({
       earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
       isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
 
-      // TODO: do this better
       config.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
       config.isSuitesSkippingEnabled = isSuitesSkippingEnabled
       config.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -21,6 +21,7 @@ const {
   runnableWrapper,
   getOnTestHandler,
   getOnTestEndHandler,
+  getOnTestRetryHandler,
   getOnHookEndHandler,
   getOnFailHandler,
   getOnPendingHandler,
@@ -37,10 +38,12 @@ let isSuitesSkipped = false
 let skippedSuites = []
 let isEarlyFlakeDetectionEnabled = false
 let isSuitesSkippingEnabled = false
+let isFlakyTestRetriesEnabled = false
 let earlyFlakeDetectionNumRetries = 0
 let knownTests = []
 let itrCorrelationId = ''
 let isForcedToRun = false
+let config = {}
 
 // We'll preserve the original coverage here
 const originalCoverageMap = createCoverageMap()
@@ -227,6 +230,13 @@ addHook({
       isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
       isSuitesSkippingEnabled = libraryConfig.isSuitesSkippingEnabled
       earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
+      isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
+
+      // TODO: do this better
+      config.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
+      config.isSuitesSkippingEnabled = isSuitesSkippingEnabled
+      config.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
+      config.isFlakyTestRetriesEnabled = isFlakyTestRetriesEnabled
 
       if (isEarlyFlakeDetectionEnabled) {
         knownTestsCh.publish({
@@ -317,6 +327,8 @@ addHook({
 
     this.on('test end', getOnTestEndHandler())
 
+    this.on('retry', getOnTestRetryHandler())
+
     // If the hook passes, 'hook end' will be emitted. Otherwise, 'fail' will be emitted
     this.on('hook end', getOnHookEndHandler())
 
@@ -401,7 +413,7 @@ addHook({
   name: 'mocha',
   versions: ['>=5.2.0'],
   file: 'lib/runnable.js'
-}, runnableWrapper)
+}, (runnablePackage) => runnableWrapper(runnablePackage, config))
 
 // Only used in parallel mode (--parallel flag is passed)
 // Used to generate suite events and receive test payloads from workers

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -258,14 +258,12 @@ function getOnFailHandler (isMain) {
 
 function getOnTestRetryHandler () {
   return function (test) {
-    debugger
     const asyncResource = getTestAsyncResource(test)
     if (asyncResource) {
       asyncResource.runInAsyncScope(() => {
         testRetryCh.publish()
       })
     }
-    debugger
     const key = getTestToArKey(test)
     // could we simply remove the asyncResource here?
     testToAr.delete(key)

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -42,7 +42,6 @@ addHook({
   return Runner
 })
 
-// TODO: does this need `libraryConfig` ?
 // Used both in serial and parallel mode, and by both the main process and the workers
 // Used to set the correct async resource to the test.
 addHook({
@@ -50,3 +49,4 @@ addHook({
   versions: ['>=5.2.0'],
   file: 'lib/runnable.js'
 }, runnableWrapper)
+// TODO: parallel mode does not support flaky test retries, so no library config is passed.

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -42,6 +42,7 @@ addHook({
   return Runner
 })
 
+// TODO: does this need `libraryConfig` ?
 // Used both in serial and parallel mode, and by both the main process and the workers
 // Used to set the correct async resource to the test.
 addHook({

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -204,8 +204,8 @@ class MochaPlugin extends CiPlugin {
 
     this.addSub('ci:mocha:test:error', (err) => {
       const store = storage.getStore()
-      if (err && store && store.span) {
-        const span = store.span
+      const span = store?.span
+      if (err && span) {
         if (err.constructor.name === 'Pending' && !this.forbidPending) {
           span.setTag(TEST_STATUS, 'skip')
         } else {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -215,6 +215,23 @@ class MochaPlugin extends CiPlugin {
       }
     })
 
+    this.addSub('ci:mocha:test:retry', () => {
+      const store = storage.getStore()
+      const span = store?.span
+      if (span) {
+        span.setTag(TEST_STATUS, 'fail')
+        span.setTag(TEST_IS_RETRY, 'true')
+
+        span.finish()
+        this.telemetry.ciVisEvent(
+          TELEMETRY_EVENT_FINISHED,
+          'test',
+          { hasCodeOwners: !!span.context()._tags[TEST_CODE_OWNERS] }
+        )
+        finishAllTraceSpans(span)
+      }
+    })
+
     this.addSub('ci:mocha:test:parameterize', ({ title, params }) => {
       this._testTitleToParams[title] = params
     })

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -190,7 +190,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
       requireGit,
       isEarlyFlakeDetectionEnabled,
       earlyFlakeDetectionNumRetries,
-      earlyFlakeDetectionFaultyThreshold
+      earlyFlakeDetectionFaultyThreshold,
+      isFlakyTestRetriesEnabled
     } = remoteConfiguration
     return {
       isCodeCoverageEnabled,
@@ -199,7 +200,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
       requireGit,
       isEarlyFlakeDetectionEnabled: isEarlyFlakeDetectionEnabled && this._config.isEarlyFlakeDetectionEnabled,
       earlyFlakeDetectionNumRetries,
-      earlyFlakeDetectionFaultyThreshold
+      earlyFlakeDetectionFaultyThreshold,
+      isFlakyTestRetriesEnabled
     }
   }
 

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -93,7 +93,8 @@ function getLibraryConfiguration ({
               tests_skipping: isSuitesSkippingEnabled,
               itr_enabled: isItrEnabled,
               require_git: requireGit,
-              early_flake_detection: earlyFlakeDetectionConfig
+              early_flake_detection: earlyFlakeDetectionConfig,
+              flaky_test_retries_enabled: isFlakyTestRetriesEnabled
             }
           }
         } = JSON.parse(res)
@@ -107,7 +108,8 @@ function getLibraryConfiguration ({
           earlyFlakeDetectionNumRetries:
             earlyFlakeDetectionConfig?.slow_test_retries?.['5s'] || DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES,
           earlyFlakeDetectionFaultyThreshold:
-            earlyFlakeDetectionConfig?.faulty_session_threshold ?? DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD
+            earlyFlakeDetectionConfig?.faulty_session_threshold ?? DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD,
+          isFlakyTestRetriesEnabled
         }
 
         log.debug(() => `Remote settings: ${JSON.stringify(settings)}`)


### PR DESCRIPTION
### What does this PR do?

Whenever the configuration API responds `flaky_test_retries_enabled: true`, we'll mark tests in mocha retriable by calling `this.retries()` to leverage mocha's mechanism for retrying failed tests: https://mochajs.org/#retry-tests.

### Motivation

Allow users to automatically retry failed tests to reduce flakiness of their test sessions.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
