### PR TITLE
[test-visibility] Do not unsafely access `.steps` from test result in playwright 

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-max-failures/failing-test-and-another-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-max-failures/failing-test-and-another-test.js
@@ -1,0 +1,17 @@
+const { test, expect } = require('@playwright/test')
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(process.env.PW_BASE_URL)
+})
+
+test('should work with failing tests', async ({ page }) => {
+  await expect(page.locator('.hello-world')).toHaveText([
+    'Hello Warld'
+  ])
+})
+
+test('does not crash afterwards', async ({ page }) => {
+  await expect(page.locator('.hello-world')).toHaveText([
+    'Hello World'
+  ])
+})

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -1,7 +1,7 @@
 // Playwright config file for integration tests
 const { devices } = require('@playwright/test')
 
-module.exports = {
+const config = {
   baseURL: process.env.PW_BASE_URL,
   testDir: process.env.TEST_DIR || './ci-visibility/playwright-tests',
   timeout: Number(process.env.TEST_TIMEOUT) || 30000,
@@ -17,3 +17,9 @@ module.exports = {
   ],
   testMatch: '**/*-test.js'
 }
+
+if (process.env.MAX_FAILURES) {
+  config.maxFailures = Number(process.env.MAX_FAILURES)
+}
+
+module.exports = config

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -249,7 +249,7 @@ function testEndHandler (test, annotations, testStatus, error, isTimeout) {
   testAsyncResource.runInAsyncScope(() => {
     testFinishCh.publish({
       testStatus,
-      steps: testResult.steps,
+      steps: testResult?.steps || [],
       error,
       extraTags: annotationTags,
       isNew: test._ddIsNew,


### PR DESCRIPTION
### What does this PR do?
Do not unsafely access `testResult.steps`, since `testResult` can be undefined if `maxFailures` is passed and there's a test after the test has failed. 

### Motivation
Fixes #4466

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
