### PR TITLE
[test visibility] Add errors in retried tests in mocha

### DIFF
--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1875,7 +1875,7 @@ describe('mocha CommonJS', function () {
     })
   })
 
-  context('flaky test retries', () => {
+  context('auto test retries', () => {
     it('retries failed tests automatically', (done) => {
       receiver.setSettings({
         itr_enabled: false,
@@ -1910,6 +1910,10 @@ describe('mocha CommonJS', function () {
 
           const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
           assert.equal(failedAttempts.length, 2)
+
+          failedAttempts.forEach((failedTest, index) => {
+            assert.include(failedTest.meta[ERROR_MESSAGE], `expected ${index + 1} to equal 3`)
+          })
 
           // The first attempt is not marked as a retry
           const retriedFailure = failedAttempts.filter(test => test.meta[TEST_IS_RETRY] === 'true')

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -280,12 +280,12 @@ function getOnFailHandler (isMain) {
 }
 
 function getOnTestRetryHandler () {
-  return function (test) {
+  return function (test, err) {
     const asyncResource = getTestAsyncResource(test)
     if (asyncResource) {
       const isFirstAttempt = test._currentRetry === 0
       asyncResource.runInAsyncScope(() => {
-        testRetryCh.publish(isFirstAttempt)
+        testRetryCh.publish({ isFirstAttempt, err })
       })
     }
     const key = getTestToArKey(test)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -242,13 +242,16 @@ class MochaPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:mocha:test:retry', (isFirstAttempt) => {
+    this.addSub('ci:mocha:test:retry', ({ isFirstAttempt, err }) => {
       const store = storage.getStore()
       const span = store?.span
       if (span) {
         span.setTag(TEST_STATUS, 'fail')
         if (!isFirstAttempt) {
           span.setTag(TEST_IS_RETRY, 'true')
+        }
+        if (err) {
+          span.setTag('error', err)
         }
 
         const spanTags = span.context()._tags


### PR DESCRIPTION
### What does this PR do?
Add test error on retry handler in `mocha`

### Motivation
They weren't being added

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
