### PR TITLE
eslint: better match desired Node.js support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,12 @@
   ],
   "env": {
     "node": true,
-    "es2020": true
+    "es2021": true
+  },
+  "settings": {
+    "node": {
+      "version": ">=16.0.0"
+    }
   },
   "rules": {
     "max-len": [2, 120, 2],

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@datadog/native-appsec": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "homepage": "https://github.com/DataDog/dd-trace-js#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18"
   },
   "dependencies": {
     "@datadog/native-appsec": "8.0.1",


### PR DESCRIPTION
Two things are changed:

1. The eslint-plugin-n module uses the `engines` field from package.json to know which Node.js versions to support. To ensure we don't accidentally use Node.js features not supported by the v4.x branch (whos `engines` field is set to `>=16`), we override the Node.js version from the `engines` field used by the plugin.
2. Ensure the ECMAScript version specified in `parserOptions` is also used in `env`.