### PR TITLE
split appsec nextjs tests by nextjs version

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -207,9 +207,11 @@ jobs:
         version:
           - 18
           - latest
+        range: ['>=9.5 <11.1', '>=11.1 <13.2', '>=13.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: next
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split AppSec Next.js tests by Next.js version.

### Motivation
<!-- What inspired you to submit this pull request? -->

Make the tests finish faster. We also already do this for plugin tests, so I simply reused the same logic for AppSec.
