### PR TITLE
Use DD_VERSION as version for tracer computed stats if available

### DIFF
--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -127,7 +127,8 @@ class SpanStatsProcessor {
     url,
     env,
     tags,
-    appsec
+    appsec,
+    version
   } = {}) {
     this.exporter = new SpanStatsExporter({
       hostname,
@@ -143,6 +144,7 @@ class SpanStatsProcessor {
     this.env = env
     this.tags = tags || {}
     this.sequence = 0
+    this.version = version
 
     if (this.enabled) {
       this.timer = setInterval(this.onInterval.bind(this), interval * 1e3)
@@ -157,7 +159,7 @@ class SpanStatsProcessor {
     this.exporter.export({
       Hostname: this.hostname,
       Env: this.env,
-      Version: version,
+      Version: this.version || version,
       Stats: serialized,
       Lang: 'javascript',
       TracerVersion: pkg.version,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

If available, use the value in the `DD_VERSION` environment variable provided by the end user on trace metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

This `version` tag on all trace metrics in Azure Functions is set to `3.10.0` regardless of the value in the `DD_VERSION` environment variable.

https://datadoghq.atlassian.net/browse/SVLS-5074

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The `3.10.0` value comes from this package: https://github.com/Azure/azure-functions-nodejs-worker.


