### PR TITLE
aws-sdk: add batchPropagationEnabled env variable configuration

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -163,9 +163,15 @@ function normalizeConfig (config, serviceIdentifier) {
       break
   }
 
+  // check if AWS batch propagation or AWS_[SERVICE] batch propagation is enabled via env variable
+  const serviceId = serviceIdentifier.toUpperCase()
+  const serviceBatchPropagationValue = process.env.DD_TRACE_AWS_SDK_BATCH_PROPAGATION_ENABLED ??
+    process.env[`DD_TRACE_AWS_SDK_${serviceId}_BATCH_PROPAGATION_ENABLED`]
+  const serviceBatchPropagationEnabled = serviceBatchPropagationValue ? isTrue(serviceBatchPropagationValue) : false
+
   return Object.assign({}, config, specificConfig, {
     splitByAwsService: config.splitByAwsService !== false,
-    batchPropagationEnabled: config.batchPropagationEnabled !== false,
+    batchPropagationEnabled: config.batchPropagationEnabled !== false || serviceBatchPropagationEnabled !== false,
     hooks
   })
 }

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -164,36 +164,24 @@ function normalizeConfig (config, serviceIdentifier) {
       break
   }
 
-  const baseAWSBatchPropagationEnabled = isTrue(
-    coalesce(
-      config.batchPropagationEnabled,
-      process.env.DD_TRACE_SPAN_LEAK_DEBUG,
-      false
-    )
-  )
-
   // check if AWS batch propagation or AWS_[SERVICE] batch propagation is enabled via env variable
   const serviceId = serviceIdentifier.toUpperCase()
-  const serviceBatchPropagationEnabled = isTrue(
+  const batchPropagationEnabled = isTrue(
     coalesce(
       specificConfig.batchPropagationEnabled,
       process.env[`DD_TRACE_AWS_SDK_${serviceId}_BATCH_PROPAGATION_ENABLED`],
-      baseAWSBatchPropagationEnabled,
+      config.batchPropagationEnabled,
+      process.env.DD_TRACE_AWS_SDK_BATCH_PROPAGATION_ENABLED,
       false
     )
   )
 
   // Merge the specific config back into the main config
-  return {
-    ...config,
-    [serviceIdentifier]: {
-      ...specificConfig,
-      batchPropagationEnabled: serviceBatchPropagationEnabled
-    },
+  return Object.assign({}, config, specificConfig, {
     splitByAwsService: config.splitByAwsService !== false,
-    batchPropagationEnabled: baseAWSBatchPropagationEnabled,
+    batchPropagationEnabled,
     hooks
-  }
+  })
 }
 
 function getHooks (config) {

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -156,7 +156,7 @@ class Kinesis extends BaseAwsSdkPlugin {
             span,
             params.Records[i],
             stream,
-            i === 0 || (this.config.kinesis && this.config.kinesis.batchPropagationEnabled)
+            i === 0 || (this.config.batchPropagationEnabled)
           )
         }
     }

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -63,7 +63,7 @@ class Sns extends BaseAwsSdkPlugin {
             span,
             params.PublishBatchRequestEntries[i],
             params.TopicArn,
-            i === 0 || (this.config.sns && this.config.sns.batchPropagationEnabled)
+            i === 0 || (this.config.batchPropagationEnabled)
           )
         }
         break

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -222,7 +222,7 @@ class Sqs extends BaseAwsSdkPlugin {
             span,
             params.Entries[i],
             params.QueueUrl,
-            i === 0 || (this.config.sqs && this.config.sqs.batchPropagationEnabled)
+            i === 0 || (this.config.batchPropagationEnabled)
           )
         }
         break

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -315,7 +315,7 @@ describe('Plugin', () => {
         })
       })
 
-      describe('with batch propagation configuration', () => {
+      describe('with programmatic batchPropagationEnabled configuration', () => {
         before(() => {
           return agent.load(['aws-sdk'], [{
             service: 'test',
@@ -345,6 +345,32 @@ describe('Plugin', () => {
           expect(sns.config.batchPropagationEnabled).to.equal(true)
           expect(sns.config.enabled).to.equal(false)
           expect(sqs.config.batchPropagationEnabled).to.equal(false)
+        })
+      })
+
+      describe('with env variable _BATCH_PROPAGATION_ENABLED configuration', () => {
+        before(() => {
+          process.env.DD_TRACE_AWS_SDK_BATCH_PROPAGATION_ENABLED = true
+          process.env.DD_TRACE_AWS_SDK_KINESIS_BATCH_PROPAGATION_ENABLED = false
+          process.env.DD_TRACE_AWS_SDK_SQS_BATCH_PROPAGATION_ENABLED = true
+
+          return agent.load(['aws-sdk'])
+        })
+
+        before(() => {
+          tracer = require('../../dd-trace')
+        })
+
+        after(() => {
+          return agent.close({ ritmReset: false })
+        })
+
+        it('should be configurable on a per-service basis', () => {
+          const { kinesis, sns, sqs } = tracer._pluginManager._pluginsByName['aws-sdk'].services
+
+          expect(kinesis.config.batchPropagationEnabled).to.equal(false)
+          expect(sns.config.batchPropagationEnabled).to.equal(true)
+          expect(sqs.config.batchPropagationEnabled).to.equal(true)
         })
       })
     })

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -314,6 +314,39 @@ describe('Plugin', () => {
           }, 250)
         })
       })
+
+      describe('with batch propagation configuration', () => {
+        before(() => {
+          return agent.load(['aws-sdk'], [{
+            service: 'test',
+            batchPropagationEnabled: true,
+            kinesis: {
+              batchPropagationEnabled: false
+            },
+            sns: false,
+            sqs: {
+              batchPropagationEnabled: false
+            }
+          }])
+        })
+
+        before(() => {
+          tracer = require('../../dd-trace')
+        })
+
+        after(() => {
+          return agent.close({ ritmReset: false })
+        })
+
+        it('should be configurable on a per-service basis', () => {
+          const { kinesis, sns, sqs } = tracer._pluginManager._pluginsByName['aws-sdk'].services
+
+          expect(kinesis.config.batchPropagationEnabled).to.equal(false)
+          expect(sns.config.batchPropagationEnabled).to.equal(true)
+          expect(sns.config.enabled).to.equal(false)
+          expect(sqs.config.batchPropagationEnabled).to.equal(false)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
This PR adds the following env variables:
`DD_TRACE_AWS_SDK_BATCH_PROPAGATION_ENABLED` and `DD_TRACE_AWS_SDK_<SERVICE>_BATCH_PROPAGATION_ENABLED` . These env variables enable Datadog APM trace context injection for each message in batch send operations, as opposed to only injecting the first message in batches. The configuration is available for the following supported AWS SDK messaging services:
- SQS
- SNS
- Kinesis

### Motivation
Customer request

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


