### PR TITLE
[DI] Drop snapshot if JSON payload is too large

### DIFF
--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const { assert } = require('chai')
-const { setup } = require('./utils')
+const { setup, getBreakpointInfo } = require('./utils')
+
+const { line } = getBreakpointInfo()
 
 describe('Dynamic Instrumentation', function () {
   const t = setup()
@@ -15,7 +17,7 @@ describe('Dynamic Instrumentation', function () {
           assert.isBelow(Buffer.byteLength(JSON.stringify(payload)), 1024 * 1024) // 1MB
           assert.deepEqual(payload['debugger.snapshot'].captures, {
             lines: {
-              17: {
+              [line]: {
                 locals: {
                   notCapturedReason: 'Snapshot was too large',
                   size: 6

--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const { assert } = require('chai')
+const { setup } = require('./utils')
+
+describe('Dynamic Instrumentation', function () {
+  const t = setup()
+
+  describe('input messages', function () {
+    describe('with snapshot', function () {
+      beforeEach(t.triggerBreakpoint)
+
+      it('should prune snapshot if payload is too large', function (done) {
+        t.agent.on('debugger-input', ({ payload }) => {
+          assert.isBelow(Buffer.byteLength(JSON.stringify(payload)), 1024 * 1024) // 1MB
+          done()
+        })
+
+        t.agent.addRemoteConfig(t.generateRemoteConfig({ captureSnapshot: true }))
+      })
+    })
+  })
+})

--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -13,10 +13,28 @@ describe('Dynamic Instrumentation', function () {
       it('should prune snapshot if payload is too large', function (done) {
         t.agent.on('debugger-input', ({ payload }) => {
           assert.isBelow(Buffer.byteLength(JSON.stringify(payload)), 1024 * 1024) // 1MB
+          assert.deepEqual(payload['debugger.snapshot'].captures, {
+            lines: {
+              17: {
+                locals: {
+                  notCapturedReason: 'Snapshot was too large',
+                  size: 6
+                }
+              }
+            }
+          })
           done()
         })
 
-        t.agent.addRemoteConfig(t.generateRemoteConfig({ captureSnapshot: true }))
+        t.agent.addRemoteConfig(t.generateRemoteConfig({
+          captureSnapshot: true,
+          capture: {
+            // ensure we get a large snapshot
+            maxCollectionSize: Number.MAX_SAFE_INTEGER,
+            maxFieldCount: Number.MAX_SAFE_INTEGER,
+            maxLength: Number.MAX_SAFE_INTEGER
+          }
+        }))
       })
     })
   })

--- a/integration-tests/debugger/target-app/snapshot-pruning.js
+++ b/integration-tests/debugger/target-app/snapshot-pruning.js
@@ -1,0 +1,41 @@
+'use strict'
+
+require('dd-trace/init')
+
+const { randomBytes } = require('crypto')
+const Fastify = require('fastify')
+
+const fastify = Fastify()
+
+const TARGET_SIZE = 1024 * 1024 // 1MB
+const LARGE_STRING = randomBytes(1024).toString('hex')
+
+fastify.get('/:name', function handler (request) {
+  // eslint-disable-next-line no-unused-vars
+  const obj = generateObjectWithJSONSizeLargerThan1MB()
+
+  return { hello: request.params.name } // BREAKPOINT
+})
+
+fastify.listen({ port: process.env.APP_PORT }, (err) => {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+  process.send({ port: process.env.APP_PORT })
+})
+
+function generateObjectWithJSONSizeLargerThan1MB () {
+  const obj = {}
+  let i = 0
+
+  while (++i) {
+    if (i % 100 === 0) {
+      const size = JSON.stringify(obj).length
+      if (size > TARGET_SIZE) break
+    }
+    obj[i] = LARGE_STRING
+  }
+
+  return obj
+}

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -43,7 +43,11 @@ function send (message, logger, snapshot, cb) {
 
   if (Buffer.byteLength(json) > MAX_PAYLOAD_SIZE) {
     // TODO: This is a very crude way to handle large payloads. Proper pruning will be implemented later (DEBUG-2624)
-    delete payload['debugger.snapshot']
+    const line = Object.values(payload['debugger.snapshot'].captures.lines)[0]
+    line.locals = {
+      notCapturedReason: 'Snapshot was too large',
+      size: Object.keys(line.locals).length
+    }
     json = JSON.stringify(payload)
   }
 

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -9,6 +9,8 @@ const { GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('../../plugins/util/tags'
 
 module.exports = send
 
+const MAX_PAYLOAD_SIZE = 1024 * 1024 // 1MB
+
 const ddsource = 'dd_debugger'
 const hostname = getHostname()
 const service = config.service
@@ -37,5 +39,13 @@ function send (message, logger, snapshot, cb) {
     'debugger.snapshot': snapshot
   }
 
-  request(JSON.stringify(payload), opts, cb)
+  let json = JSON.stringify(payload)
+
+  if (Buffer.byteLength(json) > MAX_PAYLOAD_SIZE) {
+    // TODO: This is a very crude way to handle large payloads. Proper pruning will be implemented later (DEBUG-2624)
+    delete payload['debugger.snapshot']
+    json = JSON.stringify(payload)
+  }
+
+  request(json, opts, cb)
 }

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/complex-types.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/complex-types.spec.js
@@ -23,7 +23,7 @@ describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', fu
       session.once('Debugger.paused', async ({ params }) => {
         expect(params.hitBreakpoints.length).to.eq(1)
 
-        resolve((await getLocalStateForCallFrame(params.callFrames[0], { maxFieldCount: Infinity }))())
+        resolve((await getLocalStateForCallFrame(params.callFrames[0], { maxFieldCount: Number.MAX_SAFE_INTEGER }))())
       })
 
       await setAndTriggerBreakpoint(target, 10)


### PR DESCRIPTION
The log track has a 1MB limit of the JSON payload. The client is not notified if the payload is too large, but it is simply never indexed.

This is a very crude approach. In the future a more sophsticated algorithm will be implemented that reduces the size of the snapshot instead of removing it completely.
