### PR TITLE
Bump `import-in-the-middle` to 1.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "crypto-randomuuid": "^1.0.0",
     "dc-polyfill": "^0.1.4",
     "ignore": "^5.2.4",
-    "import-in-the-middle": "1.11.0",
+    "import-in-the-middle": "1.11.2",
     "int64-buffer": "^0.1.9",
     "istanbul-lib-coverage": "3.2.0",
     "jest-docblock": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,10 +2555,10 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz#a94c4925b8da18256cde3b3b7b38253e6ca5e708"
-  integrity sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==
+import-in-the-middle@1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.2.tgz#dd848e72b63ca6cd7c34df8b8d97fc9baee6174f"
+  integrity sha512-gK6Rr6EykBcc6cVWRSBR5TWf8nn6hZMYSRYqCcHa0l0d1fPK7JSYo6+Mlmck76jIX9aL/IZ71c06U2VpFwl1zA==
   dependencies:
     acorn "^8.8.2"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
### What does this PR do?
Bump `import-in-the-middle` dependency to 1.11.2 by running

```
yarn add import-in-the-middle@1.11.2
```

### Motivation
It has been just released (https://github.com/nodejs/import-in-the-middle/releases/tag/import-in-the-middle-v1.11.2) with the fix that caused us to pin 1.11.0: https://github.com/DataDog/dd-trace-js/pull/4732

