### PR TITLE
Update the expected telemetry tags for OTel env-var mapping

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -147,44 +147,44 @@ describe('opentelemetry', () => {
       assert.strictEqual(otelInvalid.length, 0)
 
       assert.deepStrictEqual(otelHiding[0].tags, [
-        'config.datadog:DD_TRACE_LOG_LEVEL', 'config.opentelemetry:OTEL_LOG_LEVEL',
+        'config_datadog:dd_trace_log_level', 'config_opentelemetry:otel_log_level',
         `version:${process.version}`
       ])
       assert.deepStrictEqual(otelHiding[1].tags, [
-        'config.datadog:DD_TRACE_PROPAGATION_STYLE', 'config.opentelemetry:OTEL_PROPAGATORS',
+        'config_datadog:dd_trace_propagation_style', 'config_opentelemetry:otel_propagators',
         `version:${process.version}`
       ])
       assert.deepStrictEqual(otelHiding[2].tags, [
-        'config.datadog:DD_SERVICE', 'config.opentelemetry:OTEL_SERVICE_NAME',
+        'config_datadog:dd_service', 'config_opentelemetry:otel_service_name',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelHiding[3].tags, [
-        'config.datadog:DD_TRACE_SAMPLE_RATE', 'config.opentelemetry:OTEL_TRACES_SAMPLER', `version:${process.version}`
+        'config_datadog:dd_trace_sample_rate', 'config_opentelemetry:otel_traces_sampler', `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelHiding[4].tags, [
-        'config.datadog:DD_TRACE_SAMPLE_RATE', 'config.opentelemetry:OTEL_TRACES_SAMPLER_ARG',
+        'config_datadog:dd_trace_sample_rate', 'config_opentelemetry:otel_traces_sampler_arg',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelHiding[5].tags, [
-        'config.datadog:DD_TRACE_ENABLED', 'config.opentelemetry:OTEL_TRACES_EXPORTER',
+        'config_datadog:dd_trace_enabled', 'config_opentelemetry:otel_traces_exporter',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelHiding[6].tags, [
-        'config.datadog:DD_RUNTIME_METRICS_ENABLED', 'config.opentelemetry:OTEL_METRICS_EXPORTER',
+        'config_datadog:dd_runtime_metrics_enabled', 'config_opentelemetry:otel_metrics_exporter',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelHiding[7].tags, [
-        'config.datadog:DD_TAGS', 'config.opentelemetry:OTEL_RESOURCE_ATTRIBUTES',
+        'config_datadog:dd_tags', 'config_opentelemetry:otel_resource_attributes',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelHiding[8].tags, [
-        'config.datadog:DD_TRACE_OTEL_ENABLED', 'config.opentelemetry:OTEL_SDK_DISABLED',
+        'config_datadog:dd_trace_otel_enabled', 'config_opentelemetry:otel_sdk_disabled',
         `version:${process.version}`
       ])
 
@@ -229,50 +229,50 @@ describe('opentelemetry', () => {
       assert.strictEqual(otelInvalid.length, 8)
 
       assert.deepStrictEqual(otelHiding[0].tags, [
-        'config.datadog:DD_TRACE_OTEL_ENABLED', 'config.opentelemetry:OTEL_SDK_DISABLED',
+        'config_datadog:dd_trace_otel_enabled', 'config_opentelemetry:otel_sdk_disabled',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelInvalid[0].tags, [
-        'config.datadog:DD_TRACE_LOG_LEVEL', 'config.opentelemetry:OTEL_LOG_LEVEL',
+        'config_datadog:dd_trace_log_level', 'config_opentelemetry:otel_log_level',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelInvalid[1].tags, [
-        'config.datadog:DD_TRACE_SAMPLE_RATE',
-        'config.opentelemetry:OTEL_TRACES_SAMPLER',
+        'config_datadog:dd_trace_sample_rate',
+        'config_opentelemetry:otel_traces_sampler',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelInvalid[2].tags, [
-        'config.datadog:DD_TRACE_SAMPLE_RATE',
-        'config.opentelemetry:OTEL_TRACES_SAMPLER_ARG',
+        'config_datadog:dd_trace_sample_rate',
+        'config_opentelemetry:otel_traces_sampler_arg',
         `version:${process.version}`
       ])
       assert.deepStrictEqual(otelInvalid[3].tags, [
-        'config.datadog:DD_TRACE_ENABLED', 'config.opentelemetry:OTEL_TRACES_EXPORTER',
+        'config_datadog:dd_trace_enabled', 'config_opentelemetry:otel_traces_exporter',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelInvalid[4].tags, [
-        'config.datadog:DD_RUNTIME_METRICS_ENABLED',
-        'config.opentelemetry:OTEL_METRICS_EXPORTER',
+        'config_datadog:dd_runtime_metrics_enabled',
+        'config_opentelemetry:otel_metrics_exporter',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelInvalid[5].tags, [
-        'config.datadog:DD_TRACE_OTEL_ENABLED', 'config.opentelemetry:OTEL_SDK_DISABLED',
+        'config_datadog:dd_trace_otel_enabled', 'config_opentelemetry:otel_sdk_disabled',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelInvalid[6].tags, [
-        'config.opentelemetry:OTEL_LOGS_EXPORTER',
+        'config_opentelemetry:otel_logs_exporter',
         `version:${process.version}`
       ])
 
       assert.deepStrictEqual(otelInvalid[7].tags, [
-        'config.datadog:DD_TRACE_PROPAGATION_STYLE',
-        'config.opentelemetry:OTEL_PROPAGATORS',
+        'config_datadog:dd_trace_propagation_style',
+        'config_opentelemetry:otel_propagators',
         `version:${process.version}`
       ])
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -29,14 +29,14 @@ const telemetryCounters = {
 function getCounter (event, ddVar, otelVar) {
   const counters = telemetryCounters[event]
   const tags = []
-  const ddVarPrefix = 'config.datadog:'
-  const otelVarPrefix = 'config.opentelemetry:'
+  const ddVarPrefix = 'config_datadog:'
+  const otelVarPrefix = 'config_opentelemetry:'
   if (ddVar) {
-    ddVar = ddVarPrefix + ddVar
+    ddVar = ddVarPrefix + ddVar.toLowerCase()
     tags.push(ddVar)
   }
   if (otelVar) {
-    otelVar = otelVarPrefix + otelVar
+    otelVar = otelVarPrefix + otelVar.toLowerCase()
     tags.push(otelVar)
   }
 


### PR DESCRIPTION
### What does this PR do?

The expected telemetry tags when reporting OTel env-var mapping issues now use snake-case:
```
 config.datadog       -> config_datadog
 config.opentelemetry -> config_opentelemetry
```
The expected tag values should also be lower-case.

### Motivation

The [RFC](https://docs.google.com/document/d/1gtdjhsMSIvuTnM9E4EreI7oZ-bAUoAxkhXX0-fBvdDY/edit?usp=sharing) has been revised since #4248

