### PR TITLE
Remove tight coupling between logger and config

### DIFF
--- a/init.js
+++ b/init.js
@@ -3,12 +3,9 @@
 const path = require('path')
 const Module = require('module')
 const semver = require('semver')
+const log = require('./packages/dd-trace/src/log')
 const { isTrue } = require('./packages/dd-trace/src/util')
 const telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
-
-const log = semver.satisfies(process.versions.node, '>=16')
-  ? require('./packages/dd-trace/src/log')
-  : { info: isTrue(process.env.DD_TRACE_DEBUG) ? console.log : () => {} } // eslint-disable-line no-console
 
 let initBailout = false
 let clobberBailout = false

--- a/init.js
+++ b/init.js
@@ -2,22 +2,13 @@
 
 const path = require('path')
 const Module = require('module')
-const telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
 const semver = require('semver')
+const { isTrue } = require('./packages/dd-trace/src/util')
+const telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
 
-function isTrue (envVar) {
-  return ['1', 'true', 'True'].includes(envVar)
-}
-
-// eslint-disable-next-line no-console
-let log = { info: isTrue(process.env.DD_TRACE_DEBUG) ? console.log : () => {} }
-if (semver.satisfies(process.versions.node, '>=16')) {
-  const Config = require('./packages/dd-trace/src/config')
-  log = require('./packages/dd-trace/src/log')
-
-  // eslint-disable-next-line no-new
-  new Config() // we need this to initialize the logger
-}
+const log = semver.satisfies(process.versions.node, '>=16')
+  ? require('./packages/dd-trace/src/log')
+  : { info: isTrue(process.env.DD_TRACE_DEBUG) ? console.log : () => {} } // eslint-disable-line no-console
 
 let initBailout = false
 let clobberBailout = false

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -211,33 +211,23 @@ function propagationStyle (key, option, defaultValue) {
 }
 
 class Config {
-  constructor (options) {
-    options = options || {}
+  constructor (options = {}) {
     options = this.options = {
       ...options,
       appsec: options.appsec != null ? options.appsec : options.experimental?.appsec,
       iast: options.iast != null ? options.iast : options.experimental?.iast
     }
 
-    checkIfBothOtelAndDdEnvVarSet()
-
     // Configure the logger first so it can be used to warn about other configs
-    this.debug = isTrue(coalesce(
-      process.env.DD_TRACE_DEBUG,
-      process.env.OTEL_LOG_LEVEL && process.env.OTEL_LOG_LEVEL === 'debug',
-      false
-    ))
-    this.logger = options.logger
-
-    this.logLevel = coalesce(
-      options.logLevel,
-      process.env.DD_TRACE_LOG_LEVEL,
-      process.env.OTEL_LOG_LEVEL,
-      'debug'
-    )
+    const logConfig = log.getConfig()
+    this.debug = logConfig.enabled
+    this.logger = coalesce(options.logger, logConfig.logger)
+    this.logLevel = coalesce(options.logLevel, logConfig.logLevel)
 
     log.use(this.logger)
-    log.toggle(this.debug, this.logLevel, this)
+    log.toggle(this.debug, this.logLevel)
+
+    checkIfBothOtelAndDdEnvVarSet()
 
     const DD_TRACE_MEMCACHED_COMMAND_ENABLED = coalesce(
       process.env.DD_TRACE_MEMCACHED_COMMAND_ENABLED,

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -33,7 +33,7 @@ const log = {
    * @returns Read-only version of logging config. To modify config, call `log.use` and `log.toggle`
    */
   getConfig () {
-    return Object.freeze({ ...config })
+    return { ...config }
   },
 
   use (logger) {

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -8,361 +8,431 @@ const { storage } = require('../../datadog-core')
 /* eslint-disable no-console */
 
 describe('log', () => {
-  let log
-  let logger
-  let error
-
-  beforeEach(() => {
-    sinon.stub(console, 'info')
-    sinon.stub(console, 'error')
-    sinon.stub(console, 'warn')
-    sinon.stub(console, 'debug')
-
-    error = new Error()
-
-    logger = {
-      debug: sinon.spy(),
-      error: sinon.spy()
-    }
-
-    log = require('../src/log')
-    log.toggle(true)
-  })
-
-  afterEach(() => {
-    log.reset()
-    console.info.restore()
-    console.error.restore()
-    console.warn.restore()
-    console.debug.restore()
-  })
-
-  it('should support chaining', () => {
-    expect(() => {
-      log
-        .use(logger)
-        .toggle(true)
-        .error('error')
-        .debug('debug')
-        .reset()
-    }).to.not.throw()
-  })
-
-  it('should call the logger in a noop context', () => {
-    logger.debug = () => {
-      expect(storage.getStore()).to.have.property('noop', true)
-    }
-
-    log.use(logger).debug('debug')
-  })
-
-  describe('debug', () => {
-    it('should log to console by default', () => {
-      log.debug('debug')
-
-      expect(console.debug).to.have.been.calledWith('debug')
-    })
-
-    it('should support callbacks that return a message', () => {
-      log.debug(() => 'debug')
-
-      expect(console.debug).to.have.been.calledWith('debug')
-    })
-  })
-
-  describe('error', () => {
-    it('should log to console by default', () => {
-      log.error(error)
-
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should support callbacks that return a error', () => {
-      log.error(() => error)
-
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should convert strings to errors', () => {
-      log.error('error')
-
-      expect(console.error).to.have.been.called
-      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
-      expect(console.error.firstCall.args[0]).to.have.property('message', 'error')
-    })
-
-    it('should convert empty values to errors', () => {
-      log.error()
-
-      expect(console.error).to.have.been.called
-      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
-      expect(console.error.firstCall.args[0]).to.have.property('message', 'undefined')
-    })
-
-    it('should convert invalid types to errors', () => {
-      log.error(123)
-
-      expect(console.error).to.have.been.called
-      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
-      expect(console.error.firstCall.args[0]).to.have.property('message', '123')
-    })
-
-    it('should reuse error messages for non-errors', () => {
-      log.error({ message: 'test' })
-
-      expect(console.error).to.have.been.called
-      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
-      expect(console.error.firstCall.args[0]).to.have.property('message', 'test')
-    })
-
-    it('should convert messages from callbacks to errors', () => {
-      log.error(() => 'error')
-
-      expect(console.error).to.have.been.called
-      expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
-      expect(console.error.firstCall.args[0]).to.have.property('message', 'error')
-    })
-  })
-
-  describe('toggle', () => {
-    it('should disable the logger', () => {
-      log.toggle(false)
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.not.have.been.called
-      expect(console.error).to.not.have.been.called
-    })
-
-    it('should enable the logger', () => {
-      log.toggle(false)
-      log.toggle(true)
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should set minimum log level when enabled with logLevel argument set to a valid string', () => {
-      log.toggle(true, 'error')
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.not.have.been.called
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should set default log level when enabled with logLevel argument set to an invalid string', () => {
-      log.toggle(true, 'not a real log level')
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should set min log level when enabled w/logLevel arg set to valid string w/wrong case or whitespace', () => {
-      log.toggle(true, ' ErRoR   ')
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.not.have.been.called
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should log all log levels greater than or equal to minimum log level', () => {
-      log.toggle(true, 'debug')
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should enable default log level when enabled with logLevel argument set to invalid input', () => {
-      log.toggle(true, ['trace', 'info', 'eror'])
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should enable default log level when enabled without logLevel argument', () => {
-      log.toggle(true)
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-  })
-
-  describe('use', () => {
-    it('should set the underlying logger when valid', () => {
-      log.use(logger)
-      log.debug('debug')
-      log.error(error)
-
-      expect(logger.debug).to.have.been.calledWith('debug')
-      expect(logger.error).to.have.been.calledWith(error)
-    })
-
-    it('be a no op with an empty logger', () => {
-      log.use(null)
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('be a no op with an invalid logger', () => {
-      log.use('invalid')
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-  })
-
-  describe('reset', () => {
-    it('should reset the logger', () => {
-      log.use(logger)
-      log.reset()
-      log.toggle(true)
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-
-    it('should reset the toggle', () => {
-      log.use(logger)
-      log.reset()
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.not.have.been.called
-      expect(console.error).to.not.have.been.called
-    })
-
-    it('should reset the minimum log level to defaults', () => {
-      log.use(logger)
-      log.toggle(true, 'error')
-      log.reset()
-      log.toggle(true)
-      log.debug('debug')
-      log.error(error)
-
-      expect(console.debug).to.have.been.calledWith('debug')
-      expect(console.error).to.have.been.calledWith(error)
-    })
-  })
-
-  describe('deprecate', () => {
-    it('should log a deprecation warning', () => {
-      log.deprecate('test', 'message')
-
-      expect(console.error).to.have.been.calledOnce
-      const consoleErrorArg = console.error.getCall(0).args[0]
-      expect(typeof consoleErrorArg).to.be.eq('object')
-      expect(consoleErrorArg.message).to.be.eq('message')
-    })
-
-    it('should only log once for a given code', () => {
-      log.deprecate('test', 'message')
-      log.deprecate('test', 'message')
-
-      expect(console.error).to.have.been.calledOnce
-    })
-  })
-
-  describe('logWriter', () => {
-    let logWriter
+  describe('config', () => {
+    let env
 
     beforeEach(() => {
-      logWriter = require('../src/log/writer')
+      env = process.env
+      process.env = {}
     })
 
     afterEach(() => {
-      logWriter.reset()
+      process.env = env
     })
 
-    describe('error', () => {
-      it('should call logger error', () => {
-        logWriter.error(error)
-
-        expect(console.error).to.have.been.calledOnceWith(error)
-      })
-
-      it('should call console.error no matter enable flag value', () => {
-        logWriter.toggle(false)
-        logWriter.error(error)
-
-        expect(console.error).to.have.been.calledOnceWith(error)
-      })
+    it('should have getConfig function', () => {
+      const log = require('../src/log')
+      expect(log.getConfig).to.be.a('function')
     })
 
-    describe('warn', () => {
-      it('should call logger warn', () => {
-        logWriter.warn('warn')
-
-        expect(console.warn).to.have.been.calledOnceWith('warn')
-      })
-
-      it('should call logger debug if warn is not provided', () => {
-        logWriter.use(logger)
-        logWriter.warn('warn')
-
-        expect(logger.debug).to.have.been.calledOnceWith('warn')
-      })
-
-      it('should call console.warn no matter enable flag value', () => {
-        logWriter.toggle(false)
-        logWriter.warn('warn')
-
-        expect(console.warn).to.have.been.calledOnceWith('warn')
+    it('should be configured with default config if no environment variables are set', () => {
+      const log = require('../src/log')
+      expect(log.getConfig()).to.deep.equal({
+        enabled: false,
+        logger: undefined,
+        logLevel: 'debug'
       })
     })
 
-    describe('info', () => {
-      it('should call logger info', () => {
-        logWriter.info('info')
-
-        expect(console.info).to.have.been.calledOnceWith('info')
+    it('should not be possbile to mutate config object returned by getConfig', () => {
+      const log = require('../src/log')
+      const config = log.getConfig()
+      expect(() => { config.enabled = 1 }).to.throw()
+      expect(() => { config.logger = 1 }).to.throw()
+      expect(() => { config.logLevel = 1 }).to.throw()
+      expect(log.getConfig()).to.deep.equal({
+        enabled: false,
+        logger: undefined,
+        logLevel: 'debug'
       })
+    })
 
-      it('should call logger debug if info is not provided', () => {
-        logWriter.use(logger)
-        logWriter.info('info')
+    it('should initialize from environment variables with DD env vars taking precedence OTEL env vars', () => {
+      process.env.DD_TRACE_LOG_LEVEL = 'error'
+      process.env.DD_TRACE_DEBUG = 'false'
+      process.env.OTEL_LOG_LEVEL = 'debug'
+      const config = proxyquire('../src/log', {}).getConfig()
+      expect(config).to.have.property('enabled', false)
+      expect(config).to.have.property('logLevel', 'error')
+    })
 
-        expect(logger.debug).to.have.been.calledOnceWith('info')
-      })
+    it('should initialize with OTEL environment variables when DD env vars are not set', () => {
+      process.env.OTEL_LOG_LEVEL = 'debug'
+      const config = proxyquire('../src/log', {}).getConfig()
+      expect(config).to.have.property('enabled', true)
+      expect(config).to.have.property('logLevel', 'debug')
+    })
 
-      it('should call console.info no matter enable flag value', () => {
-        logWriter.toggle(false)
-        logWriter.info('info')
+    it('should initialize from environment variables', () => {
+      process.env.DD_TRACE_DEBUG = 'true'
+      const config = proxyquire('../src/log', {}).getConfig()
+      expect(config).to.have.property('enabled', true)
+    })
 
-        expect(console.info).to.have.been.calledOnceWith('info')
-      })
+    it('should read case-insensitive booleans from environment variables', () => {
+      process.env.DD_TRACE_DEBUG = 'TRUE'
+      const config = proxyquire('../src/log', {}).getConfig()
+      expect(config).to.have.property('enabled', true)
+    })
+  })
+
+  describe('general usage', () => {
+    let log
+    let logger
+    let error
+
+    beforeEach(() => {
+      sinon.stub(console, 'info')
+      sinon.stub(console, 'error')
+      sinon.stub(console, 'warn')
+      sinon.stub(console, 'debug')
+
+      error = new Error()
+
+      logger = {
+        debug: sinon.spy(),
+        error: sinon.spy()
+      }
+
+      log = proxyquire('../src/log', {})
+      log.toggle(true)
+    })
+
+    afterEach(() => {
+      log.reset()
+      console.info.restore()
+      console.error.restore()
+      console.warn.restore()
+      console.debug.restore()
+    })
+
+    it('should support chaining', () => {
+      expect(() => {
+        log
+          .use(logger)
+          .toggle(true)
+          .error('error')
+          .debug('debug')
+          .reset()
+      }).to.not.throw()
+    })
+
+    it('should call the logger in a noop context', () => {
+      logger.debug = () => {
+        expect(storage.getStore()).to.have.property('noop', true)
+      }
+
+      log.use(logger).debug('debug')
     })
 
     describe('debug', () => {
-      it('should call logger debug', () => {
-        logWriter.debug('debug')
+      it('should log to console by default', () => {
+        log.debug('debug')
 
-        expect(console.debug).to.have.been.calledOnceWith('debug')
+        expect(console.debug).to.have.been.calledWith('debug')
       })
 
-      it('should call console.debug no matter enable flag value', () => {
-        logWriter.toggle(false)
-        logWriter.debug('debug')
+      it('should support callbacks that return a message', () => {
+        log.debug(() => 'debug')
 
-        expect(console.debug).to.have.been.calledOnceWith('debug')
+        expect(console.debug).to.have.been.calledWith('debug')
+      })
+    })
+
+    describe('error', () => {
+      it('should log to console by default', () => {
+        log.error(error)
+
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should support callbacks that return a error', () => {
+        log.error(() => error)
+
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should convert strings to errors', () => {
+        log.error('error')
+
+        expect(console.error).to.have.been.called
+        expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+        expect(console.error.firstCall.args[0]).to.have.property('message', 'error')
+      })
+
+      it('should convert empty values to errors', () => {
+        log.error()
+
+        expect(console.error).to.have.been.called
+        expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+        expect(console.error.firstCall.args[0]).to.have.property('message', 'undefined')
+      })
+
+      it('should convert invalid types to errors', () => {
+        log.error(123)
+
+        expect(console.error).to.have.been.called
+        expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+        expect(console.error.firstCall.args[0]).to.have.property('message', '123')
+      })
+
+      it('should reuse error messages for non-errors', () => {
+        log.error({ message: 'test' })
+
+        expect(console.error).to.have.been.called
+        expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+        expect(console.error.firstCall.args[0]).to.have.property('message', 'test')
+      })
+
+      it('should convert messages from callbacks to errors', () => {
+        log.error(() => 'error')
+
+        expect(console.error).to.have.been.called
+        expect(console.error.firstCall.args[0]).to.be.instanceof(Error)
+        expect(console.error.firstCall.args[0]).to.have.property('message', 'error')
+      })
+    })
+
+    describe('toggle', () => {
+      it('should disable the logger', () => {
+        log.toggle(false)
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.not.have.been.called
+        expect(console.error).to.not.have.been.called
+      })
+
+      it('should enable the logger', () => {
+        log.toggle(false)
+        log.toggle(true)
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should set minimum log level when enabled with logLevel argument set to a valid string', () => {
+        log.toggle(true, 'error')
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.not.have.been.called
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should set default log level when enabled with logLevel argument set to an invalid string', () => {
+        log.toggle(true, 'not a real log level')
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should set min log level when enabled w/logLevel arg set to valid string w/wrong case or whitespace', () => {
+        log.toggle(true, ' ErRoR   ')
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.not.have.been.called
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should log all log levels greater than or equal to minimum log level', () => {
+        log.toggle(true, 'debug')
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should enable default log level when enabled with logLevel argument set to invalid input', () => {
+        log.toggle(true, ['trace', 'info', 'eror'])
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should enable default log level when enabled without logLevel argument', () => {
+        log.toggle(true)
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+    })
+
+    describe('use', () => {
+      it('should set the underlying logger when valid', () => {
+        log.use(logger)
+        log.debug('debug')
+        log.error(error)
+
+        expect(logger.debug).to.have.been.calledWith('debug')
+        expect(logger.error).to.have.been.calledWith(error)
+      })
+
+      it('be a no op with an empty logger', () => {
+        log.use(null)
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('be a no op with an invalid logger', () => {
+        log.use('invalid')
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+    })
+
+    describe('reset', () => {
+      it('should reset the logger', () => {
+        log.use(logger)
+        log.reset()
+        log.toggle(true)
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+
+      it('should reset the toggle', () => {
+        log.use(logger)
+        log.reset()
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.not.have.been.called
+        expect(console.error).to.not.have.been.called
+      })
+
+      it('should reset the minimum log level to defaults', () => {
+        log.use(logger)
+        log.toggle(true, 'error')
+        log.reset()
+        log.toggle(true)
+        log.debug('debug')
+        log.error(error)
+
+        expect(console.debug).to.have.been.calledWith('debug')
+        expect(console.error).to.have.been.calledWith(error)
+      })
+    })
+
+    describe('deprecate', () => {
+      it('should log a deprecation warning', () => {
+        log.deprecate('test', 'message')
+
+        expect(console.error).to.have.been.calledOnce
+        const consoleErrorArg = console.error.getCall(0).args[0]
+        expect(typeof consoleErrorArg).to.be.eq('object')
+        expect(consoleErrorArg.message).to.be.eq('message')
+      })
+
+      it('should only log once for a given code', () => {
+        log.deprecate('test', 'message')
+        log.deprecate('test', 'message')
+
+        expect(console.error).to.have.been.calledOnce
+      })
+    })
+
+    describe('logWriter', () => {
+      let logWriter
+
+      beforeEach(() => {
+        logWriter = require('../src/log/writer')
+      })
+
+      afterEach(() => {
+        logWriter.reset()
+      })
+
+      describe('error', () => {
+        it('should call logger error', () => {
+          logWriter.error(error)
+
+          expect(console.error).to.have.been.calledOnceWith(error)
+        })
+
+        it('should call console.error no matter enable flag value', () => {
+          logWriter.toggle(false)
+          logWriter.error(error)
+
+          expect(console.error).to.have.been.calledOnceWith(error)
+        })
+      })
+
+      describe('warn', () => {
+        it('should call logger warn', () => {
+          logWriter.warn('warn')
+
+          expect(console.warn).to.have.been.calledOnceWith('warn')
+        })
+
+        it('should call logger debug if warn is not provided', () => {
+          logWriter.use(logger)
+          logWriter.warn('warn')
+
+          expect(logger.debug).to.have.been.calledOnceWith('warn')
+        })
+
+        it('should call console.warn no matter enable flag value', () => {
+          logWriter.toggle(false)
+          logWriter.warn('warn')
+
+          expect(console.warn).to.have.been.calledOnceWith('warn')
+        })
+      })
+
+      describe('info', () => {
+        it('should call logger info', () => {
+          logWriter.info('info')
+
+          expect(console.info).to.have.been.calledOnceWith('info')
+        })
+
+        it('should call logger debug if info is not provided', () => {
+          logWriter.use(logger)
+          logWriter.info('info')
+
+          expect(logger.debug).to.have.been.calledOnceWith('info')
+        })
+
+        it('should call console.info no matter enable flag value', () => {
+          logWriter.toggle(false)
+          logWriter.info('info')
+
+          expect(console.info).to.have.been.calledOnceWith('info')
+        })
+      })
+
+      describe('debug', () => {
+        it('should call logger debug', () => {
+          logWriter.debug('debug')
+
+          expect(console.debug).to.have.been.calledOnceWith('debug')
+        })
+
+        it('should call console.debug no matter enable flag value', () => {
+          logWriter.toggle(false)
+          logWriter.debug('debug')
+
+          expect(console.debug).to.have.been.calledOnceWith('debug')
+        })
       })
     })
   })

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -37,9 +37,9 @@ describe('log', () => {
     it('should not be possbile to mutate config object returned by getConfig', () => {
       const log = require('../src/log')
       const config = log.getConfig()
-      expect(() => { config.enabled = 1 }).to.throw()
-      expect(() => { config.logger = 1 }).to.throw()
-      expect(() => { config.logLevel = 1 }).to.throw()
+      config.enabled = 1
+      config.logger = 1
+      config.logLevel = 1
       expect(log.getConfig()).to.deep.equal({
         enabled: false,
         logger: undefined,


### PR DESCRIPTION
Removes the need to create a dummy `Config` object just in order to initialize the logger. This was previously required because the logging config wasn't initialized before calling the `Config` constructor. With this PR, the logger is now responsible for initializing itself and the `Config` constructor simply fetches the already initialized logging config from the logger.

## Improvement ideas

Though reduced, there still exist a coupling between the `Config` class and the logger as is evident in the tests. To further reduce this, one option is to simply remove the following properties from the config object:

- `debug`: This is currently accessed in a few places, but it should be possible to change those to get it directly from the logger
- `logger`: This is currently accessed in a few places, but it should be possible to change those to get it directly from the logger
- `logLevel`: This is currently never accessed outside tests

Furthermore, we could remove the ability to configure the logger when calling the `Config` constructor. This is also currently only used by tests, but keeping this functionality only makes our tests more complicated, so I don't think it provides any benefits.

## Note to reviewers

Before this PR, the `Config` class was initialized twice during boot when the `./init.js` file was required (via for example `node -r dd-trace/init server.js`). This had the side-effect of calling `updateConfig` in `./packages/dd-trace/src/telemetry/index.js` twice as well. But since this function [behaves differently](https://github.com/DataDog/dd-trace-js/blob/4624d06be34dc18e3bdf97edde89d0c51157718f/packages/dd-trace/src/telemetry/index.js#L346-L354) the first time it's called, the telemetry that was collected when using `./init.js` vs not, differed.

This PR changes this by only ever only initializing `Config` once, which means that only subsequent calls to `config.configure` will trigger more calls to `updateConfig`. Please verify that this change in behavior is ok.

If it's ok, it must mean that we collected too much telemetry in the past when ever someone used the `./init.js` file.