### PR TITLE
[test visibility] Add check to determine whether `git` is available

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -11,7 +11,8 @@ const {
   generatePackFilesForCommits,
   getCommitsRevList,
   isShallowRepository,
-  unshallowRepository
+  unshallowRepository,
+  isGitAvailable
 } = require('../../../plugins/util/git')
 
 const {
@@ -242,6 +243,9 @@ function generateAndUploadPackFiles ({
  * This function uploads git metadata to CI Visibility's backend.
 */
 function sendGitMetadata (url, { isEvpProxy, evpProxyPrefix }, configRepositoryUrl, callback) {
+  if (!isGitAvailable()) {
+    return callback(new Error('Git is not available'))
+  }
   let repositoryUrl = configRepositoryUrl
   if (!repositoryUrl) {
     repositoryUrl = getRepositoryUrl()

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -77,6 +77,18 @@ function isDirectory (path) {
   }
 }
 
+function isGitAvailable () {
+  const isWindows = os.platform() === 'win32'
+  const command = isWindows ? 'where' : 'which'
+  try {
+    cp.execFileSync(command, ['git'], { stdio: 'pipe' })
+    return true
+  } catch (e) {
+    incrementCountMetric(TELEMETRY_GIT_COMMAND_ERRORS, { command: 'check_git', exitCode: 'missing' })
+    return false
+  }
+}
+
 function isShallowRepository () {
   return sanitizedExec(
     'git',
@@ -342,5 +354,6 @@ module.exports = {
   getCommitsRevList,
   GIT_REV_LIST_MAX_BUFFER,
   isShallowRepository,
-  unshallowRepository
+  unshallowRepository,
+  isGitAvailable
 }

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -325,17 +325,20 @@ describe('git_metadata', () => {
   })
 
   it('should not crash if git is missing', (done) => {
+    const oldPath = process.env.PATH
+    // git will not be found
+    process.env.PATH = ''
+
     const scope = nock('https://api.test.com')
       .post('/api/v2/git/repository/search_commits')
       .reply(200, JSON.stringify({ data: [] }))
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 
-    getRepositoryUrlStub.returns('')
-
     gitMetadata.sendGitMetadata(new URL('https://api.test.com'), { isEvpProxy: false }, '', (err) => {
-      expect(err.message).to.contain('Repository URL is empty')
+      expect(err.message).to.contain('Git is not available')
       expect(scope.isDone()).to.be.false
+      process.env.PATH = oldPath
       done()
     })
   })

--- a/packages/dd-trace/test/plugins/util/git.spec.js
+++ b/packages/dd-trace/test/plugins/util/git.spec.js
@@ -7,7 +7,7 @@ const os = require('os')
 const fs = require('fs')
 const path = require('path')
 
-const { GIT_REV_LIST_MAX_BUFFER } = require('../../../src/plugins/util/git')
+const { GIT_REV_LIST_MAX_BUFFER, isGitAvailable } = require('../../../src/plugins/util/git')
 const proxyquire = require('proxyquire')
 const execFileSyncStub = sinon.stub().returns('')
 
@@ -376,5 +376,27 @@ describe('user credentials', () => {
     const metadata = getGitMetadata({})
     expect(metadata[GIT_REPOSITORY_URL])
       .to.equal('ssh://host.xz:port/path/to/repo.git/')
+  })
+})
+
+describe('isGitAvailable', () => {
+  let originalPath
+
+  beforeEach(() => {
+    originalPath = process.env.PATH
+  })
+
+  afterEach(() => {
+    process.env.PATH = originalPath
+  })
+
+  it('returns true if git is available', () => {
+    expect(isGitAvailable()).to.be.true
+  })
+
+  it('returns false if git is not available', () => {
+    process.env.PATH = ''
+
+    expect(isGitAvailable()).to.be.false
   })
 })


### PR DESCRIPTION
### What does this PR do?

* Add `isGitAvailable` that executes `which git` or `where git` depending on os platform
* Call `isGitAvailable` at the beginning of `sendGitMetadata` (where we upload git metatada)

### Motivation

* Give a better error message whenever git is missing
* Report telemetry when git is missing

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
