### PR TITLE
Add error strings to telemetry, not just error instances 

### DIFF
--- a/packages/dd-trace/src/telemetry/logs/index.js
+++ b/packages/dd-trace/src/telemetry/logs/index.js
@@ -39,7 +39,12 @@ function onErrorLog (msg) {
     onLog({
       level: 'ERROR',
       message: msg.message,
-      stack: msg.stack
+      stack_trace: msg.stack
+    })
+  } else if (typeof msg === 'string') {
+    onLog({
+      level: 'ERROR',
+      message: msg
     })
   }
 }


### PR DESCRIPTION
### What does this PR do?

* Report `log.error` calls that pass a string
* Fix call to `onLog` that was passing `stack` instead of `stack_trace`: I believe this was an oversight, but please check.


### Motivation
We have plenty of `log.error('$STRING_AND_NOT_ERROR')` which we would like to register as error logs as well.

Follow up from https://github.com/DataDog/dd-trace-js/pull/4605

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
