### PR TITLE
[test-visibility] Fix vitest instrumentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,6 +26,7 @@
 /packages/datadog-instrumentations/src/cucumber.js @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/cypress.js @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/playwright.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest.js @DataDog/ci-app-libraries
 
 /integration-tests/ci-visibility/ @DataDog/ci-app-libraries
 /integration-tests/cucumber/ @DataDog/ci-app-libraries


### PR DESCRIPTION
### What does this PR do?
Change the way we extract `BaseSequencer` from `B` to `e`. 

Unrelated change: update `CODEOWNERS` to reflect ownership of `vitest` by the test visibility team.

### Motivation
https://github.com/vitest-dev/vitest/releases/tag/v2.0.0 broke our instrumentation.

### Additional Notes
No more tests needed. Just make sure that current tests pass.


