### PR TITLE
Check context disposal before calling WAF run

### DIFF
--- a/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
+++ b/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
@@ -51,6 +51,11 @@ class WAFContextWrapper {
 
     if (!payloadHasData) return
 
+    if (this.ddwafContext.disposed) {
+      log.warn('Calling run on a disposed context')
+      return
+    }
+
     try {
       const start = process.hrtime.bigint()
 

--- a/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
+++ b/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
@@ -20,6 +20,11 @@ class WAFContextWrapper {
   }
 
   run ({ persistent, ephemeral }, raspRuleType) {
+    if (this.ddwafContext.disposed) {
+      log.warn('Calling run on a disposed context')
+      return
+    }
+
     const payload = {}
     let payloadHasData = false
     const inputs = {}
@@ -50,11 +55,6 @@ class WAFContextWrapper {
     }
 
     if (!payloadHasData) return
-
-    if (this.ddwafContext.disposed) {
-      log.warn('Calling run on a disposed context')
-      return
-    }
 
     try {
       const start = process.hrtime.bigint()

--- a/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
+++ b/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
@@ -91,7 +91,7 @@ describe('WAFContextWrapper', () => {
       sinon.assert.calledOnce(ddwafContext.run)
     })
 
-    it('Should not call run if context is disposed', () => {
+    it('Should not call run and log a warn if context is disposed', () => {
       ddwafContext.disposed = true
 
       const payload = {
@@ -103,19 +103,6 @@ describe('WAFContextWrapper', () => {
       wafContextWrapper.run(payload)
 
       sinon.assert.notCalled(ddwafContext.run)
-    })
-
-    it('Should log a warn when attempting to call run on a disposed context', () => {
-      ddwafContext.disposed = true
-
-      const payload = {
-        persistent: {
-          [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
-        }
-      }
-
-      wafContextWrapper.run(payload)
-
       sinon.assert.calledOnceWithExactly(log.warn, 'Calling run on a disposed context')
     })
   })

--- a/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
+++ b/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const proxyquire = require('proxyquire')
 const WAFContextWrapper = require('../../../src/appsec/waf/waf_context_wrapper')
 const addresses = require('../../../src/appsec/addresses')
 
@@ -49,5 +50,73 @@ describe('WAFContextWrapper', () => {
         }
       }
     }, 1000)
+  })
+
+  describe('Disposal context check', () => {
+    let log
+    let ddwafContext
+    let wafContextWrapper
+
+    beforeEach(() => {
+      log = {
+        warn: sinon.stub()
+      }
+
+      ddwafContext = {
+        run: sinon.stub()
+      }
+
+      const ProxiedWafContextWrapper = proxyquire('../../../src/appsec/waf/waf_context_wrapper', {
+        '../../log': log
+      })
+
+      wafContextWrapper = new ProxiedWafContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0')
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('Should call run if context is not disposed', () => {
+      ddwafContext.disposed = false
+
+      const payload = {
+        persistent: {
+          [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
+        }
+      }
+
+      wafContextWrapper.run(payload)
+
+      sinon.assert.calledOnce(ddwafContext.run)
+    })
+
+    it('Should not call run if context is disposed', () => {
+      ddwafContext.disposed = true
+
+      const payload = {
+        persistent: {
+          [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
+        }
+      }
+
+      wafContextWrapper.run(payload)
+
+      sinon.assert.notCalled(ddwafContext.run)
+    })
+
+    it('Should log a warn when attempting to call run on a disposed context', () => {
+      ddwafContext.disposed = true
+
+      const payload = {
+        persistent: {
+          [addresses.HTTP_INCOMING_QUERY]: { key: 'value' }
+        }
+      }
+
+      wafContextWrapper.run(payload)
+
+      sinon.assert.calledOnceWithExactly(log.warn, 'Calling run on a disposed context')
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Checks WAF context before calling WAF run. If the context has been already disposed, log a warning.

### Motivation
Change the logging level of this situation to warning.


