### PR TITLE
fix child_process propagation issues

### DIFF
--- a/packages/datadog-plugin-child_process/src/index.js
+++ b/packages/datadog-plugin-child_process/src/index.js
@@ -58,7 +58,7 @@ class ChildProcessPlugin extends TracingPlugin {
       resource: (shell === true) ? 'sh' : cmdFields[0],
       type: 'system',
       meta
-    })
+    }, false)
   }
 
   end ({ result, error }) {

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -96,8 +96,8 @@ describe('Child process plugin', () => {
         done()
       })
     })
-
   })
+
   describe('unit tests', () => {
     let tracerStub, configStub, spanStub
 

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -22,6 +22,82 @@ function normalizeArgs (methodName, command, options) {
 }
 
 describe('Child process plugin', () => {
+  describe('context maintenance', () => {
+    let parent
+    let childProcess
+    let tracer
+
+    before(() => {
+      return agent.load(['child_process'])
+        .then(() => {
+          childProcess = require('child_process')
+          tracer = require('../../dd-trace')
+          tracer.init()
+          parent = tracer.startSpan('parent')
+          parent.finish()
+        }).then(_port => {
+          return new Promise(resolve => setImmediate(resolve))
+        })
+    })
+
+    after(() => {
+      return agent.close()
+    })
+
+    it('should preserve context around execSync calls', () => {
+      tracer.scope().activate(parent, () => {
+        expect(tracer.scope().active()).to.equal(parent)
+        childProcess.execSync('ls')
+        expect(tracer.scope().active()).to.equal(parent)
+      })
+    })
+
+    it('should preserve context around exec calls', (done) => {
+      tracer.scope().activate(parent, () => {
+        expect(tracer.scope().active()).to.equal(parent)
+        childProcess.exec('ls', () => {
+          expect(tracer.scope().active()).to.equal(parent)
+          done()
+        })
+      })
+    })
+
+    it('should preserve context around execFileSync calls', () => {
+      tracer.scope().activate(parent, () => {
+        expect(tracer.scope().active()).to.equal(parent)
+        childProcess.execFileSync('ls')
+        expect(tracer.scope().active()).to.equal(parent)
+      })
+    })
+
+    it('should preserve context around execFile calls', (done) => {
+      tracer.scope().activate(parent, () => {
+        expect(tracer.scope().active()).to.equal(parent)
+        childProcess.execFile('ls', () => {
+          expect(tracer.scope().active()).to.equal(parent)
+          done()
+        })
+      })
+    })
+
+    it('should preserve context around spawnSync calls', () => {
+      tracer.scope().activate(parent, () => {
+        expect(tracer.scope().active()).to.equal(parent)
+        childProcess.spawnSync('ls')
+        expect(tracer.scope().active()).to.equal(parent)
+      })
+    })
+
+    it('should preserve context around spawn calls', (done) => {
+      tracer.scope().activate(parent, () => {
+        expect(tracer.scope().active()).to.equal(parent)
+        childProcess.spawn('ls')
+        expect(tracer.scope().active()).to.equal(parent)
+        done()
+      })
+    })
+
+  })
   describe('unit tests', () => {
     let tracerStub, configStub, spanStub
 


### PR DESCRIPTION
### What does this PR do?
- disables the `enter` argument to `startSpan()` which then disables the `storage.enterWith({ ...store, span })` call

### Motivation
- otherwise it appears that sometimes unrelated spans become child spans of a child process operation

Ref #4274 