### PR TITLE
pull agent image instead of rebuilding

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -68,9 +68,11 @@ jobs:
         run: ./build.sh -i weblog
       - name: Build runner
         uses: ./.github/actions/install_runner
-      - name: Build agent
+      - name: Pull agent
         id: build-agent
-        run: ./build.sh -i agent
+        run: |
+          docker pull ghcr.io/datadog/system-tests/docker/agent:latest
+          docker tag ghcr.io/datadog/system-tests/docker/agent:latest system_tests/agent
       - name: Run scenario ${{ matrix.scenario }}
         run: ./run.sh ${{ matrix.scenario }}
       - name: Compress artifact


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pull agent image instead of rebuilding.

### Motivation
<!-- What inspired you to submit this pull request? -->

The agent can only change in the system tests repo, so there is no reason to keep rebuilding it on every commit.