### PR TITLE
Test: Allow FakeAgent to respond to remote config requests

### DIFF
--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const { promisify } = require('util')
+const { createHash } = require('crypto')
+const uuid = require('crypto-randomuuid')
 const express = require('express')
 const bodyParser = require('body-parser')
 const msgpack = require('msgpack-lite')
@@ -24,6 +26,7 @@ class FakeAgent extends EventEmitter {
   constructor (port = 0) {
     super()
     this.port = port
+    this._rc_files = []
   }
 
   async start () {
@@ -36,6 +39,78 @@ class FakeAgent extends EventEmitter {
       this.emit('message', {
         headers: req.headers,
         payload: msgpack.decode(req.body, { codec })
+      })
+    })
+    app.post('/v0.7/config', (req, res) => {
+      const {
+        client: { products },
+        cached_target_files: cachedTargetFiles
+      } = req.body
+
+      const expires = (new Date(Date.now() + 1000 * 60 * 60 * 24)).toISOString() // in 24 hours
+      const clientID = uuid() // TODO: What is this? It isn't the runtime-id
+
+      // Currently, only `opaque_backend_state` and `targets` are used by dd-trace-js in the object below
+      const targets = {
+        signatures: [],
+        signed: {
+          _type: 'targets',
+          custom: {
+            agent_refresh_interval: 5,
+            opaque_backend_state: ''
+          },
+          expires,
+          spec_version: '1.0.0',
+          targets: {},
+          version: 12345
+        }
+      }
+      const opaqueBackendState = {
+        version: 2,
+        state: { file_hashes: { key: [] } }
+      }
+      const targetFiles = []
+      const clientConfigs = []
+
+      const files = this._rc_files.filter(({ product }) => products.includes(product))
+
+      for (const { orgId, product, id, name, config } of files) {
+        const path = `datadog/${orgId}/${product}/${id}/${name}`
+        const fileDigest = createHash('sha256').update(config).digest()
+        const fileDigestHex = fileDigest.toString('hex')
+
+        if (cachedTargetFiles.some((cached) =>
+          path === cached.path &&
+          fileDigestHex === cached.hashes.find((e) => e.algorithm === 'sha256').hash
+        )) {
+          continue // skip files already cached by the client so we don't send them more than once
+        }
+
+        opaqueBackendState.state.file_hashes.key.push(fileDigest.toString('base64'))
+
+        targets.signed.targets[path] = {
+          custom: {
+            c: [clientID],
+            'tracer-predicates': { tracer_predicates_v1: [{ clientID }] },
+            v: 20
+          },
+          hashes: { sha256: fileDigestHex },
+          length: config.length
+        }
+
+        targetFiles.push({ path, raw: base64(config) })
+        clientConfigs.push(path)
+      }
+
+      targets.signed.custom.opaque_backend_state = base64(opaqueBackendState)
+
+      // TODO: What does the real agent do if there's nothing to return? Does it just return empty arrays and objects
+      // like we do here, or do we need to change the algorithm to align?
+      res.json({
+        roots: [], // Not used by dd-trace-js currently, so left empty
+        targets: base64(targets),
+        target_files: targetFiles,
+        client_configs: clientConfigs
       })
     })
     app.post('/profiling/v1/input', upload.any(), (req, res) => {
@@ -73,6 +148,31 @@ class FakeAgent extends EventEmitter {
       this.server.on('close', resolve)
       this.server.close()
     })
+  }
+
+  /**
+   * Remove any existing config added by calls to FakeAgent#addRemoteConfig.
+   */
+  resetRemoteConfig () {
+    this._rc_files = []
+  }
+
+  /**
+   * Add a config object to be returned by the fake Remote Config endpoint.
+   * @param {Object} config - Object containing the Remote Config "file" and metadata
+   * @param {number} [config.orgId=2] - The Datadog organization ID
+   * @param {string} config.product - The Remote Config product name
+   * @param {string} config.id - The Remote Config config ID
+   * @param {string} [config.name] - The Remote Config "name". Defaults to the sha256 hash of `config.id`
+   * @param {Object} config.config - The Remote Config "file" object
+   */
+  addRemoteConfig (config) {
+    config = { ...config }
+    config.orgId = config.orgId || 2
+    config.name = config.name || createHash('sha256').update(config.id).digest('hex')
+    config.config = JSON.stringify(config.config)
+
+    this._rc_files.push(config)
   }
 
   // **resolveAtFirstSuccess** - specific use case for Next.js (or any other future libraries)
@@ -484,6 +584,11 @@ function useSandbox (...args) {
 }
 function sandboxCwd () {
   return sandbox.folder
+}
+
+function base64 (strOrObj) {
+  const str = typeof strOrObj === 'string' ? strOrObj : JSON.stringify(strOrObj)
+  return Buffer.from(str).toString('base64')
 }
 
 module.exports = {

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -1,0 +1,266 @@
+'use strict'
+
+const { createHash } = require('crypto')
+const EventEmitter = require('events')
+const http = require('http')
+const uuid = require('crypto-randomuuid')
+const express = require('express')
+const bodyParser = require('body-parser')
+const msgpack = require('msgpack-lite')
+const codec = msgpack.createCodec({ int64: true })
+const upload = require('multer')()
+
+module.exports = class FakeAgent extends EventEmitter {
+  constructor (port = 0) {
+    super()
+    this.port = port
+    this._rc_files = []
+  }
+
+  async start () {
+    return new Promise((resolve, reject) => {
+      const timeoutObj = setTimeout(() => {
+        reject(new Error('agent timed out starting up'))
+      }, 10000)
+      this.server = http.createServer(buildExpressServer(this))
+      this.server.on('error', reject)
+      this.server.listen(this.port, () => {
+        this.port = this.server.address().port
+        clearTimeout(timeoutObj)
+        resolve(this)
+      })
+    })
+  }
+
+  stop () {
+    return new Promise((resolve) => {
+      this.server.on('close', resolve)
+      this.server.close()
+    })
+  }
+
+  /**
+   * Remove any existing config added by calls to FakeAgent#addRemoteConfig.
+   */
+  resetRemoteConfig () {
+    this._rc_files = []
+  }
+
+  /**
+   * Add a config object to be returned by the fake Remote Config endpoint.
+   * @param {Object} config - Object containing the Remote Config "file" and metadata
+   * @param {number} [config.orgId=2] - The Datadog organization ID
+   * @param {string} config.product - The Remote Config product name
+   * @param {string} config.id - The Remote Config config ID
+   * @param {string} [config.name] - The Remote Config "name". Defaults to the sha256 hash of `config.id`
+   * @param {Object} config.config - The Remote Config "file" object
+   */
+  addRemoteConfig (config) {
+    config = { ...config }
+    config.orgId = config.orgId || 2
+    config.name = config.name || createHash('sha256').update(config.id).digest('hex')
+    config.config = JSON.stringify(config.config)
+
+    this._rc_files.push(config)
+  }
+
+  // **resolveAtFirstSuccess** - specific use case for Next.js (or any other future libraries)
+  // where multiple payloads are generated, and only one is expected to have the proper span (ie next.request),
+  // but it't not guaranteed to be the last one (so, expectedMessageCount would not be helpful).
+  // It can still fail if it takes longer than `timeout` duration or if none pass the assertions (timeout still called)
+  assertMessageReceived (fn, timeout, expectedMessageCount = 1, resolveAtFirstSuccess) {
+    timeout = timeout || 30000
+    let resultResolve
+    let resultReject
+    let msgCount = 0
+    const errors = []
+
+    const timeoutObj = setTimeout(() => {
+      const errorsMsg = errors.length === 0 ? '' : `, additionally:\n${errors.map(e => e.stack).join('\n')}\n===\n`
+      resultReject(new Error(`timeout${errorsMsg}`, { cause: { errors } }))
+    }, timeout)
+
+    const resultPromise = new Promise((resolve, reject) => {
+      resultResolve = () => {
+        clearTimeout(timeoutObj)
+        resolve()
+      }
+      resultReject = (e) => {
+        clearTimeout(timeoutObj)
+        reject(e)
+      }
+    })
+
+    const messageHandler = msg => {
+      try {
+        msgCount += 1
+        fn(msg)
+        if (resolveAtFirstSuccess || msgCount === expectedMessageCount) {
+          resultResolve()
+          this.removeListener('message', messageHandler)
+        }
+      } catch (e) {
+        errors.push(e)
+      }
+    }
+    this.on('message', messageHandler)
+
+    return resultPromise
+  }
+
+  assertTelemetryReceived (fn, timeout, requestType, expectedMessageCount = 1) {
+    timeout = timeout || 30000
+    let resultResolve
+    let resultReject
+    let msgCount = 0
+    const errors = []
+
+    const timeoutObj = setTimeout(() => {
+      const errorsMsg = errors.length === 0 ? '' : `, additionally:\n${errors.map(e => e.stack).join('\n')}\n===\n`
+      resultReject(new Error(`timeout${errorsMsg}`, { cause: { errors } }))
+    }, timeout)
+
+    const resultPromise = new Promise((resolve, reject) => {
+      resultResolve = () => {
+        clearTimeout(timeoutObj)
+        resolve()
+      }
+      resultReject = (e) => {
+        clearTimeout(timeoutObj)
+        reject(e)
+      }
+    })
+
+    const messageHandler = msg => {
+      if (msg.payload.request_type !== requestType) return
+      msgCount += 1
+      try {
+        fn(msg)
+        if (msgCount === expectedMessageCount) {
+          resultResolve()
+        }
+      } catch (e) {
+        errors.push(e)
+      }
+      if (msgCount === expectedMessageCount) {
+        this.removeListener('telemetry', messageHandler)
+      }
+    }
+    this.on('telemetry', messageHandler)
+
+    return resultPromise
+  }
+}
+
+function buildExpressServer (agent) {
+  const app = express()
+
+  app.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
+  app.use(bodyParser.json({ limit: Infinity, type: 'application/json' }))
+
+  app.put('/v0.4/traces', (req, res) => {
+    if (req.body.length === 0) return res.status(200).send()
+    res.status(200).send({ rate_by_service: { 'service:,env:': 1 } })
+    agent.emit('message', {
+      headers: req.headers,
+      payload: msgpack.decode(req.body, { codec })
+    })
+  })
+
+  app.post('/v0.7/config', (req, res) => {
+    const {
+      client: { products },
+      cached_target_files: cachedTargetFiles
+    } = req.body
+
+    const expires = (new Date(Date.now() + 1000 * 60 * 60 * 24)).toISOString() // in 24 hours
+    const clientID = uuid() // TODO: What is this? It isn't the runtime-id
+
+    // Currently, only `opaque_backend_state` and `targets` are used by dd-trace-js in the object below
+    const targets = {
+      signatures: [],
+      signed: {
+        _type: 'targets',
+        custom: {
+          agent_refresh_interval: 5,
+          opaque_backend_state: ''
+        },
+        expires,
+        spec_version: '1.0.0',
+        targets: {},
+        version: 12345
+      }
+    }
+    const opaqueBackendState = {
+      version: 2,
+      state: { file_hashes: { key: [] } }
+    }
+    const targetFiles = []
+    const clientConfigs = []
+
+    const files = agent._rc_files.filter(({ product }) => products.includes(product))
+
+    for (const { orgId, product, id, name, config } of files) {
+      const path = `datadog/${orgId}/${product}/${id}/${name}`
+      const fileDigest = createHash('sha256').update(config).digest()
+      const fileDigestHex = fileDigest.toString('hex')
+
+      if (cachedTargetFiles.some((cached) =>
+        path === cached.path &&
+        fileDigestHex === cached.hashes.find((e) => e.algorithm === 'sha256').hash
+      )) {
+        continue // skip files already cached by the client so we don't send them more than once
+      }
+
+      opaqueBackendState.state.file_hashes.key.push(fileDigest.toString('base64'))
+
+      targets.signed.targets[path] = {
+        custom: {
+          c: [clientID],
+          'tracer-predicates': { tracer_predicates_v1: [{ clientID }] },
+          v: 20
+        },
+        hashes: { sha256: fileDigestHex },
+        length: config.length
+      }
+
+      targetFiles.push({ path, raw: base64(config) })
+      clientConfigs.push(path)
+    }
+
+    targets.signed.custom.opaque_backend_state = base64(opaqueBackendState)
+
+    // TODO: What does the real agent do if there's nothing to return? Does it just return empty arrays and objects
+    // like we do here, or do we need to change the algorithm to align?
+    res.json({
+      roots: [], // Not used by dd-trace-js currently, so left empty
+      targets: base64(targets),
+      target_files: targetFiles,
+      client_configs: clientConfigs
+    })
+  })
+
+  app.post('/profiling/v1/input', upload.any(), (req, res) => {
+    res.status(200).send()
+    agent.emit('message', {
+      headers: req.headers,
+      payload: req.body,
+      files: req.files
+    })
+  })
+
+  app.post('/telemetry/proxy/api/v2/apmtelemetry', (req, res) => {
+    res.status(200).send()
+    agent.emit('telemetry', {
+      headers: req.headers,
+      payload: req.body
+    })
+  })
+
+  return app
+}
+
+function base64 (strOrObj) {
+  const str = typeof strOrObj === 'string' ? strOrObj : JSON.stringify(strOrObj)
+  return Buffer.from(str).toString('base64')
+}

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -209,13 +209,15 @@ function buildExpressServer (agent) {
 
     // The real response object also contains a `roots` property which has been omitted here since it's not currently
     // used by the Node.js tracer.
-    // TODO: What does the real agent do if there's nothing to return? Does it just return empty arrays and objects
-    // like we do here, or do we need to change the algorithm to align?
-    res.json({
-      targets: base64(targets),
-      target_files: targetFiles,
-      client_configs: clientConfigs
-    })
+    res.json(
+      clientConfigs.length === 0
+        ? {}
+        : {
+            targets: targets.signed.targets.length === 0 ? '' : base64(targets),
+            target_files: targetFiles,
+            client_configs: clientConfigs
+          }
+    )
   })
 
   app.post('/profiling/v1/input', upload.any(), (req, res) => {

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -224,7 +224,7 @@ function buildExpressServer (agent) {
     }
 
     if (agent._rcTargetsVersion === state.targets_version) {
-      // If the state hasn't changed since the last time the client asked, hyst return an empty result
+      // If the state hasn't changed since the last time the client asked, just return an empty result
       res.json({})
       return
     }

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -168,9 +168,21 @@ function buildExpressServer (agent) {
 
   app.post('/v0.7/config', (req, res) => {
     const {
-      client: { products },
+      client: { products, state },
       cached_target_files: cachedTargetFiles
     } = req.body
+
+    if (state.has_error) {
+      // Print the error sent by the client in case it's useful in debugging tests
+      console.error(state.error) // eslint-disable-line no-console
+    }
+
+    for (const { apply_error: error } of state.config_states) {
+      if (error) {
+        // Print the error sent by the client in case it's useful in debugging tests
+        console.error(error) // eslint-disable-line no-console
+      }
+    }
 
     // The actual targets object is much more complicated,
     // but the Node.js tracer currently only cares about the following properties.

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -1,13 +1,6 @@
 'use strict'
 
 const { promisify } = require('util')
-const { createHash } = require('crypto')
-const uuid = require('crypto-randomuuid')
-const express = require('express')
-const bodyParser = require('body-parser')
-const msgpack = require('msgpack-lite')
-const codec = msgpack.createCodec({ int64: true })
-const EventEmitter = require('events')
 const childProcess = require('child_process')
 const { fork, spawn } = childProcess
 const exec = promisify(childProcess.exec)
@@ -15,253 +8,12 @@ const http = require('http')
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
-const rimraf = promisify(require('rimraf'))
-const id = require('../packages/dd-trace/src/id')
-const upload = require('multer')()
 const assert = require('assert')
+const rimraf = promisify(require('rimraf'))
+const FakeAgent = require('./fake-agent')
+const id = require('../../packages/dd-trace/src/id')
 
 const hookFile = 'dd-trace/loader-hook.mjs'
-
-class FakeAgent extends EventEmitter {
-  constructor (port = 0) {
-    super()
-    this.port = port
-    this._rc_files = []
-  }
-
-  async start () {
-    const app = express()
-    app.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
-    app.use(bodyParser.json({ limit: Infinity, type: 'application/json' }))
-    app.put('/v0.4/traces', (req, res) => {
-      if (req.body.length === 0) return res.status(200).send()
-      res.status(200).send({ rate_by_service: { 'service:,env:': 1 } })
-      this.emit('message', {
-        headers: req.headers,
-        payload: msgpack.decode(req.body, { codec })
-      })
-    })
-    app.post('/v0.7/config', (req, res) => {
-      const {
-        client: { products },
-        cached_target_files: cachedTargetFiles
-      } = req.body
-
-      const expires = (new Date(Date.now() + 1000 * 60 * 60 * 24)).toISOString() // in 24 hours
-      const clientID = uuid() // TODO: What is this? It isn't the runtime-id
-
-      // Currently, only `opaque_backend_state` and `targets` are used by dd-trace-js in the object below
-      const targets = {
-        signatures: [],
-        signed: {
-          _type: 'targets',
-          custom: {
-            agent_refresh_interval: 5,
-            opaque_backend_state: ''
-          },
-          expires,
-          spec_version: '1.0.0',
-          targets: {},
-          version: 12345
-        }
-      }
-      const opaqueBackendState = {
-        version: 2,
-        state: { file_hashes: { key: [] } }
-      }
-      const targetFiles = []
-      const clientConfigs = []
-
-      const files = this._rc_files.filter(({ product }) => products.includes(product))
-
-      for (const { orgId, product, id, name, config } of files) {
-        const path = `datadog/${orgId}/${product}/${id}/${name}`
-        const fileDigest = createHash('sha256').update(config).digest()
-        const fileDigestHex = fileDigest.toString('hex')
-
-        if (cachedTargetFiles.some((cached) =>
-          path === cached.path &&
-          fileDigestHex === cached.hashes.find((e) => e.algorithm === 'sha256').hash
-        )) {
-          continue // skip files already cached by the client so we don't send them more than once
-        }
-
-        opaqueBackendState.state.file_hashes.key.push(fileDigest.toString('base64'))
-
-        targets.signed.targets[path] = {
-          custom: {
-            c: [clientID],
-            'tracer-predicates': { tracer_predicates_v1: [{ clientID }] },
-            v: 20
-          },
-          hashes: { sha256: fileDigestHex },
-          length: config.length
-        }
-
-        targetFiles.push({ path, raw: base64(config) })
-        clientConfigs.push(path)
-      }
-
-      targets.signed.custom.opaque_backend_state = base64(opaqueBackendState)
-
-      // TODO: What does the real agent do if there's nothing to return? Does it just return empty arrays and objects
-      // like we do here, or do we need to change the algorithm to align?
-      res.json({
-        roots: [], // Not used by dd-trace-js currently, so left empty
-        targets: base64(targets),
-        target_files: targetFiles,
-        client_configs: clientConfigs
-      })
-    })
-    app.post('/profiling/v1/input', upload.any(), (req, res) => {
-      res.status(200).send()
-      this.emit('message', {
-        headers: req.headers,
-        payload: req.body,
-        files: req.files
-      })
-    })
-    app.post('/telemetry/proxy/api/v2/apmtelemetry', (req, res) => {
-      res.status(200).send()
-      this.emit('telemetry', {
-        headers: req.headers,
-        payload: req.body
-      })
-    })
-
-    return new Promise((resolve, reject) => {
-      const timeoutObj = setTimeout(() => {
-        reject(new Error('agent timed out starting up'))
-      }, 10000)
-      this.server = http.createServer(app)
-      this.server.on('error', reject)
-      this.server.listen(this.port, () => {
-        this.port = this.server.address().port
-        clearTimeout(timeoutObj)
-        resolve(this)
-      })
-    })
-  }
-
-  stop () {
-    return new Promise((resolve) => {
-      this.server.on('close', resolve)
-      this.server.close()
-    })
-  }
-
-  /**
-   * Remove any existing config added by calls to FakeAgent#addRemoteConfig.
-   */
-  resetRemoteConfig () {
-    this._rc_files = []
-  }
-
-  /**
-   * Add a config object to be returned by the fake Remote Config endpoint.
-   * @param {Object} config - Object containing the Remote Config "file" and metadata
-   * @param {number} [config.orgId=2] - The Datadog organization ID
-   * @param {string} config.product - The Remote Config product name
-   * @param {string} config.id - The Remote Config config ID
-   * @param {string} [config.name] - The Remote Config "name". Defaults to the sha256 hash of `config.id`
-   * @param {Object} config.config - The Remote Config "file" object
-   */
-  addRemoteConfig (config) {
-    config = { ...config }
-    config.orgId = config.orgId || 2
-    config.name = config.name || createHash('sha256').update(config.id).digest('hex')
-    config.config = JSON.stringify(config.config)
-
-    this._rc_files.push(config)
-  }
-
-  // **resolveAtFirstSuccess** - specific use case for Next.js (or any other future libraries)
-  // where multiple payloads are generated, and only one is expected to have the proper span (ie next.request),
-  // but it't not guaranteed to be the last one (so, expectedMessageCount would not be helpful).
-  // It can still fail if it takes longer than `timeout` duration or if none pass the assertions (timeout still called)
-  assertMessageReceived (fn, timeout, expectedMessageCount = 1, resolveAtFirstSuccess) {
-    timeout = timeout || 30000
-    let resultResolve
-    let resultReject
-    let msgCount = 0
-    const errors = []
-
-    const timeoutObj = setTimeout(() => {
-      const errorsMsg = errors.length === 0 ? '' : `, additionally:\n${errors.map(e => e.stack).join('\n')}\n===\n`
-      resultReject(new Error(`timeout${errorsMsg}`, { cause: { errors } }))
-    }, timeout)
-
-    const resultPromise = new Promise((resolve, reject) => {
-      resultResolve = () => {
-        clearTimeout(timeoutObj)
-        resolve()
-      }
-      resultReject = (e) => {
-        clearTimeout(timeoutObj)
-        reject(e)
-      }
-    })
-
-    const messageHandler = msg => {
-      try {
-        msgCount += 1
-        fn(msg)
-        if (resolveAtFirstSuccess || msgCount === expectedMessageCount) {
-          resultResolve()
-          this.removeListener('message', messageHandler)
-        }
-      } catch (e) {
-        errors.push(e)
-      }
-    }
-    this.on('message', messageHandler)
-
-    return resultPromise
-  }
-
-  assertTelemetryReceived (fn, timeout, requestType, expectedMessageCount = 1) {
-    timeout = timeout || 30000
-    let resultResolve
-    let resultReject
-    let msgCount = 0
-    const errors = []
-
-    const timeoutObj = setTimeout(() => {
-      const errorsMsg = errors.length === 0 ? '' : `, additionally:\n${errors.map(e => e.stack).join('\n')}\n===\n`
-      resultReject(new Error(`timeout${errorsMsg}`, { cause: { errors } }))
-    }, timeout)
-
-    const resultPromise = new Promise((resolve, reject) => {
-      resultResolve = () => {
-        clearTimeout(timeoutObj)
-        resolve()
-      }
-      resultReject = (e) => {
-        clearTimeout(timeoutObj)
-        reject(e)
-      }
-    })
-
-    const messageHandler = msg => {
-      if (msg.payload.request_type !== requestType) return
-      msgCount += 1
-      try {
-        fn(msg)
-        if (msgCount === expectedMessageCount) {
-          resultResolve()
-        }
-      } catch (e) {
-        errors.push(e)
-      }
-      if (msgCount === expectedMessageCount) {
-        this.removeListener('telemetry', messageHandler)
-      }
-    }
-    this.on('telemetry', messageHandler)
-
-    return resultPromise
-  }
-}
 
 async function runAndCheckOutput (filename, cwd, expectedOut) {
   const proc = spawn('node', [filename], { cwd, stdio: 'pipe' })
@@ -346,7 +98,7 @@ async function runAndCheckWithTelemetry (filename, expectedOut, ...expectedTelem
       language_version: process.versions.node,
       runtime_name: 'nodejs',
       runtime_version: process.versions.node,
-      tracer_version: require('../package.json').version,
+      tracer_version: require('../../package.json').version,
       pid: Number(pid)
     }
   }
@@ -447,7 +199,7 @@ async function createSandbox (dependencies = [], isGitRepo = false,
 
 function telemetryForwarder (expectedTelemetryPoints) {
   process.env.DD_TELEMETRY_FORWARDER_PATH =
-    path.join(__dirname, 'telemetry-forwarder.sh')
+    path.join(__dirname, '..', 'telemetry-forwarder.sh')
   process.env.FORWARDER_OUT = path.join(__dirname, `forwarder-${Date.now()}.out`)
 
   let retries = 0
@@ -584,11 +336,6 @@ function useSandbox (...args) {
 }
 function sandboxCwd () {
   return sandbox.folder
-}
-
-function base64 (strOrObj) {
-  const str = typeof strOrObj === 'string' ? strOrObj : JSON.stringify(strOrObj)
-  return Buffer.from(str).toString('base64')
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -120,7 +120,10 @@ class RemoteConfigManager extends EventEmitter {
     const options = {
       url: this.url,
       method: 'POST',
-      path: '/v0.7/config'
+      path: '/v0.7/config',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      }
     }
 
     request(this.getPayload(), options, (err, data, statusCode) => {

--- a/packages/dd-trace/test/appsec/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/manager.spec.js
@@ -178,8 +178,16 @@ describe('RemoteConfigManager', () => {
   })
 
   describe('poll', () => {
+    let expectedPayload
+
     beforeEach(() => {
       sinon.stub(rc, 'parseConfig')
+      expectedPayload = {
+        url: rc.url,
+        method: 'POST',
+        path: '/v0.7/config',
+        headers: { 'Content-Type': 'application/json; charset=utf-8' }
+      }
     })
 
     it('should request and do nothing when received status 404', (cb) => {
@@ -188,11 +196,7 @@ describe('RemoteConfigManager', () => {
       const payload = JSON.stringify(rc.state)
 
       rc.poll(() => {
-        expect(request).to.have.been.calledOnceWith(payload, {
-          url: rc.url,
-          method: 'POST',
-          path: '/v0.7/config'
-        })
+        expect(request).to.have.been.calledOnceWith(payload, expectedPayload)
         expect(log.error).to.not.have.been.called
         expect(rc.parseConfig).to.not.have.been.called
         cb()
@@ -206,11 +210,7 @@ describe('RemoteConfigManager', () => {
       const payload = JSON.stringify(rc.state)
 
       rc.poll(() => {
-        expect(request).to.have.been.calledOnceWith(payload, {
-          url: rc.url,
-          method: 'POST',
-          path: '/v0.7/config'
-        })
+        expect(request).to.have.been.calledOnceWith(payload, expectedPayload)
         expect(log.error).to.have.been.calledOnceWithExactly(err)
         expect(rc.parseConfig).to.not.have.been.called
         cb()
@@ -223,11 +223,7 @@ describe('RemoteConfigManager', () => {
       const payload = JSON.stringify(rc.state)
 
       rc.poll(() => {
-        expect(request).to.have.been.calledOnceWith(payload, {
-          url: rc.url,
-          method: 'POST',
-          path: '/v0.7/config'
-        })
+        expect(request).to.have.been.calledOnceWith(payload, expectedPayload)
         expect(log.error).to.not.have.been.called
         expect(rc.parseConfig).to.have.been.calledOnceWithExactly({ a: 'b' })
         cb()
@@ -243,11 +239,7 @@ describe('RemoteConfigManager', () => {
       const payload = JSON.stringify(rc.state)
 
       rc.poll(() => {
-        expect(request).to.have.been.calledOnceWith(payload, {
-          url: rc.url,
-          method: 'POST',
-          path: '/v0.7/config'
-        })
+        expect(request).to.have.been.calledOnceWith(payload, expectedPayload)
         expect(rc.parseConfig).to.have.been.calledOnceWithExactly({ a: 'b' })
         expect(log.error).to.have.been
           .calledOnceWithExactly('Could not parse remote config response: Error: Unable to parse config')
@@ -258,11 +250,7 @@ describe('RemoteConfigManager', () => {
 
         rc.poll(() => {
           expect(request).to.have.been.calledTwice
-          expect(request.secondCall).to.have.been.calledWith(payload2, {
-            url: rc.url,
-            method: 'POST',
-            path: '/v0.7/config'
-          })
+          expect(request.secondCall).to.have.been.calledWith(payload2, expectedPayload)
           expect(rc.parseConfig).to.have.been.calledOnce
           expect(log.error).to.have.been.calledOnce
           expect(rc.state.client.state.has_error).to.be.false
@@ -278,11 +266,7 @@ describe('RemoteConfigManager', () => {
       const payload = JSON.stringify(rc.state)
 
       rc.poll(() => {
-        expect(request).to.have.been.calledOnceWith(payload, {
-          url: rc.url,
-          method: 'POST',
-          path: '/v0.7/config'
-        })
+        expect(request).to.have.been.calledOnceWith(payload, expectedPayload)
         expect(log.error).to.not.have.been.called
         expect(rc.parseConfig).to.not.have.been.called
         cb()
@@ -299,11 +283,7 @@ describe('RemoteConfigManager', () => {
       expect(JSON.parse(payload).client.client_tracer.extra_services).to.deep.equal(extraServices)
 
       rc.poll(() => {
-        expect(request).to.have.been.calledOnceWith(payload, {
-          url: rc.url,
-          method: 'POST',
-          path: '/v0.7/config'
-        })
+        expect(request).to.have.been.calledOnceWith(payload, expectedPayload)
         cb()
       })
     })


### PR DESCRIPTION
Allow integration tests to mock the remote config abilities of the agent.

This is done by first setting up a new remote config "file" using the new `FakeAgent#addRemoteConfig` method before running the main part of the integration test. This primes the fake agent to respond with this config for http requests to the `/v0.7/config` endpoint.

## Note to reviewers

This ability is needed by the integration tests in an upcoming Dynamic Instrumentation PR. I've separated it into its own PR to make the review easier.

I have not updated any of the existing tests to make uses of this ability. So this new ability of the `FakeAgent` class isn't actually used by any of our existing code in this PR. Let me know if there's an obvious place where we could make use of this so that I can update the PR to do so.

To make the review process easier, I've split this PR into two commits:

1. 73cf5d765948f368857a7a50448555bfb160b614: This commit contains the actual code changes and is a good starting point for easier diffing.
2. bc05f98d46c8634ae4c42cc16771533114cdd505: This commit contains only some refactoring to move code around to easier maintenance.

## Usage example

Here's an example of how we'd use the new `FakeAgent#addRemoteConfig` method to register a Remote Config file for use in Dynamic Instrumentation:

```js
agent.addRemoteConfig({
  product: 'LIVE_DEBUGGING',
  id: 'foobar',
  config: {
    id: 'foobar,
    version: 0,
    type: 'LOG_PROBE',
    language: 'javascript',
    where: { sourceFile: 'index.js', lines: ['15'] },
    tags: [],
    template: 'Hello World!',
    segments: [{ str: 'Hello World!' }],
    captureSnapshot: false,
    capture: { maxReferenceDepth: 3 },
    sampling: { snapshotsPerSecond: 5000 },
    evaluateAt: 'EXIT'
  }
})
```