### PR TITLE
Update to actions/upload-artifact@v4 in system tests workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ always() }}
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: logs_${{ matrix.weblog-variant }}-${{ matrix.scenario }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update to actions/upload-artifact@v4 in system tests workflow

### Motivation
<!-- What inspired you to submit this pull request? -->
Seems that `actions/upload-artifact@v2` is not supported anymore and CIs are failing.



