### PR TITLE
[DI] Adhere to maxFieldCount limit in snapshots

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -23,13 +23,14 @@ session.on('Debugger.paused', async ({ params }) => {
   const timestamp = Date.now()
 
   let captureSnapshotForProbe = null
-  let maxReferenceDepth, maxCollectionSize, maxLength
+  let maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength
   const probes = params.hitBreakpoints.map((id) => {
     const probe = breakpoints.get(id)
     if (probe.captureSnapshot) {
       captureSnapshotForProbe = probe
       maxReferenceDepth = highestOrUndefined(probe.capture.maxReferenceDepth, maxReferenceDepth)
       maxCollectionSize = highestOrUndefined(probe.capture.maxCollectionSize, maxCollectionSize)
+      maxFieldCount = highestOrUndefined(probe.capture.maxFieldCount, maxFieldCount)
       maxLength = highestOrUndefined(probe.capture.maxLength, maxLength)
     }
     return probe
@@ -41,7 +42,7 @@ session.on('Debugger.paused', async ({ params }) => {
       // TODO: Create unique states for each affected probe based on that probes unique `capture` settings (DEBUG-2863)
       processLocalState = await getLocalStateForCallFrame(
         params.callFrames[0],
-        { maxReferenceDepth, maxCollectionSize, maxLength }
+        { maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength }
       )
     } catch (err) {
       // TODO: This error is not tied to a specific probe, but to all probes with `captureSnapshot: true`.

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { collectionSizeSym } = require('./symbols')
+const { collectionSizeSym, fieldCountSym } = require('./symbols')
 const session = require('../session')
 
 const LEAF_SUBTYPES = new Set(['date', 'regexp'])
@@ -30,6 +30,11 @@ async function getObject (objectId, opts, depth = 0, collection = false) {
       result.splice(opts.maxCollectionSize)
       result[collectionSizeSym] = size
     }
+  } else if (result.length > opts.maxFieldCount) {
+    // Trim the number of properties on the object if there's too many.
+    const size = result.length
+    result.splice(opts.maxFieldCount)
+    result[fieldCountSym] = size
   } else if (privateProperties) {
     result.push(...privateProperties)
   }

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/index.js
@@ -5,6 +5,7 @@ const { processRawState } = require('./processor')
 
 const DEFAULT_MAX_REFERENCE_DEPTH = 3
 const DEFAULT_MAX_COLLECTION_SIZE = 100
+const DEFAULT_MAX_FIELD_COUNT = 20
 const DEFAULT_MAX_LENGTH = 255
 
 module.exports = {
@@ -16,6 +17,7 @@ async function getLocalStateForCallFrame (
   {
     maxReferenceDepth = DEFAULT_MAX_REFERENCE_DEPTH,
     maxCollectionSize = DEFAULT_MAX_COLLECTION_SIZE,
+    maxFieldCount = DEFAULT_MAX_FIELD_COUNT,
     maxLength = DEFAULT_MAX_LENGTH
   } = {}
 ) {
@@ -24,7 +26,10 @@ async function getLocalStateForCallFrame (
 
   for (const scope of callFrame.scopeChain) {
     if (scope.type === 'global') continue // The global scope is too noisy
-    rawState.push(...await getRuntimeObject(scope.object.objectId, { maxReferenceDepth, maxCollectionSize }))
+    rawState.push(...await getRuntimeObject(
+      scope.object.objectId,
+      { maxReferenceDepth, maxCollectionSize, maxFieldCount }
+    ))
   }
 
   // Deplay calling `processRawState` so the caller gets a chance to resume the main thread before processing `rawState`

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/processor.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/processor.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { collectionSizeSym } = require('./symbols')
+const { collectionSizeSym, fieldCountSym } = require('./symbols')
 
 module.exports = {
   processRawState: processProperties
@@ -139,7 +139,18 @@ function toString (str, maxLength) {
 
 function toObject (type, props, maxLength) {
   if (props === undefined) return notCapturedDepth(type)
-  return { type, fields: processProperties(props, maxLength) }
+
+  const result = {
+    type,
+    fields: processProperties(props, maxLength)
+  }
+
+  if (fieldCountSym in props) {
+    result.notCapturedReason = 'fieldCount'
+    result.size = props[fieldCountSym]
+  }
+
+  return result
 }
 
 function toArray (type, elements, maxLength) {

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/symbols.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/symbols.js
@@ -1,5 +1,6 @@
 'use stict'
 
 module.exports = {
-  collectionSizeSym: Symbol('datadog.collectionSize')
+  collectionSizeSym: Symbol('datadog.collectionSize'),
+  fieldCountSym: Symbol('datadog.fieldCount')
 }

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/complex-types.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/complex-types.spec.js
@@ -23,7 +23,7 @@ describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', fu
       session.once('Debugger.paused', async ({ params }) => {
         expect(params.hitBreakpoints.length).to.eq(1)
 
-        resolve((await getLocalStateForCallFrame(params.callFrames[0]))())
+        resolve((await getLocalStateForCallFrame(params.callFrames[0], { maxFieldCount: Infinity }))())
       })
 
       await setAndTriggerBreakpoint(target, 10)

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count-scopes.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count-scopes.spec.js
@@ -1,0 +1,32 @@
+'use strict'
+
+require('../../../setup/mocha')
+
+const { getTargetCodePath, enable, teardown, assertOnBreakpoint, setAndTriggerBreakpoint } = require('./utils')
+
+const target = getTargetCodePath(__filename)
+
+describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', function () {
+  describe('maxFieldCount', function () {
+    beforeEach(enable(__filename))
+
+    afterEach(teardown)
+
+    describe('shold respect maxFieldCount on each collected scope', function () {
+      const maxFieldCount = 3
+      let state
+
+      beforeEach(function (done) {
+        assertOnBreakpoint(done, { maxFieldCount }, (_state) => {
+          state = _state
+        })
+        setAndTriggerBreakpoint(target, 11)
+      })
+
+      it('should capture expected snapshot', function () {
+        // Expect the snapshot to have captured the first 3 fields from each scope
+        expect(state).to.have.keys(['a1', 'b1', 'c1', 'a2', 'b2', 'c2'])
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count.spec.js
@@ -1,0 +1,49 @@
+'use strict'
+
+require('../../../setup/mocha')
+
+const { getTargetCodePath, enable, teardown, assertOnBreakpoint, setAndTriggerBreakpoint } = require('./utils')
+
+const DEFAULT_MAX_FIELD_COUNT = 20
+const target = getTargetCodePath(__filename)
+
+describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', function () {
+  describe('maxFieldCount', function () {
+    beforeEach(enable(__filename))
+
+    afterEach(teardown)
+
+    describe('shold respect the default maxFieldCount if not set', generateTestCases())
+
+    describe('shold respect maxFieldCount if set to 10', generateTestCases({ maxFieldCount: 10 }))
+  })
+})
+
+function generateTestCases (config) {
+  const maxFieldCount = config?.maxFieldCount ?? DEFAULT_MAX_FIELD_COUNT
+  let state
+
+  const expectedFields = {}
+  for (let i = 1; i <= maxFieldCount; i++) {
+    expectedFields[`field${i}`] = { type: 'number', value: i.toString() }
+  }
+
+  return function () {
+    beforeEach(function (done) {
+      assertOnBreakpoint(done, config, (_state) => {
+        state = _state
+      })
+      setAndTriggerBreakpoint(target, 11)
+    })
+
+    it('should capture expected snapshot', function () {
+      expect(state).to.have.keys(['obj'])
+      expect(state).to.have.deep.property('obj', {
+        type: 'Object',
+        fields: expectedFields,
+        notCapturedReason: 'fieldCount',
+        size: 40
+      })
+    })
+  }
+}

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/max-field-count-scopes.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/max-field-count-scopes.js
@@ -1,0 +1,15 @@
+'use stict'
+
+function run () {
+  // local scope
+  const { a1, b1, c1, d1 } = {}
+
+  {
+    // block scope
+    const { a2, b2, c2, d2 } = {}
+
+    return { a1, b1, c1, d1, a2, b2, c2, d2 } // breakpoint at this line
+  }
+}
+
+module.exports = { run }

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/max-field-count.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/max-field-count.js
@@ -1,0 +1,14 @@
+'use stict'
+
+function run () {
+  const obj = {}
+
+  // 40 is larger the default maxFieldCount of 20
+  for (let i = 1; i <= 40; i++) {
+    obj[`field${i}`] = i
+  }
+
+  return 'my return value' // breakpoint at this line
+}
+
+module.exports = { run }


### PR DESCRIPTION
This PR adds support for the `maxFieldCount` limit in Dynamic Instrumentation (provided by the probe configuration via Remote Configuraiton).

The limit controls the maximum number of properties collected on an object. The default is `20`.
    
It's also applied on each scope when collecting properties. If there's for example more than `maxFieldCount` properties in the current scope, they are not all collected. 
