### PR TITLE
[test-visibility] Fix mocha plugin tests flakiness

### DIFF
--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -395,9 +395,13 @@ addHook({
       }
 
       const asyncResource = testFileToSuiteAr.get(suite.file)
-      asyncResource.runInAsyncScope(() => {
-        testSuiteFinishCh.publish(status)
-      })
+      if (asyncResource) {
+        asyncResource.runInAsyncScope(() => {
+          testSuiteFinishCh.publish(status)
+        })
+      } else {
+        log.warn(() => `No AsyncResource found for suite ${suite.file}`)
+      }
     })
 
     return run.apply(this, arguments)

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -480,15 +480,15 @@ describe('Plugin', () => {
           })
         })
 
-        Promise.all(assertionPromises)
-          .then(() => done())
-          .catch(done)
-
         const mocha = new Mocha({
           reporter: function () {} // silent on internal tests
         })
         mocha.addFile(testFilePath)
-        mocha.run()
+        mocha.run().on('end', () => {
+          Promise.all(assertionPromises)
+            .then(() => done())
+            .catch(done)
+        })
       })
 
       it('works when skipping suites', function (done) {


### PR DESCRIPTION
### What does this PR do?

* Guard against a missing `asyncResource`
* Run the `assertionPromises` after mocha has finished, to make sure we don't finish the test before mocha has finished. 

### Motivation
The tests are still flaking. I think it's an issue with the programmatic API. The fact that we run `mocha.run` multiple times potentially before a previous run has finished could make it so that the `'suite end'` event runs _after_ a `'end'` event. 

