### PR TITLE
feat: add dd_tags to datastreams monitoring stats payload

### DIFF
--- a/packages/dd-trace/src/datastreams/processor.js
+++ b/packages/dd-trace/src/datastreams/processor.js
@@ -211,7 +211,8 @@ class DataStreamsProcessor {
       Stats,
       TracerVersion: pkg.version,
       Version: this.version,
-      Lang: 'javascript'
+      Lang: 'javascript',
+      Tags: Object.entries(this.tags).map(([key, value]) => `${key}:${value}`)
     }
     this.writer.flush(payload)
   }

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -203,7 +203,7 @@ describe('DataStreamsProcessor', () => {
     env: 'test',
     version: 'v1',
     service: 'service1',
-    tags: { DD_TAG: 'some tag', DD_OTHER_TAG: 'some other tag' }
+    tags: { foo: 'foovalue', bar: 'barvalue' }
   }
 
   beforeEach(() => {
@@ -307,7 +307,7 @@ describe('DataStreamsProcessor', () => {
       }],
       TracerVersion: pkg.version,
       Lang: 'javascript',
-      Tags: ['DD_TAG:some tag', 'DD_OTHER_TAG:some other tag']
+      Tags: ['foo:foovalue', 'bar:barvalue']
     })
   })
 })

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -203,7 +203,7 @@ describe('DataStreamsProcessor', () => {
     env: 'test',
     version: 'v1',
     service: 'service1',
-    tags: { tag: 'some tag' }
+    tags: { DD_TAG: 'some tag', DD_OTHER_TAG: 'some other tag' }
   }
 
   beforeEach(() => {
@@ -306,7 +306,8 @@ describe('DataStreamsProcessor', () => {
         Backlogs: []
       }],
       TracerVersion: pkg.version,
-      Lang: 'javascript'
+      Lang: 'javascript',
+      Tags: ['DD_TAG:some tag', 'DD_OTHER_TAG:some other tag']
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Adds base tracer and otel tags to DSM payload if any are configured. To be used for DSM filtering within UI

### Motivation
customer request

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


