### PR TITLE
Defend against ref being undefined

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -301,7 +301,8 @@ class NativeWallProfiler {
 
     const labels = { ...getThreadLabels() }
 
-    const { context: { ref: { spanId, rootSpanId, webTags, endpoint } }, timestamp } = context
+    const { context: { ref }, timestamp } = context
+    const { spanId, rootSpanId, webTags, endpoint } = ref ?? {}
 
     if (this._timelineEnabled) {
       // Incoming timestamps are in microseconds, we emit nanos.


### PR DESCRIPTION
### What does this PR do?
Defends against a `TypeError: Cannot read properties of undefined (reading 'spanId')` error while generating labels for CPU samples.

### Motivation
Bug was observed in telemetry logs.

### Additional Notes
JIRA [PROF-10821]




[PROF-10821]: https://datadoghq.atlassian.net/browse/PROF-10821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ