### PR TITLE
Allow Remote Config acknowledgements to be async

### DIFF
--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -28,8 +28,7 @@ function enable (config, appsec) {
       rc.updateCapabilities(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
     }
 
-    rc.on('ASM_FEATURES', (action, rcConfig, id, ack) => {
-      ack()
+    rc.setProductHandler('ASM_FEATURES', (action, rcConfig) => {
       if (!rcConfig) return
 
       if (activation === Activation.ONECLICK) {
@@ -77,9 +76,9 @@ function enableWafUpdate (appsecConfig) {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
 
-    rc.on('ASM_DATA', ackNoop)
-    rc.on('ASM_DD', ackNoop)
-    rc.on('ASM', ackNoop)
+    rc.setProductHandler('ASM_DATA', noop)
+    rc.setProductHandler('ASM_DD', noop)
+    rc.setProductHandler('ASM', noop)
 
     rc.on(RemoteConfigManager.kPreUpdate, RuleManager.updateWafFromRC)
   }
@@ -99,15 +98,14 @@ function disableWafUpdate () {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, false)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_TRUSTED_IPS, false)
 
-    rc.off('ASM_DATA', noop)
-    rc.off('ASM_DD', noop)
-    rc.off('ASM', noop)
+    rc.removeProductHandler('ASM_DATA')
+    rc.removeProductHandler('ASM_DD')
+    rc.removeProductHandler('ASM')
 
     rc.off(RemoteConfigManager.kPreUpdate, RuleManager.updateWafFromRC)
   }
 }
 
-function ackNoop (a, b, c, ack) { ack() }
 function noop () {}
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -76,6 +76,7 @@ function enableWafUpdate (appsecConfig) {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
 
+    // TODO: delete noop handlers and kPreUpdate and replace with batched handlers
     rc.setProductHandler('ASM_DATA', noop)
     rc.setProductHandler('ASM_DD', noop)
     rc.setProductHandler('ASM', noop)

--- a/packages/dd-trace/src/appsec/remote_config/index.js
+++ b/packages/dd-trace/src/appsec/remote_config/index.js
@@ -28,7 +28,8 @@ function enable (config, appsec) {
       rc.updateCapabilities(RemoteConfigCapabilities.ASM_API_SECURITY_SAMPLE_RATE, true)
     }
 
-    rc.on('ASM_FEATURES', (action, rcConfig) => {
+    rc.on('ASM_FEATURES', (action, rcConfig, id, ack) => {
+      ack()
       if (!rcConfig) return
 
       if (activation === Activation.ONECLICK) {
@@ -76,9 +77,9 @@ function enableWafUpdate (appsecConfig) {
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_CUSTOM_BLOCKING_RESPONSE, true)
     rc.updateCapabilities(RemoteConfigCapabilities.ASM_TRUSTED_IPS, true)
 
-    rc.on('ASM_DATA', noop)
-    rc.on('ASM_DD', noop)
-    rc.on('ASM', noop)
+    rc.on('ASM_DATA', ackNoop)
+    rc.on('ASM_DD', ackNoop)
+    rc.on('ASM', ackNoop)
 
     rc.on(RemoteConfigManager.kPreUpdate, RuleManager.updateWafFromRC)
   }
@@ -106,6 +107,7 @@ function disableWafUpdate () {
   }
 }
 
+function ackNoop (a, b, c, ack) { ack() }
 function noop () {}
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -222,6 +222,8 @@ class RemoteConfigManager extends EventEmitter {
       this.dispatch(toApply, 'apply')
       this.dispatch(toModify, 'modify')
 
+      // TODO: Possible race condition: If this property is overwritten before a product handler has time to update the
+      // `apply_state` of the previous call to `parseConfig`, the future state update will be ignored.
       this.state.client.state.config_states = []
       this.state.cached_target_files = []
 

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -244,7 +244,7 @@ class RemoteConfigManager extends EventEmitter {
       // TODO: we need a way to tell if unapply configs were handled by kPreUpdate or not, because they're always
       // emitted unlike the apply and modify configs
 
-      callHandlerFor(action, item)
+      callHandlerFor.call(this, action, item)
 
       if (action === 'unapply') {
         this.appliedConfigs.delete(item.path)

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -244,13 +244,56 @@ class RemoteConfigManager extends EventEmitter {
       // TODO: we need a way to tell if unapply configs were handled by kPreUpdate or not, because they're always
       // emitted unlike the apply and modify configs
 
-      callHandlerFor.call(this, action, item)
+      this._callHandlerFor(action, item)
 
       if (action === 'unapply') {
         this.appliedConfigs.delete(item.path)
       } else {
         this.appliedConfigs.set(item.path, item)
       }
+    }
+  }
+
+  _callHandlerFor (action, item) {
+    // in case the item was already handled by kPreUpdate
+    if (item.apply_state !== UNACKNOWLEDGED && action !== 'unapply') return
+
+    const handler = this._handlers.get(item.product)
+
+    if (!handler) return
+
+    try {
+      if (supportsAckCallback(handler)) {
+        // If the handler accepts an `ack` callback, expect that to be called and set `apply_state` accordinly
+        // TODO: do we want to pass old and new config ?
+        handler(action, item.file, item.id, (err) => {
+          if (err) {
+            item.apply_state = ERROR
+            item.apply_error = err.toString()
+          } else if (item.apply_state !== ERROR) {
+            item.apply_state = ACKNOWLEDGED
+          }
+        })
+      } else {
+        // If the handler doesn't accept an `ack` callback, assume `apply_state` is `ACKNOWLEDGED`,
+        // unless it returns a promise, in which case we wait for the promise to be resolved or rejected.
+        // TODO: do we want to pass old and new config ?
+        const result = handler(action, item.file, item.id)
+        if (result instanceof Promise) {
+          result.then(
+            () => { item.apply_state = ACKNOWLEDGED },
+            (err) => {
+              item.apply_state = ERROR
+              item.apply_error = err.toString()
+            }
+          )
+        } else {
+          item.apply_state = ACKNOWLEDGED
+        }
+      }
+    } catch (err) {
+      item.apply_state = ERROR
+      item.apply_error = err.toString()
     }
   }
 }
@@ -273,49 +316,6 @@ function parseConfigPath (configPath) {
   return {
     product: match[1],
     id: match[2]
-  }
-}
-
-function callHandlerFor (action, item) {
-  // in case the item was already handled by kPreUpdate
-  if (item.apply_state !== UNACKNOWLEDGED && action !== 'unapply') return
-
-  const handler = this._handlers.get(item.product)
-
-  if (!handler) return
-
-  try {
-    if (supportsAckCallback(handler)) {
-      // If the handler accepts an `ack` callback, expect that to be called and set `apply_state` accordinly
-      // TODO: do we want to pass old and new config ?
-      handler(action, item.file, item.id, (err) => {
-        if (err) {
-          item.apply_state = ERROR
-          item.apply_error = err.toString()
-        } else if (item.apply_state !== ERROR) {
-          item.apply_state = ACKNOWLEDGED
-        }
-      })
-    } else {
-      // If the handler doesn't accept an `ack` callback, assume `apply_state` is `ACKNOWLEDGED`,
-      // unless it returns a promise, in which case we wait for the promise to be resolved or rejected.
-      // TODO: do we want to pass old and new config ?
-      const result = handler(action, item.file, item.id)
-      if (result instanceof Promise) {
-        result.then(
-          () => { item.apply_state = ACKNOWLEDGED },
-          (err) => {
-            item.apply_state = ERROR
-            item.apply_error = err.toString()
-          }
-        )
-      } else {
-        item.apply_state = ACKNOWLEDGED
-      }
-    }
-  } catch (err) {
-    item.apply_state = ERROR
-    item.apply_error = err.toString()
   }
 }
 

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -258,7 +258,7 @@ class RemoteConfigManager extends EventEmitter {
             if (supportsAckCallback(handler)) {
               // If the handler accepts an `ack` callback, expect that to be called and set `apply_state` accordinly
               // TODO: do we want to pass old and new config ?
-              handler(action, item.file, (err) => {
+              handler(action, item.file, item.id, (err) => {
                 if (err) {
                   item.apply_state = ERROR
                   item.apply_error = err.toString()
@@ -270,7 +270,7 @@ class RemoteConfigManager extends EventEmitter {
               // If the handler doesn't accept an `ack` callback, assume `apply_state` is `ACKNOWLEDGED`,
               // unless it returns a promise, in which case we wait for the promise to be resolved or rejected.
               // TODO: do we want to pass old and new config ?
-              const result = handler(action, item.file)
+              const result = handler(action, item.file, item.id)
               if (result instanceof Promise) {
                 result.then(
                   () => { item.apply_state = ACKNOWLEDGED },
@@ -326,7 +326,7 @@ function supportsAckCallback (handler) {
   const numOfArgs = handler.length
   let result = false
 
-  if (numOfArgs >= 3) {
+  if (numOfArgs >= 4) {
     result = true
   } else if (numOfArgs !== 0) {
     const source = handler.toString()

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -83,7 +83,8 @@ class Tracer extends NoopProxy {
       if (config.remoteConfig.enabled && !config.isCiVisibility) {
         const rc = remoteConfig.enable(config, this._modules.appsec)
 
-        rc.on('APM_TRACING', (action, conf) => {
+        rc.on('APM_TRACING', (action, conf, id, ack) => {
+          ack()
           if (action === 'unapply') {
             config.configure({}, true)
           } else {
@@ -92,7 +93,8 @@ class Tracer extends NoopProxy {
           this._enableOrDisableTracing(config)
         })
 
-        rc.on('AGENT_CONFIG', (action, conf) => {
+        rc.on('AGENT_CONFIG', (action, conf, id, ack) => {
+          ack()
           if (!conf?.name?.startsWith('flare-log-level.')) return
 
           if (action === 'unapply') {
@@ -103,7 +105,8 @@ class Tracer extends NoopProxy {
           }
         })
 
-        rc.on('AGENT_TASK', (action, conf) => {
+        rc.on('AGENT_TASK', (action, conf, id, ack) => {
+          ack()
           if (action === 'unapply' || !conf) return
           if (conf.task_type !== 'tracer_flare' || !conf.args) return
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -83,8 +83,7 @@ class Tracer extends NoopProxy {
       if (config.remoteConfig.enabled && !config.isCiVisibility) {
         const rc = remoteConfig.enable(config, this._modules.appsec)
 
-        rc.on('APM_TRACING', (action, conf, id, ack) => {
-          ack()
+        rc.setProductHandler('APM_TRACING', (action, conf) => {
           if (action === 'unapply') {
             config.configure({}, true)
           } else {
@@ -93,8 +92,7 @@ class Tracer extends NoopProxy {
           this._enableOrDisableTracing(config)
         })
 
-        rc.on('AGENT_CONFIG', (action, conf, id, ack) => {
-          ack()
+        rc.setProductHandler('AGENT_CONFIG', (action, conf) => {
           if (!conf?.name?.startsWith('flare-log-level.')) return
 
           if (action === 'unapply') {
@@ -105,8 +103,7 @@ class Tracer extends NoopProxy {
           }
         })
 
-        rc.on('AGENT_TASK', (action, conf, id, ack) => {
-          ack()
+        rc.setProductHandler('AGENT_TASK', (action, conf) => {
           if (action === 'unapply' || !conf) return
           if (conf.task_type !== 'tracer_flare' || !conf.args) return
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -1182,6 +1182,7 @@ describe('IP blocking', function () {
         }).then(() => {
           throw new Error('Not expected')
         }).catch((err) => {
+          expect(err.message).to.not.equal('Not expected')
           expect(err.response.status).to.be.equal(500)
           expect(err.response.data).to.deep.equal(jsonDefaultContent)
         })
@@ -1196,6 +1197,7 @@ describe('IP blocking', function () {
         }).then(() => {
           throw new Error('Not expected')
         }).catch((err) => {
+          expect(err.message).to.not.equal('Not expected')
           expect(err.response.status).to.be.equal(500)
           expect(err.response.data).to.deep.equal(htmlDefaultContent)
         })
@@ -1241,6 +1243,7 @@ describe('IP blocking', function () {
         }).then(() => {
           throw new Error('Not resolve expected')
         }).catch((err) => {
+          expect(err.message).to.not.equal('Not resolve expected')
           expect(err.response.status).to.be.equal(301)
           expect(err.response.headers.location).to.be.equal('/error')
         })

--- a/packages/dd-trace/test/appsec/remote_config/index.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/index.spec.js
@@ -50,6 +50,13 @@ describe('Remote Config index', () => {
   })
 
   describe('enable', () => {
+    let ack
+    const id = 1
+
+    beforeEach(() => {
+      ack = sinon.spy()
+    })
+
     it('should listen to remote config when appsec is not explicitly configured', () => {
       config.appsec = { enabled: undefined }
 
@@ -116,28 +123,32 @@ describe('Remote Config index', () => {
       })
 
       it('should enable appsec when listener is called with apply and enabled', () => {
-        listener('apply', { asm: { enabled: true } })
+        listener('apply', { asm: { enabled: true } }, id, ack)
 
         expect(appsec.enable).to.have.been.called
+        expect(ack).to.have.been.calledOnceWithExactly()
       })
 
       it('should enable appsec when listener is called with modify and enabled', () => {
-        listener('modify', { asm: { enabled: true } })
+        listener('modify', { asm: { enabled: true } }, id, ack)
 
         expect(appsec.enable).to.have.been.called
+        expect(ack).to.have.been.calledOnceWithExactly()
       })
 
       it('should disable appsec when listener is called with unnaply and enabled', () => {
-        listener('unnaply', { asm: { enabled: true } })
+        listener('unnaply', { asm: { enabled: true } }, id, ack)
 
         expect(appsec.disable).to.have.been.calledOnce
+        expect(ack).to.have.been.calledOnceWithExactly()
       })
 
       it('should not do anything when listener is called with apply and malformed data', () => {
-        listener('apply', {})
+        listener('apply', {}, id, ack)
 
         expect(appsec.enable).to.not.have.been.called
         expect(appsec.disable).to.not.have.been.called
+        expect(ack).to.have.been.calledOnceWithExactly()
       })
     })
 
@@ -165,9 +176,10 @@ describe('Remote Config index', () => {
             api_security: {
               request_sample_rate: 0.5
             }
-          })
+          }, id, ack)
 
           expect(apiSecuritySampler.setRequestSampling).to.be.calledOnceWithExactly(0.5)
+          expect(ack).to.have.been.calledOnceWithExactly()
         })
 
         it('should update apiSecuritySampler config and disable it', () => {
@@ -175,9 +187,10 @@ describe('Remote Config index', () => {
             api_security: {
               request_sample_rate: 0
             }
-          })
+          }, id, ack)
 
           expect(apiSecuritySampler.setRequestSampling).to.be.calledOnceWithExactly(0)
+          expect(ack).to.have.been.calledOnceWithExactly()
         })
 
         it('should not update apiSecuritySampler config with values greater than 1', () => {
@@ -185,9 +198,10 @@ describe('Remote Config index', () => {
             api_security: {
               request_sample_rate: 5
             }
-          })
+          }, id, ack)
 
           expect(apiSecuritySampler.configure).to.not.be.called
+          expect(ack).to.have.been.calledOnceWithExactly()
         })
 
         it('should not update apiSecuritySampler config with values less than 0', () => {
@@ -195,9 +209,10 @@ describe('Remote Config index', () => {
             api_security: {
               request_sample_rate: -0.4
             }
-          })
+          }, id, ack)
 
           expect(apiSecuritySampler.configure).to.not.be.called
+          expect(ack).to.have.been.calledOnceWithExactly()
         })
 
         it('should not update apiSecuritySampler config with incorrect values', () => {
@@ -205,9 +220,10 @@ describe('Remote Config index', () => {
             api_security: {
               request_sample_rate: 'not_a_number'
             }
-          })
+          }, id, ack)
 
           expect(apiSecuritySampler.configure).to.not.be.called
+          expect(ack).to.have.been.calledOnceWithExactly()
         })
       })
 
@@ -234,9 +250,10 @@ describe('Remote Config index', () => {
             api_security: {
               request_sample_rate: 0.5
             }
-          })
+          }, id, ack)
 
           expect(apiSecuritySampler.setRequestSampling).to.be.calledOnceWithExactly(0.5)
+          expect(ack).to.have.been.calledOnceWithExactly()
         })
       })
     })

--- a/packages/dd-trace/test/appsec/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/manager.spec.js
@@ -556,13 +556,13 @@ describe('RemoteConfigManager', () => {
       const syncBadNonAckHandler = sinon.spy(() => { throw new Error('sync fn') })
       const asyncGoodHandler = sinon.spy(async () => {})
       const asyncBadHandler = sinon.spy(async () => { throw new Error('async fn') })
-      const syncGoodAckHandler = sinon.spy((action, conf, ack) => { ack() })
-      const syncBadAckHandler = sinon.spy((action, conf, ack) => { ack(new Error('sync ack fn')) })
-      const asyncGoodAckHandler = sinon.spy((action, conf, ack) => { setImmediate(ack) })
-      const asyncBadAckHandler = sinon.spy((action, conf, ack) => {
+      const syncGoodAckHandler = sinon.spy((action, conf, id, ack) => { ack() })
+      const syncBadAckHandler = sinon.spy((action, conf, id, ack) => { ack(new Error('sync ack fn')) })
+      const asyncGoodAckHandler = sinon.spy((action, conf, id, ack) => { setImmediate(ack) })
+      const asyncBadAckHandler = sinon.spy((action, conf, id, ack) => {
         setImmediate(ack.bind(null, new Error('async ack fn')))
       })
-      const unackHandler = sinon.spy((action, conf, ack) => {})
+      const unackHandler = sinon.spy((action, conf, id, ack) => {})
 
       rc.setProductHandler('PRODUCT_0', syncGoodNonAckHandler)
       rc.setProductHandler('PRODUCT_1', syncBadNonAckHandler)
@@ -588,15 +588,15 @@ describe('RemoteConfigManager', () => {
 
       rc.dispatch(list, 'apply')
 
-      expect(syncGoodNonAckHandler).to.have.been.calledOnceWithExactly('apply', list[0].file)
-      expect(syncBadNonAckHandler).to.have.been.calledOnceWithExactly('apply', list[1].file)
-      expect(asyncGoodHandler).to.have.been.calledOnceWithExactly('apply', list[2].file)
-      expect(asyncBadHandler).to.have.been.calledOnceWithExactly('apply', list[3].file)
-      assertAsyncHandlerCallArguments(syncGoodAckHandler, 'apply', list[4].file)
-      assertAsyncHandlerCallArguments(syncBadAckHandler, 'apply', list[5].file)
-      assertAsyncHandlerCallArguments(asyncGoodAckHandler, 'apply', list[6].file)
-      assertAsyncHandlerCallArguments(asyncBadAckHandler, 'apply', list[7].file)
-      assertAsyncHandlerCallArguments(unackHandler, 'apply', list[8].file)
+      expect(syncGoodNonAckHandler).to.have.been.calledOnceWithExactly('apply', list[0].file, list[0].id)
+      expect(syncBadNonAckHandler).to.have.been.calledOnceWithExactly('apply', list[1].file, list[1].id)
+      expect(asyncGoodHandler).to.have.been.calledOnceWithExactly('apply', list[2].file, list[2].id)
+      expect(asyncBadHandler).to.have.been.calledOnceWithExactly('apply', list[3].file, list[3].id)
+      assertAsyncHandlerCallArguments(syncGoodAckHandler, 'apply', list[4].file, list[4].id)
+      assertAsyncHandlerCallArguments(syncBadAckHandler, 'apply', list[5].file, list[5].id)
+      assertAsyncHandlerCallArguments(asyncGoodAckHandler, 'apply', list[6].file, list[6].id)
+      assertAsyncHandlerCallArguments(asyncBadAckHandler, 'apply', list[7].file, list[7].id)
+      assertAsyncHandlerCallArguments(unackHandler, 'apply', list[8].file, list[8].id)
 
       expect(list[0].apply_state).to.equal(ACKNOWLEDGED)
       expect(list[0].apply_error).to.equal('')
@@ -657,7 +657,7 @@ describe('RemoteConfigManager', () => {
 
       rc.dispatch([rc.appliedConfigs.get('datadog/42/ASM_FEATURES/confId/config')], 'unapply')
 
-      expect(handler).to.have.been.calledOnceWithExactly('unapply', { asm: { enabled: true } })
+      expect(handler).to.have.been.calledOnceWithExactly('unapply', { asm: { enabled: true } }, 'asm_data')
       expect(rc.appliedConfigs).to.be.empty
     })
   })

--- a/packages/dd-trace/test/appsec/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/manager.spec.js
@@ -151,10 +151,12 @@ describe('RemoteConfigManager', () => {
 
   describe('setProductHandler/removeProductHandler', () => {
     it('should update the product list and autostart or autostop', () => {
+      expect(rc.scheduler.start).to.not.have.been.called
+
       rc.setProductHandler('ASM_FEATURES', noop)
 
       expect(rc.state.client.products).to.deep.equal(['ASM_FEATURES'])
-      expect(rc.scheduler.start).to.have.been.calledOnce
+      expect(rc.scheduler.start).to.have.been.called
 
       rc.setProductHandler('ASM_DATA', noop)
       rc.setProductHandler('ASM_DD', noop)
@@ -171,7 +173,7 @@ describe('RemoteConfigManager', () => {
 
       rc.removeProductHandler('ASM_DD')
 
-      expect(rc.scheduler.stop).to.have.been.calledOnce
+      expect(rc.scheduler.stop).to.have.been.called
       expect(rc.state.client.products).to.be.empty
     })
   })


### PR DESCRIPTION
## Old API

Remote Config updates coming from the Agent needs to be acknowledged. Currently this is done synchronously in the Node.js tracer:

If a listener is attached to a given product, any config updates to that product is automatically acknowledged (if the listener doesn't throw, the state is set to `ACKNOWLEDGED` and if it throws, it's set to `ERROR`).

However, just because there's a listener and it doesn't throw, doesn't mean that the received config can be processed by the listener. It could be that the listener needs to do some async things before it can determine if the received config is valid.

## New API

~This PR changes the existing behavior by making the acknowledgement async: A 4th argument is emitted to listeners of `rc.on(product)` which is an `ack` callback which should be called once the listener wants to acknowledge the received config. It can optionally be called with an error object as its only argument to set the state to `ERROR` instead of `ACKNOWLEDGED`.~

**Update:**

This PR changes the existing behavior by optionally allowing the acknowledgement to be async. This is achieved by:

- Changing the way you register products from using the `EventEmitter` API to a custom API that only allows a single handler per product (event emitters can have more than one listener, which is problematic as we can't support more than one of the listeners to acknowledge the config). The new API is as follows:
  - `rc.setProductHandler(product, handler)` (prevously `rc.on(product, handler)`)
  - `rc.removeProductHandler(product)` (prevously `rc.off(product, handler)`)
- The new product handler is called similar to the old event listener, with the following exception: A new optional 4th argument is supplied called `ack`. This is a callback which can be called (sync or async) either without any arguments (to set the state to `ACKNOWLEDGED`) or with a single error argument (to set the state to `ERROR`).
  - If the handler function signature takes less than 4 arguments or doesn't use the rest operator (`...args`), and...
    - ...the handler doesn't return a `Promise`: The state is set to `ACKNOWLEDGED` right away without the handler having to do anything (existing behavior)
    - ...the handler returns a `Promise`, we wait until the promise is resolved or rejected and set the state accordingly (new behavior)
  - If the handler function signature takes 4 or more arguments or use the rest operator (`...args`): The state is left as `UNACKNOWLEDGED` until the `ack` callback is called (new behavior)
  - In any case, the state is still set to `ERROR` if the handler throws (existing behavior)

The `RemoteConfigManager` is still an `EventEmitter` however because the `kPreUpdate` symbol is still being emitted. That part could do with a complete refactor, but is out of scope for this PR.