### PR TITLE
kafkajs: support eachBatch consumer callback

### DIFF
--- a/packages/datadog-plugin-kafkajs/src/batch-consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/batch-consumer.js
@@ -1,0 +1,39 @@
+const ConsumerPlugin = require('dd-trace/packages/dd-trace/src/plugins/consumer')
+const { getMessageSize } = require('../../dd-trace/src/datastreams/processor')
+const { DsmPathwayCodec } = require('../../dd-trace/src/datastreams/pathway')
+
+class KafkajsBatchConsumerPlugin extends ConsumerPlugin {
+  static get operation () {
+    return 'consume-batch'
+  }
+
+  start ({ topic, partition, messages, groupId }) {
+    const span = this.startSpan({
+      resource: topic,
+      type: 'worker',
+      meta: {
+        component: 'kafkajs',
+        'kafka.topic': topic,
+        'kafka.message.offset': messages[0].offset,
+        'kafka.message.offset.last': messages[messages.length - 1].offset
+      },
+      metrics: {
+        'kafka.partition': partition,
+        'kafka.batch_size': messages.length
+      }
+    })
+
+    if (this.config.dsmEnabled) {
+      for (const message of messages) {
+        if (message?.headers && DsmPathwayCodec.contextExists(message.headers)) {
+          const payloadSize = getMessageSize(message)
+          this.tracer.decodeDataStreamsContext(message.headers)
+          this.tracer
+            .setCheckpoint(['direction:in', `group:${groupId}`, `topic:${topic}`, 'type:kafka'], span, payloadSize)
+        }
+      }
+    }
+  }
+}
+
+module.exports = KafkajsBatchConsumerPlugin

--- a/packages/datadog-plugin-kafkajs/src/consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/consumer.js
@@ -90,6 +90,26 @@ class KafkajsConsumerPlugin extends ConsumerPlugin {
     }
   }
 
+  startBatch ({ topic, partition, messages, groupId }) {
+    if (this.config.dsmEnabled) {
+      this.tracer.setCheckpoint(['direction:in', `group:${groupId}`, `topic:${topic}`, 'type:kafka'])
+    }
+    this.startSpan({
+      resource: topic,
+      type: 'worker',
+      meta: {
+        component: 'kafkajs',
+        'kafka.topic': topic,
+        'kafka.message.offset': messages[0].offset,
+        'kafka.message.offset.last': messages[messages.length - 1].offset
+      },
+      metrics: {
+        'kafka.partition': partition,
+        'kafka.batch_size': messages.length
+      }
+    })
+  }
+
   finish () {
     if (beforeFinishCh.hasSubscribers) {
       beforeFinishCh.publish()

--- a/packages/datadog-plugin-kafkajs/src/index.js
+++ b/packages/datadog-plugin-kafkajs/src/index.js
@@ -2,6 +2,7 @@
 
 const ProducerPlugin = require('./producer')
 const ConsumerPlugin = require('./consumer')
+const BatchConsumerPlugin = require('./batch-consumer')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class KafkajsPlugin extends CompositePlugin {
@@ -9,7 +10,8 @@ class KafkajsPlugin extends CompositePlugin {
   static get plugins () {
     return {
       producer: ProducerPlugin,
-      consumer: ConsumerPlugin
+      consumer: ConsumerPlugin,
+      batchConsumer: BatchConsumerPlugin
     }
   }
 }

--- a/packages/datadog-plugin-kafkajs/src/utils.js
+++ b/packages/datadog-plugin-kafkajs/src/utils.js
@@ -1,0 +1,17 @@
+function extract (tracer, bufferMap) {
+  if (!bufferMap) return null
+
+  const textMap = {}
+
+  for (const key of Object.keys(bufferMap)) {
+    if (bufferMap[key] === null || bufferMap[key] === undefined) continue
+
+    textMap[key] = bufferMap[key].toString()
+  }
+
+  return tracer.extract('text_map', textMap)
+}
+
+module.exports = {
+  extract
+}

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -406,7 +406,7 @@ describe('Plugin', () => {
                 service: 'test-kafka',
                 resource: testTopic
               })
-              expect(span.metrics).to.include({
+              expect(span.metrics).to.be.gt({
                 'kafka.batch_size': 1
               })
 
@@ -659,7 +659,7 @@ describe('Plugin', () => {
                 service: 'test-kafka',
                 resource: testTopic
               })
-              expect(span.metrics).to.include({
+              expect(span.metrics).to.be.gt({
                 'kafka.batch_size': 1
               })
 
@@ -714,7 +714,7 @@ describe('Plugin', () => {
                 service: 'test-kafka',
                 resource: testTopic
               })
-              expect(span.metrics).to.include({
+              expect(span.metrics).to.be.gt({
                 'kafka.batch_size': 1
               })
 

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -406,9 +406,7 @@ describe('Plugin', () => {
                 service: 'test-kafka',
                 resource: testTopic
               })
-              expect(span.metrics).to.be.gt({
-                'kafka.batch_size': 1
-              })
+              expect(span.metrics['kafka.batch_size']).to.be.at.least(1)
 
               expect(parseInt(span.parent_id.toString())).to.equal(0)
             })
@@ -620,7 +618,7 @@ describe('Plugin', () => {
         })
       })
 
-      describe('with api configuration', () => {
+      describe('with configuration', () => {
         const messages = [{ key: 'key1', value: 'test2' }]
 
         beforeEach(async () => {
@@ -659,64 +657,7 @@ describe('Plugin', () => {
                 service: 'test-kafka',
                 resource: testTopic
               })
-              expect(span.metrics).to.be.gt({
-                'kafka.batch_size': 1
-              })
-
-              expect(parseInt(span.parent_id.toString())).to.be.gt(0)
-            })
-
-            await consumer.run({ eachBatch: () => {} })
-            await sendMessages(kafka, testTopic, messages)
-            await expectedSpanPromise
-          })
-        })
-      })
-      describe('with env variable configuration', () => {
-        const messages = [{ key: 'key1', value: 'test2' }]
-
-        beforeEach(async () => {
-          process.env.DD_TRACE_KAFKAJS_BATCHED_PARENT_PROPAGATION_ENABLED = 'true'
-          tracer = require('../../dd-trace').init()
-          await agent.load('kafkajs')
-          const lib = require(`../../../versions/kafkajs@${version}`).get()
-          Kafka = lib.Kafka
-          kafka = new Kafka({
-            clientId: `kafkajs-test-${version}`,
-            brokers: ['127.0.0.1:9092'],
-            logLevel: lib.logLevel.WARN
-          })
-        })
-
-        afterEach(() => {
-          process.env.DD_TRACE_KAFKAJS_BATCHED_PARENT_PROPAGATION_ENABLED = 'false'
-        })
-
-        describe('consumer (eachBatch)', () => {
-          let consumer
-
-          beforeEach(async () => {
-            consumer = kafka.consumer({ groupId: 'test-group' })
-            await consumer.subscribe({ topic: testTopic })
-            await consumer.connect()
-          })
-
-          afterEach(async () => {
-            await consumer.disconnect()
-          })
-
-          it('should propagate context when configured', async () => {
-            const expectedSpanPromise = agent.use(traces => {
-              const span = traces[0][0]
-
-              expect(span).to.include({
-                name: 'kafka.consume',
-                service: 'test-kafka',
-                resource: testTopic
-              })
-              expect(span.metrics).to.be.gt({
-                'kafka.batch_size': 1
-              })
+              expect(span.metrics['kafka.batch_size']).to.be.at.least(1)
 
               expect(parseInt(span.parent_id.toString())).to.be.gt(0)
             })


### PR DESCRIPTION
### What does this PR do?

Adds support for KafkaJS batch consumes using `eachBatch` callback.
Also adds an experimental `batchedParentPropagationEnabled` config for kafkajs that is disabled by defaut and enables parent-child propagation using the first valid trace context found within returned messages, including a matching env variable configuration of `DD_TRACE_KAFKAJS_BATCHED_PARENT_PROPAGATION_ENABLED`.

### Motivation
Client FR

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


