### PR TITLE
Fix: esbuild plugin when requiring esm files

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -29,6 +29,7 @@ require,retry,MIT,Copyright 2011 Tim Koschützki Felix Geisendörfer
 require,rfdc,MIT,Copyright 2019 David Mark Clements
 require,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 require,shell-quote,mit,Copyright (c) 2013 James Halliday
+dev,@apollo/server,MIT,Copyright (c) 2016-2020 Apollo Graph, Inc. (Formerly Meteor Development Group, Inc.)
 dev,@types/node,MIT,Copyright Authors
 dev,autocannon,MIT,Copyright 2016 Matteo Collina
 dev,aws-sdk,Apache 2.0,Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/integration-tests/esbuild/basic-test.js
+++ b/integration-tests/esbuild/basic-test.js
@@ -6,6 +6,7 @@ const assert = require('assert')
 const express = require('express')
 const http = require('http')
 require('knex') // has dead code paths for multiple instrumented packages
+require('@apollo/server')
 
 const app = express()
 const PORT = 31415

--- a/integration-tests/esbuild/package.json
+++ b/integration-tests/esbuild/package.json
@@ -18,6 +18,7 @@
   "author": "Thomas Hunter II <tlhunter@datadog.com>",
   "license": "ISC",
   "dependencies": {
+    "@apollo/server": "^4.11.0",
     "aws-sdk": "^2.1446.0",
     "axios": "^1.6.7",
     "esbuild": "0.16.12",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "tlhunter-sorted-set": "^0.1.0"
   },
   "devDependencies": {
+    "@apollo/server": "^4.11.0",
     "@types/node": "^16.18.103",
     "autocannon": "^4.5.2",
     "aws-sdk": "^2.1446.0",

--- a/package.json
+++ b/package.json
@@ -143,5 +143,6 @@
     "sinon-chai": "^3.7.0",
     "tap": "^16.3.7",
     "tiktoken": "^1.0.15"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -143,6 +143,5 @@
     "sinon-chai": "^3.7.0",
     "tap": "^16.3.7",
     "tiktoken": "^1.0.15"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -96,7 +96,7 @@ module.exports.setup = function (build) {
 
       let pathToPackageJson
       try {
-        pathToPackageJson = require.resolve(extracted.pkg, { paths: [args.resolveDir] })
+        pathToPackageJson = require.resolve(`${extracted.pkg}`, { paths: [args.resolveDir] })
         pathToPackageJson = extractPackageAndModulePath(pathToPackageJson).pkgJson
       } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -96,7 +96,8 @@ module.exports.setup = function (build) {
 
       let pathToPackageJson
       try {
-        pathToPackageJson = require.resolve(`${extracted.pkg}/package.json`, { paths: [args.resolveDir] })
+        pathToPackageJson = require.resolve(extracted.pkg, { paths: [args.resolveDir] })
+        pathToPackageJson = extractPackageAndModulePath(pathToPackageJson).pkgJson
       } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {
           if (!internal) {
@@ -111,7 +112,7 @@ module.exports.setup = function (build) {
         }
       }
 
-      const packageJson = require(pathToPackageJson)
+      const packageJson = JSON.parse(fs.readFileSync(pathToPackageJson).toString())
 
       if (DEBUG) console.log(`RESOLVE: ${args.path}@${packageJson.version}`)
 

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -96,6 +96,7 @@ module.exports.setup = function (build) {
 
       let pathToPackageJson
       try {
+        // we can't use require.resolve('pkg/package.json') as ESM modules don't make the file available
         pathToPackageJson = require.resolve(`${extracted.pkg}`, { paths: [args.resolveDir] })
         pathToPackageJson = extractPackageAndModulePath(pathToPackageJson).pkgJson
       } catch (err) {

--- a/packages/datadog-instrumentations/src/utils/src/extract-package-and-module-path.js
+++ b/packages/datadog-instrumentations/src/utils/src/extract-package-and-module-path.js
@@ -6,7 +6,7 @@ const NM = 'node_modules/'
  * For a given full path to a module,
  *   return the package name it belongs to and the local path to the module
  *   input: '/foo/node_modules/@co/stuff/foo/bar/baz.js'
- *   output: { pkg: '@co/stuff', path: 'foo/bar/baz.js' }
+ *   output: { pkg: '@co/stuff', path: 'foo/bar/baz.js',  pkgJson: '/foo/node_modules/@co/stuff/package.json' }
  */
 module.exports = function extractPackageAndModulePath (fullPath) {
   const nm = fullPath.lastIndexOf(NM)
@@ -17,17 +17,20 @@ module.exports = function extractPackageAndModulePath (fullPath) {
   const subPath = fullPath.substring(nm + NM.length)
   const firstSlash = subPath.indexOf('/')
 
+  const firstPath = fullPath.substring(fullPath[0], nm + NM.length)
+
   if (subPath[0] === '@') {
     const secondSlash = subPath.substring(firstSlash + 1).indexOf('/')
-
     return {
       pkg: subPath.substring(0, firstSlash + 1 + secondSlash),
-      path: subPath.substring(firstSlash + 1 + secondSlash + 1)
+      path: subPath.substring(firstSlash + 1 + secondSlash + 1),
+      pkgJson: firstPath + subPath.substring(0, firstSlash + 1 + secondSlash) + '/package.json'
     }
   }
 
   return {
     pkg: subPath.substring(0, firstSlash),
-    path: subPath.substring(firstSlash + 1)
+    path: subPath.substring(firstSlash + 1),
+    pkgJson: firstPath + subPath.substring(0, firstSlash) + '/package.json'
   }
 }


### PR DESCRIPTION
### What does this PR do?
This is a fix related to a Jira issue: https://datadoghq.atlassian.net/browse/APMS-13434 where the customer was receiving an error when building using the esbuild plugin with esm modules.

```
Error: Build failed with 1 error:
node_modules ERROR: [plugin: datadog-esbuild] Package subpath './package.json' is not defined by "exports" in /Users/*/ddtrace-esbuild-repro/node_modules/@apollo/server/package.json
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


