### PR TITLE
correctly handle 128 bit traceids in log injection

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/log.js
+++ b/packages/dd-trace/src/opentracing/propagation/log.js
@@ -15,7 +15,7 @@ class LogPropagator {
 
     if (spanContext) {
       if (this._config.traceId128BitLoggingEnabled && spanContext._trace.tags['_dd.p.tid']) {
-        carrier.dd.trace_id = spanContext._trace.tags['_dd.p.tid'] + spanContext._traceId.toString(16)
+        carrier.dd.trace_id = spanContext.toTraceId(true)
       } else {
         carrier.dd.trace_id = spanContext.toTraceId()
       }

--- a/packages/dd-trace/test/opentracing/propagation/log.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/log.spec.js
@@ -76,6 +76,25 @@ describe('LogPropagator', () => {
       expect(carrier.dd).to.have.property('span_id', '456')
     })
 
+    it('should correctly inject 128 bit trace ids when _dd.p.tid is present', () => {
+      config.traceId128BitLoggingEnabled = true
+      const carrier = {}
+      const traceId = id('4e2a9c1573d240b1a3b7e3c1d4c2f9a7', 16)
+      const traceIdTag = '8765432187654321'
+      const spanContext = new SpanContext({
+        traceId,
+        spanId: id('456', 10)
+      })
+
+      spanContext._trace.tags['_dd.p.tid'] = traceIdTag
+
+      propagator.inject(spanContext, carrier)
+
+      expect(carrier).to.have.property('dd')
+      expect(carrier.dd).to.have.property('trace_id', '4e2a9c1573d240b1a3b7e3c1d4c2f9a7')
+      expect(carrier.dd).to.have.property('span_id', '456')
+    })
+
     it('should not inject 128-bit trace IDs when disabled', () => {
       const carrier = {}
       const traceId = id('123', 10)


### PR DESCRIPTION
### What does this PR do?
use the span context's toTraceId helper method to set the trace_id instead of constructing it manually

### Motivation
Addressing a bug where log injection outputs a 192 bit trace id when the traceId in the span context is already 128 bits


