### PR TITLE
Fix Node.js version to v22.7 instead of "latest"

### DIFF
--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -4,4 +4,4 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 'latest'
+        node-version: '22.6'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -208,7 +208,7 @@ jobs:
       matrix:
         version:
           - 18
-          - latest
+          - 22.6
         range: ['9.5.0', '11.1.4', '13.2.0', '*']
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -139,7 +139,7 @@ jobs:
   aws-sdk:
     strategy:
       matrix:
-        node-version: ['18', 'latest']
+        node-version: ['18', '22.6']
     runs-on: ubuntu-latest
     services:
       localstack:
@@ -412,7 +412,7 @@ jobs:
   http:
     strategy:
       matrix:
-        node-version: ['18', '20', 'latest']
+        node-version: ['18', '20', '22.6']
     runs-on: ubuntu-latest
     env:
       PLUGINS: http
@@ -648,7 +648,7 @@ jobs:
       matrix:
         version:
           - 18
-          - latest
+          - 22.6
         range: ['9.5.0', '11.1.4', '13.2.0', '*']
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,7 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [18, 20, latest]
+        version: [18, 20, 22.6]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [18, latest]
+        version: [18, 22.6]
         framework: [cucumber, playwright, selenium, jest, mocha]
     runs-on: ubuntu-latest
     env:
@@ -89,7 +89,7 @@ jobs:
         # Important: This is outside the minimum supported version of dd-trace-js
         # Node > 16 does not work with Cypress@6.7.0 (not even without our plugin)
         # TODO: figure out what to do with this: we might have to deprecate support for cypress@6.7.0
-        version: [16, latest]
+        version: [16, 22.6]
         # 6.7.0 is the minimum version we support
         cypress-version: [6.7.0, latest]
         module-type: ['commonJS', 'esm']


### PR DESCRIPTION
This is a temporary fix until Node.js v22.8.0 is released due to a bug in Node.js v22.7.0.

For more details see Node.js bug-report: https://github.com/nodejs/node/issues/54518

