### PR TITLE
[DI] Fix issue with RC message being acknowleged more than once

### DIFF
--- a/packages/dd-trace/src/debugger/index.js
+++ b/packages/dd-trace/src/debugger/index.js
@@ -30,7 +30,14 @@ function start (config, rc) {
   })
 
   rcChannel.port2.on('message', ({ ackId, error }) => {
-    rcAckCallbacks.get(ackId)(error)
+    const ack = rcAckCallbacks.get(ackId)
+    if (ack) {
+      ack(error)
+    } else {
+      // TODO: In what scenario would this happen? Should we handle this differently?
+      log.error(`Product handler already acknowleged for LIVE_DEBUGGING-${ackId}`)
+      log.error(error)
+    }
     rcAckCallbacks.delete(ackId)
   })
   rcChannel.port2.on('messageerror', (err) => log.error(err))


### PR DESCRIPTION
### What does this PR do?

This fixes a bug where if a Remote Config message was acknowleged more
than once, an error would be thrown, because the `rcAckCallback` was
deleted after the first acknowlegement.

### Motivation

The system tests were failing because of this issue:

https://github.com/DataDog/system-tests/actions/runs/11367975600/job/31622526321?pr=3250#step:58:47

