### PR TITLE
fix(openai): do not add usage tags or emit usage metrics if they are not returned

### DIFF
--- a/packages/datadog-plugin-openai/src/index.js
+++ b/packages/datadog-plugin-openai/src/index.js
@@ -276,25 +276,34 @@ class OpenApiPlugin extends TracingPlugin {
     const completionTokens = spanTags['openai.response.usage.completion_tokens']
     const completionTokensEstimated = spanTags['openai.response.usage.completion_tokens_estimated']
 
+    const totalTokens = spanTags['openai.response.usage.total_tokens']
+
     if (!error) {
-      if (promptTokensEstimated) {
-        this.metrics.distribution(
-          'openai.tokens.prompt', promptTokens, [...tags, 'openai.estimated:true'])
-      } else {
-        this.metrics.distribution('openai.tokens.prompt', promptTokens, tags)
-      }
-      if (completionTokensEstimated) {
-        this.metrics.distribution(
-          'openai.tokens.completion', completionTokens, [...tags, 'openai.estimated:true'])
-      } else {
-        this.metrics.distribution('openai.tokens.completion', completionTokens, tags)
+      if (promptTokens != null) {
+        if (promptTokensEstimated) {
+          this.metrics.distribution(
+            'openai.tokens.prompt', promptTokens, [...tags, 'openai.estimated:true'])
+        } else {
+          this.metrics.distribution('openai.tokens.prompt', promptTokens, tags)
+        }
       }
 
-      if (promptTokensEstimated || completionTokensEstimated) {
-        this.metrics.distribution(
-          'openai.tokens.total', promptTokens + completionTokens, [...tags, 'openai.estimated:true'])
-      } else {
-        this.metrics.distribution('openai.tokens.total', promptTokens + completionTokens, tags)
+      if (completionTokens != null) {
+        if (completionTokensEstimated) {
+          this.metrics.distribution(
+            'openai.tokens.completion', completionTokens, [...tags, 'openai.estimated:true'])
+        } else {
+          this.metrics.distribution('openai.tokens.completion', completionTokens, tags)
+        }
+      }
+
+      if (totalTokens != null) {
+        if (promptTokensEstimated || completionTokensEstimated) {
+          this.metrics.distribution(
+            'openai.tokens.total', totalTokens, [...tags, 'openai.estimated:true'])
+        } else {
+          this.metrics.distribution('openai.tokens.total', totalTokens, tags)
+        }
       }
     }
 
@@ -777,9 +786,9 @@ function usageExtraction (tags, body, methodName, openaiStore) {
     if (completionEstimated) tags['openai.response.usage.completion_tokens_estimated'] = true
   }
 
-  if (promptTokens) tags['openai.response.usage.prompt_tokens'] = promptTokens
-  if (completionTokens) tags['openai.response.usage.completion_tokens'] = completionTokens
-  if (totalTokens) tags['openai.response.usage.total_tokens'] = totalTokens
+  if (promptTokens != null) tags['openai.response.usage.prompt_tokens'] = promptTokens
+  if (completionTokens != null) tags['openai.response.usage.completion_tokens'] = completionTokens
+  if (totalTokens != null) tags['openai.response.usage.total_tokens'] = totalTokens
 }
 
 function truncateApiKey (apiKey) {


### PR DESCRIPTION
### What does this PR do?
Ensures that OpenAI usages that are not reported from OpenAI are not tagged and not emitted as metrics.

### Motivation
Fixes #4697 

There is an edge case with OpenAI embeddings that might not cause them to have output tokens attached

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


