### PR TITLE
[test visibility] Fix memory leak in workerpool hook

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@
 /packages/dd-trace/test/plugins/util/ci-env/ @DataDog/ci-app-libraries
 
 /packages/datadog-instrumentations/src/jest.js @DataDog/ci-app-libraries
-/packages/datadog-instrumentations/src/mocha.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/mocha/ @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/cucumber.js @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/cypress.js @DataDog/ci-app-libraries
 /packages/datadog-instrumentations/src/playwright.js @DataDog/ci-app-libraries


### PR DESCRIPTION
### What does this PR do?
Remove the `onMessage` handler after finishing the `exec` method.

### Motivation
Fixes #4551 

### Plugin Checklist
A manual test checking memory consumption with a simple `workerpool` usage was done. 