### PR TITLE
ensure require-package-json is called with try-catch

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -90,7 +90,14 @@ for (const packageName of names) {
       }
 
       if (matchesFile) {
-        const version = moduleVersion || getVersion(moduleBaseDir)
+        let version = moduleVersion
+        try {
+          version = version || getVersion(moduleBaseDir)
+        } catch (e) {
+          log.error(`Error getting version for "${name}": ${e.message}`)
+          log.error(e)
+          continue
+        }
         if (!Object.hasOwnProperty(namesAndSuccesses, name)) {
           namesAndSuccesses[`${name}@${version}`] = false
         }


### PR DESCRIPTION
require-package-json can throw. This was the only place it was called without being surrounded by a try-catch.


