### PR TITLE
[MLOB-1055] Revert `openai>=4.0.0` resource names to follow standards

### DIFF
--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -270,9 +270,7 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: semver.satisfies(realVersion, '>=4.0.0')
-              ? 'sampled completions.create'
-              : 'sampled createCompletion',
+            message: 'sampled createCompletion',
             prompt: 'Hello, \n\nFriend\t\tHi',
             choices: [
               {
@@ -397,7 +395,7 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: semver.satisfies(realVersion, '>=4.0.0') ? 'sampled embeddings.create' : 'sampled createEmbedding',
+            message: 'sampled createEmbedding',
             input: 'Cat?'
           })
         })
@@ -467,7 +465,7 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: semver.satisfies(realVersion, '>=4.0.0') ? 'sampled embeddings.create' : 'sampled createEmbedding',
+            message: 'sampled createEmbedding',
             input: 'Cat?'
           })
         })
@@ -751,7 +749,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0') ? 'sampled edits.create' : 'sampled createEdit',
+              message: 'sampled createEdit',
               input: 'What day of the wek is it?',
               instruction: 'Fix the spelling mistakes',
               choices: [{
@@ -2028,9 +2026,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled moderations.create'
-                : 'sampled createModeration',
+              message: 'sampled createModeration',
               input: 'I want to harm the robots'
             })
           })
@@ -2115,9 +2111,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: 'A datadog wearing headphones'
             })
           })
@@ -2154,9 +2148,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: [999, 888, 777, 666, 555]
             })
           })
@@ -2194,9 +2186,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: ['foo', 'bar']
             })
           })
@@ -2237,9 +2227,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: [[111, 222, 333], [444, 555, 666]]
             })
           })
@@ -2328,9 +2316,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.edit'
-                : 'sampled createImageEdit',
+              message: 'sampled createImageEdit',
               prompt: 'Change all red to blue',
               file: 'ntsc.png',
               mask: 'ntsc.png'
@@ -2410,9 +2396,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.createVariation'
-                : 'sampled createImageVariation',
+              message: 'sampled createImageVariation',
               file: 'ntsc.png'
             })
           })
@@ -2558,10 +2542,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message:
-                  semver.satisfies(realVersion, '>=4.0.0')
-                    ? 'sampled chat.completions.create'
-                    : 'sampled createChatCompletion',
+              message: 'sampled createChatCompletion',
               messages: [
                 {
                   role: 'user',
@@ -2768,10 +2749,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message:
-                  semver.satisfies(realVersion, '>=4.0.0')
-                    ? 'sampled chat.completions.create'
-                    : 'sampled createChatCompletion',
+              message: 'sampled createChatCompletion',
               messages: [
                 {
                   role: 'user',
@@ -2896,9 +2874,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled audio.transcriptions.create'
-                : 'sampled createTranscription',
+              message: 'sampled createTranscription',
               prompt: 'what does this say',
               file: 'hello-friend.m4a'
             })
@@ -2994,9 +2970,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled audio.translations.create'
-                : 'sampled createTranslation',
+              message: 'sampled createTranslation',
               prompt: 'greeting',
               file: 'guten-tag.m4a'
             })

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -187,11 +187,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'completions.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createCompletion')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createCompletion')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/completions')
@@ -367,11 +363,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'embeddings.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/embeddings')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -440,11 +432,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'embeddings.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/embeddings')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -559,11 +547,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'models.list')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listModels')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listModels')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models')
@@ -633,11 +617,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'models.retrieve')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'retrieveModel')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'retrieveModel')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models/*')
@@ -831,11 +811,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.list')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listFiles')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listFiles')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -896,11 +872,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/files')
@@ -965,11 +937,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.del')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'deleteFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'deleteFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'DELETE')
@@ -1030,11 +998,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.retrieve')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'retrieveFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'retrieveFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1093,13 +1057,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0 <4.17.1')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.retrieveContent')
-              } else if (semver.satisfies(realVersion, '>=4.17.1')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.content')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'downloadFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'downloadFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1211,13 +1169,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.create')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createFineTune')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createFineTune')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG') // no name just id
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -1476,13 +1428,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.retrieve')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.retrieve')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'retrieveFineTune')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'retrieveFineTune')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG') // no name just id
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1622,13 +1568,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.list')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.list')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listFineTunes')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listFineTunes')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               if (semver.satisfies(realVersion, '>=4.1.0')) {
@@ -1757,13 +1697,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.listEvents')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.listEvents')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listFineTuneEvents')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listFineTuneEvents')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               if (semver.satisfies(realVersion, '>=4.1.0')) {
@@ -1825,11 +1759,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'models.del')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'deleteModel')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'deleteModel')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'DELETE')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models/*')
@@ -1940,13 +1870,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.cancel')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.cancel')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'cancelFineTune')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'cancelFineTune')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2052,11 +1976,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'moderations.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createModeration')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createModeration')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2151,11 +2071,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'images.generate')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createImage')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createImage')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2362,11 +2278,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'images.edit')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createImageEdit')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createImageEdit')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2459,11 +2371,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'images.createVariation')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createImageVariation')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createImageVariation')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2559,11 +2467,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'chat.completions.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createChatCompletion')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createChatCompletion')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -2944,11 +2848,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'audio.transcriptions.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createTranscription')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createTranscription')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -3050,11 +2950,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'audio.translations.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createTranslation')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createTranslation')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 


### PR DESCRIPTION
### What does this PR do?
Reverts OpenAI resource names for `openai>=4.0.0` to follow standards of resource naming between the Node.js tracer and Python tracer. For example:

`chat.completions.create` &#8594; `createChatCompletion`
`completions.create` &#8594; `createCompletion`
etc.

### Motivation
Consistency for resource names not only between versions of OpenAI SDK for our integration, but also between languages for the Datadog tracers.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js


