### PR TITLE
ci: upgrade elasticsearch service to latest 7.x

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -465,7 +465,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       elasticsearch:
-        image: elasticsearch:7.14.0
+        image: elasticsearch:7.17.22
         env:
           discovery.type: single-node
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - '127.0.0.1:1521:1521'
       - '127.0.0.1:5500:5500'
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+    image: elasticsearch:7.17.22
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms128m -Xmx128m"


### PR DESCRIPTION
~~This should really be upgraded to the latest 8.x, but upgrading to the latest 7.x is the first step~~ I guess we can't upgrade it if we want to test older versions of the client that doesn't support 8.x yet?