### PR TITLE
Pin import-in-the-middle to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "crypto-randomuuid": "^1.0.0",
     "dc-polyfill": "^0.1.4",
     "ignore": "^5.2.4",
-    "import-in-the-middle": "^1.8.1",
+    "import-in-the-middle": "1.11.0",
     "int64-buffer": "^0.1.9",
     "istanbul-lib-coverage": "3.2.0",
     "jest-docblock": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,10 +2555,10 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.8.1.tgz#8b51c2cc631b64e53e958d7048d2d9463ce628f8"
-  integrity sha512-yhRwoHtiLGvmSozNOALgjRPFI6uYsds60EoMqqnXyyv+JOIW/BrrLejuTGBt+bq0T5tLzOHrN0T7xYTm4Qt/ng==
+import-in-the-middle@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz#a94c4925b8da18256cde3b3b7b38253e6ca5e708"
+  integrity sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==
   dependencies:
     acorn "^8.8.2"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
### What does this PR do?

Pin `import-in-the-middle` dependency to 1.11.0.

### Motivation
It seems the latest release of import-in-the-middle has broken something: https://github.com/nodejs/import-in-the-middle/releases/tag/import-in-the-middle-v1.11.1

Specifically, it breaks our `vitest` integration by throwing this error 

```
/private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/import-in-the-middle/lib/register.js:20
    return getters.get(target)[name]()
                                    ^

TypeError: getters.get(...)[name] is not a function
    at Object.get (/private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/import-in-the-middle/lib/register.js:20:37)
    at /private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/dd-trace/packages/datadog-instrumentations/src/helpers/hook.js:41:40
    at callHookFn (/private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/import-in-the-middle/index.js:29:22)
    at Hook._iitmHook (/private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/import-in-the-middle/index.js:150:11)
    at /private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/import-in-the-middle/lib/register.js:37:31
    at Array.forEach (<anonymous>)
    at register (/private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/import-in-the-middle/lib/register.js:37:15)
    at file:///private/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T/224f78e3fac620df/node_modules/vitest/dist/vendor/constants.5J7I254_.js?iitm=true:104:1
    at ModuleJob.run (node:internal/modules/esm/module_job:234:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
```

Related fix in iitm: https://github.com/nodejs/import-in-the-middle/pull/155