### PR TITLE
Add getSpanLimits() method

### DIFF
--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -15,7 +15,7 @@ class Tracer {
     this._tracerProvider = tracerProvider
     // Is there a reason this is public?
     this.instrumentationLibrary = library
-    this._spanLimits = {};
+    this._spanLimits = {}
   }
 
   get resource () {

--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -121,7 +121,7 @@ class Tracer {
   }
 
   getSpanLimits() {
-    return this._spanLimits;
+    return this._spanLimits
   }
 }
 

--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -120,6 +120,7 @@ class Tracer {
     return this._tracerProvider.getActiveSpanProcessor()
   }
 
+  // not used in our codebase but needed for compatibility. See issue #1244 
   getSpanLimits() {
     return this._spanLimits
   }

--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -15,6 +15,7 @@ class Tracer {
     this._tracerProvider = tracerProvider
     // Is there a reason this is public?
     this.instrumentationLibrary = library
+    this._spanLimits = {};
   }
 
   get resource () {
@@ -117,6 +118,10 @@ class Tracer {
 
   getActiveSpanProcessor () {
     return this._tracerProvider.getActiveSpanProcessor()
+  }
+
+  getSpanLimits() {
+    return this._spanLimits;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds the getSpanLimits method to the Tracer class in dd-trace to ensure compatibility with @opentelemetry/sdk-trace-base. This method is necessary for creating spans in @prisma/instrumentation.

### Motivation
<!-- What inspired you to submit this pull request? -->
related issue #1244, [getSpanLimits is not a function error](https://github.com/DataDog/dd-trace-js/issues/1244#issuecomment-2200401180)

While integrating @prisma/instrumentation with dd-trace, an error was encountered due to the absence of the getSpanLimits method in dd-trace's Tracer class. The @opentelemetry/sdk-trace-base [Span constructor](https://github.com/open-telemetry/opentelemetry-js/blob/01a2c35a694e57df45f063d61506ef9e9938eb7d/packages/opentelemetry-sdk-trace-base/src/Span.ts#L126) calls this method, which led to the error. Implementing this method resolves the issue and allows the integration to work correctly.

### Additional Notes
During the integration of @prisma/instrumentation, it was discovered that dd-trace lacks the getSpanLimits method required by @opentelemetry/sdk-trace-base. This PR addresses this by adding a basic implementation of the method. If dd-trace has its own span limits, they should be returned instead of the empty object.

