### PR TITLE
add namespace support for async storage

### DIFF
--- a/packages/datadog-core/index.js
+++ b/packages/datadog-core/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { AsyncLocalStorage } = require('async_hooks')
-
-const storage = new AsyncLocalStorage()
+const storage = require('./src/storage')
 
 module.exports = { storage }

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { AsyncLocalStorage } = require('async_hooks')
+
+const storages = Object.create(null)
+const legacyStorage = new AsyncLocalStorage()
+
+const storage = function (namespace) {
+  if (!storages[namespace]) {
+    storages[namespace] = new AsyncLocalStorage()
+  }
+  return storages[namespace]
+}
+
+storage.enterWith = legacyStorage.enterWith.bind(legacyStorage)
+storage.exit = legacyStorage.exit.bind(legacyStorage)
+storage.getStore = legacyStorage.getStore.bind(legacyStorage)
+storage.run = legacyStorage.run.bind(legacyStorage)
+
+module.exports = storage

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -12,6 +12,7 @@ const storage = function (namespace) {
   return storages[namespace]
 }
 
+storage.disable = legacyStorage.disable.bind(legacyStorage)
 storage.enterWith = legacyStorage.enterWith.bind(legacyStorage)
 storage.exit = legacyStorage.exit.bind(legacyStorage)
 storage.getStore = legacyStorage.getStore.bind(legacyStorage)

--- a/packages/datadog-core/test/storage.spec.js
+++ b/packages/datadog-core/test/storage.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+
+require('../../dd-trace/test/setup/tap')
+
+const { expect } = require('chai')
+const storage = require('../src/storage')
+
+describe('storage', () => {
+  let testStorage
+  let testStorage2
+
+  beforeEach(() => {
+    testStorage = storage('test')
+    testStorage2 = storage('test2')
+  })
+
+  afterEach(() => {
+    testStorage.enterWith(undefined)
+    testStorage2.enterWith(undefined)
+  })
+
+  it('should enter a store', done => {
+    const store = 'foo'
+
+    testStorage.enterWith(store)
+
+    setImmediate(() => {
+      expect(testStorage.getStore()).to.equal(store)
+      done()
+    })
+  })
+
+  it('should enter stores by namespace', done => {
+    const store = 'foo'
+    const store2 = 'bar'
+
+    testStorage.enterWith(store)
+    testStorage2.enterWith(store2)
+
+    setImmediate(() => {
+      expect(testStorage.getStore()).to.equal(store)
+      expect(testStorage2.getStore()).to.equal(store2)
+      done()
+    })
+  })
+
+  it('should return the same storage for a namespace', () => {
+    expect(storage('test')).to.equal(testStorage)
+  })
+})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds centralized named storages similar to channels.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now we are mainly relying on a single global storage with products reading or writing data to it according to their needs. This has a few downsides. First, it means that holding onto one piece of data ends up holding on everything else on that store. Second, there is no control over the scope of the individual properties of the store, as everything just ends up in whatever scope the main store is.

The goal of this PR is similar to why there is a `channel(name)` helper for diagnostics channel, to provide a central registry where it doesn't matter who initializes the storage or even if it was initialized at all, and to properly isolate the scope of each individual store.