### PR TITLE
Upgrade iast rewriter to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "@datadog/native-appsec": "8.1.1",
-    "@datadog/native-iast-rewriter": "2.4.1",
+    "@datadog/native-iast-rewriter": "2.5.0",
     "@datadog/native-iast-taint-tracking": "3.1.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.3.0",

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/csi-methods.js
@@ -12,6 +12,7 @@ const csiMethods = [
   { src: 'substring' },
   { src: 'toLowerCase', dst: 'stringCase' },
   { src: 'toUpperCase', dst: 'stringCase' },
+  { src: 'tplOperator', operator: true },
   { src: 'trim' },
   { src: 'trimEnd' },
   { src: 'trimStart', dst: 'trim' },

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -29,6 +29,7 @@ const TaintTrackingNoop = {
   substr: noop,
   substring: noop,
   stringCase: noop,
+  tplOperator: noop,
   trim: noop,
   trimEnd: noop
 }
@@ -112,6 +113,20 @@ function csiMethodsOverrides (getContext) {
         }
       } catch (e) {
         iastLog.error('Error invoking CSI plusOperator')
+          .errorAndPublish(e)
+      }
+      return res
+    },
+
+    tplOperator: function (res, ...rest) {
+      try {
+        const iastContext = getContext()
+        const transactionId = getTransactionId(iastContext)
+        if (transactionId) {
+          return TaintedUtils.concat(transactionId, res, ...rest)
+        }
+      } catch (e) {
+        iastLog.error('Error invoking CSI tplOperator')
           .errorAndPublish(e)
       }
       return res

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/resources/propagationFunctions.js
@@ -12,6 +12,13 @@ function templateLiteralEndingWithNumberParams (str) {
   return `${str}Literal${num1}${num2}`
 }
 
+function templateLiteralWithTaintedAtTheEnd (str) {
+  const num1 = 1
+  const num2 = 2
+  const hello = 'world'
+  return `Literal${num1}${num2}-${hello}-${str}`
+}
+
 function appendStr (str) {
   let pre = 'pre_'
   pre += str
@@ -108,6 +115,7 @@ module.exports = {
   substrStr,
   substringStr,
   templateLiteralEndingWithNumberParams,
+  templateLiteralWithTaintedAtTheEnd,
   toLowerCaseStr,
   toUpperCaseStr,
   trimEndStr,

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -26,6 +26,7 @@ const propagationFns = [
   'substrStr',
   'substringStr',
   'templateLiteralEndingWithNumberParams',
+  'templateLiteralWithTaintedAtTheEnd',
   'toLowerCaseStr',
   'toUpperCaseStr',
   'trimEndStr',
@@ -137,7 +138,8 @@ describe('TaintTracking', () => {
       'concatSuffix',
       'concatTaintedStr',
       'insertStr',
-      'templateLiteralEndingWithNumberParams'
+      'templateLiteralEndingWithNumberParams',
+      'templateLiteralWithTaintedAtTheEnd'
     ]
     propagationFns.forEach((propFn) => {
       if (filtered.includes(propFn)) return

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,10 +263,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.4.1.tgz#e8211f78c818906513fb96a549374da0382c7623"
-  integrity sha512-j3auTmyyn63e2y+SL28CGNy/l+jXQyh+pxqoGTacWaY5FW/dvo5nGQepAismgJ3qJ8VhQfVWRdxBSiT7wu9clw==
+"@datadog/native-iast-rewriter@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.5.0.tgz#b613defe86e78168f750d1f1662d4ffb3cf002e6"
+  integrity sha512-WRu34A3Wwp6oafX8KWNAbedtDaaJO+nzfYQht7pcJKjyC2ggfPeF7SoP+eDo9wTn4/nQwEOscSR4hkJqTRlpXQ==
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"


### PR DESCRIPTION
### What does this PR do?
Upgrade iast rewriter to 2.5.0

### Motivation
Better template literal rewrite, support spread operator in some expressions

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


