### PR TITLE
Set latest in action.yml to force running with latest nodejs

### DIFF
--- a/.github/actions/node/22/action.yml
+++ b/.github/actions/node/22/action.yml
@@ -1,4 +1,4 @@
-name: Node 20
+name: Node 22
 runs:
   using: composite
   steps:

--- a/.github/actions/node/22/action.yml
+++ b/.github/actions/node/22/action.yml
@@ -1,0 +1,7 @@
+name: Node 20
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '22'

--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -4,4 +4,4 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: '22' # Update this line to the latest Node.js version
+        node-version: 'latest'

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -98,6 +98,19 @@ jobs:
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
+  # TODO When next job fails, update postgres job to node/latest
+  postgres-fail-on-support:
+    runs-on: ubuntu-latest
+    env:
+      PG_TEST_NATIVE: 'true'
+      PLUGINS: pg
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/install
+      - uses: ./.github/actions/node/latest
+      - run: if yarn services; then exit -1; else exit 0; fi
+
   mysql:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -94,7 +94,7 @@ jobs:
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/22
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -31,6 +31,8 @@ jobs:
       - run: yarn test:appsec:ci
       - uses: ./.github/actions/node/20
       - run: yarn test:appsec:ci
+      - uses: ./.github/actions/node/22
+      - run: yarn test:appsec:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:appsec:ci
       - uses: codecov/codecov-action@v3
@@ -92,7 +94,7 @@ jobs:
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/18
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/latest
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -115,7 +117,7 @@ jobs:
       - uses: ./.github/actions/install
       - uses: ./.github/actions/node/18
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/latest
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@v3
 
@@ -198,6 +200,8 @@ jobs:
       - uses: ./.github/actions/node/18
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/20
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/22
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:appsec:plugins:ci

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -897,7 +897,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/22
+      - uses: ./.github/actions/node/latest
       - run: if yarn services; then exit -1; else exit 0; fi
 
   promise:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -885,9 +885,11 @@ jobs:
     env:
       PG_TEST_NATIVE: 'true'
       PLUGINS: pg
-      SERVICES: postgres
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/node/22
+      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/install
       - run: if yarn services; then exit -1; else exit 0; fi
 
   promise:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -882,14 +882,22 @@ jobs:
         uses: ./.github/actions/testagent/logs
   postgres-fail-on-support:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:9.5
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
     env:
       PG_TEST_NATIVE: 'true'
       PLUGINS: pg
+      SERVICES: postgres
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
+      - uses: ./.github/actions/node/latest
       - run: if yarn services; then exit -1; else exit 0; fi
 
   promise:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -880,19 +880,13 @@ jobs:
       - uses: codecov/codecov-action@v3
       - if: always()
         uses: ./.github/actions/testagent/logs
+
+# TODO When next job fails, update postgres job to node/latest
   postgres-fail-on-support:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:9.5
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
     env:
       PG_TEST_NATIVE: 'true'
       PLUGINS: pg
-      SERVICES: postgres
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -887,7 +887,7 @@ jobs:
       PLUGINS: pg
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/node/22
+      - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
       - run: if yarn services; then exit -1; else exit 0; fi

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -578,7 +578,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/plugins/test
-
   mariadb:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -880,6 +880,15 @@ jobs:
       - uses: codecov/codecov-action@v3
       - if: always()
         uses: ./.github/actions/testagent/logs
+  postgres-fail-on-support:
+    runs-on: ubuntu-latest
+    env:
+      PG_TEST_NATIVE: 'true'
+      PLUGINS: pg
+      SERVICES: postgres
+    steps:
+      - uses: ./.github/actions/node/22
+      - run: if yarn services; then exit -1; else exit 0; fi
 
   promise:
     runs-on: ubuntu-latest

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -897,7 +897,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/node/setup
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/22
       - run: if yarn services; then exit -1; else exit 0; fi
 
   promise:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -578,7 +578,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/plugins/test
-  
+
   mariadb:
     runs-on: ubuntu-latest
     services:
@@ -867,7 +867,20 @@ jobs:
       SERVICES: postgres
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/plugins/test
+#        TODO Restore next line and delete the rest when new pg version is released
+#      - uses: ./.github/actions/plugins/test
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/install
+      - uses: ./.github/actions/node/oldest
+      - run: yarn test:plugins:ci
+        shell: bash
+      - uses: ./.github/actions/node/22
+      - run: yarn test:plugins:ci
+        shell: bash
+      - uses: codecov/codecov-action@v3
+      - if: always()
+        uses: ./.github/actions/testagent/logs
 
   promise:
     runs-on: ubuntu-latest

--- a/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
@@ -8,13 +8,18 @@ const {
 } = require('../../../../integration-tests/helpers')
 const { spawn } = require('child_process')
 const { assert } = require('chai')
+const { NODE_MAJOR } = require('../../../../version')
+const { satisfies } = require('semver')
 
 describe('esm', () => {
   let agent
   let proc
   let sandbox
 
-  withVersions('azure-functions', '@azure/functions', version => {
+  withVersions('azure-functions', '@azure/functions', (version, module, specificVersion) => {
+    // last version (currently 4.5.1) of @azure/functions is not supporting node 23 yet
+    if (NODE_MAJOR === 23 && satisfies(specificVersion, '<=4.5.1')) return
+
     before(async function () {
       this.timeout(50000)
       sandbox = await createSandbox([`@azure/functions@${version}`, 'azure-functions-core-tools@4'], false,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the CI to run with node 23 and fixes failing tests.
- azure functions test: do not execute it in the current versions + node 23
- pg does not support node 23, `npm install` fails in the ci, also in local. So this PR is disabling the pg tests for node 23.

### Motivation
<!-- What inspired you to submit this pull request? -->
azure-functions red ci:
https://github.com/DataDog/dd-trace-js/actions/runs/11514337850/job/32052773122?pr=4825

Error:
> https://github.com/DataDog/dd-trace-js/actions/runs/11514337850/job/32052773122?pr=4825

Error on success CI: https://github.com/DataDog/dd-trace-js/actions/runs/11521605330/job/32075696568?pr=4825
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


