### PR TITLE
remove yarn caching for windows job in tracing workflow

### DIFF
--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          cache: yarn
           node-version: '18'
       - uses: ./.github/actions/install
       - run: yarn test:trace:core:ci


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove yarn caching for Windows job in tracing workflow.

### Motivation
<!-- What inspired you to submit this pull request? -->

It was already removed from other workflows as caching is slower than a full `yarn install` on Windows, but this workflow was missed.