### PR TITLE
temporary upper bound to the router instrumentation

### DIFF
--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -170,7 +170,7 @@ function createWrapRouterMethod (name) {
 
 const wrapRouterMethod = createWrapRouterMethod('router')
 
-addHook({ name: 'router', versions: ['>=1'] }, Router => {
+addHook({ name: 'router', versions: ['>=1 <2.0.0'] }, Router => {
   shimmer.wrap(Router.prototype, 'use', wrapRouterMethod)
   shimmer.wrap(Router.prototype, 'route', wrapRouterMethod)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

When you try to spin up an Express 5.x application with the tracer, there's an error about `fast_star`:
```
TypeError: Cannot read properties of undefined (reading 'fast_star')
```

It looks like Express 5.x uses Router 2.x which the instrumentation isn't ready to handle at the moment.

This PR adds a temporary upper bound so we only try to trace router 1.x so the error doesn't get thrown. 

One problem I'm seeing right now is that even though the test passes, the application throws errors like:
```
Found incompatible integration version: router@2.0.0
Error during ddtrace instrumentation of application, aborting.
Error: No original method use.
```

Researching an alternative with https://github.com/DataDog/dd-trace-js/pull/4872

### Motivation
<!-- What inspired you to submit this pull request? -->

Related to AIDM-438

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


