### PR TITLE
rasp lfi subs delayed

### DIFF
--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -31,9 +31,8 @@ function disable () {
 }
 
 function onFirstReceivedRequest () {
+  // nodejs unsubscribe during publish bug: https://github.com/nodejs/node/pull/55116
   process.nextTick(() => {
-    // TODO: review. If unsubscribe is called synchronously other incomingHttpRequestStart listeners like
-    // appsec incomingHttpStartTranslator are not called
     incomingHttpRequestStart.unsubscribe(onFirstReceivedRequest)
   })
 

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -31,7 +31,11 @@ function disable () {
 }
 
 function onFirstReceivedRequest () {
-  incomingHttpRequestStart.unsubscribe(onFirstReceivedRequest)
+  process.nextTick(() => {
+    // TODO: review. If unsubscribe is called synchronously other incomingHttpRequestStart listeners like
+    // appsec incomingHttpStartTranslator are not called
+    incomingHttpRequestStart.unsubscribe(onFirstReceivedRequest)
+  })
 
   enableFsPlugin('rasp')
 

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -9,9 +9,14 @@ const { RULE_TYPES, handleResult } = require('./utils')
 const { isAbsolute } = require('path')
 
 let config
+let enabled
 
 function enable (_config) {
   config = _config
+
+  if (enabled) return
+
+  enabled = true
 
   incomingHttpRequestStart.subscribe(onFirstReceivedRequest)
 }
@@ -21,6 +26,8 @@ function disable () {
   if (incomingHttpRequestStart.hasSubscribers) incomingHttpRequestStart.unsubscribe(onFirstReceivedRequest)
 
   disableFsPlugin('rasp')
+
+  enabled = false
 }
 
 function onFirstReceivedRequest () {

--- a/packages/dd-trace/test/appsec/index.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.express.plugin.spec.js
@@ -95,6 +95,9 @@ withVersions('express', 'express', version => {
             rules: path.join(__dirname, 'api_security_rules.json'),
             apiSecurity: {
               enabled: true
+            },
+            rasp: {
+              enabled: false
             }
           }
         })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -24,6 +24,7 @@ const blockedTemplate = require('../../src/appsec/blocked_templates')
 const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../../src/telemetry/metrics')
 const addresses = require('../../src/appsec/addresses')
+const { disable: disableLfi } = require('../../src/appsec/rasp/lfi')
 
 const resultActions = {
   block_request: {
@@ -1061,6 +1062,8 @@ describe('IP blocking', function () {
         enabled: true
       }
     }))
+
+    disableLfi()
 
     RuleManager.updateWafFromRC({ toUnapply: [], toApply: [], toModify })
   })

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -5,7 +5,7 @@ const { fsOperationStart, incomingHttpRequestStart } = require('../../../src/app
 const { FS_OPERATION_PATH } = require('../../../src/appsec/addresses')
 
 describe('RASP - lfi.js', () => {
-  let waf, datadogCore, lfi, web, blocking, appsecFsPlugin
+  let waf, datadogCore, lfi, web, blocking, appsecFsPlugin, config
 
   beforeEach(() => {
     datadogCore = {
@@ -39,7 +39,7 @@ describe('RASP - lfi.js', () => {
       './fs-plugin': appsecFsPlugin
     })
 
-    const config = {
+    config = {
       appsec: {
         stackTrace: {
           enabled: true,
@@ -51,8 +51,6 @@ describe('RASP - lfi.js', () => {
 
     sinon.spy(incomingHttpRequestStart, 'subscribe')
     sinon.spy(incomingHttpRequestStart, 'unsubscribe')
-
-    lfi.enable(config)
   })
 
   afterEach(() => {
@@ -62,11 +60,16 @@ describe('RASP - lfi.js', () => {
 
   describe('enable', () => {
     it('should subscribe to first http req', () => {
+      lfi.enable(config)
+
       sinon.assert.calledOnce(incomingHttpRequestStart.subscribe)
     })
 
     it('should enable AppsecFsPlugin after the first request', () => {
+      lfi.enable(config)
+
       incomingHttpRequestStart.publish({})
+
       sinon.assert.calledOnceWithExactly(appsecFsPlugin.enable, 'rasp')
       sinon.assert.calledOnce(incomingHttpRequestStart.unsubscribe)
     })
@@ -74,6 +77,8 @@ describe('RASP - lfi.js', () => {
 
   describe('disable', () => {
     it('should disable AppsecFsPlugin', () => {
+      lfi.enable(config)
+
       lfi.disable()
       sinon.assert.calledOnceWithExactly(appsecFsPlugin.disable, 'rasp')
     })
@@ -85,6 +90,8 @@ describe('RASP - lfi.js', () => {
     const req = {}
 
     beforeEach(() => {
+      lfi.enable(config)
+
       incomingHttpRequestStart.publish({})
     })
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -57,22 +57,22 @@ describe('RASP - lfi.js', () => {
 
   describe('enable', () => {
     it('should subscribe to first http req', () => {
-      sinon.spy(incomingHttpRequestStart, 'subscribe')
+      const subscribe = sinon.stub(incomingHttpRequestStart, 'subscribe')
 
       lfi.enable(config)
 
-      sinon.assert.calledOnce(incomingHttpRequestStart.subscribe)
+      sinon.assert.calledOnce(subscribe)
     })
 
     it('should enable AppsecFsPlugin after the first request', () => {
-      sinon.spy(incomingHttpRequestStart, 'unsubscribe')
+      const unsubscribe = sinon.stub(incomingHttpRequestStart, 'unsubscribe')
 
       lfi.enable(config)
 
       incomingHttpRequestStart.publish({})
 
       sinon.assert.calledOnceWithExactly(appsecFsPlugin.enable, 'rasp')
-      sinon.assert.calledOnce(incomingHttpRequestStart.unsubscribe)
+      sinon.assert.calledOnce(unsubscribe)
     })
   })
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -72,7 +72,10 @@ describe('RASP - lfi.js', () => {
       incomingHttpRequestStart.publish({})
 
       sinon.assert.calledOnceWithExactly(appsecFsPlugin.enable, 'rasp')
-      sinon.assert.calledOnce(unsubscribe)
+
+      process.nextTick(() => {
+        sinon.assert.calledOnce(unsubscribe)
+      })
     })
   })
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -48,9 +48,6 @@ describe('RASP - lfi.js', () => {
         }
       }
     }
-
-    sinon.spy(incomingHttpRequestStart, 'subscribe')
-    sinon.spy(incomingHttpRequestStart, 'unsubscribe')
   })
 
   afterEach(() => {
@@ -60,12 +57,16 @@ describe('RASP - lfi.js', () => {
 
   describe('enable', () => {
     it('should subscribe to first http req', () => {
+      sinon.spy(incomingHttpRequestStart, 'subscribe')
+
       lfi.enable(config)
 
       sinon.assert.calledOnce(incomingHttpRequestStart.subscribe)
     })
 
     it('should enable AppsecFsPlugin after the first request', () => {
+      sinon.spy(incomingHttpRequestStart, 'unsubscribe')
+
       lfi.enable(config)
 
       incomingHttpRequestStart.publish({})

--- a/packages/dd-trace/test/appsec/response_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/response_blocking.spec.js
@@ -9,7 +9,7 @@ const path = require('path')
 const WafContext = require('../../src/appsec/waf/waf_context_wrapper')
 const blockingResponse = JSON.parse(require('../../src/appsec/blocked_templates').json)
 const fs = require('fs')
-const { disable: disableFsPlugin } = require('../../src/appsec/rasp/fs-plugin')
+const { disable: disableLfi } = require('../../src/appsec/rasp/lfi')
 
 describe('HTTP Response Blocking', () => {
   let server
@@ -57,7 +57,7 @@ describe('HTTP Response Blocking', () => {
       }
     }))
 
-    disableFsPlugin('rasp')
+    disableLfi()
   })
 
   beforeEach(() => {


### PR DESCRIPTION
### What does this PR do?
delay LFI subscription to fs:operation channels until first http req is received to avoid application startup overhead due to fs operations

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


