### PR TITLE
PROF-10497: Add span IDs to timeline DNS and TCP events

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -125,10 +125,12 @@ async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args
   const addressKey = strings.dedup('address')
   const portKey = strings.dedup('port')
   const nameKey = strings.dedup('operation')
+  const spanIdKey = strings.dedup('span id')
+  const localRootSpanIdKey = strings.dedup('local root span id')
   const eventValue = strings.dedup(eventType)
   const events = []
   for (const sample of profile.sample) {
-    let ts, event, host, address, port, name
+    let ts, event, host, address, port, name, spanId, localRootSpanId
     for (const label of sample.label) {
       switch (label.key) {
         case tsKey: ts = label.num; break
@@ -137,6 +139,8 @@ async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args
         case hostKey: host = label.str; break
         case addressKey: address = label.str; break
         case portKey: port = label.num; break
+        case spanIdKey: spanId = label.str; break
+        case localRootSpanIdKey: localRootSpanId = label.str; break
         default: assert.fail(`Unexpected label key ${label.key} ${strings.strings[label.key]} ${encoded}`)
       }
     }
@@ -144,6 +148,13 @@ async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args
     assert.isDefined(ts, encoded)
     assert.isTrue(ts <= procEnd, encoded)
     assert.isTrue(ts >= procStart, encoded)
+    if (process.platform !== 'win32') {
+      assert.isDefined(spanId, encoded)
+      assert.isDefined(localRootSpanId, encoded)
+    } else {
+      assert.isUndefined(spanId, encoded)
+      assert.isUndefined(localRootSpanId, encoded)
+    }
     // Gather only DNS events; ignore sporadic GC events
     if (event === eventValue) {
       assert.isDefined(name, encoded)

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns.js
@@ -1,0 +1,13 @@
+const EventPlugin = require('./event')
+
+class DNSPlugin extends EventPlugin {
+  static get id () {
+    return 'dns'
+  }
+
+  static get entryType () {
+    return 'dns'
+  }
+}
+
+module.exports = DNSPlugin

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookup.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookup.js
@@ -1,0 +1,16 @@
+const DNSPlugin = require('./dns')
+
+class DNSLookupPlugin extends DNSPlugin {
+  static get operation () {
+    return 'lookup'
+  }
+
+  extendEvent (event, startEvent) {
+    event.name = 'lookup'
+    event.detail = { hostname: startEvent[0] }
+
+    return event
+  }
+}
+
+module.exports = DNSLookupPlugin

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookupservice.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookupservice.js
@@ -1,0 +1,16 @@
+const DNSPlugin = require('./dns')
+
+class DNSLookupServicePlugin extends DNSPlugin {
+  static get operation () {
+    return 'lookup_service'
+  }
+
+  extendEvent (event, startEvent) {
+    event.name = 'lookupService'
+    event.detail = { host: startEvent[0], port: startEvent[1] }
+
+    return event
+  }
+}
+
+module.exports = DNSLookupServicePlugin

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_resolve.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_resolve.js
@@ -1,0 +1,24 @@
+const DNSPlugin = require('./dns')
+
+const queryNames = new Map()
+
+class DNSResolvePlugin extends DNSPlugin {
+  static get operation () {
+    return 'resolve'
+  }
+
+  extendEvent (event, startEvent) {
+    const rrtype = startEvent[1]
+    let name = queryNames.get(rrtype)
+    if (!name) {
+      name = `query${rrtype}`
+      queryNames.set(rrtype, name)
+    }
+    event.name = name
+    event.detail = { host: startEvent[0] }
+
+    return event
+  }
+}
+
+module.exports = DNSResolvePlugin

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_reverse.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_reverse.js
@@ -1,0 +1,16 @@
+const DNSPlugin = require('./dns')
+
+class DNSReversePlugin extends DNSPlugin {
+  static get operation () {
+    return 'reverse'
+  }
+
+  extendEvent (event, startEvent) {
+    event.name = 'getHostByAddr'
+    event.detail = { host: startEvent[0] }
+
+    return event
+  }
+}
+
+module.exports = DNSReversePlugin

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -1,0 +1,48 @@
+const { AsyncLocalStorage } = require('async_hooks')
+const TracingPlugin = require('../../../plugins/tracing')
+const { performance } = require('perf_hooks')
+
+// We are leveraging the TracingPlugin class for its functionality to bind
+// start/error/finish methods to the appropriate diagnostic channels.
+class EventPlugin extends TracingPlugin {
+  constructor (eventHandler) {
+    super()
+    this.eventHandler = eventHandler
+    this.store = new AsyncLocalStorage()
+    this.entryType = this.constructor.entryType
+  }
+
+  start (startEvent) {
+    this.store.enterWith({
+      startEvent,
+      startTime: performance.now()
+    })
+  }
+
+  error () {
+    this.store.getStore().error = true
+  }
+
+  finish () {
+    const { startEvent, startTime, error } = this.store.getStore()
+    if (error) {
+      return // don't emit perf events for failed operations
+    }
+    const duration = performance.now() - startTime
+
+    const context = this.activeSpan?.context()
+    const _ddSpanId = context?.toSpanId()
+    const _ddRootSpanId = context?._trace.started[0]?.context().toSpanId() || _ddSpanId
+
+    const event = {
+      entryType: this.entryType,
+      startTime,
+      duration,
+      _ddSpanId,
+      _ddRootSpanId
+    }
+    this.eventHandler(this.extendEvent(event, startEvent))
+  }
+}
+
+module.exports = EventPlugin

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/net.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/net.js
@@ -1,0 +1,24 @@
+const EventPlugin = require('./event')
+
+class NetPlugin extends EventPlugin {
+  static get id () {
+    return 'net'
+  }
+
+  static get operation () {
+    return 'tcp'
+  }
+
+  static get entryType () {
+    return 'net'
+  }
+
+  extendEvent (event, { options }) {
+    event.name = 'connect'
+    event.detail = options
+
+    return event
+  }
+}
+
+module.exports = NetPlugin

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -1,11 +1,7 @@
 const { performance, constants, PerformanceObserver } = require('perf_hooks')
 const { END_TIMESTAMP_LABEL } = require('./shared')
-const semver = require('semver')
 const { Function, Label, Line, Location, Profile, Sample, StringTable, ValueType } = require('pprof-format')
 const pprof = require('@datadog/pprof/')
-
-// Format of perf_hooks events changed with Node 16, we need to be mindful of it.
-const node16 = semver.gte(process.version, '16.0.0')
 
 // perf_hooks uses millis, with fractional part representing nanos. We emit nanos into the pprof file.
 const MS_TO_NS = 1000000
@@ -48,7 +44,7 @@ class GCDecorator {
   }
 
   decorateSample (sampleInput, item) {
-    const { kind, flags } = node16 ? item.detail : item
+    const { kind, flags } = item.detail
     sampleInput.label.push(this.kindLabels[kind])
     const reasonLabel = this.getReasonLabel(flags)
     if (reasonLabel) {
@@ -140,12 +136,9 @@ class NetDecorator {
 // Keys correspond to PerformanceEntry.entryType, values are constructor
 // functions for type-specific decorators.
 const decoratorTypes = {
-  gc: GCDecorator
-}
-// Needs at least node 16 for DNS and Net
-if (node16) {
-  decoratorTypes.dns = DNSDecorator
-  decoratorTypes.net = NetDecorator
+  gc: GCDecorator,
+  dns: DNSDecorator,
+  net: NetDecorator
 }
 
 // Translates performance entries into pprof samples.

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -259,7 +259,6 @@ class NodeApiEventSource {
 class EventsProfiler {
   constructor (options = {}) {
     this.type = 'events'
-    this._flushIntervalNanos = (options.flushInterval || 60000) * 1e6 // 60 sec
     this.eventSerializer = new EventSerializer()
 
     const eventHandler = event => this.eventSerializer.addEvent(event)

--- a/packages/dd-trace/src/profiling/profilers/shared.js
+++ b/packages/dd-trace/src/profiling/profilers/shared.js
@@ -6,6 +6,9 @@ const END_TIMESTAMP_LABEL = 'end_timestamp_ns'
 const THREAD_NAME_LABEL = 'thread name'
 const OS_THREAD_ID_LABEL = 'os thread id'
 const THREAD_ID_LABEL = 'thread id'
+const SPAN_ID_LABEL = 'span id'
+const LOCAL_ROOT_SPAN_ID_LABEL = 'local root span id'
+
 const threadNamePrefix = isMainThread ? 'Main' : `Worker #${threadId}`
 const eventLoopThreadName = `${threadNamePrefix} Event Loop`
 
@@ -38,6 +41,8 @@ module.exports = {
   THREAD_NAME_LABEL,
   THREAD_ID_LABEL,
   OS_THREAD_ID_LABEL,
+  SPAN_ID_LABEL,
+  LOCAL_ROOT_SPAN_ID_LABEL,
   threadNamePrefix,
   eventLoopThreadName,
   getNonJSThreadsLabels,

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -7,7 +7,13 @@ const { HTTP_METHOD, HTTP_ROUTE, RESOURCE_NAME, SPAN_TYPE } = require('../../../
 const { WEB } = require('../../../../../ext/types')
 const runtimeMetrics = require('../../runtime_metrics')
 const telemetryMetrics = require('../../telemetry/metrics')
-const { END_TIMESTAMP_LABEL, getNonJSThreadsLabels, getThreadLabels } = require('./shared')
+const {
+  END_TIMESTAMP_LABEL,
+  SPAN_ID_LABEL,
+  LOCAL_ROOT_SPAN_ID_LABEL,
+  getNonJSThreadsLabels,
+  getThreadLabels
+} = require('./shared')
 
 const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
@@ -275,10 +281,10 @@ class NativeWallProfiler {
     }
 
     if (spanId) {
-      labels['span id'] = spanId
+      labels[SPAN_ID_LABEL] = spanId
     }
     if (rootSpanId) {
-      labels['local root span id'] = rootSpanId
+      labels[LOCAL_ROOT_SPAN_ID_LABEL] = rootSpanId
     }
     if (webTags && Object.keys(webTags).length !== 0) {
       labels['trace endpoint'] = endpointNameFromTags(webTags)


### PR DESCRIPTION
### What does this PR do?
Switches from using the Node `perf_hooks` API to using Datadog tracing instrumentation for DNS and TCP events in profiling timeline.

### Motivation
With this change, DNS and TCP events in timeline are associated with spans, so they can be correctly assigned in e.g. tracing Code Hotspots view. `perf_hooks` API is still used for GC events or when code hotspots feature is turned off.

### Additional Notes
* The implementation uses tracing plugins, but it is managing its own plugin instances internally.
* The implementation will add additional subscribers to `apm:dns:*` and `apm:tcp:*` diagnostic channels. This does not contribute notable overhead since both the `net` and `dns` tracing plugins are on by default, and they add subscribers anyway, triggering the use of the more complicated code path in the `net` and `dns` instrumentations.
* If profiling is on, but code hotspots are explicitly turned off (they're on by default, except on Windows) then the implementation falls back to the Node API as it does not require span IDs.