### PR TITLE
Update/fix settings in .vscode directory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,15 +8,11 @@
       "type": "node",
       "request": "launch",
       "name": "Test Current File",
-      "runtimeExecutable": "yarn",
-      "runtimeArgs": [
-        "tdd",
-        "${file}",
-        "--inspect-brk=9229"
+      "skipFiles": [
+        "<node_internals>/**"
       ],
-      "port": 9229,
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
-    },
+      "program": "${file}",
+      "console": "integratedTerminal"
+    }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "debug.node.autoAttach": "on"
-}


### PR DESCRIPTION
Two files have been modified, which was added to the repo 5 years ago and never touched again:

The `.vscode/launch.json` file was outdated and didn't actually work, as it expected `tdd` to exist in the path.

Read more about `launch.json` attributes here:
https://code.visualstudio.com/Docs/editor/debugging#_launchjson-attributes

The `.vscode/settings.json` file was outdated and used a config property no longer supported. The proper equivalent setting would have been:

    "debug.javascript.autoAttachFilter": "always"

But I don't think we want that as it will auto-attach a debugger to every script you run in the console. I've opted for removing this altogether.

Read more about auto-attaching here:
https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_auto-attach
