### PR TITLE
Update native-iast-rewriter to fix bug with template literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@datadog/native-appsec": "8.0.1",
-    "@datadog/native-iast-rewriter": "2.4.0",
+    "@datadog/native-iast-rewriter": "2.4.1",
     "@datadog/native-iast-taint-tracking": "3.1.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.3.0",

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -6,6 +6,12 @@ function insertStr (str) {
   return `pre_${str}_suf`
 }
 
+function templateLiteralEndingWithNumberParams (str) {
+  const num1 = 1
+  const num2 = 2
+  return `${str}Literal${num1}${num2}`
+}
+
 function appendStr (str) {
   let pre = 'pre_'
   pre += str
@@ -101,6 +107,7 @@ module.exports = {
   sliceStr,
   substrStr,
   substringStr,
+  templateLiteralEndingWithNumberParams,
   toLowerCaseStr,
   toUpperCaseStr,
   trimEndStr,

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -25,6 +25,7 @@ const propagationFns = [
   'sliceStr',
   'substrStr',
   'substringStr',
+  'templateLiteralEndingWithNumberParams',
   'toLowerCaseStr',
   'toUpperCaseStr',
   'trimEndStr',
@@ -135,7 +136,8 @@ describe('TaintTracking', () => {
       'arrayProtoJoin',
       'concatSuffix',
       'concatTaintedStr',
-      'insertStr'
+      'insertStr',
+      'templateLiteralEndingWithNumberParams'
     ]
     propagationFns.forEach((propFn) => {
       if (filtered.includes(propFn)) return

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,10 +263,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.0.tgz#369de141ecb31118882d3339ba6e4d3487c9de97"
-  integrity sha512-vmcPM9h/jfv1vsej0tBglTah/gia4r6cwzWd4EDsSVOjuNdD+a7L2ZcCtYUxRlrETsOfuiblp6D+o921Qcb0MQ==
+"@datadog/native-iast-rewriter@2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz#e8211f78c818906513fb96a549374da0382c7623"
+  integrity sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates `@datadog/native-iast-rewriter` library to fix a bug
### Motivation
<!-- What inspired you to submit this pull request? -->
Issue rewriting TemplateLiterals ending with two parameters with number values without literals in the middle, for example:
```
`Literal${num1}${num2}`
```


