### PR TITLE
[MLOB-1540] add llmobs configuration to global tracer config

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -339,7 +339,7 @@ class Config {
     this._applyDefaults()
     this._applyEnvironment()
     this._applyOptions(options)
-    this._applyCalculated(options)
+    this._applyCalculated()
     this._applyRemote({})
     this._merge()
 
@@ -399,7 +399,7 @@ class Config {
     }
 
     // TODO: test
-    this._applyCalculated(options)
+    this._applyCalculated()
     this._merge()
   }
 
@@ -425,10 +425,10 @@ class Config {
     return inAWSLambda || isGCPFunction || isAzureFunction
   }
 
-  _isLLMObsEnabled (options = {}) {
+  _isLLMObsEnabled () {
     return coalesce(
       process.env.DD_LLMOBS_ENABLED,
-      !!options.llmobs
+      !!this._optionsArg.llmobs
     )
   }
 
@@ -1045,7 +1045,7 @@ class Config {
   }
 
   // handles values calculated from a mixture of options and env vars
-  _applyCalculated (options) {
+  _applyCalculated () {
     const calc = setHiddenProperty(this, '_calculated', {})
 
     const {
@@ -1090,7 +1090,7 @@ class Config {
       calc['tracePropagationStyle.extract'] = calc['tracePropagationStyle.extract'] || defaultPropagationStyle
     }
 
-    this._setBoolean(calc, 'llmobs.enabled', this._isLLMObsEnabled(options))
+    this._setBoolean(calc, 'llmobs.enabled', this._isLLMObsEnabled())
   }
 
   _applyRemote (options) {

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -506,7 +506,7 @@ class Config {
     this._setValue(defaults, 'isManualApiEnabled', false)
     this._setValue(defaults, 'llmobs.agentlessEnabled', false)
     this._setValue(defaults, 'llmobs.apiKey', undefined)
-    this._setBoolean(defaults, 'llmobs.enabled', false)
+    this._setValue(defaults, 'llmobs.enabled', false)
     this._setValue(defaults, 'llmobs.mlApp', undefined)
     this._setValue(defaults, 'ciVisibilitySessionName', '')
     this._setValue(defaults, 'logInjection', false)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -284,6 +284,11 @@ class Config {
       options.appsec = {}
     }
 
+    const DD_LLMOBS_ENABLED = coalesce(
+      process.env.DD_LLMOBS_ENABLED,
+      !!options.llmobs
+    )
+
     const DD_INSTRUMENTATION_INSTALL_ID = coalesce(
       process.env.DD_INSTRUMENTATION_INSTALL_ID,
       null
@@ -319,6 +324,10 @@ class Config {
 
     // TODO: refactor
     this.apiKey = DD_API_KEY
+
+    this.llmobs = {
+      enabled: isTrue(DD_LLMOBS_ENABLED)
+    }
 
     // sent in telemetry event app-started
     this.installSignature = {
@@ -497,6 +506,9 @@ class Config {
     this._setValue(defaults, 'isGitUploadEnabled', false)
     this._setValue(defaults, 'isIntelligentTestRunnerEnabled', false)
     this._setValue(defaults, 'isManualApiEnabled', false)
+    this._setValue(defaults, 'llmobs.agentlessEnabled', false)
+    this._setValue(defaults, 'llmobs.apiKey', undefined)
+    this._setValue(defaults, 'llmobs.mlApp', undefined)
     this._setValue(defaults, 'ciVisibilitySessionName', '')
     this._setValue(defaults, 'logInjection', false)
     this._setValue(defaults, 'lookup', undefined)
@@ -594,6 +606,8 @@ class Config {
       DD_INSTRUMENTATION_TELEMETRY_ENABLED,
       DD_INSTRUMENTATION_CONFIG_ID,
       DD_LOGS_INJECTION,
+      DD_LLMOBS_AGENTLESS_ENABLED,
+      DD_LLMOBS_ML_APP,
       DD_OPENAI_LOGS_ENABLED,
       DD_OPENAI_SPAN_CHAR_LIMIT,
       DD_PROFILING_ENABLED,
@@ -734,6 +748,8 @@ class Config {
     this._setArray(env, 'injectionEnabled', DD_INJECTION_ENABLED)
     this._setBoolean(env, 'isAzureFunction', getIsAzureFunction())
     this._setBoolean(env, 'isGCPFunction', getIsGCPFunction())
+    this._setBoolean(env, 'llmobs.agentlessEnabled', DD_LLMOBS_AGENTLESS_ENABLED)
+    this._setString(env, 'llmobs.mlApp', DD_LLMOBS_ML_APP)
     this._setBoolean(env, 'logInjection', DD_LOGS_INJECTION)
     // Requires an accompanying DD_APM_OBFUSCATION_MEMCACHED_KEEP_COMMAND=true in the agent
     this._setBoolean(env, 'memcachedCommandEnabled', DD_TRACE_MEMCACHED_COMMAND_ENABLED)
@@ -902,6 +918,9 @@ class Config {
     }
     this._setString(opts, 'iast.telemetryVerbosity', options.iast && options.iast.telemetryVerbosity)
     this._setBoolean(opts, 'isCiVisibility', options.isCiVisibility)
+    this._setBoolean(opts, 'llmobs.agentlessEnabled', options.llmobs?.agentlessEnabled)
+    this._setString(opts, 'llmobs.apiKey', options.llmobs?.apiKey)
+    this._setString(opts, 'llmobs.mlApp', options.llmobs?.mlApp)
     this._setBoolean(opts, 'logInjection', options.logInjection)
     this._setString(opts, 'lookup', options.lookup)
     this._setBoolean(opts, 'openAiLogsEnabled', options.openAiLogsEnabled)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -2015,29 +2015,54 @@ describe('Config', () => {
     it('should disable llmobs by default', () => {
       const config = new Config()
       expect(config.llmobs.enabled).to.be.false
+
+      // check origin computation
+      expect(updateConfig.getCall(0).args[0]).to.deep.include({
+        name: 'llmobs.enabled', value: false, origin: 'default'
+      })
     })
 
     it('should enable llmobs if DD_LLMOBS_ENABLED is set to true', () => {
       process.env.DD_LLMOBS_ENABLED = 'true'
       const config = new Config()
       expect(config.llmobs.enabled).to.be.true
+
+      // check origin computation
+      expect(updateConfig.getCall(0).args[0]).to.deep.include({
+        name: 'llmobs.enabled', value: true, origin: 'env_var'
+      })
     })
 
     it('should disable llmobs if DD_LLMOBS_ENABLED is set to false', () => {
       process.env.DD_LLMOBS_ENABLED = 'false'
       const config = new Config()
       expect(config.llmobs.enabled).to.be.false
+
+      // check origin computation
+      expect(updateConfig.getCall(0).args[0]).to.deep.include({
+        name: 'llmobs.enabled', value: false, origin: 'env_var'
+      })
     })
 
     it('should enable llmobs with options and DD_LLMOBS_ENABLED is not set', () => {
       const config = new Config({ llmobs: {} })
       expect(config.llmobs.enabled).to.be.true
+
+      // check origin computation
+      expect(updateConfig.getCall(0).args[0]).to.deep.include({
+        name: 'llmobs.enabled', value: true, origin: 'code'
+      })
     })
 
     it('should have DD_LLMOBS_ENABLED take priority over options', () => {
       process.env.DD_LLMOBS_ENABLED = 'false'
-      const config = new Config({ llmobs: { enabled: true } })
+      const config = new Config({ llmobs: {} })
       expect(config.llmobs.enabled).to.be.false
+
+      // check origin computation
+      expect(updateConfig.getCall(0).args[0]).to.deep.include({
+        name: 'llmobs.enabled', value: false, origin: 'env_var'
+      })
     })
   })
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -261,6 +261,9 @@ describe('Config', () => {
     expect(config).to.have.nested.property('installSignature.id', null)
     expect(config).to.have.nested.property('installSignature.time', null)
     expect(config).to.have.nested.property('installSignature.type', null)
+    expect(config).to.have.nested.property('llmobs.mlApp', undefined)
+    expect(config).to.have.nested.property('llmobs.agentlessEnabled', false)
+    expect(config).to.have.nested.property('llmobs.apiKey', undefined)
 
     expect(updateConfig).to.be.calledOnce
 
@@ -323,6 +326,9 @@ describe('Config', () => {
       { name: 'isGitUploadEnabled', value: false, origin: 'default' },
       { name: 'isIntelligentTestRunnerEnabled', value: false, origin: 'default' },
       { name: 'isManualApiEnabled', value: false, origin: 'default' },
+      { name: 'llmobs.agentlessEnabled', value: false, origin: 'default' },
+      { name: 'llmobs.apiKey', value: undefined, origin: 'default' },
+      { name: 'llmobs.mlApp', value: undefined, origin: 'default' },
       { name: 'ciVisibilitySessionName', value: '', origin: 'default' },
       { name: 'logInjection', value: false, origin: 'default' },
       { name: 'lookup', value: undefined, origin: 'default' },
@@ -490,6 +496,8 @@ describe('Config', () => {
     process.env.DD_INSTRUMENTATION_INSTALL_TYPE = 'k8s_single_step'
     process.env.DD_INSTRUMENTATION_INSTALL_TIME = '1703188212'
     process.env.DD_INSTRUMENTATION_CONFIG_ID = 'abcdef123'
+    process.env.DD_LLMOBS_AGENTLESS_ENABLED = 'true'
+    process.env.DD_LLMOBS_ML_APP = 'myMlApp'
 
     // required if we want to check updates to config.debug and config.logLevel which is fetched from logger
     reloadLoggerAndConfig()
@@ -584,6 +592,8 @@ describe('Config', () => {
       type: 'k8s_single_step',
       time: '1703188212'
     })
+    expect(config).to.have.nested.property('llmobs.mlApp', 'myMlApp')
+    expect(config).to.have.nested.property('llmobs.agentlessEnabled', true)
 
     expect(updateConfig).to.be.calledOnce
 
@@ -647,7 +657,9 @@ describe('Config', () => {
       { name: 'traceId128BitGenerationEnabled', value: true, origin: 'env_var' },
       { name: 'traceId128BitLoggingEnabled', value: true, origin: 'env_var' },
       { name: 'tracing', value: false, origin: 'env_var' },
-      { name: 'version', value: '1.0.0', origin: 'env_var' }
+      { name: 'version', value: '1.0.0', origin: 'env_var' },
+      { name: 'llmobs.mlApp', value: 'myMlApp', origin: 'env_var' },
+      { name: 'llmobs.agentlessEnabled', value: true, origin: 'env_var' }
     ])
   })
 
@@ -793,7 +805,12 @@ describe('Config', () => {
         pollInterval: 42
       },
       traceId128BitGenerationEnabled: true,
-      traceId128BitLoggingEnabled: true
+      traceId128BitLoggingEnabled: true,
+      llmobs: {
+        mlApp: 'myMlApp',
+        agentlessEnabled: true,
+        apiKey: 'myApiKey'
+      }
     })
 
     expect(config).to.have.property('protocolVersion', '0.5')
@@ -866,6 +883,9 @@ describe('Config', () => {
       a: 'aa',
       b: 'bb'
     })
+    expect(config).to.have.nested.property('llmobs.mlApp', 'myMlApp')
+    expect(config).to.have.nested.property('llmobs.agentlessEnabled', true)
+    expect(config).to.have.nested.property('llmobs.apiKey', 'myApiKey')
 
     expect(updateConfig).to.be.calledOnce
 
@@ -911,7 +931,10 @@ describe('Config', () => {
       { name: 'stats.enabled', value: false, origin: 'calculated' },
       { name: 'traceId128BitGenerationEnabled', value: true, origin: 'code' },
       { name: 'traceId128BitLoggingEnabled', value: true, origin: 'code' },
-      { name: 'version', value: '0.1.0', origin: 'code' }
+      { name: 'version', value: '0.1.0', origin: 'code' },
+      { name: 'llmobs.mlApp', value: 'myMlApp', origin: 'code' },
+      { name: 'llmobs.agentlessEnabled', value: true, origin: 'code' },
+      { name: 'llmobs.apiKey', value: 'myApiKey', origin: 'code' }
     ])
   })
 
@@ -1085,6 +1108,8 @@ describe('Config', () => {
     process.env.DD_IAST_REDACTION_VALUE_PATTERN = 'value_pattern_to_be_overriden_by_options'
     process.env.DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = 'true'
     process.env.DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = 'true'
+    process.env.DD_LLMOBS_ML_APP = 'myMlApp'
+    process.env.DD_LLMOBS_AGENTLESS_ENABLED = 'true'
 
     const config = new Config({
       protocolVersion: '0.5',
@@ -1162,7 +1187,11 @@ describe('Config', () => {
         pollInterval: 42
       },
       traceId128BitGenerationEnabled: false,
-      traceId128BitLoggingEnabled: false
+      traceId128BitLoggingEnabled: false,
+      llmobs: {
+        mlApp: 'myOtherMlApp',
+        agentlessEnabled: false
+      }
     })
 
     expect(config).to.have.property('protocolVersion', '0.5')
@@ -1221,6 +1250,8 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.redactionEnabled', true)
     expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
     expect(config).to.have.nested.property('iast.redactionValuePattern', 'REDACTION_VALUE_PATTERN')
+    expect(config).to.have.nested.property('llmobs.mlApp', 'myOtherMlApp')
+    expect(config).to.have.nested.property('llmobs.agentlessEnabled', false)
   })
 
   it('should give priority to non-experimental options', () => {
@@ -1976,6 +2007,36 @@ describe('Config', () => {
       const config = new Config({})
       expect(config).not.to.have.property('commitSHA')
       expect(config).not.to.have.property('repositoryUrl')
+    })
+  })
+
+  context('llmobs config', () => {
+    it('should disable llmobs by default', () => {
+      const config = new Config()
+      expect(config.llmobs.enabled).to.be.false
+    })
+
+    it('should enable llmobs if DD_LLMOBS_ENABLED is set to true', () => {
+      process.env.DD_LLMOBS_ENABLED = 'true'
+      const config = new Config()
+      expect(config.llmobs.enabled).to.be.true
+    })
+
+    it('should disable llmobs if DD_LLMOBS_ENABLED is set to false', () => {
+      process.env.DD_LLMOBS_ENABLED = 'false'
+      const config = new Config()
+      expect(config.llmobs.enabled).to.be.false
+    })
+
+    it('should enable llmobs with options and DD_LLMOBS_ENABLED is not set', () => {
+      const config = new Config({ llmobs: {} })
+      expect(config.llmobs.enabled).to.be.true
+    })
+
+    it('should have DD_LLMOBS_ENABLED take priority over options', () => {
+      process.env.DD_LLMOBS_ENABLED = 'false'
+      const config = new Config({ llmobs: { enabled: true } })
+      expect(config.llmobs.enabled).to.be.false
     })
   })
 

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -264,6 +264,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('llmobs.mlApp', undefined)
     expect(config).to.have.nested.property('llmobs.agentlessEnabled', false)
     expect(config).to.have.nested.property('llmobs.apiKey', undefined)
+    expect(config).to.have.nested.property('llmobs.enabled', false)
 
     expect(updateConfig).to.be.calledOnce
 


### PR DESCRIPTION
### What does this PR do?
Adds LLM Observability configuration options to the global tracer config.

There is one caveat in the behavior implemented in the config here: `config.llmobs.enabled` is computed intentionally with regards to environment variable first (`DD_LLMOBS_ENABLED`), then if the corresponding options object exists. This breaks the normal pattern of `options` taking precedence over `environment`, but is in parity with our [LLMObs Python SDK](https://github.com/DataDog/dd-trace-py/blob/cc824a2da7c39ce296624844ad8e8057ec12b701/ddtrace/llmobs/_llmobs.py#L155-L157).

Additionally, there is no consensus on if we'll want this to be placed under `experimental` yet or not. I've included in this PR a change that will coalesce `llmobs` from either the general or `experimental` options onto the general options, and is used as such for the rest of the config (as is done with `appsec` and `iast`).

### Motivation
First PR in a set of PRs to release a Node.js LLM Obs SDK within the tracer.


