### PR TITLE
Fix amqp instrumentation

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
-          ref: 'piotr-wolski/update-node-js-test'
       - name: Checkout dd-trace-js
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
+          ref: 'piotr-wolski/update-node-js-test'
       - name: Checkout dd-trace-js
         uses: actions/checkout@v4
         with:

--- a/packages/datadog-instrumentations/src/amqplib.js
+++ b/packages/datadog-instrumentations/src/amqplib.js
@@ -25,6 +25,61 @@ addHook({ name: 'amqplib', file: 'lib/defs.js', versions: [MIN_VERSION] }, defs 
   return defs
 })
 
+addHook({ name: 'amqplib', file: 'lib/channel_model.js', versions: [MIN_VERSION] }, x => {
+  shimmer.wrap(x.Channel.prototype, 'get', getMessage => function (queue, options) {
+    return getMessage.apply(this, arguments).then(message => {
+      startCh.publish({ method: 'basic.get', message, fields: message.fields, queue })
+      // finish right away
+      finishCh.publish()
+      return message
+    })
+  })
+  shimmer.wrap(x.Channel.prototype, 'consume', consume => function (queue, callback, options) {
+    if (!startCh.hasSubscribers) {
+      return consume.apply(this, arguments)
+    }
+    arguments[1] = (message, ...args) => {
+      startCh.publish({ method: 'basic.deliver', message, fields: message.fields, queue })
+      const result = callback(message, ...args)
+      finishCh.publish()
+      return result
+    }
+    return consume.apply(this, arguments)
+  })
+  return x
+})
+
+addHook({ name: 'amqplib', file: 'lib/callback_model.js', versions: [MIN_VERSION] }, channel => {
+  shimmer.wrap(channel.Channel.prototype, 'get', getMessage => function (queue, options, callback) {
+    if (!startCh.hasSubscribers) {
+      return getMessage.apply(this, arguments)
+    }
+    arguments[2] = (error, message, ...args) => {
+      if (error !== null || message === null) {
+        return callback(error, message, ...args)
+      }
+      startCh.publish({ method: 'basic.get', message, fields: message.fields, queue })
+      const result = callback(error, message, ...args)
+      finishCh.publish()
+      return result
+    }
+    return getMessage.apply(this, arguments)
+  })
+  shimmer.wrap(channel.Channel.prototype, 'consume', consume => function (queue, callback) {
+    if (!startCh.hasSubscribers) {
+      return consume.apply(this, arguments)
+    }
+    arguments[1] = (message, ...args) => {
+      startCh.publish({ method: 'basic.deliver', message, fields: message.fields, queue })
+      const result = callback(message, ...args)
+      finishCh.publish()
+      return result
+    }
+    return consume.apply(this, arguments)
+  })
+  return channel
+})
+
 addHook({ name: 'amqplib', file: 'lib/channel.js', versions: [MIN_VERSION] }, channel => {
   shimmer.wrap(channel.Channel.prototype, 'sendImmediately', sendImmediately => function (method, fields) {
     return instrument(sendImmediately, this, arguments, methods[method], fields)
@@ -33,15 +88,11 @@ addHook({ name: 'amqplib', file: 'lib/channel.js', versions: [MIN_VERSION] }, ch
   shimmer.wrap(channel.Channel.prototype, 'sendMessage', sendMessage => function (fields) {
     return instrument(sendMessage, this, arguments, 'basic.publish', fields, arguments[2])
   })
-
-  shimmer.wrap(channel.BaseChannel.prototype, 'dispatchMessage', dispatchMessage => function (fields, message) {
-    return instrument(dispatchMessage, this, arguments, 'basic.deliver', fields, message)
-  })
   return channel
 })
 
 function instrument (send, channel, args, method, fields, message) {
-  if (!startCh.hasSubscribers) {
+  if (!startCh.hasSubscribers || method === 'basic.get') {
     return send.apply(channel, args)
   }
 

--- a/packages/datadog-plugin-amqplib/src/consumer.js
+++ b/packages/datadog-plugin-amqplib/src/consumer.js
@@ -9,17 +9,18 @@ class AmqplibConsumerPlugin extends ConsumerPlugin {
   static get id () { return 'amqplib' }
   static get operation () { return 'command' }
 
-  start ({ method, fields, message }) {
+  start ({ method, fields, message, queue }) {
     if (method !== 'basic.deliver' && method !== 'basic.get') return
 
     const childOf = extract(this.tracer, message)
 
+    const queueName = queue || fields.queue || fields.routingKey
     const span = this.startSpan({
       childOf,
       resource: getResourceName(method, fields),
       type: 'worker',
       meta: {
-        'amqp.queue': fields.queue,
+        'amqp.queue': queueName,
         'amqp.exchange': fields.exchange,
         'amqp.routingKey': fields.routingKey,
         'amqp.consumerTag': fields.consumerTag,
@@ -32,10 +33,9 @@ class AmqplibConsumerPlugin extends ConsumerPlugin {
       this.config.dsmEnabled && message?.properties?.headers
     ) {
       const payloadSize = getAmqpMessageSize({ headers: message.properties.headers, content: message.content })
-      const queue = fields.queue ? fields.queue : fields.routingKey
       this.tracer.decodeDataStreamsContext(message.properties.headers)
       this.tracer
-        .setCheckpoint(['direction:in', `topic:${queue}`, 'type:rabbitmq'], span, payloadSize)
+        .setCheckpoint(['direction:in', `topic:${queueName}`, 'type:rabbitmq'], span, payloadSize)
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The amqp instrumentation was not getting the queue name correctly.
In some cases (when using the Get function) it was also not propagating context correctly.

This PR addresses these two issues.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


