### PR TITLE
[test-visibility] Add flaky test retries to jest

### DIFF
--- a/integration-tests/ci-visibility/jest-flaky/flaky-fails.js
+++ b/integration-tests/ci-visibility/jest-flaky/flaky-fails.js
@@ -1,0 +1,6 @@
+describe('test-flaky-test-retries', () => {
+  it('can retry failed tests', () => {
+    // eslint-disable-next-line
+    expect(1).toEqual(2)
+  })
+})

--- a/integration-tests/ci-visibility/jest-flaky/flaky-passes.js
+++ b/integration-tests/ci-visibility/jest-flaky/flaky-passes.js
@@ -1,0 +1,13 @@
+let counter = 0
+
+describe('test-flaky-test-retries', () => {
+  it('can retry flaky tests', () => {
+    // eslint-disable-next-line
+    expect(++counter).toEqual(3)
+  })
+
+  it('will not retry passed tests', () => {
+    // eslint-disable-next-line
+    expect(3).toEqual(3)
+  })
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -230,6 +230,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             retriedTestsToNumAttempts.set(originalTestName, numEfdRetry + 1)
           }
         }
+        const isJestRetry = event.test?.invocations > 1
         asyncResource.runInAsyncScope(() => {
           testStartCh.publish({
             name: removeEfdStringFromTestName(testName),
@@ -240,7 +241,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             testParameters,
             frameworkVersion: jestVersion,
             isNew: isNewTest,
-            isEfdRetry: numEfdRetry > 0
+            isEfdRetry: numEfdRetry > 0,
+            isJestRetry
           })
           originalTestFns.set(event.test, event.test.fn)
           event.test.fn = asyncResource.bind(event.test.fn)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -12,7 +12,8 @@ const {
   getTestParametersString,
   addEfdStringToTestName,
   removeEfdStringFromTestName,
-  getIsFaultyEarlyFlakeDetection
+  getIsFaultyEarlyFlakeDetection,
+  NUM_FAILED_TEST_RETRIES
 } = require('../../dd-trace/src/plugins/util/test')
 const {
   getFormattedJestTestParameters,
@@ -49,6 +50,9 @@ const itrSkippedSuitesCh = channel('ci:jest:itr:skipped-suites')
 const CHILD_MESSAGE_CALL = 1
 // Maximum time we'll wait for the tracer to flush
 const FLUSH_TIMEOUT = 10000
+// eslint-disable-next-line
+// https://github.com/jestjs/jest/blob/41f842a46bb2691f828c3a5f27fc1d6290495b82/packages/jest-circus/src/types.ts#L9C8-L9C54
+const RETRY_TIMES = Symbol.for('RETRY_TIMES')
 
 let skippableSuites = []
 let knownTests = {}
@@ -127,6 +131,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       }
 
       this.isEarlyFlakeDetectionEnabled = this.testEnvironmentOptions._ddIsEarlyFlakeDetectionEnabled
+      this.isFlakyTestRetriesEnabled = this.testEnvironmentOptions._ddIsFlakyTestRetriesEnabled
 
       if (this.isEarlyFlakeDetectionEnabled) {
         const hasKnownTests = !!knownTests.jest
@@ -138,6 +143,13 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         } catch (e) {
           // If there has been an error parsing the tests, we'll disable Early Flake Deteciton
           this.isEarlyFlakeDetectionEnabled = false
+        }
+      }
+
+      if (this.isFlakyTestRetriesEnabled) {
+        const currentNumRetries = this.global[RETRY_TIMES]
+        if (!currentNumRetries) {
+          this.global[RETRY_TIMES] = NUM_FAILED_TEST_RETRIES
         }
       }
     }
@@ -758,6 +770,7 @@ addHook({
       _ddIsEarlyFlakeDetectionEnabled,
       _ddEarlyFlakeDetectionNumRetries,
       _ddRepositoryRoot,
+      _ddIsFlakyTestRetriesEnabled,
       ...restOfTestEnvironmentOptions
     } = testEnvironmentOptions
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -148,6 +148,7 @@ class JestPlugin extends CiPlugin {
         config._ddIsEarlyFlakeDetectionEnabled = !!this.libraryConfig?.isEarlyFlakeDetectionEnabled
         config._ddEarlyFlakeDetectionNumRetries = this.libraryConfig?.earlyFlakeDetectionNumRetries ?? 0
         config._ddRepositoryRoot = this.repositoryRoot
+        config._ddIsFlakyTestRetriesEnabled = this.libraryConfig?.isFlakyTestRetriesEnabled ?? false
       })
     })
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -325,7 +325,8 @@ class JestPlugin extends CiPlugin {
       testStartLine,
       testSourceFile,
       isNew,
-      isEfdRetry
+      isEfdRetry,
+      isJestRetry
     } = test
 
     const extraTags = {
@@ -348,6 +349,10 @@ class JestPlugin extends CiPlugin {
       if (isEfdRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
       }
+    }
+
+    if (isJestRetry) {
+      extraTags[TEST_IS_RETRY] = 'true'
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)


### PR DESCRIPTION
### What does this PR do?
If we receive `flaky_test_retries_enabled: true` from the API, we'll leverage the retry mechanism from jest: https://jestjs.io/docs/jest-object#jestretrytimesnumretries-options

### Motivation
Same as #4504, #4489, #4453, #4513 and #4518: allow users to automatically retry their tests if they fail.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
