### PR TITLE
[test visibility] Add option to automatically report logs within tests when using `winston`

### DIFF
--- a/integration-tests/automatic-log-submission.spec.js
+++ b/integration-tests/automatic-log-submission.spec.js
@@ -12,13 +12,22 @@ const {
 } = require('./helpers')
 const { FakeCiVisIntake } = require('./ci-visibility-intake')
 const webAppServer = require('./ci-visibility/web-app-server')
+const { NODE_MAJOR } = require('../version')
+
+const cucumberVersion = NODE_MAJOR <= 16 ? '9' : 'latest'
 
 describe('test visibility automatic log submission', () => {
   let sandbox, cwd, receiver, childProcess, webAppPort
   let testOutput = ''
 
   before(async () => {
-    sandbox = await createSandbox(['mocha', 'jest', 'winston', 'chai@4'], true)
+    sandbox = await createSandbox([
+      'mocha',
+      `@cucumber/cucumber@${cucumberVersion}`,
+      'jest',
+      'winston',
+      'chai@4'
+    ], true)
     cwd = sandbox.folder
     webAppPort = await getPort()
     webAppServer.listen(webAppPort)
@@ -48,6 +57,10 @@ describe('test visibility automatic log submission', () => {
     {
       name: 'jest',
       command: 'node ./node_modules/jest/bin/jest --config ./ci-visibility/automatic-log-submission/config-jest.js'
+    },
+    {
+      name: 'cucumber',
+      command: './node_modules/.bin/cucumber-js ci-visibility/automatic-log-submission-cucumber/*.feature'
     }
   ]
 

--- a/integration-tests/automatic-log-submission.spec.js
+++ b/integration-tests/automatic-log-submission.spec.js
@@ -113,11 +113,6 @@ describe('test visibility automatic log submission', () => {
       })
 
       it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is not set', (done) => {
-        receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
-            throw new Error('should not report logs')
-          }).catch(done)
-
         childProcess = exec(command,
           {
             cwd,
@@ -145,11 +140,6 @@ describe('test visibility automatic log submission', () => {
       })
 
       it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is set but DD_API_KEY is not', (done) => {
-        receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
-            throw new Error('should not report logs')
-          }).catch(done)
-
         childProcess = exec(command,
           {
             cwd,

--- a/integration-tests/automatic-log-submission.spec.js
+++ b/integration-tests/automatic-log-submission.spec.js
@@ -88,9 +88,8 @@ describe('test visibility automatic log submission', () => {
             env: {
               ...getCiVisAgentlessConfig(receiver.port),
               DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-              DD_CIVISIBILITY_AGENTLESS_LOGS_HOST: 'localhost',
-              DD_CIVISIBILITY_AGENTLESS_LOGS_PORT: receiver.port,
-              DD_API_KEY: '1', // TODO: check that if this is not set, this does not happen
+              DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
+              DD_API_KEY: '1',
               DD_SERVICE: 'my-service'
             },
             stdio: 'pipe'
@@ -118,8 +117,7 @@ describe('test visibility automatic log submission', () => {
             cwd,
             env: {
               ...getCiVisAgentlessConfig(receiver.port),
-              DD_CIVISIBILITY_AGENTLESS_LOGS_HOST: 'localhost',
-              DD_CIVISIBILITY_AGENTLESS_LOGS_PORT: receiver.port,
+              DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
               DD_SERVICE: 'my-service'
             },
             stdio: 'pipe'
@@ -146,8 +144,7 @@ describe('test visibility automatic log submission', () => {
             env: {
               ...getCiVisEvpProxyConfig(receiver.port),
               DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
-              DD_CIVISIBILITY_AGENTLESS_LOGS_HOST: 'localhost',
-              DD_CIVISIBILITY_AGENTLESS_LOGS_PORT: receiver.port,
+              DD_AGENTLESS_LOG_SUBMISSION_URL: `http://localhost:${receiver.port}`,
               DD_SERVICE: 'my-service',
               DD_TRACE_DEBUG: '1',
               DD_TRACE_LOG_LEVEL: 'warn',

--- a/integration-tests/automatic-log-submission.spec.js
+++ b/integration-tests/automatic-log-submission.spec.js
@@ -1,0 +1,171 @@
+'use strict'
+
+const { exec } = require('child_process')
+
+const { assert } = require('chai')
+const getPort = require('get-port')
+
+const {
+  createSandbox,
+  getCiVisAgentlessConfig,
+  getCiVisEvpProxyConfig
+} = require('./helpers')
+const { FakeCiVisIntake } = require('./ci-visibility-intake')
+const webAppServer = require('./ci-visibility/web-app-server')
+
+describe('test visibility automatic log submission', () => {
+  let sandbox, cwd, receiver, childProcess, webAppPort
+  let testOutput = ''
+
+  before(async () => {
+    sandbox = await createSandbox(['mocha', 'jest', 'winston', 'chai@4'], true)
+    cwd = sandbox.folder
+    webAppPort = await getPort()
+    webAppServer.listen(webAppPort)
+  })
+
+  after(async () => {
+    await sandbox.remove()
+    await new Promise(resolve => webAppServer.close(resolve))
+  })
+
+  beforeEach(async function () {
+    const port = await getPort()
+    receiver = await new FakeCiVisIntake(port).start()
+  })
+
+  afterEach(async () => {
+    testOutput = ''
+    childProcess.kill()
+    await receiver.stop()
+  })
+
+  const testFrameworks = [
+    {
+      name: 'mocha',
+      command: 'mocha ./ci-visibility/automatic-log-submission/automatic-log-submission-test.js'
+    },
+    {
+      name: 'jest',
+      command: 'node ./node_modules/jest/bin/jest --config ./ci-visibility/automatic-log-submission/config-jest.js'
+    }
+  ]
+
+  testFrameworks.forEach(({ name, command }) => {
+    context(`with ${name}`, () => {
+      it('can automatically submit logs', (done) => {
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
+            const logMessages = payloads.flatMap(({ logMessage }) => logMessage)
+            const [url] = payloads.flatMap(({ url }) => url)
+
+            assert.equal(url, '/api/v2/logs?dd-api-key=1&ddsource=winston&service=my-service')
+            assert.equal(logMessages.length, 1)
+            const [{ dd, level, message }] = logMessages
+
+            assert.equal(level, 'info')
+            assert.equal(message, 'Hello simple log!')
+            assert.equal(dd.service, 'my-service')
+            assert.hasAllKeys(dd, ['trace_id', 'span_id', 'service'])
+          }).catch(done)
+
+        childProcess = exec(command,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+              DD_CIVISIBILITY_AGENTLESS_LOGS_HOST: 'localhost',
+              DD_CIVISIBILITY_AGENTLESS_LOGS_PORT: receiver.port,
+              DD_API_KEY: '1', // TODO: check that if this is not set, this does not happen
+              DD_SERVICE: 'my-service'
+            },
+            stdio: 'pipe'
+          }
+        )
+        childProcess.on('exit', () => {
+          receiverPromise.then(() => {
+            assert.include(testOutput, 'Hello simple log!')
+            assert.include(testOutput, 'span_id')
+            done()
+          })
+        })
+
+        childProcess.stdout.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+      })
+
+      it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is not set', (done) => {
+        receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
+            throw new Error('should not report logs')
+          }).catch(done)
+
+        childProcess = exec(command,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              DD_CIVISIBILITY_AGENTLESS_LOGS_HOST: 'localhost',
+              DD_CIVISIBILITY_AGENTLESS_LOGS_PORT: receiver.port,
+              DD_SERVICE: 'my-service'
+            },
+            stdio: 'pipe'
+          }
+        )
+        childProcess.on('exit', () => {
+          assert.include(testOutput, 'Hello simple log!')
+          assert.notInclude(testOutput, 'span_id')
+          done()
+        })
+
+        childProcess.stdout.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+      })
+
+      it('does not submit logs when DD_AGENTLESS_LOG_SUBMISSION_ENABLED is set but DD_API_KEY is not', (done) => {
+        receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
+            throw new Error('should not report logs')
+          }).catch(done)
+
+        childProcess = exec(command,
+          {
+            cwd,
+            env: {
+              ...getCiVisEvpProxyConfig(receiver.port),
+              DD_AGENTLESS_LOG_SUBMISSION_ENABLED: '1',
+              DD_CIVISIBILITY_AGENTLESS_LOGS_HOST: 'localhost',
+              DD_CIVISIBILITY_AGENTLESS_LOGS_PORT: receiver.port,
+              DD_SERVICE: 'my-service',
+              DD_TRACE_DEBUG: '1',
+              DD_TRACE_LOG_LEVEL: 'warn',
+              DD_API_KEY: ''
+            },
+            stdio: 'pipe'
+          }
+        )
+        childProcess.on('exit', () => {
+          assert.include(testOutput, 'Hello simple log!')
+          assert.include(testOutput, 'no automatic log submission will be performed')
+          done()
+        })
+
+        childProcess.stdout.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+        childProcess.stderr.on('data', (chunk) => {
+          testOutput += chunk.toString()
+        })
+      })
+    })
+  })
+})

--- a/integration-tests/automatic-log-submission.spec.js
+++ b/integration-tests/automatic-log-submission.spec.js
@@ -71,10 +71,13 @@ describe('test visibility automatic log submission', () => {
 
         const logsPromise = receiver
           .gatherPayloadsMaxTimeout(({ url }) => url.includes('/api/v2/logs'), payloads => {
+            payloads.forEach(({ headers }) => {
+              assert.equal(headers['dd-api-key'], '1')
+            })
             const logMessages = payloads.flatMap(({ logMessage }) => logMessage)
             const [url] = payloads.flatMap(({ url }) => url)
 
-            assert.equal(url, '/api/v2/logs?dd-api-key=1&ddsource=winston&service=my-service')
+            assert.equal(url, '/api/v2/logs?ddsource=winston&service=my-service')
             assert.equal(logMessages.length, 2)
 
             logMessages.forEach(({ dd, level }) => {

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -208,6 +208,15 @@ class FakeCiVisIntake extends FakeAgent {
       })
     })
 
+    app.post('/api/v2/logs', express.json(), (req, res) => {
+      res.status(200).send('OK')
+      this.emit('message', {
+        headers: req.headers,
+        url: req.url,
+        logMessage: req.body
+      })
+    })
+
     return new Promise((resolve, reject) => {
       const timeoutObj = setTimeout(() => {
         reject(new Error('Intake timed out starting up'))

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/automatic-log-submission.feature
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/automatic-log-submission.feature
@@ -1,0 +1,4 @@
+Feature: Automatic Log Submission
+  Scenario: Run Automatic Log Submission
+    When we run a test
+    Then I should have made a log

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/logger.js
@@ -1,0 +1,10 @@
+const { createLogger, format, transports } = require('winston')
+
+module.exports = createLogger({
+  level: 'info',
+  exitOnError: false,
+  format: format.json(),
+  transports: [
+    new transports.Console()
+  ]
+})

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
@@ -1,0 +1,20 @@
+const { expect } = require('chai')
+const { createLogger, format, transports } = require('winston')
+const { When, Then } = require('@cucumber/cucumber')
+
+const logger = createLogger({
+  level: 'info',
+  exitOnError: false,
+  format: format.json(),
+  transports: [
+    new transports.Console()
+  ]
+})
+
+Then('I should have made a log', async function () {
+  expect(true).to.equal(true)
+})
+
+When('we run a test', async function () {
+  logger.log('info', 'Hello simple log!')
+})

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/steps.js
@@ -1,18 +1,12 @@
 const { expect } = require('chai')
-const { createLogger, format, transports } = require('winston')
 const { When, Then } = require('@cucumber/cucumber')
 
-const logger = createLogger({
-  level: 'info',
-  exitOnError: false,
-  format: format.json(),
-  transports: [
-    new transports.Console()
-  ]
-})
+const logger = require('./logger')
+const sum = require('./sum')
 
 Then('I should have made a log', async function () {
   expect(true).to.equal(true)
+  expect(sum(1, 2)).to.equal(3)
 })
 
 When('we run a test', async function () {

--- a/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/sum.js
+++ b/integration-tests/ci-visibility/automatic-log-submission-cucumber/support/sum.js
@@ -1,0 +1,6 @@
+const logger = require('./logger')
+
+module.exports = function (a, b) {
+  logger.log('info', 'sum function being called')
+  return a + b
+}

--- a/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
@@ -1,0 +1,19 @@
+const { createLogger, format, transports } = require('winston')
+const { expect } = require('chai')
+
+const logger = createLogger({
+  level: 'info',
+  exitOnError: false,
+  format: format.json(),
+  transports: [
+    new transports.Console()
+  ]
+})
+
+describe('test', () => {
+  it('should return true', () => {
+    logger.log('info', 'Hello simple log!')
+
+    expect(true).to.be.true
+  })
+})

--- a/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/automatic-log-submission-test.js
@@ -1,19 +1,13 @@
-const { createLogger, format, transports } = require('winston')
 const { expect } = require('chai')
 
-const logger = createLogger({
-  level: 'info',
-  exitOnError: false,
-  format: format.json(),
-  transports: [
-    new transports.Console()
-  ]
-})
+const logger = require('./logger')
+const sum = require('./sum')
 
 describe('test', () => {
   it('should return true', () => {
     logger.log('info', 'Hello simple log!')
 
     expect(true).to.be.true
+    expect(sum(1, 2)).to.equal(3)
   })
 })

--- a/integration-tests/ci-visibility/automatic-log-submission/config-jest.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/config-jest.js
@@ -1,0 +1,8 @@
+module.exports = {
+  projects: [],
+  testPathIgnorePatterns: ['/node_modules/'],
+  cache: false,
+  testMatch: [
+    '**/ci-visibility/automatic-log-submission/automatic-log-submission-*'
+  ]
+}

--- a/integration-tests/ci-visibility/automatic-log-submission/logger.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/logger.js
@@ -1,0 +1,10 @@
+const { createLogger, format, transports } = require('winston')
+
+module.exports = createLogger({
+  level: 'info',
+  exitOnError: false,
+  format: format.json(),
+  transports: [
+    new transports.Console()
+  ]
+})

--- a/integration-tests/ci-visibility/automatic-log-submission/sum.js
+++ b/integration-tests/ci-visibility/automatic-log-submission/sum.js
@@ -1,0 +1,6 @@
+const logger = require('./logger')
+
+module.exports = function (a, b) {
+  logger.log('info', 'sum function being called')
+  return a + b
+}

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -18,7 +18,7 @@ const {
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { NODE_MAJOR } = require('../../version')
 
-const cucumberVersion = NODE_MAJOR <= 16 ? '9' : '10'
+const cucumberVersion = NODE_MAJOR <= 16 ? '9' : 'latest'
 
 const webAppServer = require('../ci-visibility/web-app-server')
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -850,7 +850,8 @@ addHook({
 }, jestConfigSyncWrapper)
 
 const LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE = [
-  'selenium-webdriver'
+  'selenium-webdriver',
+  'winston'
 ]
 
 function shouldBypassJestRequireEngine (moduleName) {

--- a/packages/datadog-instrumentations/src/winston.js
+++ b/packages/datadog-instrumentations/src/winston.js
@@ -8,6 +8,17 @@ const shimmer = require('../../datadog-shimmer')
 
 const patched = new WeakSet()
 
+const configureCh = channel('ci:winston:configure')
+const addTransport = channel('ci:winston:add-transport')
+
+addHook({ name: 'winston', file: 'lib/winston/transports/index.js', versions: ['>=3'] }, transportsPackage => {
+  if (configureCh.hasSubscribers) {
+    configureCh.publish(transportsPackage.Http)
+  }
+
+  return transportsPackage
+})
+
 addHook({ name: 'winston', file: 'lib/winston/logger.js', versions: ['>=3'] }, Logger => {
   const logCh = channel('apm:winston:log')
   shimmer.wrap(Logger.prototype, 'write', write => {
@@ -20,6 +31,16 @@ addHook({ name: 'winston', file: 'lib/winston/logger.js', versions: ['>=3'] }, L
       return write.apply(this, arguments)
     }
   })
+
+  shimmer.wrap(Logger.prototype, 'configure', configure => function () {
+    const configureResponse = configure.apply(this, arguments)
+    // we add it _after_ the original configure, because configure resets any transport
+    if (addTransport.hasSubscribers) {
+      addTransport.publish(this)
+    }
+    return configureResponse
+  })
+
   return Logger
 })
 

--- a/packages/datadog-instrumentations/src/winston.js
+++ b/packages/datadog-instrumentations/src/winston.js
@@ -8,8 +8,9 @@ const shimmer = require('../../datadog-shimmer')
 
 const patched = new WeakSet()
 
-const configureCh = channel('ci:winston:configure')
-const addTransport = channel('ci:winston:add-transport')
+// Test Visibility log submission channels
+const configureCh = channel('ci:log-submission:winston:configure')
+const addTransport = channel('ci:log-submission:winston:add-transport')
 
 addHook({ name: 'winston', file: 'lib/winston/transports/index.js', versions: ['>=3'] }, transportsPackage => {
   if (configureCh.hasSubscribers) {
@@ -34,7 +35,7 @@ addHook({ name: 'winston', file: 'lib/winston/logger.js', versions: ['>=3'] }, L
 
   shimmer.wrap(Logger.prototype, 'configure', configure => function () {
     const configureResponse = configure.apply(this, arguments)
-    // we add it _after_ the original configure, because configure resets any transport
+    // After the original `configure`, because it resets transports
     if (addTransport.hasSubscribers) {
       addTransport.publish(this)
     }

--- a/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
@@ -6,8 +6,11 @@ function getWinstonLogSubmissionParameters (config) {
 
   const defaultParameters = {
     host: `http-intake.logs.${site}`,
-    path: `/api/v2/logs?dd-api-key=${process.env.DD_API_KEY}&ddsource=winston&service=${service}`,
-    ssl: true
+    path: `/api/v2/logs?ddsource=winston&service=${service}`,
+    ssl: true,
+    headers: {
+      'DD-API-KEY': process.env.DD_API_KEY
+    }
   }
 
   if (!process.env.DD_AGENTLESS_LOG_SUBMISSION_URL) {
@@ -20,7 +23,8 @@ function getWinstonLogSubmissionParameters (config) {
       host: url.hostname,
       port: url.port,
       ssl: url.protocol === 'https:',
-      path: defaultParameters.path
+      path: defaultParameters.path,
+      headers: defaultParameters.headers
     }
   } catch (e) {
     log.error('Could not parse DD_AGENTLESS_LOG_SUBMISSION_URL')

--- a/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
@@ -3,9 +3,10 @@ const Plugin = require('../../plugins/plugin')
 function getWinstonLogSubmissionParameters (config) {
   const { site, service } = config
   return {
-    host: `http-intake.logs.${site}`,
+    host: process.env.DD_CIVISIBILITY_AGENTLESS_LOGS_HOST || `http-intake.logs.${site}`,
+    port: process.env.DD_CIVISIBILITY_AGENTLESS_LOGS_PORT,
     path: `/api/v2/logs?dd-api-key=${process.env.DD_API_KEY}&ddsource=winston&service=${service}`,
-    ssl: true
+    ssl: !process.env.DD_CIVISIBILITY_AGENTLESS_LOGS_HOST
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
@@ -1,0 +1,30 @@
+const Plugin = require('../../plugins/plugin')
+
+function getWinstonLogSubmissionParameters (config) {
+  const { site, service } = config
+  return {
+    host: `http-intake.logs.${site}`,
+    path: `/api/v2/logs?dd-api-key=${process.env.DD_API_KEY}&ddsource=winston&service=${service}`,
+    ssl: true
+  }
+}
+
+class LogSubmissionPlugin extends Plugin {
+  static get id () {
+    return 'log-submission'
+  }
+
+  constructor (...args) {
+    super(...args)
+
+    this.addSub('ci:log-submission:winston:configure', (httpClass) => {
+      this.HttpClass = httpClass
+    })
+
+    this.addSub('ci:log-submission:winston:add-transport', (logger) => {
+      logger.add(new this.HttpClass(getWinstonLogSubmissionParameters(this.config)))
+    })
+  }
+}
+
+module.exports = LogSubmissionPlugin

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -498,6 +498,7 @@ class Config {
     this._setValue(defaults, 'isIntelligentTestRunnerEnabled', false)
     this._setValue(defaults, 'isManualApiEnabled', false)
     this._setValue(defaults, 'ciVisibilityTestSessionName', '')
+    this._setValue(defaults, 'ciVisAgentlessLogSubmissionEnabled', false)
     this._setValue(defaults, 'logInjection', false)
     this._setValue(defaults, 'lookup', undefined)
     this._setValue(defaults, 'memcachedCommandEnabled', false)
@@ -1035,7 +1036,8 @@ class Config {
       DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED,
       DD_CIVISIBILITY_FLAKY_RETRY_ENABLED,
       DD_CIVISIBILITY_FLAKY_RETRY_COUNT,
-      DD_TEST_SESSION_NAME
+      DD_TEST_SESSION_NAME,
+      DD_AGENTLESS_LOG_SUBMISSION_ENABLED
     } = process.env
 
     if (DD_CIVISIBILITY_AGENTLESS_URL) {
@@ -1052,6 +1054,7 @@ class Config {
       this._setBoolean(calc, 'isIntelligentTestRunnerEnabled', isTrue(this._isCiVisibilityItrEnabled()))
       this._setBoolean(calc, 'isManualApiEnabled', !isFalse(this._isCiVisibilityManualApiEnabled()))
       this._setString(calc, 'ciVisibilityTestSessionName', DD_TEST_SESSION_NAME)
+      this._setBoolean(calc, 'ciVisAgentlessLogSubmissionEnabled', isTrue(DD_AGENTLESS_LOG_SUBMISSION_ENABLED))
     }
     this._setString(calc, 'dogstatsd.hostname', this._getHostname())
     this._setBoolean(calc, 'isGitUploadEnabled',

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -137,7 +137,8 @@ module.exports = class PluginManager {
       dsmEnabled,
       clientIpEnabled,
       memcachedCommandEnabled,
-      ciVisibilityTestSessionName
+      ciVisibilityTestSessionName,
+      ciVisAgentlessLogSubmissionEnabled
     } = this._tracerConfig
 
     const sharedConfig = {
@@ -147,7 +148,8 @@ module.exports = class PluginManager {
       site,
       url,
       headers: headerTags || [],
-      ciVisibilityTestSessionName
+      ciVisibilityTestSessionName,
+      ciVisAgentlessLogSubmissionEnabled
     }
 
     if (logInjection !== undefined) {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -100,7 +100,9 @@ module.exports = class CiPlugin extends Plugin {
           ...testSessionSpanMetadata
         }
       })
+      // TODO: add telemetry tag when we can add `is_agentless_log_submission_enabled` for agentless log submission
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'session')
+
       this.testModuleSpan = this.tracer.startSpan(`${this.constructor.id}.test_module`, {
         childOf: this.testSessionSpan,
         tags: {

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -49,12 +49,34 @@ module.exports = class LogPlugin extends Plugin {
       this.tracer.inject(span, LOG, holder)
       arg.message = messageProxy(arg.message, holder)
     })
+    // TODO: create a different pluginf or this
+    // probably good idea to do it in a _different_ plugin specific to ci vis
+    this.addSub(`ci:${this.constructor.id}:configure`, (httpClass) => {
+      if (!this.isCiVisAgentlessLogSubmissionEnabled) {
+        return
+      }
+      this.HttpClass = httpClass
+    })
+
+    this.addSub(`ci:${this.constructor.id}:add-transport`, (logger) => {
+      if (!this.isCiVisAgentlessLogSubmissionEnabled) {
+        return
+      }
+      // TODO: change site, ddsource and service
+      const httpTransportOptions = {
+        host: 'http-intake.logs.datad0g.com',
+        path: `/api/v2/logs?dd-api-key=${process.env.DD_API_KEY}&ddsource=nodejs&service=nodejs-example`,
+        ssl: true
+      }
+      logger.add(new this.HttpClass(httpTransportOptions))
+    })
   }
 
   configure (config) {
+    this.isCiVisAgentlessLogSubmissionEnabled = config.ciVisAgentlessLogSubmissionEnabled
     return super.configure({
       ...config,
-      enabled: config.enabled && config.logInjection
+      enabled: config.enabled && (config.logInjection || config.ciVisAgentlessLogSubmissionEnabled)
     })
   }
 }

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -49,31 +49,9 @@ module.exports = class LogPlugin extends Plugin {
       this.tracer.inject(span, LOG, holder)
       arg.message = messageProxy(arg.message, holder)
     })
-    // TODO: create a different pluginf or this
-    // probably good idea to do it in a _different_ plugin specific to ci vis
-    this.addSub(`ci:${this.constructor.id}:configure`, (httpClass) => {
-      if (!this.isCiVisAgentlessLogSubmissionEnabled) {
-        return
-      }
-      this.HttpClass = httpClass
-    })
-
-    this.addSub(`ci:${this.constructor.id}:add-transport`, (logger) => {
-      if (!this.isCiVisAgentlessLogSubmissionEnabled) {
-        return
-      }
-      // TODO: change site, ddsource and service
-      const httpTransportOptions = {
-        host: 'http-intake.logs.datad0g.com',
-        path: `/api/v2/logs?dd-api-key=${process.env.DD_API_KEY}&ddsource=nodejs&service=nodejs-example`,
-        ssl: true
-      }
-      logger.add(new this.HttpClass(httpTransportOptions))
-    })
   }
 
   configure (config) {
-    this.isCiVisAgentlessLogSubmissionEnabled = config.ciVisAgentlessLogSubmissionEnabled
     return super.configure({
       ...config,
       enabled: config.enabled && (config.logInjection || config.ciVisAgentlessLogSubmissionEnabled)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -162,6 +162,18 @@ class Tracer extends NoopProxy {
           this._testApiManualPlugin.configure({ ...config, enabled: true })
         }
       }
+      if (config.ciVisAgentlessLogSubmissionEnabled) {
+        if (process.env.DD_API_KEY) {
+          const LogSubmissionPlugin = require('./ci-visibility/log-submission/log-submission-plugin')
+          const automaticLogPlugin = new LogSubmissionPlugin(this)
+          automaticLogPlugin.configure({ ...config, enabled: true })
+        } else {
+          log.warn(
+            'DD_AGENTLESS_LOG_SUBMISSION_ENABLED is set, ' +
+            'but DD_API_KEY is undefined, so no automatic log submission will be performed.'
+          )
+        }
+      }
     } catch (e) {
       log.error(e)
     }


### PR DESCRIPTION
### What does this PR do?

Add instrumentation to `winston` to automatically add a transport configuration that reports logs to datadog agentlessly, following the same instructions shown in the docs today for agentless logs: https://docs.datadoghq.com/logs/log_collection/nodejs/?tab=winston30#agentless-logging. This only happens if `LogSubmissionPlugin` is active, which only happens if `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` is passed.


### Motivation
Same as we do for other languages like Java ([see docs](https://docs.datadoghq.com/tests/correlate_logs_and_tests?tab=cloudciprovideragentless#setup)), we want to be able to automatically report logs to Datadog's logs product if `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` is passed. 

ℹ️ Only `winston` in `jest`, `mocha` and `cucumber` is supported at the moment.

```javascript
const { createLogger, format, transports } = require('winston')
const { expect } = require('chai')

const logger = createLogger({
  level: 'info',
  exitOnError: false,
  format: format.json(),
  transports: [
    new transports.Console()
  ]
})

describe('test', () => {
  it('should return true', () => {
    logger.log('info', 'Hello simple log!') // this log will be automatically submitted if `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` is defined

    expect(true).to.be.true
  })
})
```


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
