### PR TITLE
[test-visibility] Fix mocha plugin tests (now for real)

### DIFF
--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -55,8 +55,7 @@ const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
 describe('Plugin', function () {
   let Cucumber
   this.timeout(10000)
-  withVersions('cucumber', '@cucumber/cucumber', version => {
-    const specificVersion = require(`../../../versions/@cucumber/cucumber@${version}`).version()
+  withVersions('cucumber', '@cucumber/cucumber', (version, _, specificVersion) => {
     if ((NODE_MAJOR <= 16) && semver.satisfies(specificVersion, '>=10')) return
 
     afterEach(() => {

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -78,7 +78,7 @@ const ASYNC_TESTS = [
 
 describe('Plugin', () => {
   let Mocha
-  withVersions('mocha', 'mocha', version => {
+  withVersions('mocha', 'mocha', (version, _, specificVersion) => {
     afterEach(() => {
       // This needs to be done when using the programmatic API:
       // https://github.com/mochajs/mocha/wiki/Using-Mocha-programmatically
@@ -452,7 +452,7 @@ describe('Plugin', () => {
       it('works with retries', (done) => {
         let testNames = []
         // retry listener did not happen until 6.0.0
-        if (semver.satisfies(version, '>=6.0.0')) {
+        if (semver.satisfies(specificVersion, '>=6.0.0')) {
           testNames = [
             ['mocha-test-retries will be retried and pass', 'fail'],
             ['mocha-test-retries will be retried and pass', 'fail'],

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -245,7 +245,7 @@ function withVersions (plugin, modules, range, cb) {
             require('module').Module._initPaths()
           })
 
-          cb(v.test, moduleName)
+          cb(v.test, moduleName, v.version)
 
           after(() => {
             process.env.NODE_PATH = nodePath


### PR DESCRIPTION
### What does this PR do?
#4495 tried to fix the flakiness with mocha plugin tests.

Sadly, while the fix was right, the version check was wrong in:
https://github.com/DataDog/dd-trace-js/pull/4495/files#diff-117158f289a04492bb2d486e73218d40186fe58c5be2b76bf3bccc3f11a6c5f5R455

`version` in this case is `>=5.2.0`, which isn't helpful: I need the actual version being resolved.

### Motivation
Fix flakiness in mocha plugin tests.

### Additional Notes
Instead of having to run `require(`../../../versions/$YOUR_LIBRARY@${version}`).version()` every time we need to extract the resolved version, I've added to the `withVersions` callback, since it was right there. 


