### PR TITLE
[test visibility] Remove beta flag from manual test API

### DIFF
--- a/integration-tests/ci-visibility/test-api-manual/test.fake.js
+++ b/integration-tests/ci-visibility/test-api-manual/test.fake.js
@@ -31,7 +31,7 @@ describe('can run tests', () => {
   })
   test('integration test', () => {
     // Just for testing purposes, so we don't create a custom span
-    if (!process.env.DD_CIVISIBILITY_MANUAL_API_ENABLED) {
+    if (process.env.DD_CIVISIBILITY_MANUAL_API_ENABLED === 'false') {
       return Promise.resolve()
     }
     const testSpan = tracer.scope().active()

--- a/integration-tests/test-api-manual.spec.js
+++ b/integration-tests/test-api-manual.spec.js
@@ -73,7 +73,7 @@ describe('test-api-manual', () => {
       '--require ./ci-visibility/test-api-manual/test.fake.js ./ci-visibility/test-api-manual/run-fake-test-framework',
       {
         cwd,
-        env: { ...getCiVisAgentlessConfig(receiver.port), DD_CIVISIBILITY_MANUAL_API_ENABLED: '1' },
+        env: getCiVisAgentlessConfig(receiver.port),
         stdio: 'pipe'
       }
     )
@@ -82,7 +82,7 @@ describe('test-api-manual', () => {
     })
   })
 
-  it('does not report test spans if DD_CIVISIBILITY_MANUAL_API_ENABLED is not set', (done) => {
+  it('does not report test spans if DD_CIVISIBILITY_MANUAL_API_ENABLED is set to false', (done) => {
     receiver.assertPayloadReceived(() => {
       const error = new Error('should not report spans')
       done(error)
@@ -93,7 +93,10 @@ describe('test-api-manual', () => {
       '--require ./ci-visibility/test-api-manual/test.fake.js ./ci-visibility/test-api-manual/run-fake-test-framework',
       {
         cwd,
-        env: getCiVisAgentlessConfig(receiver.port),
+        env: {
+          ...getCiVisAgentlessConfig(receiver.port),
+          DD_CIVISIBILITY_MANUAL_API_ENABLED: 'false'
+        },
         stdio: 'pipe'
       }
     )

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -1003,10 +1003,10 @@ class Config {
   }
 
   _isCiVisibilityManualApiEnabled () {
-    return isTrue(coalesce(
+    return coalesce(
       process.env.DD_CIVISIBILITY_MANUAL_API_ENABLED,
-      false
-    ))
+      true
+    )
   }
 
   _isTraceStatsComputationEnabled () {
@@ -1050,7 +1050,7 @@ class Config {
         coalesce(DD_CIVISIBILITY_FLAKY_RETRY_ENABLED, true))
       this._setValue(calc, 'flakyTestRetriesCount', coalesce(maybeInt(DD_CIVISIBILITY_FLAKY_RETRY_COUNT), 5))
       this._setBoolean(calc, 'isIntelligentTestRunnerEnabled', isTrue(this._isCiVisibilityItrEnabled()))
-      this._setBoolean(calc, 'isManualApiEnabled', this._isCiVisibilityManualApiEnabled())
+      this._setBoolean(calc, 'isManualApiEnabled', !isFalse(this._isCiVisibilityManualApiEnabled()))
       this._setString(calc, 'ciVisibilitySessionName', DD_SESSION_NAME)
     }
     this._setString(calc, 'dogstatsd.hostname', this._getHostname())

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1824,11 +1824,7 @@ describe('Config', () => {
         const config = new Config(options)
         expect(config).to.have.property('isIntelligentTestRunnerEnabled', false)
       })
-      it('should disable manual testing API by default', () => {
-        const config = new Config(options)
-        expect(config).to.have.property('isManualApiEnabled', false)
-      })
-      it('should enable manual testing API if DD_CIVISIBILITY_MANUAL_API_ENABLED is not set to false', () => {
+      it('should enabled manual testing API by default', () => {
         const config = new Config(options)
         expect(config).to.have.property('isManualApiEnabled', true)
       })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1828,10 +1828,14 @@ describe('Config', () => {
         const config = new Config(options)
         expect(config).to.have.property('isManualApiEnabled', false)
       })
-      it('should enable manual testing API if DD_CIVISIBILITY_MANUAL_API_ENABLED is passed', () => {
-        process.env.DD_CIVISIBILITY_MANUAL_API_ENABLED = 'true'
+      it('should enable manual testing API if DD_CIVISIBILITY_MANUAL_API_ENABLED is not set to false', () => {
         const config = new Config(options)
         expect(config).to.have.property('isManualApiEnabled', true)
+      })
+      it('should disable manual testing API if DD_CIVISIBILITY_MANUAL_API_ENABLED is set to false', () => {
+        process.env.DD_CIVISIBILITY_MANUAL_API_ENABLED = 'false'
+        const config = new Config(options)
+        expect(config).to.have.property('isManualApiEnabled', false)
       })
       it('should disable memcached command tagging by default', () => {
         const config = new Config(options)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1824,7 +1824,7 @@ describe('Config', () => {
         const config = new Config(options)
         expect(config).to.have.property('isIntelligentTestRunnerEnabled', false)
       })
-      it('should enabled manual testing API by default', () => {
+      it('should enable manual testing API by default', () => {
         const config = new Config(options)
         expect(config).to.have.property('isManualApiEnabled', true)
       })


### PR DESCRIPTION
### What does this PR do?
* Change `DD_CIVISIBILITY_MANUAL_API_ENABLED` default value to `true`, so that it only acts as a kill switch.
* The manual API will be available unless `DD_CIVISIBILITY_MANUAL_API_ENABLED` is set to `false`. 

### Motivation
We're not making changes to it so it doesn't make sense to call it beta.

### Plugin Checklist
N/A