### PR TITLE
Use static vulnerability hash source when the cookie name is too long

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -128,6 +128,7 @@ tracer.init({
   },
   iast: {
     enabled: true,
+    cookieFilterPattern: '.*',
     requestSampling: 50,
     maxConcurrentRequests: 4,
     maxContextOperations: 30,
@@ -143,6 +144,7 @@ tracer.init({
   experimental: {
     iast: {
       enabled: true,
+      cookieFilterPattern: '.*',
       requestSampling: 50,
       maxConcurrentRequests: 4,
       maxContextOperations: 30,

--- a/index.d.ts
+++ b/index.d.ts
@@ -2163,7 +2163,7 @@ declare namespace tracer {
      * Defines the pattern to ignore cookie names in the vulnerability hash calculation
      * @default ".{32,}"
      */
-    cookieFilterPattern?: boolean,
+    cookieFilterPattern?: string,
 
     /**
      * Whether to enable vulnerability deduplication

--- a/index.d.ts
+++ b/index.d.ts
@@ -1739,7 +1739,6 @@ declare namespace tracer {
      * on the tracer.
      */
     interface pino extends Integration {}
-  
     /**
      * This plugin automatically patches the [protobufjs](https://protobufjs.github.io/protobuf.js/)
      * to collect protobuf message schemas when Datastreams Monitoring is enabled.
@@ -2159,6 +2158,12 @@ declare namespace tracer {
      * @default 2
      */
     maxContextOperations?: number,
+
+    /**
+     * Defines the pattern to ignore cookie names in the vulnerability hash calculation
+     * @default ".{32,}"
+     */
+    cookieFilterPattern?: boolean,
 
     /**
      * Whether to enable vulnerability deduplication

--- a/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
@@ -12,7 +12,11 @@ class CookieAnalyzer extends Analyzer {
   }
 
   onConfigure (config) {
-    this.cookieFilterRegExp = new RegExp(config.iast.cookieFilterPattern)
+    try {
+      this.cookieFilterRegExp = new RegExp(config.iast.cookieFilterPattern)
+    } catch {
+      this.cookieFilterRegExp = /.{32,}/
+    }
 
     this.addSub(
       { channelName: 'datadog:iast:set-cookie', moduleName: 'http' },

--- a/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
@@ -2,6 +2,7 @@
 
 const Analyzer = require('./vulnerability-analyzer')
 const { getNodeModulesPaths } = require('../path-line')
+const iastLog = require('../iast-log')
 
 const EXCLUDED_PATHS = getNodeModulesPaths('express/lib/response.js')
 
@@ -15,6 +16,7 @@ class CookieAnalyzer extends Analyzer {
     try {
       this.cookieFilterRegExp = new RegExp(config.iast.cookieFilterPattern)
     } catch {
+      iastLog.error('Invalid regex in cookieFilterPattern')
       this.cookieFilterRegExp = /.{32,}/
     }
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
@@ -11,7 +11,9 @@ class CookieAnalyzer extends Analyzer {
     this.propertyToBeSafe = propertyToBeSafe.toLowerCase()
   }
 
-  onConfigure () {
+  onConfigure (config) {
+    this.cookieFilterRegExp = new RegExp(config.iast.cookieFilterPattern)
+
     this.addSub(
       { channelName: 'datadog:iast:set-cookie', moduleName: 'http' },
       (cookieInfo) => this.analyze(cookieInfo)
@@ -28,6 +30,10 @@ class CookieAnalyzer extends Analyzer {
   }
 
   _createHashSource (type, evidence, location) {
+    if (typeof evidence.value === 'string' && evidence.value.match(this.cookieFilterRegExp)) {
+      return 'FILTERED_' + this._type
+    }
+
     return `${type}:${evidence.value}`
   }
 

--- a/packages/dd-trace/src/appsec/iast/iast-plugin.js
+++ b/packages/dd-trace/src/appsec/iast/iast-plugin.js
@@ -127,7 +127,7 @@ class IastPlugin extends Plugin {
       config = { enabled: config }
     }
     if (config.enabled && !this.configured) {
-      this.onConfigure()
+      this.onConfigure(config.tracerConfig)
       this.configured = true
     }
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -478,6 +478,7 @@ class Config {
     this._setValue(defaults, 'gitMetadataEnabled', true)
     this._setValue(defaults, 'headerTags', [])
     this._setValue(defaults, 'hostname', '127.0.0.1')
+    this._setValue(defaults, 'iast.cookieFilterPattern', '.{32,}')
     this._setValue(defaults, 'iast.deduplicationEnabled', true)
     this._setValue(defaults, 'iast.enabled', false)
     this._setValue(defaults, 'iast.maxConcurrentRequests', 2)
@@ -581,6 +582,7 @@ class Config {
       DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED,
       DD_EXPERIMENTAL_PROFILING_ENABLED,
       JEST_WORKER_ID,
+      DD_IAST_COOKIE_FILTER_PATTERN,
       DD_IAST_DEDUPLICATION_ENABLED,
       DD_IAST_ENABLED,
       DD_IAST_MAX_CONCURRENT_REQUESTS,
@@ -716,6 +718,7 @@ class Config {
     this._setBoolean(env, 'gitMetadataEnabled', DD_TRACE_GIT_METADATA_ENABLED)
     this._setArray(env, 'headerTags', DD_TRACE_HEADER_TAGS)
     this._setString(env, 'hostname', coalesce(DD_AGENT_HOST, DD_TRACE_AGENT_HOSTNAME))
+    this._setString(env, 'iast.cookieFilterPattern', DD_IAST_COOKIE_FILTER_PATTERN)
     this._setBoolean(env, 'iast.deduplicationEnabled', DD_IAST_DEDUPLICATION_ENABLED)
     this._setBoolean(env, 'iast.enabled', DD_IAST_ENABLED)
     this._setValue(env, 'iast.maxConcurrentRequests', maybeInt(DD_IAST_MAX_CONCURRENT_REQUESTS))
@@ -884,6 +887,7 @@ class Config {
     this._optsUnprocessed.flushMinSpans = options.flushMinSpans
     this._setArray(opts, 'headerTags', options.headerTags)
     this._setString(opts, 'hostname', options.hostname)
+    this._setString(opts, 'iast.cookieFilterPattern', options.iast?.cookieFilterPattern)
     this._setBoolean(opts, 'iast.deduplicationEnabled', options.iast && options.iast.deduplicationEnabled)
     this._setBoolean(opts, 'iast.enabled',
       options.iast && (options.iast === true || options.iast.enabled === true))

--- a/packages/dd-trace/test/appsec/iast/analyzers/cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/cookie-analyzer.spec.js
@@ -1,0 +1,110 @@
+'use strict'
+
+const { assert } = require('chai')
+const CookieAnalyzer = require('../../../../src/appsec/iast/analyzers/cookie-analyzer')
+const Analyzer = require('../../../../src/appsec/iast/analyzers/vulnerability-analyzer')
+const Config = require('../../../../src/config')
+
+describe('CookieAnalyzer', () => {
+  const VULNERABILITY_TYPE = 'VULN_TYPE'
+
+  it('should extends Analyzer', () => {
+    assert.isTrue(Analyzer.isPrototypeOf(CookieAnalyzer))
+  })
+
+  describe('_createHashSource', () => {
+    let cookieAnalyzer
+
+    beforeEach(() => {
+      cookieAnalyzer = new CookieAnalyzer(VULNERABILITY_TYPE, 'prop')
+    })
+
+    describe('default config', () => {
+      beforeEach(() => {
+        cookieAnalyzer.onConfigure(new Config({ iast: true }))
+      })
+
+      it('should create hash from vulnerability type and not long enough evidence value', () => {
+        const evidence = {
+          value: '0'.repeat(31)
+        }
+
+        const vulnerability = cookieAnalyzer._createVulnerability(VULNERABILITY_TYPE, evidence, null, {})
+
+        assert.equal(vulnerability.hash, cookieAnalyzer._createHash(`${VULNERABILITY_TYPE}:${evidence.value}`))
+      })
+
+      it('should create different hash from vulnerability type and long evidence value', () => {
+        const evidence = {
+          value: '0'.repeat(32)
+        }
+
+        const vulnerability = cookieAnalyzer._createVulnerability(VULNERABILITY_TYPE, evidence, null, {})
+
+        assert.equal(vulnerability.hash, cookieAnalyzer._createHash(`FILTERED_${VULNERABILITY_TYPE}`))
+      })
+    })
+
+    describe('custom cookieFilterPattern', () => {
+      beforeEach(() => {
+        cookieAnalyzer.onConfigure(new Config({
+          iast: {
+            enabled: true,
+            cookieFilterPattern: '^filtered$'
+          }
+        }))
+      })
+
+      it('should create hash from vulnerability with the default pattern', () => {
+        const evidence = {
+          value: 'notfiltered'
+        }
+
+        const vulnerability = cookieAnalyzer._createVulnerability(VULNERABILITY_TYPE, evidence, null, {})
+
+        assert.equal(vulnerability.hash, cookieAnalyzer._createHash(`${VULNERABILITY_TYPE}:${evidence.value}`))
+      })
+
+      it('should create different hash from vulnerability type and long evidence value', () => {
+        const evidence = {
+          value: 'filtered'
+        }
+
+        const vulnerability = cookieAnalyzer._createVulnerability(VULNERABILITY_TYPE, evidence, null, {})
+
+        assert.equal(vulnerability.hash, cookieAnalyzer._createHash(`FILTERED_${VULNERABILITY_TYPE}`))
+      })
+    })
+
+    describe('invalid cookieFilterPattern maintains default behaviour', () => {
+      beforeEach(() => {
+        cookieAnalyzer.onConfigure(new Config({
+          iast: {
+            enabled: true,
+            cookieFilterPattern: '('
+          }
+        }))
+      })
+
+      it('should create hash from vulnerability type and not long enough evidence value', () => {
+        const evidence = {
+          value: '0'.repeat(31)
+        }
+
+        const vulnerability = cookieAnalyzer._createVulnerability(VULNERABILITY_TYPE, evidence, null, {})
+
+        assert.equal(vulnerability.hash, cookieAnalyzer._createHash(`${VULNERABILITY_TYPE}:${evidence.value}`))
+      })
+
+      it('should create different hash from vulnerability type and long evidence value', () => {
+        const evidence = {
+          value: '0'.repeat(32)
+        }
+
+        const vulnerability = cookieAnalyzer._createVulnerability(VULNERABILITY_TYPE, evidence, null, {})
+
+        assert.equal(vulnerability.hash, cookieAnalyzer._createHash(`FILTERED_${VULNERABILITY_TYPE}`))
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.spec.js
@@ -52,7 +52,7 @@ describe('insecure cookie analyzer', () => {
       }, INSECURE_COOKIE, 1)
 
       testThatRequestHasVulnerability((req, res) => {
-        const cookieNamePrefix = '0'.repeat(50)
+        const cookieNamePrefix = '0'.repeat(32)
         res.setHeader('set-cookie', [cookieNamePrefix + 'key1=value', cookieNamePrefix + 'key2=value2'])
       }, INSECURE_COOKIE, 1, undefined, undefined,
       'Should be detected as the same INSECURE_COOKIE vulnerability when the cookie name is long')

--- a/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.spec.js
@@ -43,6 +43,12 @@ describe('insecure cookie analyzer', () => {
         res.setHeader('set-cookie', ['key=value; HttpOnly', 'key2=value2; Secure'])
       }, INSECURE_COOKIE, 1)
 
+      testThatRequestHasVulnerability((req, res) => {
+        const cookieNamePrefix = (new Array(50)).join('0')
+        res.setHeader('set-cookie', [cookieNamePrefix + 'key1=value', cookieNamePrefix + 'key2=value2'])
+      }, INSECURE_COOKIE, 1, undefined, undefined,
+      'Should be detected as the same INSECURE_COOKIE vulnerability when the cookie name is long')
+
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('set-cookie', 'key=value; Secure')
       }, INSECURE_COOKIE)

--- a/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/insecure-cookie-analyzer.spec.js
@@ -3,12 +3,20 @@
 const { prepareTestServerForIast } = require('../utils')
 const Analyzer = require('../../../../src/appsec/iast/analyzers/vulnerability-analyzer')
 const { INSECURE_COOKIE } = require('../../../../src/appsec/iast/vulnerabilities')
+const insecureCookieAnalyzer = require('../../../../src/appsec/iast/analyzers/insecure-cookie-analyzer')
+const CookieAnalyzer = require('../../../../src/appsec/iast/analyzers/cookie-analyzer')
+
 const analyzer = new Analyzer()
 
 describe('insecure cookie analyzer', () => {
   it('Expected vulnerability identifier', () => {
     expect(INSECURE_COOKIE).to.be.equals('INSECURE_COOKIE')
   })
+
+  it('InsecureCookieAnalyzer extends CookieAnalyzer', () => {
+    expect(CookieAnalyzer.isPrototypeOf(insecureCookieAnalyzer.constructor)).to.be.true
+  })
+
   // In these test, even when we are having multiple vulnerabilities, all the vulnerabilities
   // are in the same cookies method, and it is expected to detect both even when the max operations is 1
   const iastConfig = {
@@ -44,7 +52,7 @@ describe('insecure cookie analyzer', () => {
       }, INSECURE_COOKIE, 1)
 
       testThatRequestHasVulnerability((req, res) => {
-        const cookieNamePrefix = (new Array(50)).join('0')
+        const cookieNamePrefix = '0'.repeat(50)
         res.setHeader('set-cookie', [cookieNamePrefix + 'key1=value', cookieNamePrefix + 'key2=value2'])
       }, INSECURE_COOKIE, 1, undefined, undefined,
       'Should be detected as the same INSECURE_COOKIE vulnerability when the cookie name is long')

--- a/packages/dd-trace/test/appsec/iast/analyzers/no-httponly-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/no-httponly-cookie-analyzer.spec.js
@@ -56,7 +56,7 @@ describe('no HttpOnly cookie analyzer', () => {
       }, NO_HTTPONLY_COOKIE, 1)
 
       testThatRequestHasVulnerability((req, res) => {
-        const cookieNamePrefix = (new Array(50)).join('0')
+        const cookieNamePrefix = '0'.repeat(32)
         res.setHeader('set-cookie', [cookieNamePrefix + 'key1=value', cookieNamePrefix + 'key2=value2'])
       }, NO_HTTPONLY_COOKIE, 1, undefined, undefined,
       'Should be detected as the same NO_HTTPONLY_COOKIE vulnerability when the cookie name is long')

--- a/packages/dd-trace/test/appsec/iast/analyzers/no-httponly-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/no-httponly-cookie-analyzer.spec.js
@@ -18,6 +18,7 @@ describe('no HttpOnly cookie analyzer', () => {
     maxConcurrentRequests: 1,
     maxContextOperations: 1
   }
+
   prepareTestServerForIast('no HttpOnly cookie analyzer',
     (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       testThatRequestHasVulnerability((req, res) => {
@@ -46,6 +47,12 @@ describe('no HttpOnly cookie analyzer', () => {
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('set-cookie', ['key=value; HttpOnly', 'key2=value2; Secure'])
       }, NO_HTTPONLY_COOKIE, 1)
+
+      testThatRequestHasVulnerability((req, res) => {
+        const cookieNamePrefix = (new Array(50)).join('0')
+        res.setHeader('set-cookie', [cookieNamePrefix + 'key1=value', cookieNamePrefix + 'key2=value2'])
+      }, NO_HTTPONLY_COOKIE, 1, undefined, undefined,
+      'Should be detected as the same NO_HTTPONLY_COOKIE vulnerability when the cookie name is long')
 
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('set-cookie', 'key=value; HttpOnly')

--- a/packages/dd-trace/test/appsec/iast/analyzers/no-httponly-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/no-httponly-cookie-analyzer.spec.js
@@ -3,11 +3,18 @@
 const { prepareTestServerForIast } = require('../utils')
 const Analyzer = require('../../../../src/appsec/iast/analyzers/vulnerability-analyzer')
 const { NO_HTTPONLY_COOKIE } = require('../../../../src/appsec/iast/vulnerabilities')
+const CookieAnalyzer = require('../../../../src/appsec/iast/analyzers/cookie-analyzer')
+const noHttponlyCookieAnalyzer = require('../../../../src/appsec/iast/analyzers/no-httponly-cookie-analyzer')
+
 const analyzer = new Analyzer()
 
 describe('no HttpOnly cookie analyzer', () => {
   it('Expected vulnerability identifier', () => {
     expect(NO_HTTPONLY_COOKIE).to.be.equals('NO_HTTPONLY_COOKIE')
+  })
+
+  it('NoHttponlyCookieAnalyzer extends CookieAnalyzer', () => {
+    expect(CookieAnalyzer.isPrototypeOf(noHttponlyCookieAnalyzer.constructor)).to.be.true
   })
 
   // In these test, even when we are having multiple vulnerabilities, all the vulnerabilities

--- a/packages/dd-trace/test/appsec/iast/analyzers/no-samesite-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/no-samesite-cookie-analyzer.spec.js
@@ -3,11 +3,18 @@
 const { prepareTestServerForIast } = require('../utils')
 const Analyzer = require('../../../../src/appsec/iast/analyzers/vulnerability-analyzer')
 const { NO_SAMESITE_COOKIE } = require('../../../../src/appsec/iast/vulnerabilities')
+const CookieAnalyzer = require('../../../../src/appsec/iast/analyzers/cookie-analyzer')
+const noSamesiteCookieAnalyzer = require('../../../../src/appsec/iast/analyzers/no-samesite-cookie-analyzer')
+
 const analyzer = new Analyzer()
 
 describe('no SameSite cookie analyzer', () => {
   it('Expected vulnerability identifier', () => {
     expect(NO_SAMESITE_COOKIE).to.be.equals('NO_SAMESITE_COOKIE')
+  })
+
+  it('NoSamesiteCookieAnalyzer extends CookieAnalyzer', () => {
+    expect(CookieAnalyzer.isPrototypeOf(noSamesiteCookieAnalyzer.constructor)).to.be.true
   })
 
   // In these test, even when we are having multiple vulnerabilities, all the vulnerabilities

--- a/packages/dd-trace/test/appsec/iast/analyzers/no-samesite-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/no-samesite-cookie-analyzer.spec.js
@@ -59,6 +59,12 @@ describe('no SameSite cookie analyzer', () => {
         res.setHeader('set-cookie', 'key=value; SameSite=strict')
       }, NO_SAMESITE_COOKIE)
 
+      testThatRequestHasVulnerability((req, res) => {
+        const cookieNamePrefix = (new Array(50)).join('0')
+        res.setHeader('set-cookie', [cookieNamePrefix + 'key1=value', cookieNamePrefix + 'key2=value2'])
+      }, NO_SAMESITE_COOKIE, 1, undefined, undefined,
+      'Should be detected as the same NO_SAMESITE_COOKIE vulnerability when the cookie name is long')
+
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('set-cookie', 'key=')
       }, NO_SAMESITE_COOKIE)

--- a/packages/dd-trace/test/appsec/iast/analyzers/no-samesite-cookie-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/no-samesite-cookie-analyzer.spec.js
@@ -67,7 +67,7 @@ describe('no SameSite cookie analyzer', () => {
       }, NO_SAMESITE_COOKIE)
 
       testThatRequestHasVulnerability((req, res) => {
-        const cookieNamePrefix = (new Array(50)).join('0')
+        const cookieNamePrefix = '0'.repeat(32)
         res.setHeader('set-cookie', [cookieNamePrefix + 'key1=value', cookieNamePrefix + 'key2=value2'])
       }, NO_SAMESITE_COOKIE, 1, undefined, undefined,
       'Should be detected as the same NO_SAMESITE_COOKIE vulnerability when the cookie name is long')

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -112,9 +112,7 @@ function beforeEachIastTest (iastConfig) {
   beforeEach(() => {
     vulnerabilityReporter.clearCache()
     iast.enable(new Config({
-      experimental: {
-        iast: iastConfig
-      }
+      iast: iastConfig
     }))
   })
 }
@@ -249,8 +247,8 @@ function prepareTestServerForIast (description, tests, iastConfig) {
       return agent.close({ ritmReset: false })
     })
 
-    function testThatRequestHasVulnerability (fn, vulnerability, occurrences, cb, makeRequest) {
-      it(`should have ${vulnerability} vulnerability`, function (done) {
+    function testThatRequestHasVulnerability (fn, vulnerability, occurrences, cb, makeRequest, description) {
+      it(description || `should have ${vulnerability} vulnerability`, function (done) {
         this.timeout(5000)
         app = fn
         checkVulnerabilityInRequest(vulnerability, occurrences, cb, makeRequest, config, done)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -305,6 +305,7 @@ describe('Config', () => {
       { name: 'gitMetadataEnabled', value: true, origin: 'default' },
       { name: 'headerTags', value: [], origin: 'default' },
       { name: 'hostname', value: '127.0.0.1', origin: 'default' },
+      { name: 'iast.cookieFilterPattern', value: '.{32,}', origin: 'default' },
       { name: 'iast.deduplicationEnabled', value: true, origin: 'default' },
       { name: 'iast.enabled', value: false, origin: 'default' },
       { name: 'iast.maxConcurrentRequests', value: 2, origin: 'default' },
@@ -475,6 +476,7 @@ describe('Config', () => {
     process.env.DD_IAST_REQUEST_SAMPLING = '40'
     process.env.DD_IAST_MAX_CONCURRENT_REQUESTS = '3'
     process.env.DD_IAST_MAX_CONTEXT_OPERATIONS = '4'
+    process.env.DD_IAST_COOKIE_FILTER_PATTERN = '.*'
     process.env.DD_IAST_DEDUPLICATION_ENABLED = false
     process.env.DD_IAST_REDACTION_ENABLED = false
     process.env.DD_IAST_REDACTION_NAME_PATTERN = 'REDACTION_NAME_PATTERN'
@@ -574,6 +576,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.requestSampling', 40)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 3)
     expect(config).to.have.nested.property('iast.maxContextOperations', 4)
+    expect(config).to.have.nested.property('iast.cookieFilterPattern', '.*')
     expect(config).to.have.nested.property('iast.deduplicationEnabled', false)
     expect(config).to.have.nested.property('iast.redactionEnabled', false)
     expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
@@ -612,6 +615,7 @@ describe('Config', () => {
       { name: 'experimental.exporter', value: 'log', origin: 'env_var' },
       { name: 'experimental.runtimeId', value: true, origin: 'env_var' },
       { name: 'hostname', value: 'agent', origin: 'env_var' },
+      { name: 'iast.cookieFilterPattern', value: '.*', origin: 'env_var' },
       { name: 'iast.deduplicationEnabled', value: false, origin: 'env_var' },
       { name: 'iast.enabled', value: true, origin: 'env_var' },
       { name: 'iast.maxConcurrentRequests', value: '3', origin: 'env_var' },
@@ -776,6 +780,7 @@ describe('Config', () => {
           requestSampling: 50,
           maxConcurrentRequests: 4,
           maxContextOperations: 5,
+          cookieFilterPattern: '.*',
           deduplicationEnabled: false,
           redactionEnabled: false,
           redactionNamePattern: 'REDACTION_NAME_PATTERN',
@@ -841,6 +846,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.requestSampling', 50)
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 4)
     expect(config).to.have.nested.property('iast.maxContextOperations', 5)
+    expect(config).to.have.nested.property('iast.cookieFilterPattern', '.*')
     expect(config).to.have.nested.property('iast.deduplicationEnabled', false)
     expect(config).to.have.nested.property('iast.redactionEnabled', false)
     expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
@@ -884,6 +890,7 @@ describe('Config', () => {
       { name: 'flushInterval', value: 5000, origin: 'code' },
       { name: 'flushMinSpans', value: 500, origin: 'code' },
       { name: 'hostname', value: 'agent', origin: 'code' },
+      { name: 'iast.cookieFilterPattern', value: '.*', origin: 'code' },
       { name: 'iast.deduplicationEnabled', value: false, origin: 'code' },
       { name: 'iast.enabled', value: true, origin: 'code' },
       { name: 'iast.maxConcurrentRequests', value: 4, origin: 'code' },
@@ -1081,6 +1088,7 @@ describe('Config', () => {
     process.env.DD_API_SECURITY_REQUEST_SAMPLE_RATE = 0.5
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
+    process.env.DD_IAST_COOKIE_FILTER_PATTERN = '.*'
     process.env.DD_IAST_REDACTION_NAME_PATTERN = 'name_pattern_to_be_overriden_by_options'
     process.env.DD_IAST_REDACTION_VALUE_PATTERN = 'value_pattern_to_be_overriden_by_options'
     process.env.DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = 'true'
@@ -1155,6 +1163,7 @@ describe('Config', () => {
       },
       iast: {
         enabled: true,
+        cookieFilterPattern: '.{10,}',
         redactionNamePattern: 'REDACTION_NAME_PATTERN',
         redactionValuePattern: 'REDACTION_VALUE_PATTERN'
       },
@@ -1218,6 +1227,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('iast.maxConcurrentRequests', 2)
     expect(config).to.have.nested.property('iast.maxContextOperations', 2)
     expect(config).to.have.nested.property('iast.deduplicationEnabled', true)
+    expect(config).to.have.nested.property('iast.cookieFilterPattern', '.{10,}')
     expect(config).to.have.nested.property('iast.redactionEnabled', true)
     expect(config).to.have.nested.property('iast.redactionNamePattern', 'REDACTION_NAME_PATTERN')
     expect(config).to.have.nested.property('iast.redactionValuePattern', 'REDACTION_VALUE_PATTERN')
@@ -1251,6 +1261,7 @@ describe('Config', () => {
         requestSampling: 15,
         maxConcurrentRequests: 3,
         maxContextOperations: 4,
+        cookieFilterPattern: '.*',
         deduplicationEnabled: false,
         redactionEnabled: false,
         redactionNamePattern: 'REDACTION_NAME_PATTERN',
@@ -1284,6 +1295,7 @@ describe('Config', () => {
           requestSampling: 25,
           maxConcurrentRequests: 6,
           maxContextOperations: 7,
+          cookieFilterPattern: '.{10,}',
           deduplicationEnabled: true,
           redactionEnabled: true,
           redactionNamePattern: 'IGNORED_REDACTION_NAME_PATTERN',
@@ -1332,6 +1344,7 @@ describe('Config', () => {
       requestSampling: 15,
       maxConcurrentRequests: 3,
       maxContextOperations: 4,
+      cookieFilterPattern: '.*',
       deduplicationEnabled: false,
       redactionEnabled: false,
       redactionNamePattern: 'REDACTION_NAME_PATTERN',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use static vulnerability hash source when the cookie name is too long.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prevent identifying multiple vulnerabilities when there is only one. For example, when the cookie name contains a hash or timestamp.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

System tests PR: https://github.com/DataDog/system-tests/pull/3181


