### PR TITLE
Add parallelism information to profiles

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/event_serializer.js
+++ b/packages/dd-trace/src/profiling/exporters/event_serializer.js
@@ -56,11 +56,17 @@ class EventSerializer {
           version
         },
         runtime: {
+          // os.availableParallelism only available in node 18.14.0/19.4.0 and above
+          available_processors: typeof os.availableParallelism === 'function'
+            ? os.availableParallelism()
+            : os.cpus().length,
           // Using `nodejs` for consistency with the existing `runtime` tag.
           // Note that the event `family` property uses `node`, as that's what's
           // proscribed by the Intake API, but that's an internal enum and is
           // not customer visible.
           engine: 'nodejs',
+          // Sent as a string, we'll let the backend figure out the effective numeric value.
+          libuv_threadpool_size: process.env.UV_THREADPOOL_SIZE,
           // strip off leading 'v'. This makes the format consistent with other
           // runtimes (e.g. Ruby) but not with the existing `runtime_version` tag.
           // We'll keep it like this as we want cross-engine consistency. We

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -115,7 +115,8 @@ describe('exporters/agent', function () {
     expect(event.info.profiler.ssi).to.have.property('mechanism', 'none')
     expect(event.info.profiler).to.have.property('version', version)
     expect(event.info).to.have.property('runtime')
-    expect(Object.keys(event.info.runtime)).to.have.length(2)
+    expect(Object.keys(event.info.runtime)).to.have.length(3)
+    expect(event.info.runtime).to.have.property('available_processors')
     expect(event.info.runtime).to.have.property('engine', 'nodejs')
     expect(event.info.runtime).to.have.property('version', process.version.substring(1))
 


### PR DESCRIPTION
### What does this PR do?
Adds information about available parallelism and size of libuv thread pool to profiles.

### Motivation
Combined with timeline events activity, this can allow us to determine in the backend if the libuv thread pool is undersized and offer an analysis/insight for it.

### Additional Notes
Jira link: [PROF-10686]




[PROF-10686]: https://datadoghq.atlassian.net/browse/PROF-10686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ