### PR TITLE
[test visibility] Fix `@jest/test-sequencer` instrumentation

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -404,7 +404,7 @@ addHook({
 
 addHook({
   name: '@jest/test-sequencer',
-  versions: ['>=24.8.0']
+  versions: ['>=28']
 }, (sequencerPackage, frameworkVersion) => {
   shimmer.wrap(sequencerPackage.default.prototype, 'shard', shard => function () {
     const shardedTests = shard.apply(this, arguments)


### PR DESCRIPTION
### What does this PR do?
* Bump version of `@jest/test-sequencer` to `28`.

### Motivation
The `shard` method was added in jest@28: https://github.com/jestjs/jest/releases/tag/v28.0.0, so you would get this error when using older `jest` versions:

```
Determining test suites to run...Error during ddtrace instrumentation of application, aborting.
Error: No original method shard.
```

### Plugin Checklist

Just make sure that the tests are still passing. 