### PR TITLE
release dev version only when a label is used

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,12 +1,14 @@
 name: Release dev release line
 
 on:
-  push:
+  pull_request_target:
+    types: [labeled]
     branches:
       - master
 
 jobs:
   dev_release:
+    if: ${{ github.event.label.name == 'release-dev' }}
     runs-on: ubuntu-latest
     environment: npm
     permissions:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Release dev version only when a label is used.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise, every time a PR is merged, a deployment is created which fails if no one approves it, which is in most cases. This makes it explicit so that a label must be added to a PR to release instead of having every PR fail 24h later because nobody approved the deployment before the timeout.