### PR TITLE
Bump `@datadog/native-appsec` to `8.1.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@datadog/native-appsec": "8.1.0",
+    "@datadog/native-appsec": "8.1.1",
     "@datadog/native-iast-rewriter": "2.4.1",
     "@datadog/native-iast-taint-tracking": "3.1.0",
     "@datadog/native-metrics": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@datadog/native-appsec": "8.0.1",
+    "@datadog/native-appsec": "8.1.0",
     "@datadog/native-iast-rewriter": "2.4.1",
     "@datadog/native-iast-taint-tracking": "3.1.0",
     "@datadog/native-metrics": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,10 +256,10 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k= sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
 
-"@datadog/native-appsec@8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-8.0.1.tgz#be06be92d79d7462aa64ee3a33108133083134fc"
-  integrity sha512-SpWkoo7K4+pwxFze1ogRF1qBaKm8sZjWfZKnQ8Ex67f6L5odLjWOoiiIAs5rp01sLKGXjxU8IJf+X9j4PvI2zQ==
+"@datadog/native-appsec@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-8.1.0.tgz#df2382cb694452ce69a90c2d4685a846a5a8b29e"
+  integrity sha512-BlFvmO20kalWeKWQtznTbbdEj37Ms6NKphqxxYMJiXK6oLkf73Jpk6zzXdtFoACgybqsXOb/ngkfFYlZIQO4hQ==
   dependencies:
     node-gyp-build "^3.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,10 +256,10 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k= sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
 
-"@datadog/native-appsec@8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-8.1.0.tgz#df2382cb694452ce69a90c2d4685a846a5a8b29e"
-  integrity sha512-BlFvmO20kalWeKWQtznTbbdEj37Ms6NKphqxxYMJiXK6oLkf73Jpk6zzXdtFoACgybqsXOb/ngkfFYlZIQO4hQ==
+"@datadog/native-appsec@8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-8.1.1.tgz#76aa34697e6ecbd3d9ef7e6938d3cdcfa689b1f3"
+  integrity sha512-mf+Ym/AzET4FeUTXOs8hz0uLOSsVIUnavZPUx8YoKWK5lKgR2L+CLfEzOpjBwgFpDgbV8I1/vyoGelgGpsMKHA==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
Bump the WAF bindings version to update `libddwaf` to version `1.19.1`

### Motivation
Be up to date with the latest version of `libddwaf`


[APPSEC-54667](https://datadoghq.atlassian.net/browse/APPSEC-54667)


[APPSEC-54667]: https://datadoghq.atlassian.net/browse/APPSEC-54667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ