### PR TITLE
switch to kafka-native as the container for kafkajs tests

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -632,14 +632,19 @@ jobs:
     runs-on: ubuntu-latest
     services:
       kafka:
-        image: debezium/kafka:1.7
+        image: apache/kafka-native:3.8.0-rc2
         env:
-          CLUSTER_ID: 5Yr1SIgYQz-b-dgRabWx4g
-          NODE_ID: "1"
-          CREATE_TOPICS: "test-topic:1:1"
-          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_NODE_ID: '1'
+          KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_CLUSTER_ID: r4zt_wrqTRuT7W2NJsB_GA
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
-          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
+          KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
         ports:
           - 9092:9092
           - 9093:9093

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,25 +119,22 @@ services:
       - LAMBDA_EXECUTOR=local
   kafka:
     platform: linux/arm64
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: apache/kafka-native:3.8.0-rc2
     ports:
       - "127.0.0.1:9092:9092"
       - "127.0.0.1:9093:9093"
     environment:
-      - CLUSTER_ID=5Yr1SIgYQz-b-dgRabWx4g
-      - NODE_ID=1
-      - CREATE_TOPICS="test-topic:1:1"
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_NODE_ID=1
+      - KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CLUSTER_ID=r4zt_wrqTRuT7W2NJsB_GA
       - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
       - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
-    depends_on:
-      - zookeeper
-  zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-      - "2181:2181"
   opensearch:
     image: opensearchproject/opensearch:2
     environment:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Switch to kafka-native as the container for kafkajs tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

Kafka and ZooKeeper total over 1GB together. Newer versions of Kafka no longer depend on ZooKeeper in Raft mode and can be compiled with GraalVM, reducing its size to ~100MB.