### PR TITLE
Add CI options to prepare and merge release branches

### DIFF
--- a/.github/workflows/prepare-release-proposal.yml
+++ b/.github/workflows/prepare-release-proposal.yml
@@ -2,14 +2,6 @@ name: Prepare release proposal
 
 on:
   workflow_dispatch:
-    inputs:
-      release-type:
-        description: 'Release type'
-        required: true
-        type: choice
-        options:
-        - minor
-        - patch
 
 jobs:
   create-proposal:
@@ -50,12 +42,6 @@ jobs:
         run: |
           yarn
 
-      - name: Create proposal branch
-        id: create_branch
-        run: |
-          branch_name=`node _scripts/prepare-release-proposal.js create-branch ${{ github.event.inputs.release-type }}`
-          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
-
       - name: Install branch-diff
         run: |
           npm i -g @bengl/branch-diff
@@ -68,7 +54,19 @@ jobs:
       - name: Commit branch diffs
         id: commit_branch_diffs
         run: |
-          node _scripts/prepare-release-proposal.js commit-branch-diffs ${{ matrix.base-branch }} ${{ github.event.inputs.release-type }} > branch-diffs.txt
+          node _scripts/prepare-release-proposal.js commit-branch-diffs ${{ matrix.base-branch }} > branch-diffs.txt
+
+      - name: Calculate release type
+        id: calc-release-type
+        run: |
+          release_type=`grep -q "(SEMVER-MINOR)" branch-diffs.txt && echo "minor" || echo "patch"`
+          echo "release-type=$release_type" >> $GITHUB_OUTPUT
+
+      - name: Create proposal branch
+        id: create_branch
+        run: |
+          branch_name=`node _scripts/prepare-release-proposal.js create-branch ${{ steps.calc-release-type.outputs.release-type }}`
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
       - name: Push proposal branch
         run: |
@@ -77,7 +75,7 @@ jobs:
       - name: Update package.json
         id: pkg
         run: |
-          content=`node _scripts/prepare-release-proposal.js update-package-json ${{ github.event.inputs.release-type }}`
+          content=`node _scripts/prepare-release-proposal.js update-package-json ${{ steps.calc-release-type.outputs.release-type }}`
           echo "version=$content" >> $GITHUB_OUTPUT
 
       - name: Create PR

--- a/.github/workflows/prepare-release-proposal.yml
+++ b/.github/workflows/prepare-release-proposal.yml
@@ -3,13 +3,6 @@ name: Prepare release proposal
 on:
   workflow_dispatch:
     inputs:
-      base-branch:
-        description: 'Release branch'
-        required: true
-        type: choice
-        options:
-        - v4.x
-        - v5.x
       release-type:
         description: 'Release type'
         required: true
@@ -20,6 +13,11 @@ on:
 
 jobs:
   create-proposal:
+    strategy:
+      matrix:
+        base-branch:
+          - v4.x
+          - v5.x
     runs-on: ubuntu-latest
 
     permissions: write-all
@@ -29,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.base-branch }}
+          ref: ${{ matrix.base-branch }}
           token: ${{ secrets.GH_ACCESS_TOKEN_RELEASE }}
 
       - name: Set up Git
@@ -41,7 +39,8 @@ jobs:
         run: |
           git checkout master
           git pull
-          git checkout ${{ github.event.inputs.base-branch }}
+          cp -r scripts _scripts
+          git checkout ${{ matrix.base-branch }}
 
 
       - name: Configure node
@@ -54,7 +53,7 @@ jobs:
       - name: Create proposal branch
         id: create_branch
         run: |
-          branch_name=`node scripts/prepare-release-proposal.js create-branch ${{ github.event.inputs.release-type }}`
+          branch_name=`node _scripts/prepare-release-proposal.js create-branch ${{ github.event.inputs.release-type }}`
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
       - name: Install branch-diff
@@ -69,7 +68,7 @@ jobs:
       - name: Commit branch diffs
         id: commit_branch_diffs
         run: |
-          node scripts/prepare-release-proposal.js commit-branch-diffs ${{ github.event.inputs.base-branch }} ${{ github.event.inputs.release-type }} > branch-diffs.txt
+          node _scripts/prepare-release-proposal.js commit-branch-diffs ${{ matrix.base-branch }} ${{ github.event.inputs.release-type }} > branch-diffs.txt
 
       - name: Push proposal branch
         run: |
@@ -78,12 +77,12 @@ jobs:
       - name: Update package.json
         id: pkg
         run: |
-          content=`node scripts/prepare-release-proposal.js update-package-json ${{ github.event.inputs.release-type }}`
+          content=`node _scripts/prepare-release-proposal.js update-package-json ${{ github.event.inputs.release-type }}`
           echo "version=$content" >> $GITHUB_OUTPUT
 
       - name: Create PR
         run: |
-          gh pr create --draft --base ${{ github.event.inputs.base-branch }} --title "v${{ steps.pkg.outputs.version }}" -F branch-diffs.txt
+          gh pr create --draft --base ${{ matrix.base-branch }} --title "v${{ steps.pkg.outputs.version }}" -F branch-diffs.txt
           rm branch-diffs.txt
         env:
           GH_TOKEN: ${{ github.token }}
@@ -98,3 +97,6 @@ jobs:
         run: |
           git push origin ${{steps.create_branch.outputs.branch_name}}
 
+      - name: Clean _scripts
+        run: |
+          rm -rf _scripts

--- a/.github/workflows/prepare-release-proposal.yml
+++ b/.github/workflows/prepare-release-proposal.yml
@@ -1,0 +1,100 @@
+name: Prepare release proposal
+
+on:
+  workflow_dispatch:
+    inputs:
+      base-branch:
+        description: 'Release branch'
+        required: true
+        type: choice
+        options:
+        - v4.x
+        - v5.x
+      release-type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+        - minor
+        - patch
+
+jobs:
+  create-proposal:
+    runs-on: ubuntu-latest
+
+    permissions: write-all
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.base-branch }}
+          token: ${{ secrets.GH_ACCESS_TOKEN_RELEASE }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Pull master branch
+        run: |
+          git checkout master
+          git pull
+          git checkout ${{ github.event.inputs.base-branch }}
+
+
+      - name: Configure node
+        uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: |
+          yarn
+
+      - name: Create proposal branch
+        id: create_branch
+        run: |
+          branch_name=`node scripts/prepare-release-proposal.js create-branch ${{ github.event.inputs.release-type }}`
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+
+      - name: Install branch-diff
+        run: |
+          npm i -g @bengl/branch-diff
+
+      - name: Configure branch-diff
+        run: |
+          mkdir -p ~/.config/changelog-maker
+          echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
+
+      - name: Commit branch diffs
+        id: commit_branch_diffs
+        run: |
+          node scripts/prepare-release-proposal.js commit-branch-diffs ${{ github.event.inputs.base-branch }} ${{ github.event.inputs.release-type }} > branch-diffs.txt
+
+      - name: Push proposal branch
+        run: |
+          git push origin ${{steps.create_branch.outputs.branch_name}}
+
+      - name: Update package.json
+        id: pkg
+        run: |
+          content=`node scripts/prepare-release-proposal.js update-package-json ${{ github.event.inputs.release-type }}`
+          echo "version=$content" >> $GITHUB_OUTPUT
+
+      - name: Create PR
+        run: |
+          gh pr create --draft --base ${{ github.event.inputs.base-branch }} --title "v${{ steps.pkg.outputs.version }}" -F branch-diffs.txt
+          rm branch-diffs.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Commit package.json and push to proposal branch after the PR is created to force CI execution
+      - name: Commit package.json
+        run: |
+          git add package.json
+          git commit -m "v${{ steps.pkg.outputs.version }}"
+
+      - name: Push package.json update
+        run: |
+          git push origin ${{steps.create_branch.outputs.branch_name}}
+

--- a/.github/workflows/rebase-release-proposal.yml
+++ b/.github/workflows/rebase-release-proposal.yml
@@ -1,0 +1,86 @@
+name: Rebase release proposal
+
+on:
+  workflow_dispatch:
+    inputs:
+      base-branch:
+        description: 'Branch to rebase onto'
+        required: true
+        type: choice
+        options:
+        - v4.x
+        - v5.x
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get PR details
+        id: get_pr
+        run: |
+          pr_number=$(gh pr list --head ${{ github.ref_name }} --json number --jq '.[0].number')
+          echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check PR approval
+        id: check_approval
+        run: |
+          approvals=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                      "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+                      | jq '[.[] | select(.state == "APPROVED")] | length')
+          if [ "$approvals" -eq 0 ]; then
+            exit 1
+          fi
+
+      - name: Check CI status
+        id: check_ci_status
+        run: |
+          status=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/status" \
+                  | jq -r '.state')
+          if [ "$status" != "success" ]; then
+            exit 1
+          fi
+
+  release:
+    needs: check
+
+    runs-on: ubuntu-latest
+
+    permissions: write-all
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_ACCESS_TOKEN_RELEASE }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Checkout base branch
+        run: |
+          git checkout ${{ github.event.inputs.base-branch }}
+
+      - name: Rebase branch
+        run: |
+          git rebase ${{ github.ref_name }}
+
+      - name: Push rebased branch
+        run: |
+          git push

--- a/scripts/prepare-release-proposal.js
+++ b/scripts/prepare-release-proposal.js
@@ -44,26 +44,19 @@ function createReleaseBranch (args) {
 }
 
 function commitBranchDiffs (args) {
-  if (args.length !== 2) {
-    console.log('usage: node prepare-release-proposal.js commit-branch-diffs <release-branch> <release-type>')
+  if (args.length !== 1) {
+    console.log('usage: node prepare-release-proposal.js commit-branch-diffs <release-branch>')
     console.log('release-branches:')
     console.log('  v4.x')
     console.log('  v5.x')
-    console.log('release-types:')
-    console.log('  minor')
-    console.log('  patch')
     return
   }
   const releaseBranch = args[0]
-  const releaseType = args[1]
 
   const excludedLabels = [
     'semver-major',
     `dont-land-on-${releaseBranch}`
   ]
-  if (releaseType === 'patch') {
-    excludedLabels.push('semver-minor')
-  }
 
   const commandCore = `branch-diff --user DataDog --repo test-node-release-rebase \
 --exclude-label=${excludedLabels.join(',')}`

--- a/scripts/prepare-release-proposal.js
+++ b/scripts/prepare-release-proposal.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict'
+
+const semver = require('semver')
+const packageJson = require('../package.json')
+const path = require('path')
+const { execSync } = require('child_process')
+const { readFileSync, writeFileSync } = require('fs')
+
+function helpAndExit () {
+  console.log('usage: node prepare-release-proposal.js <action>')
+  console.log('Actions:')
+  console.log('  create-branch  Create a branch for the release proposal')
+  console.log('  commit-branch-diffs  Commit the branch diffs to the release proposal branch')
+  console.log('  update-package-json  Update the package.json version to the release proposal version')
+  console.log('  help           Show this help message and exit')
+  process.exit()
+}
+
+function createReleaseBranch (args) {
+  if (typeof args === 'string') {
+    const newVersion = semver.inc(packageJson.version, args[0])
+    const branchName = `v${newVersion}-proposal`
+    execSync(`git checkout -b ${branchName}`, { stdio: 'ignore' })
+
+    console.log(branchName)
+    return
+  }
+
+  switch (args[0]) {
+    case 'minor':
+    case 'patch':
+      createReleaseBranch(args[0])
+      break
+    case 'help':
+    default:
+      console.log('usage: node prepare-release-proposal.js create-branch <version-type>')
+      console.log('Version types:')
+      console.log('  minor  Create a branch for a minor release proposal')
+      console.log('  patch  Create a branch for a patch release proposal')
+      break
+  }
+}
+
+function commitBranchDiffs (args) {
+  if (args.length !== 2) {
+    console.log('usage: node prepare-release-proposal.js commit-branch-diffs <release-branch> <release-type>')
+    console.log('release-branches:')
+    console.log('  v4.x')
+    console.log('  v5.x')
+    console.log('release-types:')
+    console.log('  minor')
+    console.log('  patch')
+    return
+  }
+  const releaseBranch = args[0]
+  const releaseType = args[1]
+
+  const excludedLabels = [
+    'semver-major',
+    `dont-land-on-${releaseBranch}`
+  ]
+  if (releaseType === 'patch') {
+    excludedLabels.push('semver-minor')
+  }
+
+  const commandCore = `branch-diff --user DataDog --repo test-node-release-rebase \
+--exclude-label=${excludedLabels.join(',')}`
+
+  const releaseNotesDraft = execSync(`${commandCore} ${releaseBranch} master`).toString()
+
+  execSync(`${commandCore} --format=sha --reverse ${releaseBranch} master | xargs git cherry-pick`)
+
+  console.log(releaseNotesDraft)
+}
+
+function updatePackageJson (args) {
+  if (args.length !== 1) {
+    console.log('usage: node prepare-release-proposal.js update-package-json <release-type>')
+    console.log('  minor')
+    console.log('  patch')
+    return
+  }
+
+  const newVersion = semver.inc(packageJson.version, args[0])
+  const packageJsonPath = path.join(__dirname, '..', 'package.json')
+
+  const packageJsonString = readFileSync(packageJsonPath).toString()
+    .replace(`"version": "${packageJson.version}"`, `"version": "${newVersion}"`)
+
+  writeFileSync(packageJsonPath, packageJsonString)
+
+  console.log(newVersion)
+}
+
+const methodArgs = process.argv.slice(3)
+switch (process.argv[2]) {
+  case 'create-branch':
+    createReleaseBranch(methodArgs)
+    break
+  case 'commit-branch-diffs':
+    commitBranchDiffs(methodArgs)
+    break
+  case 'update-package-json':
+    updatePackageJson(methodArgs)
+    break
+  case 'help':
+  default:
+    helpAndExit()
+    break
+}

--- a/scripts/prepare-release-proposal.js
+++ b/scripts/prepare-release-proposal.js
@@ -20,7 +20,7 @@ function helpAndExit () {
 
 function createReleaseBranch (args) {
   if (typeof args === 'string') {
-    const newVersion = semver.inc(packageJson.version, args[0])
+    const newVersion = semver.inc(packageJson.version, args)
     const branchName = `v${newVersion}-proposal`
     execSync(`git checkout -b ${branchName}`, { stdio: 'ignore' })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds two Github action jobs to be executed manually. One to prepare release proposal PR, and other to rebase the branch in release branches.

### Motivation
<!-- What inspired you to submit this pull request? -->
Try to make releases easier and adds the possibility to block "rebase merge" option from merge options. To prevent rebasing to master. Eventually we will be able to prevent manual merges in `v[\d].x` branches.


### Additional Notes
<!-- Anything else we should know when reviewing? -->


