### PR TITLE
remove optional chaining operator in agent exporter

### DIFF
--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -15,7 +15,7 @@ class AgentExporter {
     }))
 
     const headers = {}
-    if (stats.enabled || appsec && appsec.standalone && appsec.standalone.enabled) { {
+    if (stats.enabled || appsec && appsec.standalone && appsec.standalone.enabled) {
       headers['Datadog-Client-Computed-Stats'] = 'yes'
     }
 

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -15,7 +15,7 @@ class AgentExporter {
     }))
 
     const headers = {}
-    if (stats.enabled || appsec?.standalone?.enabled) {
+    if (stats.enabled || appsec && appsec.standalone && appsec.standalone.enabled) { {
       headers['Datadog-Client-Computed-Stats'] = 'yes'
     }
 

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -15,7 +15,7 @@ class AgentExporter {
     }))
 
     const headers = {}
-    if (stats.enabled || appsec && appsec.standalone && appsec.standalone.enabled) {
+    if (stats.enabled || (appsec && appsec.standalone && appsec.standalone.enabled)) {
       headers['Datadog-Client-Computed-Stats'] = 'yes'
     }
 


### PR DESCRIPTION
### What does this PR do?
remove optional chaining operator in agent exporter inorder to mitigate any issues with dependency versions that don't support optional chaining

### Motivation
Customer is running into issues with appsec?.standalone?.enabled with the error:

`if (stats.enabled || appsec?.standalone?.enabled) {
                                ^

SyntaxError: Invalid or unexpected token
`


