### PR TITLE
Use sampling on timeline events

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -105,10 +105,9 @@ async function gatherNetworkTimelineEvents (cwd, scriptFilePath, eventType, args
   const proc = fork(path.join(cwd, scriptFilePath), args, {
     cwd,
     env: {
-      DD_PROFILING_PROFILERS: 'wall',
       DD_PROFILING_EXPORTERS: 'file',
       DD_PROFILING_ENABLED: 1,
-      DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: 1
+      DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED: 0 // capture all events
     }
   })
 
@@ -205,12 +204,8 @@ describe('profiler', () => {
       const proc = fork(path.join(cwd, 'profiler/codehotspots.js'), {
         cwd,
         env: {
-          DD_PROFILING_PROFILERS: 'wall',
           DD_PROFILING_EXPORTERS: 'file',
-          DD_PROFILING_ENABLED: 1,
-          DD_PROFILING_CODEHOTSPOTS_ENABLED: 1,
-          DD_PROFILING_ENDPOINT_COLLECTION_ENABLED: 1,
-          DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED: 1
+          DD_PROFILING_ENABLED: 1
         }
       })
 

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -21,6 +21,7 @@ class Config {
     const {
       DD_AGENT_HOST,
       DD_ENV,
+      DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED, // used for testing
       DD_PROFILING_CODEHOTSPOTS_ENABLED,
       DD_PROFILING_CPU_ENABLED,
       DD_PROFILING_DEBUG_SOURCE_MAPS,
@@ -175,6 +176,8 @@ class Config {
       DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED, samplingContextsAvailable))
     logExperimentalVarDeprecation('TIMELINE_ENABLED')
     checkOptionWithSamplingContextAllowed(this.timelineEnabled, 'Timeline view')
+    this.timelineSamplingEnabled = isTrue(coalesce(options.timelineSamplingEnabled,
+      DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED, true))
 
     this.codeHotspotsEnabled = isTrue(coalesce(options.codeHotspotsEnabled,
       DD_PROFILING_CODEHOTSPOTS_ENABLED,

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -5,9 +5,10 @@ const { performance } = require('perf_hooks')
 // We are leveraging the TracingPlugin class for its functionality to bind
 // start/error/finish methods to the appropriate diagnostic channels.
 class EventPlugin extends TracingPlugin {
-  constructor (eventHandler) {
+  constructor (eventHandler, eventFilter) {
     super()
     this.eventHandler = eventHandler
+    this.eventFilter = eventFilter
     this.store = storage('profiling')
     this.entryType = this.constructor.entryType
   }
@@ -30,17 +31,20 @@ class EventPlugin extends TracingPlugin {
     }
     const duration = performance.now() - startTime
 
-    const context = this.activeSpan?.context()
-    const _ddSpanId = context?.toSpanId()
-    const _ddRootSpanId = context?._trace.started[0]?.context().toSpanId() || _ddSpanId
-
     const event = {
       entryType: this.entryType,
       startTime,
-      duration,
-      _ddSpanId,
-      _ddRootSpanId
+      duration
     }
+
+    if (!this.eventFilter(event)) {
+      return
+    }
+
+    const context = this.activeSpan?.context()
+    event._ddSpanId = context?.toSpanId()
+    event._ddRootSpanId = context?._trace.started[0]?.context().toSpanId() || event._ddSpanId
+
     this.eventHandler(this.extendEvent(event, startEvent))
   }
 }


### PR DESCRIPTION
### What does this PR do?
Instead of recording all events for the timeline, uses sampling to only select those events that occur during sampling instants. Sampling instants are produced by a Poisson point process with rate equal to the overall configured profiling sampling rate.

### Motivation
We'll be introducing some new event types, increasing their cardinality. Introducing sampling will reduce the number of recorded events, with higher likelihood of discarding short events.

### Additional Notes
JIRA issue [PROF-10852]




[PROF-10852]: https://datadoghq.atlassian.net/browse/PROF-10852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ