### PR TITLE
Make iast config available out of experimental config properties

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -125,6 +125,17 @@ tracer.init({
       maxStackTraces: 5,
       maxDepth: 42
     }
+  },
+  iast: {
+    enabled: true,
+    requestSampling: 50,
+    maxConcurrentRequests: 4,
+    maxContextOperations: 30,
+    deduplicationEnabled: true,
+    redactionEnabled: true,
+    redactionNamePattern: 'password',
+    redactionValuePattern: 'bearer',
+    telemetryVerbosity: 'OFF'
   }
 });
 
@@ -138,7 +149,8 @@ tracer.init({
       deduplicationEnabled: true,
       redactionEnabled: true,
       redactionNamePattern: 'password',
-      redactionValuePattern: 'bearer'
+      redactionValuePattern: 'bearer',
+      telemetryVerbosity: 'OFF'
     },
     appsec: {
       standalone: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -555,7 +555,12 @@ declare namespace tracer {
         /**
          * Specifies a regex that will redact sensitive source values in vulnerability reports.
          */
-        redactionValuePattern?: string
+        redactionValuePattern?: string,
+
+        /**
+         * Specifies the verbosity of the send telemetry. Default 'INFORMATION'
+         */
+        telemetryVerbosity?: string
       }
 
       appsec?: {
@@ -735,6 +740,61 @@ declare namespace tracer {
         maxDepth?: number,
       }
     };
+
+    /**
+     * Configuration of the IAST. Can be a boolean as an alias to `iast.enabled`.
+     */
+    iast?: boolean | {
+      /**
+       * Whether to enable IAST.
+       * @default false
+       */
+      enabled?: boolean,
+
+      /**
+       * Controls the percentage of requests that iast will analyze
+       * @default 30
+       */
+      requestSampling?: number,
+
+      /**
+       * Controls how many request can be analyzing code vulnerabilities at the same time
+       * @default 2
+       */
+      maxConcurrentRequests?: number,
+
+      /**
+       * Controls how many code vulnerabilities can be detected in the same request
+       * @default 2
+       */
+      maxContextOperations?: number,
+
+      /**
+       * Whether to enable vulnerability deduplication
+       */
+      deduplicationEnabled?: boolean,
+
+      /**
+       * Whether to enable vulnerability redaction
+       * @default true
+       */
+      redactionEnabled?: boolean,
+
+      /**
+       * Specifies a regex that will redact sensitive source names in vulnerability reports.
+       */
+      redactionNamePattern?: string,
+
+      /**
+       * Specifies a regex that will redact sensitive source values in vulnerability reports.
+       */
+      redactionValuePattern?: string,
+
+      /**
+       * Specifies the verbosity of the sent telemetry. Default 'INFORMATION'
+       */
+      telemetryVerbosity?: string
+    }
 
     /**
      * Configuration of ASM Remote Configuration

--- a/index.d.ts
+++ b/index.d.ts
@@ -2115,49 +2115,49 @@ declare namespace tracer {
      */
     enabled?: boolean,
 
-      /**
-       * Controls the percentage of requests that iast will analyze
-       * @default 30
-       */
-      requestSampling?: number,
+    /**
+     * Controls the percentage of requests that iast will analyze
+     * @default 30
+     */
+    requestSampling?: number,
 
-      /**
-       * Controls how many request can be analyzing code vulnerabilities at the same time
-       * @default 2
-       */
-      maxConcurrentRequests?: number,
+    /**
+     * Controls how many request can be analyzing code vulnerabilities at the same time
+     * @default 2
+     */
+    maxConcurrentRequests?: number,
 
-      /**
-       * Controls how many code vulnerabilities can be detected in the same request
-       * @default 2
-       */
-      maxContextOperations?: number,
+    /**
+     * Controls how many code vulnerabilities can be detected in the same request
+     * @default 2
+     */
+    maxContextOperations?: number,
 
-      /**
-       * Whether to enable vulnerability deduplication
-       */
-      deduplicationEnabled?: boolean,
+    /**
+     * Whether to enable vulnerability deduplication
+     */
+    deduplicationEnabled?: boolean,
 
-      /**
-       * Whether to enable vulnerability redaction
-       * @default true
-       */
-      redactionEnabled?: boolean,
+    /**
+     * Whether to enable vulnerability redaction
+     * @default true
+     */
+    redactionEnabled?: boolean,
 
-      /**
-       * Specifies a regex that will redact sensitive source names in vulnerability reports.
-       */
-      redactionNamePattern?: string,
+    /**
+     * Specifies a regex that will redact sensitive source names in vulnerability reports.
+     */
+    redactionNamePattern?: string,
 
-      /**
-       * Specifies a regex that will redact sensitive source values in vulnerability reports.
-       */
-      redactionValuePattern?: string,
+    /**
+     * Specifies a regex that will redact sensitive source values in vulnerability reports.
+     */
+    redactionValuePattern?: string,
 
-      /**
-       * Specifies the verbosity of the sent telemetry. Default 'INFORMATION'
-       */
-      telemetryVerbosity?: string
+    /**
+     * Specifies the verbosity of the sent telemetry. Default 'INFORMATION'
+     */
+    telemetryVerbosity?: string
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -518,50 +518,7 @@ declare namespace tracer {
       /**
        * Configuration of the IAST. Can be a boolean as an alias to `iast.enabled`.
        */
-      iast?: boolean | {
-        /**
-         * Whether to enable IAST.
-         * @default false
-         */
-        enabled?: boolean,
-        /**
-         * Controls the percentage of requests that iast will analyze
-         * @default 30
-         */
-        requestSampling?: number,
-        /**
-         * Controls how many request can be analyzing code vulnerabilities at the same time
-         * @default 2
-         */
-        maxConcurrentRequests?: number,
-        /**
-         * Controls how many code vulnerabilities can be detected in the same request
-         * @default 2
-         */
-        maxContextOperations?: number,
-        /**
-         * Whether to enable vulnerability deduplication
-         */
-        deduplicationEnabled?: boolean,
-        /**
-         * Whether to enable vulnerability redaction
-         * @default true
-         */
-        redactionEnabled?: boolean,
-        /**
-         * Specifies a regex that will redact sensitive source names in vulnerability reports.
-         */
-        redactionNamePattern?: string,
-        /**
-         * Specifies a regex that will redact sensitive source values in vulnerability reports.
-         */
-        redactionValuePattern?: string,
-
-        /**
-         * Specifies the verbosity of the send telemetry. Default 'INFORMATION'
-         */
-        telemetryVerbosity?: string
-      }
+      iast?: boolean | IastOptions
 
       appsec?: {
         /**
@@ -744,57 +701,7 @@ declare namespace tracer {
     /**
      * Configuration of the IAST. Can be a boolean as an alias to `iast.enabled`.
      */
-    iast?: boolean | {
-      /**
-       * Whether to enable IAST.
-       * @default false
-       */
-      enabled?: boolean,
-
-      /**
-       * Controls the percentage of requests that iast will analyze
-       * @default 30
-       */
-      requestSampling?: number,
-
-      /**
-       * Controls how many request can be analyzing code vulnerabilities at the same time
-       * @default 2
-       */
-      maxConcurrentRequests?: number,
-
-      /**
-       * Controls how many code vulnerabilities can be detected in the same request
-       * @default 2
-       */
-      maxContextOperations?: number,
-
-      /**
-       * Whether to enable vulnerability deduplication
-       */
-      deduplicationEnabled?: boolean,
-
-      /**
-       * Whether to enable vulnerability redaction
-       * @default true
-       */
-      redactionEnabled?: boolean,
-
-      /**
-       * Specifies a regex that will redact sensitive source names in vulnerability reports.
-       */
-      redactionNamePattern?: string,
-
-      /**
-       * Specifies a regex that will redact sensitive source values in vulnerability reports.
-       */
-      redactionValuePattern?: string,
-
-      /**
-       * Specifies the verbosity of the sent telemetry. Default 'INFORMATION'
-       */
-      telemetryVerbosity?: string
-    }
+    iast?: boolean | IastOptions
 
     /**
      * Configuration of ASM Remote Configuration
@@ -2196,6 +2103,61 @@ declare namespace tracer {
     export type SpanStatus = otel.SpanStatus;
     export type TimeInput = otel.TimeInput;
     export type TraceState = otel.TraceState;
+  }
+
+  /**
+   * Iast configuration used in `tracer` and `tracer.experimental` options
+   */
+  interface IastOptions {
+    /**
+     * Whether to enable IAST.
+     * @default false
+     */
+    enabled?: boolean,
+
+      /**
+       * Controls the percentage of requests that iast will analyze
+       * @default 30
+       */
+      requestSampling?: number,
+
+      /**
+       * Controls how many request can be analyzing code vulnerabilities at the same time
+       * @default 2
+       */
+      maxConcurrentRequests?: number,
+
+      /**
+       * Controls how many code vulnerabilities can be detected in the same request
+       * @default 2
+       */
+      maxContextOperations?: number,
+
+      /**
+       * Whether to enable vulnerability deduplication
+       */
+      deduplicationEnabled?: boolean,
+
+      /**
+       * Whether to enable vulnerability redaction
+       * @default true
+       */
+      redactionEnabled?: boolean,
+
+      /**
+       * Specifies a regex that will redact sensitive source names in vulnerability reports.
+       */
+      redactionNamePattern?: string,
+
+      /**
+       * Specifies a regex that will redact sensitive source values in vulnerability reports.
+       */
+      redactionValuePattern?: string,
+
+      /**
+       * Specifies the verbosity of the sent telemetry. Default 'INFORMATION'
+       */
+      telemetryVerbosity?: string
   }
 }
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -216,7 +216,7 @@ class Config {
     options = this.options = {
       ...options,
       appsec: options.appsec != null ? options.appsec : options.experimental?.appsec,
-      iastOptions: options.experimental?.iast
+      iast: options.iast != null ? options.iast : options.experimental?.iast
     }
 
     checkIfBothOtelAndDdEnvVarSet()
@@ -858,23 +858,23 @@ class Config {
     this._optsUnprocessed.flushMinSpans = options.flushMinSpans
     this._setArray(opts, 'headerTags', options.headerTags)
     this._setString(opts, 'hostname', options.hostname)
-    this._setBoolean(opts, 'iast.deduplicationEnabled', options.iastOptions && options.iastOptions.deduplicationEnabled)
+    this._setBoolean(opts, 'iast.deduplicationEnabled', options.iast && options.iast.deduplicationEnabled)
     this._setBoolean(opts, 'iast.enabled',
-      options.iastOptions && (options.iastOptions === true || options.iastOptions.enabled === true))
+      options.iast && (options.iast === true || options.iast.enabled === true))
     this._setValue(opts, 'iast.maxConcurrentRequests',
-      maybeInt(options.iastOptions?.maxConcurrentRequests))
-    this._optsUnprocessed['iast.maxConcurrentRequests'] = options.iastOptions?.maxConcurrentRequests
-    this._setValue(opts, 'iast.maxContextOperations', maybeInt(options.iastOptions?.maxContextOperations))
-    this._optsUnprocessed['iast.maxContextOperations'] = options.iastOptions?.maxContextOperations
-    this._setBoolean(opts, 'iast.redactionEnabled', options.iastOptions?.redactionEnabled)
-    this._setString(opts, 'iast.redactionNamePattern', options.iastOptions?.redactionNamePattern)
-    this._setString(opts, 'iast.redactionValuePattern', options.iastOptions?.redactionValuePattern)
-    const iastRequestSampling = maybeInt(options.iastOptions?.requestSampling)
+      maybeInt(options.iast?.maxConcurrentRequests))
+    this._optsUnprocessed['iast.maxConcurrentRequests'] = options.iast?.maxConcurrentRequests
+    this._setValue(opts, 'iast.maxContextOperations', maybeInt(options.iast?.maxContextOperations))
+    this._optsUnprocessed['iast.maxContextOperations'] = options.iast?.maxContextOperations
+    this._setBoolean(opts, 'iast.redactionEnabled', options.iast?.redactionEnabled)
+    this._setString(opts, 'iast.redactionNamePattern', options.iast?.redactionNamePattern)
+    this._setString(opts, 'iast.redactionValuePattern', options.iast?.redactionValuePattern)
+    const iastRequestSampling = maybeInt(options.iast?.requestSampling)
     if (iastRequestSampling > -1 && iastRequestSampling < 101) {
       this._setValue(opts, 'iast.requestSampling', iastRequestSampling)
-      this._optsUnprocessed['iast.requestSampling'] = options.iastOptions?.requestSampling
+      this._optsUnprocessed['iast.requestSampling'] = options.iast?.requestSampling
     }
-    this._setString(opts, 'iast.telemetryVerbosity', options.iastOptions && options.iastOptions.telemetryVerbosity)
+    this._setString(opts, 'iast.telemetryVerbosity', options.iast && options.iast.telemetryVerbosity)
     this._setBoolean(opts, 'isCiVisibility', options.isCiVisibility)
     this._setBoolean(opts, 'logInjection', options.logInjection)
     this._setString(opts, 'lookup', options.lookup)
@@ -904,7 +904,7 @@ class Config {
     this._setBoolean(opts, 'startupLogs', options.startupLogs)
     this._setTags(opts, 'tags', tags)
     const hasTelemetryLogsUsingFeatures =
-      (options.iastOptions && (options.iastOptions === true || options.iastOptions?.enabled === true)) ||
+      (options.iast && (options.iast === true || options.iast?.enabled === true)) ||
       (options.profiling && options.profiling === true)
     this._setBoolean(opts, 'telemetry.logCollection', hasTelemetryLogsUsingFeatures)
     this._setBoolean(opts, 'traceId128BitGenerationEnabled', options.traceId128BitGenerationEnabled)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1093,12 +1093,7 @@ describe('Config', () => {
         traceparent: false,
         runtimeId: false,
         exporter: 'agent',
-        enableGetRumData: false,
-        iast: {
-          enabled: true,
-          redactionNamePattern: 'REDACTION_NAME_PATTERN',
-          redactionValuePattern: 'REDACTION_VALUE_PATTERN'
-        }
+        enableGetRumData: false
       },
       appsec: {
         enabled: true,
@@ -1125,6 +1120,11 @@ describe('Config', () => {
           maxDepth: 42,
           maxStackTraces: 5
         }
+      },
+      iast: {
+        enabled: true,
+        redactionNamePattern: 'REDACTION_NAME_PATTERN',
+        redactionValuePattern: 'REDACTION_VALUE_PATTERN'
       },
       remoteConfig: {
         pollInterval: 42
@@ -1210,6 +1210,17 @@ describe('Config', () => {
           requestSampling: 1.0
         }
       },
+      iast: {
+        enabled: true,
+        requestSampling: 15,
+        maxConcurrentRequests: 3,
+        maxContextOperations: 4,
+        deduplicationEnabled: false,
+        redactionEnabled: false,
+        redactionNamePattern: 'REDACTION_NAME_PATTERN',
+        redactionValuePattern: 'REDACTION_VALUE_PATTERN',
+        telemetryVerbosity: 'DEBUG'
+      },
       experimental: {
         appsec: {
           enabled: false,
@@ -1228,6 +1239,17 @@ describe('Config', () => {
             enabled: false,
             requestSampling: 0.5
           }
+        },
+        iast: {
+          enabled: false,
+          requestSampling: 25,
+          maxConcurrentRequests: 6,
+          maxContextOperations: 7,
+          deduplicationEnabled: true,
+          redactionEnabled: true,
+          redactionNamePattern: 'IGNORED_REDACTION_NAME_PATTERN',
+          redactionValuePattern: 'IGNORED_REDACTION_VALUE_PATTERN',
+          telemetryVerbosity: 'OFF'
         }
       }
     })
@@ -1264,6 +1286,18 @@ describe('Config', () => {
         maxStackTraces: 2,
         maxDepth: 32
       }
+    })
+
+    expect(config).to.have.deep.property('iast', {
+      enabled: true,
+      requestSampling: 15,
+      maxConcurrentRequests: 3,
+      maxContextOperations: 4,
+      deduplicationEnabled: false,
+      redactionEnabled: false,
+      redactionNamePattern: 'REDACTION_NAME_PATTERN',
+      redactionValuePattern: 'REDACTION_VALUE_PATTERN',
+      telemetryVerbosity: 'DEBUG'
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `iast` property to config options, to be able to configure it without `experimental` namespace.

### Motivation
<!-- What inspired you to submit this pull request? -->
We should have implemented it long time ago.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


