### PR TITLE
aws-sdk: ensure correct response data is being extracted from

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -73,7 +73,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
       if (!cbExists && this.serviceIdentifier === 'sqs') {
         const params = response.request.params
         const operation = response.request.operation
-        this.responseExtractDSMContext(operation, params, response.data, span)
+        this.responseExtractDSMContext(operation, params, response.data ?? response, span)
       }
       this.addResponseTags(span, response)
       this.finish(span, response, response.error)


### PR DESCRIPTION
### What does this PR do?
For some reason, when called via typescript, AWS SQS request has a different shape. When trying to extract context from message attributes, we are trying to extract from an empty object.

### Motivation
Internal team was impacted

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


