### PR TITLE
Add permissions to package-size-report workflow

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   package-size-report:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js


### PR DESCRIPTION
### What does this PR do?
Set `pull-requests: write` permission for `package-size-report` job

### Motivation
After changing the default workflow permissions in the repo, it is necessary to adjust the permissions in the workflow file.

### Additional Notes
[Create an issue comment](https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment)
[Controlling permissions for GH Token](https://docs.github.com/es/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)


