### PR TITLE
Update @datadog/native-iast-taint-tracking module to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@datadog/native-appsec": "8.0.1",
     "@datadog/native-iast-rewriter": "2.3.1",
-    "@datadog/native-iast-taint-tracking": "2.1.0",
+    "@datadog/native-iast-taint-tracking": "3.0.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.3.0",
     "@datadog/sketches-js": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,10 +427,10 @@
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-2.1.0.tgz#65e0350f04064a991e3a980daf1b68147069c9f2"
-  integrity sha512-DjZ6itJcjLrTdKk2vP96hak2xS0ABd0NIB8poZG3OBQU5efkzu8JOQoxbIKMklG/0P2zh7EquvGP88PdVXT9aA==
+"@datadog/native-iast-taint-tracking@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.0.0.tgz#a0be16f49f49c2a5917d08e5986c0fc6c877ed13"
+  integrity sha512-V+25+edlNCQSNRUvL45IajN+CFEjii9NbjfSMG6HRHbH/zeLL9FCNE+GU88dwB1bqXKNpBdrIxsfgTN65Yq9tA==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update @datadog/native-iast-taint-tracking module to 3.0.0

### Motivation
<!-- What inspired you to submit this pull request? -->
v3.0.0 removes support to node 14 and reduce dependencies size.

