### PR TITLE
Do not run fastify >=5 plugin tests in node <=18

### DIFF
--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -56,7 +56,7 @@ describe('Plugin', function () {
   let Cucumber
   this.timeout(10000)
   withVersions('cucumber', '@cucumber/cucumber', (version, _, specificVersion) => {
-    if ((NODE_MAJOR <= 16) && semver.satisfies(specificVersion, '>=10')) return
+    if (NODE_MAJOR <= 16 && semver.satisfies(specificVersion, '>=10')) return
 
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -26,7 +26,7 @@ describe('Plugin', () => {
 
       withExports('fastify', version, ['default', 'fastify'], '>=3', getExport => {
         describe('without configuration', () => {
-          if ((NODE_MAJOR <= 18) && semver.satisfies(specificVersion, '>=5')) return
+          if (NODE_MAJOR <= 18 && semver.satisfies(specificVersion, '>=5')) return
 
           before(() => {
             return agent.load(['fastify', 'find-my-way', 'http'], [{}, {}, { client: false }])

--- a/packages/datadog-plugin-fastify/test/index.spec.js
+++ b/packages/datadog-plugin-fastify/test/index.spec.js
@@ -5,6 +5,7 @@ const axios = require('axios')
 const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
+const { NODE_MAJOR } = require('../../../version')
 
 const host = 'localhost'
 
@@ -14,7 +15,7 @@ describe('Plugin', () => {
   let app
 
   describe('fastify', () => {
-    withVersions('fastify', 'fastify', version => {
+    withVersions('fastify', 'fastify', (version, _, specificVersion) => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
       })
@@ -25,6 +26,8 @@ describe('Plugin', () => {
 
       withExports('fastify', version, ['default', 'fastify'], '>=3', getExport => {
         describe('without configuration', () => {
+          if ((NODE_MAJOR <= 18) && semver.satisfies(specificVersion, '>=5')) return
+
           before(() => {
             return agent.load(['fastify', 'find-my-way', 'http'], [{}, {}, { client: false }])
           })

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
 
   // skip older versions of fastify due to syntax differences
   withVersions('fastify', 'fastify', '>=3', (version, _, specificVersion) => {
-    if ((NODE_MAJOR <= 18) && semver.satisfies(specificVersion, '>=5')) return
+    if (NODE_MAJOR <= 18 && semver.satisfies(specificVersion, '>=5')) return
 
     before(async function () {
       this.timeout(20000)

--- a/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fastify/test/integration-test/client.spec.js
@@ -1,5 +1,5 @@
 'use strict'
-
+const semver = require('semver')
 const {
   FakeAgent,
   createSandbox,
@@ -8,6 +8,7 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const { NODE_MAJOR } = require('../../../../version')
 
 describe('esm', () => {
   let agent
@@ -15,7 +16,9 @@ describe('esm', () => {
   let sandbox
 
   // skip older versions of fastify due to syntax differences
-  withVersions('fastify', 'fastify', '>=3', version => {
+  withVersions('fastify', 'fastify', '>=3', (version, _, specificVersion) => {
+    if ((NODE_MAJOR <= 18) && semver.satisfies(specificVersion, '>=5')) return
+
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`'fastify@${version}'`], false,

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -23,7 +23,7 @@ describe('Plugin', () => {
   describe('undici-fetch', () => {
     withVersions('undici', 'undici', version => {
       const specificVersion = require(`../../../versions/undici@${version}`).version()
-      if ((NODE_MAJOR <= 16) && semver.satisfies(specificVersion, '>=6')) return
+      if (NODE_MAJOR <= 16 && semver.satisfies(specificVersion, '>=6')) return
 
       function server (app, listener) {
         const server = require('http').createServer(app)


### PR DESCRIPTION
### What does this PR do?
Skip tests if the fastify version is >=5 and node is <=18, since it's not supported anymore:

https://github.com/fastify/fastify/releases/tag/v5.0.0: it's not clearly put as a breaking change but it seems like that's indeed what's happening: https://github.com/fastify/fastify/pull/5481

### Motivation
It's currently blocking the release. 

