### PR TITLE
create isNoop method on scope

### DIFF
--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -58,6 +58,10 @@ class Scope {
   _isPromise (promise) {
     return promise && typeof promise.then === 'function'
   }
+
+  isNoop () {
+    return storage.getStore()?.noop
+  }
 }
 
 module.exports = Scope

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -3,7 +3,6 @@
 const Tracer = require('./opentracing/tracer')
 const tags = require('../../../ext/tags')
 const Scope = require('./scope')
-const { storage } = require('../../datadog-core')
 const { isError } = require('./util')
 const { setStartupLogConfig } = require('./startup-log')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
@@ -106,9 +105,7 @@ class DatadogTracer extends Tracer {
     const tracer = this
 
     return function () {
-      const store = storage.getStore()
-
-      if (store && store.noop) return fn.apply(this, arguments)
+      if (tracer.scope().isNoop()) return fn.apply(this, arguments)
 
       let optionsObj = options
       if (typeof optionsObj === 'function' && typeof fn === 'function') {


### PR DESCRIPTION
### What does this PR do?
Adds an isNoop() method on the Scope clas.

### Motivation
<!-- What inspired you to submit this pull request? -->
This enables `wrap()` and `trace()` to be written solely in terms of methods already available on publicly accessible classes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Not documenting it _or_ testing it in isolation for now, since it's there just to enable internal things.