### PR TITLE
Don't update waf version if it doesn't exist

### DIFF
--- a/packages/dd-trace/src/appsec/waf/waf_manager.js
+++ b/packages/dd-trace/src/appsec/waf/waf_manager.js
@@ -51,7 +51,9 @@ class WAFManager {
   update (newRules) {
     this.ddwaf.update(newRules)
 
-    this.rulesVersion = this.ddwaf.diagnostics.ruleset_version
+    if (this.ddwaf.diagnostics.ruleset_version) {
+      this.rulesVersion = this.ddwaf.diagnostics.ruleset_version
+    }
 
     Reporter.reportWafUpdate(this.ddwafVersion, this.rulesVersion)
   }

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -181,6 +181,7 @@ describe('WAF Manager', () => {
       waf.update(rules)
 
       expect(DDWAF.prototype.update).to.be.calledOnceWithExactly(rules)
+      expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion, '1.0.0')
     })
 
     it('should call Reporter.reportWafUpdate', () => {


### PR DESCRIPTION
### What does this PR do?
Do not override the waf version variable if by an empty value