### PR TITLE
[MLOB-1556] LLM Observability tagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "test:core:ci": "npm run test:core -- --coverage --nyc-arg=--include=\"packages/datadog-core/src/**/*.js\"",
     "test:lambda": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/lambda/**/*.spec.js\"",
     "test:lambda:ci": "nyc --no-clean --include \"packages/dd-trace/src/lambda/**/*.js\" -- npm run test:lambda",
+    "test:llmobs": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/llmobs/**/*.spec.js\"",
+    "test:llmobs:ci": "nyc --no-clean --include \"packages/dd-trace/src/llmobs/**/*.js\" -- npm run test:llmobs",
     "test:plugins": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/datadog-instrumentations/test/@($(echo $PLUGINS)).spec.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\"",
     "test:plugins:ci": "yarn services && nyc --no-clean --include \"packages/datadog-instrumentations/src/@($(echo $PLUGINS)).js\" --include \"packages/datadog-instrumentations/src/@($(echo $PLUGINS))/**/*.js\" --include \"packages/datadog-plugin-@($(echo $PLUGINS))/src/**/*.js\" -- npm run test:plugins",
     "test:plugins:upstream": "node ./packages/dd-trace/test/plugins/suite.js",

--- a/packages/dd-trace/src/llmobs/constants.js
+++ b/packages/dd-trace/src/llmobs/constants.js
@@ -12,6 +12,7 @@ module.exports = {
   NAME: '_ml_obs.name',
   TRACE_ID: '_ml_obs.trace_id',
   PROPAGATED_TRACE_ID_KEY: '_dd.p.llmobs_trace_id',
+  ROOT_PARENT_ID: 'undefined',
 
   MODEL_NAME: '_ml_obs.meta.model_name',
   MODEL_PROVIDER: '_ml_obs.meta.model_provider',

--- a/packages/dd-trace/src/llmobs/constants.js
+++ b/packages/dd-trace/src/llmobs/constants.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = {
+  SPAN_KIND: '_ml_obs.meta.span.kind',
+  SESSION_ID: '_ml_obs.session_id',
+  METADATA: '_ml_obs.meta.metadata',
+  METRICS: '_ml_obs.metrics',
+  ML_APP: '_ml_obs.meta.ml_app',
+  PROPAGATED_PARENT_ID_KEY: '_dd.p.llmobs_parent_id',
+  PARENT_ID_KEY: '_ml_obs.llmobs_parent_id',
+  TAGS: '_ml_obs.tags',
+  NAME: '_ml_obs.name',
+  TRACE_ID: '_ml_obs.trace_id',
+  PROPAGATED_TRACE_ID_KEY: '_dd.p.llmobs_trace_id',
+
+  MODEL_NAME: '_ml_obs.meta.model_name',
+  MODEL_PROVIDER: '_ml_obs.meta.model_provider',
+
+  INPUT_DOCUMENTS: '_ml_obs.meta.input.documents',
+  INPUT_MESSAGES: '_ml_obs.meta.input.messages',
+  INPUT_VALUE: '_ml_obs.meta.input.value',
+
+  OUTPUT_DOCUMENTS: '_ml_obs.meta.output.documents',
+  OUTPUT_MESSAGES: '_ml_obs.meta.output.messages',
+  OUTPUT_VALUE: '_ml_obs.meta.output.value'
+}

--- a/packages/dd-trace/src/llmobs/constants.js
+++ b/packages/dd-trace/src/llmobs/constants.js
@@ -24,7 +24,7 @@ module.exports = {
   OUTPUT_DOCUMENTS: '_ml_obs.meta.output.documents',
   OUTPUT_MESSAGES: '_ml_obs.meta.output.messages',
   OUTPUT_VALUE: '_ml_obs.meta.output.value',
-  
+
   EVP_PROXY_AGENT_BASE_PATH: 'evp_proxy/v2',
   EVP_PROXY_AGENT_ENDPOINT: 'evp_proxy/v2/api/v2/llmobs',
   EVP_SUBDOMAIN_HEADER_NAME: 'X-Datadog-EVP-Subdomain',

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -21,7 +21,8 @@ const {
   OUTPUT_MESSAGES,
   TAGS,
   NAME,
-  PROPAGATED_PARENT_ID_KEY
+  PROPAGATED_PARENT_ID_KEY,
+  ROOT_PARENT_ID
 } = require('./constants')
 
 class LLMObsTagger {
@@ -51,7 +52,7 @@ class LLMObsTagger {
     const parentId =
       parentLLMObsSpan?.context().toSpanId() ||
       span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY] ||
-      'undefined'
+      ROOT_PARENT_ID
     span.setTag(PARENT_ID_KEY, parentId)
   }
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -1,0 +1,206 @@
+'use strict'
+
+const logger = require('../log')
+const {
+  SPAN_TYPE
+} = require('../../../../ext/tags')
+const {
+  MODEL_NAME,
+  MODEL_PROVIDER,
+  SESSION_ID,
+  ML_APP,
+  SPAN_KIND,
+  INPUT_VALUE,
+  OUTPUT_DOCUMENTS,
+  INPUT_DOCUMENTS,
+  OUTPUT_VALUE,
+  METADATA,
+  METRICS,
+  PARENT_ID_KEY,
+  INPUT_MESSAGES,
+  OUTPUT_MESSAGES,
+  TAGS,
+  NAME,
+  PROPAGATED_PARENT_ID_KEY
+} = require('./constants')
+
+class LLMObsTagger {
+  constructor (config) {
+    this._config = config
+  }
+
+  setLLMObsSpanTags (
+    span,
+    kind,
+    { modelName, modelProvider, sessionId, mlApp, parentLLMObsSpan } = {},
+    name
+  ) {
+    if (kind) span.setTag(SPAN_TYPE, 'llm') // only mark it as an llm span if it was a valid kind
+    if (name) span.setTag(NAME, name)
+
+    span.setTag(SPAN_KIND, kind)
+    if (modelName) span.setTag(MODEL_NAME, modelName)
+    if (modelProvider) span.setTag(MODEL_PROVIDER, modelProvider)
+
+    sessionId = sessionId || parentLLMObsSpan?.context()._tags[SESSION_ID]
+    if (sessionId) span.setTag(SESSION_ID, sessionId)
+
+    if (!mlApp) mlApp = parentLLMObsSpan?.context()._tags[ML_APP] || this._config.llmobs.mlApp
+    span.setTag(ML_APP, mlApp)
+
+    const parentId =
+      parentLLMObsSpan?.context().toSpanId() ||
+      span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY] ||
+      'undefined'
+    span.setTag(PARENT_ID_KEY, parentId)
+  }
+
+  tagLLMIO (span, inputData, outputData) {
+    this._tagMessages(span, inputData, INPUT_MESSAGES)
+    this._tagMessages(span, outputData, OUTPUT_MESSAGES)
+  }
+
+  tagEmbeddingIO (span, inputData, outputData) {
+    this._tagDocuments(span, inputData, INPUT_DOCUMENTS)
+    this._tagText(span, outputData, OUTPUT_VALUE)
+  }
+
+  tagRetrievalIO (span, inputData, outputData) {
+    this._tagText(span, inputData, INPUT_VALUE)
+    this._tagDocuments(span, outputData, OUTPUT_DOCUMENTS)
+  }
+
+  tagTextIO (span, inputData, outputData) {
+    this._tagText(span, inputData, INPUT_VALUE)
+    this._tagText(span, outputData, OUTPUT_VALUE)
+  }
+
+  tagMetadata (span, metadata) {
+    try {
+      span.setTag(METADATA, JSON.stringify(metadata))
+    } catch {
+      logger.warn('Failed to parse span metadata. Metadata key-value pairs must be JSON serializable.')
+    }
+  }
+
+  tagMetrics (span, metrics) {
+    try {
+      span.setTag(METRICS, JSON.stringify(metrics))
+    } catch {
+      logger.warn('Failed to parse span metrics. Metrics key-value pairs must be JSON serializable.')
+    }
+  }
+
+  tagSpanTags (span, tags) {
+    try {
+      const currentTags = span.context()._tags[TAGS]
+      if (currentTags) {
+        Object.assign(tags, currentTags)
+      }
+      span.setTag(TAGS, JSON.stringify(tags))
+    } catch {
+      logger.warn('Failed to parse span tags. Tag key-value pairs must be JSON serializable.')
+    }
+  }
+
+  _tagText (span, data, key) {
+    if (data) {
+      if (typeof data === 'string') {
+        span.setTag(key, data)
+      } else {
+        try {
+          // this will help showcase unfinished promises being passed in as values
+          span.setTag(key, JSON.stringify(data))
+        } catch {
+          const type = key === INPUT_VALUE ? 'input' : 'output'
+          logger.warn(`Failed to parse ${type} value, must be JSON serializable.`)
+        }
+      }
+    }
+  }
+
+  _tagDocuments (span, data, key) {
+    if (data) {
+      if (!Array.isArray(data)) {
+        data = [data]
+      }
+
+      try {
+        const documents = data.map(document => {
+          if (typeof document === 'string') {
+            return document
+          }
+
+          const { text, name, id, score } = document
+
+          if (text && typeof text !== 'string') {
+            logger.warn(`Invalid property found in ${document}: text must be a string.`)
+            return undefined
+          }
+
+          if (name && typeof name !== 'string') {
+            logger.warn(`Invalid property found in ${document}: name must be a string.`)
+            return undefined
+          }
+
+          if (id && typeof id !== 'string') {
+            logger.warn(`Invalid property found in ${document}: id must be a string.`)
+            return undefined
+          }
+
+          if (score && typeof score !== 'number') {
+            logger.warn(`Invalid property found in ${document}: score must be a number.`)
+            return undefined
+          }
+
+          return document
+        }).filter(doc => !!doc) // filter out bad documents?
+
+        span.setTag(key, JSON.stringify(documents))
+      } catch {
+        const type = key === INPUT_DOCUMENTS ? 'input' : 'output'
+        logger.warn(`Failed to parse ${type} documents.`)
+      }
+    }
+  }
+
+  _tagMessages (span, data, key) {
+    if (data) {
+      if (!Array.isArray(data)) {
+        data = [data]
+      }
+
+      try {
+        const messages = data.map(message => {
+          if (typeof message === 'string') {
+            return message
+          }
+
+          const content = message.content || ''
+          const role = message.role
+
+          if (typeof content !== 'string') {
+            logger.warn(`Invalid property found in ${message}: content must be a string.`)
+            return undefined
+          }
+
+          message.content = content
+
+          if (role && typeof role !== 'string') {
+            logger.warn(`Invalid property found in ${message}: role must be a string.`)
+            return undefined
+          }
+
+          return message
+        }).filter(msg => !!msg) // filter out bad messages?
+
+        span.setTag(key, JSON.stringify(messages))
+      } catch {
+        const type = key === INPUT_MESSAGES ? 'input' : 'output'
+        logger.warn(`Failed to parse ${type} messages.`)
+      }
+    }
+  }
+}
+
+module.exports = LLMObsTagger

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -210,7 +210,7 @@ describe('tagger', () => {
     })
   })
 
-  describe.only('tagLLMIO', () => {
+  describe('tagLLMIO', () => {
     it('tags a span with llm io', () => {
       const inputData = [
         'you are an amazing assistant',

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -184,245 +184,180 @@ describe('tagger', () => {
     })
   })
 
+  describe('tagSpanTags', () => {
+    it('sets tags on a span', () => {
+      const tags = { foo: 'bar' }
+      tagger.tagSpanTags(span, tags)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.tags': '{"foo":"bar"}'
+      })
+    })
+
+    it('merges tags so they do not overwrite', () => {
+      span.context()._tags['_ml_obs.tags'] = '{"a":1}'
+      const tags = { a: 2, b: 1 }
+      tagger.tagSpanTags(span, tags)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.tags': '{"a":1,"b":1}'
+      })
+    })
+  })
+
   describe('tagLLMIO', () => {
-    beforeEach(() => {
-      sinon.stub(tagger, '_tagMessages')
-    })
-
-    afterEach(() => {
-      tagger._tagMessages.restore()
-    })
-
     it('tags a span with llm io', () => {
-      tagger.tagLLMIO(span, { a: 'foo' }, { b: 'bar' })
-      expect(tagger._tagMessages).to.have.been.calledTwice
-      expect(tagger._tagMessages).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.messages')
-      expect(tagger._tagMessages).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.messages')
+      const inputData = [
+        'you are an amazing assistant',
+        { content: 'hello! my name is foobar' },
+        { content: 'I am a robot', role: 'assistant' },
+        { content: 'I am a human', role: 'user' }
+      ]
+
+      const outputData = 'Nice to meet you, human!'
+
+      tagger.tagLLMIO(span, inputData, outputData)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":"you are an amazing assistant"},' +
+        '{"content":"hello! my name is foobar"},{"content":"I am a robot","role":"assistant"},' +
+        '{"content":"I am a human","role":"user"}]',
+        '_ml_obs.meta.output.messages': '[{"content":"Nice to meet you, human!"}]'
+      })
+    })
+
+    it('filters out non-string properties on messages', () => {
+      const inputData = [
+        true,
+        { content: 5 },
+        { content: 'hello', role: 5 },
+        'hi'
+      ]
+      const outputData = [
+        undefined,
+        null,
+        { content: 5 },
+        { content: 'goodbye', role: 5 }
+      ]
+      tagger.tagLLMIO(span, inputData, outputData)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":"hi"}]'
+      })
+
+      expect(logger.warn.getCall(0).firstArg).to.equal('Messages must be a string, object, or list of objects')
+      expect(logger.warn.getCall(1).firstArg).to.equal('Message content must be a string.')
+      expect(logger.warn.getCall(2).firstArg).to.equal('Message role must be a string.')
+      expect(logger.warn.getCall(3).firstArg).to.equal('Messages must be a string, object, or list of objects')
+      expect(logger.warn.getCall(4).firstArg).to.equal('Messages must be a string, object, or list of objects')
+      expect(logger.warn.getCall(5).firstArg).to.equal('Message content must be a string.')
+      expect(logger.warn.getCall(6).firstArg).to.equal('Message role must be a string.')
     })
   })
 
   describe('tagEmbeddingIO', () => {
-    beforeEach(() => {
-      sinon.stub(tagger, '_tagDocuments')
-      sinon.stub(tagger, '_tagText')
-    })
-
-    afterEach(() => {
-      tagger._tagDocuments.restore()
-      tagger._tagText.restore()
-    })
-
     it('tags a span with embedding io', () => {
-      tagger.tagEmbeddingIO(span, { a: 'foo' }, { b: 'bar' })
-      expect(tagger._tagDocuments).to.have.been.calledOnce
-      expect(tagger._tagDocuments).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.documents')
-      expect(tagger._tagText).to.have.been.calledOnce
-      expect(tagger._tagText).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.value')
+      const inputData = [
+        'my string document',
+        { text: 'my object document' },
+        { text: 'foo', name: 'bar' },
+        { text: 'baz', id: 'qux' },
+        { text: 'quux', score: 5 },
+        { text: 'foo', name: 'bar', id: 'qux', score: 5 }
+      ]
+      const outputData = 'embedded documents'
+      tagger.tagEmbeddingIO(span, inputData, outputData)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.documents': '[{"text":"my string document"},{"text":"my object document"},' +
+        '{"text":"foo","name":"bar"},{"text":"baz","id":"qux"},{"text":"quux","score":5},' +
+        '{"text":"foo","name":"bar","id":"qux","score":5}]',
+        '_ml_obs.meta.output.value': 'embedded documents'
+      })
+    })
+
+    it('filters out non-string properties on documents', () => {
+      const inputData = [
+        true,
+        { text: 5 },
+        { text: 'foo', name: 5 },
+        'hi',
+        null,
+        undefined
+      ]
+      const outputData = 'output'
+      tagger.tagEmbeddingIO(span, inputData, outputData)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.documents': '[{"text":"hi"}]',
+        '_ml_obs.meta.output.value': 'output'
+      })
+
+      expect(logger.warn.getCall(0).firstArg).to.equal('Documents must be a string, object, or list of objects.')
+      expect(logger.warn.getCall(1).firstArg).to.equal('Document text must be a string.')
+      expect(logger.warn.getCall(2).firstArg).to.equal('Document name must be a string.')
+      expect(logger.warn.getCall(3).firstArg).to.equal('Documents must be a string, object, or list of objects.')
+      expect(logger.warn.getCall(4).firstArg).to.equal('Documents must be a string, object, or list of objects.')
     })
   })
 
   describe('tagRetrievalIO', () => {
-    beforeEach(() => {
-      sinon.stub(tagger, '_tagDocuments')
-      sinon.stub(tagger, '_tagText')
-    })
-
-    afterEach(() => {
-      tagger._tagDocuments.restore()
-      tagger._tagText.restore()
-    })
-
     it('tags a span with retrieval io', () => {
-      tagger.tagRetrievalIO(span, { a: 'foo' }, { b: 'bar' })
-      expect(tagger._tagDocuments).to.have.been.calledOnce
-      expect(tagger._tagDocuments).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.documents')
-      expect(tagger._tagText).to.have.been.calledOnce
-      expect(tagger._tagText).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.value')
+      const inputData = 'some query'
+      const outputData = [
+        'result 1',
+        { text: 'result 2' },
+        { text: 'foo', name: 'bar' },
+        { text: 'baz', id: 'qux' },
+        { text: 'quux', score: 5 },
+        { text: 'foo', name: 'bar', id: 'qux', score: 5 }
+      ]
+
+      tagger.tagRetrievalIO(span, inputData, outputData)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.value': 'some query',
+        '_ml_obs.meta.output.documents': '[{"text":"result 1"},{"text":"result 2"},' +
+        '{"text":"foo","name":"bar"},{"text":"baz","id":"qux"},{"text":"quux","score":5},' +
+        '{"text":"foo","name":"bar","id":"qux","score":5}]'
+      })
+    })
+
+    it('filters out non-string properties on documents', () => {
+      const inputData = 'some query'
+      const outputData = [
+        true,
+        { text: 5 },
+        { text: 'foo', name: 5 },
+        'hi',
+        null,
+        undefined
+      ]
+      tagger.tagRetrievalIO(span, inputData, outputData)
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.value': 'some query',
+        '_ml_obs.meta.output.documents': '[{"text":"hi"}]'
+      })
+
+      expect(logger.warn.getCall(0).firstArg).to.equal('Documents must be a string, object, or list of objects.')
+      expect(logger.warn.getCall(1).firstArg).to.equal('Document text must be a string.')
+      expect(logger.warn.getCall(2).firstArg).to.equal('Document name must be a string.')
+      expect(logger.warn.getCall(3).firstArg).to.equal('Documents must be a string, object, or list of objects.')
+      expect(logger.warn.getCall(4).firstArg).to.equal('Documents must be a string, object, or list of objects.')
     })
   })
 
   describe('tagTextIO', () => {
-    beforeEach(() => {
-      sinon.stub(tagger, '_tagText')
-    })
-
-    afterEach(() => {
-      tagger._tagText.restore()
-    })
-
     it('tags a span with text io', () => {
-      tagger.tagTextIO(span, { a: 'foo' }, { b: 'bar' })
-      expect(tagger._tagText).to.have.been.calledTwice
-      expect(tagger._tagText).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.value')
-      expect(tagger._tagText).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.value')
-    })
-  })
-
-  // maybe confirm this one
-  describe('tagSpanTags', () => {})
-
-  describe('_tagText', () => {
-    it('tags a span with text', () => {
-      tagger._tagText(span, 'my-text', '_ml_obs.meta.input.value')
-
+      const inputData = { some: 'object' }
+      const outputData = 'some text'
+      tagger.tagTextIO(span, inputData, outputData)
       expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.value': 'my-text'
-      })
-    })
-
-    it('tags a span with an object', () => {
-      tagger._tagText(span, { a: 1, b: 2 }, '_ml_obs.meta.input.value')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.value': '{"a":1,"b":2}'
+        '_ml_obs.meta.input.value': '{"some":"object"}',
+        '_ml_obs.meta.output.value': 'some text'
       })
     })
 
     it('logs when the value is not JSON serializable', () => {
       const data = unserializbleObject()
-      tagger._tagText(span, data, '_ml_obs.meta.input.value')
-      expect(logger.warn).to.have.been.calledOnce
-    })
-  })
-
-  describe('_tagDocuments', () => {
-    it('tags a single document object', () => {
-      const document = { text: 'my-text', name: 'my-name', id: 'my-id', score: 0.5 }
-      tagger._tagDocuments(span, document, '_ml_obs.meta.input.documents')
-
+      tagger.tagTextIO(span, data, 'output')
+      expect(logger.warn).to.have.been.calledOnceWith('Failed to parse input value, must be JSON serializable.')
       expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.documents': '[{"text":"my-text","name":"my-name","id":"my-id","score":0.5}]'
+        '_ml_obs.meta.output.value': 'output'
       })
-    })
-
-    it('tags a single document string', () => {
-      const document = 'my-text'
-      tagger._tagDocuments(span, document, '_ml_obs.meta.input.documents')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.documents': '["my-text"]'
-      })
-    })
-
-    it('tags a document with a subset of properties', () => {
-      const document = { text: 'my-text', score: 0.5 }
-      tagger._tagDocuments(span, document, '_ml_obs.meta.input.documents')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.documents': '[{"text":"my-text","score":0.5}]'
-      })
-    })
-
-    it('tags multiple documents', () => {
-      const documents = [
-        { text: 'my-text', name: 'my-name', id: 'my-id', score: 0.5 },
-        { text: 'my-text2', name: 'my-name2', id: 'my-id2', score: 0.6 }
-      ]
-      tagger._tagDocuments(span, documents, '_ml_obs.meta.input.documents')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.documents': '[{"text":"my-text","name":"my-name"' +
-        ',"id":"my-id","score":0.5},{"text":"my-text2","name":"my-name2","id":"my-id2","score":0.6}]'
-      })
-    })
-
-    it('does not include malformed documents', () => {
-      const documents = [
-        { text: 'my-text', name: 'my-name', id: 'my-id', score: 0.5 },
-        { text: 'my-text2', score: 'not-a-number' }
-      ]
-
-      tagger._tagDocuments(span, documents, '_ml_obs.meta.input.documents')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.documents': '[{"text":"my-text","name":"my-name","id":"my-id","score":0.5}]'
-      })
-    })
-
-    it('logs when a document is not JSON serializable', () => {
-      const documents = [unserializbleObject()]
-      tagger._tagDocuments(span, documents, '_ml_obs.meta.input.documents')
-      expect(logger.warn).to.have.been.calledOnce
-    })
-  })
-
-  describe('_tagMessages', () => {
-    it('tags a single message object', () => {
-      const message = { content: 'my-content', role: 'my-role' }
-      tagger._tagMessages(span, message, '_ml_obs.meta.input.messages')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.messages': '[{"content":"my-content","role":"my-role"}]'
-      })
-    })
-
-    it('tags a single message string', () => {
-      tagger._tagMessages(span, 'my-message', '_ml_obs.meta.input.messages')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.messages': '["my-message"]'
-      })
-    })
-
-    it('tags a message with only content', () => {
-      const message = { content: 'my-content' }
-      tagger._tagMessages(span, message, '_ml_obs.meta.input.messages')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.messages': '[{"content":"my-content"}]'
-      })
-    })
-
-    it('defaults missing content to empty content', () => {
-      const message = {}
-      tagger._tagMessages(span, message, '_ml_obs.meta.input.messages')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.messages': '[{"content":""}]'
-      })
-    })
-
-    it('filters out messages with non-string content', () => {
-      const messages = [
-        { content: 'my-content' },
-        { role: 'my-role', content: 6 }
-      ]
-      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.messages': '[{"content":"my-content"}]'
-      })
-    })
-
-    it('filters out messages with non-string role', () => {
-      const messages = [
-        { content: 'my-content', role: 'my-role' },
-        { content: 'my-content2', role: 6 }
-      ]
-      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.messages': '[{"content":"my-content","role":"my-role"}]'
-      })
-    })
-
-    it('tags multiple messages', () => {
-      const messages = [
-        { content: 'my-content', role: 'my-role' },
-        { content: 'my-content2', role: 'my-role2' }
-      ]
-      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
-
-      expect(span.context()._tags).to.deep.equal({
-        '_ml_obs.meta.input.messages': '[{"content":"my-content","role":"my-role"},' +
-        '{"content":"my-content2","role":"my-role2"}]'
-      })
-    })
-
-    it('logs when a message is not JSON serializable', () => {
-      const messages = [unserializbleObject()]
-      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
-      expect(logger.warn).to.have.been.calledOnce
     })
   })
 })

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -124,8 +124,6 @@ describe('tagger', () => {
     })
 
     it('uses the propagated trace id if provided', () => {
-      spanContext._trace.tags['_dd.p.llmobs_trace_id'] = '-123'
-
       tagger.setLLMObsSpanTags(span, 'llm')
 
       expect(span.context()._tags).to.deep.equal({

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -1,0 +1,430 @@
+'use strict'
+
+const { expect } = require('chai')
+const proxyquire = require('proxyquire')
+
+function unserializbleObject () {
+  const obj = {}
+  obj.obj = obj
+  return obj
+}
+
+describe('tagger', () => {
+  let span
+  let spanContext
+  let Tagger
+  let tagger
+  let logger
+  let util
+
+  beforeEach(() => {
+    spanContext = {
+      _tags: {},
+      _trace: { tags: {} }
+    }
+
+    span = {
+      context () { return spanContext },
+      setTag (k, v) {
+        this.context()._tags[k] = v
+      }
+    }
+
+    util = {
+      generateTraceId: sinon.stub().returns('0123')
+    }
+
+    logger = {
+      warn: sinon.stub()
+    }
+
+    Tagger = proxyquire('../../src/llmobs/tagger', {
+      '../log': logger,
+      './util': util
+    })
+
+    tagger = new Tagger({ llmobs: { mlApp: 'my-default-ml-app' } })
+  })
+
+  describe('setLLMObsSpanTags', () => {
+    it('tags an llm obs span with basic and default properties', () => {
+      tagger.setLLMObsSpanTags(span, 'workflow')
+
+      expect(span.context()._tags).to.deep.equal({
+        'span.type': 'llm',
+        '_ml_obs.meta.span.kind': 'workflow',
+        '_ml_obs.meta.ml_app': 'my-default-ml-app',
+        '_ml_obs.llmobs_parent_id': 'undefined' // no parent id provided
+      })
+    })
+
+    it('uses options passed in to set tags', () => {
+      tagger.setLLMObsSpanTags(span, 'llm', {
+        modelName: 'my-model',
+        modelProvider: 'my-provider',
+        sessionId: 'my-session',
+        mlApp: 'my-app'
+      })
+
+      expect(span.context()._tags).to.deep.equal({
+        'span.type': 'llm',
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.meta.model_name': 'my-model',
+        '_ml_obs.meta.model_provider': 'my-provider',
+        '_ml_obs.session_id': 'my-session',
+        '_ml_obs.meta.ml_app': 'my-app',
+        '_ml_obs.llmobs_parent_id': 'undefined'
+      })
+    })
+
+    it('uses the name if provided', () => {
+      tagger.setLLMObsSpanTags(span, 'llm', {}, 'my-span-name')
+
+      expect(span.context()._tags).to.deep.equal({
+        'span.type': 'llm',
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.meta.ml_app': 'my-default-ml-app',
+        '_ml_obs.llmobs_parent_id': 'undefined',
+        '_ml_obs.name': 'my-span-name'
+      })
+    })
+
+    it('defaults parent id to undefined', () => {
+      tagger.setLLMObsSpanTags(span, 'llm')
+
+      expect(span.context()._tags).to.deep.equal({
+        'span.type': 'llm',
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.meta.ml_app': 'my-default-ml-app',
+        '_ml_obs.llmobs_parent_id': 'undefined'
+      })
+    })
+
+    it('uses the parent span if provided to populate fields', () => {
+      const parentSpan = {
+        context () {
+          return {
+            _tags: {
+              '_ml_obs.meta.ml_app': 'my-ml-app',
+              '_ml_obs.session_id': 'my-session'
+            },
+            toSpanId () { return '5678' }
+          }
+        }
+      }
+      tagger.setLLMObsSpanTags(span, 'llm', { parentLLMObsSpan: parentSpan })
+
+      expect(span.context()._tags).to.deep.equal({
+        'span.type': 'llm',
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.meta.ml_app': 'my-ml-app',
+        '_ml_obs.session_id': 'my-session',
+        '_ml_obs.llmobs_parent_id': '5678'
+      })
+    })
+
+    it('uses the propagated trace id if provided', () => {
+      spanContext._trace.tags['_dd.p.llmobs_trace_id'] = '-123'
+
+      tagger.setLLMObsSpanTags(span, 'llm')
+
+      expect(span.context()._tags).to.deep.equal({
+        'span.type': 'llm',
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.meta.ml_app': 'my-default-ml-app',
+        '_ml_obs.llmobs_parent_id': 'undefined'
+      })
+    })
+
+    it('uses the propagated parent id if provided', () => {
+      spanContext._trace.tags['_dd.p.llmobs_parent_id'] = '-567'
+
+      tagger.setLLMObsSpanTags(span, 'llm')
+
+      expect(span.context()._tags).to.deep.equal({
+        'span.type': 'llm',
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.meta.ml_app': 'my-default-ml-app',
+        '_ml_obs.llmobs_parent_id': '-567'
+      })
+    })
+
+    it('does not set span type if the LLMObs span kind is falsy', () => {
+      tagger.setLLMObsSpanTags(span, false)
+
+      expect(span.context()._tags['span.type']).to.be.undefined
+    })
+  })
+
+  describe('tagMetadata', () => {
+    it('tags a span with metadata', () => {
+      tagger.tagMetadata(span, { a: 'foo', b: 'bar' })
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.metadata': '{"a":"foo","b":"bar"}'
+      })
+    })
+
+    it('logs when metadata is not JSON serializable', () => {
+      const metadata = unserializbleObject()
+      tagger.tagMetadata(span, metadata)
+      expect(logger.warn).to.have.been.calledOnce
+    })
+  })
+
+  describe('tagMetrics', () => {
+    it('tags a span with metrics', () => {
+      tagger.tagMetadata(span, { a: 1, b: 2 })
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.metadata': '{"a":1,"b":2}'
+      })
+    })
+
+    it('logs when metrics is not JSON serializable', () => {
+      const metadata = unserializbleObject()
+      tagger.tagMetadata(span, metadata)
+      expect(logger.warn).to.have.been.calledOnce
+    })
+  })
+
+  describe('tagLLMIO', () => {
+    beforeEach(() => {
+      sinon.stub(tagger, '_tagMessages')
+    })
+
+    afterEach(() => {
+      tagger._tagMessages.restore()
+    })
+
+    it('tags a span with llm io', () => {
+      tagger.tagLLMIO(span, { a: 'foo' }, { b: 'bar' })
+      expect(tagger._tagMessages).to.have.been.calledTwice
+      expect(tagger._tagMessages).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.messages')
+      expect(tagger._tagMessages).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.messages')
+    })
+  })
+
+  describe('tagEmbeddingIO', () => {
+    beforeEach(() => {
+      sinon.stub(tagger, '_tagDocuments')
+      sinon.stub(tagger, '_tagText')
+    })
+
+    afterEach(() => {
+      tagger._tagDocuments.restore()
+      tagger._tagText.restore()
+    })
+
+    it('tags a span with embedding io', () => {
+      tagger.tagEmbeddingIO(span, { a: 'foo' }, { b: 'bar' })
+      expect(tagger._tagDocuments).to.have.been.calledOnce
+      expect(tagger._tagDocuments).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.documents')
+      expect(tagger._tagText).to.have.been.calledOnce
+      expect(tagger._tagText).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.value')
+    })
+  })
+
+  describe('tagRetrievalIO', () => {
+    beforeEach(() => {
+      sinon.stub(tagger, '_tagDocuments')
+      sinon.stub(tagger, '_tagText')
+    })
+
+    afterEach(() => {
+      tagger._tagDocuments.restore()
+      tagger._tagText.restore()
+    })
+
+    it('tags a span with retrieval io', () => {
+      tagger.tagRetrievalIO(span, { a: 'foo' }, { b: 'bar' })
+      expect(tagger._tagDocuments).to.have.been.calledOnce
+      expect(tagger._tagDocuments).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.documents')
+      expect(tagger._tagText).to.have.been.calledOnce
+      expect(tagger._tagText).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.value')
+    })
+  })
+
+  describe('tagTextIO', () => {
+    beforeEach(() => {
+      sinon.stub(tagger, '_tagText')
+    })
+
+    afterEach(() => {
+      tagger._tagText.restore()
+    })
+
+    it('tags a span with text io', () => {
+      tagger.tagTextIO(span, { a: 'foo' }, { b: 'bar' })
+      expect(tagger._tagText).to.have.been.calledTwice
+      expect(tagger._tagText).to.have.been.calledWith(span, { a: 'foo' }, '_ml_obs.meta.input.value')
+      expect(tagger._tagText).to.have.been.calledWith(span, { b: 'bar' }, '_ml_obs.meta.output.value')
+    })
+  })
+
+  // maybe confirm this one
+  describe('tagSpanTags', () => {})
+
+  describe('_tagText', () => {
+    it('tags a span with text', () => {
+      tagger._tagText(span, 'my-text', '_ml_obs.meta.input.value')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.value': 'my-text'
+      })
+    })
+
+    it('tags a span with an object', () => {
+      tagger._tagText(span, { a: 1, b: 2 }, '_ml_obs.meta.input.value')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.value': '{"a":1,"b":2}'
+      })
+    })
+
+    it('logs when the value is not JSON serializable', () => {
+      const data = unserializbleObject()
+      tagger._tagText(span, data, '_ml_obs.meta.input.value')
+      expect(logger.warn).to.have.been.calledOnce
+    })
+  })
+
+  describe('_tagDocuments', () => {
+    it('tags a single document object', () => {
+      const document = { text: 'my-text', name: 'my-name', id: 'my-id', score: 0.5 }
+      tagger._tagDocuments(span, document, '_ml_obs.meta.input.documents')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.documents': '[{"text":"my-text","name":"my-name","id":"my-id","score":0.5}]'
+      })
+    })
+
+    it('tags a single document string', () => {
+      const document = 'my-text'
+      tagger._tagDocuments(span, document, '_ml_obs.meta.input.documents')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.documents': '["my-text"]'
+      })
+    })
+
+    it('tags a document with a subset of properties', () => {
+      const document = { text: 'my-text', score: 0.5 }
+      tagger._tagDocuments(span, document, '_ml_obs.meta.input.documents')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.documents': '[{"text":"my-text","score":0.5}]'
+      })
+    })
+
+    it('tags multiple documents', () => {
+      const documents = [
+        { text: 'my-text', name: 'my-name', id: 'my-id', score: 0.5 },
+        { text: 'my-text2', name: 'my-name2', id: 'my-id2', score: 0.6 }
+      ]
+      tagger._tagDocuments(span, documents, '_ml_obs.meta.input.documents')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.documents': '[{"text":"my-text","name":"my-name"' +
+        ',"id":"my-id","score":0.5},{"text":"my-text2","name":"my-name2","id":"my-id2","score":0.6}]'
+      })
+    })
+
+    it('does not include malformed documents', () => {
+      const documents = [
+        { text: 'my-text', name: 'my-name', id: 'my-id', score: 0.5 },
+        { text: 'my-text2', score: 'not-a-number' }
+      ]
+
+      tagger._tagDocuments(span, documents, '_ml_obs.meta.input.documents')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.documents': '[{"text":"my-text","name":"my-name","id":"my-id","score":0.5}]'
+      })
+    })
+
+    it('logs when a document is not JSON serializable', () => {
+      const documents = [unserializbleObject()]
+      tagger._tagDocuments(span, documents, '_ml_obs.meta.input.documents')
+      expect(logger.warn).to.have.been.calledOnce
+    })
+  })
+
+  describe('_tagMessages', () => {
+    it('tags a single message object', () => {
+      const message = { content: 'my-content', role: 'my-role' }
+      tagger._tagMessages(span, message, '_ml_obs.meta.input.messages')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":"my-content","role":"my-role"}]'
+      })
+    })
+
+    it('tags a single message string', () => {
+      tagger._tagMessages(span, 'my-message', '_ml_obs.meta.input.messages')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '["my-message"]'
+      })
+    })
+
+    it('tags a message with only content', () => {
+      const message = { content: 'my-content' }
+      tagger._tagMessages(span, message, '_ml_obs.meta.input.messages')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":"my-content"}]'
+      })
+    })
+
+    it('defaults missing content to empty content', () => {
+      const message = {}
+      tagger._tagMessages(span, message, '_ml_obs.meta.input.messages')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":""}]'
+      })
+    })
+
+    it('filters out messages with non-string content', () => {
+      const messages = [
+        { content: 'my-content' },
+        { role: 'my-role', content: 6 }
+      ]
+      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":"my-content"}]'
+      })
+    })
+
+    it('filters out messages with non-string role', () => {
+      const messages = [
+        { content: 'my-content', role: 'my-role' },
+        { content: 'my-content2', role: 6 }
+      ]
+      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":"my-content","role":"my-role"}]'
+      })
+    })
+
+    it('tags multiple messages', () => {
+      const messages = [
+        { content: 'my-content', role: 'my-role' },
+        { content: 'my-content2', role: 'my-role2' }
+      ]
+      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
+
+      expect(span.context()._tags).to.deep.equal({
+        '_ml_obs.meta.input.messages': '[{"content":"my-content","role":"my-role"},' +
+        '{"content":"my-content2","role":"my-role2"}]'
+      })
+    })
+
+    it('logs when a message is not JSON serializable', () => {
+      const messages = [unserializbleObject()]
+      tagger._tagMessages(span, messages, '_ml_obs.meta.input.messages')
+      expect(logger.warn).to.have.been.calledOnce
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Adds a tagger for the LLM Observability product. Responsible for setting temporary tags that will later be removed as part of the `span_processor` and `format` steps in a separate PR.

### Motivation
Adds more functionality to LLM Observability in preparation for a feature release in an upcoming PR, with the squashed commit of this PR being on of the few commits in that PR.

**Note**: will likely have some merge conflicts here once other PRs are merged


