### PR TITLE
[test-visibility] Flaky test retries for cucumber

### DIFF
--- a/integration-tests/ci-visibility/features-retry/flaky.feature
+++ b/integration-tests/ci-visibility/features-retry/flaky.feature
@@ -1,0 +1,4 @@
+Feature: Farewell
+  Scenario: Say flaky
+    When the greeter says flaky
+    Then I should have heard "flaky"

--- a/integration-tests/ci-visibility/features-retry/support/steps.js
+++ b/integration-tests/ci-visibility/features-retry/support/steps.js
@@ -1,0 +1,15 @@
+const assert = require('assert')
+const { When, Then } = require('@cucumber/cucumber')
+
+let globalCounter = 0
+
+Then('I should have heard {string}', function (expectedResponse) {
+  assert.equal(this.whatIHeard, expectedResponse)
+})
+
+When('the greeter says flaky', function () {
+  if (++globalCounter < 3) {
+    throw new Error('Not good enough!')
+  }
+  this.whatIHeard = 'flaky'
+})

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -777,6 +777,7 @@ versions.forEach(version => {
               })
             })
           })
+
           context('early flake detection', () => {
             it('retries new tests', (done) => {
               const NUM_RETRIES_EFD = 3
@@ -1033,6 +1034,56 @@ versions.forEach(version => {
               })
             })
           })
+
+          if (version === 'latest') { // flaky test retries only supported from >=8.0.0
+            context('flaky test retries', () => {
+              it('can retry failed tests', (done) => {
+                receiver.setSettings({
+                  itr_enabled: false,
+                  code_coverage: false,
+                  tests_skipping: false,
+                  flaky_test_retries_enabled: true,
+                  early_flake_detection: {
+                    enabled: false
+                  }
+                })
+
+                const eventsPromise = receiver
+                  .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+                    const events = payloads.flatMap(({ payload }) => payload.events)
+
+                    const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+                    // 2 failures and 1 passed attempt
+                    assert.equal(tests.length, 3)
+
+                    const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+                    assert.equal(failedTests.length, 2)
+                    const passedTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
+                    assert.equal(passedTests.length, 1)
+
+                    // All but the first one are retries
+                    const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+                    assert.equal(retriedTests.length, 2)
+                  })
+
+                childProcess = exec(
+                  './node_modules/.bin/cucumber-js ci-visibility/features-retry/*.feature',
+                  {
+                    cwd,
+                    env: envVars,
+                    stdio: 'pipe'
+                  }
+                )
+
+                childProcess.on('exit', () => {
+                  eventsPromise.then(() => {
+                    done()
+                  }).catch(done)
+                })
+              })
+            })
+          }
         })
       })
     })

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -3,7 +3,8 @@
 const {
   getTestSuitePath,
   removeEfdStringFromTestName,
-  addEfdStringToTestName
+  addEfdStringToTestName,
+  NUM_FAILED_TEST_RETRIES
 } = require('../../../dd-trace/src/plugins/util/test')
 const { channel, AsyncResource } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
@@ -24,8 +25,6 @@ const originalFns = new WeakMap()
 const testToStartLine = new WeakMap()
 const testFileToSuiteAr = new Map()
 const wrappedFunctions = new WeakSet()
-
-const NUM_FAILED_TEST_RETRIES = 5
 
 function isNewTest (test, knownTests) {
   const testSuite = getTestSuitePath(test.file, process.cwd())

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -195,6 +195,15 @@ class CucumberPlugin extends CiPlugin {
       this.enter(testSpan, store)
     })
 
+    this.addSub('ci:cucumber:test:retry', () => {
+      const store = storage.getStore()
+      const span = store.span
+      // span.setTag(TEST_IS_RETRY, 'true') // TODO: not quite
+      span.setTag(TEST_STATUS, 'fail')
+      span.finish()
+      finishAllTraceSpans(span)
+    })
+
     this.addSub('ci:cucumber:test-step:start', ({ resource }) => {
       const store = storage.getStore()
       const childOf = store ? store.span : store

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -195,10 +195,12 @@ class CucumberPlugin extends CiPlugin {
       this.enter(testSpan, store)
     })
 
-    this.addSub('ci:cucumber:test:retry', () => {
+    this.addSub('ci:cucumber:test:retry', (isFlakyRetry) => {
       const store = storage.getStore()
       const span = store.span
-      // span.setTag(TEST_IS_RETRY, 'true') // TODO: not quite
+      if (isFlakyRetry) {
+        span.setTag(TEST_IS_RETRY, 'true')
+      }
       span.setTag(TEST_STATUS, 'fail')
       span.finish()
       finishAllTraceSpans(span)
@@ -248,7 +250,15 @@ class CucumberPlugin extends CiPlugin {
       })
     })
 
-    this.addSub('ci:cucumber:test:finish', ({ isStep, status, skipReason, errorMessage, isNew, isEfdRetry }) => {
+    this.addSub('ci:cucumber:test:finish', ({
+      isStep,
+      status,
+      skipReason,
+      errorMessage,
+      isNew,
+      isEfdRetry,
+      isFlakyRetry
+    }) => {
       const span = storage.getStore().span
       const statusTag = isStep ? 'step.status' : TEST_STATUS
 
@@ -267,6 +277,10 @@ class CucumberPlugin extends CiPlugin {
 
       if (errorMessage) {
         span.setTag(ERROR_MESSAGE, errorMessage)
+      }
+
+      if (isFlakyRetry > 0) {
+        span.setTag(TEST_IS_RETRY, 'true')
       }
 
       span.finish()

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -95,6 +95,9 @@ const MOCHA_WORKER_TRACE_PAYLOAD_CODE = 80
 const EFD_STRING = "Retried by Datadog's Early Flake Detection"
 const EFD_TEST_NAME_REGEX = new RegExp(EFD_STRING + ' \\(#\\d+\\): ', 'g')
 
+// Flaky test retries
+const NUM_FAILED_TEST_RETRIES = 5
+
 module.exports = {
   TEST_CODE_OWNERS,
   TEST_FRAMEWORK,
@@ -167,7 +170,8 @@ module.exports = {
   TEST_BROWSER_DRIVER,
   TEST_BROWSER_DRIVER_VERSION,
   TEST_BROWSER_NAME,
-  TEST_BROWSER_VERSION
+  TEST_BROWSER_VERSION,
+  NUM_FAILED_TEST_RETRIES
 }
 
 // Returns pkg manager and its version, separated by '-', e.g. npm-8.15.0 or yarn-1.22.19


### PR DESCRIPTION
### What does this PR do?

If we receive `flaky_test_retries_enabled: true` from the API, we'll leverage the `retry` mechanism from `cucumber`: https://github.com/cucumber/cucumber-js/blob/main/docs/retry.md. 

This mechanism retries failed tests until they pass or they reach the maximum number of retries (which is 5 in our case).

### Motivation

Similarly to #4453, allow users to automatically retry failed tests to reduce flakiness of their test sessions.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
