### PR TITLE
Fix `init.spec.js` test for node 16 (v4 release)

### DIFF
--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -7,6 +7,7 @@ const {
 } = require('./helpers')
 const path = require('path')
 const fs = require('fs')
+const { DD_MAJOR } = require('../version')
 
 const DD_INJECTION_ENABLED = 'tracing'
 const DD_INJECT_FORCE = 'true'
@@ -95,12 +96,14 @@ function testRuntimeVersionChecks (arg, filename) {
 
             it('should not initialize the tracer', () =>
               doTest(`Aborting application instrumentation due to incompatible_runtime.
-Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs >=18.
+Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs \
+>=${DD_MAJOR === 4 ? '16' : '18'}.
 false
 `, ...telemetryAbort))
             it('should initialize the tracer, if DD_INJECT_FORCE', () =>
               doTestForced(`Aborting application instrumentation due to incompatible_runtime.
-Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs >=18.
+Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs \
+>=${DD_MAJOR === 4 ? '16' : '18'}.
 DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.
 Application instrumentation bootstrapping complete
 true


### PR DESCRIPTION
### What does this PR do?
Make the test `DD_MAJOR` independent.

### Motivation
Fixes https://github.com/DataDog/dd-trace-js/actions/runs/9872333104/job/27262238777?pr=4497

