### PR TITLE
Run onboarding tests with and without profiling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ onboarding_tests_installer:
   parallel:
     matrix:
       - ONBOARDING_FILTER_WEBLOG: [test-app-nodejs,test-app-nodejs-container]
+        SCENARIO: [ INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING ]
 
 onboarding_tests_k8s_injection:
   variables:


### PR DESCRIPTION
### What does this PR do?
Adds back onboarding tests with profiling enabled.

### Motivation
The old `SIMPLE_HOST_AUTO_INJECTION_PROFILING` and `SIMPLE_CONTAINER_AUTO_INJECTION_PROFILING` tests were deprecated and replaced in #4527 . However, one-pipeline was merged without incorporating those changes

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


