### PR TITLE
test: fix the chrome selenium identifier

### DIFF
--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -84,7 +84,7 @@ versionRange.forEach(version => {
               const seleniumTest = events.find(event => event.type === 'test').content
               assert.include(seleniumTest.meta, {
                 [TEST_BROWSER_DRIVER]: 'selenium',
-                [TEST_BROWSER_NAME]: 'chrome-headless-shell',
+                [TEST_BROWSER_NAME]: 'chrome',
                 [TEST_TYPE]: 'browser',
                 [TEST_IS_RUM_ACTIVE]: 'true'
               })


### PR DESCRIPTION
### What does this PR do?
- fixes a test currently failing in master

### Motivation
- all green policy
- I suspect a dependent package updated the identifier
- https://pptr.dev/guides/headless-modes