### PR TITLE
wrap all callbacks in instrumentations with wrapFunction

### DIFF
--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -75,7 +75,7 @@ function wrapSmithySend (send) {
       })
 
       if (typeof cb === 'function') {
-        args[args.length - 1] = function (err, result) {
+        args[args.length - 1] = shimmer.wrapFunction(cb, cb => function (err, result) {
           const message = getMessage(request, err, result)
 
           completeChannel.publish(message)
@@ -89,7 +89,7 @@ function wrapSmithySend (send) {
               responseFinishChannel.publish(message.response.error)
             }
           })
-        }
+        })
       } else { // always a promise
         return send.call(this, command, ...args)
           .then(
@@ -113,7 +113,7 @@ function wrapSmithySend (send) {
 
 function wrapCb (cb, serviceName, request, ar) {
   // eslint-disable-next-line n/handle-callback-err
-  return function wrappedCb (err, response) {
+  return shimmer.wrapFunction(cb, cb => function wrappedCb (err, response) {
     const obj = { request, response }
     return ar.runInAsyncScope(() => {
       channel(`apm:aws:response:start:${serviceName}`).publish(obj)
@@ -141,7 +141,7 @@ function wrapCb (cb, serviceName, request, ar) {
         throw e
       }
     })
-  }
+  })
 }
 
 function getMessage (request, error, result) {

--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -6,7 +6,7 @@ const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 const bodyParserReadCh = channel('datadog:body-parser:read:finish')
 
 function publishRequestBodyAndNext (req, res, next) {
-  return function () {
+  return shimmer.wrapFunction(next, next => function () {
     if (bodyParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const body = req.body
@@ -17,7 +17,7 @@ function publishRequestBodyAndNext (req, res, next) {
     }
 
     return next.apply(this, arguments)
-  }
+  })
 }
 
 addHook({

--- a/packages/datadog-instrumentations/src/cassandra-driver.js
+++ b/packages/datadog-instrumentations/src/cassandra-driver.js
@@ -180,12 +180,12 @@ function finish (finishCh, errorCh, error) {
 }
 
 function wrapCallback (finishCh, errorCh, asyncResource, callback) {
-  return asyncResource.bind(function (err) {
+  return shimmer.wrapFunction(callback, callback => asyncResource.bind(function (err) {
     finish(finishCh, errorCh, err)
     if (callback) {
       return callback.apply(this, arguments)
     }
-  })
+  }))
 }
 
 function isRequestValid (exec, args, length) {

--- a/packages/datadog-instrumentations/src/connect.js
+++ b/packages/datadog-instrumentations/src/connect.js
@@ -90,7 +90,7 @@ function wrapLayerHandle (layer) {
 }
 
 function wrapNext (req, next) {
-  return function (error) {
+  return shimmer.wrapFunction(next, next => function (error) {
     if (error) {
       errorChannel.publish({ req, error })
     }
@@ -99,7 +99,7 @@ function wrapNext (req, next) {
     finishChannel.publish({ req })
 
     next.apply(this, arguments)
-  }
+  })
 }
 
 addHook({ name: 'connect', versions: ['>=3'] }, connect => {

--- a/packages/datadog-instrumentations/src/cookie-parser.js
+++ b/packages/datadog-instrumentations/src/cookie-parser.js
@@ -6,7 +6,7 @@ const { channel, addHook } = require('./helpers/instrument')
 const cookieParserReadCh = channel('datadog:cookie-parser:read:finish')
 
 function publishRequestCookieAndNext (req, res, next) {
-  return function cookieParserWrapper () {
+  return shimmer.wrapFunction(next, next => function cookieParserWrapper () {
     if (cookieParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
 
@@ -18,7 +18,7 @@ function publishRequestCookieAndNext (req, res, next) {
     }
 
     return next.apply(this, arguments)
-  }
+  })
 }
 
 addHook({

--- a/packages/datadog-instrumentations/src/couchbase.js
+++ b/packages/datadog-instrumentations/src/couchbase.js
@@ -76,13 +76,13 @@ function wrap (prefix, fn) {
 
       startCh.publish({ bucket: { name: this.name || this._name }, seedNodes: this._dd_hosts })
 
-      arguments[callbackIndex] = asyncResource.bind(function (error, result) {
+      arguments[callbackIndex] = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
         if (error) {
           errorCh.publish(error)
         }
         finishCh.publish(result)
         return cb.apply(this, arguments)
-      })
+      }))
 
       try {
         return fn.apply(this, arguments)
@@ -118,13 +118,13 @@ function wrapCBandPromise (fn, name, startData, thisArg, args) {
         // v3 offers callback or promises event handling
         // NOTE: this does not work with v3.2.0-3.2.1 cluster.query, as there is a bug in the couchbase source code
         const cb = callbackResource.bind(args[cbIndex])
-        args[cbIndex] = asyncResource.bind(function (error, result) {
+        args[cbIndex] = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
           if (error) {
             errorCh.publish(error)
           }
           finishCh.publish({ result })
           return cb.apply(thisArg, arguments)
-        })
+        }))
       }
       const res = fn.apply(thisArg, args)
 

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -188,7 +188,7 @@ function wrapRun (pl, isLatestVersion) {
       testStartCh.publish(testStartPayload)
     })
     try {
-      this.eventBroadcaster.on('envelope', (testCase) => {
+      this.eventBroadcaster.on('envelope', shimmer.wrapFunction(null, () => (testCase) => {
         // Only supported from >=8.0.0
         if (testCase?.testCaseFinished) {
           const { testCaseFinished: { willBeRetried } } = testCase
@@ -206,7 +206,7 @@ function wrapRun (pl, isLatestVersion) {
             })
           }
         }
-      })
+      }))
       let promise
 
       asyncResource.runInAsyncScope(() => {

--- a/packages/datadog-instrumentations/src/dns.js
+++ b/packages/datadog-instrumentations/src/dns.js
@@ -72,13 +72,13 @@ function wrap (prefix, fn, expectedArgs, rrtype) {
     return asyncResource.runInAsyncScope(() => {
       startCh.publish(startArgs)
 
-      arguments[arguments.length - 1] = asyncResource.bind(function (error, result) {
+      arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
         if (error) {
           errorCh.publish(error)
         }
         finishCh.publish(result)
         cb.apply(this, arguments)
-      })
+      }))
 
       try {
         return fn.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/elasticsearch.js
+++ b/packages/datadog-instrumentations/src/elasticsearch.js
@@ -48,12 +48,12 @@ function createWrapSelect () {
     return function () {
       if (arguments.length === 1) {
         const cb = arguments[0]
-        arguments[0] = function (err, connection) {
+        arguments[0] = shimmer.wrapFunction(cb, cb => function (err, connection) {
           if (connectCh.hasSubscribers && connection && connection.host) {
             connectCh.publish({ hostname: connection.host.host, port: connection.host.port })
           }
           cb(err, connection)
-        }
+        })
       }
       return request.apply(this, arguments)
     }
@@ -86,10 +86,10 @@ function createWrapRequest (name) {
           if (typeof cb === 'function') {
             cb = parentResource.bind(cb)
 
-            arguments[lastIndex] = asyncResource.bind(function (error) {
+            arguments[lastIndex] = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error) {
               finish(params, error)
               return cb.apply(null, arguments)
-            })
+            }))
             return request.apply(this, arguments)
           } else {
             const promise = request.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -49,7 +49,7 @@ addHook({ name: 'express', versions: ['>=4'] }, express => {
 const queryParserReadCh = channel('datadog:query:read:finish')
 
 function publishQueryParsedAndNext (req, res, next) {
-  return function () {
+  return shimmer.wrapFunction(next, next => function () {
     if (queryParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const query = req.query
@@ -60,7 +60,7 @@ function publishQueryParsedAndNext (req, res, next) {
     }
 
     return next.apply(this, arguments)
-  }
+  })
 }
 
 addHook({

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -34,7 +34,7 @@ function wrapFastify (fastify, hasParsingEvents) {
 }
 
 function wrapAddHook (addHook) {
-  return function addHookWithTrace (name, fn) {
+  return shimmer.wrapFunction(addHook, addHook => function addHookWithTrace (name, fn) {
     fn = arguments[arguments.length - 1]
 
     if (typeof fn !== 'function') return addHook.apply(this, arguments)
@@ -78,7 +78,7 @@ function wrapAddHook (addHook) {
     })
 
     return addHook.apply(this, arguments)
-  }
+  })
 }
 
 function onRequest (request, reply, done) {

--- a/packages/datadog-instrumentations/src/find-my-way.js
+++ b/packages/datadog-instrumentations/src/find-my-way.js
@@ -9,11 +9,11 @@ function wrapOn (on) {
   return function onWithTrace (method, path, opts) {
     const index = typeof opts === 'function' ? 2 : 3
     const handler = arguments[index]
-    const wrapper = function (req) {
+    const wrapper = shimmer.wrapFunction(handler, handler => function (req) {
       routeChannel.publish({ req, route: path })
 
       return handler.apply(this, arguments)
-    }
+    })
 
     if (typeof handler === 'function') {
       arguments[index] = wrapper

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -271,7 +271,7 @@ function createWrapFunction (prefix = '', override = '') {
       if (cb) {
         const outerResource = new AsyncResource('bound-anonymous-fn')
 
-        arguments[lastIndex] = innerResource.bind(function (e) {
+        arguments[lastIndex] = shimmer.wrapFunction(cb, cb => innerResource.bind(function (e) {
           if (e !== null && typeof e === 'object') { // fs.exists receives a boolean
             errorChannel.publish(e)
           }
@@ -279,7 +279,7 @@ function createWrapFunction (prefix = '', override = '') {
           finishChannel.publish()
 
           return outerResource.runInAsyncScope(() => cb.apply(this, arguments))
-        })
+        }))
       }
 
       return innerResource.runInAsyncScope(() => {

--- a/packages/datadog-instrumentations/src/google-cloud-pubsub.js
+++ b/packages/datadog-instrumentations/src/google-cloud-pubsub.js
@@ -76,7 +76,7 @@ function wrapMethod (method) {
       if (typeof cb === 'function') {
         const outerAsyncResource = new AsyncResource('bound-anonymous-fn')
 
-        arguments[arguments.length - 1] = innerAsyncResource.bind(function (error) {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => innerAsyncResource.bind(function (error) {
           if (error) {
             requestErrorCh.publish(error)
           }
@@ -84,7 +84,7 @@ function wrapMethod (method) {
           requestFinishCh.publish()
 
           return outerAsyncResource.runInAsyncScope(() => cb.apply(this, arguments))
-        })
+        }))
 
         return method.apply(this, arguments)
       } else {

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -88,10 +88,10 @@ function wrapMethod (method, path, type, hasPeer) {
     return method
   }
 
-  const wrapped = function () {
+  const wrapped = shimmer.wrapFunction(method, method => function () {
     const args = ensureMetadata(this, arguments, 1)
     return callMethod(this, method, args, path, args[1], type, hasPeer)
-  }
+  })
 
   Object.assign(wrapped, method)
 
@@ -101,7 +101,7 @@ function wrapMethod (method, path, type, hasPeer) {
 }
 
 function wrapCallback (ctx, callback = () => { }) {
-  return function (err) {
+  return shimmer.wrapFunction(callback, callback => function (err) {
     if (err) {
       ctx.error = err
       errorChannel.publish(ctx)
@@ -111,7 +111,7 @@ function wrapCallback (ctx, callback = () => { }) {
       return callback.apply(this, arguments)
       // No async end channel needed
     })
-  }
+  })
 }
 
 function createWrapEmit (ctx, hasPeer = false) {

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -93,8 +93,6 @@ function wrapMethod (method, path, type, hasPeer) {
     return callMethod(this, method, args, path, args[1], type, hasPeer)
   })
 
-  Object.assign(wrapped, method)
-
   patched.add(wrapped)
 
   return wrapped

--- a/packages/datadog-instrumentations/src/grpc/server.js
+++ b/packages/datadog-instrumentations/src/grpc/server.js
@@ -119,7 +119,7 @@ function wrapStream (call, ctx, onCancel) {
 }
 
 function wrapCallback (callback = () => {}, call, ctx, onCancel) {
-  return function (err, value, trailer, flags) {
+  return shimmer.wrapFunction(callback, callback => function (err, value, trailer, flags) {
     if (err) {
       ctx.error = err
       errorChannel.publish(ctx)
@@ -136,7 +136,7 @@ function wrapCallback (callback = () => {}, call, ctx, onCancel) {
       return callback.apply(this, arguments)
       // No async end channel needed
     })
-  }
+  })
 }
 
 function wrapSendStatus (sendStatus, ctx) {

--- a/packages/datadog-instrumentations/src/hapi.js
+++ b/packages/datadog-instrumentations/src/hapi.js
@@ -27,17 +27,17 @@ function wrapServer (server) {
 }
 
 function wrapStart (start) {
-  return function () {
+  return shimmer.wrapFunction(start, start => function () {
     if (this && typeof this.ext === 'function') {
       this.ext('onPreResponse', onPreResponse)
     }
 
     return start.apply(this, arguments)
-  }
+  })
 }
 
 function wrapExt (ext) {
-  return function (events, method, options) {
+  return shimmer.wrapFunction(ext, ext => function (events, method, options) {
     if (events !== null && typeof events === 'object') {
       arguments[0] = wrapEvents(events)
     } else {
@@ -45,7 +45,7 @@ function wrapExt (ext) {
     }
 
     return ext.apply(this, arguments)
-  }
+  })
 }
 
 function wrapDispatch (dispatch) {
@@ -91,7 +91,7 @@ function wrapEvents (events) {
 function wrapHandler (handler) {
   if (typeof handler !== 'function') return handler
 
-  return function (request, h) {
+  return shimmer.wrapFunction(handler, handler => function (request, h) {
     const req = request && request.raw && request.raw.req
 
     if (!req) return handler.apply(this, arguments)
@@ -103,7 +103,7 @@ function wrapHandler (handler) {
 
       return handler.apply(this, arguments)
     })
-  }
+  })
 }
 
 function onPreResponse (request, h) {

--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -52,11 +52,11 @@ function patch (http, methodName) {
         let callback = args.callback
 
         if (callback) {
-          callback = function () {
+          callback = shimmer.wrapFunction(args.callback, cb => function () {
             return asyncStartChannel.runStores(ctx, () => {
-              return args.callback.apply(this, arguments)
+              return cb.apply(this, arguments)
             })
-          }
+          })
         }
 
         const options = args.options

--- a/packages/datadog-instrumentations/src/knex.js
+++ b/packages/datadog-instrumentations/src/knex.js
@@ -81,8 +81,8 @@ addHook({
 function wrapCallbackWithFinish (callback, finish) {
   if (typeof callback !== 'function') return callback
 
-  return function () {
+  return shimmer.wrapFunction(callback, callback => function () {
     finish()
     callback.apply(this, arguments)
-  }
+  })
 }

--- a/packages/datadog-instrumentations/src/koa.js
+++ b/packages/datadog-instrumentations/src/koa.js
@@ -84,7 +84,7 @@ function wrapMiddleware (fn, layer) {
 
   const name = fn.name
 
-  return function (ctx, next) {
+  return shimmer.wrapFunction(fn, fn => function (ctx, next) {
     if (!ctx || !enterChannel.hasSubscribers) return fn.apply(this, arguments)
 
     const req = ctx.req
@@ -122,7 +122,7 @@ function wrapMiddleware (fn, layer) {
     } finally {
       exitChannel.publish({ req })
     }
-  }
+  })
 }
 
 function fulfill (ctx, error) {
@@ -142,11 +142,11 @@ function fulfill (ctx, error) {
 }
 
 function wrapNext (req, next) {
-  return function () {
+  return shimmer.wrapFunction(next, next => function () {
     nextChannel.publish({ req })
 
     return next.apply(this, arguments)
-  }
+  })
 }
 
 addHook({ name: 'koa', versions: ['>=2'] }, Koa => {

--- a/packages/datadog-instrumentations/src/memcached.js
+++ b/packages/datadog-instrumentations/src/memcached.js
@@ -26,14 +26,14 @@ addHook({ name: 'memcached', versions: ['>=2.2'] }, Memcached => {
       const query = queryCompiler.apply(this, arguments)
       const callback = callbackResource.bind(query.callback)
 
-      query.callback = asyncResource.bind(function (err) {
+      query.callback = shimmer.wrapFunction(callback, callback => asyncResource.bind(function (err) {
         if (err) {
           errorCh.publish(err)
         }
         finishCh.publish()
 
         return callback.apply(this, arguments)
-      })
+      }))
       startCh.publish({ client, server, query })
 
       return query

--- a/packages/datadog-instrumentations/src/microgateway-core.js
+++ b/packages/datadog-instrumentations/src/microgateway-core.js
@@ -40,7 +40,7 @@ function wrapPluginsFactory (pluginsFactory) {
 }
 
 function wrapNext (req, res, next) {
-  return function nextWithTrace (err) {
+  return shimmer.wrapFunction(next, next => function nextWithTrace (err) {
     const requestResource = requestResources.get(req)
 
     requestResource.runInAsyncScope(() => {
@@ -54,7 +54,7 @@ function wrapNext (req, res, next) {
     })
 
     return next.apply(this, arguments)
-  }
+  })
 }
 
 addHook({ name, versions, file: 'lib/config-proxy-middleware.js' }, configProxyFactory => {

--- a/packages/datadog-instrumentations/src/mocha.js
+++ b/packages/datadog-instrumentations/src/mocha.js
@@ -3,3 +3,7 @@ if (process.env.MOCHA_WORKER_ID) {
 } else {
   require('./mocha/main')
 }
+
+// TODO add appropriate calls to wrapFunction whenever we're adding a callback
+// wrapper. Right now this is less of an issue since that only has effect in
+// SSI, where CI Vis isn't supported.

--- a/packages/datadog-instrumentations/src/moleculer/server.js
+++ b/packages/datadog-instrumentations/src/moleculer/server.js
@@ -24,7 +24,7 @@ function createMiddleware () {
     localAction (next, action) {
       const broker = this
 
-      return function datadogMiddleware (ctx) {
+      return shimmer.wrapFunction(next, next => function datadogMiddleware (ctx) {
         const actionResource = new AsyncResource('bound-anonymous-fn')
 
         return actionResource.runInAsyncScope(() => {
@@ -47,7 +47,7 @@ function createMiddleware () {
             finishChannel.publish()
           }
         })
-      }
+      })
     }
   }
 }

--- a/packages/datadog-instrumentations/src/mongodb-core.js
+++ b/packages/datadog-instrumentations/src/mongodb-core.js
@@ -164,7 +164,7 @@ function instrument (operation, command, ctx, args, server, ns, ops, options = {
   return asyncResource.runInAsyncScope(() => {
     startCh.publish({ ns, ops, options: serverInfo, name })
 
-    args[index] = asyncResource.bind(function (err, res) {
+    args[index] = shimmer.wrapFunction(callback, callback => asyncResource.bind(function (err, res) {
       if (err) {
         errorCh.publish(err)
       }
@@ -174,7 +174,7 @@ function instrument (operation, command, ctx, args, server, ns, ops, options = {
       if (callback) {
         return callback.apply(this, arguments)
       }
-    })
+    }))
 
     try {
       return command.apply(ctx, args)

--- a/packages/datadog-instrumentations/src/mongoose.js
+++ b/packages/datadog-instrumentations/src/mongoose.js
@@ -128,22 +128,21 @@ addHook({
                     const resolve = arguments[0]
                     const reject = arguments[1]
 
-                    // not using shimmer here because resolve/reject could be empty
-                    arguments[0] = function wrappedResolve () {
+                    arguments[0] = shimmer.wrapFunction(resolve, resolve => function wrappedResolve () {
                       finish()
 
                       if (resolve) {
                         return resolve.apply(this, arguments)
                       }
-                    }
+                    })
 
-                    arguments[1] = function wrappedReject () {
+                    arguments[1] = shimmer.wrapFunction(reject, reject => function wrappedReject () {
                       finish()
 
                       if (reject) {
                         return reject.apply(this, arguments)
                       }
-                    }
+                    })
 
                     return originalThen.apply(this, arguments)
                   }

--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -37,14 +37,14 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
 
         if (res._callback) {
           const cb = callbackResource.bind(res._callback)
-          res._callback = asyncResource.bind(function (error, result) {
+          res._callback = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
             if (error) {
               errorCh.publish(error)
             }
             finishCh.publish(result)
 
             return cb.apply(this, arguments)
-          })
+          }))
         } else {
           const cb = asyncResource.bind(function () {
             finishCh.publish(undefined)

--- a/packages/datadog-instrumentations/src/net.js
+++ b/packages/datadog-instrumentations/src/net.js
@@ -58,7 +58,7 @@ addHook({ name: names }, (net, version, name) => {
       }
 
       const emit = this.emit
-      this.emit = function (eventName) {
+      this.emit = shimmer.wrapFunction(emit, emit => function (eventName) {
         switch (eventName) {
           case 'ready':
           case 'connect':
@@ -68,7 +68,7 @@ addHook({ name: names }, (net, version, name) => {
           default:
             return emit.apply(this, arguments)
         }
-      }
+      })
 
       try {
         return connect.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -31,10 +31,10 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
       if (arguments.length && typeof arguments[arguments.length - 1] === 'function') {
         const cb = arguments[arguments.length - 1]
         const outerAr = new AsyncResource('apm:oracledb:outer-scope')
-        arguments[arguments.length - 1] = function wrappedCb (err, result) {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => function wrappedCb (err, result) {
           finish(err)
           return outerAr.runInAsyncScope(() => cb.apply(this, arguments))
-        }
+        })
       }
 
       return new AsyncResource('apm:oracledb:inner-scope').runInAsyncScope(() => {
@@ -67,12 +67,12 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
   shimmer.wrap(oracledb, 'getConnection', getConnection => {
     return function wrappedGetConnection (connAttrs, callback) {
       if (callback) {
-        arguments[1] = (err, connection) => {
+        arguments[1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
           if (connection) {
             connectionAttributes.set(connection, connAttrs)
           }
           callback(err, connection)
-        }
+        })
 
         getConnection.apply(this, arguments)
       } else {
@@ -86,12 +86,12 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
   shimmer.wrap(oracledb, 'createPool', createPool => {
     return function wrappedCreatePool (poolAttrs, callback) {
       if (callback) {
-        arguments[1] = (err, pool) => {
+        arguments[1] = shimmer.wrapFunction(callback, callback => (err, pool) => {
           if (pool) {
             poolAttributes.set(pool, poolAttrs)
           }
           callback(err, pool)
-        }
+        })
 
         createPool.apply(this, arguments)
       } else {
@@ -109,12 +109,12 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
         callback = arguments[arguments.length - 1]
       }
       if (callback) {
-        arguments[arguments.length - 1] = (err, connection) => {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
           if (connection) {
             connectionAttributes.set(connection, poolAttributes.get(this))
           }
           callback(err, connection)
-        }
+        })
         getConnection.apply(this, arguments)
       } else {
         return getConnection.apply(this, arguments).then((connection) => {

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -156,12 +156,12 @@ function start (client, command, args, url = {}) {
 }
 
 function wrapCallback (finishCh, errorCh, callback) {
-  return function (err) {
+  return shimmer.wrapFunction(callback, callback => function (err) {
     finish(finishCh, errorCh, err)
     if (callback) {
       return callback.apply(this, arguments)
     }
-  }
+  })
 }
 
 function finish (finishCh, errorCh, error) {

--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -40,7 +40,7 @@ function wrapMiddleware (middleware) {
 function wrapFn (fn) {
   if (Array.isArray(fn)) return wrapMiddleware(fn)
 
-  return function (req, res, next) {
+  return shimmer.wrapFunction(fn, fn => function (req, res, next) {
     if (typeof next === 'function') {
       arguments[2] = wrapNext(req, next)
     }
@@ -72,16 +72,16 @@ function wrapFn (fn) {
     } finally {
       exitChannel.publish({ req })
     }
-  }
+  })
 }
 
 function wrapNext (req, next) {
-  return function () {
+  return shimmer.wrapFunction(next, next => function () {
     nextChannel.publish({ req })
     finishChannel.publish({ req })
 
     next.apply(this, arguments)
-  }
+  })
 }
 
 addHook({ name: 'restify', versions: ['>=3'], file: 'lib/server.js' }, Server => {

--- a/packages/datadog-instrumentations/src/rhea.js
+++ b/packages/datadog-instrumentations/src/rhea.js
@@ -153,11 +153,11 @@ function wrapDeliveryUpdate (obj, update) {
   const asyncResource = context.asyncResource
   if (obj && asyncResource) {
     const cb = asyncResource.bind(update)
-    return AsyncResource.bind(function wrappedUpdate (settled, stateData) {
+    return shimmer.wrapFunction(cb, cb => AsyncResource.bind(function wrappedUpdate (settled, stateData) {
       const state = getStateFromData(stateData)
       dispatchReceiveCh.publish({ state })
       return cb.apply(this, arguments)
-    })
+    }))
   }
   return function wrappedUpdate (settled, stateData) {
     return update.apply(this, arguments)
@@ -178,7 +178,7 @@ function patchCircularBuffer (proto, Session) {
         }
         if (CircularBuffer && !patched.has(CircularBuffer.prototype)) {
           shimmer.wrap(CircularBuffer.prototype, 'pop_if', popIf => function (fn) {
-            arguments[0] = AsyncResource.bind(function (entry) {
+            arguments[0] = shimmer.wrapFunction(fn, fn => AsyncResource.bind(function (entry) {
               const context = contexts.get(entry)
               const asyncResource = context && context.asyncResource
 
@@ -198,7 +198,7 @@ function patchCircularBuffer (proto, Session) {
               }
 
               return shouldPop
-            })
+            }))
             return popIf.apply(this, arguments)
           })
           patched.add(CircularBuffer.prototype)

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -89,7 +89,7 @@ function createWrapRouterMethod (name) {
   }
 
   function wrapNext (req, next) {
-    return function (error) {
+    return shimmer.wrapFunction(next, next => function (error) {
       if (error && error !== 'route' && error !== 'router') {
         errorChannel.publish({ req, error })
       }
@@ -98,7 +98,7 @@ function createWrapRouterMethod (name) {
       finishChannel.publish({ req })
 
       next.apply(this, arguments)
-    }
+    })
   }
 
   function extractMatchers (fn) {
@@ -151,7 +151,7 @@ function createWrapRouterMethod (name) {
   }
 
   function wrapMethod (original) {
-    return function methodWithTrace (fn) {
+    return shimmer.wrapFunction(original, original => function methodWithTrace (fn) {
       const offset = this.stack ? [].concat(this.stack).length : 0
       const router = original.apply(this, arguments)
 
@@ -162,7 +162,7 @@ function createWrapRouterMethod (name) {
       wrapStack(this.stack, offset, extractMatchers(fn))
 
       return router
-    }
+    })
   }
 
   return wrapMethod

--- a/packages/datadog-instrumentations/src/sharedb.js
+++ b/packages/datadog-instrumentations/src/sharedb.js
@@ -48,14 +48,14 @@ addHook({ name: 'sharedb', versions: ['>=1'], file: 'lib/agent.js' }, Agent => {
 
       callback = callbackResource.bind(callback)
 
-      arguments[1] = asyncResource.bind(function (error, res) {
+      arguments[1] = shimmer.wrapFunction(callback, callback => asyncResource.bind(function (error, res) {
         if (error) {
           errorCh.publish(error)
         }
         finishCh.publish({ request, res })
 
         return callback.apply(this, arguments)
-      })
+      }))
 
       try {
         return origHandleMessageFn.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/winston.js
+++ b/packages/datadog-instrumentations/src/winston.js
@@ -42,8 +42,7 @@ function wrapMethod (method, logCh) {
 
         if (patched.has(transport) || typeof transport.log !== 'function') continue
 
-        const log = transport.log
-        transport.log = shimmer.wrapFunction(log, log => function wrappedLog (level, msg, meta, callback) {
+        shimmer.wrap(transport, 'log', log => function wrappedLog (level, msg, meta, callback) {
           const payload = { message: meta || {} }
           logCh.publish(payload)
           arguments[2] = payload.message

--- a/packages/datadog-instrumentations/src/winston.js
+++ b/packages/datadog-instrumentations/src/winston.js
@@ -43,12 +43,12 @@ function wrapMethod (method, logCh) {
         if (patched.has(transport) || typeof transport.log !== 'function') continue
 
         const log = transport.log
-        transport.log = function wrappedLog (level, msg, meta, callback) {
+        transport.log = shimmer.wrapFunction(log, log => function wrappedLog (level, msg, meta, callback) {
           const payload = { message: meta || {} }
           logCh.publish(payload)
           arguments[2] = payload.message
           log.apply(this, arguments)
-        }
+        })
         patched.add(transport)
       }
     }

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -435,6 +435,12 @@ describe('shimmer', () => {
       expect(() => shimmer.wrap(() => {}, () => {})).to.throw()
     })
 
+    it('should work without a function', () => {
+      const a = { b: 1 }
+      const wrapped = shimmer.wrapFunction(a, x => () => x)
+      expect(wrapped()).to.equal(a)
+    })
+
     it('should wrap the function', () => {
       const count = inc => inc
 


### PR DESCRIPTION
These were the remaining areas with non-trivial code that might not be caught by try/catches when our code throws an exception. Adding `wrapFunction` adds that try/catch appropriately, but only when SSI is enabled. Otherwise these are all passthroughs. In the future, we may enable those try/catches at all times.

I considered the following to be out of scope:

* Many (but not all) completely trivial wrappers.
* Exceptions that might originate in `async_hooks`.

I may have missed some. It's an extremely difficult task to verify that all opportunities for throwing an exception are covered.
