### PR TITLE
speed up shimmer by about 50x

### DIFF
--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -6,8 +6,6 @@ const log = require('../../dd-trace/src/log')
 const unwrappers = new WeakMap()
 
 function copyProperties (original, wrapped) {
-  Object.setPrototypeOf(wrapped, original)
-
   const props = Object.getOwnPropertyDescriptors(original)
   const keys = Reflect.ownKeys(props)
 


### PR DESCRIPTION
The `copyProperties` function was doing an `Object.setPrototypeOf`, which is rather costly. We don't actually need this because all it was doing was acting as a stopgap in case we don't get all the properties from the original function. We're using `Reflect.ownKeys()` to get those properties, so this can't happen, therefore there's no need to set the prototype.

On a benchmark I whipped up separately for another project, I had noticed that shimmer + our instrumentations adds a significant amount of overhead. On a run with 100 iterations, I found that overhead to be about 10000%. When I ran the same benchmark after this change, I saw that overhead to be about 200%. To be fair, this benchmark is not a realistic application loading, and is explicitly clearing the cache and re-loading everything repeatedly, so I'm not sure how impactful this change will be. That said, we'll see what the benchmarks say.


