### PR TITLE
Prevent errors in Express 5.x applications

### DIFF
--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -57,7 +57,7 @@ function wrapResponseRender (render) {
   }
 }
 
-addHook({ name: 'express', versions: ['>=4 <5.0.0'] }, express => {
+addHook({ name: 'express', versions: ['>=4'] }, express => {
   shimmer.wrap(express.application, 'handle', wrapHandle)
   shimmer.wrap(express.Router, 'use', wrapRouterMethod)
   shimmer.wrap(express.Router, 'route', wrapRouterMethod)
@@ -88,7 +88,7 @@ function publishQueryParsedAndNext (req, res, next) {
 
 addHook({
   name: 'express',
-  versions: ['>=4 <5.0.0'],
+  versions: ['>=4'],
   file: 'lib/middleware/query.js'
 }, query => {
   return shimmer.wrapFunction(query, query => function () {
@@ -129,7 +129,7 @@ addHook({ name: 'express', versions: ['>=4.0.0 <4.3.0'] }, express => {
   return express
 })
 
-addHook({ name: 'express', versions: ['>=4.3.0 <5.0.0'] }, express => {
+addHook({ name: 'express', versions: ['>=4.3.0'] }, express => {
   shimmer.wrap(express.Router, 'process_params', wrapProcessParamsMethod(2))
   return express
 })

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -57,7 +57,7 @@ function wrapResponseRender (render) {
   }
 }
 
-addHook({ name: 'express', versions: ['>=4'] }, express => {
+addHook({ name: 'express', versions: ['>=4 <5.0.0'] }, express => {
   shimmer.wrap(express.application, 'handle', wrapHandle)
   shimmer.wrap(express.Router, 'use', wrapRouterMethod)
   shimmer.wrap(express.Router, 'route', wrapRouterMethod)
@@ -88,7 +88,7 @@ function publishQueryParsedAndNext (req, res, next) {
 
 addHook({
   name: 'express',
-  versions: ['>=4'],
+  versions: ['>=4 <5.0.0'],
   file: 'lib/middleware/query.js'
 }, query => {
   return shimmer.wrapFunction(query, query => function () {
@@ -129,7 +129,7 @@ addHook({ name: 'express', versions: ['>=4.0.0 <4.3.0'] }, express => {
   return express
 })
 
-addHook({ name: 'express', versions: ['>=4.3.0'] }, express => {
+addHook({ name: 'express', versions: ['>=4.3.0 <5.0.0'] }, express => {
   shimmer.wrap(express.Router, 'process_params', wrapProcessParamsMethod(2))
   return express
 })

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -120,7 +120,7 @@ function createWrapRouterMethod (name) {
   }
 
   function isFastStar (layer, matchers) {
-    if (layer.regexp.fast_star !== undefined) {
+    if (layer.regexp?.hasOwnProperty('fast_star') && layer.regexp.fast_star !== undefined) {
       return layer.regexp.fast_star
     }
 
@@ -128,7 +128,7 @@ function createWrapRouterMethod (name) {
   }
 
   function isFastSlash (layer, matchers) {
-    if (layer.regexp.fast_slash !== undefined) {
+    if (layer.regexp?.hasOwnProperty('fast_slash') && layer.regexp.fast_slash !== undefined) {
       return layer.regexp.fast_slash
     }
 
@@ -177,7 +177,7 @@ function createWrapRouterMethod (name) {
 
 const wrapRouterMethod = createWrapRouterMethod('router')
 
-addHook({ name: 'router', versions: ['>=1 <2.0.0'] }, Router => {
+addHook({ name: 'router', versions: ['>=1'] }, Router => {
   shimmer.wrap(Router.prototype, 'use', wrapRouterMethod)
   shimmer.wrap(Router.prototype, 'route', wrapRouterMethod)
 

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -120,7 +120,7 @@ function createWrapRouterMethod (name) {
   }
 
   function isFastStar (layer, matchers) {
-    if (layer.regexp?.hasOwnProperty('fast_star') && layer.regexp.fast_star !== undefined) {
+    if (layer.regexp?.fast_star !== undefined) {
       return layer.regexp.fast_star
     }
 
@@ -128,7 +128,7 @@ function createWrapRouterMethod (name) {
   }
 
   function isFastSlash (layer, matchers) {
-    if (layer.regexp?.hasOwnProperty('fast_slash') && layer.regexp.fast_slash !== undefined) {
+    if (layer.regexp?.fast_slash !== undefined) {
       return layer.regexp.fast_slash
     }
 

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -114,7 +114,6 @@ function createWrapRouterMethod (name) {
         const matchers = layerMatchers.get(layer)
         return !isFastStar(layer, matchers) &&
           !isFastSlash(layer, matchers) &&
-          !isSlash(layer, matchers) &&
           cachedPathToRegExp(pattern).test(layer.path)
       }
     }))
@@ -131,15 +130,6 @@ function createWrapRouterMethod (name) {
   function isFastSlash (layer, matchers) {
     if (layer.regexp?.hasOwnProperty('fast_slash') && layer.regexp.fast_slash !== undefined) {
       return layer.regexp.fast_slash
-    }
-
-    return matchers.some(matcher => matcher.path === '/')
-  }
-
-  // Router 2.x has a slash under layer instead of regexp https://github.com/pillarjs/router/pull/117
-  function isSlash (layer, matchers) {
-    if (layer.hasOwnProperty('slash') && layer.slash !== undefined) {
-      return layer.slash
     }
 
     return matchers.some(matcher => matcher.path === '/')

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -114,6 +114,7 @@ function createWrapRouterMethod (name) {
         const matchers = layerMatchers.get(layer)
         return !isFastStar(layer, matchers) &&
           !isFastSlash(layer, matchers) &&
+          !isSlash(layer, matchers) &&
           cachedPathToRegExp(pattern).test(layer.path)
       }
     }))

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -136,6 +136,7 @@ function createWrapRouterMethod (name) {
     return matchers.some(matcher => matcher.path === '/')
   }
 
+  // Router 2.x has a slash under layer instead of regexp https://github.com/pillarjs/router/pull/117
   function isSlash (layer, matchers) {
     if (layer.hasOwnProperty('slash') && layer.slash !== undefined) {
       return layer.slash

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -112,7 +112,6 @@ function createWrapRouterMethod (name) {
       path: pattern instanceof RegExp ? `(${pattern})` : pattern,
       test: layer => {
         const matchers = layerMatchers.get(layer)
-
         return !isFastStar(layer, matchers) &&
           !isFastSlash(layer, matchers) &&
           cachedPathToRegExp(pattern).test(layer.path)
@@ -131,6 +130,14 @@ function createWrapRouterMethod (name) {
   function isFastSlash (layer, matchers) {
     if (layer.regexp.fast_slash !== undefined) {
       return layer.regexp.fast_slash
+    }
+
+    return matchers.some(matcher => matcher.path === '/')
+  }
+
+  function isSlash (layer, matchers) {
+    if (layer.hasOwnProperty('slash') && layer.slash !== undefined) {
+      return layer.slash
     }
 
     return matchers.some(matcher => matcher.path === '/')
@@ -170,7 +177,7 @@ function createWrapRouterMethod (name) {
 
 const wrapRouterMethod = createWrapRouterMethod('router')
 
-addHook({ name: 'router', versions: ['>=1'] }, Router => {
+addHook({ name: 'router', versions: ['>=1 <2.0.0'] }, Router => {
   shimmer.wrap(Router.prototype, 'use', wrapRouterMethod)
   shimmer.wrap(Router.prototype, 'route', wrapRouterMethod)
 


### PR DESCRIPTION
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

**UPDATE: Fixed the unsafe access to a property, we will not be capping the instrumentation version **

When you try to spin up an Express 5.x application with the tracer, there's an error about fast_star:

```
TypeError: Cannot read properties of undefined (reading 'fast_star')
It looks like Express 5.x uses Router 2.x which the instrumentation isn't ready to handle at the moment.
```

While investigating adding an upper bound in https://github.com/DataDog/dd-trace-js/pull/4862, I looked to see if the router instrumentation could be fixed and Express be capped to not instrument 5.x. 

This PR attempts to just fix some of the checks that don't exist any more rather than only setting an upper limit of router.

**Caveat:** The resulting trace does not load express at all for Express 5.x applications.

The trace goes from `web.request` -> `router.middleware`, ie:
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/63d0cd1a-037c-494a-906b-f9ceae05f528">


Related to AIDM-438
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


