### PR TITLE
PROF-10330: Slim SSI metadata from 3 elements to 2

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -41,11 +41,7 @@ function expectProfileMessagePromise (agent, timeout,
       event = JSON.parse(files[0].buffer.toString())
       assert.propertyVal(event, 'family', 'node')
       assert.isString(event.info.profiler.activation)
-      const ssiEnabled = event.info.profiler.ssi.enabled
-      assert.isBoolean(ssiEnabled)
-      if (ssiEnabled) {
-        assert.isString(event.info.profiler.ssi.mechanism)
-      }
+      assert.isString(event.info.profiler.ssi.mechanism)
       assert.deepPropertyVal(event, 'attachments', fileNames)
       for (const [index, fileName] of fileNames.entries()) {
         assert.propertyVal(files[index + 1], 'originalname', fileName)

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -109,8 +109,7 @@ class AgentExporter {
         profiler: {
           activation: this._activation,
           ssi: {
-            enabled: this._libraryInjected,
-            mechanism: this._libraryInjected ? 'injected_agent' : undefined
+            mechanism: this._libraryInjected ? 'injected_agent' : 'none'
           },
           version
         },

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -118,7 +118,7 @@ describe('exporters/agent', function () {
     expect(Object.keys(event.info.profiler)).to.have.length(3)
     expect(event.info.profiler).to.have.property('activation', 'unknown')
     expect(event.info.profiler).to.have.property('ssi')
-    expect(event.info.profiler.ssi).to.have.property('enabled', false)
+    expect(event.info.profiler.ssi).to.have.property('mechanism', 'none')
     expect(event.info.profiler).to.have.property('version', version)
     expect(event.info).to.have.property('runtime')
     expect(Object.keys(event.info.runtime)).to.have.length(2)


### PR DESCRIPTION
### What does this PR do?
Eliminates `profiler.ssi.enabled` from profiler metadata system info.

### Motivation
It can be replaced with `profiler.ssi.mechanism: 'none'` thus reducing the need for one piece of metadata. This will also be mirrored in profiler backend metrics, reducing their cardinality.

