### PR TITLE
Fix header injection test for `access-control-allow-origin` exclusion

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/header-injection.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/header-injection.express.plugin.spec.js
@@ -226,7 +226,7 @@ describe('Header injection vulnerability', () => {
           testDescription: 'should have HEADER_INJECTION vulnerability when ' +
             'the header is "access-control-allow-origin" and the origin is not a header',
           fn: (req, res) => {
-            setHeaderFunction('set-cookie', req.body.test, res)
+            setHeaderFunction('access-control-allow-origin', req.body.test, res)
           },
           vulnerability: 'HEADER_INJECTION',
           makeRequest: (done, config) => {


### PR DESCRIPTION
### What does this PR do?
Fixes a test to check the exclusion of `access-control-allow-origin` for header injection.

### Motivation
Test this case properly
