### PR TITLE
more correct package guardrails

### DIFF
--- a/integration-tests/package-guardrails.spec.js
+++ b/integration-tests/package-guardrails.spec.js
@@ -64,7 +64,9 @@ false
     })
     context('when fastify is latest and logging enabled', () => {
       useSandbox(['fastify'])
-      it('should instrument the package', () => runTest('true\n'))
+      useEnv({ DD_TRACE_DEBUG })
+      it('should instrument the package', () =>
+        runTest('Application instrumentation bootstrapping complete\ntrue\n'))
     })
   })
 

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -98,7 +98,7 @@ for (const packageName of names) {
           log.error(e)
           continue
         }
-        if (!Object.hasOwnProperty(namesAndSuccesses, name)) {
+        if (typeof namesAndSuccesses[`${name}@${version}`] === 'undefined') {
           namesAndSuccesses[`${name}@${version}`] = false
         }
 


### PR DESCRIPTION
While _functioning_ correctly, the logging and telemetry was broken for packages that met one range, but didn't meet a subsequent range. This is now fixed.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


