### PR TITLE
[test visibility][DO NOT MERGE] Do not report negative duration

### DIFF
--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -83,7 +83,7 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     this._encodeString(bytes, 'start')
     this._encodeNumber(bytes, content.start)
     this._encodeString(bytes, 'duration')
-    this._encodeNumber(bytes, content.duration)
+    this._encodeNumber(bytes, content.duration < 0 ? 0 : content.duration)
     this._encodeString(bytes, 'meta')
     this._encodeMap(bytes, content.meta)
     this._encodeString(bytes, 'metrics')
@@ -112,7 +112,7 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     this._encodeString(bytes, 'start')
     this._encodeNumber(bytes, content.start)
     this._encodeString(bytes, 'duration')
-    this._encodeNumber(bytes, content.duration)
+    this._encodeNumber(bytes, content.duration < 0 ? 0 : content.duration)
     this._encodeString(bytes, 'meta')
     this._encodeMap(bytes, content.meta)
     this._encodeString(bytes, 'metrics')
@@ -138,7 +138,7 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     this._encodeString(bytes, 'start')
     this._encodeNumber(bytes, content.start)
     this._encodeString(bytes, 'duration')
-    this._encodeNumber(bytes, content.duration)
+    this._encodeNumber(bytes, content.duration < 0 ? 0 : content.duration)
     this._encodeString(bytes, 'meta')
     this._encodeMap(bytes, content.meta)
     this._encodeString(bytes, 'metrics')
@@ -185,7 +185,7 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     this._encodeString(bytes, 'start')
     this._encodeNumber(bytes, content.start)
     this._encodeString(bytes, 'duration')
-    this._encodeNumber(bytes, content.duration)
+    this._encodeNumber(bytes, content.duration < 0 ? 0 : content.duration)
     /**
      * We include `test_session_id` and `test_suite_id`
      * in the root of the event by passing them via the `meta` dict.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Negative duration is rejected by the intake

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


