### PR TITLE
Revise OTel Context and API Implementation To Enable OTel Auto Instrumentation Support

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -398,11 +398,11 @@ describe('opentelemetry', () => {
 
       // Should have expected span names and ordering
       assert.isTrue(eachEqual(trace, [
-        'GET',
+        'GET /second-endpoint',
         'middleware - query',
         'middleware - expressInit',
         'request handler - /second-endpoint',
-        'GET',
+        'GET /first-endpoint',
         'middleware - query',
         'middleware - expressInit',
         'request handler - /first-endpoint',

--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -5,6 +5,7 @@ const { fork } = require('child_process')
 const { join } = require('path')
 const { assert } = require('chai')
 const { satisfies } = require('semver')
+const axios = require('axios')
 
 function check (agent, proc, timeout, onMessage = () => { }, isMetrics) {
   const messageReceiver = isMetrics
@@ -56,7 +57,11 @@ describe('opentelemetry', () => {
 
   before(async () => {
     const dependencies = [
-      '@opentelemetry/api@1.8.0'
+      '@opentelemetry/api@1.8.0',
+      '@opentelemetry/instrumentation',
+      '@opentelemetry/instrumentation-http',
+      '@opentelemetry/instrumentation-express',
+      'express'
     ]
     if (satisfies(process.version.slice(1), '>=14')) {
       dependencies.push('@opentelemetry/sdk-node')
@@ -371,6 +376,55 @@ describe('opentelemetry', () => {
     })
   })
 
+  it('should work with otel express & http auto instrumentation', async () => {
+    const SERVER_PORT = 6666
+    proc = fork(join(cwd, 'opentelemetry/auto-instrumentation.js'), {
+      cwd,
+      env: {
+        DD_TRACE_AGENT_PORT: agent.port,
+        DD_TRACE_OTEL_ENABLED: 1,
+        SERVER_PORT,
+        DD_TRACE_DISABLED_INSTRUMENTATIONS: 'http,dns,express,net'
+      }
+    })
+    await new Promise(resolve => setTimeout(resolve, 1000)) // Adjust the delay as necessary
+    await axios.get(`http://localhost:${SERVER_PORT}/first-endpoint`)
+
+    return check(agent, proc, 10000, ({ payload }) => {
+      const trace = payload
+
+      assert.strictEqual(payload.length, 9)
+
+      // Should have expected span names and ordering
+      assert.isTrue(eachEqual(trace, [
+        'middleware - query',
+        'middleware - expressInit',
+        'request handler - /first-endpoint',
+        'GET',
+        'middleware - query',
+        'middleware - expressInit',
+        'request handler - /second-endpoint',
+        'GET',
+        'GET'
+      ],
+      ([span]) => span.name))
+
+      assert.isTrue(allEqual(trace, ([span]) => {
+        span.trace_id.toString()
+      }))
+
+      const [query1, init1, handler1, get1, query2, init2, handler2, get3, get2] = trace
+      isChildOf(query1, get1)
+      isChildOf(init1, get1)
+      isChildOf(handler1, get1)
+      isChildOf(get2, get1)
+      isChildOf(get3, get2)
+      isChildOf(query2, get3)
+      isChildOf(init2, get3)
+      isChildOf(handler2, get3)
+    })
+  })
+
   if (satisfies(process.version.slice(1), '>=14')) {
     it('should auto-instrument @opentelemetry/sdk-node', async () => {
       proc = fork(join(cwd, 'opentelemetry/env-var.js'), {
@@ -392,3 +446,9 @@ describe('opentelemetry', () => {
     })
   }
 })
+
+function isChildOf ([childSpan], [parentSpan]) {
+  assert.strictEqual(childSpan.trace_id.toString(), parentSpan.trace_id.toString())
+  assert.notStrictEqual(childSpan.span_id.toString(), parentSpan.span_id.toString())
+  assert.strictEqual(childSpan.parent_id.toString(), parentSpan.span_id.toString())
+}

--- a/integration-tests/opentelemetry/auto-instrumentation.js
+++ b/integration-tests/opentelemetry/auto-instrumentation.js
@@ -1,5 +1,4 @@
 const tracer = require('dd-trace').init()
-
 const { TracerProvider } = tracer
 const provider = new TracerProvider()
 provider.register()
@@ -28,8 +27,8 @@ registerInstrumentations({
 })
 
 const express = require('express')
-const app = express()
 const http = require('http')
+const app = express()
 const PORT = process.env.SERVER_PORT
 
 app.get('/second-endpoint', (req, res) => {

--- a/integration-tests/opentelemetry/auto-instrumentation.js
+++ b/integration-tests/opentelemetry/auto-instrumentation.js
@@ -1,0 +1,56 @@
+const tracer = require('dd-trace').init()
+
+const { TracerProvider } = tracer
+const provider = new TracerProvider()
+provider.register()
+
+const { registerInstrumentations } = require('@opentelemetry/instrumentation')
+const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http')
+const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express')
+
+registerInstrumentations({
+  instrumentations: [
+    new HttpInstrumentation({
+      ignoreIncomingRequestHook (req) {
+        // Ignore spans from static assets.
+        return req.path === '/v0.4/traces' || req.path === '/v0.7/config' ||
+        req.path === '/telemetry/proxy/api/v2/apmtelemetry'
+      },
+      ignoreOutgoingRequestHook (req) {
+        // Ignore spans from static assets.
+        return req.path === '/v0.4/traces' || req.path === '/v0.7/config' ||
+        req.path === '/telemetry/proxy/api/v2/apmtelemetry'
+      }
+    }),
+    new ExpressInstrumentation()
+  ],
+  tracerProvider: provider
+})
+
+const express = require('express')
+const app = express()
+const http = require('http')
+const PORT = process.env.SERVER_PORT
+
+app.get('/second-endpoint', (req, res) => {
+  res.send('Response from second endpoint')
+  server.close(() => {
+  })
+})
+
+app.get('/first-endpoint', async (req, res) => {
+  try {
+    const response = await new Promise((resolve, reject) => {
+      http.get(`http://localhost:${PORT}/second-endpoint`).on('finish', (response) => {
+        resolve(response)
+      }).on('error', (error) => {
+        reject(error)
+      })
+    })
+    res.send(`First endpoint received: ${response}`)
+  } catch (error) {
+    res.status(500).send(`Error occurred while making nested call ${error}`)
+  }
+})
+
+const server = app.listen(PORT, () => {})

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -26,15 +26,14 @@ class ContextManager {
   with (context, fn, thisArg, ...args) {
     const span = trace.getSpan(context)
     const ddScope = tracer.scope()
-    if (span && span._ddSpan) {
-      return ddScope.activate(span._ddSpan, () => {
-        const cb = thisArg == null ? fn : fn.bind(thisArg)
-        return this._store.run(context, cb, ...args)
-      })
+    const run = () => {
+      const cb = thisArg == null ? fn : fn.bind(thisArg)
+      return this._store.run(context, cb, ...args)
     }
-
-    const cb = thisArg == null ? fn : fn.bind(thisArg)
-    return this._store.run(context, cb, ...args)
+    if (span && span._ddSpan) {
+      return ddScope.activate(span._ddSpan, run)
+    }
+    return run()
   }
 
   bind (context, target) {

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -2,38 +2,10 @@
 
 const { AsyncLocalStorage } = require('async_hooks')
 const { trace, ROOT_CONTEXT } = require('@opentelemetry/api')
+const DataDogSpanContext = require('../opentracing/span_context')
 
 const SpanContext = require('./span_context')
 const tracer = require('../../')
-
-// Horrible hack to acquire the otherwise inaccessible SPAN_KEY so we can redirect it...
-// This is used for getting the current span context in OpenTelemetry, but the SPAN_KEY value is
-// not exposed as it's meant to be read-only from outside the module. We want to hijack this logic
-// so we can instead get the span context from the datadog context manager instead.
-let SPAN_KEY
-trace.getSpan({
-  getValue (key) {
-    SPAN_KEY = key
-  }
-})
-
-// Whenever a value is acquired from the context map we should mostly delegate to the real getter,
-// but when accessing the current span we should hijack that access to instead provide a fake span
-// which we can use to get an OTel span context wrapping the datadog active scope span context.
-function wrappedGetValue (target) {
-  return (key) => {
-    if (key === SPAN_KEY) {
-      return {
-        spanContext () {
-          const activeSpan = tracer.scope().active()
-          const context = activeSpan && activeSpan.context()
-          return new SpanContext(context)
-        }
-      }
-    }
-    return target.getValue(key)
-  }
-}
 
 class ContextManager {
   constructor () {
@@ -41,22 +13,28 @@ class ContextManager {
   }
 
   active () {
-    const active = this._store.getStore() || ROOT_CONTEXT
+    const activeSpan = tracer.scope().active()
 
-    return new Proxy(active, {
-      get (target, key) {
-        return key === 'getValue' ? wrappedGetValue(target) : target[key]
-      }
-    })
+    const context = (activeSpan && activeSpan.context()) || this._store.getStore() || ROOT_CONTEXT
+    if (context instanceof DataDogSpanContext) {
+      const newSpanContext = new SpanContext(context)
+      return trace.setSpanContext(ROOT_CONTEXT, newSpanContext)
+    }
+    return context
   }
 
   with (context, fn, thisArg, ...args) {
     const span = trace.getSpan(context)
     const ddScope = tracer.scope()
-    return ddScope.activate(span._ddSpan, () => {
-      const cb = thisArg == null ? fn : fn.bind(thisArg)
-      return this._store.run(context, cb, ...args)
-    })
+    if (span && span._ddSpan) {
+      return ddScope.activate(span._ddSpan, () => {
+        const cb = thisArg == null ? fn : fn.bind(thisArg)
+        return this._store.run(context, cb, ...args)
+      })
+    }
+
+    const cb = thisArg == null ? fn : fn.bind(thisArg)
+    return this._store.run(context, cb, ...args)
   }
 
   bind (context, target) {
@@ -66,9 +44,7 @@ class ContextManager {
     }
   }
 
-  // Not part of the spec but the Node.js API expects these
   enable () {}
   disable () {}
 }
-
 module.exports = ContextManager

--- a/packages/dd-trace/src/opentelemetry/span_context.js
+++ b/packages/dd-trace/src/opentelemetry/span_context.js
@@ -24,11 +24,11 @@ class SpanContext {
   }
 
   get traceId () {
-    return this._ddContext._traceId.toString(16)
+    return this._ddContext.toTraceId(true)
   }
 
   get spanId () {
-    return this._ddContext._spanId.toString(16)
+    return this._ddContext.toSpanId(true)
   }
 
   get traceFlags () {

--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -30,7 +30,7 @@ class Tracer {
       spanId: id(),
       parentId: parent._spanId,
       sampling: parent._sampling,
-      baggageItems: { ...parent._baggageItems },
+      baggageItems: Object.assign({}, parent._baggageItems),
       trace: parent._trace,
       tracestate: parent._tracestate
     })
@@ -48,9 +48,10 @@ class Tracer {
       context = api.trace.deleteSpan(context)
     }
     const parentSpan = api.trace.getSpan(context)
+    const parentSpanContext = parentSpan && parentSpan.spanContext()
     let spanContext
-    if (parentSpan) {
-      spanContext = parentSpan._ddSpan
+    if (parentSpanContext && parentSpanContext.traceId) {
+      spanContext = parentSpanContext._ddContext
         ? this._createSpanContextFromParent(parentSpan)
         : this._createSpanContextForNewSpan(context)
     } else {

--- a/packages/dd-trace/src/opentelemetry/tracer_provider.js
+++ b/packages/dd-trace/src/opentelemetry/tracer_provider.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { trace, context } = require('@opentelemetry/api')
+const { trace, context, propagation } = require('@opentelemetry/api')
+const { W3CTraceContextPropagator } = require('@opentelemetry/core')
 
 const tracer = require('../../')
 
@@ -51,6 +52,13 @@ class TracerProvider {
     context.setGlobalContextManager(this._contextManager)
     if (!trace.setGlobalTracerProvider(this)) {
       trace.getTracerProvider().setDelegate(this)
+    }
+    // The default propagator used is the W3C Trace Context propagator, users should be able to pass in others
+    // as needed
+    if (config.propagator) {
+      propagation.setGlobalPropagator(config.propagator)
+    } else {
+      propagation.setGlobalPropagator(new W3CTraceContextPropagator())
     }
   }
 

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -622,7 +622,7 @@ class TextMapPropagator {
 
   static _convertOtelContextToDatadog (traceId, spanId, traceFlag, ts, meta = {}) {
     const origin = null
-    let samplingPriority = traceFlag // Assuming traceFlag is an integer
+    let samplingPriority = traceFlag
 
     ts = ts?.traceparent || null
 
@@ -696,8 +696,7 @@ class TextMapPropagator {
       const samplingPriorityTsInt = samplingPriorityTs !== undefined ? parseInt(samplingPriorityTs, 10) : null
       let origin = dd.o
       if (origin) {
-      // Assuming _TraceContext.decodeTagVal is a function that decodes "=" to "~"
-        origin = TextMapPropagator.decodeTagVal(origin) // You need to implement this function
+        origin = TextMapPropagator.decodeTagVal(origin)
       }
 
       const lpid = dd.p || '0000000000000000'

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -27,6 +27,7 @@ class DatadogSpanContext {
       finished: [],
       tags: {}
     }
+    this._otelSpanContext = undefined
   }
 
   toTraceId (get128bitId = false) {

--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -10,6 +10,7 @@ const api = require('@opentelemetry/api')
 describe('OTel Context Manager', () => {
   let contextManager
   let db
+
   beforeEach(() => {
     contextManager = new ContextManager()
     api.context.setGlobalContextManager(contextManager)
@@ -20,12 +21,14 @@ describe('OTel Context Manager', () => {
       }
     }
   })
+
   it('should create a new context', () => {
     const key1 = api.createContextKey('My first key')
     const key2 = api.createContextKey('My second key')
     expect(key1.description).to.equal('My first key')
     expect(key2.description).to.equal('My second key')
   })
+
   it('should delete a context', () => {
     const key = api.createContextKey('some key')
     const ctx = api.ROOT_CONTEXT
@@ -38,6 +41,7 @@ describe('OTel Context Manager', () => {
     expect(ctx2.getValue(key)).to.equal('context 2')
     expect(ctx.getValue(key)).to.equal(undefined)
   })
+
   it('should create a new root context', () => {
     const key = api.createContextKey('some key')
     const ctx = api.ROOT_CONTEXT
@@ -45,10 +49,12 @@ describe('OTel Context Manager', () => {
     expect(ctx2.getValue(key)).to.equal('context 2')
     expect(ctx.getValue(key)).to.equal(undefined)
   })
+
   it('should return root context', () => {
     const ctx = api.context.active()
     expect(ctx).to.be.an.instanceof(ROOT_CONTEXT.constructor)
   })
+
   it('should set active context', () => {
     const key = api.createContextKey('Key to store a value')
     const ctx = api.context.active()
@@ -57,6 +63,7 @@ describe('OTel Context Manager', () => {
       expect(api.context.active().getValue(key)).to.equal('context 2')
     })
   })
+
   it('should set active context on an asynchronous callback and return the result synchronously', async () => {
     const name = await api.context.with(api.context.active(), async () => {
       const row = await db.getSomeValue()
@@ -65,6 +72,7 @@ describe('OTel Context Manager', () => {
 
     expect(name).to.equal('Dummy Name')
   })
+
   it('should set active contexts in nested functions', async () => {
     const key = api.createContextKey('Key to store a value')
     const ctx = api.context.active()
@@ -78,6 +86,7 @@ describe('OTel Context Manager', () => {
     })
     expect(api.context.active().getValue(key)).to.equal(undefined)
   })
+
   it('should not modify contexts, instead it should create new context objects', async () => {
     const key = api.createContextKey('Key to store a value')
 

--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -1,0 +1,108 @@
+'use strict'
+
+require('../setup/tap')
+
+const { expect } = require('chai')
+const ContextManager = require('../../src/opentelemetry/context_manager')
+const { ROOT_CONTEXT } = require('@opentelemetry/api')
+const api = require('@opentelemetry/api')
+
+describe('OTel Context Manager', () => {
+  let contextManager
+  let db
+  beforeEach(() => {
+    contextManager = new ContextManager()
+    api.context.setGlobalContextManager(contextManager)
+    db = {
+      getSomeValue: async () => {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        return { name: 'Dummy Name' }
+      }
+    }
+  })
+  it('should create a new context', () => {
+    const key1 = api.createContextKey('My first key')
+    const key2 = api.createContextKey('My second key')
+    expect(key1.description).to.equal('My first key')
+    expect(key2.description).to.equal('My second key')
+  })
+  it('should delete a context', () => {
+    const key = api.createContextKey('some key')
+    const ctx = api.ROOT_CONTEXT
+    const ctx2 = ctx.setValue(key, 'context 2')
+
+    // remove the entry
+    const ctx3 = ctx.deleteValue(key)
+
+    expect(ctx3.getValue(key)).to.equal(undefined)
+    expect(ctx2.getValue(key)).to.equal('context 2')
+    expect(ctx.getValue(key)).to.equal(undefined)
+  })
+  it('should create a new root context', () => {
+    const key = api.createContextKey('some key')
+    const ctx = api.ROOT_CONTEXT
+    const ctx2 = ctx.setValue(key, 'context 2')
+    expect(ctx2.getValue(key)).to.equal('context 2')
+    expect(ctx.getValue(key)).to.equal(undefined)
+  })
+  it('should return root context', () => {
+    const ctx = api.context.active()
+    expect(ctx).to.be.an.instanceof(ROOT_CONTEXT.constructor)
+  })
+  it('should set active context', () => {
+    const key = api.createContextKey('Key to store a value')
+    const ctx = api.context.active()
+
+    api.context.with(ctx.setValue(key, 'context 2'), async () => {
+      expect(api.context.active().getValue(key)).to.equal('context 2')
+    })
+  })
+  it('should set active context on an asynchronous callback and return the result synchronously', async () => {
+    const name = await api.context.with(api.context.active(), async () => {
+      const row = await db.getSomeValue()
+      return row.name
+    })
+
+    expect(name).to.equal('Dummy Name')
+  })
+  it('should set active contexts in nested functions', async () => {
+    const key = api.createContextKey('Key to store a value')
+    const ctx = api.context.active()
+    expect(api.context.active().getValue(key)).to.equal(undefined)
+    api.context.with(ctx.setValue(key, 'context 2'), () => {
+      expect(api.context.active().getValue(key)).to.equal('context 2')
+      api.context.with(ctx.setValue(key, 'context 3'), () => {
+        expect(api.context.active().getValue(key)).to.equal('context 3')
+      })
+      expect(api.context.active().getValue(key)).to.equal('context 2')
+    })
+    expect(api.context.active().getValue(key)).to.equal(undefined)
+  })
+  it('should not modify contexts, instead it should create new context objects', async () => {
+    const key = api.createContextKey('Key to store a value')
+
+    const ctx = api.context.active()
+
+    const ctx2 = ctx.setValue(key, 'context 2')
+    expect(ctx.getValue(key)).to.equal(undefined)
+    expect(ctx).to.be.an.instanceof(ROOT_CONTEXT.constructor)
+    expect(ctx2.getValue(key)).to.equal('context 2')
+
+    const ret = api.context.with(ctx2, () => {
+      const ctx3 = api.context.active().setValue(key, 'context 3')
+
+      expect(api.context.active().getValue(key)).to.equal('context 2')
+      expect(ctx.getValue(key)).to.equal(undefined)
+      expect(ctx2.getValue(key)).to.equal('context 2')
+      expect(ctx3.getValue(key)).to.equal('context 3')
+
+      api.context.with(ctx3, () => {
+        expect(api.context.active().getValue(key)).to.equal('context 3')
+      })
+      expect(api.context.active().getValue(key)).to.equal('context 2')
+
+      return 'return value'
+    })
+    expect(ret).to.equal('return value')
+  })
+})

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -46,7 +46,6 @@ describe('OTel Span', () => {
   it('should expose parent span id', () => {
     tracer.trace('outer', (outer) => {
       const span = makeSpan('name', {})
-
       expect(span.parentSpanId).to.equal(outer.context()._spanId.toString(16))
     })
   })

--- a/packages/dd-trace/test/opentelemetry/span_context.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span_context.spec.js
@@ -42,7 +42,9 @@ describe('OTel Span Context', () => {
     const context = new SpanContext({
       traceId
     })
-    expect(context.traceId).to.equal(traceId.toString(16))
+    // normalize to 128 bit since that is what otel expects
+    const normalizedTraceId = traceId.toString(16).padStart(32, '0')
+    expect(context.traceId).to.equal(normalizedTraceId)
   })
 
   it('should get span id as hex', () => {

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -56,7 +56,8 @@ describe('SpanContext', () => {
         tags: { foo: 'bar' }
       },
       _traceparent: '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01',
-      _tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar')
+      _tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar'),
+      _otelSpanContext: undefined
     })
   })
 
@@ -84,7 +85,8 @@ describe('SpanContext', () => {
         tags: {}
       },
       _traceparent: undefined,
-      _tracestate: undefined
+      _tracestate: undefined,
+      _otelSpanContext: undefined
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
This PR reworks the existing OpenTelemetry context and API implementation to align more closely with the dd-trace-py implementation. This change aims to fix the bug affecting the integration between OTel's Express auto-instrumentation and dd-trace-js and thus add support for OTel auto instrumentations through dd-trace-js.

### Motivation
Upon testing the OTel Express auto-instrumentation through dd-trace-js, broken traces were observed. These issues stemmed from a lack of proper handling of distributed trace context propagation in the dd-trace-js implementation of the OpenTelemetry context and core API.


