### PR TITLE
Don't use deprecated url.parse function

### DIFF
--- a/packages/datadog-plugin-cypress/test/app/cypress/plugins/index.js
+++ b/packages/datadog-plugin-cypress/test/app/cypress/plugins/index.js
@@ -1,32 +1,3 @@
-// TODO: Remove `urlToHttpOptions` polyfill once we drop support for the older Cypress versions that uses a built-in
-// version of Node.js doesn't include that function.
-const url = require('url')
-if (url.urlToHttpOptions === undefined) {
-  url.urlToHttpOptions = (url) => {
-    const { hostname, pathname, port, username, password, search } = url
-    const options = {
-      __proto__: null,
-      ...url, // In case the url object was extended by the user.
-      protocol: url.protocol,
-      hostname: typeof hostname === 'string' && hostname.startsWith('[')
-        ? hostname.slice(1, -1)
-        : hostname,
-      hash: url.hash,
-      search,
-      pathname,
-      path: `${pathname || ''}${search || ''}`,
-      href: url.href
-    }
-    if (port !== '') {
-      options.port = Number(port)
-    }
-    if (username || password) {
-      options.auth = `${decodeURIComponent(username)}:${decodeURIComponent(password)}`
-    }
-    return options
-  }
-}
-
 module.exports = (on, config) => {
   // We can't use the tracer available in the testing process, because this code is
   // run in a different process. We need to init a different tracer reporting to the

--- a/packages/datadog-plugin-cypress/test/app/cypress/plugins/index.js
+++ b/packages/datadog-plugin-cypress/test/app/cypress/plugins/index.js
@@ -1,3 +1,32 @@
+// TODO: Remove `urlToHttpOptions` polyfill once we drop support for the older Cypress versions that uses a built-in
+// version of Node.js doesn't include that function.
+const url = require('url')
+if (url.urlToHttpOptions === undefined) {
+  url.urlToHttpOptions = (url) => {
+    const { hostname, pathname, port, username, password, search } = url
+    const options = {
+      __proto__: null,
+      ...url, // In case the url object was extended by the user.
+      protocol: url.protocol,
+      hostname: typeof hostname === 'string' && hostname.startsWith('[')
+        ? hostname.slice(1, -1)
+        : hostname,
+      hash: url.hash,
+      search,
+      pathname,
+      path: `${pathname || ''}${search || ''}`,
+      href: url.href
+    }
+    if (port !== '') {
+      options.port = Number(port)
+    }
+    if (username || password) {
+      options.auth = `${decodeURIComponent(username)}:${decodeURIComponent(password)}`
+    }
+    return options
+  }
+}
+
 module.exports = (on, config) => {
   // We can't use the tracer available in the testing process, because this code is
   // run in a different process. We need to init a different tracer reporting to the

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -6,9 +6,9 @@
 const { Readable } = require('stream')
 const http = require('http')
 const https = require('https')
-const { urlToHttpOptions } = require('url')
 const zlib = require('zlib')
 
+const { urlToHttpOptions } = require('./url-to-http-options-polyfill')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
 const { storage } = require('../../../../datadog-core')

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -6,8 +6,7 @@
 const { Readable } = require('stream')
 const http = require('http')
 const https = require('https')
-// eslint-disable-next-line n/no-deprecated-api
-const { parse: urlParse } = require('url')
+const { urlToHttpOptions } = require('url')
 const zlib = require('zlib')
 
 const docker = require('./docker')
@@ -20,39 +19,14 @@ const containerId = docker.id()
 
 let activeRequests = 0
 
-// TODO: Replace with `url.urlToHttpOptions` when supported by all versions
-function urlToOptions (url) {
-  const agent = url.agent || http.globalAgent
-  const options = {
-    protocol: url.protocol || agent.protocol,
-    hostname: typeof url.hostname === 'string' && url.hostname.startsWith('[')
-      ? url.hostname.slice(1, -1)
-      : url.hostname ||
-      url.host ||
-      'localhost',
-    hash: url.hash,
-    search: url.search,
-    pathname: url.pathname,
-    path: `${url.pathname || ''}${url.search || ''}`,
-    href: url.href
-  }
-  if (url.port !== '') {
-    options.port = Number(url.port)
-  }
-  if (url.username || url.password) {
-    options.auth = `${url.username}:${url.password}`
-  }
-  return options
-}
+function parseUrl (urlObjOrString) {
+  if (typeof urlObjOrString === 'object') return urlToHttpOptions(urlObjOrString)
 
-function fromUrlString (urlString) {
-  const url = typeof urlToHttpOptions === 'function'
-    ? urlToOptions(new URL(urlString))
-    : urlParse(urlString)
+  const url = urlToHttpOptions(new URL(urlObjOrString))
 
-  // Add the 'hostname' back if we're using named pipes
-  if (url.protocol === 'unix:' && url.host === '.') {
-    const udsPath = urlString.replace(/^unix:/, '')
+  // Special handling if we're using named pipes on Windows
+  if (url.protocol === 'unix:' && url.hostname === '.') {
+    const udsPath = urlObjOrString.slice(5)
     url.path = udsPath
     url.pathname = udsPath
   }
@@ -66,7 +40,7 @@ function request (data, options, callback) {
   }
 
   if (options.url) {
-    const url = typeof options.url === 'object' ? urlToOptions(options.url) : fromUrlString(options.url)
+    const url = parseUrl(options.url)
     if (url.protocol === 'unix:') {
       options.socketPath = url.pathname
     } else {

--- a/packages/dd-trace/src/exporters/common/url-to-http-options-polyfill.js
+++ b/packages/dd-trace/src/exporters/common/url-to-http-options-polyfill.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const { urlToHttpOptions } = require('url')
+
+// TODO: Remove `urlToHttpOptions` polyfill once we drop support for the older Cypress versions that uses a built-in
+// version of Node.js doesn't include that function.
+module.exports = {
+  urlToHttpOptions: urlToHttpOptions ?? function (url) {
+    const { hostname, pathname, port, username, password, search } = url
+    const options = {
+      __proto__: null,
+      ...url, // In case the url object was extended by the user.
+      protocol: url.protocol,
+      hostname: typeof hostname === 'string' && hostname.startsWith('[')
+        ? hostname.slice(1, -1)
+        : hostname,
+      hash: url.hash,
+      search,
+      pathname,
+      path: `${pathname || ''}${search || ''}`,
+      href: url.href
+    }
+    if (port !== '') {
+      options.port = Number(port)
+    }
+    if (username || password) {
+      options.auth = `${decodeURIComponent(username)}:${decodeURIComponent(password)}`
+    }
+    return options
+  }
+}


### PR DESCRIPTION
The old code had several bugs/issues:

1. The inlined polyfill was lifted from Node.js core several years ago. Bugs have since been fixed in Node.js core that hasn't made it into our inlined version.
2. The check to see if `url.urlToHttpOptions` was a function had a bug (as `urlToHttpOptions` was never imported) so the check would always return `false`.
3. The fallback in case `url.urlToHttpOptions` wasn't present didn't load the polyfill, but instead the deprecated `url.parse`, so the polyfill was actually never used in that case.
4. Perf: The check to see if `url.urlToHttpOptions` was pressent was performed on every request instead of at load-time.
5. Perf: No need to use a RegEx to strip `unix:` from the URL when using named pipes on Windows.

## Note to reviewers

The minimum Node.js version supported by this tracer now ships with `url.urlToHttpOptions`, so from that point of view, the polyfill is no longer needed. However, we still maintain support for an old version of Cypress that ships with an older built-in version of Node.js that doesn't have `url.urlToHttpOptions`. So for that reason, we need to still have a polyfill.
