### PR TITLE
capping version ranges for plugin test in ci

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -265,8 +265,6 @@ jobs:
     strategy:
       matrix:
         node-version: [16]
-        // each comma should create a new test such that we test node 16
-        // against 2.6.12 and also node 16 against 3.0.7 & latest of major 3
         range: ['^2.6.12', '^3.0.7', '4.4.1']
         include:
           - node-version: 18

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -58,7 +58,7 @@ jobs:
         range: ['5.2.0 - 5.7.0']
         include:
           - node-version: 20
-            range: '>=5.8.0'
+            range: ['5.12.1']
     runs-on: ubuntu-latest
     services:
       aerospike:
@@ -97,6 +97,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   amqp10: # TODO: move rhea to its own job
+    strategy:
+      matrix:
+        range: ['3.6.0']
     runs-on: ubuntu-latest
     services:
       qpid:
@@ -115,6 +118,9 @@ jobs:
       - uses: ./.github/actions/plugins/test-and-upstream
 
   amqplib:
+    strategy:
+      matrix:
+        range: ['0.10.4' ]
     runs-on: ubuntu-latest
     services:
       rabbitmq:
@@ -129,6 +135,9 @@ jobs:
       - uses: ./.github/actions/plugins/test-and-upstream
 
   apollo:
+    strategy:
+      matrix:
+        range: ['2.9.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: apollo
@@ -140,6 +149,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['18', 'latest']
+        range: ['2.1691.0']
     runs-on: ubuntu-latest
     services:
       localstack:
@@ -197,6 +207,9 @@ jobs:
       - uses: ./.github/actions/plugins/upstream
 
   bluebird:
+    strategy:
+      matrix:
+        range: ['3.7.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: bluebird
@@ -205,6 +218,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   bunyan:
+    strategy:
+      matrix:
+        range: ['1.8.15']
     runs-on: ubuntu-latest
     env:
       PLUGINS: bunyan
@@ -213,6 +229,9 @@ jobs:
       - uses: ./.github/actions/plugins/test-and-upstream
 
   cassandra:
+    strategy:
+      matrix:
+        range: ['>=3.0.0 <=4.7.2']
     runs-on: ubuntu-latest
     services:
       cassandra:
@@ -246,10 +265,12 @@ jobs:
     strategy:
       matrix:
         node-version: [16]
-        range: ['^2.6.12', '^3.0.7', '>=4.0.0 <4.2.0']
+        // each comma should create a new test such that we test node 16
+        // against 2.6.12 and also node 16 against 3.0.7 & latest of major 3
+        range: ['^2.6.12', '^3.0.7', '4.4.1']
         include:
           - node-version: 18
-            range: '>=4.2.0'
+            range: '4.4.1'
     runs-on: ubuntu-latest
     services:
       couchbase:
@@ -274,6 +295,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   connect:
+    strategy:
+      matrix:
+        range: ['3.7.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: connect
@@ -282,6 +306,9 @@ jobs:
       - uses: ./.github/actions/plugins/test-and-upstream
 
   cucumber:
+    strategy:
+      matrix:
+        range: ['11.0.1']
     runs-on: ubuntu-latest
     env:
       PLUGINS: cucumber
@@ -291,6 +318,9 @@ jobs:
 
   # TODO: fix performance issues and test more Node versions
   cypress:
+    strategy:
+      matrix:
+        range: ['13.14.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: cypress
@@ -324,6 +354,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   elasticsearch:
+    strategy:
+      matrix:
+        range: ['16.7.3']
     runs-on: ubuntu-latest
     services:
       elasticsearch:
@@ -347,6 +380,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   express:
+    strategy:
+      matrix:
+        range: ['4.21.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: express|body-parser|cookie-parser
@@ -355,6 +391,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   fastify:
+    strategy:
+      matrix:
+        range: ['4.28.1']
     runs-on: ubuntu-latest
     env:
       PLUGINS: fastify
@@ -371,6 +410,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   generic-pool:
+    strategy:
+      matrix:
+        range: ['3.9.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: generic-pool
@@ -379,6 +421,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   google-cloud-pubsub:
+    strategy:
+      matrix:
+        range: ['4.7.2']
     runs-on: ubuntu-latest
     services:
       pubsub:
@@ -393,6 +438,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   graphql:
+    strategy:
+      matrix:
+        range: ['16.9.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: graphql
@@ -401,6 +449,9 @@ jobs:
       - uses: ./.github/actions/plugins/test-and-upstream
 
   grpc:
+    strategy:
+      matrix:
+        range: ['1.11.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: grpc
@@ -409,6 +460,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   hapi:
+    strategy:
+      matrix:
+        range: ['18.1.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: hapi
@@ -457,6 +511,9 @@ jobs:
 
   # TODO: fix performance issues and test more Node versions
   jest:
+    strategy:
+      matrix:
+        range: ['29.7.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: jest
@@ -471,6 +528,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   kafkajs:
+    strategy:
+      matrix:
+        range: ['2.2.4']
     runs-on: ubuntu-latest
     services:
       kafka:
@@ -498,6 +558,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   knex:
+    strategy:
+      matrix:
+        range: ['3.1.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: knex
@@ -506,6 +569,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   koa:
+    strategy:
+      matrix:
+        range: ['2.15.3']
     runs-on: ubuntu-latest
     env:
       PLUGINS: koa
@@ -514,6 +580,9 @@ jobs:
       - uses: ./.github/actions/plugins/test-and-upstream
 
   limitd-client:
+    strategy:
+      matrix:
+        range: ['2.14.1']
     runs-on: ubuntu-latest
     services:
       limitd:
@@ -532,6 +601,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   memcached:
+    strategy:
+      matrix:
+        range: ['2.2.2']
     runs-on: ubuntu-latest
     services:
       memcached:
@@ -546,6 +618,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   microgateway-core:
+    strategy:
+      matrix:
+        range: ['3.3.4']
     runs-on: ubuntu-latest
     env:
       PLUGINS: microgateway-core
@@ -554,6 +629,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   mocha:
+    strategy:
+      matrix:
+        range: ['10.7.3']
     runs-on: ubuntu-latest
     env:
       PLUGINS: mocha
@@ -562,6 +640,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   moleculer:
+    strategy:
+      matrix:
+        range: ['0.14.34']
     runs-on: ubuntu-latest
     env:
       PLUGINS: moleculer
@@ -570,6 +651,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   mongodb:
+    strategy:
+      matrix:
+        range: ['6.9.0']
     runs-on: ubuntu-latest
     services:
       mongodb:
@@ -585,6 +669,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   mongodb-core:
+    strategy:
+      matrix:
+        range: ['3.2.7']
     runs-on: ubuntu-latest
     services:
       mongodb:
@@ -600,6 +687,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   mongoose:
+    strategy:
+      matrix:
+        range: ['8.6.2']
     runs-on: ubuntu-latest
     services:
       mongodb:
@@ -614,6 +704,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   mysql:
+    strategy:
+      matrix:
+        range: ['2.18.1']
     runs-on: ubuntu-latest
     services:
       mysql:
@@ -656,6 +749,7 @@ jobs:
         version:
           - 18
           - latest
+        range: ['14.2.6']
     runs-on: ubuntu-latest
     env:
       PLUGINS: next
@@ -671,6 +765,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   openai:
+    strategy:
+      matrix:
+        range: ['4.61.1']
     runs-on: ubuntu-latest
     env:
       PLUGINS: openai
@@ -679,6 +776,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   opensearch:
+    strategy:
+      matrix:
+        range: ['2.12.0']
     runs-on: ubuntu-latest
     services:
       opensearch:
@@ -698,6 +798,9 @@ jobs:
   # TODO: Install the Oracle client on the host and test Node >=16.
   # TODO: Figure out why nyc stopped working with EACCESS errors.
   oracledb:
+    strategy:
+      matrix:
+        range: ['6.6.0']
     runs-on: ubuntu-latest
     container: bengl/node-12-with-oracle-client
     services:
@@ -736,6 +839,9 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   paperplane:
+    strategy:
+      matrix:
+        range: ['3.1.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: paperplane
@@ -752,6 +858,9 @@ jobs:
 
   # TODO: re-enable upstream tests if it ever stops being flaky
   pino:
+    strategy:
+      matrix:
+        range: ['9.4.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: pino
@@ -770,6 +879,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   postgres:
+    strategy:
+      matrix:
+        range: ['8.13.0']
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -787,6 +899,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   promise:
+    strategy:
+      matrix:
+        range: ['8.3.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: promise
@@ -795,6 +910,9 @@ jobs:
       - uses: ./.github/actions/plugins/test-and-upstream
 
   promise-js:
+    strategy:
+      matrix:
+        range: ['0.0.7']
     runs-on: ubuntu-latest
     env:
       PLUGINS: promise-js
@@ -803,6 +921,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   q:
+    strategy:
+      matrix:
+        range: ['1.5.1']
     runs-on: ubuntu-latest
     env:
       PLUGINS: q
@@ -811,6 +932,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   redis:
+    strategy:
+      matrix:
+        range: ['4.7.0']
     runs-on: ubuntu-latest
     services:
       redis:
@@ -825,6 +949,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   restify:
+    strategy:
+      matrix:
+        range: ['11.1.0']
     runs-on: ubuntu-latest
     env:
       PLUGINS: restify
@@ -833,6 +960,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   router:
+    strategy:
+      matrix:
+        range: ['1.3.8']
     runs-on: ubuntu-latest
     env:
       PLUGINS: router
@@ -841,6 +971,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   sharedb:
+    strategy:
+      matrix:
+        range: ['5.0.4']
     runs-on: ubuntu-latest
     env:
       PLUGINS: sharedb
@@ -856,6 +989,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   tedious:
+    strategy:
+      matrix:
+        range: ['18.6.1']
     runs-on: ubuntu-latest
     services:
       mssql:
@@ -882,6 +1018,9 @@ jobs:
       - uses: codecov/codecov-action@v3
 
   undici:
+    strategy:
+      matrix:
+        range: ['4.16.0', '5.28.4', '6.19.8']
     runs-on: ubuntu-latest
     env:
       PLUGINS: undici
@@ -890,6 +1029,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   when:
+    strategy:
+      matrix:
+        range: ['3.7.8']
     runs-on: ubuntu-latest
     env:
       PLUGINS: when
@@ -898,6 +1040,9 @@ jobs:
       - uses: ./.github/actions/plugins/test
 
   winston:
+    strategy:
+      matrix:
+        range: ['3.14.2'] 
     runs-on: ubuntu-latest
     env:
       PLUGINS: winston

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -858,7 +858,7 @@ jobs:
   pino:
     strategy:
       matrix:
-        range: ['9.4.0']
+        range: ['9.3.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: pino

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -989,7 +989,7 @@ jobs:
   tedious:
     strategy:
       matrix:
-        range: ['18.6.1']
+        range: ['18.5.0']
     runs-on: ubuntu-latest
     services:
       mssql:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -858,7 +858,7 @@ jobs:
   pino:
     strategy:
       matrix:
-        range: ['9.3.2']
+        range: ['<=9.3.2']
     runs-on: ubuntu-latest
     env:
       PLUGINS: pino

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -150,7 +150,7 @@ function publishError (error, req) {
   return error
 }
 
-addHook({ name: 'fastify', versions: ['>=3'] }, fastify => {
+addHook({ name: 'fastify', versions: ['>=3 <=4.28.1'] }, fastify => {
   const wrapped = shimmer.wrapFunction(fastify, fastify => wrapFastify(fastify, true))
 
   wrapped.fastify = wrapped


### PR DESCRIPTION
### What does this PR do?
This will cap versions ranges tested for plugin CI tests. The current implementation is to cap the version at the last successful version tested. The instrumentations have minimum versions which also are tested. 

This Pull Request does not cover, older major versions with new releases. 

### Plugin Checklist

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].



