### PR TITLE
remove shimmer.unwrap and shimmer.massUnwrap

### DIFF
--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -331,11 +331,6 @@ for (const shim of V4_PACKAGE_SHIMS) {
 
                 throw error
               })
-              .finally(() => {
-              // maybe we don't want to unwrap here in case the promise is re-used?
-              // other hand: we want to avoid resource leakage
-                shimmer.unwrap(apiProm, 'parse')
-              })
           })
 
           return apiProm

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -2,9 +2,6 @@
 
 const log = require('../../dd-trace/src/log')
 
-// Use a weak map to avoid polluting the wrapped function/method.
-const unwrappers = new WeakMap()
-
 function copyProperties (original, wrapped) {
   // TODO getPrototypeOf is not fast. Should we instead do this in specific
   // instrumentations where needed?
@@ -29,19 +26,11 @@ function wrapFunction (original, wrapper) {
   // TODO This needs to be re-done so that this and wrapMethod are distinct.
   const target = { func: original }
   wrapMethod(target, 'func', wrapper, typeof original !== 'function')
-  let delegate = target.func
+  const delegate = target.func
 
-  const shim = function shim () {
-    return delegate.apply(this, arguments)
-  }
+  if (typeof original === 'function') copyProperties(original, delegate)
 
-  unwrappers.set(shim, () => {
-    delegate = original
-  })
-
-  if (typeof original === 'function') copyProperties(original, shim)
-
-  return shim
+  return delegate
 }
 
 const wrapFn = function (original, delegate) {
@@ -187,8 +176,6 @@ function wrapMethod (target, name, wrapper, noAssert) {
   if (typeof original === 'function') copyProperties(original, wrapped)
 
   if (descriptor) {
-    unwrappers.set(wrapped, () => Object.defineProperty(target, name, descriptor))
-
     if (descriptor.get || descriptor.set) {
       attributes.get = () => wrapped
     } else {
@@ -202,7 +189,6 @@ function wrapMethod (target, name, wrapper, noAssert) {
       })
     }
   } else { // no descriptor means original was on the prototype
-    unwrappers.set(wrapped, () => delete target[name])
     attributes.value = wrapped
     attributes.writable = true
   }
@@ -218,18 +204,6 @@ function wrap (target, name, wrapper) {
     : wrapMethod(target, name, wrapper)
 }
 
-function unwrap (target, name) {
-  if (!target) return target // no target to unwrap
-
-  const unwrapper = unwrappers.get(name ? target[name] : target)
-
-  if (!unwrapper) return target // target is already unwrapped or isn't wrapped
-
-  unwrapper()
-
-  return target
-}
-
 function massWrap (targets, names, wrapper) {
   targets = toArray(targets)
   names = toArray(names)
@@ -237,17 +211,6 @@ function massWrap (targets, names, wrapper) {
   for (const target of targets) {
     for (const name of names) {
       wrap(target, name, wrapper)
-    }
-  }
-}
-
-function massUnwrap (targets, names) {
-  targets = toArray(targets)
-  names = toArray(names)
-
-  for (const target of targets) {
-    for (const name of names) {
-      unwrap(target, name)
     }
   }
 }
@@ -294,7 +257,5 @@ module.exports = {
   wrap,
   wrapFunction,
   massWrap,
-  unwrap,
-  massUnwrap,
   setSafe
 }

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -166,28 +166,6 @@ describe('shimmer', () => {
       expect(count).to.have.property('enumerable', false)
     })
 
-    it('should unwrap a method', () => {
-      const count = inc => inc
-      const obj = { count }
-
-      shimmer.wrap(obj, 'count', count => inc => count(inc) + 1)
-      shimmer.unwrap(obj, 'count')
-
-      expect(obj.count(1)).to.equal(1)
-    })
-
-    it('should unwrap a method from the prototype', () => {
-      const count = inc => inc
-      const obj = {}
-
-      Object.setPrototypeOf(obj, { count })
-
-      shimmer.wrap(obj, 'count', count => inc => count(inc) + 1)
-      shimmer.unwrap(obj, 'count')
-
-      expect(obj).to.not.have.ownProperty('count')
-    })
-
     it('should validate that there is a target object', () => {
       expect(() => shimmer.wrap()).to.throw()
     })
@@ -210,22 +188,6 @@ describe('shimmer', () => {
 
     it('should validate that the method wrapper is a function', () => {
       expect(() => shimmer.wrap({ a: () => {} }, 'a', 'notafunction')).to.throw()
-    })
-
-    it('should not throw when unwrapping without a target', () => {
-      expect(() => shimmer.unwrap(null, 'a')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping without a method', () => {
-      expect(() => shimmer.unwrap({}, 'a')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping an invalid type', () => {
-      expect(() => shimmer.unwrap({ a: 'b' }, 'a')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping a method that was not wrapped', () => {
-      expect(() => shimmer.unwrap({ a: () => {} }, 'a')).to.not.throw()
     })
 
     describe('safe mode', () => {
@@ -539,34 +501,6 @@ describe('shimmer', () => {
       expect(Object.getOwnPropertyNames(wrapped)).to.not.include('test')
     })
 
-    it('should unwrap a function', () => {
-      const count = inc => inc
-
-      const wrapped = shimmer.wrapFunction(count, count => inc => count(inc) + 1)
-
-      shimmer.unwrap(wrapped)
-
-      expect(wrapped(1)).to.equal(1)
-    })
-
-    it('should unwrap a constructor', () => {
-      const Counter = function (start) {
-        this.value = start
-      }
-
-      const WrappedCounter = shimmer.wrapFunction(Counter, Counter => function (...args) {
-        Counter.apply(this, arguments)
-        this.value++
-      })
-
-      shimmer.unwrap(WrappedCounter)
-
-      const counter = new WrappedCounter(1)
-
-      expect(counter.value).to.equal(1)
-      expect(counter).to.be.an.instanceof(Counter)
-    })
-
     it('should mass wrap methods on objects', () => {
       const foo = {
         a: () => 'original',
@@ -586,44 +520,12 @@ describe('shimmer', () => {
       expect(bar.b()).to.equal('wrapped')
     })
 
-    it('should mass wrap methods on objects', () => {
-      const foo = {
-        a: () => 'original',
-        b: () => 'original'
-      }
-
-      const bar = {
-        a: () => 'original',
-        b: () => 'original'
-      }
-
-      shimmer.massWrap([foo, bar], ['a', 'b'], () => () => 'wrapped')
-      shimmer.massUnwrap([foo, bar], ['a', 'b'])
-
-      expect(foo.a()).to.equal('original')
-      expect(foo.b()).to.equal('original')
-      expect(bar.a()).to.equal('original')
-      expect(bar.b()).to.equal('original')
-    })
-
     it('should validate that the function wrapper exists', () => {
       expect(() => shimmer.wrap(() => {})).to.throw()
     })
 
     it('should validate that the function wrapper is a function', () => {
       expect(() => shimmer.wrap(() => {}, 'a')).to.throw()
-    })
-
-    it('should never throw when unwrapping', () => {
-      expect(() => shimmer.unwrap(() => {})).to.not.throw()
-    })
-
-    it('should not throw when unwrapping an invalid type', () => {
-      expect(() => shimmer.unwrap('foo')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping a function that was not wrapped', () => {
-      expect(() => shimmer.unwrap(() => {})).to.not.throw()
     })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -32,8 +32,7 @@ describe('IAST Rewriter', () => {
       }
 
       shimmer = {
-        wrap: sinon.spy(),
-        unwrap: sinon.spy()
+        wrap: sinon.spy()
       }
 
       const kSymbolPrepareStackTrace = Symbol('kTestSymbolPrepareStackTrace')
@@ -67,13 +66,6 @@ describe('IAST Rewriter', () => {
       expect(shimmer.wrap.getCall(0).args[1]).eq('_compile')
 
       rewriter.disableRewriter()
-    })
-
-    it('Should unwrap module compile method on taint tracking disable', () => {
-      rewriter.disableRewriter()
-
-      expect(shimmer.unwrap).to.be.calledOnce
-      expect(shimmer.unwrap.getCall(0).args[1]).eq('_compile')
     })
 
     it('Should keep original prepareStackTrace fn when calling enable and then disable', () => {


### PR DESCRIPTION
We weren't using them outside a few use cases:

1) In appsec, where it was used as enabled/disabled state, and that's
   now been replaced with a variable.
2) In OpenAI, where it was added out of fear of the map in shimmer
   holding on to objects. That map gets removed by this commit anyway.

Meanwhile, unwrap added an extra unnecessary stack frame to every function call when using `wrapFunction`.

