### PR TITLE
Fix tedious and fastify plugin tests

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -871,10 +871,11 @@ jobs:
       SERVICES: mssql
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '22.8.0'
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - run: yarn test:plugins:upstream
       - if: always()

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -859,7 +859,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mssql:
-        image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+        image: mcr.microsoft.com/mssql/server:2019-latest
         env:
           ACCEPT_EULA: 'Y'
           SA_PASSWORD: DD_HUNTER2

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -871,11 +871,10 @@ jobs:
       SERVICES: mssql
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '22.8.0'
       - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
+      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - run: yarn test:plugins:upstream
       - if: always()

--- a/packages/datadog-plugin-fastify/test/integration-test/helper.mjs
+++ b/packages/datadog-plugin-fastify/test/integration-test/helper.mjs
@@ -4,7 +4,7 @@ export async function createAndStartServer (app) {
   })
 
   try {
-    await app.listen(0)
+    await app.listen({ port: 0 })
     const address = app.server.address()
     const port = address.port
     process.send({ port })


### PR DESCRIPTION
### What does this PR do?
I just checked this issue: 

https://github.com/microsoft/mssql-docker/issues/868#issuecomment-2080122626 

which suggests 

> Looks like this has been fixed in 2019-CU26-ubuntu-20.04 release which is now 2019-latest.


I also used the changes in https://github.com/DataDog/dd-trace-js/pull/4702 to fix fastify errors (so that we comply with the all green policy) 

### Motivation
Fix tedious tests: https://github.com/DataDog/dd-trace-js/actions/runs/10959496034/job/30432009961?pr=4710

