### PR TITLE
PROF-10329, APMAPI-213: Make sure `products.profiler.enabled` is boolean for telemetry

### DIFF
--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -337,8 +337,6 @@ function updateConfig (changes, config) {
       }
     } else if (entry.name === 'DD_TRACE_SAMPLING_RULES') {
       entry.value = JSON.stringify(entry.value)
-    } else if (entry.name === 'profiling.enabled') {
-      entry.value = profilingEnabledToBoolean(entry.value)
     } else if (Array.isArray(entry.value)) {
       entry.value = value.join(',')
     }

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -89,7 +89,7 @@ function getProducts (config) {
     },
     profiler: {
       version: tracerVersion,
-      enabled: config.profiling.enabled
+      enabled: profilingEnabledToBoolean(config.profiling.enabled)
     }
   }
   if (errors.profilingError) {
@@ -338,11 +338,7 @@ function updateConfig (changes, config) {
     } else if (entry.name === 'DD_TRACE_SAMPLING_RULES') {
       entry.value = JSON.stringify(entry.value)
     } else if (entry.name === 'profiling.enabled') {
-      if (['auto', 'true'].includes(entry.value)) {
-        entry.value = true
-      } else if (entry.value === 'false') {
-        entry.value = false
-      }
+      entry.value = profilingEnabledToBoolean(entry.value)
     } else if (Array.isArray(entry.value)) {
       entry.value = value.join(',')
     }
@@ -362,6 +358,19 @@ function updateConfig (changes, config) {
     const { reqType, payload } = createPayload('app-client-configuration-change', { configuration })
     sendData(config, application, host, reqType, payload, updateRetryData)
   }
+}
+
+function profilingEnabledToBoolean (profilingEnabled) {
+  if (typeof profilingEnabled === 'boolean') {
+    return profilingEnabled
+  }
+  if (['auto', 'true'].includes(profilingEnabled)) {
+    return true
+  }
+  if (profilingEnabled === 'false') {
+    return false
+  }
+  return undefined
 }
 
 module.exports = {

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -70,7 +70,7 @@ describe('telemetry', () => {
       },
       circularObject,
       appsec: { enabled: true },
-      profiling: { enabled: true },
+      profiling: { enabled: 'true' },
       peerServiceMapping: {
         service_1: 'remapped_service_1',
         service_2: 'remapped_service_2'


### PR DESCRIPTION
### What does this PR do?
For purposes of emitting `app-started` telemetry events, ensures `products.profiler.enabled` is a boolean. 'auto' is mapped as true, while 'true' and 'false' are self-explanatory.

### Motivation
Telemetry schema expects `products.profiler.enabled` in `app-started` to be a boolean. https://github.com/DataDog/dd-trace-js/pull/4592 broke that assumption. Also, https://github.com/DataDog/dd-trace-js/pull/4613 fixed a wrong thing, it ensured change record for `profiling.enabled` is a boolean in `app-client-configuration-change` events. This is the real fix.
