### PR TITLE
[test visibility] Early flake detection for mocha (parallel mode)

### DIFF
--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1610,67 +1610,135 @@ describe('mocha CommonJS', function () {
         }).catch(done)
       })
     })
-    it('retries new tests in parallel mode', (done) => {
-      // Tests from ci-visibility/test/occasionally-failing-test will be considered new
-      receiver.setKnownTests({})
+    context('parallel mode', () => {
+      it('retries new tests', (done) => {
+        // Tests from ci-visibility/test/occasionally-failing-test will be considered new
+        receiver.setKnownTests({})
 
-      const NUM_RETRIES_EFD = 5
-      receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        early_flake_detection: {
-          enabled: true,
-          slow_test_retries: {
-            '5s': NUM_RETRIES_EFD
-          },
-          faulty_session_threshold: 100
-        }
-      })
-
-      const eventsPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const testSession = events.find(event => event.type === 'test_session_end').content
-          assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_ENABLED, 'true')
-          assert.propertyVal(testSession.meta, MOCHA_IS_PARALLEL, 'true')
-
-          const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-          // all but one has been retried
-          assert.equal(
-            tests.length - 1,
-            retriedTests.length
-          )
-          assert.equal(retriedTests.length, NUM_RETRIES_EFD)
-          // Out of NUM_RETRIES_EFD + 1 total runs, half will be passing and half will be failing,
-          // based on the global counter in the test file
-          const passingTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
-          const failingTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
-          assert.equal(passingTests.length, (NUM_RETRIES_EFD + 1) / 2)
-          assert.equal(failingTests.length, (NUM_RETRIES_EFD + 1) / 2)
-          // Test name does not change
-          retriedTests.forEach(test => {
-            assert.equal(test.meta[TEST_NAME], 'fail occasionally fails')
-          })
+        const NUM_RETRIES_EFD = 5
+        receiver.setSettings({
+          itr_enabled: false,
+          code_coverage: false,
+          tests_skipping: false,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD
+            },
+            faulty_session_threshold: 100
+          }
         })
 
-      childProcess = exec('mocha --parallel ./ci-visibility/test-early-flake-detection/occasionally-failing-test.js', {
-        cwd,
-        env: getCiVisAgentlessConfig(receiver.port),
-        stdio: 'inherit'
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_ENABLED, 'true')
+            assert.propertyVal(testSession.meta, MOCHA_IS_PARALLEL, 'true')
+
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            // all but one has been retried
+            assert.equal(
+              tests.length - 1,
+              retriedTests.length
+            )
+            assert.equal(retriedTests.length, NUM_RETRIES_EFD)
+            // Out of NUM_RETRIES_EFD + 1 total runs, half will be passing and half will be failing,
+            // based on the global counter in the test file
+            const passingTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
+            const failingTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+            assert.equal(passingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+            assert.equal(failingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+            // Test name does not change
+            retriedTests.forEach(test => {
+              assert.equal(test.meta[TEST_NAME], 'fail occasionally fails')
+            })
+          })
+
+        childProcess = exec(
+          'mocha --parallel ./ci-visibility/test-early-flake-detection/occasionally-failing-test.js', {
+            cwd,
+            env: getCiVisAgentlessConfig(receiver.port),
+            stdio: 'inherit'
+          })
+
+        childProcess.on('exit', (exitCode) => {
+          eventsPromise.then(() => {
+            assert.equal(exitCode, 0)
+            done()
+          }).catch(done)
+        })
       })
+      it('retries new tests when using the programmatic API', (done) => {
+        // Tests from ci-visibility/test/occasionally-failing-test will be considered new
+        receiver.setKnownTests({})
 
-      childProcess.stdout.pipe(process.stdout)
-      childProcess.stderr.pipe(process.stderr)
+        const NUM_RETRIES_EFD = 5
+        receiver.setSettings({
+          itr_enabled: false,
+          code_coverage: false,
+          tests_skipping: false,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD
+            },
+            faulty_session_threshold: 100
+          }
+        })
 
-      childProcess.on('exit', (exitCode) => {
-        eventsPromise.then(() => {
-          assert.equal(exitCode, 0)
-          done()
-        }).catch(done)
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_ENABLED, 'true')
+            assert.propertyVal(testSession.meta, MOCHA_IS_PARALLEL, 'true')
+
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            // all but one has been retried
+            assert.equal(
+              tests.length - 1,
+              retriedTests.length
+            )
+            assert.equal(retriedTests.length, NUM_RETRIES_EFD)
+            // Out of NUM_RETRIES_EFD + 1 total runs, half will be passing and half will be failing,
+            // based on the global counter in the test file
+            const passingTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
+            const failingTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+            assert.equal(passingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+            assert.equal(failingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+            // Test name does not change
+            retriedTests.forEach(test => {
+              assert.equal(test.meta[TEST_NAME], 'fail occasionally fails')
+            })
+          })
+
+        childProcess = exec(
+          runTestsWithCoverageCommand,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              RUN_IN_PARALLEL: true,
+              TESTS_TO_RUN: JSON.stringify([
+                './test-early-flake-detection/occasionally-failing-test.js'
+              ])
+            },
+            stdio: 'inherit'
+          }
+        )
+        childProcess.on('exit', (exitCode) => {
+          eventsPromise.then(() => {
+            assert.equal(exitCode, 0)
+            done()
+          }).catch(done)
+        })
       })
     })
     // TODO: faulty threshold

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1356,9 +1356,11 @@ describe('mocha CommonJS', function () {
           stdio: 'inherit'
         }
       )
-      childProcess.on('exit', () => {
+
+      childProcess.on('exit', (exitCode) => {
         // TODO: check exit code: if a new, retried test fails, the exit code should remain 0
         eventsPromise.then(() => {
+          assert.equal(exitCode, 0)
           done()
         }).catch(done)
       })
@@ -1608,6 +1610,72 @@ describe('mocha CommonJS', function () {
         }).catch(done)
       })
     })
+    it('retries new tests in parallel mode', (done) => {
+      // Tests from ci-visibility/test/occasionally-failing-test will be considered new
+      receiver.setKnownTests({})
+
+      const NUM_RETRIES_EFD = 5
+      receiver.setSettings({
+        itr_enabled: false,
+        code_coverage: false,
+        tests_skipping: false,
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': NUM_RETRIES_EFD
+          },
+          faulty_session_threshold: 100
+        }
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_ENABLED, 'true')
+          assert.propertyVal(testSession.meta, MOCHA_IS_PARALLEL, 'true')
+
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          // all but one has been retried
+          assert.equal(
+            tests.length - 1,
+            retriedTests.length
+          )
+          assert.equal(retriedTests.length, NUM_RETRIES_EFD)
+          // Out of NUM_RETRIES_EFD + 1 total runs, half will be passing and half will be failing,
+          // based on the global counter in the test file
+          const passingTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
+          const failingTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+          assert.equal(passingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+          assert.equal(failingTests.length, (NUM_RETRIES_EFD + 1) / 2)
+          // Test name does not change
+          retriedTests.forEach(test => {
+            assert.equal(test.meta[TEST_NAME], 'fail occasionally fails')
+          })
+        })
+
+      childProcess = exec('mocha --parallel ./ci-visibility/test-early-flake-detection/occasionally-failing-test.js', {
+        cwd,
+        env: getCiVisAgentlessConfig(receiver.port),
+        stdio: 'inherit'
+      })
+
+      childProcess.stdout.pipe(process.stdout)
+      childProcess.stderr.pipe(process.stderr)
+
+      childProcess.on('exit', (exitCode) => {
+        eventsPromise.then(() => {
+          assert.equal(exitCode, 0)
+          done()
+        }).catch(done)
+      })
+    })
+    // TODO: faulty threshold
+
+    // TODO: duration threshold
   })
 
   context('flaky test retries', () => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1159,6 +1159,7 @@ describe('mocha CommonJS', function () {
           stdio: 'inherit'
         }
       )
+
       childProcess.on('exit', () => {
         eventsPromise.then(() => {
           done()

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -277,7 +277,7 @@ addHook({
         const testSuites = this.files.map(file => getTestSuitePath(file, process.cwd()))
         const isFaulty = getIsFaultyEarlyFlakeDetection(
           testSuites,
-          config.knownTests.mocha,
+          config.knownTests?.mocha || {},
           config.earlyFlakeDetectionFaultyThreshold
         )
         if (isFaulty) {
@@ -541,7 +541,7 @@ addHook({
         const testSuites = files.map(file => getTestSuitePath(file, process.cwd()))
         const isFaulty = getIsFaultyEarlyFlakeDetection(
           testSuites,
-          config.knownTests.mocha,
+          config.knownTests?.mocha || {},
           config.earlyFlakeDetectionFaultyThreshold
         )
         if (isFaulty) {

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -358,7 +358,7 @@ addHook({
 
   patched.add(Runner)
 
-  // Is there a equivalent of runTests for parallel mode? -> yes, it's exactly the same
+  // TODO: same handler as parallel mode -> reuse
   shimmer.wrap(Runner.prototype, 'runTests', runTests => function (suite, fn) {
     if (isEarlyFlakeDetectionEnabled) {
       // by the time we reach `this.on('test')`, it is too late. We need to add retries here
@@ -512,9 +512,6 @@ addHook({
 
     this.worker.on('message', onMessage)
 
-    // test suites are created in the main process -
-    // we could filter knownTests here and pass them to the worker (only the ones for the suite)
-    // TODO: how to pass the worker this data?
     testSuiteAsyncResource.runInAsyncScope(() => {
       testSuiteStartCh.publish({
         testSuiteAbsolutePath

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -536,7 +536,7 @@ addHook({
 // In this hook we pass the known tests to the worker and collect the new tests that run
 addHook({
   name: 'mocha',
-  versions: ['>=8.0.0'], // probably other version
+  versions: ['>=8.0.0'],
   file: 'lib/nodejs/buffered-worker-pool.js'
 }, (BufferedWorkerPoolPackage) => {
   const { BufferedWorkerPool } = BufferedWorkerPoolPackage

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -329,6 +329,7 @@ function getOnPendingHandler () {
   }
 }
 
+// Hook to add retries to tests if EFD is enabled
 function getRunTestsWrapper (runTests, config) {
   return function (suite, fn) {
     if (config.isEarlyFlakeDetectionEnabled) {

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -328,6 +328,22 @@ function getOnPendingHandler () {
     }
   }
 }
+
+function getRunTestsWrapper (runTests, config) {
+  return function (suite, fn) {
+    if (config.isEarlyFlakeDetectionEnabled) {
+      // by the time we reach `this.on('test')`, it is too late. We need to add retries here
+      suite.tests.forEach(test => {
+        if (!test.isPending() && isNewTest(test, config.knownTests)) {
+          test._ddIsNew = true
+          retryTest(test, config.earlyFlakeDetectionNumRetries)
+        }
+      })
+    }
+    return runTests.apply(this, arguments)
+  }
+}
+
 module.exports = {
   isNewTest,
   retryTest,
@@ -347,5 +363,6 @@ module.exports = {
   getOnFailHandler,
   getOnPendingHandler,
   testFileToSuiteAr,
+  getRunTestsWrapper,
   newTests
 }

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -24,6 +24,7 @@ const originalFns = new WeakMap()
 const testToStartLine = new WeakMap()
 const testFileToSuiteAr = new Map()
 const wrappedFunctions = new WeakSet()
+const newTests = {}
 
 function isNewTest (test, knownTests) {
   const testSuite = getTestSuitePath(test.file, process.cwd())
@@ -151,7 +152,7 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
   return RunnablePackage
 }
 
-function getOnTestHandler (isMain, newTests) {
+function getOnTestHandler (isMain) {
   return function (test) {
     const testStartLine = testToStartLine.get(test)
     const asyncResource = new AsyncResource('bound-anonymous-fn')
@@ -179,20 +180,20 @@ function getOnTestHandler (isMain, newTests) {
       testStartLine
     }
 
-    if (isMain) {
-      testInfo.isNew = isNew
-      testInfo.isEfdRetry = isEfdRetry
-      // We want to store the result of the new tests
-      if (isNew) {
-        const testFullName = getTestFullName(test)
-        if (newTests[testFullName]) {
-          newTests[testFullName].push(test)
-        } else {
-          newTests[testFullName] = [test]
-        }
-      }
-    } else {
+    if (!isMain) {
       testInfo.isParallel = true
+    }
+
+    testInfo.isNew = isNew
+    testInfo.isEfdRetry = isEfdRetry
+    // We want to store the result of the new tests
+    if (isNew) {
+      const testFullName = getTestFullName(test)
+      if (newTests[testFullName]) {
+        newTests[testFullName].push(test)
+      } else {
+        newTests[testFullName] = [test]
+      }
     }
 
     asyncResource.runInAsyncScope(() => {
@@ -345,5 +346,6 @@ module.exports = {
   getOnHookEndHandler,
   getOnFailHandler,
   getOnPendingHandler,
-  testFileToSuiteAr
+  testFileToSuiteAr,
+  newTests
 }

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -22,6 +22,7 @@ let workerKnownTests = {
   mocha: {}
 }
 let isEarlyFlakeDetectionEnabled = false
+let earlyFlakeDetectionNumRetries = 0
 
 addHook({
   name: 'mocha',
@@ -33,7 +34,9 @@ addHook({
       // if there's a list of known tests, it means EFD is enabled
       isEarlyFlakeDetectionEnabled = true
       workerKnownTests = this.options._ddKnownTests
+      earlyFlakeDetectionNumRetries = this.options._ddEfdNumRetries
       delete this.options._ddKnownTests
+      delete this.options._ddEfdNumRetries
     }
     return run.apply(this, arguments)
   })
@@ -54,8 +57,7 @@ addHook({
       suite.tests.forEach(test => {
         if (!test.isPending() && isNewTest(test, workerKnownTests)) {
           test._ddIsNew = true
-          // TODO: do not hardcode 10
-          retryTest(test, 10)
+          retryTest(test, earlyFlakeDetectionNumRetries)
         }
       })
     }

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -20,7 +20,7 @@ const config = {}
 
 addHook({
   name: 'mocha',
-  versions: ['>=5.2.0'],
+  versions: ['>=8.0.0'],
   file: 'lib/mocha.js'
 }, (Mocha) => {
   shimmer.wrap(Mocha.prototype, 'run', run => function () {

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -29,11 +29,9 @@ addHook({
   file: 'lib/mocha.js'
 }, (Mocha) => {
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
-    // maybe this is the place to retry tests, instead of `runTests` - here we have access to tests already (and opts!)
     if (this.options._ddKnownTests) {
       // if there's a list of known tests, it means EFD is enabled
       isEarlyFlakeDetectionEnabled = true
-      // PICK SOMETHING BETTER HERE INSTEAAD OF READING THIS.FILES
       workerKnownTests = this.options._ddKnownTests
       delete this.options._ddKnownTests
     }
@@ -56,7 +54,7 @@ addHook({
       suite.tests.forEach(test => {
         if (!test.isPending() && isNewTest(test, workerKnownTests)) {
           test._ddIsNew = true
-          // PASS THIS INFO TOO INSTEAD OF HARD CODING 10
+          // TODO: do not hardcode 10
           retryTest(test, 10)
         }
       })

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -21,6 +21,7 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
+  TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_SESSION_ID,
   TEST_MODULE_ID,
   TEST_MODULE,
@@ -280,6 +281,7 @@ class MochaPlugin extends CiPlugin {
       hasUnskippableSuites,
       error,
       isEarlyFlakeDetectionEnabled,
+      isEarlyFlakeDetectionFaulty,
       isParallel
     }) => {
       if (this.testSessionSpan) {
@@ -313,6 +315,9 @@ class MochaPlugin extends CiPlugin {
 
         if (isEarlyFlakeDetectionEnabled) {
           this.testSessionSpan.setTag(TEST_EARLY_FLAKE_ENABLED, 'true')
+        }
+        if (isEarlyFlakeDetectionFaulty) {
+          this.testSessionSpan.setTag(TEST_EARLY_FLAKE_ABORT_REASON, 'faulty')
         }
 
         this.testModuleSpan.finish()

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -266,7 +266,7 @@
   "mocha": [
     {
       "name": "mocha",
-      "versions": [">=5.2.0"]
+      "versions": [">=5.2.0", ">=8.0.0"]
     },
     {
       "name": "mocha-each",


### PR DESCRIPTION
### What does this PR do?

Add early flake detection logic when `--parallel` is passed to mocha.

Additionally, add the faulty threshold logic to mocha, which was missing: if too many tests are considered new, we'll bail out of EFD.

### Motivation
Allow users of the parallel mode of mocha to use early flake detection.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
