### PR TITLE
remove collection of http.useragent in appsec reporter

### DIFF
--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -207,10 +207,6 @@ function finishRequest (req, res) {
 
   // collect some headers even when no attack is detected
   const mandatoryTags = filterHeaders(req.headers, REQUEST_HEADERS_MAP)
-  const ua = mandatoryTags['http.request.headers.user-agent']
-  if (ua) {
-    mandatoryTags['http.useragent'] = ua
-  }
   rootSpan.addTags(mandatoryTags)
 
   const tags = rootSpan.context()._tags

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -444,8 +444,7 @@ describe('reporter', () => {
         'http.request.headers.akamai-user-risk': 'h',
         'http.request.headers.content-type': 'i',
         'http.request.headers.accept': 'j',
-        'http.request.headers.user-agent': 'k',
-        'http.useragent': 'k'
+        'http.request.headers.user-agent': 'k'
       })
     })
 
@@ -523,8 +522,7 @@ describe('reporter', () => {
       Reporter.finishRequest(req, res)
 
       expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni',
-        'http.useragent': 'arachni'
+        'http.request.headers.user-agent': 'arachni'
       })
 
       expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)
@@ -549,8 +547,7 @@ describe('reporter', () => {
       Reporter.finishRequest(req, res)
 
       expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni',
-        'http.useragent': 'arachni'
+        'http.request.headers.user-agent': 'arachni'
       })
 
       expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)
@@ -575,8 +572,7 @@ describe('reporter', () => {
       Reporter.finishRequest(req, res)
 
       expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni',
-        'http.useragent': 'arachni'
+        'http.request.headers.user-agent': 'arachni'
       })
 
       expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)
@@ -601,8 +597,7 @@ describe('reporter', () => {
       Reporter.finishRequest(req, res)
 
       expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni',
-        'http.useragent': 'arachni'
+        'http.request.headers.user-agent': 'arachni'
       })
 
       expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)


### PR DESCRIPTION
### What does this PR do?
Remove a special if in the appsec reporter that collects the user agent in a special tag

### Motivation
It's already collected by APM and the backend has an alias anyway.
