### PR TITLE
Prepare prerelease branch after each push

### DIFF
--- a/.github/actions/prepare-prerelease/action.yml
+++ b/.github/actions/prepare-prerelease/action.yml
@@ -1,0 +1,67 @@
+name: Prepare prerelease branch
+
+inputs:
+  base-branch:
+    description: 'The base branch to create the prerelease branch from'
+    required: true
+  github-token:
+    description: 'Github token to use in branch-diff'
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Configure node
+      uses: actions/setup-node@v3
+
+    - name: Checkout master
+      shell: bash
+      run: |
+        git fetch
+        git checkout master
+        git pull
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        yarn
+
+    - name: Install branch-diff
+      shell: bash
+      run: |
+        npm i -g @bengl/branch-diff
+
+    - name: Configure branch-diff
+      shell: bash
+      run: |
+        mkdir -p ~/.config/changelog-maker
+        echo "{\"token\":\"${{inputs.github-token}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
+
+    - name: Copy scripts
+      shell: bash
+      run: |
+        cp -r scripts _scripts
+
+    - name: Set up Git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Checkout proposal branch
+      shell: bash
+      run: |
+        git fetch
+        git checkout ${{ inputs.base-branch}}-proposal || (git checkout ${{ inputs.base-branch}} && git checkout -b ${{ inputs.base-branch}}-proposal)
+
+    - name: Commit branch diffs
+      id: commit_branch_diffs
+      shell: bash
+      run: |
+        node _scripts/prepare-release-proposal.js commit-branch-diffs ${{ inputs.base-branch }}-proposal
+
+    - name: Push prerelease branch
+      shell: bash
+      run: |
+        git push origin ${{ inputs.base-branch}}-proposal

--- a/.github/workflows/prepare-prerelease-branches.yml
+++ b/.github/workflows/prepare-prerelease-branches.yml
@@ -1,0 +1,47 @@
+name: Prepare prelease branches
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  check-no-pending-release:
+    strategy:
+      matrix:
+        release-line:
+          - v4
+          - v5
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check pending release
+        run: |
+          git fetch
+          git ls-remote --heads | grep -E '${{ matrix.release-line}}\.[1-9]+\.[1-9]+-proposal' && echo "Release already in progress, can not create proposal branch now" && exit 1 || exit 0
+
+  update-prelease-branches:
+    needs: check-no-pending-release
+
+    strategy:
+      matrix:
+        base-branch:
+          - v4.x
+          - v5.x
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_ACCESS_TOKEN_RELEASE }}
+
+      - uses: ./.github/actions/prepare-prerelease
+        with:
+          base-branch: ${{ matrix.base-branch }}
+          github-token: ${{ secrets.GH_ACCESS_TOKEN_RELEASE }}

--- a/.github/workflows/prepare-release-proposal.yml
+++ b/.github/workflows/prepare-release-proposal.yml
@@ -12,50 +12,30 @@ jobs:
           - v5.x
     runs-on: ubuntu-latest
 
-    permissions: write-all
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ matrix.base-branch }}
           token: ${{ secrets.GH_ACCESS_TOKEN_RELEASE }}
 
-      - name: Set up Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Update prerelease-branch
+        uses: ./.github/actions/prepare-prerelease
+        with:
+          base-branch: ${{ matrix.base-branch }}
+          github-token: ${{ secrets.GH_ACCESS_TOKEN_RELEASE }}
 
-      - name: Pull master branch
+      - name: Checkout prerelease branch
         run: |
-          git checkout master
-          git pull
-          cp -r scripts _scripts
           git checkout ${{ matrix.base-branch }}
+          git pull
+          git checkout ${{ matrix.base-branch }}-proposal
+          git pull
 
-
-      - name: Configure node
-        uses: actions/setup-node@v3
-
-      - name: Install dependencies
+      - name: Get branch diffs
+        id: get_branch_diffs
         run: |
-          yarn
-          git checkout yarn.lock
-
-      - name: Install branch-diff
-        run: |
-          npm i -g @bengl/branch-diff
-
-      - name: Configure branch-diff
-        run: |
-          mkdir -p ~/.config/changelog-maker
-          echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
-
-      - name: Commit branch diffs
-        id: commit_branch_diffs
-        run: |
-          node _scripts/prepare-release-proposal.js commit-branch-diffs ${{ matrix.base-branch }} > branch-diffs.txt
+          node _scripts/prepare-release-proposal.js print-branch-diffs ${{ matrix.base-branch }} ${{ matrix.base-branch }}-proposal > branch-diffs.txt
 
       - name: Calculate release type
         id: calc-release-type

--- a/.github/workflows/remove-prerelease-branch.yml
+++ b/.github/workflows/remove-prerelease-branch.yml
@@ -1,0 +1,17 @@
+name: Remove prerelease branch on release
+
+on:
+  push:
+    branches: [v4.x, v5.x]
+
+jobs:
+  remove-prerelease-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Remove prerelease branch
+          run: |
+            git push origin --delete ${{ github.event.ref }}-proposal


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Each time that something is pushed in `master` branch, it will try to create a `v5.x-proposal` (and `v4x-proposal`) branch from v5.x branch to cherry pick all the changes.
This new branch will be pushed to remote, and each time that something is merged in `master` the proposal branch will be updated. 
If conflict is detected, the job will fail and we are going to have to fix it manually, cherry-picking and resolving the error in local and pushing it. 

These prerelease proposal branches are going to be used to create the new `v5.x.y-proposal` branch and the PR, with all the conflicts already resolved by the people who created it.



> **TODO** in a not too distant future, we could run tests nightly to check if next release will start to fail.

### Motivation
<!-- What inspired you to submit this pull request? -->
Try to make the release process easier, without need to understand and fix other people code when a conflict happens.


