### PR TITLE
skip warning if propagator is baggage

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -324,7 +324,7 @@ class TextMapPropagator {
           spanContext = this._extractB3MultiContext(carrier)
           break
         default:
-          log.warn(`Unknown propagation style: ${extractor}`)
+          if (extractor !== 'baggage') log.warn(`Unknown propagation style: ${extractor}`)
       }
 
       if (this._config.tracePropagationStyle.extract.includes('baggage') && carrier.baggage) {


### PR DESCRIPTION
### What does this PR do?
skip warning for the unconventional propagator [baggage](https://opentelemetry.io/docs/concepts/signals/baggage/). Lucas gave a [good explanation](https://github.com/DataDog/dd-trace-js/pull/4563#discussion_r1815786436) for having baggage as a propagator.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


