### PR TITLE
chore: bump import-in-the-middle

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "crypto-randomuuid": "^1.0.0",
     "dc-polyfill": "^0.1.4",
     "ignore": "^5.2.4",
-    "import-in-the-middle": "^1.8.1",
+    "import-in-the-middle": "^1.11.0",
     "int64-buffer": "^0.1.9",
     "istanbul-lib-coverage": "3.2.0",
     "jest-docblock": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,10 +2555,10 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.8.1.tgz#8b51c2cc631b64e53e958d7048d2d9463ce628f8"
-  integrity sha512-yhRwoHtiLGvmSozNOALgjRPFI6uYsds60EoMqqnXyyv+JOIW/BrrLejuTGBt+bq0T5tLzOHrN0T7xYTm4Qt/ng==
+import-in-the-middle@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz#a94c4925b8da18256cde3b3b7b38253e6ca5e708"
+  integrity sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==
   dependencies:
     acorn "^8.8.2"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
### What does this PR do?
Pull in https://github.com/nodejs/import-in-the-middle/pull/76. 

### Motivation
We've been getting a recurrence of this issue: https://github.com/DataDog/dd-trace-js/issues/2221#issuecomment-1243122554 that was originally solved in v.3.3.1 of `dd-trace-js`.

```
$ node --import dd-trace/register.js ./server.js

node:internal/process/esm_loader:34
      internalBinding('errors').triggerUncaughtException(
                                ^
TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file
    at fileURLToPath (node:internal/url:1469:11)
```

This has been solved again in the linked fix to `import-in-the-middle`.



