### PR TITLE
fix incompatibilities with node 16 for 4.49.0 release

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "main": "typedoc.js",
   "scripts": {
     "build": "typedoc ../index.d.ts && ./add-redirects.sh",
-    "pretest": "tsc -p . && tsc test",
+    "pretest": "tsc -p tsconfig.json && tsc --types node test",
     "test": "node test"
   },
   "license": "BSD-3-Clause",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "main": "typedoc.js",
   "scripts": {
     "build": "typedoc ../index.d.ts && ./add-redirects.sh",
-    "pretest": "tsc -p tsconfig.json && tsc --types node test",
+    "pretest": "tsc -p . && tsc --types node test",
     "test": "node test"
   },
   "license": "BSD-3-Clause",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -4,7 +4,8 @@
     "moduleResolution": "node",
     "module": "commonjs",
     "baseUrl": ".",
-    "strict": true
+    "strict": true,
+    "types": ["node"]
   },
   "files": [
     "../index.d.ts"

--- a/integration-tests/appsec/multer.spec.js
+++ b/integration-tests/appsec/multer.spec.js
@@ -10,6 +10,10 @@ const {
   spawnProc
 } = require('../helpers')
 
+const { NODE_MAJOR } = require('../../version')
+
+const describe = NODE_MAJOR <= 16 ? globalThis.describe.skip : globalThis.describe
+
 describe('multer', () => {
   let sandbox, cwd, startupTestFile, agent, proc, env
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix incompatibilities with node 16 for 4.49.0 release. This means:

- Specifying TypeScript types explicitly to avoid TypeScript trying to load types that are incompatible with TypeScript 3.x which were added with the `@apollo/server` dependency.
- Skip `multer` tests as they use FormData which wasn't available in Node 16.

### Motivation
<!-- What inspired you to submit this pull request? -->

These issues are blocking the 4.49.0 release proposal.