### PR TITLE
Filter addresses before calling to waf to prevent running without knownAddresses

### DIFF
--- a/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
+++ b/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
@@ -11,12 +11,13 @@ const preventDuplicateAddresses = new Set([
 ])
 
 class WAFContextWrapper {
-  constructor (ddwafContext, wafTimeout, wafVersion, rulesVersion) {
+  constructor (ddwafContext, wafTimeout, wafVersion, rulesVersion, knownAddresses) {
     this.ddwafContext = ddwafContext
     this.wafTimeout = wafTimeout
     this.wafVersion = wafVersion
     this.rulesVersion = rulesVersion
     this.addressesToSkip = new Set()
+    this.knownAddresses = knownAddresses
   }
 
   run ({ persistent, ephemeral }, raspRuleType) {
@@ -27,7 +28,8 @@ class WAFContextWrapper {
 
     const payload = {}
     let payloadHasData = false
-    const inputs = {}
+    const persistentInputs = {}
+    const ephemeralInputs = {}
     const newAddressesToSkip = new Set(this.addressesToSkip)
 
     if (persistent !== null && typeof persistent === 'object') {
@@ -35,8 +37,8 @@ class WAFContextWrapper {
       for (const key of Object.keys(persistent)) {
         // TODO: requiredAddresses is no longer used due to processor addresses are not included in the list. Check on
         // future versions when the actual addresses are included in the 'loaded' section inside diagnostics.
-        if (!this.addressesToSkip.has(key)) {
-          inputs[key] = persistent[key]
+        if (!this.addressesToSkip.has(key) && this.knownAddresses.has(key)) {
+          persistentInputs[key] = persistent[key]
           if (preventDuplicateAddresses.has(key)) {
             newAddressesToSkip.add(key)
           }
@@ -44,13 +46,21 @@ class WAFContextWrapper {
       }
     }
 
-    if (Object.keys(inputs).length) {
-      payload.persistent = inputs
+    if (ephemeral !== null && typeof ephemeral === 'object') {
+      for (const key of Object.keys(ephemeral)) {
+        if (this.knownAddresses.has(key)) {
+          ephemeralInputs[key] = ephemeral[key]
+        }
+      }
+    }
+
+    if (Object.keys(persistentInputs).length) {
+      payload.persistent = persistentInputs
       payloadHasData = true
     }
 
-    if (ephemeral && Object.keys(ephemeral).length) {
-      payload.ephemeral = ephemeral
+    if (Object.keys(ephemeralInputs).length) {
+      payload.ephemeral = ephemeralInputs
       payloadHasData = true
     }
 

--- a/packages/dd-trace/src/appsec/waf/waf_manager.js
+++ b/packages/dd-trace/src/appsec/waf/waf_manager.js
@@ -39,7 +39,8 @@ class WAFManager {
         this.ddwaf.createContext(),
         this.wafTimeout,
         this.ddwafVersion,
-        this.rulesVersion
+        this.rulesVersion,
+        this.ddwaf.knownAddresses
       )
       contexts.set(req, wafContext)
     }

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -7,6 +7,14 @@ const Reporter = require('../../../src/appsec/reporter')
 const web = require('../../../src/plugins/util/web')
 
 describe('WAF Manager', () => {
+  const knownAddresses = new Set([
+    'server.io.net.url',
+    'server.request.headers.no_cookies',
+    'server.request.uri.raw',
+    'processor.address',
+    'server.request.body',
+    'waf.context.processor'
+  ])
   let waf, WAFManager
   let DDWAF
   let config
@@ -26,6 +34,7 @@ describe('WAF Manager', () => {
         loaded: ['rule_1'], failed: []
       }
     }
+    DDWAF.prototype.knownAddresses = knownAddresses
 
     WAFManager = proxyquire('../../../src/appsec/waf/waf_manager', {
       '@datadog/native-appsec': { DDWAF }

--- a/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
+++ b/packages/dd-trace/test/appsec/waf/waf_context_wrapper.spec.js
@@ -5,11 +5,16 @@ const WAFContextWrapper = require('../../../src/appsec/waf/waf_context_wrapper')
 const addresses = require('../../../src/appsec/addresses')
 
 describe('WAFContextWrapper', () => {
+  const knownAddresses = new Set([
+    addresses.HTTP_INCOMING_QUERY,
+    addresses.HTTP_INCOMING_GRAPHQL_RESOLVER
+  ])
+
   it('Should send HTTP_INCOMING_QUERY only once', () => {
     const ddwafContext = {
       run: sinon.stub()
     }
-    const wafContextWrapper = new WAFContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0')
+    const wafContextWrapper = new WAFContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0', knownAddresses)
 
     const payload = {
       persistent: {
@@ -27,7 +32,7 @@ describe('WAFContextWrapper', () => {
     const ddwafContext = {
       run: sinon.stub()
     }
-    const wafContextWrapper = new WAFContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0')
+    const wafContextWrapper = new WAFContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0', knownAddresses)
 
     const payload = {
       persistent: {
@@ -52,6 +57,26 @@ describe('WAFContextWrapper', () => {
     }, 1000)
   })
 
+  it('Should ignore run without known addresses', () => {
+    const ddwafContext = {
+      run: sinon.stub()
+    }
+    const wafContextWrapper = new WAFContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0', knownAddresses)
+
+    const payload = {
+      persistent: {
+        'persistent-unknown-address': { key: 'value' }
+      },
+      ephemeral: {
+        'ephemeral-unknown-address': { key: 'value' }
+      }
+    }
+
+    wafContextWrapper.run(payload)
+
+    expect(ddwafContext.run).to.have.not.been.called
+  })
+
   describe('Disposal context check', () => {
     let log
     let ddwafContext
@@ -70,7 +95,7 @@ describe('WAFContextWrapper', () => {
         '../../log': log
       })
 
-      wafContextWrapper = new ProxiedWafContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0')
+      wafContextWrapper = new ProxiedWafContextWrapper(ddwafContext, 1000, '1.14.0', '1.8.0', knownAddresses)
     })
 
     afterEach(() => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


