### PR TITLE
disable caching for windows ci

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -39,7 +39,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/node/setup
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - run: yarn install
       - run: yarn test:appsec:ci
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -43,7 +43,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/node/setup
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - run: yarn install
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -39,7 +39,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/node/setup
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: '18'
       - run: yarn install
       - run: yarn test:trace:core:ci
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable caching for Windows CI.

### Motivation
<!-- What inspired you to submit this pull request? -->

GHA caching is completely broken on Windows and it takes longer to unpack/pack the cache than do a full `yarn install`.