### PR TITLE
fix(openai): tracing occurs in correct async context

### DIFF
--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -166,23 +166,7 @@ describe('Plugin', () => {
                 finish_reason: 'length'
               }],
               usage: { prompt_tokens: 3, completion_tokens: 16, total_tokens: 19 }
-            }, [
-              'Date', 'Mon, 15 May 2023 17:24:22 GMT',
-              'Content-Type', 'application/json',
-              'Content-Length', '349',
-              'Connection', 'close',
-              'openai-model', 'text-davinci-002',
-              'openai-organization', 'kill-9',
-              'openai-processing-ms', '442',
-              'openai-version', '2020-10-01',
-              'x-ratelimit-limit-requests', '3000',
-              'x-ratelimit-limit-tokens', '250000',
-              'x-ratelimit-remaining-requests', '2999',
-              'x-ratelimit-remaining-tokens', '249984',
-              'x-ratelimit-reset-requests', '20ms',
-              'x-ratelimit-reset-tokens', '3ms',
-              'x-request-id', '7df89d8afe7bf24dc04e2c4dd4962d7f'
-            ])
+            })
 
           await tracer.trace('outer', async (outerSpan) => {
             const params = {
@@ -198,12 +182,12 @@ describe('Plugin', () => {
               expect(result.data.id).to.eql('cmpl-7GWDlQbOrAYGmeFZtoRdOEjDXDexM')
             }
 
-            tracer.trace('child of outer', () => {
-              const currentSpan = tracer.scope().active()
-              expect(currentSpan.context()._parentId).to.equal(outerSpan.context()._spanId)
+            tracer.trace('child of outer', innerSpan => {
+              expect(innerSpan.context()._parentId).to.equal(outerSpan.context()._spanId)
             })
           })
         })
+
         if (semver.intersects('>4.1.0', version)) {
           it('should maintain the context with a streamed call', async () => {
             nock('https://api.openai.com:443')
@@ -228,9 +212,8 @@ describe('Plugin', () => {
                 expect(part.choices[0]).to.have.property('delta')
               }
 
-              tracer.trace('child of outer', () => {
-                const currentSpan = tracer.scope().active()
-                expect(currentSpan.context()._parentId).to.equal(outerSpan.context()._spanId)
+              tracer.trace('child of outer', innerSpan => {
+                expect(innerSpan.context()._parentId).to.equal(outerSpan.context()._spanId)
               })
             })
           })

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -150,6 +150,7 @@ describe('Plugin', () => {
         afterEach(() => {
           nock.cleanAll()
         })
+
         it('should maintain the context with a non-streamed call', async () => {
           nock('https://api.openai.com:443')
             .post('/v1/completions')

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -21,13 +21,14 @@ describe('Plugin', () => {
   let metricStub
   let externalLoggerStub
   let realVersion
+  let tracer
 
   describe('openai', () => {
     withVersions('openai', 'openai', version => {
       const moduleRequirePath = `../../../versions/openai@${version}`
 
       beforeEach(() => {
-        require(tracerRequirePath)
+        tracer = require(tracerRequirePath)
       })
 
       before(() => {
@@ -143,6 +144,96 @@ describe('Plugin', () => {
           expect(metricStub).to.not.have.been.calledWith('openai.ratelimit.remaining.requests')
           expect(metricStub).to.not.have.been.calledWith('openai.ratelimit.remaining.tokens')
         })
+      })
+
+      describe.only('maintains context', () => {
+        afterEach(() => {
+          nock.cleanAll()
+        })
+        it('should maintain the context with a non-streamed call', async () => {
+          nock('https://api.openai.com:443')
+            .post('/v1/completions')
+            .reply(200, {
+              id: 'cmpl-7GWDlQbOrAYGmeFZtoRdOEjDXDexM',
+              object: 'text_completion',
+              created: 1684171461,
+              model: 'text-davinci-002',
+              choices: [{
+                text: 'FOO BAR BAZ',
+                index: 0,
+                logprobs: null,
+                finish_reason: 'length'
+              }],
+              usage: { prompt_tokens: 3, completion_tokens: 16, total_tokens: 19 }
+            }, [
+              'Date', 'Mon, 15 May 2023 17:24:22 GMT',
+              'Content-Type', 'application/json',
+              'Content-Length', '349',
+              'Connection', 'close',
+              'openai-model', 'text-davinci-002',
+              'openai-organization', 'kill-9',
+              'openai-processing-ms', '442',
+              'openai-version', '2020-10-01',
+              'x-ratelimit-limit-requests', '3000',
+              'x-ratelimit-limit-tokens', '250000',
+              'x-ratelimit-remaining-requests', '2999',
+              'x-ratelimit-remaining-tokens', '249984',
+              'x-ratelimit-reset-requests', '20ms',
+              'x-ratelimit-reset-tokens', '3ms',
+              'x-request-id', '7df89d8afe7bf24dc04e2c4dd4962d7f'
+            ])
+
+          await tracer.trace('outer', async (outerSpan) => {
+            const params = {
+              model: 'text-davinci-002',
+              prompt: 'Hello, \n\nFriend\t\tHi'
+            }
+
+            if (semver.satisfies(realVersion, '>=4.0.0')) {
+              const result = await openai.completions.create(params)
+              expect(result.id).to.eql('cmpl-7GWDlQbOrAYGmeFZtoRdOEjDXDexM')
+            } else {
+              const result = await openai.createCompletion(params)
+              expect(result.data.id).to.eql('cmpl-7GWDlQbOrAYGmeFZtoRdOEjDXDexM')
+            }
+
+            tracer.trace('child of outer', () => {
+              const currentSpan = tracer.scope().active()
+              expect(currentSpan.context()._parentId).to.equal(outerSpan.context()._spanId)
+            })
+          })
+        })
+        if (semver.intersects('>4.1.0', version)) {
+          it('should maintain the context with a streamed call', async () => {
+            nock('https://api.openai.com:443')
+              .post('/v1/chat/completions')
+              .reply(200, function () {
+                return fs.createReadStream(Path.join(__dirname, 'streamed-responses/chat.completions.simple.txt'))
+              }, {
+                'Content-Type': 'text/plain',
+                'openai-organization': 'kill-9'
+              })
+
+            await tracer.trace('outer', async (outerSpan) => {
+              const stream = await openai.chat.completions.create({
+                model: 'gpt-4o',
+                messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
+                temperature: 0.5,
+                stream: true
+              })
+
+              for await (const part of stream) {
+                expect(part).to.have.property('choices')
+                expect(part.choices[0]).to.have.property('delta')
+              }
+
+              tracer.trace('child of outer', () => {
+                const currentSpan = tracer.scope().active()
+                expect(currentSpan.context()._parentId).to.equal(outerSpan.context()._spanId)
+              })
+            })
+          })
+        }
       })
 
       describe('create completion', () => {

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -146,7 +146,7 @@ describe('Plugin', () => {
         })
       })
 
-      describe.only('maintains context', () => {
+      describe('maintains context', () => {
         afterEach(() => {
           nock.cleanAll()
         })


### PR DESCRIPTION
### What does this PR do?
Ensures tracing and parentage is tracked appropriately across different async contexts by migrating the OpenAI plugin to use tracing channel/appropriate internal APIs.

### Motivation
Previously, something like:
```javascript
await tracer.trace('outer', async () => {
  await openai.chat.completions.create(...)
  tracer.trace('child', () => {})
})
```
Would have `child` as a child span of the `openai.request` span, and not the `outer` span. By migrating to tracing channel and using the internal APIs for later versions, this parentage/context is maintained. This is validated with a regression test, for both streamed and non-streamed cases.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js


