### PR TITLE
Rename rasp metrics

### DIFF
--- a/packages/dd-trace/src/appsec/telemetry.js
+++ b/packages/dd-trace/src/appsec/telemetry.js
@@ -90,14 +90,14 @@ function updateRaspRequestsMetricTags (metrics, req, raspRuleType) {
   if (!enabled) return
 
   const tags = { rule_type: raspRuleType, waf_version: metrics.wafVersion }
-  appsecMetrics.count('appsec.rasp.rule.eval', tags).inc(1)
+  appsecMetrics.count('rasp.rule.eval', tags).inc(1)
 
   if (metrics.wafTimeout) {
-    appsecMetrics.count('appsec.rasp.timeout', tags).inc(1)
+    appsecMetrics.count('rasp.timeout', tags).inc(1)
   }
 
   if (metrics.ruleTriggered) {
-    appsecMetrics.count('appsec.rasp.rule.match', tags).inc(1)
+    appsecMetrics.count('rasp.rule.match', tags).inc(1)
   }
 }
 

--- a/packages/dd-trace/test/appsec/telemetry.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry.spec.js
@@ -162,41 +162,41 @@ describe('Appsec Telemetry metrics', () => {
     })
 
     describe('updateRaspRequestsMetricTags', () => {
-      it('should increment appsec.rasp.rule.eval metric', () => {
+      it('should increment rasp.rule.eval metric', () => {
         appsecTelemetry.updateRaspRequestsMetricTags({
           duration: 42,
           durationExt: 52
         }, req, 'rule-type')
 
-        expect(count).to.have.been.calledWith('appsec.rasp.rule.eval')
-        expect(count).to.not.have.been.calledWith('appsec.rasp.timeout')
-        expect(count).to.not.have.been.calledWith('appsec.rasp.rule.match')
+        expect(count).to.have.been.calledWith('rasp.rule.eval')
+        expect(count).to.not.have.been.calledWith('rasp.timeout')
+        expect(count).to.not.have.been.calledWith('rasp.rule.match')
         expect(inc).to.have.been.calledOnceWith(1)
       })
 
-      it('should increment appsec.rasp.timeout metric if timeout', () => {
+      it('should increment rasp.timeout metric if timeout', () => {
         appsecTelemetry.updateRaspRequestsMetricTags({
           duration: 42,
           durationExt: 52,
           wafTimeout: true
         }, req, 'rule-type')
 
-        expect(count).to.have.been.calledWith('appsec.rasp.rule.eval')
-        expect(count).to.have.been.calledWith('appsec.rasp.timeout')
-        expect(count).to.not.have.been.calledWith('appsec.rasp.rule.match')
+        expect(count).to.have.been.calledWith('rasp.rule.eval')
+        expect(count).to.have.been.calledWith('rasp.timeout')
+        expect(count).to.not.have.been.calledWith('rasp.rule.match')
         expect(inc).to.have.been.calledTwice
       })
 
-      it('should increment appsec.rasp.rule.match metric if ruleTriggered', () => {
+      it('should increment rasp.rule.match metric if ruleTriggered', () => {
         appsecTelemetry.updateRaspRequestsMetricTags({
           duration: 42,
           durationExt: 52,
           ruleTriggered: true
         }, req, 'rule-type')
 
-        expect(count).to.have.been.calledWith('appsec.rasp.rule.match')
-        expect(count).to.have.been.calledWith('appsec.rasp.rule.eval')
-        expect(count).to.not.have.been.calledWith('appsec.rasp.timeout')
+        expect(count).to.have.been.calledWith('rasp.rule.match')
+        expect(count).to.have.been.calledWith('rasp.rule.eval')
+        expect(count).to.not.have.been.calledWith('rasp.timeout')
         expect(inc).to.have.been.calledTwice
       })
 


### PR DESCRIPTION
### What does this PR do?
Remove appsec prefix from rasp metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


