### PR TITLE
[test visibility] Fix vitest@2.1.0

### DIFF
--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -19,7 +19,7 @@ const {
   TEST_COMMAND
 } = require('../../packages/dd-trace/src/plugins/util/test')
 
-const versions = ['1.6.0', '2.0.5']
+const versions = ['1.6.0', 'latest']
 
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -184,7 +184,7 @@ function getCreateCliWrapper (vitestPackage, frameworkVersion) {
 
 addHook({
   name: 'vitest',
-  versions: ['>=1.6.0 <2.1.0'],
+  versions: ['>=1.6.0'],
   file: 'dist/runners.js'
 }, (vitestPackage) => {
   const { VitestTestRunner } = vitestPackage
@@ -270,6 +270,15 @@ addHook({
 
 addHook({
   name: 'vitest',
+  versions: ['>=2.1.0'],
+  filePattern: 'dist/chunks/RandomSequencer.*'
+}, (randomSequencerPackage) => {
+  shimmer.wrap(randomSequencerPackage.B.prototype, 'sort', getSortWrapper)
+  return randomSequencerPackage
+})
+
+addHook({
+  name: 'vitest',
   versions: ['>=2.0.5 <2.1.0'],
   filePattern: 'dist/chunks/index.*'
 }, (vitestPackage) => {
@@ -289,7 +298,7 @@ addHook({
 
 addHook({
   name: 'vitest',
-  versions: ['>=2.0.5 <2.1.0'],
+  versions: ['>=2.0.5'],
   filePattern: 'dist/chunks/cac.*'
 }, getCreateCliWrapper)
 
@@ -297,7 +306,7 @@ addHook({
 // only relevant for workers
 addHook({
   name: '@vitest/runner',
-  versions: ['>=1.6.0 <2.1.0'],
+  versions: ['>=1.6.0'],
   file: 'dist/index.js'
 }, (vitestPackage, frameworkVersion) => {
   shimmer.wrap(vitestPackage, 'startTests', startTests => async function (testPath) {


### PR DESCRIPTION
### What does this PR do?
The `BaseSequencer` class that we need for our instrumentation changed its file from `dist/chunks/index.*` to `dist/chunks/RandomSequencer.*`.

### Motivation
https://github.com/vitest-dev/vitest/releases/tag/v2.1.0 broke our instrumentation.

### Plugin Checklist
Same unit tests, only not capped to <2.1.0

- [x] Unit tests.
