### PR TITLE
Fix appsec rate limiter flaky test

### DIFF
--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -248,6 +248,7 @@ describe('reporter', () => {
       expect(Reporter.reportAttack('', params)).to.not.be.false
       expect(addTags.getCall(4).firstArg).to.have.property('appsec.event').that.equals('true')
       expect(addTags.getCall(4).firstArg).to.not.have.property('manual.keep')
+      // TODO delete this comment
 
       setTimeout(() => {
         expect(Reporter.reportAttack('', params)).to.not.be.false

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -248,13 +248,12 @@ describe('reporter', () => {
       expect(Reporter.reportAttack('', params)).to.not.be.false
       expect(addTags.getCall(4).firstArg).to.have.property('appsec.event').that.equals('true')
       expect(addTags.getCall(4).firstArg).to.not.have.property('manual.keep')
-      // TODO delete this comment
 
       setTimeout(() => {
         expect(Reporter.reportAttack('', params)).to.not.be.false
         expect(addTags.getCall(5).firstArg).to.have.property('manual.keep').that.equals('true')
         done()
-      }, 1e3)
+      }, 1020)
     })
 
     it('should not overwrite origin tag', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Change a test to wait +20ms in a setTimeout instead of a exact second to fix a flaky test
### Motivation
<!-- What inspired you to submit this pull request? -->
fix flaky test

PR opened after 10 executions in a row without failures: 
https://github.com/DataDog/dd-trace-js/actions/runs/11164716938?pr=4754
