### PR TITLE
Have one version tag in metrics

### DIFF
--- a/packages/dd-trace/src/telemetry/metrics.js
+++ b/packages/dd-trace/src/telemetry/metrics.js
@@ -27,13 +27,18 @@ function hasPoints (metric) {
   return metric.points.length > 0
 }
 
+let versionTag
+
 class Metric {
   constructor (namespace, metric, common, tags) {
     this.namespace = namespace.toString()
     this.metric = common ? metric : `nodejs.${metric}`
     this.tags = tagArray(tags)
     if (common) {
-      this.tags.push(`version:${process.version}`)
+      if (versionTag === undefined) {
+        versionTag = `version:${process.version}`
+      }
+      this.tags.push(versionTag)
     }
     this.common = common
 


### PR DESCRIPTION
### What does this PR do?
Lazily creates and then reuses the common "version" tag in metrics.

### Motivation
An opportunity to save few bytes per metric by not having a bunch of copies of the same string in them.
