### PR TITLE
docs: add a Testing Prerequisites section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,13 @@ $ yarn
 
 ## Testing
 
+### Prerequisites
+
+The `pg-native` package requires `pg_config` to be in your `$PATH` to be able to install.
+Please refer to [the "Install" section](https://github.com/brianc/node-postgres/tree/master/packages/pg-native#install) of the `pg-native` documentation for how to ensure your environment is configured correctly.
+
+### Setup
+
 Before running _plugin_ tests, the data stores need to be running.
 The easiest way to start all of them is to use the provided
 docker-compose configuration:


### PR DESCRIPTION
If `pg_config` insn't in your path, you'll get this error when trying to run `PLUGINS=pg yarn services`:

```
yarn run v1.22.22
$ node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services
$ yarn --ignore-engines
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
error /Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/versions/node_modules/libpq: Command failed.
Exit code: 1
Command: node-gyp rebuild
Arguments: 
Directory: /Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/versions/node_modules/libpq
Output:
gyp info it worked if it ends with ok
gyp info using node-gyp@10.1.0
gyp info using node@22.2.0 | darwin | arm64
gyp info find Python using Python version 3.12.4 found at "/opt/homebrew/opt/python@3.12/bin/python3.12"

gyp info spawn /opt/homebrew/opt/python@3.12/bin/python3.12
gyp info spawn args [
gyp info spawn args '/Users/thomas.watson/.nvm/versions/node/v22.2.0/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/versions/node_modules/libpq/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/thomas.watson/.nvm/versions/node/v22.2.0/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/thomas.watson/Library/Caches/node-gyp/22.2.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/Users/thomas.watson/Library/Caches/node-gyp/22.2.0',
gyp info spawn args '-Dnode_gyp_dir=/Users/thomas.watson/.nvm/versions/node/v22.2.0/lib/node_modules/npm/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/Users/thomas.watson/Library/Caches/node-gyp/22.2.0/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/versions/node_modules/libpq',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
/bin/sh: pg_config: command not found
gyp: Call to 'pg_config --libdir' returned exit status 127 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack at ChildProcess.<anonymous> (/Users/thomas.watson/.nvm/versions/node/v22.2.0/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:297:18)
gyp ERR! stack at ChildProcess.emit (node:events:520:28)
gyp ERR! stack at ChildProcess._handle.onexit (node:internal/child_process:294:12)
gyp ERR! System Darwin 23.5.0
gyp ERR! command "/Users/thomas.watson/.nvm/versions/node/v22.2.0/bin/node" "/Users/thomas.watson/.nvm/versions/node/v22.2.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/versions/node_modules/libpq
gyp ERR! node -v v22.2.0
gyp ERR! node-gyp -v v10.1.0
gyp ERR! not ok
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
node:internal/errors:983
  const err = new Error(message);
              ^

Error: Command failed: yarn --ignore-engines
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:889:11)
    at execSync (node:child_process:961:15)
    at exec (/Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/scripts/helpers/exec.js:11:10)
    at install (/Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/scripts/install_plugin_modules.js:212:3)
    at run (/Users/thomas.watson/go/src/github.com/DataDog/node_modules/dd-trace/scripts/install_plugin_modules.js:51:3) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 22097,
  stdout: null,
  stderr: null
}

Node.js v22.2.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```