### PR TITLE
Fix a typo that disabled debug message logging

### DIFF
--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -69,7 +69,7 @@ class Profiler extends EventEmitter {
       setLogger(config.logger)
 
       mapper = await maybeSourceMap(config.sourceMap, SourceMapper, config.debugSourceMaps)
-      if (config.SourceMap && config.debugSourceMaps) {
+      if (config.sourceMap && config.debugSourceMaps) {
         this._logger.debug(() => {
           return mapper.infoMap.size === 0
             ? 'Found no source maps'


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in a property name that disabled emitting a debug log message about source maps loading.

### Motivation
It's a bug.
