### PR TITLE
[ASM] Fix `checkNoVulnerabilityInRequest` for IAST tests

### DIFF
--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -136,6 +136,7 @@ function endResponse (res, appResult) {
 function checkNoVulnerabilityInRequest (vulnerability, config, done, makeRequest) {
   agent
     .use(traces => {
+      if (traces[0][0].type !== 'web') throw new Error('Not a web span')
       // iastJson == undefiend is valid
       const iastJson = traces[0][0].meta['_dd.iast.json'] || ''
       expect(iastJson).to.not.include(`"${vulnerability}"`)


### PR DESCRIPTION
### What does this PR do?
Discard non web spans when checking there is no vulnerability present in traces in a test.

### Motivation
Correctly check there is no vulnerability in traces.

### Additional Notes
The `agent.use` callback will potentially be called multiple times during a test. By checking that there is no vulnerability present in these traces, it could happen that one of these calls will pass the test (no vulnerability present in traces, because spans are not of web type) while others, in the same test, will fail because there is a vulnerability.  However, as soon as a callback succeeds, the promise is fulfilled, `then` is called, which in turn calls the test's `done` successfully.


