### PR TITLE
Identify span metrics from OpenTelemetry libraries with 'otel.library' tag

### DIFF
--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -142,7 +142,7 @@ class Span {
       context: spanContext._ddContext,
       startTime,
       hostname: _tracer._hostname,
-      integrationName: 'otel',
+      integrationName: parentTracer?._isOtelLibrary ? 'otel.library' : 'otel',
       tags: {
         [SERVICE_NAME]: _tracer._service,
         [RESOURCE_NAME]: spanName

--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -16,6 +16,7 @@ class Tracer {
     this._tracerProvider = tracerProvider
     // Is there a reason this is public?
     this.instrumentationLibrary = library
+    this._isOtelLibrary = library?.name?.startsWith('@opentelemetry/instrumentation-')
     this._spanLimits = {}
   }
 


### PR DESCRIPTION
### What does this PR do?
Identify span metrics from OpenTelemetry libraries with 'otel.library' tag. Use existing 'otel' tag for other sources of spans, such as manual tracing.

### Motivation
We'd like to track span metrics from OpenTelemetry auto-instrumentations separately to those from manual instrumentation. This PR uses the integration details from the OTel tracer to decide whether to use the new 'otel.library' tag or the existing 'otel' tag. 

Jira ticket: [APMAPI-154]


[APMAPI-154]: https://datadoghq.atlassian.net/browse/APMAPI-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ