### PR TITLE
[DI] Adhere to maxCollectionSize limit in snapshots

### DIFF
--- a/integration-tests/debugger/target-app/index.js
+++ b/integration-tests/debugger/target-app/index.js
@@ -36,7 +36,7 @@ function getSomeData () {
     lstr: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     sym: Symbol('foo'),
     regex: /bar/i,
-    arr: [1, 2, 3],
+    arr: [1, 2, 3, 4, 5],
     obj: {
       foo: {
         baz: 42,

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { collectionSizeSym } = require('./symbols')
 const session = require('../session')
 
 const LEAF_SUBTYPES = new Set(['date', 'regexp'])
@@ -14,22 +15,33 @@ module.exports = {
 // each lookup will just finish in its own time and traverse the child nodes when the event loop allows it.
 // Alternatively, use `Promise.all` or something like that, but the code would probably be more complex.
 
-async function getObject (objectId, maxDepth, depth = 0) {
+async function getObject (objectId, opts, depth = 0, collection = false) {
   const { result, privateProperties } = await session.post('Runtime.getProperties', {
     objectId,
     ownProperties: true // exclude inherited properties
   })
 
-  if (privateProperties) result.push(...privateProperties)
+  if (collection) {
+    // Trim the collection if it's too large.
+    // Collections doesn't contain private properties, so the code in this block doesn't have to deal with it.
+    removeNonEnumerableProperties(result) // remove the `length` property
+    const size = result.length
+    if (size > opts.maxCollectionSize) {
+      result.splice(opts.maxCollectionSize)
+      result[collectionSizeSym] = size
+    }
+  } else if (privateProperties) {
+    result.push(...privateProperties)
+  }
 
-  return traverseGetPropertiesResult(result, maxDepth, depth)
+  return traverseGetPropertiesResult(result, opts, depth)
 }
 
-async function traverseGetPropertiesResult (props, maxDepth, depth) {
+async function traverseGetPropertiesResult (props, opts, depth) {
   // TODO: Decide if we should filter out non-enumerable properties or not:
   // props = props.filter((e) => e.enumerable)
 
-  if (depth >= maxDepth) return props
+  if (depth >= opts.maxReferenceDepth) return props
 
   for (const prop of props) {
     if (prop.value === undefined) continue
@@ -37,33 +49,33 @@ async function traverseGetPropertiesResult (props, maxDepth, depth) {
     if (type === 'object') {
       if (objectId === undefined) continue // if `subtype` is "null"
       if (LEAF_SUBTYPES.has(subtype)) continue // don't waste time with these subtypes
-      prop.value.properties = await getObjectProperties(subtype, objectId, maxDepth, depth)
+      prop.value.properties = await getObjectProperties(subtype, objectId, opts, depth)
     } else if (type === 'function') {
-      prop.value.properties = await getFunctionProperties(objectId, maxDepth, depth + 1)
+      prop.value.properties = await getFunctionProperties(objectId, opts, depth + 1)
     }
   }
 
   return props
 }
 
-async function getObjectProperties (subtype, objectId, maxDepth, depth) {
+async function getObjectProperties (subtype, objectId, opts, depth) {
   if (ITERABLE_SUBTYPES.has(subtype)) {
-    return getIterable(objectId, maxDepth, depth)
+    return getIterable(objectId, opts, depth)
   } else if (subtype === 'promise') {
-    return getInternalProperties(objectId, maxDepth, depth)
+    return getInternalProperties(objectId, opts, depth)
   } else if (subtype === 'proxy') {
-    return getProxy(objectId, maxDepth, depth)
+    return getProxy(objectId, opts, depth)
   } else if (subtype === 'arraybuffer') {
-    return getArrayBuffer(objectId, maxDepth, depth)
+    return getArrayBuffer(objectId, opts, depth)
   } else {
-    return getObject(objectId, maxDepth, depth + 1)
+    return getObject(objectId, opts, depth + 1, subtype === 'array' || subtype === 'typedarray')
   }
 }
 
 // TODO: The following extra information from `internalProperties` might be relevant to include for functions:
 // - Bound function: `[[TargetFunction]]`, `[[BoundThis]]` and `[[BoundArgs]]`
 // - Non-bound function: `[[FunctionLocation]]`, and `[[Scopes]]`
-async function getFunctionProperties (objectId, maxDepth, depth) {
+async function getFunctionProperties (objectId, opts, depth) {
   let { result } = await session.post('Runtime.getProperties', {
     objectId,
     ownProperties: true // exclude inherited properties
@@ -72,10 +84,12 @@ async function getFunctionProperties (objectId, maxDepth, depth) {
   // For legacy reasons (I assume) functions has a `prototype` property besides the internal `[[Prototype]]`
   result = result.filter(({ name }) => name !== 'prototype')
 
-  return traverseGetPropertiesResult(result, maxDepth, depth)
+  return traverseGetPropertiesResult(result, opts, depth)
 }
 
-async function getIterable (objectId, maxDepth, depth) {
+async function getIterable (objectId, opts, depth) {
+  // TODO: If the iterable has any properties defined on the object directly, instead of in its collection, they will
+  // exist in the return value below in the `result` property. We currently do not collect these.
   const { internalProperties } = await session.post('Runtime.getProperties', {
     objectId,
     ownProperties: true // exclude inherited properties
@@ -93,10 +107,17 @@ async function getIterable (objectId, maxDepth, depth) {
     ownProperties: true // exclude inherited properties
   })
 
-  return traverseGetPropertiesResult(result, maxDepth, depth)
+  removeNonEnumerableProperties(result) // remove the `length` property
+  const size = result.length
+  if (size > opts.maxCollectionSize) {
+    result.splice(opts.maxCollectionSize)
+    result[collectionSizeSym] = size
+  }
+
+  return traverseGetPropertiesResult(result, opts, depth)
 }
 
-async function getInternalProperties (objectId, maxDepth, depth) {
+async function getInternalProperties (objectId, opts, depth) {
   const { internalProperties } = await session.post('Runtime.getProperties', {
     objectId,
     ownProperties: true // exclude inherited properties
@@ -105,10 +126,10 @@ async function getInternalProperties (objectId, maxDepth, depth) {
   // We want all internal properties except the prototype
   const props = internalProperties.filter(({ name }) => name !== '[[Prototype]]')
 
-  return traverseGetPropertiesResult(props, maxDepth, depth)
+  return traverseGetPropertiesResult(props, opts, depth)
 }
 
-async function getProxy (objectId, maxDepth, depth) {
+async function getProxy (objectId, opts, depth) {
   const { internalProperties } = await session.post('Runtime.getProperties', {
     objectId,
     ownProperties: true // exclude inherited properties
@@ -127,14 +148,14 @@ async function getProxy (objectId, maxDepth, depth) {
     ownProperties: true // exclude inherited properties
   })
 
-  return traverseGetPropertiesResult(result, maxDepth, depth)
+  return traverseGetPropertiesResult(result, opts, depth)
 }
 
 // Support for ArrayBuffer is a bit trickly because the internal structure stored in `internalProperties` is not
 // documented and is not straight forward. E.g. ArrayBuffer(3) will internally contain both Int8Array(3) and
 // UInt8Array(3), whereas ArrayBuffer(8) internally contains both Int8Array(8), Uint8Array(8), Int16Array(4), and
 // Int32Array(2) - all representing the same data in different ways.
-async function getArrayBuffer (objectId, maxDepth, depth) {
+async function getArrayBuffer (objectId, opts, depth) {
   const { internalProperties } = await session.post('Runtime.getProperties', {
     objectId,
     ownProperties: true // exclude inherited properties
@@ -149,5 +170,13 @@ async function getArrayBuffer (objectId, maxDepth, depth) {
     ownProperties: true // exclude inherited properties
   })
 
-  return traverseGetPropertiesResult(result, maxDepth, depth)
+  return traverseGetPropertiesResult(result, opts, depth)
+}
+
+function removeNonEnumerableProperties (props) {
+  for (let i = 0; i < props.length; i++) {
+    if (props[i].enumerable === false) {
+      props.splice(i--, 1)
+    }
+  }
 }

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/index.js
@@ -4,6 +4,7 @@ const { getRuntimeObject } = require('./collector')
 const { processRawState } = require('./processor')
 
 const DEFAULT_MAX_REFERENCE_DEPTH = 3
+const DEFAULT_MAX_COLLECTION_SIZE = 100
 const DEFAULT_MAX_LENGTH = 255
 
 module.exports = {
@@ -12,14 +13,18 @@ module.exports = {
 
 async function getLocalStateForCallFrame (
   callFrame,
-  { maxReferenceDepth = DEFAULT_MAX_REFERENCE_DEPTH, maxLength = DEFAULT_MAX_LENGTH } = {}
+  {
+    maxReferenceDepth = DEFAULT_MAX_REFERENCE_DEPTH,
+    maxCollectionSize = DEFAULT_MAX_COLLECTION_SIZE,
+    maxLength = DEFAULT_MAX_LENGTH
+  } = {}
 ) {
   const rawState = []
   let processedState = null
 
   for (const scope of callFrame.scopeChain) {
     if (scope.type === 'global') continue // The global scope is too noisy
-    rawState.push(...await getRuntimeObject(scope.object.objectId, maxReferenceDepth))
+    rawState.push(...await getRuntimeObject(scope.object.objectId, { maxReferenceDepth, maxCollectionSize }))
   }
 
   // Deplay calling `processRawState` so the caller gets a chance to resume the main thread before processing `rawState`

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/symbols.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/symbols.js
@@ -1,0 +1,5 @@
+'use stict'
+
+module.exports = {
+  collectionSizeSym: Symbol('datadog.collectionSize')
+}

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/max-collection-size.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/max-collection-size.spec.js
@@ -1,0 +1,129 @@
+'use strict'
+
+require('../../../setup/mocha')
+
+const { getTargetCodePath, enable, teardown, assertOnBreakpoint, setAndTriggerBreakpoint } = require('./utils')
+
+const DEFAULT_MAX_COLLECTION_SIZE = 100
+const target = getTargetCodePath(__filename)
+
+describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', function () {
+  describe('maxCollectionSize', function () {
+    const configs = [
+      undefined,
+      { maxCollectionSize: 3 }
+    ]
+
+    beforeEach(enable(__filename))
+
+    afterEach(teardown)
+
+    for (const config of configs) {
+      const maxCollectionSize = config?.maxCollectionSize ?? DEFAULT_MAX_COLLECTION_SIZE
+      const postfix = config === undefined ? 'not set' : `set to ${config.maxCollectionSize}`
+
+      describe(`shold respect the default maxCollectionSize if ${postfix}`, function () {
+        let state
+
+        const expectedElements = []
+        const expectedEntries = []
+        for (let i = 1; i <= maxCollectionSize; i++) {
+          expectedElements.push({ type: 'number', value: i.toString() })
+          expectedEntries.push([
+            { type: 'number', value: i.toString() },
+            {
+              type: 'Object',
+              fields: { i: { type: 'number', value: i.toString() } }
+            }
+          ])
+        }
+
+        beforeEach(function (done) {
+          assertOnBreakpoint(done, config, (_state) => {
+            state = _state
+          })
+          setAndTriggerBreakpoint(target, 24)
+        })
+
+        it('should have expected number of elements in state', function () {
+          expect(state).to.have.keys(['arr', 'map', 'set', 'wmap', 'wset', 'typedArray'])
+        })
+
+        it('Array', function () {
+          expect(state).to.have.deep.property('arr', {
+            type: 'Array',
+            elements: expectedElements,
+            notCapturedReason: 'collectionSize',
+            size: 1000
+          })
+        })
+
+        it('Map', function () {
+          expect(state).to.have.deep.property('map', {
+            type: 'Map',
+            entries: expectedEntries,
+            notCapturedReason: 'collectionSize',
+            size: 1000
+          })
+        })
+
+        it('Set', function () {
+          expect(state).to.have.deep.property('set', {
+            type: 'Set',
+            elements: expectedElements,
+            notCapturedReason: 'collectionSize',
+            size: 1000
+          })
+        })
+
+        it('WeakMap', function () {
+          expect(state.wmap).to.include({
+            type: 'WeakMap',
+            notCapturedReason: 'collectionSize',
+            size: 1000
+          })
+
+          expect(state.wmap.entries).to.have.lengthOf(maxCollectionSize)
+
+          // The order of the entries is not guaranteed, so we don't know which were removed
+          for (const entry of state.wmap.entries) {
+            expect(entry).to.have.lengthOf(2)
+            expect(entry[0]).to.have.property('type', 'Object')
+            expect(entry[0].fields).to.have.property('i')
+            expect(entry[0].fields.i).to.have.property('type', 'number')
+            expect(entry[0].fields.i).to.have.property('value').to.match(/^\d+$/)
+            expect(entry[1]).to.have.property('type', 'number')
+            expect(entry[1]).to.have.property('value', entry[0].fields.i.value)
+          }
+        })
+
+        it('WeakSet', function () {
+          expect(state.wset).to.include({
+            type: 'WeakSet',
+            notCapturedReason: 'collectionSize',
+            size: 1000
+          })
+
+          expect(state.wset.elements).to.have.lengthOf(maxCollectionSize)
+
+          // The order of the elements is not guaranteed, so we don't know which were removed
+          for (const element of state.wset.elements) {
+            expect(element).to.have.property('type', 'Object')
+            expect(element.fields).to.have.property('i')
+            expect(element.fields.i).to.have.property('type', 'number')
+            expect(element.fields.i).to.have.property('value').to.match(/^\d+$/)
+          }
+        })
+
+        it('TypedArray', function () {
+          expect(state).to.have.deep.property('typedArray', {
+            type: 'Uint16Array',
+            elements: expectedElements,
+            notCapturedReason: 'collectionSize',
+            size: 1000
+          })
+        })
+      })
+    }
+  })
+})

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/max-collection-size.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/max-collection-size.js
@@ -1,0 +1,27 @@
+'use stict'
+
+function run () {
+  const arr = []
+  const map = new Map()
+  const set = new Set()
+  const wmap = new WeakMap()
+  const wset = new WeakSet()
+  const typedArray = new Uint16Array(new ArrayBuffer(2000))
+
+  // 1000 is larger the default maxCollectionSize of 100
+  for (let i = 1; i <= 1000; i++) {
+    // A reference that can be used in WeakMap/WeakSet to avoid GC
+    const obj = { i }
+
+    arr.push(i)
+    map.set(i, obj)
+    set.add(i)
+    wmap.set(obj, i)
+    wset.add(obj)
+    typedArray[i - 1] = i
+  }
+
+  return 'my return value' // breakpoint at this line
+}
+
+module.exports = { run }


### PR DESCRIPTION
The `maxCollectionSize` limit affects the following types:
- `Array`
- `Map` / `WeakMap`
- `Set` / `WeakSet`
- All `TypedArray` types (`UInt8Array` etc)

This limit contols the maximum about of elements collected for those types. The default is 100.

If, for example, an array contains more than the allowed amount of elements, a `notCapturedReason` of `collectionSize` is added to the collected array and the original size of the array is also captured.
