### PR TITLE
PROF-9979: Use SIMPLE_CONTAINER_AUTO_INJECTION_PROFILING in SSI tests

### DIFF
--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -57,7 +57,7 @@ onboarding_tests:
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs]
           SCENARIO: [SIMPLE_HOST_AUTO_INJECTION_PROFILING]
         - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs-container]
-          SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
+          SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION_PROFILING]
   script:
     - git clone https://git@github.com/DataDog/system-tests.git system-tests
     - cp packaging/*.rpm system-tests/binaries


### PR DESCRIPTION
### What does this PR do?
Similar to #4450, but for Docker instead of host deployments. For onboarding tests, uses `SIMPLE_CONTAINER_AUTO_INJECTION_PROFILING` target as that tests both tracing and profiling.

### Motivation
The new scenario tests tracing the same way as the old scenario did, but in addition it also tests profiling, specifically the scenario where profiling is manually enabled on a containerized Node.js app into which the agent has injected the tracing library.

