### PR TITLE
Do not run undici tests for node16 and >=6.0.0

### DIFF
--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const semver = require('semver')
+
 const agent = require('../../dd-trace/test/plugins/agent')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
 const { rawExpectedSchema } = require('./naming')
 const { DD_MAJOR } = require('../../../version')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { NODE_MAJOR } = require('../../../version')
 
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
@@ -19,6 +22,9 @@ describe('Plugin', () => {
 
   describe('undici-fetch', () => {
     withVersions('undici', 'undici', version => {
+      const specificVersion = require(`../../../versions/undici@${version}`).version()
+      if ((NODE_MAJOR <= 16) && semver.satisfies(specificVersion, '>=6')) return
+
       function server (app, listener) {
         const server = require('http').createServer(app)
         server.listen(0, 'localhost', () => listener(server.address().port))


### PR DESCRIPTION
### What does this PR do?
Tests are failing in node16 because 6.0.0 only supports >=18:

* failing test in v4: https://github.com/DataDog/dd-trace-js/actions/runs/9875683402/job/27274310799?pr=4497
* the failure comes from `ReadableStream` not being global: https://github.com/nodejs/undici/blob/v6.0.0/lib/fetch/response.js#L506
* supported node for >=6.0.0 is >=18: https://github.com/nodejs/undici/blob/v6.0.0/package.json#L138

### Motivation
Fix v4 release.

