### PR TITLE
[test visibility] Fix suite-less tests in vitest

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/test-visibility-passed-suite.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/test-visibility-passed-suite.mjs
@@ -30,3 +30,18 @@ describe('other context', () => {
     expect(sum(1, 2)).to.equal(3)
   })
 })
+
+test('no suite', () => {
+  expect(sum(1, 2)).to.equal(3)
+})
+
+test.skip('skip no suite', () => {
+  expect(sum(1, 2)).to.equal(3)
+})
+
+// eslint-disable-next-line
+test('programmatic skip no suite', (context) => {
+  // eslint-disable-next-line
+  context.skip()
+  expect(sum(1, 2)).to.equal(3)
+})

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -89,7 +89,10 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/test-visibility-failed-hooks.mjs.context can report failed test',
             'ci-visibility/vitest-tests/test-visibility-failed-hooks.mjs.context can report more',
             'ci-visibility/vitest-tests/test-visibility-failed-hooks.mjs.other context can report passed test',
-            'ci-visibility/vitest-tests/test-visibility-failed-hooks.mjs.other context can report more'
+            'ci-visibility/vitest-tests/test-visibility-failed-hooks.mjs.other context can report more',
+            'ci-visibility/vitest-tests/test-visibility-passed-suite.mjs.no suite',
+            'ci-visibility/vitest-tests/test-visibility-passed-suite.mjs.skip no suite',
+            'ci-visibility/vitest-tests/test-visibility-passed-suite.mjs.programmatic skip no suite'
           ]
         )
 

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -134,7 +134,7 @@ addHook({
     taskToAsync.set(task, asyncResource)
 
     asyncResource.runInAsyncScope(() => {
-      testStartCh.publish({ testName: getTestName(task), testSuiteAbsolutePath: task.suite.file.filepath })
+      testStartCh.publish({ testName: getTestName(task), testSuiteAbsolutePath: task.file.filepath })
     })
     return onBeforeTryTask.apply(this, arguments)
   })
@@ -242,7 +242,7 @@ addHook({
       if (result) {
         const { state, duration, errors } = result
         if (state === 'skip') { // programmatic skip
-          testSkipCh.publish({ testName: getTestName(task), testSuiteAbsolutePath: task.suite.file.filepath })
+          testSkipCh.publish({ testName: getTestName(task), testSuiteAbsolutePath: task.file.filepath })
         } else if (state === 'pass') {
           if (testAsyncResource) {
             testAsyncResource.runInAsyncScope(() => {
@@ -267,7 +267,7 @@ addHook({
           }
         }
       } else { // test.skip or test.todo
-        testSkipCh.publish({ testName: getTestName(task), testSuiteAbsolutePath: task.suite.file.filepath })
+        testSkipCh.publish({ testName: getTestName(task), testSuiteAbsolutePath: task.file.filepath })
       }
     })
 


### PR DESCRIPTION
### What does this PR do?
Use `task.file.filepath` instead of `task.suite.file.filepath`, which should be defined regardless of whether the test is within a `describe` or not.

### Motivation
If a `test` showed up without a parent `describe` we were throwing an error: 
```
TypeError: Cannot read properties of undefined (reading 'file')
 ❯ node_modules/dd-trace/packages/datadog-instrumentations/src/vitest.js:168:92
 ❯ VitestTestRunner.onBeforeTryTask node_modules/dd-trace/packages/datadog-instrumentations/src/vitest.js:167:19
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
