### PR TITLE
[test visibility] Cap vitest support until we fix it

### DIFF
--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -19,7 +19,7 @@ const {
   TEST_COMMAND
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
-const versions = ['1.6.0', 'latest']
+const versions = ['1.6.0', '2.0.5']
 
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -184,7 +184,7 @@ function getCreateCliWrapper (vitestPackage, frameworkVersion) {
 
 addHook({
   name: 'vitest',
-  versions: ['>=1.6.0'],
+  versions: ['>=1.6.0 <2.1.0'],
   file: 'dist/runners.js'
 }, (vitestPackage) => {
   const { VitestTestRunner } = vitestPackage
@@ -270,7 +270,7 @@ addHook({
 
 addHook({
   name: 'vitest',
-  versions: ['>=2.0.5'],
+  versions: ['>=2.0.5 <2.1.0'],
   filePattern: 'dist/chunks/index.*'
 }, (vitestPackage) => {
   if (isReporterPackageNewest(vitestPackage)) {
@@ -289,7 +289,7 @@ addHook({
 
 addHook({
   name: 'vitest',
-  versions: ['>=2.0.5'],
+  versions: ['>=2.0.5 <2.1.0'],
   filePattern: 'dist/chunks/cac.*'
 }, getCreateCliWrapper)
 
@@ -297,7 +297,7 @@ addHook({
 // only relevant for workers
 addHook({
   name: '@vitest/runner',
-  versions: ['>=1.6.0'],
+  versions: ['>=1.6.0 <2.1.0'],
   file: 'dist/index.js'
 }, (vitestPackage, frameworkVersion) => {
   shimmer.wrap(vitestPackage, 'startTests', startTests => async function (testPath) {


### PR DESCRIPTION
### What does this PR do?
Cap support to <2.1.0 (https://github.com/vitest-dev/vitest/releases/tag/v2.1.0)

### Motivation
https://github.com/vitest-dev/vitest/releases/tag/v2.1.0 broke our instrumentation, so we want to unblock CI until we fix it.


