### PR TITLE
[test] remove unnecessary file

### DIFF
--- a/packages/dd-trace/test/proxyquire.js
+++ b/packages/dd-trace/test/proxyquire.js
@@ -1,3 +1,0 @@
-'use strict'
-
-module.exports = require('proxyquire')

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -3,7 +3,7 @@
 const sinon = require('sinon')
 const chai = require('chai')
 const sinonChai = require('sinon-chai')
-const proxyquire = require('../proxyquire')
+const proxyquire = require('proxyquire')
 
 {
   // get-port can often return a port that is already in use, thanks to a race


### PR DESCRIPTION
The module `packages/dd-trace/test/proxyquire.js` was just re-exporting
the npm module `proxyquire`. Simplyfy the code by removing this extra
require layer and just require the npm module directly.
