### PR TITLE
use npm pack instead of git clone for system test binaries

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: dd-trace-js
       - name: Pack dd-trace-js
-        run: mkdir -p && npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
+        run: mkdir -p ./binaries && npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: dd-trace-js
       - name: Pack dd-trace-js
-        run: mkdir -p ./binaries && npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
+        run: mkdir -p ./binaries && echo /binaries/$(npm pack --pack-destination ./binaries ./dd-trace-js) > ./binaries/nodejs-load-from-npm
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -18,13 +18,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: dd-trace-js
+      - name: Pack dd-trace-js
+        runs: npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: system_tests_binaries
-          path: |
-            .
-            !dd-trace-js/.git/**
+          path: ./binaries
 
   get-essential-scenarios:
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: dd-trace-js
       - name: Pack dd-trace-js
-        run: npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
+        run: mkdir -p && npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: system_tests_binaries
-          path: ./binaries
+          path: ./binaries/**/*
 
   get-essential-scenarios:
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: dd-trace-js
       - name: Pack dd-trace-js
-        runs: npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
+        run: npm pack --pack-destination ./binaries ./dd-trace-js > ./binaries/nodejs-load-from-npm
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use `npm pack` instead of `git clone` for system test binaries.

### Motivation
<!-- What inspired you to submit this pull request? -->

The repository contains a lot more files than what would generally be published to npm which can cause unexpected issues with system tests in CI.

