### PR TITLE
[test visibility] Report logical CPU count

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -38,6 +38,7 @@ const {
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 
 const isOldNode = semver.satisfies(process.version, '<=16')
 const versions = ['7.0.0', isOldNode ? '9' : 'latest']
@@ -181,6 +182,7 @@ versions.forEach(version => {
                     assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
                     assert.isTrue(meta[TEST_SOURCE_FILE].startsWith(featuresPath))
                     assert.equal(metrics[TEST_SOURCE_START], 1)
+                    assert.exists(metrics[DD_HOST_CPU_COUNT])
                   })
 
                   assert.includeMembers(testEvents.map(test => test.content.resource), [
@@ -201,6 +203,7 @@ versions.forEach(version => {
                   testEvents.forEach(({
                     content: {
                       meta,
+                      metrics,
                       test_suite_id: testSuiteId,
                       test_module_id: testModuleId,
                       test_session_id: testSessionId
@@ -218,6 +221,7 @@ versions.forEach(version => {
                     if (runMode === 'parallel') {
                       assert.propertyVal(meta, CUCUMBER_IS_PARALLEL, 'true')
                     }
+                    assert.exists(metrics[DD_HOST_CPU_COUNT])
                   })
 
                   stepEvents.forEach(stepEvent => {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -37,6 +37,7 @@ const {
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const { NODE_MAJOR } = require('../../version')
 
@@ -289,6 +290,7 @@ moduleTypes.forEach(({
             assert.equal(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
             assert.isTrue(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'))
             assert.equal(metrics[TEST_SOURCE_START], 1)
+            assert.exists(metrics[DD_HOST_CPU_COUNT])
           })
 
           assert.includeMembers(testEvents.map(test => test.content.resource), [
@@ -306,6 +308,7 @@ moduleTypes.forEach(({
           testEvents.forEach(({
             content: {
               meta,
+              metrics,
               test_suite_id: testSuiteId,
               test_module_id: testModuleId,
               test_session_id: testSessionId
@@ -320,6 +323,7 @@ moduleTypes.forEach(({
             // Can read DD_TAGS
             assert.propertyVal(meta, 'test.customtag', 'customvalue')
             assert.propertyVal(meta, 'test.customtag2', 'customvalue2')
+            assert.exists(metrics[DD_HOST_CPU_COUNT])
           })
         }, 25000)
 

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -35,6 +35,7 @@ const {
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
 const testFile = 'ci-visibility/run-jest.js'
@@ -169,11 +170,13 @@ describe('jest CommonJS', () => {
           // Can read DD_TAGS
           assert.propertyVal(testEvent.meta, 'test.customtag', 'customvalue')
           assert.propertyVal(testEvent.meta, 'test.customtag2', 'customvalue2')
+          assert.exists(testEvent.metrics[DD_HOST_CPU_COUNT])
         })
 
         suites.forEach(testSuite => {
           assert.isTrue(testSuite.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/test/ci-visibility-test'))
           assert.equal(testSuite.metrics[TEST_SOURCE_START], 1)
+          assert.exists(testSuite.metrics[DD_HOST_CPU_COUNT])
         })
 
         done()

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -36,6 +36,7 @@ const {
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
 const runTestsWithCoverageCommand = './node_modules/nyc/bin/nyc.js -r=text-summary node ./ci-visibility/run-mocha.js'
@@ -169,11 +170,13 @@ describe('mocha CommonJS', function () {
           // Can read DD_TAGS
           assert.propertyVal(testEvent.meta, 'test.customtag', 'customvalue')
           assert.propertyVal(testEvent.meta, 'test.customtag2', 'customvalue2')
+          assert.exists(testEvent.metrics[DD_HOST_CPU_COUNT])
         })
 
         suites.forEach(testSuite => {
           assert.isTrue(testSuite.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/test/ci-visibility-test'))
           assert.equal(testSuite.metrics[TEST_SOURCE_START], 1)
+          assert.exists(testSuite.metrics[DD_HOST_CPU_COUNT])
         })
 
         done()

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -147,7 +147,7 @@ versions.forEach((version) => {
               assert.propertyVal(testEvent.content.meta, 'test.customtag2', 'customvalue2')
               // Adds the browser used
               assert.propertyVal(testEvent.content.meta, TEST_CONFIGURATION_BROWSER_NAME, 'chromium')
-              assert.exists(testEvents.content.metrics[DD_HOST_CPU_COUNT])
+              assert.exists(testEvent.content.metrics[DD_HOST_CPU_COUNT])
             })
 
             stepEvents.forEach(stepEvent => {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -26,6 +26,7 @@ const {
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 
 const NUM_RETRIES_EFD = 3
@@ -118,6 +119,7 @@ versions.forEach((version) => {
               }
               assert.isTrue(testSuiteEvent.content.meta[TEST_SOURCE_FILE].endsWith('-test.js'))
               assert.equal(testSuiteEvent.content.metrics[TEST_SOURCE_START], 1)
+              assert.exists(testSuiteEvent.content.metrics[DD_HOST_CPU_COUNT])
             })
 
             assert.includeMembers(testEvents.map(test => test.content.resource), [
@@ -145,6 +147,7 @@ versions.forEach((version) => {
               assert.propertyVal(testEvent.content.meta, 'test.customtag2', 'customvalue2')
               // Adds the browser used
               assert.propertyVal(testEvent.content.meta, TEST_CONFIGURATION_BROWSER_NAME, 'chromium')
+              assert.exists(testEvents.content.metrics[DD_HOST_CPU_COUNT])
             })
 
             stepEvents.forEach(stepEvent => {

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -21,6 +21,7 @@ const {
   TEST_SOURCE_FILE,
   TEST_SOURCE_START
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 
 const versions = ['1.6.0', 'latest']
 
@@ -145,6 +146,7 @@ versions.forEach((version) => {
 
         testEvents.forEach(test => {
           assert.equal(test.content.meta[TEST_COMMAND], 'vitest run')
+          assert.exists(test.content.metrics[DD_HOST_CPU_COUNT])
         })
 
         testSuiteEvents.forEach(testSuite => {
@@ -153,6 +155,7 @@ versions.forEach((version) => {
             testSuite.content.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/vitest-tests/test-visibility')
           )
           assert.equal(testSuite.content.metrics[TEST_SOURCE_START], 1)
+          assert.exists(testSuite.content.metrics[DD_HOST_CPU_COUNT])
         })
         // TODO: check error messages
       }).then(() => done()).catch(done)

--- a/packages/dd-trace/src/plugins/util/env.js
+++ b/packages/dd-trace/src/plugins/util/env.js
@@ -5,6 +5,7 @@ const OS_VERSION = 'os.version'
 const OS_ARCHITECTURE = 'os.architecture'
 const RUNTIME_NAME = 'runtime.name'
 const RUNTIME_VERSION = 'runtime.version'
+const DD_HOST_CPU_COUNT = '_dd.host.vcpu_count'
 
 function getRuntimeAndOSMetadata () {
   return {
@@ -12,7 +13,8 @@ function getRuntimeAndOSMetadata () {
     [OS_ARCHITECTURE]: process.arch,
     [OS_PLATFORM]: process.platform,
     [RUNTIME_NAME]: 'node',
-    [OS_VERSION]: os.release()
+    [OS_VERSION]: os.release(),
+    [DD_HOST_CPU_COUNT]: os.cpus().length
   }
 }
 
@@ -22,5 +24,6 @@ module.exports = {
   OS_VERSION,
   OS_ARCHITECTURE,
   RUNTIME_NAME,
-  RUNTIME_VERSION
+  RUNTIME_VERSION,
+  DD_HOST_CPU_COUNT
 }

--- a/packages/dd-trace/test/plugins/util/env.spec.js
+++ b/packages/dd-trace/test/plugins/util/env.spec.js
@@ -9,7 +9,8 @@ const {
   OS_PLATFORM,
   OS_VERSION,
   RUNTIME_NAME,
-  RUNTIME_VERSION
+  RUNTIME_VERSION,
+  DD_HOST_CPU_COUNT
 } = require('../../../src/plugins/util/env')
 
 describe('env', () => {
@@ -22,7 +23,8 @@ describe('env', () => {
         [OS_ARCHITECTURE]: process.arch,
         [OS_PLATFORM]: process.platform,
         [RUNTIME_NAME]: 'node',
-        [OS_VERSION]: os.release()
+        [OS_VERSION]: os.release(),
+        [DD_HOST_CPU_COUNT]: os.cpus().length
       }
     )
   })


### PR DESCRIPTION
### What does this PR do?
Report `os.cpus().length` in `_dd.host.vcpu_count` numerical tag.

### Motivation
Get more information about the machine running tests.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
