### PR TITLE
WIP Rasp LFI first approach

### DIFF
--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -36,15 +36,15 @@ function wrapResponseJson (json) {
   }
 }
 
-const responseRenderStartChannel = tracingChannel('datadog:express:response:render')
+const responseRenderChannel = tracingChannel('datadog:express:response:render')
 
 function wrapResponseRender (render) {
   return function wrappedRender (view, options, callback) {
-    if (!responseRenderStartChannel.start.hasSubscribers) {
+    if (!responseRenderChannel.start.hasSubscribers) {
       return render.apply(this, arguments)
     }
 
-    return responseRenderStartChannel.traceSync(
+    return responseRenderChannel.traceSync(
       render,
       {
         req: this.req,

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -3,6 +3,7 @@
 const { createWrapRouterMethod } = require('./router')
 const shimmer = require('../../datadog-shimmer')
 const { addHook, channel } = require('./helpers/instrument')
+const tracingChannel = require('dc-polyfill').tracingChannel
 
 const handleChannel = channel('apm:express:request:handle')
 
@@ -35,6 +36,28 @@ function wrapResponseJson (json) {
   }
 }
 
+const responseRenderStartChannel = tracingChannel('datadog:express:response:render')
+
+function wrapResponseRender (render) {
+  return function wrappedRender (view, options, callback) {
+    if (!responseRenderStartChannel.start.hasSubscribers) {
+      return render.apply(this, arguments)
+    }
+
+    return responseRenderStartChannel.traceSync(
+      render,
+      {
+        req: this.req,
+        view,
+        options,
+        callback // TODO: callback should be included or excluded in the start-end lifetime?
+      },
+      this,
+      ...arguments
+    )
+  }
+}
+
 addHook({ name: 'express', versions: ['>=4'] }, express => {
   shimmer.wrap(express.application, 'handle', wrapHandle)
   shimmer.wrap(express.Router, 'use', wrapRouterMethod)
@@ -42,6 +65,7 @@ addHook({ name: 'express', versions: ['>=4'] }, express => {
 
   shimmer.wrap(express.response, 'json', wrapResponseJson)
   shimmer.wrap(express.response, 'jsonp', wrapResponseJson)
+  shimmer.wrap(express.response, 'render', wrapResponseRender)
 
   return express
 })

--- a/packages/dd-trace/src/appsec/addresses.js
+++ b/packages/dd-trace/src/appsec/addresses.js
@@ -22,5 +22,6 @@ module.exports = {
   USER_ID: 'usr.id',
   WAF_CONTEXT_PROCESSOR: 'waf.context.processor',
 
-  HTTP_OUTGOING_URL: 'server.io.net.url'
+  HTTP_OUTGOING_URL: 'server.io.net.url',
+  FS_OPERATION_PATH: 'server.io.fs.file'
 }

--- a/packages/dd-trace/src/appsec/channels.js
+++ b/packages/dd-trace/src/appsec/channels.js
@@ -21,6 +21,6 @@ module.exports = {
   responseWriteHead: dc.channel('apm:http:server:response:writeHead:start'),
   httpClientRequestStart: dc.channel('apm:http:client:request:start'),
   responseSetHeader: dc.channel('datadog:http:server:response:set-header:start'),
-  setUncaughtExceptionCaptureCallbackStart: dc.channel('datadog:process:setUncaughtExceptionCaptureCallback:start')
-
+  setUncaughtExceptionCaptureCallbackStart: dc.channel('datadog:process:setUncaughtExceptionCaptureCallback:start'),
+  fsOperationStart: dc.channel('apm:fs:operation:start')
 }

--- a/packages/dd-trace/src/appsec/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/fs-plugin.js
@@ -46,7 +46,6 @@ class AppsecFsPlugin extends Plugin {
   _onFsOperationFinishOrRenderEnd () {
     const store = storage.getStore()
     if (store?.fs?.parentStore) {
-      // TODO: could a fs:operation finish a render store?
       storage.enterWith(store.fs.parentStore)
     }
   }

--- a/packages/dd-trace/src/appsec/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/fs-plugin.js
@@ -41,7 +41,7 @@ class AppsecFsPlugin extends Plugin {
   _onFsOperationStart () {
     const store = storage.getStore()
     if (store) {
-      enterWith({ root: store.fs?.root === undefined }, store) // could be used opExcluded flag instead root flag?
+      enterWith({ root: store.fs?.root === undefined }, store)
     }
   }
 
@@ -58,7 +58,7 @@ class AppsecFsPlugin extends Plugin {
 }
 
 function enable (mod) {
-  if (!mod || enabledFor[mod]) return
+  if (enabledFor[mod] !== false) return
 
   enabledFor[mod] = true
 
@@ -75,9 +75,12 @@ function disable (mod) {
 
   enabledFor[mod] = false
 
-  fsPlugin?.disable()
+  const allDisabled = Object.values(enabledFor).every(val => val === false)
+  if (allDisabled) {
+    fsPlugin?.disable()
 
-  fsPlugin = undefined
+    fsPlugin = undefined
+  }
 
   log.info(`Disabled AppsecFsPlugin for ${mod}`)
 }

--- a/packages/dd-trace/src/appsec/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/fs-plugin.js
@@ -5,55 +5,49 @@ const { storage } = require('../../../datadog-core')
 
 let fsPlugin
 
+function enterWith (fsProps, store = storage.getStore()) {
+  if (store && !store.fs?.opExcluded) {
+    storage.enterWith({
+      ...store,
+      fs: {
+        ...store.fs,
+        ...fsProps,
+        parentStore: store
+      }
+    })
+  }
+}
+
 class AppsecFsPlugin extends Plugin {
   enable () {
     this.addSub('apm:fs:operation:start', this._onFsOperationStart)
-    this.addSub('apm:fs:operation:finish', this._onFsOperationFinish)
+    this.addSub('apm:fs:operation:finish', this._onFsOperationFinishOrRenderEnd)
     this.addSub('tracing:datadog:express:response:render:start', this._onResponseRenderStart)
-    this.addSub('tracing:datadog:express:response:render:end', this._onResponseRenderEnd)
+    this.addSub('tracing:datadog:express:response:render:end', this._onFsOperationFinishOrRenderEnd)
 
     super.configure(true)
   }
 
-  _onFsOperationStart () {
-    const store = storage.getStore()
-    if (store && !store.fs?.opExcluded) {
-      storage.enterWith({
-        ...store,
-        fs: {
-          ...store.fs,
-          root: store.fs?.root === undefined, // nested fs.operation should have fs property
-          parentStore: store
-        }
-      })
-    }
+  disable () {
+    super.configure(false)
   }
 
-  _onFsOperationFinish () {
+  _onFsOperationStart () {
     const store = storage.getStore()
-    if (store?.fs?.parentStore) {
-      storage.enterWith(store.fs.parentStore)
+    if (store) {
+      enterWith({ root: store.fs?.root === undefined }, store) // could be used opExcluded flag instead root flag?
     }
   }
 
   _onResponseRenderStart () {
-    const store = storage.getStore()
-    if (store) {
-      storage.enterWith({
-        ...store,
-        fs: {
-          ...store.fs,
-          opExcluded: true
-        }
-      })
-    }
+    enterWith({ opExcluded: true })
   }
 
-  _onResponseRenderEnd () {
+  _onFsOperationFinishOrRenderEnd () {
     const store = storage.getStore()
-    if (store) {
-      delete store.fs?.opExcluded // NOTE: is it OK, or original store should be restored like we do with parentStore?
-      storage.enterWith(store)
+    if (store?.fs?.parentStore) {
+      // TODO: could a fs:operation finish a render store?
+      storage.enterWith(store.fs.parentStore)
     }
   }
 }
@@ -69,12 +63,14 @@ function disable () {
   if (!fsPlugin) return
 
   // FIXME: AppsecFsPlugin could be used by appsec and iast
-  fsPlugin.configure(false)
+  fsPlugin.disable()
 
   fsPlugin = undefined
 }
 
 module.exports = {
   enable,
-  disable
+  disable,
+
+  AppsecFsPlugin
 }

--- a/packages/dd-trace/src/appsec/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/fs-plugin.js
@@ -2,6 +2,12 @@
 
 const Plugin = require('../plugins/plugin')
 const { storage } = require('../../../datadog-core')
+const log = require('../log')
+
+const enabledFor = {
+  rasp: false,
+  iast: false
+}
 
 let fsPlugin
 
@@ -51,20 +57,29 @@ class AppsecFsPlugin extends Plugin {
   }
 }
 
-function enable () {
-  if (fsPlugin) return
+function enable (mod) {
+  if (!mod || enabledFor[mod]) return
 
-  fsPlugin = new AppsecFsPlugin()
-  fsPlugin.enable()
+  enabledFor[mod] = true
+
+  if (!fsPlugin) {
+    fsPlugin = new AppsecFsPlugin()
+    fsPlugin.enable()
+  }
+
+  log.info(`Enabled AppsecFsPlugin for ${mod}`)
 }
 
-function disable () {
-  if (!fsPlugin) return
+function disable (mod) {
+  if (!mod || !enabledFor[mod]) return
 
-  // FIXME: AppsecFsPlugin could be used by appsec and iast
-  fsPlugin.disable()
+  enabledFor[mod] = false
+
+  fsPlugin?.disable()
 
   fsPlugin = undefined
+
+  log.info(`Disabled AppsecFsPlugin for ${mod}`)
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/fs-plugin.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const Plugin = require('../plugins/plugin')
+const { storage } = require('../../../datadog-core')
+
+let fsPlugin
+
+class AppsecFsPlugin extends Plugin {
+  enable () {
+    this.addSub('apm:fs:operation:start', this._onFsOperationStart)
+    this.addSub('apm:fs:operation:finish', this._onFsOperationFinish)
+    this.addSub('tracing:datadog:express:response:render:start', this._onResponseRenderStart)
+    this.addSub('tracing:datadog:express:response:render:end', this._onResponseRenderEnd)
+
+    super.configure(true)
+  }
+
+  _onFsOperationStart () {
+    const store = storage.getStore()
+    if (store && !store.fs?.opExcluded) {
+      storage.enterWith({
+        ...store,
+        fs: {
+          ...store.fs,
+          root: store.fs?.root === undefined, // nested fs.operation should have fs property
+          parentStore: store
+        }
+      })
+    }
+  }
+
+  _onFsOperationFinish () {
+    const store = storage.getStore()
+    if (store?.fs?.parentStore) {
+      storage.enterWith(store.fs.parentStore)
+    }
+  }
+
+  _onResponseRenderStart () {
+    const store = storage.getStore()
+    if (store) {
+      storage.enterWith({
+        ...store,
+        fs: {
+          ...store.fs,
+          opExcluded: true
+        }
+      })
+    }
+  }
+
+  _onResponseRenderEnd () {
+    const store = storage.getStore()
+    if (store) {
+      delete store.fs?.opExcluded // NOTE: is it OK, or original store should be restored like we do with parentStore?
+      storage.enterWith(store)
+    }
+  }
+}
+
+function enable () {
+  if (fsPlugin) return
+
+  fsPlugin = new AppsecFsPlugin()
+  fsPlugin.enable()
+}
+
+function disable () {
+  if (!fsPlugin) return
+
+  // FIXME: AppsecFsPlugin could be used by appsec and iast
+  fsPlugin.configure(false)
+
+  fsPlugin = undefined
+}
+
+module.exports = {
+  enable,
+  disable
+}

--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -29,7 +29,13 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
 
   onConfigure () {
     this.addSub('apm:fs:operation:start', (obj) => {
-      if (ignoredOperations.includes(obj.operation)) return
+      const store = storage.getStore()
+      const outOfReqOrChild = !store?.fs?.root
+
+      // we could filter out all the nested fs.operations based on store.fs.root
+      // but if we spect a store in the context to be present we are going to exclude
+      // all out_of_the_request fs.operations
+      if (ignoredOperations.includes(obj.operation) || outOfReqOrChild) return
 
       const pathArguments = []
       if (obj.dest) {

--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -14,6 +14,7 @@ const {
 } = require('./taint-tracking')
 const { IAST_ENABLED_TAG_KEY } = require('./tags')
 const iastTelemetry = require('./telemetry')
+const { enable: enableFsPlugin, disable: disableFsPlugin } = require('../fs-plugin')
 
 // TODO Change to `apm:http:server:request:[start|close]` when the subscription
 //  order of the callbacks can be enforce
@@ -27,6 +28,7 @@ function enable (config, _tracer) {
   if (isEnabled) return
 
   iastTelemetry.configure(config, config.iast?.telemetryVerbosity)
+  enableFsPlugin('iast')
   enableAllAnalyzers(config)
   enableTaintTracking(config.iast, iastTelemetry.verbosity)
   requestStart.subscribe(onIncomingHttpRequestStart)
@@ -44,6 +46,7 @@ function disable () {
   isEnabled = false
 
   iastTelemetry.stop()
+  disableFsPlugin('iast')
   disableAllAnalyzers()
   disableTaintTracking()
   overheadController.finishGlobalContext()

--- a/packages/dd-trace/src/appsec/rasp.js
+++ b/packages/dd-trace/src/appsec/rasp.js
@@ -144,13 +144,14 @@ function analyzeSsrf (ctx) {
 }
 
 function analyzeLfi (ctx) {
+  const path = ctx?.path
+  if (!path) return
+
   const store = storage.getStore()
   if (!store) return
 
   const { req, fs, res } = store
-  const path = ctx?.path
-
-  if (!req || !path || !fs) return
+  if (!req || !fs) return
 
   // NOTE 1: only analyze root fs.operations and not excluded (if response is not rendering)
   // NOTE 2: only call waf if it is an absolute path or it contains ../ in the path

--- a/packages/dd-trace/src/appsec/rasp.js
+++ b/packages/dd-trace/src/appsec/rasp.js
@@ -8,7 +8,7 @@ const { reportStackTrace } = require('./stack_trace')
 const waf = require('./waf')
 const { getBlockingAction, block } = require('./blocking')
 const log = require('../log')
-const { enable: fsPluginEnable, disable: fsPluginDisable } = require('./fs-plugin')
+const { enable: enableFsPlugin, disable: disableFsPlugin } = require('./fs-plugin')
 
 const RULE_TYPES = {
   SSRF: 'ssrf',
@@ -104,7 +104,7 @@ function handleUncaughtExceptionMonitor (err) {
 function enable (_config) {
   config = _config
 
-  fsPluginEnable()
+  enableFsPlugin('rasp')
 
   httpClientRequestStart.subscribe(analyzeSsrf)
   fsOperationStart.subscribe(analyzeLfi)
@@ -121,7 +121,7 @@ function disable () {
   if (httpClientRequestStart.hasSubscribers) httpClientRequestStart.unsubscribe(analyzeSsrf)
   if (fsOperationStart.hasSubscribers) fsOperationStart.unsubscribe(analyzeLfi)
 
-  fsPluginDisable()
+  disableFsPlugin('rasp')
 
   process.off('uncaughtExceptionMonitor', handleUncaughtExceptionMonitor)
 }

--- a/packages/dd-trace/test/appsec/fs-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/fs-plugin.spec.js
@@ -1,0 +1,175 @@
+'use strict'
+
+const { assert } = require('chai')
+const path = require('path')
+const dc = require('dc-polyfill')
+const { storage } = require('../../../datadog-core')
+const { AppsecFsPlugin } = require('../../src/appsec/fs-plugin')
+const agent = require('../plugins/agent')
+
+const opStartCh = dc.channel('apm:fs:operation:start')
+const opFinishCh = dc.channel('apm:fs:operation:finish')
+
+describe('AppsecFsPlugin', () => {
+  let plugin
+
+  beforeEach(() => {
+    plugin = new AppsecFsPlugin()
+    plugin.enable()
+  })
+
+  afterEach(() => { plugin.disable() })
+
+  it('should mark fs root', () => {
+    const origStore = {}
+    storage.enterWith(origStore)
+
+    plugin._onFsOperationStart()
+
+    let store = storage.getStore()
+    assert.property(store, 'fs')
+    assert.propertyVal(store.fs, 'parentStore', origStore)
+    assert.propertyVal(store.fs, 'root', true)
+
+    plugin._onFsOperationFinishOrRenderEnd()
+
+    store = storage.getStore()
+    assert.equal(store, origStore)
+    assert.notProperty(store, 'fs')
+  })
+
+  it('should mark fs children', () => {
+    const origStore = { orig: true }
+    storage.enterWith(origStore)
+
+    plugin._onFsOperationStart()
+
+    const rootStore = storage.getStore()
+    assert.property(rootStore, 'fs')
+    assert.propertyVal(rootStore.fs, 'parentStore', origStore)
+    assert.propertyVal(rootStore.fs, 'root', true)
+
+    plugin._onFsOperationStart()
+
+    let store = storage.getStore()
+    assert.property(store, 'fs')
+    assert.propertyVal(store.fs, 'parentStore', rootStore)
+    assert.propertyVal(store.fs, 'root', false)
+    assert.propertyVal(store, 'orig', true)
+
+    plugin._onFsOperationFinishOrRenderEnd()
+
+    store = storage.getStore()
+    assert.equal(store, rootStore)
+
+    plugin._onFsOperationFinishOrRenderEnd()
+    store = storage.getStore()
+    assert.equal(store, origStore)
+  })
+
+  it('should mark fs ops as excluded while response rendering', () => {
+    plugin.enable()
+
+    const origStore = {}
+    storage.enterWith(origStore)
+
+    plugin._onResponseRenderStart()
+
+    let store = storage.getStore()
+    assert.property(store, 'fs')
+    assert.propertyVal(store.fs, 'parentStore', origStore)
+    assert.propertyVal(store.fs, 'opExcluded', true)
+
+    plugin._onFsOperationFinishOrRenderEnd()
+
+    store = storage.getStore()
+    assert.equal(store, origStore)
+    assert.notProperty(store, 'fs')
+  })
+
+  describe('integration', () => {
+    describe('apm:fs:operation', () => {
+      let fs
+
+      afterEach(() => agent.close({ ritmReset: false }))
+
+      beforeEach(() => agent.load('fs', undefined, { flushInterval: 1 }).then(() => {
+        fs = require('fs')
+      }))
+
+      it('should mark root operations', () => {
+        let count = 0
+        const onStart = () => {
+          const store = storage.getStore()
+          assert.isNotNull(store.fs)
+
+          count++
+          assert.strictEqual(count === 1, store.fs.root)
+        }
+
+        try {
+          const origStore = {}
+          storage.enterWith(origStore)
+
+          opStartCh.subscribe(onStart)
+
+          fs.readFileSync(path.join(__dirname, 'fs-plugin.spec.js'))
+
+          assert.strictEqual(count, 4)
+        } finally {
+          opStartCh.unsubscribe(onStart)
+        }
+      })
+
+      it('should mark root even if op is excluded', () => {
+        let count = 0
+        const onStart = () => {
+          const store = storage.getStore()
+          assert.isNotNull(store.fs)
+
+          count++
+          assert.isUndefined(store.fs.root)
+        }
+
+        try {
+          const origStore = {
+            fs: { opExcluded: true }
+          }
+          storage.enterWith(origStore)
+
+          opStartCh.subscribe(onStart)
+
+          fs.readFileSync(path.join(__dirname, 'fs-plugin.spec.js'))
+
+          assert.strictEqual(count, 4)
+        } finally {
+          opStartCh.unsubscribe(onStart)
+        }
+      })
+
+      it('should clean up store when finishing op', () => {
+        let count = 4
+        const onFinish = () => {
+          const store = storage.getStore()
+          count--
+
+          if (count === 0) {
+            assert.isUndefined(store.fs)
+          }
+        }
+        try {
+          const origStore = {}
+          storage.enterWith(origStore)
+
+          opFinishCh.subscribe(onFinish)
+
+          fs.readFileSync(path.join(__dirname, 'fs-plugin.spec.js'))
+
+          assert.strictEqual(count, 0)
+        } finally {
+          opFinishCh.unsubscribe(onFinish)
+        }
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -163,9 +163,9 @@ describe('path-traversal-analyzer', () => {
 prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
   function runFsMethodTest (description, vulnerableIndex, fn, ...args) {
     describe(description, () => {
-      before(() => enableFsPlugin())
+      before(() => enableFsPlugin('iast'))
 
-      after(() => disableFsPlugin())
+      after(() => disableFsPlugin('iast'))
 
       describe('vulnerable', () => {
         testThatRequestHasVulnerability(function () {

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -10,6 +10,8 @@ const proxyquire = require('proxyquire')
 const pathTraversalAnalyzer = require('../../../../src/appsec/iast/analyzers/path-traversal-analyzer')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
+const { enable: enableFsPlugin, disable: disableFsPlugin } = require('../../../../src/appsec/fs-plugin')
+
 const { prepareTestServerForIast } = require('../utils')
 const fs = require('fs')
 
@@ -161,6 +163,10 @@ describe('path-traversal-analyzer', () => {
 prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
   function runFsMethodTest (description, vulnerableIndex, fn, ...args) {
     describe(description, () => {
+      before(() => enableFsPlugin())
+
+      after(() => disableFsPlugin())
+
       describe('vulnerable', () => {
         testThatRequestHasVulnerability(function () {
           const store = storage.getStore()

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -145,7 +145,7 @@ describe('IAST Index', () => {
     describe('enable', () => {
       it('should enable AppsecFsPlugin', () => {
         mockIast.enable(config)
-        sinon.assert.calledOnceWithExactly(appsecFsPlugin.enable, 'iast')
+        expect(appsecFsPlugin.enable).to.have.been.calledOnceWithExactly('iast')
       })
     })
 
@@ -153,7 +153,7 @@ describe('IAST Index', () => {
       it('should disable AppsecFsPlugin', () => {
         mockIast.enable(config)
         mockIast.disable()
-        sinon.assert.calledOnceWithExactly(appsecFsPlugin.disable, 'iast')
+        expect(appsecFsPlugin.disable).to.have.been.calledOnceWithExactly('iast')
       })
     })
 

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -102,6 +102,7 @@ describe('IAST Index', () => {
     let mockVulnerabilityReporter
     let mockIast
     let mockOverheadController
+    let appsecFsPlugin
 
     const config = new Config({
       experimental: {
@@ -125,15 +126,35 @@ describe('IAST Index', () => {
         startGlobalContext: sinon.stub(),
         finishGlobalContext: sinon.stub()
       }
+      appsecFsPlugin = {
+        enable: sinon.stub(),
+        disable: sinon.stub()
+      }
       mockIast = proxyquire('../../../src/appsec/iast', {
         './vulnerability-reporter': mockVulnerabilityReporter,
-        './overhead-controller': mockOverheadController
+        './overhead-controller': mockOverheadController,
+        '../fs-plugin': appsecFsPlugin
       })
     })
 
     afterEach(() => {
       sinon.restore()
       mockIast.disable()
+    })
+
+    describe('enable', () => {
+      it('should enable AppsecFsPlugin', () => {
+        mockIast.enable(config)
+        sinon.assert.calledOnceWithExactly(appsecFsPlugin.enable, 'iast')
+      })
+    })
+
+    describe('disable', () => {
+      it('should disable AppsecFsPlugin', () => {
+        mockIast.enable(config)
+        mockIast.disable()
+        sinon.assert.calledOnceWithExactly(appsecFsPlugin.disable, 'iast')
+      })
     })
 
     describe('managing overhead controller global context', () => {

--- a/packages/dd-trace/test/appsec/rasp.spec.js
+++ b/packages/dd-trace/test/appsec/rasp.spec.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const { httpClientRequestStart } = require('../../src/appsec/channels')
+const { httpClientRequestStart, fsOperationStart } = require('../../src/appsec/channels')
 const addresses = require('../../src/appsec/addresses')
 const { handleUncaughtExceptionMonitor } = require('../../src/appsec/rasp')
 
 describe('RASP', () => {
-  let waf, rasp, datadogCore, stackTrace, web
+  let waf, rasp, datadogCore, stackTrace, web, blocking
 
   beforeEach(() => {
     datadogCore = {
@@ -26,11 +26,16 @@ describe('RASP', () => {
       root: sinon.stub()
     }
 
+    blocking = {
+      block: sinon.stub()
+    }
+
     rasp = proxyquire('../../src/appsec/rasp', {
       '../../../datadog-core': datadogCore,
       './waf': waf,
       './stack_trace': stackTrace,
-      './../plugins/util/web': web
+      './../plugins/util/web': web,
+      './blocking': blocking
     })
 
     const config = {
@@ -166,6 +171,81 @@ describe('RASP', () => {
       httpClientRequestStart.publish(ctx)
 
       sinon.assert.notCalled(waf.run)
+    })
+  })
+
+  describe('analyzeLfi', () => {
+    const path = '/etc/passwd'
+    const ctx = { path }
+    const req = {}
+    const res = {}
+
+    it('should analyze lfi for root fs operations', () => {
+      const fs = { root: true }
+      datadogCore.storage.getStore.returns({ req, fs })
+
+      fsOperationStart.publish(ctx)
+
+      const persistent = { [addresses.FS_OPERATION_PATH]: path }
+      sinon.assert.calledOnceWithExactly(waf.run, { persistent }, req, 'lfi')
+    })
+
+    it('should NOT analyze lfi for child fs operations', () => {
+      const fs = {}
+      datadogCore.storage.getStore.returns({ req, fs })
+
+      fsOperationStart.publish(ctx)
+
+      sinon.assert.notCalled(waf.run)
+    })
+
+    it('should NOT analyze lfi for excluded operations', () => {
+      const fs = { opExcluded: true }
+      datadogCore.storage.getStore.returns({ req, fs })
+
+      fsOperationStart.publish(ctx)
+
+      sinon.assert.notCalled(waf.run)
+    })
+
+    it('should block req if there is a block_request action', () => {
+      const fs = { root: true }
+      datadogCore.storage.getStore.returns({ req, res, fs })
+
+      const blockingAction = {
+        block_request: {}
+      }
+      waf.run.returns(blockingAction)
+
+      const rootSpan = {
+        context: () => {
+          return { _name: 'express.request' }
+        }
+      }
+      web.root.returns(rootSpan)
+
+      fsOperationStart.publish(ctx)
+
+      sinon.assert.calledOnceWithExactly(blocking.block, req, res, rootSpan, null, blockingAction.block_request)
+    })
+
+    it('should not block req if there is no block_request action', () => {
+      const fs = { root: true }
+      datadogCore.storage.getStore.returns({ req, res, fs })
+
+      const blockingAction = {}
+      waf.run.returns(blockingAction)
+
+      const rootSpan = {
+        context: () => {
+          return { _name: 'express.request' }
+        }
+      }
+      web.root.returns(rootSpan)
+
+      fsOperationStart.publish(ctx)
+
+      sinon.assert.notCalled(blocking.block)
     })
   })
 

--- a/packages/dd-trace/test/appsec/rasp.spec.js
+++ b/packages/dd-trace/test/appsec/rasp.spec.js
@@ -199,8 +199,17 @@ describe('RASP', () => {
       sinon.assert.notCalled(waf.run)
     })
 
+    it('should NOT analyze lfi for undefined fs (AppsecFsPlugin disabled)', () => {
+      const fs = undefined
+      datadogCore.storage.getStore.returns({ req, fs })
+
+      fsOperationStart.publish(ctx)
+
+      sinon.assert.notCalled(waf.run)
+    })
+
     it('should NOT analyze lfi for excluded operations', () => {
-      const fs = { opExcluded: true }
+      const fs = { opExcluded: true, root: true }
       datadogCore.storage.getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)

--- a/packages/dd-trace/test/appsec/rasp.spec.js
+++ b/packages/dd-trace/test/appsec/rasp.spec.js
@@ -6,7 +6,7 @@ const addresses = require('../../src/appsec/addresses')
 const { handleUncaughtExceptionMonitor } = require('../../src/appsec/rasp')
 
 describe('RASP', () => {
-  let waf, rasp, datadogCore, stackTrace, web, blocking
+  let waf, rasp, datadogCore, stackTrace, web, blocking, appsecFsPlugin
 
   beforeEach(() => {
     datadogCore = {
@@ -30,12 +30,18 @@ describe('RASP', () => {
       block: sinon.stub()
     }
 
+    appsecFsPlugin = {
+      enable: sinon.stub(),
+      disable: sinon.stub()
+    }
+
     rasp = proxyquire('../../src/appsec/rasp', {
       '../../../datadog-core': datadogCore,
       './waf': waf,
       './stack_trace': stackTrace,
       './../plugins/util/web': web,
-      './blocking': blocking
+      './blocking': blocking,
+      './fs-plugin': appsecFsPlugin
     })
 
     const config = {
@@ -54,6 +60,19 @@ describe('RASP', () => {
   afterEach(() => {
     sinon.restore()
     rasp.disable()
+  })
+
+  describe('enable', () => {
+    it('should enable AppsecFsPlugin', () => {
+      sinon.assert.calledOnceWithExactly(appsecFsPlugin.enable, 'rasp')
+    })
+  })
+
+  describe('disable', () => {
+    it('should disable AppsecFsPlugin', () => {
+      rasp.disable()
+      sinon.assert.calledOnceWithExactly(appsecFsPlugin.disable, 'rasp')
+    })
   })
 
   describe('handleResult', () => {

--- a/packages/dd-trace/test/appsec/response_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/response_blocking.spec.js
@@ -57,7 +57,7 @@ describe('HTTP Response Blocking', () => {
       }
     }))
 
-    disableFsPlugin()
+    disableFsPlugin('rasp')
   })
 
   beforeEach(() => {

--- a/packages/dd-trace/test/appsec/response_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/response_blocking.spec.js
@@ -9,6 +9,7 @@ const path = require('path')
 const WafContext = require('../../src/appsec/waf/waf_context_wrapper')
 const blockingResponse = JSON.parse(require('../../src/appsec/blocked_templates').json)
 const fs = require('fs')
+const { disable: disableFsPlugin } = require('../../src/appsec/fs-plugin')
 
 describe('HTTP Response Blocking', () => {
   let server
@@ -55,6 +56,8 @@ describe('HTTP Response Blocking', () => {
         rules: path.join(__dirname, 'response_blocking_rules.json')
       }
     }))
+
+    disableFsPlugin()
   })
 
   beforeEach(() => {


### PR DESCRIPTION
### What does this PR do?
WIP, at the moment:
- Define `AppsecFsPlugin` to identify root fs operations.
- Instrument express `res.render` to allow rasp LFI component to exclude fs operations caused by view rendering.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


