### PR TITLE
Fix @types/node to version 16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "tlhunter-sorted-set": "^0.1.0"
   },
   "devDependencies": {
-    "@types/node": "^18.19.40",
+    "@types/node": "^16.18.103",
     "autocannon": "^4.5.2",
     "aws-sdk": "^2.1446.0",
     "axios": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "tlhunter-sorted-set": "^0.1.0"
   },
   "devDependencies": {
-    "@types/node": ">=18",
+    "@types/node": "^18.19.40",
     "autocannon": "^4.5.2",
     "aws-sdk": "^2.1446.0",
     "axios": "^1.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,10 +657,17 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@>=13.7.0", "@types/node@>=18":
-  version "20.10.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.6.tgz#a3ec84c22965802bf763da55b2394424f22bfbb5"
-  integrity sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==
+"@types/node@>=13.7.0":
+  version "20.14.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.11.tgz#09b300423343460455043ddd4d0ded6ac579b74b"
+  integrity sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^18.19.40":
+  version "18.19.40"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.40.tgz#e9213ba98122992dafd8d55a2196f2ebb56b2555"
+  integrity sha512-MIxieZHrm4Ee8XArBIc+Or9HINt2StOmCbgRcXGSJl8q14svRvkZPe7LJq9HKtTI1SK3wU8b91TjntUm7T69Pg==
   dependencies:
     undici-types "~5.26.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,12 +664,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.19.40":
-  version "18.19.40"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.40.tgz#e9213ba98122992dafd8d55a2196f2ebb56b2555"
-  integrity sha512-MIxieZHrm4Ee8XArBIc+Or9HINt2StOmCbgRcXGSJl8q14svRvkZPe7LJq9HKtTI1SK3wU8b91TjntUm7T69Pg==
-  dependencies:
-    undici-types "~5.26.4"
+"@types/node@^16.18.103":
+  version "16.18.103"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.103.tgz#5557c7c32a766fddbec4b933b1d5c365f89b20a4"
+  integrity sha512-gOAcUSik1nR/CRC3BsK8kr6tbmNIOTpvb1sT+v5Nmmys+Ho8YtnIHP90wEsVK4hTcHndOqPVIlehEGEA5y31bA==
 
 "@types/prop-types@*":
   version "15.7.5"


### PR DESCRIPTION
This project supports Node.js >=18.0.0, so the `@types/node` dependency should not be newer. On top of that, we want to make it easy to backport to the `v4.x` branch, so until that version is deprecated, we fix the `@types/node` dependency to `^16.18.103`