### PR TITLE
Update @datadog/native-iast-taint-tracking to 3.1.0 to support linuxmusl-arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@datadog/native-appsec": "8.0.1",
     "@datadog/native-iast-rewriter": "2.4.0",
-    "@datadog/native-iast-taint-tracking": "3.0.0",
+    "@datadog/native-iast-taint-tracking": "3.1.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.3.0",
     "@datadog/sketches-js": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,10 +271,10 @@
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.0.0.tgz#a0be16f49f49c2a5917d08e5986c0fc6c877ed13"
-  integrity sha512-V+25+edlNCQSNRUvL45IajN+CFEjii9NbjfSMG6HRHbH/zeLL9FCNE+GU88dwB1bqXKNpBdrIxsfgTN65Yq9tA==
+"@datadog/native-iast-taint-tracking@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz#7b2ed7f8fad212d65e5ab03bcdea8b42a3051b2e"
+  integrity sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates version of @datadog/native-iast-taint-tracking
### Motivation
<!-- What inspired you to submit this pull request? -->
Add support to linuxmusl-arm64



