### PR TITLE
[PROF-10484] refactor: use standard profiler in serverless contexts

### DIFF
--- a/packages/dd-trace/src/profiling/index.js
+++ b/packages/dd-trace/src/profiling/index.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { Profiler, ServerlessProfiler } = require('./profiler')
+const { Profiler } = require('./profiler')
 const WallProfiler = require('./profilers/wall')
 const SpaceProfiler = require('./profilers/space')
 const { AgentExporter } = require('./exporters/agent')
 const { FileExporter } = require('./exporters/file')
 const { ConsoleLogger } = require('./loggers/console')
 
-const profiler = process.env.AWS_LAMBDA_FUNCTION_NAME ? new ServerlessProfiler() : new Profiler()
+const profiler = new Profiler()
 
 module.exports = {
   profiler,

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -198,29 +198,6 @@ class Profiler extends EventEmitter {
   }
 }
 
-class ServerlessProfiler extends Profiler {
-  constructor () {
-    super()
-    this._profiledIntervals = 0
-    this._interval = 1
-    this._flushAfterIntervals = undefined
-  }
-
-  _setInterval () {
-    this._timeoutInterval = this._interval * 1000
-    this._flushAfterIntervals = this._config.flushInterval / 1000
-  }
-
-  async _collect (snapshotKind, restart = true) {
-    if (this._profiledIntervals >= this._flushAfterIntervals || !restart) {
-      this._profiledIntervals = 0
-      await super._collect(snapshotKind, restart)
-    } else {
-      this._profiledIntervals += 1
-      this._capture(this._timeoutInterval, new Date())
-      // Don't submit profile until 65 (flushAfterIntervals) intervals have elapsed
-    }
-  }
-}
+const ServerlessProfiler = Profiler
 
 module.exports = { Profiler, ServerlessProfiler }

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -373,6 +373,18 @@ describe('profiler', function () {
       sinon.assert.notCalled(exporter.export)
     })
 
+    it('calls the profiler.profile() methods once per interval', async () => {
+      await profiler._start({ profilers, exporters })
+
+      for (let i = 0; i < flushAfterIntervals + 1; i++) {
+        clock.tick(interval)
+      }
+
+      for (const configuredProfiler of profilers) {
+        sinon.assert.callCount(configuredProfiler.profile, flushAfterIntervals);
+      }
+    });
+
     it('should flush when flush after intervals is reached', async () => {
       await profiler._start({ profilers, exporters })
 

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -81,321 +81,254 @@ describe('profiler', function () {
     sourceMapCreate = sinon.stub()
   }
 
-  describe('not serverless', function () {
-    function initProfiler () {
-      Profiler = proxyquire('../src/profiling/profiler', {
-        '@datadog/pprof': {
-          SourceMapper: {
-            create: sourceMapCreate
-          }
+  function initProfiler () {
+    Profiler = proxyquire('../src/profiling/profiler', {
+      '@datadog/pprof': {
+        SourceMapper: {
+          create: sourceMapCreate
         }
-      }).Profiler
-
-      profiler = new Profiler()
-    }
-
-    beforeEach(() => {
-      setUpProfiler()
-      initProfiler()
-    })
-
-    afterEach(() => {
-      profiler.stop()
-      clock.restore()
-    })
-
-    it('should start the internal time profilers', async () => {
-      await profiler._start({ profilers, exporters })
-
-      sinon.assert.calledOnce(wallProfiler.start)
-      sinon.assert.calledOnce(spaceProfiler.start)
-    })
-
-    it('should start only once', async () => {
-      await profiler._start({ profilers, exporters })
-      await profiler._start({ profilers, exporters })
-
-      sinon.assert.calledOnce(wallProfiler.start)
-      sinon.assert.calledOnce(spaceProfiler.start)
-    })
-
-    it('should allow configuring exporters by string or string array', async () => {
-      const checks = [
-        'agent',
-        ['agent']
-      ]
-
-      for (const exporters of checks) {
-        await profiler._start({
-          sourceMap: false,
-          exporters
-        })
-
-        expect(profiler._config.exporters[0].export).to.be.a('function')
-
-        profiler.stop()
       }
-    })
+    }).Profiler
 
-    it('should allow configuring profilers by string or string arrays', async () => {
-      const checks = [
-        ['space', SpaceProfiler],
-        ['wall', WallProfiler, EventsProfiler],
-        ['space,wall', SpaceProfiler, WallProfiler, EventsProfiler],
-        ['wall,space', WallProfiler, SpaceProfiler, EventsProfiler],
-        [['space', 'wall'], SpaceProfiler, WallProfiler, EventsProfiler],
-        [['wall', 'space'], WallProfiler, SpaceProfiler, EventsProfiler]
-      ].map(profilers => profilers.filter(profiler => samplingContextsAvailable || profiler !== EventsProfiler))
+    profiler = new Profiler()
+  }
 
-      for (const [profilers, ...expected] of checks) {
-        await profiler._start({
-          sourceMap: false,
-          profilers
-        })
-
-        expect(profiler._config.profilers.length).to.equal(expected.length)
-        for (let i = 0; i < expected.length; i++) {
-          expect(profiler._config.profilers[i]).to.be.instanceOf(expected[i])
-        }
-
-        profiler.stop()
-      }
-    })
-
-    it('should stop the internal profilers', async () => {
-      await profiler._start({ profilers, exporters })
-      profiler.stop()
-
-      sinon.assert.calledOnce(wallProfiler.stop)
-      sinon.assert.calledOnce(spaceProfiler.stop)
-    })
-
-    it('should stop when starting failed', async () => {
-      wallProfiler.start.throws()
-
-      await profiler._start({ profilers, exporters, logger })
-
-      sinon.assert.calledOnce(wallProfiler.stop)
-      sinon.assert.calledOnce(spaceProfiler.stop)
-      sinon.assert.calledOnce(consoleLogger.error)
-    })
-
-    it('should stop when capturing failed', async () => {
-      const rejected = Promise.reject(new Error('boom'))
-      wallProfiler.encode.returns(rejected)
-
-      await profiler._start({ profilers, exporters, logger })
-
-      clock.tick(interval)
-
-      await rejected.catch(() => {})
-
-      sinon.assert.calledOnce(wallProfiler.stop)
-      sinon.assert.calledOnce(spaceProfiler.stop)
-      sinon.assert.calledOnce(consoleLogger.error)
-    })
-
-    it('should flush when the interval is reached', async () => {
-      await profiler._start({ profilers, exporters })
-
-      clock.tick(interval)
-
-      await waitForExport()
-
-      sinon.assert.calledOnce(exporter.export)
-    })
-
-    it('should flush when the profiler is stopped', async () => {
-      await profiler._start({ profilers, exporters })
-
-      profiler.stop()
-
-      await waitForExport()
-
-      sinon.assert.calledOnce(exporter.export)
-    })
-
-    it('should export profiles', async () => {
-      await profiler._start({ profilers, exporters, tags: { foo: 'foo' } })
-
-      clock.tick(interval)
-
-      await waitForExport()
-
-      const { profiles, start, end, tags } = exporter.export.args[0][0]
-
-      expect(profiles).to.have.property('wall', wallProfile)
-      expect(profiles).to.have.property('space', spaceProfile)
-      expect(start).to.be.a('date')
-      expect(end).to.be.a('date')
-      expect(end - start).to.equal(65000)
-      expect(tags).to.have.property('foo', 'foo')
-    })
-
-    it('should log exporter errors', async () => {
-      exporter.export.rejects(new Error('boom'))
-
-      await profiler._start({ profilers, exporters, logger })
-
-      clock.tick(interval)
-
-      await waitForExport()
-
-      sinon.assert.calledOnce(consoleLogger.error)
-    })
-
-    it('should log encoded profile', async () => {
-      exporter.export.rejects(new Error('boom'))
-
-      await profiler._start({ profilers, exporters, logger })
-
-      clock.tick(interval)
-
-      await waitForExport()
-
-      const [
-        startWall,
-        startSpace,
-        collectWall,
-        collectSpace,
-        submit
-      ] = consoleLogger.debug.getCalls()
-
-      sinon.assert.calledWithMatch(startWall, 'Started wall profiler')
-      sinon.assert.calledWithMatch(startSpace, 'Started space profiler')
-
-      expect(collectWall.args[0]()).to.match(/^Collected wall profile: /)
-      expect(collectSpace.args[0]()).to.match(/^Collected space profile: /)
-
-      sinon.assert.calledWithMatch(submit, 'Submitted profiles')
-    })
-
-    it('should skip submit with no profiles', async () => {
-      const start = new Date()
-      const end = new Date()
-      try {
-        await profiler._submit({}, start, end)
-        throw new Error('should have got exception from _submit')
-      } catch (err) {
-        expect(err.message).to.equal('No profiles to submit')
-      }
-    })
-
-    it('should have a new start time for each capture', async () => {
-      await profiler._start({ profilers, exporters })
-
-      clock.tick(interval)
-      await waitForExport()
-
-      const { start, end } = exporter.export.args[0][0]
-      expect(start).to.be.a('date')
-      expect(end).to.be.a('date')
-      expect(end - start).to.equal(65000)
-
-      sinon.assert.calledOnce(exporter.export)
-
-      exporter.export.resetHistory()
-
-      clock.tick(interval)
-      await waitForExport()
-
-      const { start: start2, end: end2 } = exporter.export.args[0][0]
-      expect(start2).to.be.greaterThanOrEqual(end)
-      expect(start2).to.be.a('date')
-      expect(end2).to.be.a('date')
-      expect(end2 - start2).to.equal(65000)
-
-      sinon.assert.calledOnce(exporter.export)
-    })
-
-    it('should not pass source mapper to profilers when disabled', async () => {
-      await profiler._start({ profilers, exporters, sourceMap: false })
-
-      const options = profilers[0].start.args[0][0]
-      expect(options).to.have.property('mapper', undefined)
-    })
-
-    it('should pass source mapper to profilers when enabled', async () => {
-      const mapper = {}
-      sourceMapCreate.returns(mapper)
-      await profiler._start({ profilers, exporters, sourceMap: true })
-
-      const options = profilers[0].start.args[0][0]
-      expect(options).to.have.property('mapper')
-        .which.equals(mapper)
-    })
-
-    it('should work with a root working dir and source maps on', async () => {
-      const error = new Error('fail')
-      sourceMapCreate.rejects(error)
-      await profiler._start({ profilers, exporters, logger, sourceMap: true })
-      expect(consoleLogger.error.args[0][0]).to.equal(error)
-      expect(profiler._enabled).to.equal(true)
-    })
+  beforeEach(() => {
+    setUpProfiler()
+    initProfiler()
   })
 
-  describe('serverless', function () {
-    const flushAfterIntervals = 65
+  afterEach(() => {
+    profiler.stop()
+    clock.restore()
+  })
 
-    function initServerlessProfiler () {
-      Profiler = proxyquire('../src/profiling/profiler', {
-        '@datadog/pprof': {
-          SourceMapper: {
-            create: sourceMapCreate
-          }
-        }
-      }).ServerlessProfiler
+  it('should start the internal time profilers', async () => {
+    await profiler._start({ profilers, exporters })
 
-      interval = 1 * 1000
+    sinon.assert.calledOnce(wallProfiler.start)
+    sinon.assert.calledOnce(spaceProfiler.start)
+  })
 
-      profiler = new Profiler()
-    }
+  it('should start only once', async () => {
+    await profiler._start({ profilers, exporters })
+    await profiler._start({ profilers, exporters })
 
-    beforeEach(() => {
-      process.env.AWS_LAMBDA_FUNCTION_NAME = 'foobar'
-      setUpProfiler()
-      initServerlessProfiler()
-    })
+    sinon.assert.calledOnce(wallProfiler.start)
+    sinon.assert.calledOnce(spaceProfiler.start)
+  })
 
-    afterEach(() => {
+  it('should allow configuring exporters by string or string array', async () => {
+    const checks = [
+      'agent',
+      ['agent']
+    ]
+
+    for (const exporters of checks) {
+      await profiler._start({
+        sourceMap: false,
+        exporters
+      })
+
+      expect(profiler._config.exporters[0].export).to.be.a('function')
+
       profiler.stop()
-      clock.restore()
-      delete process.env.AWS_LAMBDA_FUNCTION_NAME
-    })
+    }
+  })
 
-    it('should increment profiled intervals after one interval elapses', async () => {
-      await profiler._start({ profilers, exporters })
-      expect(profiler._profiledIntervals).to.equal(0)
+  it('should allow configuring profilers by string or string arrays', async () => {
+    const checks = [
+      ['space', SpaceProfiler],
+      ['wall', WallProfiler, EventsProfiler],
+      ['space,wall', SpaceProfiler, WallProfiler, EventsProfiler],
+      ['wall,space', WallProfiler, SpaceProfiler, EventsProfiler],
+      [['space', 'wall'], SpaceProfiler, WallProfiler, EventsProfiler],
+      [['wall', 'space'], WallProfiler, SpaceProfiler, EventsProfiler]
+    ].map(profilers => profilers.filter(profiler => samplingContextsAvailable || profiler !== EventsProfiler))
 
-      clock.tick(interval)
+    for (const [profilers, ...expected] of checks) {
+      await profiler._start({
+        sourceMap: false,
+        profilers
+      })
 
-      expect(profiler._profiledIntervals).to.equal(1)
-      sinon.assert.notCalled(exporter.export)
-    })
-
-    it('calls the profiler.profile() methods once per interval', async () => {
-      await profiler._start({ profilers, exporters })
-
-      for (let i = 0; i < flushAfterIntervals + 1; i++) {
-        clock.tick(interval)
+      expect(profiler._config.profilers.length).to.equal(expected.length)
+      for (let i = 0; i < expected.length; i++) {
+        expect(profiler._config.profilers[i]).to.be.instanceOf(expected[i])
       }
 
-      for (const configuredProfiler of profilers) {
-        sinon.assert.callCount(configuredProfiler.profile, flushAfterIntervals);
-      }
-    });
+      profiler.stop()
+    }
+  })
 
-    it('should flush when flush after intervals is reached', async () => {
-      await profiler._start({ profilers, exporters })
+  it('should stop the internal profilers', async () => {
+    await profiler._start({ profilers, exporters })
+    profiler.stop()
 
-      // flushAfterIntervals + 1 becauses flushes after last interval
-      for (let i = 0; i < flushAfterIntervals + 1; i++) {
-        clock.tick(interval)
-      }
+    sinon.assert.calledOnce(wallProfiler.stop)
+    sinon.assert.calledOnce(spaceProfiler.stop)
+  })
 
-      await waitForExport()
+  it('should stop when starting failed', async () => {
+    wallProfiler.start.throws()
 
-      sinon.assert.calledOnce(exporter.export)
-    })
+    await profiler._start({ profilers, exporters, logger })
+
+    sinon.assert.calledOnce(wallProfiler.stop)
+    sinon.assert.calledOnce(spaceProfiler.stop)
+    sinon.assert.calledOnce(consoleLogger.error)
+  })
+
+  it('should stop when capturing failed', async () => {
+    const rejected = Promise.reject(new Error('boom'))
+    wallProfiler.encode.returns(rejected)
+
+    await profiler._start({ profilers, exporters, logger })
+
+    clock.tick(interval)
+
+    await rejected.catch(() => {})
+
+    sinon.assert.calledOnce(wallProfiler.stop)
+    sinon.assert.calledOnce(spaceProfiler.stop)
+    sinon.assert.calledOnce(consoleLogger.error)
+  })
+
+  it('should flush when the interval is reached', async () => {
+    await profiler._start({ profilers, exporters })
+
+    clock.tick(interval)
+
+    await waitForExport()
+
+    sinon.assert.calledOnce(exporter.export)
+  })
+
+  it('should flush when the profiler is stopped', async () => {
+    await profiler._start({ profilers, exporters })
+
+    profiler.stop()
+
+    await waitForExport()
+
+    sinon.assert.calledOnce(exporter.export)
+  })
+
+  it('should export profiles', async () => {
+    await profiler._start({ profilers, exporters, tags: { foo: 'foo' } })
+
+    clock.tick(interval)
+
+    await waitForExport()
+
+    const { profiles, start, end, tags } = exporter.export.args[0][0]
+
+    expect(profiles).to.have.property('wall', wallProfile)
+    expect(profiles).to.have.property('space', spaceProfile)
+    expect(start).to.be.a('date')
+    expect(end).to.be.a('date')
+    expect(end - start).to.equal(65000)
+    expect(tags).to.have.property('foo', 'foo')
+  })
+
+  it('should log exporter errors', async () => {
+    exporter.export.rejects(new Error('boom'))
+
+    await profiler._start({ profilers, exporters, logger })
+
+    clock.tick(interval)
+
+    await waitForExport()
+
+    sinon.assert.calledOnce(consoleLogger.error)
+  })
+
+  it('should log encoded profile', async () => {
+    exporter.export.rejects(new Error('boom'))
+
+    await profiler._start({ profilers, exporters, logger })
+
+    clock.tick(interval)
+
+    await waitForExport()
+
+    const [
+      startWall,
+      startSpace,
+      collectWall,
+      collectSpace,
+      submit
+    ] = consoleLogger.debug.getCalls()
+
+    sinon.assert.calledWithMatch(startWall, 'Started wall profiler')
+    sinon.assert.calledWithMatch(startSpace, 'Started space profiler')
+
+    expect(collectWall.args[0]()).to.match(/^Collected wall profile: /)
+    expect(collectSpace.args[0]()).to.match(/^Collected space profile: /)
+
+    sinon.assert.calledWithMatch(submit, 'Submitted profiles')
+  })
+
+  it('should skip submit with no profiles', async () => {
+    const start = new Date()
+    const end = new Date()
+    try {
+      await profiler._submit({}, start, end)
+      throw new Error('should have got exception from _submit')
+    } catch (err) {
+      expect(err.message).to.equal('No profiles to submit')
+    }
+  })
+
+  it('should have a new start time for each capture', async () => {
+    await profiler._start({ profilers, exporters })
+
+    clock.tick(interval)
+    await waitForExport()
+
+    const { start, end } = exporter.export.args[0][0]
+    expect(start).to.be.a('date')
+    expect(end).to.be.a('date')
+    expect(end - start).to.equal(65000)
+
+    sinon.assert.calledOnce(exporter.export)
+
+    exporter.export.resetHistory()
+
+    clock.tick(interval)
+    await waitForExport()
+
+    const { start: start2, end: end2 } = exporter.export.args[0][0]
+    expect(start2).to.be.greaterThanOrEqual(end)
+    expect(start2).to.be.a('date')
+    expect(end2).to.be.a('date')
+    expect(end2 - start2).to.equal(65000)
+
+    sinon.assert.calledOnce(exporter.export)
+  })
+
+  it('should not pass source mapper to profilers when disabled', async () => {
+    await profiler._start({ profilers, exporters, sourceMap: false })
+
+    const options = profilers[0].start.args[0][0]
+    expect(options).to.have.property('mapper', undefined)
+  })
+
+  it('should pass source mapper to profilers when enabled', async () => {
+    const mapper = {}
+    sourceMapCreate.returns(mapper)
+    await profiler._start({ profilers, exporters, sourceMap: true })
+
+    const options = profilers[0].start.args[0][0]
+    expect(options).to.have.property('mapper')
+      .which.equals(mapper)
+  })
+
+  it('should work with a root working dir and source maps on', async () => {
+    const error = new Error('fail')
+    sourceMapCreate.rejects(error)
+    await profiler._start({ profilers, exporters, logger, sourceMap: true })
+    expect(consoleLogger.error.args[0][0]).to.equal(error)
+    expect(profiler._enabled).to.equal(true)
   })
 })


### PR DESCRIPTION
### What does this PR do?

This PR removes the implementation of the `ServerlessProfiler`, because its behavior was effectively identical to that of the standard `Profiler`. It keeps the old constant around, just in case anybody is importing and using it, but now it's just a reference to the base `Profiler`.

Lots of whitespace differences here in the tests because I removed an outer `describe()`, so [view with whitespace off](https://github.com/DataDog/dd-trace-js/pull/4652/files?w=1) to get a clearer picture of what actually changed.

### Motivation

See the original description below for my initial investigation, when I added a failing test to reveal the failure of the serverless scheduler to actually do anything different from the non-serverless one. I could have kept the scheduler around and fixed it, but it seems better to remove it. When a Lambda function is frozen, any timers will get frozen too, so the base `Profiler` class will work just fine (instead of waiting 65 ⨉ 1-second chunks, it can just wait a single 65-second chunk with the same effect).

<details>
 <summary>Original description</summary>

In a non-serverless environment, the profiler runs for 65 seconds, then we grab the profile data and submit it.

In a serverless context, we do something different, using a different scheduler. Serverless functions may run for a short interval before being suspended (or frozen, or paused, or whatever you want to call it) and then be resumed. The intent is for us to grab profile data in smaller chunks of 1 second each. After 65 chunks, we submit to the server. I'm not sure of exactly _why_ we want to do it like that, because in practice we should end up obtaining the same profile data (the `profiler.profile()` call takes as parameters the start and end date that we care about, along with a `restart` parameter if we want the profiler to continue sampling; the fact that our timers may pause and resume should have no impact on the timestamps that get passed into the profiler).

Comments in Slack suggest that the intent of the original PR:

- https://github.com/DataDog/dd-trace-js/pull/2495

was:

> if a function is called once and runs for 1s, then frozen for a minute until the next call, the profiler would flush a very small profile
>
> so instead the idea was to collect/merge the 65 profiles over the course of multiple calls

However:

1. What the current scheduler is actually doing is just setting 65 1-second timers in a row and then grabbing all the profile data and submitting it. This commit adds a failing test to show that this is the case (the existing test only asserted that we "ticked" 65 times before flushing, not that we collected 65 1-second chunks of profiling data before flushing).
2. It's not clear to me that the scheduler is needed at all. In its current form, it is behaving basically equivalent to the non-serverless scheduler. But I don't think a scheduler that did what that PR intended to do would stop us from submitting small profiles anyway: if a Lambda is frozen (along with its timers) and resumed, we'd still only submit after 65 seconds of actual profiling. And if the Lambda is stopped (gracefully as opposed to being unceremoniously terminated), then our `_stop()` logic will run which cleans up the timers and does not flush. (The only time we eagerly submit before the time is up is if our `_nearOOMExport()` method gets triggered via a callback.)
3. 
</details>

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Nope.

