### PR TITLE
ci: exclude aerospike on arm64 archs when running 'yarn services'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ $ docker-compose up -d -V --remove-orphans --force-recreate
 $ yarn services
 ```
 
-**Note**
+> **Note**
 > The `aerospike`, `couchbase`, `grpc` and `oracledb` instrumentations rely on
 > native modules that do not compile on ARM64 devices (for example M1/M2 Mac)
 > - their tests cannot be run locally on these devices.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,10 @@ $ docker-compose up -d -V --remove-orphans --force-recreate
 $ yarn services
 ```
 
-> **Note**
-> The `couchbase`, `grpc` and `oracledb` instrumentations rely on native modules
-> that do not compile on ARM64 devices (for example M1/M2 Mac) - their tests
-> cannot be run locally on these devices.
+**Note**
+> The `aerospike`, `couchbase`, `grpc` and `oracledb` instrumentations rely on
+> native modules that do not compile on ARM64 devices (for example M1/M2 Mac)
+> - their tests cannot be run locally on these devices.
 
 ### Unit Tests
 

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -12,8 +12,9 @@ const externals = require('../packages/dd-trace/test/plugins/externals')
 
 const requirePackageJsonPath = require.resolve('../packages/dd-trace/src/require-package-json')
 
+// Can remove aerospike after removing support for aerospike < 5.2.0 (for Node.js 22, v5.12.1 is required)
 // Can remove couchbase after removing support for couchbase <= 3.2.0
-const excludeList = os.arch() === 'arm64' ? ['couchbase', 'grpc', 'oracledb'] : []
+const excludeList = os.arch() === 'arm64' ? ['aerospike', 'couchbase', 'grpc', 'oracledb'] : []
 const workspaces = new Set()
 const versionLists = {}
 const deps = {}


### PR DESCRIPTION
The `aerospike` package didn't get arm support until v5.2.0.

If running `yarn services` on an arm64 based system, you'd get an error when trying to install older versions of `aerospike`. This PR fixes that by not installing `aerospike` on arm64 architectures.