### PR TITLE
fix WAF update rules version

### DIFF
--- a/packages/dd-trace/src/appsec/waf/waf_manager.js
+++ b/packages/dd-trace/src/appsec/waf/waf_manager.js
@@ -51,6 +51,8 @@ class WAFManager {
   update (newRules) {
     this.ddwaf.update(newRules)
 
+    this.rulesVersion = this.ddwaf.diagnostics.ruleset_version
+
     Reporter.reportWafUpdate(this.ddwafVersion, this.rulesVersion)
   }
 

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -181,7 +181,9 @@ describe('WAF Manager', () => {
 
     it('should call Reporter.reportWafUpdate', () => {
       const rules = {
-        version: '4.2.0',
+        metadata: {
+          rules_version: '4.2.0'
+        },
         rules_data: [
           {
             id: 'blocked_users',

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -181,6 +181,7 @@ describe('WAF Manager', () => {
 
     it('should call Reporter.reportWafUpdate', () => {
       const rules = {
+        version: '4.2.0',
         rules_data: [
           {
             id: 'blocked_users',
@@ -197,8 +198,7 @@ describe('WAF Manager', () => {
 
       waf.update(rules)
 
-      expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion,
-        DDWAF.prototype.diagnostics.ruleset_version)
+      expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion, '4.2.0')
     })
   })
 

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -27,7 +27,11 @@ describe('WAF Manager', () => {
     DDWAF.prototype.constructor.version = sinon.stub()
     DDWAF.prototype.dispose = sinon.stub()
     DDWAF.prototype.createContext = sinon.stub()
-    DDWAF.prototype.update = sinon.stub()
+    DDWAF.prototype.update = sinon.stub().callsFake(function (newRules) {
+      if (newRules?.metadata?.rules_version) {
+        this.diagnostics.ruleset_version = newRules?.metadata?.rules_version
+      }
+    })
     DDWAF.prototype.diagnostics = {
       ruleset_version: '1.0.0',
       rules: {


### PR DESCRIPTION
### What does this PR do?
Update the internally kept value of AppSec rules when a WAF update is done. We forgot to do this when we implemented the feature.
