### PR TITLE
split aws-sdk and http tests by node version

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -224,6 +224,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   aws-sdk:
+    strategy:
+      matrix:
+        node_version: ['oldest', 'latest']
     runs-on: ubuntu-latest
     services:
       localstack:
@@ -264,9 +267,7 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
-      - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/${{ matrix.node_version }}
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -627,6 +627,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   http:
+    strategy:
+      matrix:
+        node_version: ['18', '20', 'latest']
     runs-on: ubuntu-latest
     env:
       PLUGINS: http
@@ -635,11 +638,7 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/18
-      - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/20
-      - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/${{ matrix.node_version }}
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -226,7 +226,7 @@ jobs:
   aws-sdk:
     strategy:
       matrix:
-        node_version: ['oldest', 'latest']
+        node-version: ['18', 'latest']
     runs-on: ubuntu-latest
     services:
       localstack:
@@ -267,7 +267,9 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/${{ matrix.node_version }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -629,7 +631,7 @@ jobs:
   http:
     strategy:
       matrix:
-        node_version: ['18', '20', 'latest']
+        node-version: ['18', '20', 'latest']
     runs-on: ubuntu-latest
     env:
       PLUGINS: http
@@ -638,7 +640,9 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - run: yarn install
-      - uses: ./.github/actions/node/${{ matrix.node_version }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split aws-sdk and http tests by Node version.

### Motivation
<!-- What inspired you to submit this pull request? -->

These tests are slow so splitting them makes them finish faster.