### PR TITLE
chore(w3c): avoid setting _dd.parent_id to 16 zeros

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -236,8 +236,7 @@ class TextMapPropagator {
   }
 
   _hasParentIdInTags (spanContext) {
-    return tags.DD_PARENT_ID in spanContext._trace.tags &&
-      spanContext._trace.tags[tags.DD_PARENT_ID] !== zeroTraceId
+    return tags.DD_PARENT_ID in spanContext._trace.tags
   }
 
   _updateParentIdFromDdHeaders (carrier, firstSpanContext) {
@@ -444,10 +443,6 @@ class TextMapPropagator {
           }
         }
       })
-
-      if (!spanContext._trace.tags[tags.DD_PARENT_ID]) {
-        spanContext._trace.tags[tags.DD_PARENT_ID] = zeroTraceId
-      }
 
       this._extractBaggageItems(carrier, spanContext)
       return spanContext

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -521,7 +521,7 @@ describe('TextMapPropagator', () => {
 
       const carrier = textMap
       const spanContext = propagator.extract(carrier)
-      expect(spanContext._trace.tags).to.have.property('_dd.parent_id', '0000000000000000')
+      expect(spanContext._trace.tags).to.not.have.property('_dd.parent_id')
     })
 
     it('should not extract tracestate from tracecontext when trace IDs don\'t match', () => {


### PR DESCRIPTION
### What does this PR do?
Currently when w3c tracestate headers are extracted by Datadog W3C Propagators:
1) The p value in the tracestate is stored in SpanContext.reparentID.
2) If the p value is not found in the tracestate then SpanContext.reparentID (which will be used to set Span.meta["_dd.parent_id"]) is set to 0000000000000000.

The second condition is no longer required. Datadog internal services no
longer handle the case where `Span.meta["_dd.parent_id"] == 0000000000000000`. `0000000000000000` is treated as invalid value and ignored. We should avoid setting and handling this value in client libraries.

### Motivation
- Simplify the extraction logic for w3c tracecontext headers.
- Avoids unnecessary tags to the Datadog agent.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


