### PR TITLE
[DI] Add GitHub repo and SHA tags to probe results

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/config.js
@@ -7,6 +7,8 @@ const log = require('../../log')
 const config = module.exports = {
   runtimeId: parentConfig.tags['runtime-id'],
   service: parentConfig.service,
+  commitSHA: parentConfig.commitSHA,
+  repositoryUrl: parentConfig.repositoryUrl,
   parentThreadId
 }
 

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -1,18 +1,28 @@
 'use strict'
 
+const { stringify } = require('querystring')
+
 const config = require('./config')
 const request = require('../../exporters/common/request')
+const { GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('../../plugins/util/tags')
 
 module.exports = send
 
 const ddsource = 'dd_debugger'
 const service = config.service
 
+const ddtags = [
+  [GIT_COMMIT_SHA, config.commitSHA],
+  [GIT_REPOSITORY_URL, config.repositoryUrl]
+].map((pair) => pair.join(':')).join(',')
+
+const path = `/debugger/v1/input?${stringify({ ddtags })}`
+
 function send (message, logger, snapshot, cb) {
   const opts = {
     method: 'POST',
     url: config.url,
-    path: '/debugger/v1/input',
+    path,
     headers: { 'Content-Type': 'application/json; charset=utf-8' }
   }
 


### PR DESCRIPTION
## Notes for reviewers

Please bear in mind that the `ddtags` query param goes on all requests to the `/debugger/v1/input` endpoint. Even the ones that doesn't contain a snapshot. I'm not sure the other tracers does the same, but I think it's a nice addition as knowing the git SHA/repo for any probe could be relevant debugging information - not only for the ones where we want to show source code.