### PR TITLE
[MLOB-1555] LLM Observability writers

### DIFF
--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -1,0 +1,30 @@
+name: LLMObs
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  schedule:
+    - cron: '0 4 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/install
+      - uses: ./.github/actions/node/18
+      - run: yarn test:llmobs:ci
+      - uses: ./.github/actions/node/20
+      - run: yarn test:llmobs:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:llmobs:ci
+      - if: always()
+        uses: ./.github/actions/testagent/logs
+      - uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "test:core:ci": "npm run test:core -- --coverage --nyc-arg=--include=\"packages/datadog-core/src/**/*.js\"",
     "test:lambda": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/lambda/**/*.spec.js\"",
     "test:lambda:ci": "nyc --no-clean --include \"packages/dd-trace/src/lambda/**/*.js\" -- npm run test:lambda",
+    "test:llmobs": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/llmobs/**/*.spec.js\"",
+    "test:llmobs:ci": "nyc --no-clean --include \"packages/dd-trace/src/llmobs/**/*.js\" -- npm run test:llmobs",
     "test:plugins": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/datadog-instrumentations/test/@($(echo $PLUGINS)).spec.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
     "test:plugins:ci": "yarn services && nyc --no-clean --include \"packages/datadog-instrumentations/src/@($(echo $PLUGINS)).js\" --include \"packages/datadog-instrumentations/src/@($(echo $PLUGINS))/**/*.js\" --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- npm run test:plugins",
     "test:plugins:upstream": "node ./packages/dd-trace/test/plugins/suite.js",

--- a/packages/dd-trace/src/llmobs/constants.js
+++ b/packages/dd-trace/src/llmobs/constants.js
@@ -5,6 +5,8 @@ module.exports = {
   EVP_PROXY_AGENT_ENDPOINT: 'evp_proxy/v2/api/v2/llmobs',
   EVP_SUBDOMAIN_HEADER_NAME: 'X-Datadog-EVP-Subdomain',
   EVP_SUBDOMAIN_HEADER_VALUE: 'llmobs-intake',
+  AGENTLESS_SPANS_ENDPOINT: '/api/v2/llmobs',
+  AGENTLESS_EVALULATIONS_ENDPOINT: '/api/intake/llm-obs/v1/eval-metric',
 
   EVP_PAYLOAD_SIZE_LIMIT: 5 << 20, // 5MB (actual limit is 5.1MB)
   EVP_EVENT_SIZE_LIMIT: (1 << 20) - 1024, // 999KB (actual limit is 1MB)

--- a/packages/dd-trace/src/llmobs/constants.js
+++ b/packages/dd-trace/src/llmobs/constants.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  EVP_PROXY_AGENT_BASE_PATH: 'evp_proxy/v2',
+  EVP_PROXY_AGENT_ENDPOINT: 'evp_proxy/v2/api/v2/llmobs',
+  EVP_SUBDOMAIN_HEADER_NAME: 'X-Datadog-EVP-Subdomain',
+  EVP_SUBDOMAIN_HEADER_VALUE: 'llmobs-intake',
+
+  EVP_PAYLOAD_SIZE_LIMIT: 5 << 20, // 5MB (actual limit is 5.1MB)
+  EVP_EVENT_SIZE_LIMIT: (1 << 20) - 1024, // 999KB (actual limit is 1MB)
+
+  DROPPED_IO_COLLECTION_ERROR: 'dropped_io',
+  DROPPED_VALUE_TEXT: "[This value has been dropped because this span's size exceeds the 1MB size limit.]"
+}

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -1,0 +1,16 @@
+'use strict'
+
+function encodeUnicode (str) {
+  if (!str) return str
+  return str.split('').map(char => {
+    const code = char.charCodeAt(0)
+    if (code > 127) {
+      return `\\u${code.toString(16).padStart(4, '0')}`
+    }
+    return char
+  }).join('')
+}
+
+module.exports = {
+  encodeUnicode
+}

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const request = require('../../exporters/common/request')
+const { URL, format } = require('url')
+
+const logger = require('../../log')
+
+const { encodeUnicode } = require('../util')
+
+class BaseLLMObsWriter {
+  constructor ({ interval, timeout, endpoint, intake, eventType, protocol, port }) {
+    this._interval = interval || 1000 // 1s
+    this._timeout = timeout || 5000 // 5s
+    this._eventType = eventType
+
+    this._buffer = []
+    this._bufferLimit = 1000
+    this._bufferSize = 0
+
+    this._url = new URL(format({
+      protocol: protocol || 'https:',
+      hostname: intake,
+      port: port || 443,
+      pathname: endpoint
+    }))
+
+    this._headers = {
+      'Content-Type': 'application/json'
+    }
+
+    this._periodic = setInterval(() => {
+      this.flush()
+    }, this._interval).unref()
+
+    process.once('beforeExit', () => {
+      this.destroy()
+    })
+
+    this._destroyed = false
+
+    logger.debug(`Started ${this.constructor.name} to ${this._url}`)
+  }
+
+  append (event, byteLength) {
+    if (this._buffer.length >= this._bufferLimit) {
+      logger.warn(`${this.constructor.name} event buffer full (limit is ${this._bufferLimit}), dropping event`)
+      return
+    }
+
+    this._bufferSize += byteLength || Buffer.from(JSON.stringify(event)).byteLength
+    this._buffer.push(event)
+  }
+
+  flush () {
+    if (this._buffer.length === 0) {
+      return
+    }
+
+    const events = this._buffer
+    this._buffer = []
+    this._bufferSize = 0
+    const payload = this._encode(this.makePayload(events))
+
+    const options = {
+      headers: this._headers,
+      method: 'POST',
+      url: this._url,
+      timeout: this._timeout
+    }
+
+    request(payload, options, (err, resp, code) => {
+      if (err) {
+        logger.error(
+          `Error sending ${events.length} LLMObs ${this._eventType} events to ${this._url}: ${err.message}`
+        )
+      } else if (code >= 300) {
+        logger.error(
+          `Error sending ${events.length} LLMObs ${this._eventType} events to ${this._url}: ${code}`
+        )
+      } else {
+        logger.debug(`Sent ${events.length} LLMObs ${this._eventType} events to ${this._url}`)
+      }
+    })
+  }
+
+  makePayload (events) {}
+
+  destroy () {
+    if (!this._destroyed) {
+      logger.debug(`Stopping ${this.constructor.name}`)
+      clearInterval(this._periodic)
+      process.removeListener('beforeExit', this.destroy)
+      this.flush()
+      this._destroyed = true
+    }
+  }
+
+  _encode (payload) {
+    return JSON.stringify(payload, (key, value) => {
+      if (typeof value === 'string') {
+        return encodeUnicode(value) // serialize unicode characters
+      }
+      return value
+    }).replace(/\\\\u/g, '\\u') // remove double escaping
+  }
+}
+
+module.exports = BaseLLMObsWriter

--- a/packages/dd-trace/src/llmobs/writers/evaluations.js
+++ b/packages/dd-trace/src/llmobs/writers/evaluations.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const BaseWriter = require('./base')
+
+class LLMObsEvalMetricsWriter extends BaseWriter {
+  constructor (config) {
+    super({
+      endpoint: '/api/intake/llm-obs/v1/eval-metric',
+      intake: `api.${config.site}`,
+      eventType: 'evaluation_metric'
+    })
+
+    this._headers['DD-API-KEY'] = config.llmobs?.apiKey || config.apiKey
+  }
+
+  makePayload (events) {
+    return {
+      data: {
+        type: this._eventType,
+        attributes: {
+          metrics: events
+        }
+      }
+    }
+  }
+}
+
+module.exports = LLMObsEvalMetricsWriter

--- a/packages/dd-trace/src/llmobs/writers/evaluations.js
+++ b/packages/dd-trace/src/llmobs/writers/evaluations.js
@@ -1,11 +1,12 @@
 'use strict'
 
+const { AGENTLESS_EVALULATIONS_ENDPOINT } = require('../constants')
 const BaseWriter = require('./base')
 
 class LLMObsEvalMetricsWriter extends BaseWriter {
   constructor (config) {
     super({
-      endpoint: '/api/intake/llm-obs/v1/eval-metric',
+      endpoint: AGENTLESS_EVALULATIONS_ENDPOINT,
       intake: `api.${config.site}`,
       eventType: 'evaluation_metric'
     })

--- a/packages/dd-trace/src/llmobs/writers/spans/agentProxy.js
+++ b/packages/dd-trace/src/llmobs/writers/spans/agentProxy.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { EVP_SUBDOMAIN_HEADER_NAME, EVP_SUBDOMAIN_HEADER_VALUE, EVP_PROXY_AGENT_ENDPOINT } = require('../../constants')
+const LLMObsBaseSpanWriter = require('./base')
+
+class LLMObsAgentProxySpanWriter extends LLMObsBaseSpanWriter {
+  constructor (config) {
+    super({
+      intake: config.hostname || 'localhost',
+      protocol: 'http:',
+      endpoint: EVP_PROXY_AGENT_ENDPOINT,
+      port: config.port
+    })
+
+    this._headers[EVP_SUBDOMAIN_HEADER_NAME] = EVP_SUBDOMAIN_HEADER_VALUE
+  }
+}
+
+module.exports = LLMObsAgentProxySpanWriter

--- a/packages/dd-trace/src/llmobs/writers/spans/agentless.js
+++ b/packages/dd-trace/src/llmobs/writers/spans/agentless.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const LLMObsBaseSpanWriter = require('./base')
+
+class LLMObsAgentlessSpanWriter extends LLMObsBaseSpanWriter {
+  constructor (config) {
+    super({
+      intake: `llmobs-intake.${config.site}`,
+      endpoint: '/api/v2/llmobs'
+    })
+
+    this._headers['DD-API-KEY'] = config.llmobs?.apiKey || config.apiKey
+  }
+}
+
+module.exports = LLMObsAgentlessSpanWriter

--- a/packages/dd-trace/src/llmobs/writers/spans/agentless.js
+++ b/packages/dd-trace/src/llmobs/writers/spans/agentless.js
@@ -1,12 +1,13 @@
 'use strict'
 
+const { AGENTLESS_SPANS_ENDPOINT } = require('../../constants')
 const LLMObsBaseSpanWriter = require('./base')
 
 class LLMObsAgentlessSpanWriter extends LLMObsBaseSpanWriter {
   constructor (config) {
     super({
       intake: `llmobs-intake.${config.site}`,
-      endpoint: '/api/v2/llmobs'
+      endpoint: AGENTLESS_SPANS_ENDPOINT
     })
 
     this._headers['DD-API-KEY'] = config.llmobs?.apiKey || config.apiKey

--- a/packages/dd-trace/src/llmobs/writers/spans/base.js
+++ b/packages/dd-trace/src/llmobs/writers/spans/base.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const {
+  EVP_EVENT_SIZE_LIMIT,
+  EVP_PAYLOAD_SIZE_LIMIT,
+  DROPPED_VALUE_TEXT,
+  DROPPED_IO_COLLECTION_ERROR
+} = require('../../constants')
+const BaseWriter = require('../base')
+const logger = require('../../../log')
+
+class LLMObsSpanWriter extends BaseWriter {
+  constructor (options) {
+    super({
+      ...options,
+      eventType: 'span'
+    })
+  }
+
+  append (event) {
+    const eventSizeBytes = Buffer.from(JSON.stringify(event)).byteLength
+    if (eventSizeBytes > EVP_EVENT_SIZE_LIMIT) {
+      logger.warn(`Dropping event input/output because its size (${eventSizeBytes}) exceeds the 1MB event size limit`)
+      event = this._truncateSpanEvent(event)
+    }
+
+    if (this._bufferSize + eventSizeBytes > EVP_PAYLOAD_SIZE_LIMIT) {
+      logger.debug('Flusing queue because queing next event will exceed EvP payload limit')
+      this.flush()
+    }
+
+    super.append(event, eventSizeBytes)
+  }
+
+  makePayload (events) {
+    return {
+      '_dd.stage': 'raw',
+      event_type: this._eventType,
+      spans: events
+    }
+  }
+
+  _truncateSpanEvent (event) {
+    event.meta.input = { value: DROPPED_VALUE_TEXT }
+    event.meta.output = { value: DROPPED_VALUE_TEXT }
+
+    event.collection_errors = [DROPPED_IO_COLLECTION_ERROR]
+    return event
+  }
+}
+
+module.exports = LLMObsSpanWriter

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const {
+  encodeUnicode
+} = require('../../src/llmobs/util')
+
+describe('util', () => {
+  describe('encodeUnicode', () => {
+    it('should encode unicode characters', () => {
+      expect(encodeUnicode('😀')).to.equal('\\ud83d\\ude00')
+    })
+
+    it('should encode only unicode characters in a string', () => {
+      expect(encodeUnicode('test 😀')).to.equal('test \\ud83d\\ude00')
+    })
+  })
+})

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -1,0 +1,179 @@
+'use strict'
+const { expect } = require('chai')
+const proxyquire = require('proxyquire')
+
+describe('BaseLLMObsWriter', () => {
+  let BaseLLMObsWriter
+  let writer
+  let request
+  let clock
+  let options
+  let logger
+
+  beforeEach(() => {
+    request = sinon.stub()
+    logger = {
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub()
+    }
+    BaseLLMObsWriter = proxyquire('../../../src/llmobs/writers/base', {
+      '../../exporters/common/request': request,
+      '../../log': logger
+    })
+
+    clock = sinon.useFakeTimers()
+
+    options = {
+      endpoint: '/api/v2/llmobs',
+      intake: 'llmobs-intake.datadoghq.com'
+    }
+  })
+
+  afterEach(() => {
+    clock.restore()
+    process.removeAllListeners('beforeExit')
+  })
+
+  it('constructs a writer with a url', () => {
+    writer = new BaseLLMObsWriter(options)
+
+    expect(writer._url.href).to.equal('https://llmobs-intake.datadoghq.com/api/v2/llmobs')
+    expect(logger.debug).to.have.been.calledWith(
+      'Started BaseLLMObsWriter to https://llmobs-intake.datadoghq.com/api/v2/llmobs'
+    )
+  })
+
+  it('calls flush before the process exits', () => {
+    writer = new BaseLLMObsWriter(options)
+    writer.flush = sinon.spy()
+
+    process.emit('beforeExit')
+
+    expect(writer.flush).to.have.been.calledOnce
+  })
+
+  it('calls flush at the correct interval', async () => {
+    writer = new BaseLLMObsWriter(options)
+
+    writer.flush = sinon.spy()
+
+    clock.tick(1000)
+
+    expect(writer.flush).to.have.been.calledOnce
+  })
+
+  it('appends an event to the buffer', () => {
+    writer = new BaseLLMObsWriter(options)
+    const event = { foo: 'bar–' }
+    writer.append(event)
+
+    expect(writer._buffer).to.have.lengthOf(1)
+    expect(writer._buffer[0]).to.deep.equal(event)
+    expect(writer._bufferSize).to.equal(16)
+  })
+
+  it('does not append an event if the buffer is full', () => {
+    writer = new BaseLLMObsWriter(options)
+
+    for (let i = 0; i < 1000; i++) {
+      writer.append({ foo: 'bar' })
+    }
+
+    writer.append({ foo: 'bar' })
+    expect(writer._buffer).to.have.lengthOf(1000)
+    expect(logger.warn).to.have.been.calledWith('BaseLLMObsWriter event buffer full (limit is 1000), dropping event')
+  })
+
+  it('flushes the buffer', () => {
+    writer = new BaseLLMObsWriter(options)
+
+    const event1 = { foo: 'bar' }
+    const event2 = { foo: 'baz' }
+
+    writer.append(event1)
+    writer.append(event2)
+
+    writer.makePayload = (events) => ({ events })
+
+    // Stub the request function to call its third argument
+    request.callsFake((url, options, callback) => {
+      callback(null, null, 202)
+    })
+
+    writer.flush()
+
+    expect(request).to.have.been.calledOnce
+    const calledArgs = request.getCall(0).args
+
+    expect(calledArgs[0]).to.deep.equal(JSON.stringify({ events: [event1, event2] }))
+    expect(calledArgs[1]).to.deep.equal({
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      method: 'POST',
+      url: writer._url,
+      timeout: 5000
+    })
+
+    expect(logger.debug).to.have.been.calledWith(
+      'Sent 2 LLMObs undefined events to https://llmobs-intake.datadoghq.com/api/v2/llmobs'
+    )
+
+    expect(writer._buffer).to.have.lengthOf(0)
+    expect(writer._bufferSize).to.equal(0)
+  })
+
+  it('does not flush an empty buffer', () => {
+    writer = new BaseLLMObsWriter(options)
+    writer.flush()
+
+    expect(request).to.not.have.been.called
+  })
+
+  it('logs errors from the request', () => {
+    writer = new BaseLLMObsWriter(options)
+    writer.makePayload = (events) => ({ events })
+
+    writer.append({ foo: 'bar' })
+
+    const error = new Error('boom')
+    request.callsFake((url, options, callback) => {
+      callback(error)
+    })
+
+    writer.flush()
+
+    expect(logger.error).to.have.been.calledWith(
+      'Error sending 1 LLMObs undefined events to https://llmobs-intake.datadoghq.com/api/v2/llmobs: boom'
+    )
+  })
+
+  describe('destroy', () => {
+    it('destroys the writer', () => {
+      sinon.spy(global, 'clearInterval')
+      sinon.spy(process, 'removeListener')
+      writer = new BaseLLMObsWriter(options)
+      writer.flush = sinon.stub()
+
+      writer.destroy()
+
+      expect(writer._destroyed).to.be.true
+      expect(clearInterval).to.have.been.calledWith(writer._periodic)
+      expect(process.removeListener).to.have.been.calledWith('beforeExit', writer.destroy)
+      expect(writer.flush).to.have.been.calledOnce
+      expect(logger.debug)
+        .to.have.been.calledWith('Stopping BaseLLMObsWriter')
+    })
+
+    it('does not destroy more than once', () => {
+      writer = new BaseLLMObsWriter(options)
+
+      logger.debug.reset() // ignore log from constructor
+      writer.destroy()
+      writer.destroy()
+
+      expect(logger.debug).to.have.been.calledOnce
+    })
+  })
+})

--- a/packages/dd-trace/test/llmobs/writers/evaluations.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/evaluations.spec.js
@@ -1,0 +1,60 @@
+'use strict'
+
+describe('LLMObsEvalMetricsWriter', () => {
+  let LLMObsEvalMetricsWriter
+  let writer
+  let flush
+
+  beforeEach(() => {
+    LLMObsEvalMetricsWriter = require('../../../src/llmobs/writers/evaluations')
+    flush = sinon.stub()
+  })
+
+  afterEach(() => {
+    process.removeAllListeners('beforeExit')
+  })
+
+  it('constructs the writer with the correct values', () => {
+    writer = new LLMObsEvalMetricsWriter({
+      site: 'datadoghq.com',
+      llmobs: {
+        apiKey: 'test'
+      },
+      apiKey: '1234'
+    })
+
+    writer.flush = flush // just to stop the beforeExit flush call
+
+    expect(writer._url.href).to.equal('https://api.datadoghq.com/api/intake/llm-obs/v1/eval-metric')
+    expect(writer._headers['DD-API-KEY']).to.equal('test') // defaults to llmobs api key
+    expect(writer._eventType).to.equal('evaluation_metric')
+  })
+
+  it('builds the payload correctly', () => {
+    writer = new LLMObsEvalMetricsWriter({
+      site: 'datadoghq.com',
+      llmobs: {
+        apiKey: 'test'
+      }
+    })
+
+    const events = [
+      { name: 'test', value: 1 }
+    ]
+
+    const payload = writer.makePayload(events)
+
+    expect(payload.data.type).to.equal('evaluation_metric')
+    expect(payload.data.attributes.metrics).to.deep.equal(events)
+  })
+
+  it('defaults to the regular api key if the llmobs config does not have one', () => {
+    writer = new LLMObsEvalMetricsWriter({
+      site: 'datadoghq.com',
+      llmobs: {},
+      apiKey: 'test'
+    })
+
+    expect(writer._headers['DD-API-KEY']).to.equal('test')
+  })
+})

--- a/packages/dd-trace/test/llmobs/writers/spans/agentProxy.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/spans/agentProxy.spec.js
@@ -1,0 +1,28 @@
+'use stict'
+
+describe('LLMObsAgentProxySpanWriter', () => {
+  let LLMObsAgentProxySpanWriter
+  let writer
+
+  beforeEach(() => {
+    LLMObsAgentProxySpanWriter = require('../../../../src/llmobs/writers/spans/agentProxy')
+  })
+
+  it('is initialized correctly', () => {
+    writer = new LLMObsAgentProxySpanWriter({
+      hostname: '127.0.0.1',
+      port: 8126
+    })
+
+    expect(writer._url.href).to.equal('http://127.0.0.1:8126/evp_proxy/v2/api/v2/llmobs')
+    expect(writer._headers['X-Datadog-EVP-Subdomain']).to.equal('llmobs-intake')
+  })
+
+  it('is initialized correctly with default hostname', () => {
+    writer = new LLMObsAgentProxySpanWriter({
+      port: 8126 // port will always be defaulted by config
+    })
+
+    expect(writer._url.href).to.equal('http://localhost:8126/evp_proxy/v2/api/v2/llmobs')
+  })
+})

--- a/packages/dd-trace/test/llmobs/writers/spans/agentless.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/spans/agentless.spec.js
@@ -1,0 +1,32 @@
+'use stict'
+
+describe('LLMObsAgentlessSpanWriter', () => {
+  let LLMObsAgentlessSpanWriter
+  let writer
+
+  beforeEach(() => {
+    LLMObsAgentlessSpanWriter = require('../../../../src/llmobs/writers/spans/agentless')
+  })
+
+  it('is initialized correctly', () => {
+    writer = new LLMObsAgentlessSpanWriter({
+      site: 'datadoghq.com',
+      llmobs: {
+        apiKey: 'test'
+      },
+      apiKey: '1234'
+    })
+
+    expect(writer._url.href).to.equal('https://llmobs-intake.datadoghq.com/api/v2/llmobs')
+    expect(writer._headers['DD-API-KEY']).to.equal('test')
+  })
+
+  it('uses the default api key if none is provided on llmobs', () => {
+    writer = new LLMObsAgentlessSpanWriter({
+      site: 'datadoghq.com',
+      apiKey: '1234'
+    })
+
+    expect(writer._headers['DD-API-KEY']).to.equal('1234')
+  })
+})

--- a/packages/dd-trace/test/llmobs/writers/spans/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/spans/base.spec.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+
+describe('LLMObsSpanWriter', () => {
+  let LLMObsSpanWriter
+  let writer
+  let options
+  let logger
+
+  beforeEach(() => {
+    logger = {
+      warn: sinon.stub(),
+      debug: sinon.stub()
+    }
+    LLMObsSpanWriter = proxyquire('../../../../src/llmobs/writers/spans/base', {
+      '../../../log': logger
+    })
+    options = {
+      endpoint: '/api/v2/llmobs',
+      intake: 'llmobs-intake.datadoghq.com'
+    }
+  })
+
+  afterEach(() => {
+    process.removeAllListeners('beforeExit')
+  })
+
+  it('is initialized correctly', () => {
+    writer = new LLMObsSpanWriter(options)
+
+    expect(writer._eventType).to.equal('span')
+  })
+
+  it('computes the number of bytes of the appended event', () => {
+    writer = new LLMObsSpanWriter(options)
+
+    const event = { name: 'test', value: 1 }
+    const eventSizeBytes = Buffer.from(JSON.stringify(event)).byteLength
+
+    writer.append(event)
+
+    expect(writer._bufferSize).to.equal(eventSizeBytes)
+  })
+
+  it('truncates the event if it exceeds the size limit', () => {
+    writer = new LLMObsSpanWriter(options)
+
+    const event = {
+      name: 'test',
+      meta: {
+        input: { value: 'a'.repeat(1024 * 1024) },
+        output: { value: 'a'.repeat(1024 * 1024) }
+      }
+    }
+
+    writer.append(event)
+
+    const bufferEvent = writer._buffer[0]
+    expect(bufferEvent).to.deep.equal({
+      name: 'test',
+      meta: {
+        input: { value: "[This value has been dropped because this span's size exceeds the 1MB size limit.]" },
+        output: { value: "[This value has been dropped because this span's size exceeds the 1MB size limit.]" }
+      },
+      collection_errors: ['dropped_io']
+    })
+  })
+
+  it('flushes the queue if the next event will exceed the payload limit', () => {
+    writer = new LLMObsSpanWriter(options)
+    writer.flush = sinon.stub()
+
+    writer._bufferSize = (5 << 20) - 1
+    writer._buffer = Array.from({ length: 10 })
+    const event = { name: 'test', value: 'a'.repeat(1024) }
+
+    writer.append(event)
+
+    expect(writer.flush).to.have.been.calledOnce
+    expect(logger.debug).to.have.been.calledWith(
+      'Flusing queue because queing next event will exceed EvP payload limit'
+    )
+  })
+
+  it('creates the payload correctly', () => {
+    writer = new LLMObsSpanWriter(options)
+
+    const events = [
+      { name: 'test', value: 1 }
+    ]
+
+    const payload = writer.makePayload(events)
+
+    expect(payload['_dd.stage']).to.equal('raw')
+    expect(payload.event_type).to.equal('span')
+    expect(payload.spans).to.deep.equal(events)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Adds LLM Observability writers for span events (agentless and agent proxy) as well as evaluation metrics (which write directly to our public API).

#### Important Notes
- These writers will run on intervals separate from the main agent exporter, and in a future PR will be initialized in the appropriate spots to start those intervals (as defined in the constructor of the base writer). Because of this, these writers specifically won't interact with any tracer internal exporters, writers, or encoders.
- We need to make sure unicode special characters are encoded in their `\\u` form in payload strings. I wasn't sure if there was a cleaner way to do this, so any input on this is appreciated!

### Motivation
Merge in incremental change of LLMObs writers into the LLM Observability SDK release branch. 

The timeline of changes to merge looks like (in order):
- [x] Config
- [ ] Writers
- [ ] Tagger
- [ ] Span/Trace processor
- [ ] SDK + initialization
- [ ] Type definitions
- [ ] OpenAI integration