### PR TITLE
Moving Rhea plugin test to its own job

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -96,7 +96,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
       - uses: codecov/codecov-action@v3
 
-  amqp10: # TODO: move rhea to its own job
+  amqp10:
     runs-on: ubuntu-latest
     services:
       qpid:
@@ -107,7 +107,7 @@ jobs:
         ports:
           - 5673:5672
     env:
-      PLUGINS: amqp10|rhea
+      PLUGINS: amqp10
       SERVICES: qpid
       DD_DATA_STREAMS_ENABLED: true
     steps:
@@ -829,6 +829,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PLUGINS: restify
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/plugins/test
+
+  rhea:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: rhea
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/plugins/test

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -835,11 +835,21 @@ jobs:
 
   rhea:
     runs-on: ubuntu-latest
+    services:
+      qpid:
+        image: scholzj/qpid-cpp:1.38.0
+        env:
+          QPIDD_ADMIN_USERNAME: admin
+          QPIDD_ADMIN_PASSWORD: admin
+        ports:
+          - 5673:5672
     env:
       PLUGINS: rhea
+      SERVICES: qpid
+      DD_DATA_STREAMS_ENABLED: true
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/plugins/test
+      - uses: ./.github/actions/plugins/test-and-upstream
 
   router:
     runs-on: ubuntu-latest

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -366,6 +366,12 @@
       "versions": ["^4"]
     }
   ],
+  "rhea": [
+    {
+      "name": "amqp10",
+      "versions": ["^3"]
+    }
+  ],
   "sequelize": [
     {
       "name": "express",


### PR DESCRIPTION
### What does this PR do?

Removes Rhea from Amqp10 CI test job.

### Motivation

Since we are reworking CI testing and automating how this is happening. Removing Rhea from the Amqp10 test job is important to in moving forward. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


