### PR TITLE
Add new ESLint plugin: @datadog/eslint-plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
   "extends": [
     "eslint:recommended",
     "standard",
-    "plugin:mocha/recommended"
+    "plugin:mocha/recommended",
+    "plugin:@datadog/recommended"
   ],
   "plugins": [
     "mocha",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -28,6 +28,7 @@ require,tlhunter-sorted-set,MIT,Copyright (c) 2023 Datadog Inc.
 require,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 require,shell-quote,mit,Copyright (c) 2013 James Halliday
+dev,@datadog/eslint-plugin,MIT,Copyright 2024 Datadog Inc.
 dev,@types/node,MIT,Copyright Authors
 dev,autocannon,MIT,Copyright 2016 Matteo Collina
 dev,aws-sdk,Apache 2.0,Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "tlhunter-sorted-set": "^0.1.0"
   },
   "devDependencies": {
+    "@datadog/eslint-plugin": "DataDog/eslint-plugin",
     "@types/node": ">=18",
     "autocannon": "^4.5.2",
     "aws-sdk": "^2.1446.0",

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -7,7 +7,7 @@ const hooks = require('../datadog-instrumentations/src/helpers/hooks.js')
 const extractPackageAndModulePath = require('../datadog-instrumentations/src/utils/src/extract-package-and-module-path')
 
 for (const hook of Object.values(hooks)) {
-  if (typeof hook === 'object') {
+  if (hook !== null && typeof hook === 'object') {
     hook.fn()
   } else {
     hook()

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -46,7 +46,7 @@ for (const packageName of names) {
 
   let hook = hooks[packageName]
 
-  if (typeof hook === 'object') {
+  if (hook !== null && typeof hook === 'object') {
     hookOptions.internals = hook.esmFirst
     hook = hook.fn
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
@@ -21,18 +21,16 @@ class DynamoDb extends BaseAwsSdkPlugin {
       // batch operations have different format, collect table name for batch
       // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#batchGetItem-property`
       // dynamoDB batch TableName
-      if (params.RequestItems !== null) {
-        if (typeof params.RequestItems === 'object') {
-          if (Object.keys(params.RequestItems).length === 1) {
-            const tableName = Object.keys(params.RequestItems)[0]
+      if (params.RequestItems !== null && typeof params.RequestItems === 'object') {
+        if (Object.keys(params.RequestItems).length === 1) {
+          const tableName = Object.keys(params.RequestItems)[0]
 
-            // also add span type to match serverless convention
-            Object.assign(tags, {
-              'resource.name': `${operation} ${tableName}`,
-              'aws.dynamodb.table_name': tableName,
-              tablename: tableName
-            })
-          }
+          // also add span type to match serverless convention
+          Object.assign(tags, {
+            'resource.name': `${operation} ${tableName}`,
+            'aws.dynamodb.table_name': tableName,
+            tablename: tableName
+          })
         }
       }
 

--- a/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
+++ b/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
@@ -63,7 +63,7 @@ function scrubChildProcessCmd (expression) {
 
       if (token === null) {
         continue
-      } else if (typeof token === 'object') {
+      } else if (typeof token === 'object') { // eslint-disable-line @datadog/safe-typeof-object
         if (token.pattern) {
           result.push(token.pattern)
         } else if (token.op) {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/operations-taint-object.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/operations-taint-object.js
@@ -25,6 +25,7 @@ function taintObject (iastContext, object, type) {
           } else {
             parent[key] = tainted
           }
+          // eslint-disable-next-line @datadog/safe-typeof-object
         } else if (typeof value === 'object' && !visited.has(value)) {
           visited.add(value)
 

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
@@ -45,6 +45,7 @@ class VulnerabilityFormatter {
 
     if (evidence.value == null) return { valueParts }
 
+    // eslint-disable-next-line @datadog/safe-typeof-object
     if (typeof evidence.value === 'object' && evidence.rangesToApply) {
       const { value, ranges } = stringifyWithRanges(evidence.value, evidence.rangesToApply)
       evidence.value = value

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -66,6 +66,7 @@ function request (data, options, callback) {
   }
 
   if (options.url) {
+    // eslint-disable-next-line @datadog/safe-typeof-object
     const url = typeof options.url === 'object' ? urlToOptions(options.url) : fromUrlString(options.url)
     if (url.protocol === 'unix:') {
       options.socketPath = url.pathname

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -171,6 +171,7 @@ class DatadogSpan {
   addEvent (name, attributesOrStartTime, startTime) {
     const event = { name }
     if (attributesOrStartTime) {
+      // eslint-disable-next-line @datadog/safe-typeof-object
       if (typeof attributesOrStartTime === 'object') {
         event.attributes = this._sanitizeEventAttributes(attributesOrStartTime)
       } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,6 +412,10 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k= sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
 
+"@datadog/eslint-plugin@DataDog/eslint-plugin":
+  version "1.0.0"
+  resolved "https://codeload.github.com/DataDog/eslint-plugin/tar.gz/97f4183315bbee879958d651d826f4d674b7e853"
+
 "@datadog/native-appsec@8.0.1":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-8.0.1.tgz#be06be92d79d7462aa64ee3a33108133083134fc"


### PR DESCRIPTION
Add a new ESLint plugin: [@datadog/eslint-plugin](https://github.com/DataDog/eslint-plugin)

This plugin currently only contains a single rule, `@datadog/safer-typeof-object`, which will ensure that any `typeof x === 'object'` is preceded by a not-null check:

**Bad:**

```js
typeof foo === 'object'
```

**Good:**

```js
foo !== null && typeof foo === 'object'
```

This is because `typeof null === 'object'`, so any operation on the variable that doesn't expect a `null` value will at best lead to unexpected behaviour, and at works to an uncaught exception crashing the process.

The source code previously contained a lot of instances violating this code, but this was recently fixed in #4517. This PR is an attempt to ensure no new violations sneak in.

## Note to reviewers

I'm working on publishing `@datadog/eslint-plugin` to npm (but need access first). But since it's not really an issue to have a dev-dependency that points to a GitHub repo, I think it's safe to merge this as-is. Once the package is published to npm, I'll make a follow up PR to update the dependency to use that version.