### PR TITLE
Don't stop the profiler if encoding a profile fails

### DIFF
--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -156,6 +156,10 @@ class Profiler extends EventEmitter {
         profiles.push({ profiler, profile })
       }
 
+      if (restart) {
+        this._capture(this._timeoutInterval, endDate)
+      }
+
       // encode and export asynchronously
       for (const { profiler, profile } of profiles) {
         try {
@@ -171,10 +175,6 @@ class Profiler extends EventEmitter {
           // encode and submit the other profile types.
           this._logError(err)
         }
-      }
-
-      if (restart) {
-        this._capture(this._timeoutInterval, endDate)
       }
 
       if (Object.keys(encodedProfiles).length > 0) {

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -146,6 +146,10 @@ class Profiler extends EventEmitter {
     const encodedProfiles = {}
 
     try {
+      if (Object.keys(this._config.profilers).length === 0) {
+        throw new Error('No profile types configured.')
+      }
+
       // collect profiles synchronously so that profilers can be safely stopped asynchronously
       for (const profiler of this._config.profilers) {
         const profile = profiler.profile(restart, startDate, endDate)

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -330,13 +330,13 @@ class EventsProfiler {
     if (!restart) {
       this.stop()
     }
-    const profile = this.eventSerializer.createProfile(startDate, endDate)
+    const thatEventSerializer = this.eventSerializer
     this.eventSerializer = new EventSerializer()
-    return profile
+    return () => thatEventSerializer.createProfile(startDate, endDate)
   }
 
   encode (profile) {
-    return pprof.encode(profile)
+    return pprof.encode(profile())
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
* Profiler no longer treats errors during profile encoding to be fatal and no longer stops profiling if they occur. It will submit all the profiles that were successfully encoded.
* As a minor improvement, profiler cycle restart is moved to an earlier stage in the gather-encode-send cycle (between gather and encode, it used to be between encode and submit), reducing the cadence drift. (Not that it's a big problem.)
* As another minor improvement, timeline events profiler defers creation of the Profile object until encoding, as it's a stateless operation that doesn't affect the next cycle of the profiler and can thus be in the now no longer fatal encoding path.
* Adds a test confirming encoding errors no longer stop profiling.
* Adds a test confirming sending errors do not stop profiling.
* Removes a check of an always-holding invariant from internal private `_submit` method, as well as a needless test for it.

### Motivation
Originally I was investigating a customer support case of profiles not being submitted. I revisited various code paths that could result in the profiler being stopped. At first I suspected we have a bug that would cause the profiler to stop if it encountered an error sending the HTTP request. This turned out not to be the case, fortunately, and I added a unit test to confirm it.

At the same time, I realized that profile encoding errors on the other hand _are_ treated as fatal and they shouldn't be.

To understand this, it's useful to know that the profiler has three distinct operations when its async operation fires every minute: Profiles are first **gathered** (in some internal data structure specific to profile type), then they are **encoded** (internal data structures serialized to gzipped pprof binary data), finally they are **sent** to the agent over HTTP. Of these operations, errors during gathering and encoding phases would case the profiler to stop entirely. (Even if only gathering of one type of profiles, e.g. CPU errored out, other sub-profiles, e.g. heap and event would be stopped too.)

It makes sense to stop profiling if gathering operation errors out – it is possible that something stateful in the sub-profilers can't recover from those. It also makes sense to not stop profiling when there's an error during send: these are in vast majority HTTP 502 and 503 errors, both transient. 

Stopping profilers on encoding errors is too harsh, though. Encoding is a stateless operation that transforms immutable profiling data from some internal representation to gzipped pprof file. If one of those errors out (we don't currently have evidence of such errors), we should still try to submit other profile types (e.g. if events profile encoding fails, but CPU and heap profiles succeeded, we should still send them.) This is the main aspect of this change.

### Additional Notes
JIRA ticket: [PROF-10717]




[PROF-10717]: https://datadoghq.atlassian.net/browse/PROF-10717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ