### PR TITLE
Fix ALS continuation bug in body-parser

### DIFF
--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -23,11 +23,22 @@ function publishRequestBodyAndNext (req, res, next) {
 addHook({
   name: 'body-parser',
   file: 'lib/read.js',
-  versions: ['>=1.4.0']
+  versions: ['>=1.4.0 <1.20.0']
 }, read => {
   return shimmer.wrap(read, function (req, res, next) {
     const nextResource = new AsyncResource('bound-anonymous-fn')
-    arguments[2] = nextResource.bindpublishRequestBodyAndNext(req, res, next))
+    arguments[2] = nextResource.bind(publishRequestBodyAndNext(req, res, next))
+    return read.apply(this, arguments)
+  })
+})
+
+addHook({
+  name: 'body-parser',
+  file: 'lib/read.js',
+  versions: ['>=1.20.0']
+}, read => {
+  return shimmer.wrap(read, function (req, res, next) {
+    arguments[2] = publishRequestBodyAndNext(req, res, next)
     return read.apply(this, arguments)
   })
 })

--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const shimmer = require('../../datadog-shimmer')
-const { channel, addHook } = require('./helpers/instrument')
+const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 
 const bodyParserReadCh = channel('datadog:body-parser:read:finish')
 
@@ -26,7 +26,8 @@ addHook({
   versions: ['>=1.4.0']
 }, read => {
   return shimmer.wrap(read, function (req, res, next) {
-    arguments[2] = publishRequestBodyAndNext(req, res, next)
+    const nextResource = new AsyncResource('bound-anonymous-fn')
+    arguments[2] = nextResource.bindpublishRequestBodyAndNext(req, res, next))
     return read.apply(this, arguments)
   })
 })

--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -27,7 +27,7 @@ addHook({
 }, read => {
   return shimmer.wrap(read, function (req, res, next) {
     const nextResource = new AsyncResource('bound-anonymous-fn')
-    arguments[2] = nextResource.bind(publishRequestBodyAndNext(req, res, next))
+    arguments[2] = publishRequestBodyAndNext(req, res, next)
     return read.apply(this, arguments)
   })
 })

--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -27,7 +27,7 @@ addHook({
 }, read => {
   return shimmer.wrap(read, function (req, res, next) {
     const nextResource = new AsyncResource('bound-anonymous-fn')
-    arguments[2] = publishRequestBodyAndNext(req, res, next)
+    arguments[2] = nextResource.bind(publishRequestBodyAndNext(req, res, next))
     return read.apply(this, arguments)
   })
 })

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { assert } = require('chai')
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
@@ -74,12 +73,11 @@ withVersions('body-parser', 'body-parser', version => {
     })
 
     it('should not lose the http async context', async () => {
-      function handler () {
+      function handler ({ req, res }) {
         const store = storage.getStore()
-        assert(store)
-        assert(store.req)
-        assert(store.res)
-        assert(store.span)
+        expect(store).to.have.property('req', req)
+        expect(store).to.have.property('res', res)
+        expect(store).to.have.property('span')
       }
       bodyParserReadCh.subscribe(handler)
 

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { assert } = require('chai')
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -11,7 +11,7 @@ withVersions('body-parser', 'body-parser', version => {
     let port, server, middlewareProcessBodyStub
 
     before(() => {
-      return agent.load(['express', 'body-parser'], { client: false })
+      return agent.load(['http', 'express', 'body-parser'], { client: false })
     })
 
     before((done) => {

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -73,15 +73,20 @@ withVersions('body-parser', 'body-parser', version => {
     })
 
     it('should not lose the http async context', async () => {
-      function handler ({ req, res }) {
-        const store = storage.getStore()
-        expect(store).to.have.property('req', req)
-        expect(store).to.have.property('res', res)
-        expect(store).to.have.property('span')
+      let store
+      let payload
+
+      function handler (data) {
+        store = storage.getStore()
+        payload = data
       }
       bodyParserReadCh.subscribe(handler)
 
       const res = await axios.post(`http://localhost:${port}/`, { key: 'value' })
+
+      expect(store).to.have.property('req', payload.req)
+      expect(store).to.have.property('res', payload.res)
+      expect(store).to.have.property('span')
 
       expect(middlewareProcessBodyStub).to.be.calledOnce
       expect(res.data).to.be.equal('DONE')

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -72,19 +72,22 @@ withVersions('body-parser', 'body-parser', version => {
       bodyParserReadCh.unsubscribe(blockRequest)
     })
 
-    it('should propagate the async context', async () => {
-      const store = {}
-      function noop () {
-        console.log(storage.getStore())
+    it('should not lose the http async context', async () => {
+      function handler () {
+        const store = storage.getStore()
+        assert(store)
+        assert(store.req)
+        assert(store.res)
+        assert(store.span)
       }
-      bodyParserReadCh.subscribe(noop)
+      bodyParserReadCh.subscribe(handler)
 
       const res = await axios.post(`http://localhost:${port}/`, { key: 'value' })
 
       expect(middlewareProcessBodyStub).to.be.calledOnce
       expect(res.data).to.be.equal('DONE')
 
-      bodyParserReadCh.unsubscribe(noop)
+      bodyParserReadCh.unsubscribe(handler)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Add a context continuation to fix a bug in old versions of `raw-body`.

### Motivation
Client found some body attacks were not detected.
