### PR TITLE
PROF-10329, APMAPI-213: Make sure `profiling.enabled` is boolean for telemetry

### DIFF
--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -329,13 +329,17 @@ function updateConfig (changes, config) {
     const { origin, value } = change
     const entry = { name, value, origin }
 
-    if (namesNeedFormatting.has(entry.name)) entry.value = formatMapForTelemetry(entry.value)
-    if (entry.name === 'url' && entry.value) entry.value = entry.value.toString()
-    if (entry.name === 'DD_TRACE_SAMPLING_RULES') {
+    if (namesNeedFormatting.has(entry.name)) {
+      entry.value = formatMapForTelemetry(entry.value)
+    } else if (entry.name === 'url') {
+      if (entry.value) {
+        entry.value = entry.value.toString()
+      }
+    } else if (entry.name === 'DD_TRACE_SAMPLING_RULES') {
       entry.value = JSON.stringify(entry.value)
+    } else if (Array.isArray(entry.value)) {
+      entry.value = value.join(',')
     }
-    if (Array.isArray(entry.value)) entry.value = value.join(',')
-
     configuration.push(entry)
   }
 

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -337,6 +337,12 @@ function updateConfig (changes, config) {
       }
     } else if (entry.name === 'DD_TRACE_SAMPLING_RULES') {
       entry.value = JSON.stringify(entry.value)
+    } else if (entry.name === 'profiling.enabled') {
+      if (['auto', 'true'].includes(entry.value)) {
+        entry.value = true
+      } else if (entry.value === 'false') {
+        entry.value = false
+      }
     } else if (Array.isArray(entry.value)) {
       entry.value = value.join(',')
     }


### PR DESCRIPTION
### What does this PR do?
* For purposes of emitting `app-client-configuration-change` events, ensures `profiling.enabled` is a boolean. `'auto'` is mapped as `true`, while `'true'` and `'false'` are self-explanatory.
* Improved the logic for dealing with exceptions in `telemetry/index.js:updateConfig()` to use a cascade of else-ifs for mutually exclusive items.

### Motivation
Telemetry schema expects `profiling.enabled` to be a boolean. https://github.com/DataDog/dd-trace-js/pull/4592 broke that assumption.

