### PR TITLE
Revert "hardcode the latest version of node as 22.4"

### DIFF
--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -4,7 +4,4 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        # TODO: revert to "latest" when
-        # https://github.com/nodejs/node/issues/53902 is fixed, along with
-        # other occurrences in plugins.yml
-        node-version: '22.4'
+        node-version: 'latest'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -208,7 +208,7 @@ jobs:
       matrix:
         version:
           - 18
-          - 22.4
+          - latest
         range: ['9.5.0', '11.1.4', '13.2.0', '*']
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -172,7 +172,7 @@ jobs:
   aws-sdk:
     strategy:
       matrix:
-        node-version: ['18', '22.4']
+        node-version: ['18', 'latest']
     runs-on: ubuntu-latest
     services:
       localstack:
@@ -577,7 +577,7 @@ jobs:
   http:
     strategy:
       matrix:
-        node-version: ['18', '20', '22.4']
+        node-version: ['18', '20', 'latest']
     runs-on: ubuntu-latest
     env:
       PLUGINS: http
@@ -918,7 +918,7 @@ jobs:
       matrix:
         version:
           - 18
-          - 22.4
+          - latest
         range: ['9.5.0', '11.1.4', '13.2.0', '*']
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,7 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [18, 20, 22.4]
+        version: [18, 20, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [18, 22.4]
+        version: [18, latest]
         framework: [cucumber, playwright, selenium, jest, mocha]
     runs-on: ubuntu-latest
     env:
@@ -89,7 +89,7 @@ jobs:
         # Important: This is outside the minimum supported version of dd-trace-js
         # Node > 16 does not work with Cypress@6.7.0 (not even without our plugin)
         # TODO: figure out what to do with this: we might have to deprecate support for cypress@6.7.0
-        version: [16, 22.4]
+        version: [16, latest]
         # 6.7.0 is the minimum version we support
         cypress-version: [6.7.0, latest]
         module-type: ['commonJS', 'esm']


### PR DESCRIPTION
Reverts DataDog/dd-trace-js#4526

Node 22.5.1 has now landed in Docker Hub which should fix the issue so we don't need to hardcode to an older version anymore.