### PR TITLE
Fix: Calculate correct Content-Length in requests to agent

### DIFF
--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -183,7 +183,7 @@ function request (data, options, callback) {
 }
 
 function byteLength (data) {
-  return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
+  return data.length > 0 ? data.reduce((prev, next) => prev + Buffer.byteLength(next, 'utf8'), 0) : 0
 }
 
 Object.defineProperty(request, 'writable', {


### PR DESCRIPTION
If the payload being sent to the agent contained any two-or-more-byte characters, the calculation would be incorrect because `str.length` returns the number of characters and not the number of bytes in the string.
    
If the payload was JSON, this would make it malformed and the receiver would not be able to parse it (as it would be missing one or more bytes from the end of the payload).
