### PR TITLE
[test visibility] Early Flake Detection for vitest 

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
@@ -9,7 +9,11 @@ describe('early flake detection', () => {
   })
 
   test('can retry tests that always pass', () => {
-    expect(sum(1, 2)).to.equal(3)
+    if (process.env.ALWAYS_FAIL) {
+      expect(sum(1, 2)).to.equal(4)
+    } else {
+      expect(sum(1, 2)).to.equal(3)
+    }
   })
 
   test('does not retry if it is not new', () => {

--- a/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
@@ -1,0 +1,18 @@
+import { describe, test, expect } from 'vitest'
+import { sum } from './sum'
+
+let numAttempt = 0
+
+describe('early flake detection', () => {
+  test('can retry tests that eventually pass', () => {
+    expect(sum(1, 2)).to.equal(numAttempt++ > 1 ? 3 : 4)
+  })
+
+  test('can retry tests that always pass', () => {
+    expect(sum(1, 2)).to.equal(3)
+  })
+
+  test('does not retry if it is not new', () => {
+    expect(sum(1, 2)).to.equal(3)
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest'
 import { sum } from './sum'
 
 let numAttempt = 0
+let numOtherAttempt = 0
 
 describe('early flake detection', () => {
   test('can retry tests that eventually pass', { repeats: process.env.SHOULD_REPEAT && 2 }, () => {
@@ -23,4 +24,10 @@ describe('early flake detection', () => {
   test.skip('does not retry if the test is skipped', () => {
     expect(sum(1, 2)).to.equal(3)
   })
+
+  if (process.env.SHOULD_ADD_EVENTUALLY_FAIL) {
+    test('can retry tests that eventually fail', () => {
+      expect(sum(1, 2)).to.equal(numOtherAttempt++ < 3 ? 3 : 4)
+    })
+  }
 })

--- a/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
@@ -4,11 +4,11 @@ import { sum } from './sum'
 let numAttempt = 0
 
 describe('early flake detection', () => {
-  test('can retry tests that eventually pass', () => {
+  test('can retry tests that eventually pass', { repeats: process.env.SHOULD_REPEAT && 2 }, () => {
     expect(sum(1, 2)).to.equal(numAttempt++ > 1 ? 3 : 4)
   })
 
-  test('can retry tests that always pass', () => {
+  test('can retry tests that always pass', { repeats: process.env.SHOULD_REPEAT && 2 }, () => {
     if (process.env.ALWAYS_FAIL) {
       expect(sum(1, 2)).to.equal(4)
     } else {

--- a/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
@@ -15,4 +15,8 @@ describe('early flake detection', () => {
   test('does not retry if it is not new', () => {
     expect(sum(1, 2)).to.equal(3)
   })
+
+  test.skip('does not retry if the test is skipped', () => {
+    expect(sum(1, 2)).to.equal(3)
+  })
 })

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -826,6 +826,75 @@ versions.forEach((version) => {
           }).catch(done)
         })
       })
+
+      it.only('works with repeats config when EFD is disabled', (done) => {
+        receiver.setSettings({
+          itr_enabled: false,
+          code_coverage: false,
+          tests_skipping: false,
+          early_flake_detection: {
+            enabled: false
+          }
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const tests = events.filter(event => event.type === 'test').map(test => test.content)
+
+            assert.equal(tests.length, 8)
+
+            assert.includeMembers(tests.map(test => test.meta[TEST_NAME]), [
+              'early flake detection can retry tests that eventually pass',
+              'early flake detection can retry tests that eventually pass',
+              'early flake detection can retry tests that eventually pass', // repeated twice
+              'early flake detection can retry tests that always pass',
+              'early flake detection can retry tests that always pass',
+              'early flake detection can retry tests that always pass', // repeated twice
+              'early flake detection does not retry if it is not new',
+              'early flake detection does not retry if the test is skipped'
+            ])
+            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+            assert.equal(newTests.length, 0) // no new test detected
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.equal(retriedTests.length, 4) // 2 repetitions on 2 tests
+
+            // vitest reports the test as failed if any of the repetitions fail, so we'll follow that
+            // TODO: we might want to improve htis
+            const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+            assert.equal(failedTests.length, 3)
+
+            const testSessionEvent = events.find(event => event.type === 'test_session_end').content
+            assert.propertyVal(testSessionEvent.meta, TEST_STATUS, 'fail')
+            assert.notProperty(testSessionEvent.meta, TEST_EARLY_FLAKE_ENABLED)
+          })
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              SHOULD_REPEAT: '1'
+            },
+            stdio: 'pipe'
+          }
+        )
+
+        childProcess.stdout.pipe(process.stdout)
+        childProcess.stderr.pipe(process.stderr)
+
+        childProcess.on('exit', (exitCode) => {
+          eventsPromise.then(() => {
+            assert.equal(exitCode, 1)
+            done()
+          }).catch(done)
+        })
+      })
     })
   })
 })

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -50,7 +50,6 @@ function getChannelPromise (channelToPublishTo) {
 }
 
 function getSessionStatus (state) {
-  console.log('state.getCountOfFailedTests()', state.getCountOfFailedTests())
   if (state.getCountOfFailedTests() > 0) {
     return 'fail'
   }
@@ -350,7 +349,8 @@ addHook({
         if (isEarlyFlakeDetectionEnabled) {
           const statuses = taskToStatuses.get(task)
           statuses.push(lastExecutionStatus)
-          // We forcefully report the test as passed, so vitest does not consider it failed
+          // If we don't "reset" the result.state to "pass", once a repetition fails,
+          // vitest will always consider the test as failed, so we can't read the actual status
           task.result.state = 'pass'
         }
       }

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -41,6 +41,12 @@ class VitestPlugin extends CiPlugin {
 
     this.taskToFinishTime = new WeakMap()
 
+    this.addSub('ci:vitest:test:is-new', ({ knownTests, testSuiteAbsolutePath, testName, onDone }) => {
+      const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
+      const testsForThisTestSuite = knownTests[testSuite] || []
+      onDone(!testsForThisTestSuite.includes(testName))
+    })
+
     this.addSub('ci:vitest:is-early-flake-detection-faulty', ({
       knownTests,
       testFilepaths,

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -39,7 +39,6 @@ class VitestPlugin extends CiPlugin {
     this.taskToFinishTime = new WeakMap()
 
     this.addSub('ci:vitest:test:start', ({ testName, testSuiteAbsolutePath, isRetry, isNew }) => {
-      // console.log('starting', testName)
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const store = storage.getStore()
 
@@ -66,10 +65,6 @@ class VitestPlugin extends CiPlugin {
     this.addSub('ci:vitest:test:finish-time', ({ status, task }) => {
       const store = storage.getStore()
       const span = store?.span
-      // console.log('finishing', {
-      //   name: span.context()._tags['test.name'],
-      //   id: span.context().toTraceId()
-      // })
 
       // we store the finish time to finish at a later hook
       // this is because the test might fail at a `afterEach` hook


### PR DESCRIPTION
### What does this PR do?
Add Early flake detection to vitest.

### Motivation
Allow users to detect flakiness before it reaches their default branch.

⚠️ Number of retries check if the test is too slow is not done in this PR. I'll do it later, since this has got too big already. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
