### PR TITLE
use SSI variables in CI

### DIFF
--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -21,6 +21,11 @@ const { engines } = require('../package.json')
 const supportedRange = engines.node
 const currentVersionIsSupported = semver.satisfies(process.versions.node, supportedRange)
 
+// These are on by default in release tests, so we'll turn them off for
+// more fine-grained control of these variables in these tests.
+delete process.env.DD_INJECTION_ENABLED
+delete process.env.DD_INJECT_FORCE
+
 function testInjectionScenarios (arg, filename, esmWorks = false) {
   if (!currentVersionIsSupported) return
   const doTest = (file, ...args) => testFile(file, ...args)

--- a/integration-tests/package-guardrails.spec.js
+++ b/integration-tests/package-guardrails.spec.js
@@ -13,6 +13,11 @@ const DD_TRACE_DEBUG = 'true'
 const DD_INJECTION_ENABLED = 'tracing'
 const DD_LOG_LEVEL = 'error'
 
+// These are on by default in release tests, so we'll turn them off for
+// more fine-grained control of these variables in these tests.
+delete process.env.DD_INJECTION_ENABLED
+delete process.env.DD_INJECT_FORCE
+
 describe('package guardrails', () => {
   useEnv({ NODE_OPTIONS })
   const runTest = (...args) =>

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -42,3 +42,6 @@ if (global.describe && typeof global.describe.skip !== 'function') {
 }
 
 process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
+
+process.env.DD_INJECTION_ENABLED = 'true'
+process.env.DD_INJECT_FORCE = 'true'

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -43,5 +43,8 @@ if (global.describe && typeof global.describe.skip !== 'function') {
 
 process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
 
-process.env.DD_INJECTION_ENABLED = 'true'
-process.env.DD_INJECT_FORCE = 'true'
+// If this is a release PR, set the SSI variables.
+if (/^v\d+\.x$/.test(process.env.GITHUB_BASE_REF || '')) {
+  process.env.DD_INJECTION_ENABLED = 'true'
+  process.env.DD_INJECT_FORCE = 'true'
+}


### PR DESCRIPTION
### What does this PR do?
On PR release builds (and only the PR build), run all the tests with SSI variables enabled.
This _should_ generally have no effect, and this test ensures that it doesn't. Once the PR has been merged, the tests will run again without the SSI variables enabled, so we're always testing both ways.

# Notes

* To test this, I enabled the variables _always_ and ran CI. I fixed the issues in the tests that depend on these variables, then I isolated the variables to releases.