### PR TITLE
hapi: migrate from AsyncResource to TracingChannel, see #4597

### DIFF
--- a/packages/datadog-instrumentations/src/hapi.js
+++ b/packages/datadog-instrumentations/src/hapi.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const shimmer = require('../../datadog-shimmer')
-const { addHook, channel, AsyncResource } = require('./helpers/instrument')
+const { addHook, channel } = require('./helpers/instrument')
 
 const handleChannel = channel('apm:hapi:request:handle')
 const routeChannel = channel('apm:hapi:request:route')
@@ -96,13 +96,9 @@ function wrapHandler (handler) {
 
     if (!req) return handler.apply(this, arguments)
 
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-
-    return asyncResource.runInAsyncScope(() => {
-      enterChannel.publish({ req })
-
-      return handler.apply(this, arguments)
-    })
+    enterChannel.publish({ req })
+    
+    return handler.apply(this, arguments)
   }
 }
 

--- a/packages/datadog-instrumentations/src/hapi.js
+++ b/packages/datadog-instrumentations/src/hapi.js
@@ -1,7 +1,8 @@
 'use strict'
 
+const tracingChannel = require('dc-polyfill').tracingChannel
 const shimmer = require('../../datadog-shimmer')
-const { addHook, channel, tracingChannel } = require('./helpers/instrument')
+const { addHook, channel } = require('./helpers/instrument')
 
 const handleChannel = channel('apm:hapi:request:handle')
 const routeChannel = channel('apm:hapi:request:route')

--- a/packages/datadog-instrumentations/src/hapi.js
+++ b/packages/datadog-instrumentations/src/hapi.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const dc = require('dc-polyfill')
 const shimmer = require('../../datadog-shimmer')
-const { addHook, channel } = require('./helpers/instrument')
+const { addHook, channel, tracingChannel } = require('./helpers/instrument')
 
 const handleChannel = channel('apm:hapi:request:handle')
 const routeChannel = channel('apm:hapi:request:route')
 const errorChannel = channel('apm:hapi:request:error')
-const tracingChannel = dc.tracingChannel('apm:hapi:extension')
+const hapiTracingChannel = tracingChannel('apm:hapi:extension')
 
 function wrapServer (server) {
   return function (options) {
@@ -97,7 +96,7 @@ function wrapHandler (handler) {
 
     if (!req) return handler.apply(this, arguments)
 
-    return tracingChannel.traceSync(() => {
+    return hapiTracingChannel.traceSync(() => {
       return handler.apply(this, arguments)
     })
   }

--- a/packages/datadog-instrumentations/src/hapi.js
+++ b/packages/datadog-instrumentations/src/hapi.js
@@ -97,7 +97,7 @@ function wrapHandler (handler) {
     if (!req) return handler.apply(this, arguments)
 
     enterChannel.publish({ req })
-    
+
     return handler.apply(this, arguments)
   }
 }

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -14,15 +14,6 @@ exports.channel = function (name) {
   return ch
 }
 
-const tracingChannelMap = {}
-exports.tracingChannel = function (name) {
-  const maybe = tracingChannelMap[name]
-  if (maybe) return maybe
-  const ch = dc.tracingChannel(name)
-  tracingChannelMap[name] = ch
-  return ch
-}
-
 /**
  * @param {string} args.name module name
  * @param {string[]} args.versions array of semver range strings

--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -14,6 +14,15 @@ exports.channel = function (name) {
   return ch
 }
 
+const tracingChannelMap = {}
+exports.tracingChannel = function (name) {
+  const maybe = tracingChannelMap[name]
+  if (maybe) return maybe
+  const ch = dc.tracingChannel(name)
+  tracingChannelMap[name] = ch
+  return ch
+}
+
 /**
  * @param {string} args.name module name
  * @param {string[]} args.versions array of semver range strings

--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -32,8 +32,8 @@ class HapiPlugin extends RouterPlugin {
       }
     })
 
-    this.addSub('apm:hapi:extension:enter', ({ req }) => {
-      this.enter(this._requestSpans.get(req))
+    this.addBind('apm:hapi:extension:start', ({ req }) => {
+      return this._requestSpans.get(req)
     })
   }
 }


### PR DESCRIPTION
### What does this PR do?
- creating a "blessed" version of https://github.com/DataDog/dd-trace-js/pull/4597
- obsoletes https://github.com/DataDog/dd-trace-js/pull/4598
- rebases stuff and makes history linear

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


