### PR TITLE
[DI] Add hostname to probe result

### DIFF
--- a/integration-tests/debugger/index.spec.js
+++ b/integration-tests/debugger/index.spec.js
@@ -2,6 +2,8 @@
 
 const path = require('path')
 const { randomUUID } = require('crypto')
+const os = require('os')
+
 const getPort = require('get-port')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -283,6 +285,7 @@ describe('Dynamic Instrumentation', function () {
       agent.on('debugger-input', ({ payload }) => {
         const expected = {
           ddsource: 'dd_debugger',
+          hostname: os.hostname(),
           service: 'node',
           message: 'Hello World!',
           logger: {

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const { hostname: getHostname } = require('os')
+
 const config = require('./config')
 const request = require('../../exporters/common/request')
 
 module.exports = send
 
 const ddsource = 'dd_debugger'
+const hostname = getHostname()
 const service = config.service
 
 function send (message, logger, snapshot, cb) {
@@ -18,6 +21,7 @@ function send (message, logger, snapshot, cb) {
 
   const payload = {
     ddsource,
+    hostname,
     service,
     message,
     logger,


### PR DESCRIPTION
The `hostname` property is a special field that the logs product can
use. See docs for sending logs for more details:

https://docs.datadoghq.com/api/latest/logs/#send-logs
