### PR TITLE
Use http.get instead of fetch in asm standalone tests

### DIFF
--- a/integration-tests/standalone-asm/index.js
+++ b/integration-tests/standalone-asm/index.js
@@ -30,6 +30,24 @@ const app = express()
 const valueToHash = 'iast-showcase-demo'
 const crypto = require('crypto')
 
+async function makeRequest (url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, function (res) {
+      const chunks = []
+
+      res.on('data', function (chunk) {
+        chunks.push(chunk)
+      })
+
+      res.on('end', () => {
+        resolve( Buffer.concat(chunks).toString('utf8'))
+      })
+
+      res.on('error', reject)
+    })
+  })
+}
+
 app.get('/', (req, res) => {
   res.status(200).send('hello world')
 })
@@ -58,8 +76,7 @@ app.get('/propagation-with-event', async (req, res) => {
   const port = req.query.port || server.address().port
   const url = `http://localhost:${port}/down`
 
-  const resFetch = await fetch(url)
-  await resFetch.text()
+  await makeRequest(url)
 
   res.status(200).send('propagation-with-event')
 })
@@ -71,8 +88,7 @@ app.get('/propagation-without-event', async (req, res) => {
   const span = tracer.scope().active()
   span.context()._trace.tags['_dd.p.other'] = '1'
 
-  const resFetch = await fetch(url)
-  await resFetch.text()
+  await makeRequest(url)
 
   res.status(200).send('propagation-without-event')
 })
@@ -89,8 +105,8 @@ app.get('/propagation-after-drop-and-call-sdk', async (req, res) => {
 
   const url = `http://localhost:${port}/sdk`
 
-  const resFetch = await fetch(url)
-  const sdkRes = await resFetch.text()
+  const sdkRes = await makeRequest(url)
+
 
   res.status(200).send(`drop-and-call-sdk ${sdkRes}`)
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


