### PR TITLE
Protect some lines in text_map.js

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -53,6 +53,8 @@ class TextMapPropagator {
   }
 
   inject (spanContext, carrier) {
+    if (!spanContext || !carrier) return
+
     this._injectBaggageItems(spanContext, carrier)
     this._injectDatadog(spanContext, carrier)
     this._injectB3MultipleHeaders(spanContext, carrier)
@@ -383,7 +385,7 @@ class TextMapPropagator {
       return null
     }
     const matches = headerValue.trim().match(traceparentExpr)
-    if (matches.length) {
+    if (matches?.length) {
       const [version, traceId, spanId, flags, tail] = matches.slice(1)
       const traceparent = { version }
       const tracestate = TraceState.fromString(carrier.tracestate)

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -58,6 +58,16 @@ describe('TextMapPropagator', () => {
       }
     })
 
+    it('should not crash without spanContext', () => {
+      const carrier = {}
+      propagator.inject(null, carrier)
+    })
+
+    it('should not crash without carrier', () => {
+      const spanContext = createContext()
+      propagator.inject(spanContext, null)
+    })
+
     it('should inject the span context into the carrier', () => {
       const carrier = {}
       const spanContext = createContext()
@@ -490,6 +500,12 @@ describe('TextMapPropagator', () => {
 
       expect(first._traceId.toString(16)).to.equal(traceId)
       expect(first._spanId.toString(16)).to.equal(spanId)
+    })
+
+    it('should not crash with invalid traceparent', () => {
+      textMap.traceparent = 'invalid'
+
+      propagator.extract(textMap)
     })
 
     it('should always extract tracestate from tracecontext when trace IDs match', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Protect few lines in `text_map.js` files to prevent errors.

### Motivation
<!-- What inspired you to submit this pull request? -->
Detected errors in logs


