### PR TITLE
fix(openai): include a workaround in `register.js` to resolve ESM + OpenAI errors

### DIFF
--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -14,8 +14,6 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  // limit v4 tests while the IITM issue is resolved or a workaround is introduced
-  // issue link: https://github.com/DataDog/import-in-the-middle/issues/60
   withVersions('openai', 'openai', '>=3', version => {
     const realVersion = require(`../../../../versions/openai@${version}`).version()
 
@@ -51,6 +49,10 @@ describe('esm', () => {
         await res
       }).timeout(20000)
     } else {
+      // OpenAI v4 interacts poorly with import-in-the-middle.
+      // Using the `register` import allows us to ignore OpenAI entirely, and not produce errors.
+      // However, because of this, tracing does not happen. This will require a fix in import-in-the-middle.
+      // For now, this test just verifies that the script executes without error.
       it('does not error', async () => {
         proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port, undefined, {
           NODE_OPTIONS: '--import dd-trace/register.js'

--- a/packages/datadog-plugin-openai/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-openai/test/integration-test/server.mjs
@@ -1,5 +1,5 @@
 import 'dd-trace/init.js'
-import openai from 'openai'
+import OpenAI from 'openai'
 import nock from 'nock'
 
 nock('https://api.openai.com:443')
@@ -22,13 +22,26 @@ nock('https://api.openai.com:443')
     'x-request-id', '7df89d8afe7bf24dc04e2c4dd4962d7f'
   ])
 
-const openaiApp = new openai.OpenAIApi(new openai.Configuration({
-  apiKey: 'sk-DATADOG-ACCEPTANCE-TESTS',
-}))
-
-await openaiApp.createCompletion({
-  model: 'text-davinci-002',
-  prompt: 'Hello, ',
-  suffix: 'foo',
-  stream: true
-})
+if (OpenAI.OpenAIApi) {
+  const openaiApp = new OpenAI.OpenAIApi(new OpenAI.Configuration({
+    apiKey: 'sk-DATADOG-ACCEPTANCE-TESTS',
+  }))
+  
+  await openaiApp.createCompletion({
+    model: 'text-davinci-002',
+    prompt: 'Hello, ',
+    suffix: 'foo',
+    stream: true
+  })
+} else {
+  const openai = new OpenAI({
+    apiKey: 'sk-DATADOG-ACCEPTANCE-TESTS',
+  })
+  
+  await openai.completions.create({
+    model: 'text-davinci-002',
+    prompt: 'Hello, ',
+    suffix: 'foo',
+    stream: true
+  })
+}

--- a/register.js
+++ b/register.js
@@ -1,4 +1,4 @@
 const { register } = require('node:module')
 const { pathToFileURL } = require('node:url')
 
-register('./loader-hook.mjs', pathToFileURL(__filename))
+register('./loader-hook.mjs', pathToFileURL(__filename), { data: { include: ['openai'] } })


### PR DESCRIPTION
### What does this PR do?
Introduces a workaround to not produce errors when using `openai` with ESM and the `dd-trace/register.js` import.

**Note:** This does not fix _tracing_. This is a temporary workaround to resolve import errors when using `dd-trace` + `import-in-the-middle` + `openai`. A real fix will need investigation and implementation in `import-in-the-middle`

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


