### PR TITLE
clearer profiling error

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -199,7 +199,7 @@ class AgentExporter {
             this._logger.error(`Error from the agent: ${err.message}`)
             return
           } else if (err) {
-            reject(new Error('Profiler agent export back-off period expired'))
+            reject(err)
             return
           }
 

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -270,7 +270,7 @@ describe('exporters/agent', function () {
       try {
         await exporter.export({ profiles, start, end, tags })
       } catch (err) {
-        expect(err.message).to.match(/^Profiler agent export back-off period expired$/)
+        expect(err.message).to.match(/^HTTP Error 500$/)
         failed = true
       }
       expect(failed).to.be.true


### PR DESCRIPTION
Indicating that a backoff has expired isn't enough information to diagnose what's causing the backoff in the first place, so rather than creating a new error object, this change just passes the last error along.


