### PR TITLE
split couchbase tests by node versions

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -262,7 +262,9 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -286,7 +288,9 @@ jobs:
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v3
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -265,7 +265,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 16
-      - run: yarn test:plugins:ci --ignore-engines
+      - run: yarn config set ignore-engines true
+      - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v3
 
   couchbase-node-18:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -242,10 +242,34 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 
-  couchbase:
+  couchbase-node-16:
     strategy:
       matrix:
-        range: ['^2.6.12', '^3.0.7', '>=4.2.0']
+        range: ['^2.6.12', '^3.0.7', '>=4.0.0 <4.2.0']
+    runs-on: ubuntu-latest
+    services:
+      couchbase:
+        image: ghcr.io/datadog/couchbase-server-sandbox:latest
+        ports:
+          - 8091-8095:8091-8095
+          - 11210:11210
+    env:
+      PLUGINS: couchbase
+      SERVICES: couchbase
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+      - uses: codecov/codecov-action@v3
+
+  couchbase-node-18:
+    strategy:
+      matrix:
+        range: ['>=4.2.0']
     runs-on: ubuntu-latest
     services:
       couchbase:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -265,7 +265,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 16
-      - run: yarn test:plugins:ci
+      - run: yarn test:plugins:ci --ignore-engines
       - uses: codecov/codecov-action@v3
 
   couchbase-node-18:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -242,10 +242,14 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v2
 
-  couchbase-node-16:
+  couchbase:
     strategy:
       matrix:
+        node-version: [16]
         range: ['^2.6.12', '^3.0.7', '>=4.0.0 <4.2.0']
+        include:
+          - node-version: 18
+            range: '>=4.2.0'
     runs-on: ubuntu-latest
     services:
       couchbase:
@@ -264,35 +268,9 @@ jobs:
       - uses: ./.github/actions/install
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: ${{ matrix.node-version }}
       - run: yarn config set ignore-engines true
       - run: yarn test:plugins:ci --ignore-engines
-      - uses: codecov/codecov-action@v3
-
-  couchbase-node-18:
-    strategy:
-      matrix:
-        range: ['>=4.2.0']
-    runs-on: ubuntu-latest
-    services:
-      couchbase:
-        image: ghcr.io/datadog/couchbase-server-sandbox:latest
-        ports:
-          - 8091-8095:8091-8095
-          - 11210:11210
-    env:
-      PLUGINS: couchbase
-      SERVICES: couchbase
-      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
-      - uses: ./.github/actions/install
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@v3
 
   connect:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -266,7 +266,7 @@ jobs:
         with:
           node-version: 16
       - run: yarn config set ignore-engines true
-      - run: yarn test:plugins:ci
+      - run: yarn test:plugins:ci --ignore-engines
       - uses: codecov/codecov-action@v3
 
   couchbase-node-18:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split Couchbase tests by Node versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

There were some gaps in the tested version ranges because of compatibility issues between versions for the server/SDK/Node.