### PR TITLE
[DI] Fix probe.location.lines to be string[] instead of number[]

### DIFF
--- a/integration-tests/debugger/index.spec.js
+++ b/integration-tests/debugger/index.spec.js
@@ -295,7 +295,7 @@ describe('Dynamic Instrumentation', function () {
             probe: {
               id: rcConfig.config.id,
               version: 0,
-              location: { file: probeFile, lines: [probeLineNo] }
+              location: { file: probeFile, lines: [String(probeLineNo)] }
             },
             language: 'javascript'
           }

--- a/packages/dd-trace/src/debugger/devtools_client/remote_config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/remote_config.js
@@ -114,7 +114,7 @@ async function addBreakpoint (probe) {
   const line = Number(probe.where.lines[0]) // Tracer doesn't support multiple-line breakpoints
 
   // Optimize for sending data to /debugger/v1/input endpoint
-  probe.location = { file, lines: [line] }
+  probe.location = { file, lines: [String(line)] }
   delete probe.where
 
   // TODO: Inbetween `await session.post('Debugger.enable')` and here, the scripts are parsed and cached.


### PR DESCRIPTION
In some languages, a probe can be a line range. To support that we allow that an element in the `probe.location.lines` array can look like this: `"24-28"`. As in, lines 24 to 28. Therefore all entries in this array should be strings, even though they do not represent ranges.
