### PR TITLE
Support Node 23 in the profiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@datadog/native-iast-rewriter": "2.5.0",
     "@datadog/native-iast-taint-tracking": "3.1.0",
     "@datadog/native-metrics": "^2.0.0",
-    "@datadog/pprof": "5.3.0",
+    "@datadog/pprof": "5.4.1",
     "@datadog/sketches-js": "^2.1.0",
     "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/core": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,10 +431,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.3.0.tgz#c2f58d328ecced7f99887f1a559d7fe3aecb9219"
-  integrity sha512-53z2Q3K92T6Pf4vz4Ezh8kfkVEvLzbnVqacZGgcbkP//q0joFzO8q00Etw1S6NdnCX0XmX08ULaF4rUI5r14mw==
+"@datadog/pprof@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.4.1.tgz#08c9bcf5d8efb2eeafdfc9f5bb5402f79fb41266"
+  integrity sha512-IvpL96e/cuh8ugP5O8Czdup7XQOLHeIDgM5pac5W7Lc1YzGe5zTtebKFpitvb1CPw1YY+1qFx0pWGgKP2kOfHg==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
Bumps `@datadog/pprof` dependency to 5.4.1.

### Motivation
5.4.1 supports Node 23

### Additional Notes
JIRA [PROF-10740]




[PROF-10740]: https://datadoghq.atlassian.net/browse/PROF-10740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ