### PR TITLE
[test-visibility] Add support for flaky test retries for vitest

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@
 /packages/datadog-plugin-cucumber/ @DataDog/ci-app-libraries
 /packages/datadog-plugin-cypress/ @DataDog/ci-app-libraries
 /packages/datadog-plugin-playwright/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-vitest/ @DataDog/ci-app-libraries
 /packages/dd-trace/src/plugins/util/git.js @DataDog/ci-app-libraries
 /packages/dd-trace/test/ci-visibility/ @DataDog/ci-app-libraries
 /packages/dd-trace/test/plugins/util/git.spec.js @DataDog/ci-app-libraries
@@ -38,6 +39,7 @@
 /integration-tests/cucumber/cucumber.spec.js @DataDog/ci-app-libraries
 /integration-tests/cypress/cypress.spec.js @DataDog/ci-app-libraries
 /integration-tests/vitest/vitest.spec.js @DataDog/ci-app-libraries
+/integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
 /integration-tests/test-api-manual.spec.js @DataDog/ci-app-libraries
 
 /packages/dd-trace/src/service-naming/ @Datadog/apm-idm-js

--- a/integration-tests/ci-visibility/vitest-tests/flaky-test-retries.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/flaky-test-retries.mjs
@@ -1,0 +1,18 @@
+import { describe, test, expect } from 'vitest'
+import { sum } from './sum'
+
+let numAttempt = 0
+
+describe('flaky test retries', () => {
+  test('can retry tests that eventually pass', () => {
+    expect(sum(1, 2)).to.equal(numAttempt++)
+  })
+
+  test('can retry tests that never pass', () => {
+    expect(sum(1, 2)).to.equal(0)
+  })
+
+  test('does not retry if unnecessary', () => {
+    expect(sum(1, 2)).to.equal(3)
+  })
+})

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   test: {
     include: [
-      'ci-visibility/vitest-tests/test-visibility*'
+      process.env.TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*'
     ]
   }
 })

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -136,5 +136,35 @@ versions.forEach((version) => {
         }
       )
     })
+
+    context('flaky test retries', () => {
+      it('can retry flaky tests', (done) => {
+        receiver.setSettings({
+          itr_enabled: false,
+          code_coverage: false,
+          tests_skipping: false,
+          flaky_test_retries_enabled: true,
+          early_flake_detection: {
+            enabled: false
+          }
+        })
+
+        receiver.gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+
+        }).then(() => done()).catch(done)
+        childProcess = exec(
+          './node_modules/.bin/vitest run', // TODO: change tests we run
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              // maybe only in node@20
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init' // ESM requires more flags
+            },
+            stdio: 'pipe'
+          }
+        )
+      })
+    })
   })
 })

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -1,5 +1,6 @@
 const { addHook, channel, AsyncResource } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
+const { NUM_FAILED_TEST_RETRIES } = require('../../dd-trace/src/plugins/util/test')
 
 // test hooks
 const testStartCh = channel('ci:vitest:test:start')
@@ -100,8 +101,8 @@ function getSortWrapper (sort) {
       return sort.apply(this, arguments)
     }
     // There isn't any other async function that we seem to be able to hook into
-    // So we will use the sort from BaseSequencer. This means that custom sequencer
-    // will not work, but this will be a known limitation.
+    // So we will use the sort from BaseSequencer. This means that a custom sequencer
+    // will not work. This will be a known limitation.
     let isFlakyTestRetriesEnabled = false
 
     try {
@@ -113,7 +114,7 @@ function getSortWrapper (sort) {
       isFlakyTestRetriesEnabled = false
     }
     if (isFlakyTestRetriesEnabled && !this.ctx.config.retry) {
-      this.ctx.config.retry = 3 // TODO: change to correct value
+      this.ctx.config.retry = NUM_FAILED_TEST_RETRIES
     }
 
     shimmer.wrap(this.ctx, 'exit', exit => async function () {
@@ -152,15 +153,31 @@ addHook({
 }, (vitestPackage) => {
   const { VitestTestRunner } = vitestPackage
   // test start (only tests that are not marked as skip or todo)
-  shimmer.wrap(VitestTestRunner.prototype, 'onBeforeTryTask', onBeforeTryTask => async function (task) {
+  shimmer.wrap(VitestTestRunner.prototype, 'onBeforeTryTask', onBeforeTryTask => async function (task, retryInfo) {
     if (!testStartCh.hasSubscribers) {
       return onBeforeTryTask.apply(this, arguments)
     }
+    const { retry: numAttempt } = retryInfo
+    // We finish the previous test here because we know it has failed already
+    if (numAttempt > 0) {
+      const asyncResource = taskToAsync.get(task)
+      const testError = task.result?.errors?.[0]
+      if (asyncResource) {
+        asyncResource.runInAsyncScope(() => {
+          testErrorCh.publish({ error: testError })
+        })
+      }
+    }
+
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     taskToAsync.set(task, asyncResource)
 
     asyncResource.runInAsyncScope(() => {
-      testStartCh.publish({ testName: getTestName(task), testSuiteAbsolutePath: task.file.filepath })
+      testStartCh.publish({
+        testName: getTestName(task),
+        testSuiteAbsolutePath: task.file.filepath,
+        isRetry: numAttempt > 0
+      })
     })
     return onBeforeTryTask.apply(this, arguments)
   })
@@ -261,6 +278,7 @@ addHook({
 
     const testTasks = getTypeTasks(startTestsResponse[0].tasks)
 
+    // Only one test task per test, even if there are retries
     testTasks.forEach(task => {
       const testAsyncResource = taskToAsync.get(task)
       const { result } = task
@@ -284,8 +302,10 @@ addHook({
           }
 
           if (testAsyncResource) {
+            const isRetry = task.result?.retryCount > 0
+            // `duration` is the duration of all the retries, so it can't be used if there are retries
             testAsyncResource.runInAsyncScope(() => {
-              testErrorCh.publish({ duration, error: testError })
+              testErrorCh.publish({ duration: !isRetry ? duration : undefined, error: testError })
             })
           }
           if (errors?.length) {


### PR DESCRIPTION
### What does this PR do?
If we receive `flaky_test_retries_enabled: true` from the API, we'll leverage the retry mechanism from vitest: https://vitest.dev/guide/cli.html#options.

### Motivation
Same as #4504, #4489 and #4453: allow users to automatically retry their tests if they fail.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional notes
I'm also updating the CODEOWNERS file to reflect ci-app-libraries ownership.
