### PR TITLE
[test visibility] Use new metadata field in citestcycle 

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -115,14 +115,14 @@ versions.forEach(version => {
 
               const receiverPromise = receiver
                 .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-                  const events = payloads.flatMap(({ payload }) => payload.events)
                   const metadataDicts = payloads.flatMap(({ payload }) => payload.metadata)
-
                   metadataDicts.forEach(metadata => {
                     for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
                       assert.equal(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
                     }
                   })
+
+                  const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const testSessionEvent = events.find(event => event.type === 'test_session_end')
                   const testModuleEvent = events.find(event => event.type === 'test_module_end')

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -33,7 +33,8 @@ const {
   TEST_EARLY_FLAKE_ENABLED,
   TEST_SUITE,
   TEST_CODE_OWNERS,
-  TEST_SESSION_NAME
+  TEST_SESSION_NAME,
+  TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const { NODE_MAJOR } = require('../../version')
@@ -226,6 +227,13 @@ moduleTypes.forEach(({
     it('can run and report tests', (done) => {
       const receiverPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+          const metadataDicts = payloads.flatMap(({ payload }) => payload.metadata)
+
+          metadataDicts.forEach(metadata => {
+            for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+              assert.equal(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+            }
+          })
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const testSessionEvent = events.find(event => event.type === 'test_session_end')
@@ -236,14 +244,12 @@ moduleTypes.forEach(({
           const { content: testSessionEventContent } = testSessionEvent
           const { content: testModuleEventContent } = testModuleEvent
 
-          assert.equal(testSessionEventContent.meta[TEST_SESSION_NAME], 'my-test-session')
           assert.exists(testSessionEventContent.test_session_id)
           assert.exists(testSessionEventContent.meta[TEST_COMMAND])
           assert.exists(testSessionEventContent.meta[TEST_TOOLCHAIN])
           assert.equal(testSessionEventContent.resource.startsWith('test_session.'), true)
           assert.equal(testSessionEventContent.meta[TEST_STATUS], 'fail')
 
-          assert.equal(testModuleEventContent.meta[TEST_SESSION_NAME], 'my-test-session')
           assert.exists(testModuleEventContent.test_session_id)
           assert.exists(testModuleEventContent.test_module_id)
           assert.exists(testModuleEventContent.meta[TEST_COMMAND])
@@ -274,7 +280,6 @@ moduleTypes.forEach(({
               test_session_id: testSessionId
             }
           }) => {
-            assert.equal(meta[TEST_SESSION_NAME], 'my-test-session')
             assert.exists(meta[TEST_COMMAND])
             assert.exists(meta[TEST_MODULE])
             assert.exists(testSuiteId)
@@ -302,7 +307,6 @@ moduleTypes.forEach(({
               test_session_id: testSessionId
             }
           }) => {
-            assert.equal(meta[TEST_SESSION_NAME], 'my-test-session')
             assert.exists(meta[TEST_COMMAND])
             assert.exists(meta[TEST_MODULE])
             assert.exists(testSuiteId)

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -33,7 +33,8 @@ const {
   MOCHA_IS_PARALLEL,
   TEST_SOURCE_START,
   TEST_CODE_OWNERS,
-  TEST_SESSION_NAME
+  TEST_SESSION_NAME,
+  TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
@@ -133,6 +134,14 @@ describe('mocha CommonJS', function () {
         receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       }
       receiver.gatherPayloadsMaxTimeout(({ url }) => url.endsWith('citestcycle'), (payloads) => {
+        const metadataDicts = payloads.flatMap(({ payload }) => payload.metadata)
+
+        metadataDicts.forEach(metadata => {
+          for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+            assert.equal(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+          }
+        })
+
         const events = payloads.flatMap(({ payload }) => payload.events)
         const sessionEventContent = events.find(event => event.type === 'test_session_end').content
         const moduleEventContent = events.find(event => event.type === 'test_module_end').content
@@ -149,24 +158,17 @@ describe('mocha CommonJS', function () {
         )
         assert.equal(suites.length, 2)
         assert.exists(sessionEventContent)
-        assert.equal(sessionEventContent.meta[TEST_SESSION_NAME], 'my-test-session')
         assert.exists(moduleEventContent)
-        assert.equal(moduleEventContent.meta[TEST_SESSION_NAME], 'my-test-session')
 
         assert.include(testOutput, expectedStdout)
         assert.include(testOutput, extraStdout)
 
         tests.forEach(testEvent => {
-          assert.equal(testEvent.meta[TEST_SESSION_NAME], 'my-test-session')
           assert.equal(testEvent.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/test/ci-visibility-test'), true)
           assert.exists(testEvent.metrics[TEST_SOURCE_START])
           // Can read DD_TAGS
           assert.propertyVal(testEvent.meta, 'test.customtag', 'customvalue')
           assert.propertyVal(testEvent.meta, 'test.customtag2', 'customvalue2')
-        })
-
-        suites.forEach(testSuite => {
-          assert.equal(testSuite.meta[TEST_SESSION_NAME], 'my-test-session')
         })
 
         done()
@@ -313,6 +315,14 @@ describe('mocha CommonJS', function () {
   it('works with parallel mode', (done) => {
     const eventsPromise = receiver
       .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+        const metadataDicts = payloads.flatMap(({ payload }) => payload.metadata)
+
+        metadataDicts.forEach(metadata => {
+          for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+            assert.equal(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+          }
+        })
+
         const events = payloads.flatMap(({ payload }) => payload.events)
         const sessionEventContent = events.find(event => event.type === 'test_session_end').content
         const moduleEventContent = events.find(event => event.type === 'test_module_end').content
@@ -330,7 +340,6 @@ describe('mocha CommonJS', function () {
           test_module_id: testModuleId,
           test_session_id: testSessionId
         }) => {
-          assert.equal(meta[TEST_SESSION_NAME], 'my-test-session')
           assert.exists(meta[TEST_COMMAND])
           assert.exists(meta[TEST_MODULE])
           assert.exists(testSuiteId)
@@ -345,7 +354,6 @@ describe('mocha CommonJS', function () {
           test_module_id: testModuleId,
           test_session_id: testSessionId
         }) => {
-          assert.equal(meta[TEST_SESSION_NAME], 'my-test-session')
           assert.exists(meta[TEST_COMMAND])
           assert.exists(meta[TEST_MODULE])
           assert.exists(testSuiteId)

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -23,7 +23,8 @@ const {
   TEST_EARLY_FLAKE_ENABLED,
   TEST_SUITE,
   TEST_CODE_OWNERS,
-  TEST_SESSION_NAME
+  TEST_SESSION_NAME,
+  TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
@@ -72,6 +73,14 @@ versions.forEach((version) => {
           const reportUrl = reportMethod === 'agentless' ? '/api/v2/citestcycle' : '/evp_proxy/v2/api/v2/citestcycle'
 
           receiver.gatherPayloadsMaxTimeout(({ url }) => url === reportUrl, payloads => {
+            const metadataDicts = payloads.flatMap(({ payload }) => payload.metadata)
+
+            metadataDicts.forEach(metadata => {
+              for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+                assert.equal(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+              }
+            })
+
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSessionEvent = events.find(event => event.type === 'test_session_end')
@@ -81,10 +90,8 @@ versions.forEach((version) => {
 
             const stepEvents = events.filter(event => event.type === 'span')
 
-            assert.equal(testSessionEvent.content.meta[TEST_SESSION_NAME], 'my-test-session')
             assert.include(testSessionEvent.content.resource, 'test_session.playwright test')
             assert.equal(testSessionEvent.content.meta[TEST_STATUS], 'fail')
-            assert.equal(testModuleEvent.content.meta[TEST_SESSION_NAME], 'my-test-session')
             assert.include(testModuleEvent.content.resource, 'test_module.playwright test')
             assert.equal(testModuleEvent.content.meta[TEST_STATUS], 'fail')
             assert.equal(testSessionEvent.content.meta[TEST_TYPE], 'browser')
@@ -106,7 +113,6 @@ versions.forEach((version) => {
             ])
 
             testSuiteEvents.forEach(testSuiteEvent => {
-              assert.equal(testSuiteEvent.content.meta[TEST_SESSION_NAME], 'my-test-session')
               if (testSuiteEvent.content.meta[TEST_STATUS] === 'fail') {
                 assert.exists(testSuiteEvent.content.meta[ERROR_MESSAGE])
               }
@@ -128,7 +134,6 @@ versions.forEach((version) => {
             ])
 
             testEvents.forEach(testEvent => {
-              assert.equal(testEvent.content.meta[TEST_SESSION_NAME], 'my-test-session')
               assert.exists(testEvent.content.metrics[TEST_SOURCE_START])
               assert.equal(
                 testEvent.content.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/playwright-tests/'), true

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -16,7 +16,8 @@ const {
   TEST_CODE_OWNERS,
   TEST_CODE_COVERAGE_LINES_PCT,
   TEST_SESSION_NAME,
-  TEST_COMMAND
+  TEST_COMMAND,
+  TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
 const versions = ['1.6.0', 'latest']
@@ -52,6 +53,14 @@ versions.forEach((version) => {
 
     it('can run and report tests', (done) => {
       receiver.gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+        const metadataDicts = payloads.flatMap(({ payload }) => payload.metadata)
+
+        metadataDicts.forEach(metadata => {
+          for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+            assert.equal(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+          }
+        })
+
         const events = payloads.flatMap(({ payload }) => payload.events)
 
         const testSessionEvent = events.find(event => event.type === 'test_session_end')
@@ -59,10 +68,8 @@ versions.forEach((version) => {
         const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
         const testEvents = events.filter(event => event.type === 'test')
 
-        assert.equal(testSessionEvent.content.meta[TEST_SESSION_NAME], 'my-test-session')
         assert.include(testSessionEvent.content.resource, 'test_session.vitest run')
         assert.equal(testSessionEvent.content.meta[TEST_STATUS], 'fail')
-        assert.equal(testModuleEvent.content.meta[TEST_SESSION_NAME], 'my-test-session')
         assert.include(testModuleEvent.content.resource, 'test_module.vitest run')
         assert.equal(testModuleEvent.content.meta[TEST_STATUS], 'fail')
         assert.equal(testSessionEvent.content.meta[TEST_TYPE], 'test')
@@ -135,12 +142,10 @@ versions.forEach((version) => {
         )
 
         testEvents.forEach(test => {
-          assert.equal(test.content.meta[TEST_SESSION_NAME], 'my-test-session')
           assert.equal(test.content.meta[TEST_COMMAND], 'vitest run')
         })
 
         testSuiteEvents.forEach(testSuite => {
-          assert.equal(testSuite.content.meta[TEST_SESSION_NAME], 'my-test-session')
           assert.equal(testSuite.content.meta[TEST_COMMAND], 'vitest run')
         })
         // TODO: check error messages

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -25,8 +25,7 @@ const {
   TEST_MODULE,
   TEST_MODULE_ID,
   TEST_SUITE,
-  CUCUMBER_IS_PARALLEL,
-  TEST_SESSION_NAME
+  CUCUMBER_IS_PARALLEL
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -52,8 +51,7 @@ function getTestSuiteTags (testSuiteSpan) {
     [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
     [TEST_SESSION_ID]: testSuiteSpan.context().toTraceId(),
     [TEST_COMMAND]: testSuiteSpan.context()._tags[TEST_COMMAND],
-    [TEST_MODULE]: 'cucumber',
-    [TEST_SESSION_NAME]: testSuiteSpan.context()._tags[TEST_SESSION_NAME]
+    [TEST_MODULE]: 'cucumber'
   }
   if (testSuiteSpan.context()._parentId) {
     suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)
@@ -135,9 +133,6 @@ class CucumberPlugin extends CiPlugin {
       }
       if (itrCorrelationId) {
         testSuiteMetadata[ITR_CORRELATION_ID] = itrCorrelationId
-      }
-      if (this.testSessionName) {
-        testSuiteMetadata[TEST_SESSION_NAME] = this.testSessionName
       }
       const testSuiteSpan = this.tracer.startSpan('cucumber.test_suite', {
         childOf: this.testModuleSpan,

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -393,13 +393,15 @@ class CypressPlugin {
 
     const testSessionName = getTestSessionName(this.tracer._tracer._config, this.command, this.testEnvironmentMetadata)
 
-    const metadataTags = {}
-    for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
-      metadataTags[testLevel] = {
-        [TEST_SESSION_NAME]: testSessionName
+    if (this.tracer._tracer._exporter?.setMetadataTags) {
+      const metadataTags = {}
+      for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+        metadataTags[testLevel] = {
+          [TEST_SESSION_NAME]: testSessionName
+        }
       }
+      this.tracer._tracer._exporter.setMetadataTags(metadataTags)
     }
-    this.tracer._exporter.setMetadataTags(metadataTags)
 
     this.testSessionSpan = this.tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test_session`, {
       childOf,

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -30,7 +30,8 @@ const {
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
   getTestSessionName,
-  TEST_SESSION_NAME
+  TEST_SESSION_NAME,
+  TEST_LEVEL_EVENT_TYPES
 } = require('../../dd-trace/src/plugins/util/test')
 const { isMarkedAsUnskippable } = require('../../datadog-plugin-jest/src/util')
 const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
@@ -256,7 +257,6 @@ class CypressPlugin {
       childOf: this.testModuleSpan,
       tags: {
         [COMPONENT]: TEST_FRAMEWORK_NAME,
-        [TEST_SESSION_NAME]: this.testSessionName,
         ...this.testEnvironmentMetadata,
         ...testSuiteSpanMetadata
       }
@@ -267,8 +267,7 @@ class CypressPlugin {
     const testSuiteTags = {
       [TEST_COMMAND]: this.command,
       [TEST_COMMAND]: this.command,
-      [TEST_MODULE]: TEST_FRAMEWORK_NAME,
-      [TEST_SESSION_NAME]: this.testSessionName
+      [TEST_MODULE]: TEST_FRAMEWORK_NAME
     }
     if (this.testSuiteSpan) {
       testSuiteTags[TEST_SUITE_ID] = this.testSuiteSpan.context().toSpanId()
@@ -392,13 +391,20 @@ class CypressPlugin {
       testSessionSpanMetadata[TEST_EARLY_FLAKE_ENABLED] = 'true'
     }
 
-    this.testSessionName = getTestSessionName(this.tracer._tracer._config, this.command, this.testEnvironmentMetadata)
+    const testSessionName = getTestSessionName(this.tracer._tracer._config, this.command, this.testEnvironmentMetadata)
+
+    const metadataTags = {}
+    for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+      metadataTags[testLevel] = {
+        [TEST_SESSION_NAME]: testSessionName
+      }
+    }
+    this.tracer._exporter.setMetadataTags(metadataTags)
 
     this.testSessionSpan = this.tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test_session`, {
       childOf,
       tags: {
         [COMPONENT]: TEST_FRAMEWORK_NAME,
-        [TEST_SESSION_NAME]: this.testSessionName,
         ...this.testEnvironmentMetadata,
         ...testSessionSpanMetadata
       }
@@ -409,7 +415,6 @@ class CypressPlugin {
       childOf: this.testSessionSpan,
       tags: {
         [COMPONENT]: TEST_FRAMEWORK_NAME,
-        [TEST_SESSION_NAME]: this.testSessionName,
         ...this.testEnvironmentMetadata,
         ...testModuleSpanMetadata
       }

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -150,7 +150,6 @@ class JestPlugin extends CiPlugin {
         config._ddTestSessionId = this.testSessionSpan.context().toTraceId()
         config._ddTestModuleId = this.testModuleSpan.context().toSpanId()
         config._ddTestCommand = this.testSessionSpan.context()._tags[TEST_COMMAND]
-        config._ddTestSessionName = this.testSessionName
         config._ddItrCorrelationId = this.itrCorrelationId
         config._ddIsEarlyFlakeDetectionEnabled = !!this.libraryConfig?.isEarlyFlakeDetectionEnabled
         config._ddEarlyFlakeDetectionNumRetries = this.libraryConfig?.earlyFlakeDetectionNumRetries ?? 0
@@ -164,7 +163,6 @@ class JestPlugin extends CiPlugin {
       const {
         _ddTestSessionId: testSessionId,
         _ddTestCommand: testCommand,
-        _ddTestSessionName: testSessionName,
         _ddTestModuleId: testModuleId,
         _ddItrCorrelationId: itrCorrelationId,
         _ddForcedToRun,
@@ -198,9 +196,6 @@ class JestPlugin extends CiPlugin {
       }
       if (displayName) {
         testSuiteMetadata[JEST_DISPLAY_NAME] = displayName
-      }
-      if (testSessionName) {
-        testSuiteMetadata[TEST_SESSION_NAME] = testSessionName
       }
 
       this.testSuiteSpan = this.tracer.startSpan('jest.test_suite', {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -22,8 +22,7 @@ const {
   TEST_EARLY_FLAKE_ABORT_REASON,
   JEST_DISPLAY_NAME,
   TEST_IS_RUM_ACTIVE,
-  TEST_BROWSER_DRIVER,
-  TEST_SESSION_NAME
+  TEST_BROWSER_DRIVER
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -29,8 +29,7 @@ const {
   TEST_SUITE,
   MOCHA_IS_PARALLEL,
   TEST_IS_RUM_ACTIVE,
-  TEST_BROWSER_DRIVER,
-  TEST_SESSION_NAME
+  TEST_BROWSER_DRIVER
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -53,8 +52,7 @@ function getTestSuiteLevelVisibilityTags (testSuiteSpan) {
     [TEST_SUITE_ID]: testSuiteSpanContext.toSpanId(),
     [TEST_SESSION_ID]: testSuiteSpanContext.toTraceId(),
     [TEST_COMMAND]: testSuiteSpanContext._tags[TEST_COMMAND],
-    [TEST_MODULE]: 'mocha',
-    [TEST_SESSION_NAME]: testSuiteSpanContext._tags[TEST_SESSION_NAME]
+    [TEST_MODULE]: 'mocha'
   }
   if (testSuiteSpanContext._parentId) {
     suiteTags[TEST_MODULE_ID] = testSuiteSpanContext._parentId.toString(10)
@@ -125,9 +123,6 @@ class MochaPlugin extends CiPlugin {
       if (isForcedToRun) {
         testSuiteMetadata[TEST_ITR_FORCED_RUN] = 'true'
         this.telemetry.count(TELEMETRY_ITR_FORCED_TO_RUN, { testLevel: 'suite' })
-      }
-      if (this.testSessionName) {
-        testSuiteMetadata[TEST_SESSION_NAME] = this.testSessionName
       }
 
       const testSuiteSpan = this.tracer.startSpan('mocha.test_suite', {

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -15,8 +15,7 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
-  TELEMETRY_TEST_SESSION,
-  TEST_SESSION_NAME
+  TELEMETRY_TEST_SESSION
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -77,9 +76,6 @@ class PlaywrightPlugin extends CiPlugin {
         testSuite,
         'playwright'
       )
-      if (this.testSessionName) {
-        testSuiteMetadata[TEST_SESSION_NAME] = this.testSessionName
-      }
 
       const testSuiteSpan = this.tracer.startSpan('playwright.test_suite', {
         childOf: this.testModuleSpan,

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -9,8 +9,7 @@ const {
   TEST_SOURCE_FILE,
   TEST_IS_RETRY,
   TEST_CODE_COVERAGE_LINES_PCT,
-  TEST_CODE_OWNERS,
-  TEST_SESSION_NAME
+  TEST_CODE_OWNERS
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -134,7 +133,6 @@ class VitestPlugin extends CiPlugin {
         testSuite,
         'vitest'
       )
-      testSuiteMetadata[TEST_SESSION_NAME] = process.env.DD_CIVISIBILITY_TEST_SESSION_NAME
 
       const testSuiteSpan = this.tracer.startSpan('vitest.test_suite', {
         childOf: testSessionSpanContext,

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -138,7 +138,9 @@ class VitestPlugin extends CiPlugin {
           [TEST_SESSION_NAME]: testSessionName
         }
       }
-      this.tracer._exporter.setMetadataTags(metadataTags)
+      if (this.tracer._exporter.setMetadataTags) {
+        this.tracer._exporter.setMetadataTags(metadataTags)
+      }
 
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const testSuiteMetadata = getTestSuiteCommonTags(

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -72,6 +72,10 @@ class Writer extends BaseWriter {
       done()
     })
   }
+
+  setMetadataTags (tags) {
+    this._encoder.setMetadataTags(tags)
+  }
 }
 
 module.exports = Writer

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -291,6 +291,12 @@ class CiVisibilityExporter extends AgentInfoExporter {
   _getApiUrl () {
     return this._url
   }
+
+  setMetadataTags (tags) {
+    if (this._writer.setMetadataTags) {
+      this._writer.setMetadataTags(tags)
+    }
+  }
 }
 
 module.exports = CiVisibilityExporter

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -292,9 +292,16 @@ class CiVisibilityExporter extends AgentInfoExporter {
     return this._url
   }
 
+  // By the time setMetadataTags is called, the agent info request might not have finished
   setMetadataTags (tags) {
-    if (this._writer.setMetadataTags) {
+    if (this._writer?.setMetadataTags) {
       this._writer.setMetadataTags(tags)
+    } else {
+      this._canUseCiVisProtocolPromise.then(() => {
+        if (this._writer?.setMetadataTags) {
+          this._writer.setMetadataTags(tags)
+        }
+      })
     }
   }
 }

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -283,6 +283,10 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   }
 
   _encode (bytes, trace) {
+    if (this._isReset) {
+      this._encodePayloadStart(bytes)
+      this._isReset = false
+    }
     const startTime = Date.now()
 
     const rawEvents = trace.map(formatSpan)
@@ -356,6 +360,22 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     this._encodeMapPrefix(bytes, Object.keys(payload.metadata).length)
     this._encodeString(bytes, '*')
     this._encodeMap(bytes, payload.metadata['*'])
+    if (payload.metadata.test) {
+      this._encodeString(bytes, 'test')
+      this._encodeMap(bytes, payload.metadata.test)
+    }
+    if (payload.metadata.test_suite_end) {
+      this._encodeString(bytes, 'test_suite_end')
+      this._encodeMap(bytes, payload.metadata.test_suite_end)
+    }
+    if (payload.metadata.test_module_end) {
+      this._encodeString(bytes, 'test_module_end')
+      this._encodeMap(bytes, payload.metadata.test_module_end)
+    }
+    if (payload.metadata.test_session_end) {
+      this._encodeString(bytes, 'test_session_end')
+      this._encodeMap(bytes, payload.metadata.test_session_end)
+    }
     this._encodeString(bytes, 'events')
     // Get offset of the events list to update the length of the array when calling `makePayload`
     this._eventsOffset = bytes.length
@@ -366,7 +386,7 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   reset () {
     this._reset()
     this._eventCount = 0
-    this._encodePayloadStart(this._traceBytes)
+    this._isReset = true
   }
 }
 

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -43,7 +43,13 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     // length of `payload.events` when calling `makePayload`
     this._eventCount = 0
 
+    this.metadataTags = {}
+
     this.reset()
+  }
+
+  setMetadataTags (tags) {
+    this.metadataTags = tags
   }
 
   _encodeTestSuite (bytes, content) {
@@ -330,7 +336,8 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
         '*': {
           language: 'javascript',
           library_version: ddTraceVersion
-        }
+        },
+        ...this.metadataTags
       },
       events: []
     }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -86,7 +86,10 @@ module.exports = class CiPlugin extends Plugin {
           [TEST_SESSION_NAME]: testSessionName
         }
       }
-      this.tracer._exporter.setMetadataTags(metadataTags)
+      // tracer might not be initialized correctly
+      if (this.tracer._exporter.setMetadataTags) {
+        this.tracer._exporter.setMetadataTags(metadataTags)
+      }
 
       this.testSessionSpan = this.tracer.startSpan(`${this.constructor.id}.test_session`, {
         childOf,

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -19,7 +19,8 @@ const {
   TEST_STATUS,
   TEST_SKIPPED_BY_ITR,
   ITR_CORRELATION_ID,
-  TEST_SOURCE_FILE
+  TEST_SOURCE_FILE,
+  TEST_LEVEL_EVENT_TYPES
 } = require('./util/test')
 const Plugin = require('./plugin')
 const { COMPONENT } = require('../constants')
@@ -77,13 +78,20 @@ module.exports = class CiPlugin extends Plugin {
       // only for playwright
       this.rootDir = rootDir
 
-      this.testSessionName = getTestSessionName(this.config, this.command, this.testEnvironmentMetadata)
+      const testSessionName = getTestSessionName(this.config, this.command, this.testEnvironmentMetadata)
+
+      const metadataTags = {}
+      for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+        metadataTags[testLevel] = {
+          [TEST_SESSION_NAME]: testSessionName
+        }
+      }
+      this.tracer._exporter.setMetadataTags(metadataTags)
 
       this.testSessionSpan = this.tracer.startSpan(`${this.constructor.id}.test_session`, {
         childOf,
         tags: {
           [COMPONENT]: this.constructor.id,
-          [TEST_SESSION_NAME]: this.testSessionName,
           ...this.testEnvironmentMetadata,
           ...testSessionSpanMetadata
         }
@@ -93,7 +101,6 @@ module.exports = class CiPlugin extends Plugin {
         childOf: this.testSessionSpan,
         tags: {
           [COMPONENT]: this.constructor.id,
-          [TEST_SESSION_NAME]: this.testSessionName,
           ...this.testEnvironmentMetadata,
           ...testModuleSpanMetadata
         }
@@ -104,7 +111,6 @@ module.exports = class CiPlugin extends Plugin {
         process.env.DD_CIVISIBILITY_TEST_SESSION_ID = this.testSessionSpan.context().toTraceId()
         process.env.DD_CIVISIBILITY_TEST_MODULE_ID = this.testModuleSpan.context().toSpanId()
         process.env.DD_CIVISIBILITY_TEST_COMMAND = this.command
-        process.env.DD_CIVISIBILITY_TEST_SESSION_NAME = this.testSessionName
       }
 
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'module')
@@ -216,11 +222,6 @@ module.exports = class CiPlugin extends Plugin {
       ...extraTags
     }
 
-    // this.testSessionName might be empty for parallel workers
-    if (this.testSessionName) {
-      testTags[TEST_SESSION_NAME] = this.testSessionName
-    }
-
     const { [TEST_SOURCE_FILE]: testSourceFile } = extraTags
     // We'll try with the test source file if available (it could be different from the test suite)
     let codeOwners = getCodeOwnersForFilename(testSourceFile, this.codeOwnersEntries)
@@ -242,8 +243,7 @@ module.exports = class CiPlugin extends Plugin {
         [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
         [TEST_SESSION_ID]: testSuiteSpan.context().toTraceId(),
         [TEST_COMMAND]: testSuiteSpan.context()._tags[TEST_COMMAND],
-        [TEST_MODULE]: this.constructor.id,
-        [TEST_SESSION_NAME]: testSuiteSpan.context()._tags[TEST_SESSION_NAME]
+        [TEST_MODULE]: this.constructor.id
       }
       if (testSuiteSpan.context()._parentId) {
         suiteTags[TEST_MODULE_ID] = testSuiteSpan.context()._parentId.toString(10)

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -99,6 +99,13 @@ const MOCHA_WORKER_TRACE_PAYLOAD_CODE = 80
 const EFD_STRING = "Retried by Datadog's Early Flake Detection"
 const EFD_TEST_NAME_REGEX = new RegExp(EFD_STRING + ' \\(#\\d+\\): ', 'g')
 
+const TEST_LEVEL_EVENT_TYPES = [
+  'test',
+  'test_suite_end',
+  'test_module_end',
+  'test_session_end'
+]
+
 module.exports = {
   TEST_CODE_OWNERS,
   TEST_SESSION_NAME,
@@ -173,7 +180,8 @@ module.exports = {
   TEST_BROWSER_DRIVER_VERSION,
   TEST_BROWSER_NAME,
   TEST_BROWSER_VERSION,
-  getTestSessionName
+  getTestSessionName,
+  TEST_LEVEL_EVENT_TYPES
 }
 
 // Returns pkg manager and its version, separated by '-', e.g. npm-8.15.0 or yarn-1.22.19


### PR DESCRIPTION
### What does this PR do?
Make use of new fields in the `metadata` dictionary in the agentless encoding: 

```javascript
{
  version: ENCODING_VERSION,
  metadata: {
    '*': {
      language: 'javascript',
      library_version: ddTraceVersion
    },
    test: {
       // fields applied to tests
    },
    test_suite_end: {
       // fields applied to test suites
    },
    test_module_end: {
       // fields applied to test modules
    },
    test_session_end: {
       // fields applied to test sessions
    },
  },
  events: []
}
```

This allows saving a bunch of tags in different events.

### Motivation
Follow up from #4621, now that the backend accepts these fields in the citestcycle endpoint.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
