### PR TITLE
Update @datadog/native-iast-taint-tracking

### DIFF
--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -4,4 +4,4 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: '22' # Update this line to the latest Node.js version
+        node-version: 'latest'

--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -4,4 +4,4 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 'latest'
+        node-version: '22' # Update this line to the latest Node.js version

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@datadog/native-appsec": "8.2.1",
     "@datadog/native-iast-rewriter": "2.5.0",
-    "@datadog/native-iast-taint-tracking": "3.1.0",
+    "@datadog/native-iast-taint-tracking": "3.2.0",
     "@datadog/native-metrics": "^2.0.0",
     "@datadog/pprof": "5.4.1",
     "@datadog/sketches-js": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,10 +416,10 @@
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"
 
-"@datadog/native-iast-taint-tracking@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.1.0.tgz#7b2ed7f8fad212d65e5ab03bcdea8b42a3051b2e"
-  integrity sha512-rw6qSjmxmu1yFHVvZLXFt/rVq2tUZXocNogPLB8n7MPpA0jijNGb109WokWw5ITImiW91GcGDuBW6elJDVKouQ==
+"@datadog/native-iast-taint-tracking@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.2.0.tgz#9fb6823d82f934e12c06ea1baa7399ca80deb2ec"
+  integrity sha512-Mc6FzCoyvU5yXLMsMS9yKnEqJMWoImAukJXolNWCTm+JQYCMf2yMsJ8pBAm7KyZKliamM9rCn7h7Tr2H3lXwjA==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
This new taint tracking module version supports node 23, green appsec ci running in node 23:
https://github.com/DataDog/dd-trace-js/actions/runs/11503070569/job/32019549423?pr=4824