### PR TITLE
Sql injection Exploit Prevention implementation for mysql2 library

### DIFF
--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -197,7 +197,11 @@ addHook({ name: 'mysql2', file: 'lib/pool.js', versions: ['>=1'] }, (Pool, versi
   })
 
   shimmer.wrap(Pool.prototype, 'execute', execute => function (sql, values, cb) {
-    if (!startOuterQueryCh.hasSubscribers || !sql) return execute.apply(this, arguments)
+    if (!startOuterQueryCh.hasSubscribers) return execute.apply(this, arguments)
+
+    if (typeof sql === 'object') sql = sql?.sql
+
+    if (!sql) return execute.apply(this, arguments)
 
     const abortController = new AbortController()
     startOuterQueryCh.publish({ sql, abortController })

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -42,9 +42,14 @@ addHook({ name: 'mysql2', file: 'lib/connection.js', versions: ['>=1'] }, (Conne
       startOuterQueryCh.publish({ sql: sqlString, abortController })
 
       if (abortController.signal.aborted) {
-        let queryCommand = sql
-        if (sqlIsString) {
-          queryCommand = Connection.createQuery(sqlString, values, cb, this.config)
+        const addCommand = this.addCommand
+        this.addCommand = function (cmd) { return cmd }
+
+        let queryCommand
+        try {
+          queryCommand = query.apply(this, arguments)
+        } finally {
+          this.addCommand = addCommand
         }
 
         cb = queryCommand.onResult
@@ -78,7 +83,7 @@ addHook({ name: 'mysql2', file: 'lib/connection.js', versions: ['>=1'] }, (Conne
 
       if (abortController.signal.aborted) {
         const addCommand = this.addCommand
-        this.addCommand = function () {}
+        this.addCommand = function (cmd) { return cmd }
 
         let result
         try {

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -234,8 +234,7 @@ addHook({ name: 'mysql2', file: 'lib/pool_cluster.js', versions: ['>=2.3.0'] }, 
 
         if (abortController.signal.aborted) {
           const getConnection = this.getConnection
-          this.getConnection = function () {
-          }
+          this.getConnection = function () {}
 
           let queryCommand
           try {
@@ -250,6 +249,7 @@ addHook({ name: 'mysql2', file: 'lib/pool_cluster.js', versions: ['>=2.3.0'] }, 
             } else {
               queryCommand.emit('error', abortController.signal.reason)
             }
+
             queryCommand.emit('end')
           })
 
@@ -270,6 +270,7 @@ addHook({ name: 'mysql2', file: 'lib/pool_cluster.js', versions: ['>=2.3.0'] }, 
           if (typeof values === 'function') {
             cb = values
           }
+
           process.nextTick(() => {
             cb(abortController.signal.reason)
           })

--- a/packages/datadog-instrumentations/test/mysql2.spec.js
+++ b/packages/datadog-instrumentations/test/mysql2.spec.js
@@ -74,7 +74,7 @@ describe('mysql2 instrumentation', () => {
           describe('with callback', () => {
             it('should abort the query on abortController.abort()', (done) => {
               startCh.subscribe(abort)
-              const query = connection.query(sql, (err, _) => {
+              const query = connection.query(sql, (err) => {
                 assert.propertyVal(err, 'message', 'Test')
                 sinon.assert.notCalled(apmQueryStart)
 
@@ -86,7 +86,7 @@ describe('mysql2 instrumentation', () => {
 
             it('should work without abortController.abort()', (done) => {
               startCh.subscribe(noop)
-              connection.query(sql, (err, _) => {
+              connection.query(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -95,7 +95,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              connection.query(sql, (err, _) => {
+              connection.query(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -149,7 +149,7 @@ describe('mysql2 instrumentation', () => {
           describe('with callback', () => {
             it('should abort the query on abortController.abort()', (done) => {
               startCh.subscribe(abort)
-              const query = mysql2.Connection.createQuery(sql, (err, _) => {
+              const query = mysql2.Connection.createQuery(sql, (err) => {
                 assert.propertyVal(err, 'message', 'Test')
                 sinon.assert.notCalled(apmQueryStart)
 
@@ -163,7 +163,7 @@ describe('mysql2 instrumentation', () => {
             it('should work without abortController.abort()', (done) => {
               startCh.subscribe(noop)
 
-              const query = mysql2.Connection.createQuery(sql, (err, _) => {
+              const query = mysql2.Connection.createQuery(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -174,7 +174,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              const query = mysql2.Connection.createQuery(sql, (err, _) => {
+              const query = mysql2.Connection.createQuery(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -237,7 +237,7 @@ describe('mysql2 instrumentation', () => {
             startCh.subscribe(abort)
 
             const options = { sql }
-            const commandExecute = connection.execute(options, (err, _) => {
+            const commandExecute = connection.execute(options, (err) => {
               assert.propertyVal(err, 'message', 'Test')
               sinon.assert.notCalled(apmQueryStart)
 
@@ -252,7 +252,7 @@ describe('mysql2 instrumentation', () => {
 
             const options = { sql }
 
-            connection.execute(options, (err, _) => {
+            connection.execute(options, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -263,7 +263,7 @@ describe('mysql2 instrumentation', () => {
           it('should work without subscriptions', (done) => {
             const options = { sql }
 
-            connection.execute(options, (err, _) => {
+            connection.execute(options, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -276,7 +276,7 @@ describe('mysql2 instrumentation', () => {
           it('should abort the query on abortController.abort()', (done) => {
             startCh.subscribe(abort)
 
-            connection.execute(sql, (err, _) => {
+            connection.execute(sql, (err) => {
               assert.propertyVal(err, 'message', 'Test')
               sinon.assert.notCalled(apmQueryStart)
               done()
@@ -286,7 +286,7 @@ describe('mysql2 instrumentation', () => {
           it('should work without abortController.abort()', (done) => {
             startCh.subscribe(noop)
 
-            connection.execute(sql, (err, _) => {
+            connection.execute(sql, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -297,7 +297,7 @@ describe('mysql2 instrumentation', () => {
           it('should work without subscriptions', (done) => {
             const options = { sql }
 
-            connection.execute(options, (err, _) => {
+            connection.execute(options, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -320,7 +320,7 @@ describe('mysql2 instrumentation', () => {
           describe('with callback', () => {
             it('should abort the query on abortController.abort()', (done) => {
               startCh.subscribe(abort)
-              const query = pool.query({ sql }, (err, _) => {
+              const query = pool.query({ sql }, (err) => {
                 assert.propertyVal(err, 'message', 'Test')
                 sinon.assert.notCalled(apmQueryStart)
 
@@ -333,7 +333,7 @@ describe('mysql2 instrumentation', () => {
             it('should work without abortController.abort()', (done) => {
               startCh.subscribe(noop)
 
-              pool.query({ sql }, (err, _) => {
+              pool.query({ sql }, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -342,7 +342,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              pool.query({ sql }, (err, _) => {
+              pool.query({ sql }, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -377,7 +377,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              pool.query({ sql }, (err, _) => {
+              pool.query({ sql }, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -391,7 +391,7 @@ describe('mysql2 instrumentation', () => {
           describe('with callback', () => {
             it('should abort the query on abortController.abort()', (done) => {
               startCh.subscribe(abort)
-              const query = pool.query(sql, (err, _) => {
+              const query = pool.query(sql, (err) => {
                 assert.propertyVal(err, 'message', 'Test')
                 sinon.assert.notCalled(apmQueryStart)
 
@@ -404,7 +404,7 @@ describe('mysql2 instrumentation', () => {
             it('should work without abortController.abort()', (done) => {
               startCh.subscribe(noop)
 
-              pool.query(sql, (err, _) => {
+              pool.query(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -413,7 +413,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              pool.query(sql, (err, _) => {
+              pool.query(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -448,7 +448,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              pool.query(sql, (err, _) => {
+              pool.query(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -464,7 +464,7 @@ describe('mysql2 instrumentation', () => {
           describe('with callback', () => {
             it('should abort the query on abortController.abort()', (done) => {
               startCh.subscribe(abort)
-              pool.execute({ sql }, (err, _) => {
+              pool.execute({ sql }, (err) => {
                 assert.propertyVal(err, 'message', 'Test')
 
                 setTimeout(() => {
@@ -477,7 +477,7 @@ describe('mysql2 instrumentation', () => {
             it('should work without abortController.abort()', (done) => {
               startCh.subscribe(noop)
 
-              pool.execute({ sql }, (err, _) => {
+              pool.execute({ sql }, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -486,7 +486,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              pool.execute({ sql }, (err, _) => {
+              pool.execute({ sql }, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -500,7 +500,7 @@ describe('mysql2 instrumentation', () => {
           describe('with callback', () => {
             it('should abort the query on abortController.abort()', (done) => {
               startCh.subscribe(abort)
-              pool.execute(sql, (err, _) => {
+              pool.execute(sql, (err) => {
                 assert.propertyVal(err, 'message', 'Test')
 
                 setTimeout(() => {
@@ -513,7 +513,7 @@ describe('mysql2 instrumentation', () => {
             it('should work without abortController.abort()', (done) => {
               startCh.subscribe(noop)
 
-              pool.execute(sql, (err, _) => {
+              pool.execute(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -522,7 +522,7 @@ describe('mysql2 instrumentation', () => {
             })
 
             it('should work without subscriptions', (done) => {
-              pool.execute(sql, (err, _) => {
+              pool.execute(sql, (err) => {
                 assert.isNull(err)
                 sinon.assert.called(apmQueryStart)
 
@@ -565,7 +565,7 @@ describe('mysql2 instrumentation', () => {
           it('should abort the query on abortController.abort()', (done) => {
             startCh.subscribe(abort)
             const namespace = poolCluster.of()
-            namespace.query(sql, (err, _) => {
+            namespace.query(sql, (err) => {
               assert.propertyVal(err, 'message', 'Test')
 
               setTimeout(() => {
@@ -579,7 +579,7 @@ describe('mysql2 instrumentation', () => {
             startCh.subscribe(noop)
 
             const namespace = poolCluster.of()
-            namespace.query(sql, (err, _) => {
+            namespace.query(sql, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -589,7 +589,7 @@ describe('mysql2 instrumentation', () => {
 
           it('should work without subscriptions', (done) => {
             const namespace = poolCluster.of()
-            namespace.query(sql, (err, _) => {
+            namespace.query(sql, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -602,7 +602,7 @@ describe('mysql2 instrumentation', () => {
           it('should abort the query on abortController.abort()', (done) => {
             startCh.subscribe(abort)
             const namespace = poolCluster.of()
-            namespace.query({ sql }, (err, _) => {
+            namespace.query({ sql }, (err) => {
               assert.propertyVal(err, 'message', 'Test')
 
               setTimeout(() => {
@@ -616,7 +616,7 @@ describe('mysql2 instrumentation', () => {
             startCh.subscribe(noop)
 
             const namespace = poolCluster.of()
-            namespace.query({ sql }, (err, _) => {
+            namespace.query({ sql }, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -626,7 +626,7 @@ describe('mysql2 instrumentation', () => {
 
           it('should work without subscriptions', (done) => {
             const namespace = poolCluster.of()
-            namespace.query({ sql }, (err, _) => {
+            namespace.query({ sql }, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -642,7 +642,7 @@ describe('mysql2 instrumentation', () => {
             startCh.subscribe(abort)
 
             const namespace = poolCluster.of()
-            namespace.execute(sql, (err, _) => {
+            namespace.execute(sql, (err) => {
               assert.propertyVal(err, 'message', 'Test')
 
               setTimeout(() => {
@@ -656,7 +656,7 @@ describe('mysql2 instrumentation', () => {
             startCh.subscribe(noop)
 
             const namespace = poolCluster.of()
-            namespace.execute(sql, (err, _) => {
+            namespace.execute(sql, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -666,7 +666,7 @@ describe('mysql2 instrumentation', () => {
 
           it('should work without subscriptions', (done) => {
             const namespace = poolCluster.of()
-            namespace.execute(sql, (err, _) => {
+            namespace.execute(sql, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -680,7 +680,7 @@ describe('mysql2 instrumentation', () => {
             startCh.subscribe(abort)
 
             const namespace = poolCluster.of()
-            namespace.execute({ sql }, (err, _) => {
+            namespace.execute({ sql }, (err) => {
               assert.propertyVal(err, 'message', 'Test')
 
               setTimeout(() => {
@@ -694,7 +694,7 @@ describe('mysql2 instrumentation', () => {
             startCh.subscribe(noop)
 
             const namespace = poolCluster.of()
-            namespace.execute({ sql }, (err, _) => {
+            namespace.execute({ sql }, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 
@@ -704,7 +704,7 @@ describe('mysql2 instrumentation', () => {
 
           it('should work without subscriptions', (done) => {
             const namespace = poolCluster.of()
-            namespace.execute({ sql }, (err, _) => {
+            namespace.execute({ sql }, (err) => {
               assert.isNull(err)
               sinon.assert.called(apmQueryStart)
 

--- a/packages/datadog-instrumentations/test/mysql2.spec.js
+++ b/packages/datadog-instrumentations/test/mysql2.spec.js
@@ -28,6 +28,7 @@ describe('mysql2 instrumentation', () => {
     let apmQueryStartChannel, apmQueryStart, mysql2Version
 
     before(() => {
+      startCh = channel('datadog:mysql2:outerquery:start')
       return agent.load(['mysql2'])
     })
 
@@ -65,10 +66,6 @@ describe('mysql2 instrumentation', () => {
       })
 
       describe('Connection.prototype.query', () => {
-        beforeEach(() => {
-          startCh = channel('datadog:mysql2:connection:query:start')
-        })
-
         describe('with string as query', () => {
           describe('with callback', () => {
             it('should abort the query on abortController.abort()', (done) => {
@@ -231,10 +228,6 @@ describe('mysql2 instrumentation', () => {
       })
 
       describe('Connection.prototype.execute', () => {
-        beforeEach(() => {
-          startCh = channel('datadog:mysql2:connection:execute:start')
-        })
-
         describe('with the query in options', () => {
           it('should abort the query on abortController.abort()', (done) => {
             startCh.subscribe(abort)
@@ -327,10 +320,6 @@ describe('mysql2 instrumentation', () => {
       })
 
       describe('Pool.prototype.query', () => {
-        beforeEach(() => {
-          startCh = channel('datadog:mysql2:pool:query:start')
-        })
-
         describe('with callback', () => {
           it('should abort the query on abortController.abort()', (done) => {
             startCh.subscribe(abort)
@@ -402,10 +391,6 @@ describe('mysql2 instrumentation', () => {
       })
 
       describe('Pool.prototype.execute', () => {
-        beforeEach(() => {
-          startCh = channel('datadog:mysql2:pool:execute:start')
-        })
-
         describe('with callback', () => {
           it('should abort the query on abortController.abort()', (done) => {
             startCh.subscribe(abort)
@@ -469,10 +454,6 @@ describe('mysql2 instrumentation', () => {
       })
 
       describe('PoolNamespace.prototype.query', () => {
-        beforeEach(() => {
-          startCh = channel('datadog:mysql2:poolnamespace:query:start')
-        })
-
         it('should abort the query on abortController.abort()', (done) => {
           startCh.subscribe(abort)
           const namespace = poolCluster.of()
@@ -510,10 +491,6 @@ describe('mysql2 instrumentation', () => {
       })
 
       describe('PoolNamespace.prototype.execute', () => {
-        beforeEach(() => {
-          startCh = channel('datadog:mysql2:poolnamespace:execute:start')
-        })
-
         it('should abort the query on abortController.abort()', (done) => {
           startCh.subscribe(abort)
 

--- a/packages/datadog-instrumentations/test/mysql2.spec.js
+++ b/packages/datadog-instrumentations/test/mysql2.spec.js
@@ -1,0 +1,555 @@
+'use strict'
+
+const { channel } = require('../src/helpers/instrument')
+const agent = require('../../dd-trace/test/plugins/agent')
+const { assert } = require('chai')
+const semver = require('semver')
+
+describe('mysql2 instrumentation', () => {
+  withVersions('mysql2', 'mysql2', version => {
+    function abort ({ abortController }) {
+      const error = new Error('Test')
+      abortController.abort(error)
+
+      if (!abortController.signal.reason) {
+        abortController.signal.reason = error
+      }
+    }
+
+    function noop () {}
+
+    const config = {
+      host: '127.0.0.1',
+      user: 'root',
+      database: 'db'
+    }
+
+    let startCh, mysql2, shouldEmitEndAfterQueryAbort
+    let apmQueryStartChannel, apmQueryStart, mysql2Version
+
+    before(() => {
+      return agent.load(['mysql2'])
+    })
+
+    beforeEach(() => {
+      const mysql2Require = require(`../../../versions/mysql2@${version}`)
+      mysql2Version = mysql2Require.version()
+      // in v1.3.3 CommandQuery started to emit 'end' after 'error' event
+      shouldEmitEndAfterQueryAbort = semver.intersects(mysql2Version, '>=1.3.3')
+      mysql2 = mysql2Require.get()
+
+      apmQueryStartChannel = channel('apm:mysql2:query:start')
+      apmQueryStart = sinon.stub()
+      apmQueryStartChannel.subscribe(apmQueryStart)
+    })
+
+    afterEach(() => {
+      if (startCh?.hasSubscribers) {
+        startCh.unsubscribe(abort)
+        startCh.unsubscribe(noop)
+      }
+      apmQueryStartChannel.unsubscribe(apmQueryStart)
+    })
+
+    describe('lib/connection.js', () => {
+      let connection
+
+      beforeEach(() => {
+        connection = mysql2.createConnection(config)
+
+        connection.connect()
+      })
+
+      afterEach((done) => {
+        connection.end(() => done())
+      })
+
+      describe('Connection.prototype.query', () => {
+        beforeEach(() => {
+          startCh = channel('datadog:mysql2:connection:query:start')
+        })
+
+        describe('with string as query', () => {
+          describe('with callback', () => {
+            it('should abort the query on abortController.abort()', (done) => {
+              startCh.subscribe(abort)
+              const query = connection.query('SELECT 1', (err, _) => {
+                assert.propertyVal(err, 'message', 'Test')
+                sinon.assert.notCalled(apmQueryStart)
+
+                if (!shouldEmitEndAfterQueryAbort) done()
+              })
+
+              query.on('end', () => done())
+            })
+
+            it('should work without abortController.abort()', (done) => {
+              startCh.subscribe(noop)
+              connection.query('SELECT 1', (err, _) => {
+                assert.isNull(err)
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              })
+            })
+
+            it('should work without subscriptions', (done) => {
+              connection.query('SELECT 1', (err, _) => {
+                assert.isNull(err)
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              })
+            })
+          })
+
+          describe('without callback', () => {
+            it('should abort the query on abortController.abort()', (done) => {
+              startCh.subscribe(abort)
+
+              const query = connection.query('SELECT 1')
+
+              query.on('error', (err) => {
+                assert.propertyVal(err, 'message', 'Test')
+                sinon.assert.notCalled(apmQueryStart)
+                if (!shouldEmitEndAfterQueryAbort) done()
+              })
+
+              query.on('end', () => done())
+            })
+
+            it('should work without abortController.abort()', (done) => {
+              startCh.subscribe(noop)
+
+              const query = connection.query('SELECT 1')
+
+              query.on('error', (err) => done(err))
+              query.on('end', () => {
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              })
+            })
+
+            it('should work without subscriptions', (done) => {
+              const query = connection.query('SELECT 1')
+
+              query.on('error', (err) => done(err))
+              query.on('end', () => {
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              })
+            })
+          })
+        })
+
+        describe('with object as query', () => {
+          describe('with callback', () => {
+            it('should abort the query on abortController.abort()', (done) => {
+              startCh.subscribe(abort)
+              const query = mysql2.Connection.createQuery('SELECT 1', (err, _) => {
+                assert.propertyVal(err, 'message', 'Test')
+                sinon.assert.notCalled(apmQueryStart)
+
+                if (!shouldEmitEndAfterQueryAbort) done()
+              }, null, {})
+              connection.query(query)
+
+              query.on('end', () => done())
+            })
+
+            it('should work without abortController.abort()', (done) => {
+              startCh.subscribe(noop)
+
+              const query = mysql2.Connection.createQuery('SELECT 1', (err, _) => {
+                assert.isNull(err)
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              }, null, {})
+
+              connection.query(query)
+            })
+
+            it('should work without subscriptions', (done) => {
+              const query = mysql2.Connection.createQuery('SELECT 1', (err, _) => {
+                assert.isNull(err)
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              }, null, {})
+
+              connection.query(query)
+            })
+          })
+
+          describe('without callback', () => {
+            it('should abort the query on abortController.abort()', (done) => {
+              startCh.subscribe(abort)
+
+              const query = mysql2.Connection.createQuery('SELECT 1', null, null, {})
+              query.on('error', (err) => {
+                assert.propertyVal(err, 'message', 'Test')
+                sinon.assert.notCalled(apmQueryStart)
+
+                if (!shouldEmitEndAfterQueryAbort) done()
+              })
+
+              connection.query(query)
+
+              query.on('end', () => done())
+            })
+
+            it('should work without abortController.abort()', (done) => {
+              startCh.subscribe(noop)
+
+              const query = mysql2.Connection.createQuery('SELECT 1', null, null, {})
+              query.on('error', (err) => done(err))
+              query.on('end', () => {
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              })
+
+              connection.query(query)
+            })
+
+            it('should work without subscriptions', (done) => {
+              const query = mysql2.Connection.createQuery('SELECT 1', null, null, {})
+              query.on('error', (err) => done(err))
+              query.on('end', () => {
+                sinon.assert.called(apmQueryStart)
+
+                done()
+              })
+
+              connection.query(query)
+            })
+          })
+        })
+      })
+
+      describe('Connection.prototype.execute', () => {
+        beforeEach(() => {
+          startCh = channel('datadog:mysql2:connection:execute:start')
+        })
+
+        describe('with the query in options', () => {
+          it('should abort the query on abortController.abort()', (done) => {
+            startCh.subscribe(abort)
+
+            const options = {
+              sql: 'SELECT 1'
+            }
+            const commandExecute = connection.execute(options, (err, _) => {
+              assert.propertyVal(err, 'message', 'Test')
+              sinon.assert.notCalled(apmQueryStart)
+
+              done()
+            })
+
+            assert.equal(commandExecute.sql, options.sql)
+          })
+
+          it('should work without abortController.abort()', (done) => {
+            startCh.subscribe(noop)
+
+            const options = {
+              sql: 'SELECT 1'
+            }
+
+            connection.execute(options, (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+
+          it('should work without subscriptions', (done) => {
+            const options = {
+              sql: 'SELECT 1'
+            }
+
+            connection.execute(options, (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+        })
+
+        describe('with sql as string', () => {
+          it('should abort the query on abortController.abort()', (done) => {
+            startCh.subscribe(abort)
+
+            connection.execute('SELECT 1', (err, _) => {
+              assert.propertyVal(err, 'message', 'Test')
+              sinon.assert.notCalled(apmQueryStart)
+              done()
+            })
+          })
+
+          it('should work without abortController.abort()', (done) => {
+            startCh.subscribe(noop)
+
+            connection.execute('SELECT 1', (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+
+          it('should work without subscriptions', (done) => {
+            const options = {
+              sql: 'SELECT 1'
+            }
+
+            connection.execute(options, (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+        })
+      })
+    })
+
+    describe('lib/pool.js', () => {
+      let pool
+
+      beforeEach(() => {
+        pool = mysql2.createPool(config)
+      })
+
+      describe('Pool.prototype.query', () => {
+        beforeEach(() => {
+          startCh = channel('datadog:mysql2:pool:query:start')
+        })
+
+        describe('with callback', () => {
+          it('should abort the query on abortController.abort()', (done) => {
+            startCh.subscribe(abort)
+            const query = pool.query('SELECT 1', (err, _) => {
+              assert.propertyVal(err, 'message', 'Test')
+              sinon.assert.notCalled(apmQueryStart)
+
+              if (!shouldEmitEndAfterQueryAbort) done()
+            })
+
+            query.on('end', () => done())
+          })
+
+          it('should work without abortController.abort()', (done) => {
+            startCh.subscribe(noop)
+
+            pool.query('SELECT 1', (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+
+          it('should work without subscriptions', (done) => {
+            pool.query('SELECT 1', (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+        })
+
+        describe('without callback', () => {
+          it('should abort the query on abortController.abort()', (done) => {
+            startCh.subscribe(abort)
+            const query = pool.query('SELECT 1')
+            query.on('error', err => {
+              assert.propertyVal(err, 'message', 'Test')
+              sinon.assert.notCalled(apmQueryStart)
+              if (!shouldEmitEndAfterQueryAbort) done()
+            })
+
+            query.on('end', () => done())
+          })
+
+          it('should work without abortController.abort()', (done) => {
+            startCh.subscribe(noop)
+            const query = pool.query('SELECT 1')
+
+            query.on('error', err => done(err))
+            query.on('end', () => {
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+
+          it('should work without subscriptions', (done) => {
+            pool.query('SELECT 1', (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+        })
+      })
+
+      describe('Pool.prototype.execute', () => {
+        beforeEach(() => {
+          startCh = channel('datadog:mysql2:pool:execute:start')
+        })
+
+        describe('with callback', () => {
+          it('should abort the query on abortController.abort()', (done) => {
+            startCh.subscribe(abort)
+            pool.execute('SELECT 1', (err, _) => {
+              assert.propertyVal(err, 'message', 'Test')
+
+              setTimeout(() => {
+                sinon.assert.notCalled(apmQueryStart)
+                done()
+              }, 100)
+            })
+          })
+
+          it('should work without abortController.abort()', (done) => {
+            startCh.subscribe(noop)
+
+            pool.execute('SELECT 1', (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+
+          it('should work without subscriptions', (done) => {
+            pool.execute('SELECT 1', (err, _) => {
+              assert.isNull(err)
+              sinon.assert.called(apmQueryStart)
+
+              done()
+            })
+          })
+        })
+      })
+    })
+
+    describe('lib/pool_cluster.js', () => {
+      let poolCluster, connection
+
+      before(function () {
+        if (!semver.satisfies(mysql2Version, '>=2.3.0')) this.skip()
+        poolCluster = mysql2.createPoolCluster()
+        poolCluster.add('clusterA', config)
+      })
+
+      beforeEach((done) => {
+        poolCluster.getConnection('clusterA', function (err, _connection) {
+          if (err) {
+            done(err)
+            return
+          }
+
+          connection = _connection
+
+          done()
+        })
+      })
+
+      afterEach(() => {
+        connection?.release()
+      })
+
+      describe('PoolNamespace.prototype.query', () => {
+        beforeEach(() => {
+          startCh = channel('datadog:mysql2:poolnamespace:query:start')
+        })
+
+        it('should abort the query on abortController.abort()', (done) => {
+          startCh.subscribe(abort)
+          const namespace = poolCluster.of()
+          namespace.query('SELECT 1', (err, _) => {
+            assert.propertyVal(err, 'message', 'Test')
+
+            setTimeout(() => {
+              sinon.assert.notCalled(apmQueryStart)
+              done()
+            }, 100)
+          })
+        })
+
+        it('should work without abortController.abort()', (done) => {
+          startCh.subscribe(noop)
+
+          const namespace = poolCluster.of()
+          namespace.query('SELECT 1', (err, _) => {
+            assert.isNull(err)
+            sinon.assert.called(apmQueryStart)
+
+            done()
+          })
+        })
+
+        it('should work without subscriptions', (done) => {
+          const namespace = poolCluster.of()
+          namespace.query('SELECT 1', (err, _) => {
+            assert.isNull(err)
+            sinon.assert.called(apmQueryStart)
+
+            done()
+          })
+        })
+      })
+
+      describe('PoolNamespace.prototype.execute', () => {
+        beforeEach(() => {
+          startCh = channel('datadog:mysql2:poolnamespace:execute:start')
+        })
+
+        it('should abort the query on abortController.abort()', (done) => {
+          startCh.subscribe(abort)
+
+          const namespace = poolCluster.of()
+          namespace.execute('SELECT 1', (err, _) => {
+            assert.propertyVal(err, 'message', 'Test')
+
+            setTimeout(() => {
+              sinon.assert.notCalled(apmQueryStart)
+              done()
+            }, 100)
+          })
+        })
+
+        it('should work without abortController.abort()', (done) => {
+          startCh.subscribe(noop)
+
+          const namespace = poolCluster.of()
+          namespace.execute('SELECT 1', (err, _) => {
+            assert.isNull(err)
+            sinon.assert.called(apmQueryStart)
+
+            done()
+          })
+        })
+
+        it('should work without subscriptions', (done) => {
+          const namespace = poolCluster.of()
+          namespace.execute('SELECT 1', (err, _) => {
+            assert.isNull(err)
+            sinon.assert.called(apmQueryStart)
+
+            done()
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/src/appsec/channels.js
+++ b/packages/dd-trace/src/appsec/channels.js
@@ -24,11 +24,6 @@ module.exports = {
   setUncaughtExceptionCaptureCallbackStart: dc.channel('datadog:process:setUncaughtExceptionCaptureCallback:start'),
   pgQueryStart: dc.channel('apm:pg:query:start'),
   pgPoolQueryStart: dc.channel('datadog:pg:pool:query:start'),
-  mysql2ConnectionQueryStart: dc.channel('datadog:mysql2:connection:query:start'),
-  mysql2ConnectionExecuteStart: dc.channel('datadog:mysql2:connection:execute:start'),
-  mysql2PoolQueryStart: dc.channel('datadog:mysql2:pool:query:start'),
-  mysql2PoolExecuteStart: dc.channel('datadog:mysql2:pool:execute:start'),
-  mysql2PoolNamespaceQueryStart: dc.channel('datadog:mysql2:poolnamespace:query:start'),
-  mysql2PoolNamespaceExecuteStart: dc.channel('datadog:mysql2:poolnamespace:execute:start'),
+  mysql2OuterQueryStart: dc.channel('datadog:mysql2:outerquery:start'),
   wafRunFinished: dc.channel('datadog:waf:run:finish')
 }

--- a/packages/dd-trace/src/appsec/channels.js
+++ b/packages/dd-trace/src/appsec/channels.js
@@ -24,5 +24,11 @@ module.exports = {
   setUncaughtExceptionCaptureCallbackStart: dc.channel('datadog:process:setUncaughtExceptionCaptureCallback:start'),
   pgQueryStart: dc.channel('apm:pg:query:start'),
   pgPoolQueryStart: dc.channel('datadog:pg:pool:query:start'),
+  mysql2ConnectionQueryStart: dc.channel('datadog:mysql2:connection:query:start'),
+  mysql2ConnectionExecuteStart: dc.channel('datadog:mysql2:connection:execute:start'),
+  mysql2PoolQueryStart: dc.channel('datadog:mysql2:pool:query:start'),
+  mysql2PoolExecuteStart: dc.channel('datadog:mysql2:pool:execute:start'),
+  mysql2PoolNamespaceQueryStart: dc.channel('datadog:mysql2:poolnamespace:query:start'),
+  mysql2PoolNamespaceExecuteStart: dc.channel('datadog:mysql2:poolnamespace:execute:start'),
   wafRunFinished: dc.channel('datadog:waf:run:finish')
 }

--- a/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
@@ -30,7 +30,7 @@ describe('sequelize', () => {
         // close agent
         after(() => {
           appsec.disable()
-          return agent.close()
+          return agent.close({ ritmReset: false })
         })
 
         // init database

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.mysql2.plugin.spec.js
@@ -1,0 +1,229 @@
+'use strict'
+
+const agent = require('../../plugins/agent')
+const appsec = require('../../../src/appsec')
+const Config = require('../../../src/config')
+const path = require('path')
+const Axios = require('axios')
+const { assert } = require('chai')
+const { checkRaspExecutedAndNotThreat, checkRaspExecutedAndHasThreat } = require('./utils')
+
+describe('RASP - sql_injection', () => {
+  withVersions('mysql2', 'express', expressVersion => {
+    withVersions('mysql2', 'mysql2', mysql2Version => {
+      describe('sql injection with mysql2', () => {
+        const connectionData = {
+          host: '127.0.0.1',
+          user: 'root',
+          database: 'db'
+        }
+        let server, axios, app, mysql2
+
+        before(() => {
+          return agent.load(['express', 'http', 'mysql2'], { client: false })
+        })
+
+        before(done => {
+          const express = require(`../../../../../versions/express@${expressVersion}`).get()
+          mysql2 = require(`../../../../../versions/mysql2@${mysql2Version}`).get()
+          const expressApp = express()
+
+          expressApp.get('/', (req, res) => {
+            app(req, res)
+          })
+
+          appsec.enable(new Config({
+            appsec: {
+              enabled: true,
+              rules: path.join(__dirname, 'resources', 'rasp_rules.json'),
+              rasp: { enabled: true }
+            }
+          }))
+
+          server = expressApp.listen(0, () => {
+            const port = server.address().port
+            axios = Axios.create({
+              baseURL: `http://localhost:${port}`
+            })
+            done()
+          })
+        })
+
+        after(() => {
+          appsec.disable()
+          server.close()
+          return agent.close({ ritmReset: false })
+        })
+
+        describe('Test using Connection', () => {
+          let connection
+
+          beforeEach(() => {
+            connection = mysql2.createConnection(connectionData)
+            connection.connect()
+          })
+
+          afterEach((done) => {
+            connection.end(() => done())
+          })
+
+          describe('query', () => {
+            it('Should not detect threat', async () => {
+              app = (req, res) => {
+                connection.query('SELECT ' + req.query.param, (err) => {
+                  if (err) {
+                    res.statusCode = 500
+                  }
+
+                  res.end()
+                })
+              }
+
+              axios.get('/?param=1')
+
+              await checkRaspExecutedAndNotThreat(agent)
+            })
+
+            it('Should block query with callback', async () => {
+              app = (req, res) => {
+                connection.query(`SELECT * FROM users WHERE id='${req.query.param}'`, (err) => {
+                  if (err?.name === 'DatadogRaspAbortError') {
+                    res.statusCode = 500
+                  }
+                  res.end()
+                })
+              }
+
+              try {
+                await axios.get('/?param=\' OR 1 = 1 --')
+              } catch (e) {
+                return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
+              }
+
+              assert.fail('Request should be blocked')
+            })
+          })
+
+          describe('execute', () => {
+            it('Should not detect threat', async () => {
+              app = (req, res) => {
+                connection.execute('SELECT ' + req.query.param, (err) => {
+                  if (err) {
+                    res.statusCode = 500
+                  }
+
+                  res.end()
+                })
+              }
+
+              axios.get('/?param=1')
+
+              await checkRaspExecutedAndNotThreat(agent)
+            })
+
+            it('Should block query with callback', async () => {
+              app = (req, res) => {
+                connection.execute(`SELECT * FROM users WHERE id='${req.query.param}'`, (err) => {
+                  if (err?.name === 'DatadogRaspAbortError') {
+                    res.statusCode = 500
+                  }
+                  res.end()
+                })
+              }
+
+              try {
+                await axios.get('/?param=\' OR 1 = 1 --')
+              } catch (e) {
+                return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
+              }
+
+              assert.fail('Request should be blocked')
+            })
+          })
+        })
+
+        describe('Test using Pool', () => {
+          let pool
+
+          beforeEach(() => {
+            pool = mysql2.createPool(connectionData)
+          })
+
+          describe('query', () => {
+            it('Should not detect threat', async () => {
+              app = (req, res) => {
+                pool.query('SELECT ' + req.query.param, (err) => {
+                  if (err) {
+                    res.statusCode = 500
+                  }
+
+                  res.end()
+                })
+              }
+
+              axios.get('/?param=1')
+
+              await checkRaspExecutedAndNotThreat(agent)
+            })
+
+            it('Should block query with callback', async () => {
+              app = (req, res) => {
+                pool.query(`SELECT * FROM users WHERE id='${req.query.param}'`, (err) => {
+                  if (err?.name === 'DatadogRaspAbortError') {
+                    res.statusCode = 500
+                  }
+                  res.end()
+                })
+              }
+
+              try {
+                await axios.get('/?param=\' OR 1 = 1 --')
+              } catch (e) {
+                return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
+              }
+
+              assert.fail('Request should be blocked')
+            })
+          })
+
+          describe('execute', () => {
+            it('Should not detect threat', async () => {
+              app = (req, res) => {
+                pool.execute('SELECT ' + req.query.param, (err) => {
+                  if (err) {
+                    res.statusCode = 500
+                  }
+
+                  res.end()
+                })
+              }
+
+              axios.get('/?param=1')
+
+              await checkRaspExecutedAndNotThreat(agent)
+            })
+
+            it('Should block query with callback', async () => {
+              app = (req, res) => {
+                pool.execute(`SELECT * FROM users WHERE id='${req.query.param}'`, (err) => {
+                  if (err?.name === 'DatadogRaspAbortError') {
+                    res.statusCode = 500
+                  }
+                  res.end()
+                })
+              }
+
+              try {
+                await axios.get('/?param=\' OR 1 = 1 --')
+              } catch (e) {
+                return await checkRaspExecutedAndHasThreat(agent, 'rasp-sqli-rule-id-2')
+              }
+
+              assert.fail('Request should be blocked')
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pgQueryStart, mysql2ConnectionQueryStart } = require('../../../src/appsec/channels')
+const { pgQueryStart, mysql2OuterQueryStart } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
 const proxyquire = require('proxyquire')
 
@@ -122,7 +122,7 @@ describe('RASP - sql_injection', () => {
       const req = {}
       datadogCore.storage.getStore.returns({ req })
 
-      mysql2ConnectionQueryStart.publish(ctx)
+      mysql2OuterQueryStart.publish(ctx)
 
       const persistent = {
         [addresses.DB_STATEMENT]: 'SELECT 1',
@@ -140,7 +140,7 @@ describe('RASP - sql_injection', () => {
       const req = {}
       datadogCore.storage.getStore.returns({ req })
 
-      mysql2ConnectionQueryStart.publish(ctx)
+      mysql2OuterQueryStart.publish(ctx)
 
       sinon.assert.notCalled(waf.run)
     })
@@ -151,7 +151,7 @@ describe('RASP - sql_injection', () => {
       }
       datadogCore.storage.getStore.returns(undefined)
 
-      mysql2ConnectionQueryStart.publish(ctx)
+      mysql2OuterQueryStart.publish(ctx)
 
       sinon.assert.notCalled(waf.run)
     })
@@ -162,7 +162,7 @@ describe('RASP - sql_injection', () => {
       }
       datadogCore.storage.getStore.returns({})
 
-      mysql2ConnectionQueryStart.publish(ctx)
+      mysql2OuterQueryStart.publish(ctx)
 
       sinon.assert.notCalled(waf.run)
     })
@@ -173,7 +173,7 @@ describe('RASP - sql_injection', () => {
       }
       datadogCore.storage.getStore.returns({})
 
-      mysql2ConnectionQueryStart.publish(ctx)
+      mysql2OuterQueryStart.publish(ctx)
 
       sinon.assert.notCalled(waf.run)
     })

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -95,6 +95,16 @@
       "versions": ["5", ">=6"]
     }
   ],
+  "mysql2": [
+    {
+      "name": "mysql2",
+      "versions": ["1.3.3"]
+    },
+    {
+      "name": "express",
+      "versions": [">=4"]
+    }
+  ],
   "fastify": [
     {
       "name": "fastify",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Instrument new methods in mysql2 to be able to detect the exploit when we are in a stack with app code. We need to have app code file and line in the stack to be able to share the exploited line.
In these new points, we support abortcontroller to stop sql execution when a exploit is detected.

### Motivation
<!-- What inspired you to submit this pull request? -->
Detect and stop sql injection attacks.

### Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


