### PR TITLE
fix(tracing): fix express instrumentation for v5

### DIFF
--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -57,10 +57,20 @@ function wrapResponseRender (render) {
   }
 }
 
-addHook({ name: 'express', versions: ['>=4'] }, express => {
+addHook({ name: 'express', versions: ['>=4 <5.0.0'] }, express => {
   shimmer.wrap(express.application, 'handle', wrapHandle)
   shimmer.wrap(express.Router, 'use', wrapRouterMethod)
   shimmer.wrap(express.Router, 'route', wrapRouterMethod)
+
+  shimmer.wrap(express.response, 'json', wrapResponseJson)
+  shimmer.wrap(express.response, 'jsonp', wrapResponseJson)
+  shimmer.wrap(express.response, 'render', wrapResponseRender)
+
+  return express
+})
+
+addHook({ name: 'express', versions: ['>=5.0.0'] }, express => {
+  shimmer.wrap(express.application, 'handle', wrapHandle)
 
   shimmer.wrap(express.response, 'json', wrapResponseJson)
   shimmer.wrap(express.response, 'jsonp', wrapResponseJson)
@@ -129,7 +139,7 @@ addHook({ name: 'express', versions: ['>=4.0.0 <4.3.0'] }, express => {
   return express
 })
 
-addHook({ name: 'express', versions: ['>=4.3.0'] }, express => {
+addHook({ name: 'express', versions: ['>=4.3.0 <5.0.0'] }, express => {
   shimmer.wrap(express.Router, 'process_params', wrapProcessParamsMethod(2))
   return express
 })

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -25,7 +25,7 @@ function createWrapRouterMethod (name) {
       const lastIndex = arguments.length - 1
       const name = original._name || original.name
       const req = arguments[arguments.length > 3 ? 1 : 0]
-      wrapParams(req)
+      // wrapParams(req)
       const next = arguments[lastIndex]
 
       if (typeof next === 'function') {

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -5,10 +5,11 @@ const axios = require('axios')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
+const semver = require('semver')
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
-describe('Plugin', () => {
+describe('Plugin', function () {
   let tracer
   let express
   let appListener
@@ -197,146 +198,6 @@ describe('Plugin', () => {
           })
         })
 
-        it('should do automatic instrumentation on middleware', done => {
-          const app = express()
-          const router = express.Router()
-
-          router.get('/user/:id', (req, res) => {
-            res.status(200).send()
-          })
-
-          app.use(function named (req, res, next) { next() })
-          app.use('/app', router)
-
-          appListener = app.listen(0, 'localhost', () => {
-            const port = appListener.address().port
-
-            agent
-              .use(traces => {
-                const spans = sort(traces[0])
-
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
-                expect(spans[0]).to.have.property('name', 'express.request')
-                expect(spans[0].meta).to.have.property('component', 'express')
-                expect(spans[1]).to.have.property('resource', 'query')
-                expect(spans[1]).to.have.property('name', 'express.middleware')
-                expect(spans[1].parent_id.toString()).to.equal(spans[0].span_id.toString())
-                expect(spans[1].meta).to.have.property('component', 'express')
-                expect(spans[2]).to.have.property('resource', 'expressInit')
-                expect(spans[2]).to.have.property('name', 'express.middleware')
-                expect(spans[2].parent_id.toString()).to.equal(spans[0].span_id.toString())
-                expect(spans[2].meta).to.have.property('component', 'express')
-                expect(spans[3]).to.have.property('resource', 'named')
-                expect(spans[3]).to.have.property('name', 'express.middleware')
-                expect(spans[3].parent_id.toString()).to.equal(spans[0].span_id.toString())
-                expect(spans[3].meta).to.have.property('component', 'express')
-                expect(spans[4]).to.have.property('resource', 'router')
-                expect(spans[4]).to.have.property('name', 'express.middleware')
-                expect(spans[4].parent_id.toString()).to.equal(spans[0].span_id.toString())
-                expect(spans[4].meta).to.have.property('component', 'express')
-                expect(spans[5].resource).to.match(/^bound\s.*$/)
-                expect(spans[5]).to.have.property('name', 'express.middleware')
-                expect(spans[5].parent_id.toString()).to.equal(spans[4].span_id.toString())
-                expect(spans[5].meta).to.have.property('component', 'express')
-                expect(spans[6]).to.have.property('resource', '<anonymous>')
-                expect(spans[6]).to.have.property('name', 'express.middleware')
-                expect(spans[6].parent_id.toString()).to.equal(spans[5].span_id.toString())
-                expect(spans[6].meta).to.have.property('component', 'express')
-              })
-              .then(done)
-              .catch(done)
-
-            axios
-              .get(`http://localhost:${port}/app/user/1`)
-              .catch(done)
-          })
-        })
-
-        it('should do automatic instrumentation on middleware that break the async context', done => {
-          let next
-
-          const app = express()
-          const interval = setInterval(() => {
-            if (next) {
-              next()
-              clearInterval(interval)
-            }
-          })
-
-          app.use(function breaking (req, res, _next) {
-            next = _next
-          })
-          app.get('/user/:id', (req, res) => {
-            res.status(200).send()
-          })
-
-          appListener = app.listen(0, 'localhost', () => {
-            const port = appListener.address().port
-
-            agent
-              .use(traces => {
-                const spans = sort(traces[0])
-
-                expect(spans[0]).to.have.property('resource', 'GET /user/:id')
-                expect(spans[0]).to.have.property('name', 'express.request')
-                expect(spans[0].meta).to.have.property('component', 'express')
-                expect(spans[3]).to.have.property('resource', 'breaking')
-                expect(spans[3]).to.have.property('name', 'express.middleware')
-                expect(spans[3].meta).to.have.property('component', 'express')
-              })
-              .then(done)
-              .catch(done)
-
-            axios
-              .get(`http://localhost:${port}/user/1`)
-              .catch(done)
-          })
-        })
-
-        it('should handle errors on middleware that break the async context', done => {
-          let next
-
-          const error = new Error('boom')
-          const app = express()
-          const interval = setInterval(() => {
-            if (next) {
-              next()
-              clearInterval(interval)
-            }
-          })
-
-          app.use(function breaking (req, res, _next) {
-            next = _next
-          })
-          app.use(() => { throw error })
-          // eslint-disable-next-line n/handle-callback-err
-          app.use((err, req, res, next) => next())
-          app.get('/user/:id', (req, res) => {
-            res.status(200).send()
-          })
-
-          appListener = app.listen(0, 'localhost', () => {
-            const port = appListener.address().port
-
-            agent
-              .use(traces => {
-                const spans = sort(traces[0])
-
-                expect(spans[0]).to.have.property('name', 'express.request')
-                expect(spans[4]).to.have.property('name', 'express.middleware')
-                expect(spans[4].meta).to.have.property(ERROR_TYPE, error.name)
-                expect(spans[0].meta).to.have.property('component', 'express')
-                expect(spans[4].meta).to.have.property('component', 'express')
-              })
-              .then(done)
-              .catch(done)
-
-            axios
-              .get(`http://localhost:${port}/user/1`)
-              .catch(done)
-          })
-        })
-
         it('should surround matchers based on regular expressions', done => {
           const app = express()
           const router = express.Router()
@@ -389,40 +250,6 @@ describe('Plugin', () => {
 
             axios
               .get(`http://localhost:${port}/app/user/1`)
-              .catch(done)
-          })
-        })
-
-        it('should only keep the last matching path of a middleware stack', done => {
-          const app = express()
-          const router = express.Router()
-
-          router.use('/', (req, res, next) => next())
-          router.use('*', (req, res, next) => next())
-          router.use('/bar', (req, res, next) => next())
-          router.use('/bar', (req, res, next) => {
-            res.status(200).send()
-          })
-
-          app.use('/', (req, res, next) => next())
-          app.use('*', (req, res, next) => next())
-          app.use('/foo/bar', (req, res, next) => next())
-          app.use('/foo', router)
-
-          appListener = app.listen(0, 'localhost', () => {
-            const port = appListener.address().port
-
-            agent
-              .use(traces => {
-                const spans = sort(traces[0])
-
-                expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
-              })
-              .then(done)
-              .catch(done)
-
-            axios
-              .get(`http://localhost:${port}/foo/bar`)
               .catch(done)
           })
         })
@@ -1124,121 +951,6 @@ describe('Plugin', () => {
           })
         })
 
-        it('should handle middleware errors', done => {
-          const app = express()
-          const error = new Error('boom')
-
-          app.use((req, res, next) => next(error))
-          // eslint-disable-next-line n/handle-callback-err
-          app.use((error, req, res, next) => res.status(500).send())
-
-          appListener = app.listen(0, 'localhost', () => {
-            const port = appListener.address().port
-
-            agent
-              .use(traces => {
-                const spans = sort(traces[0])
-
-                expect(spans[0]).to.have.property('error', 1)
-                expect(spans[0].meta).to.have.property(ERROR_TYPE, error.name)
-                expect(spans[0].meta).to.have.property(ERROR_MESSAGE, error.message)
-                expect(spans[0].meta).to.have.property(ERROR_STACK, error.stack)
-                expect(spans[0].meta).to.have.property('component', 'express')
-                expect(spans[3]).to.have.property('error', 1)
-                expect(spans[3].meta).to.have.property(ERROR_TYPE, error.name)
-                expect(spans[3].meta).to.have.property(ERROR_MESSAGE, error.message)
-                expect(spans[3].meta).to.have.property(ERROR_STACK, error.stack)
-                expect(spans[3].meta).to.have.property('component', 'express')
-              })
-              .then(done)
-              .catch(done)
-
-            axios
-              .get(`http://localhost:${port}/user`, {
-                validateStatus: status => status === 500
-              })
-              .catch(done)
-          })
-        })
-
-        it('should handle middleware exceptions', done => {
-          const app = express()
-          const error = new Error('boom')
-
-          app.use((req, res) => { throw error })
-          // eslint-disable-next-line n/handle-callback-err
-          app.use((error, req, res, next) => res.status(500).send())
-
-          appListener = app.listen(0, 'localhost', () => {
-            const port = appListener.address().port
-
-            agent
-              .use(traces => {
-                const spans = sort(traces[0])
-
-                expect(spans[0]).to.have.property('error', 1)
-                expect(spans[0].meta).to.have.property(ERROR_TYPE, error.name)
-                expect(spans[0].meta).to.have.property(ERROR_MESSAGE, error.message)
-                expect(spans[0].meta).to.have.property(ERROR_STACK, error.stack)
-                expect(spans[0].meta).to.have.property('component', 'express')
-                expect(spans[3]).to.have.property('error', 1)
-                expect(spans[3].meta).to.have.property(ERROR_TYPE, error.name)
-                expect(spans[3].meta).to.have.property(ERROR_MESSAGE, error.message)
-                expect(spans[3].meta).to.have.property(ERROR_STACK, error.stack)
-                expect(spans[0].meta).to.have.property('component', 'express')
-              })
-              .then(done)
-              .catch(done)
-
-            axios
-              .get(`http://localhost:${port}/user`, {
-                validateStatus: status => status === 500
-              })
-              .catch(done)
-          })
-        })
-
-        it('should support capturing groups in routes', done => {
-          const app = express()
-
-          app.get('/:path(*)', (req, res) => {
-            res.status(200).send()
-          })
-
-          appListener = app.listen(0, 'localhost', () => {
-            const port = appListener.address().port
-
-            agent
-              .use(traces => {
-                const spans = sort(traces[0])
-
-                expect(spans[0]).to.have.property('resource', 'GET /:path(*)')
-                expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
-              })
-              .then(done)
-              .catch(done)
-
-            axios
-              .get(`http://localhost:${port}/user`)
-              .catch(done)
-          })
-        })
-
-        it('should keep the properties untouched on nested router handlers', () => {
-          const router = express.Router()
-          const childRouter = express.Router()
-
-          childRouter.get('/:id', (req, res) => {
-            res.status(200).send()
-          })
-
-          router.use('/users', childRouter)
-
-          const layer = router.stack.find(layer => layer.regexp.test('/users'))
-
-          expect(layer.handle).to.have.ownProperty('stack')
-        })
-
         it('should keep user stores untouched', done => {
           const app = express()
           const storage = new AsyncLocalStorage()
@@ -1372,6 +1084,298 @@ describe('Plugin', () => {
             })
           })
         })
+
+        if (semver.intersects(version, '<5.0.0')) {
+          it('should do automatic instrumentation on middleware', done => {
+            const app = express()
+            const router = express.Router()
+
+            router.get('/user/:id', (req, res) => {
+              res.status(200).send()
+            })
+
+            app.use(function named (req, res, next) { next() })
+            app.use('/app', router)
+
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                  expect(spans[0]).to.have.property('name', 'express.request')
+                  expect(spans[0].meta).to.have.property('component', 'express')
+                  expect(spans[1]).to.have.property('resource', 'query')
+                  expect(spans[1]).to.have.property('name', 'express.middleware')
+                  expect(spans[1].parent_id.toString()).to.equal(spans[0].span_id.toString())
+                  expect(spans[1].meta).to.have.property('component', 'express')
+                  expect(spans[2]).to.have.property('resource', 'expressInit')
+                  expect(spans[2]).to.have.property('name', 'express.middleware')
+                  expect(spans[2].parent_id.toString()).to.equal(spans[0].span_id.toString())
+                  expect(spans[2].meta).to.have.property('component', 'express')
+                  expect(spans[3]).to.have.property('resource', 'named')
+                  expect(spans[3]).to.have.property('name', 'express.middleware')
+                  expect(spans[3].parent_id.toString()).to.equal(spans[0].span_id.toString())
+                  expect(spans[3].meta).to.have.property('component', 'express')
+                  expect(spans[4]).to.have.property('resource', 'router')
+                  expect(spans[4]).to.have.property('name', 'express.middleware')
+                  expect(spans[4].parent_id.toString()).to.equal(spans[0].span_id.toString())
+                  expect(spans[4].meta).to.have.property('component', 'express')
+                  expect(spans[5].resource).to.match(/^bound\s.*$/)
+                  expect(spans[5]).to.have.property('name', 'express.middleware')
+                  expect(spans[5].parent_id.toString()).to.equal(spans[4].span_id.toString())
+                  expect(spans[5].meta).to.have.property('component', 'express')
+                  expect(spans[6]).to.have.property('resource', '<anonymous>')
+                  expect(spans[6]).to.have.property('name', 'express.middleware')
+                  expect(spans[6].parent_id.toString()).to.equal(spans[5].span_id.toString())
+                  expect(spans[6].meta).to.have.property('component', 'express')
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/app/user/1`)
+                .catch(done)
+            })
+          })
+
+          it('should do automatic instrumentation on middleware that break the async context', done => {
+            let next
+
+            const app = express()
+            const interval = setInterval(() => {
+              if (next) {
+                next()
+                clearInterval(interval)
+              }
+            })
+
+            app.use(function breaking (req, res, _next) {
+              next = _next
+            })
+            app.get('/user/:id', (req, res) => {
+              res.status(200).send()
+            })
+
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('resource', 'GET /user/:id')
+                  expect(spans[0]).to.have.property('name', 'express.request')
+                  expect(spans[0].meta).to.have.property('component', 'express')
+                  expect(spans[3]).to.have.property('resource', 'breaking')
+                  expect(spans[3]).to.have.property('name', 'express.middleware')
+                  expect(spans[3].meta).to.have.property('component', 'express')
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/user/1`)
+                .catch(done)
+            })
+          })
+
+          it('should handle errors on middleware that break the async context', done => {
+            let next
+
+            const error = new Error('boom')
+            const app = express()
+            const interval = setInterval(() => {
+              if (next) {
+                next()
+                clearInterval(interval)
+              }
+            })
+
+            app.use(function breaking (req, res, _next) {
+              next = _next
+            })
+            app.use(() => { throw error })
+            // eslint-disable-next-line n/handle-callback-err
+            app.use((err, req, res, next) => next())
+            app.get('/user/:id', (req, res) => {
+              res.status(200).send()
+            })
+
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('name', 'express.request')
+                  expect(spans[4]).to.have.property('name', 'express.middleware')
+                  expect(spans[4].meta).to.have.property(ERROR_TYPE, error.name)
+                  expect(spans[0].meta).to.have.property('component', 'express')
+                  expect(spans[4].meta).to.have.property('component', 'express')
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/user/1`)
+                .catch(done)
+            })
+          })
+
+          // express v5 doesn't support regex paths
+          it('should only keep the last matching path of a middleware stack', done => {
+            const app = express()
+            const router = express.Router()
+
+            router.use('/', (req, res, next) => next())
+            router.use('*', (req, res, next) => next())
+            router.use('/bar', (req, res, next) => next())
+            router.use('/bar', (req, res, next) => {
+              res.status(200).send()
+            })
+
+            app.use('/', (req, res, next) => next())
+            app.use('*', (req, res, next) => next())
+            app.use('/foo/bar', (req, res, next) => next())
+            app.use('/foo', router)
+
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/foo/bar`)
+                .catch(done)
+            })
+          })
+
+          it('should handle middleware errors', done => {
+            const app = express()
+            const error = new Error('boom')
+
+            app.use((req, res, next) => next(error))
+            // eslint-disable-next-line n/handle-callback-err
+            app.use((error, req, res, next) => res.status(500).send())
+
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('error', 1)
+                  expect(spans[0].meta).to.have.property(ERROR_TYPE, error.name)
+                  expect(spans[0].meta).to.have.property(ERROR_MESSAGE, error.message)
+                  expect(spans[0].meta).to.have.property(ERROR_STACK, error.stack)
+                  expect(spans[0].meta).to.have.property('component', 'express')
+                  expect(spans[3]).to.have.property('error', 1)
+                  expect(spans[3].meta).to.have.property(ERROR_TYPE, error.name)
+                  expect(spans[3].meta).to.have.property(ERROR_MESSAGE, error.message)
+                  expect(spans[3].meta).to.have.property(ERROR_STACK, error.stack)
+                  expect(spans[3].meta).to.have.property('component', 'express')
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  validateStatus: status => status === 500
+                })
+                .catch(done)
+            })
+          })
+
+          it('should handle middleware exceptions', done => {
+            const app = express()
+            const error = new Error('boom')
+
+            app.use((req, res) => { throw error })
+            // eslint-disable-next-line n/handle-callback-err
+            app.use((error, req, res, next) => res.status(500).send())
+
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('error', 1)
+                  expect(spans[0].meta).to.have.property(ERROR_TYPE, error.name)
+                  expect(spans[0].meta).to.have.property(ERROR_MESSAGE, error.message)
+                  expect(spans[0].meta).to.have.property(ERROR_STACK, error.stack)
+                  expect(spans[0].meta).to.have.property('component', 'express')
+                  expect(spans[3]).to.have.property('error', 1)
+                  expect(spans[3].meta).to.have.property(ERROR_TYPE, error.name)
+                  expect(spans[3].meta).to.have.property(ERROR_MESSAGE, error.message)
+                  expect(spans[3].meta).to.have.property(ERROR_STACK, error.stack)
+                  expect(spans[0].meta).to.have.property('component', 'express')
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/user`, {
+                  validateStatus: status => status === 500
+                })
+                .catch(done)
+            })
+          })
+
+          it('should support capturing groups in routes', done => {
+            const app = express()
+
+            app.get('/:path(*)', (req, res) => {
+              res.status(200).send()
+            })
+
+            appListener = app.listen(0, 'localhost', () => {
+              const port = appListener.address().port
+
+              agent
+                .use(traces => {
+                  const spans = sort(traces[0])
+
+                  expect(spans[0]).to.have.property('resource', 'GET /:path(*)')
+                  expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
+                })
+                .then(done)
+                .catch(done)
+
+              axios
+                .get(`http://localhost:${port}/user`)
+                .catch(done)
+            })
+          })
+
+          it('should keep the properties untouched on nested router handlers', () => {
+            const router = express.Router()
+            const childRouter = express.Router()
+
+            childRouter.get('/:id', (req, res) => {
+              res.status(200).send()
+            })
+
+            router.use('/users', childRouter)
+
+            const layer = router.stack.find(layer => layer.regexp.test('/users'))
+
+            expect(layer.handle).to.have.ownProperty('stack')
+          })
+        }
       })
 
       describe('with configuration', () => {

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -7,6 +7,7 @@ const {
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
+const semver = require('semver')
 
 describe('esm', () => {
   let agent
@@ -34,18 +35,36 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    it('is instrumented', async () => {
-      proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+    // express less than <5.0 uses their own router, which creates more middleware spans than the router
+    // that is used for v5+
+    if (semver.intersects(version, '<5.0.0')) {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
 
-      return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
-        assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
-        assert.isArray(payload)
-        assert.strictEqual(payload.length, 1)
-        assert.isArray(payload[0])
-        assert.strictEqual(payload[0].length, 4)
-        assert.propertyVal(payload[0][0], 'name', 'express.request')
-        assert.propertyVal(payload[0][1], 'name', 'express.middleware')
-      })
-    }).timeout(50000)
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(payload.length, 1)
+          assert.isArray(payload[0])
+          assert.strictEqual(payload[0].length, 4)
+          assert.propertyVal(payload[0][0], 'name', 'express.request')
+          assert.propertyVal(payload[0][1], 'name', 'express.middleware')
+        })
+      }).timeout(50000)
+    } else {
+      it('is instrumented', async () => {
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'server.mjs', agent.port)
+
+        return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(payload.length, 1)
+          assert.isArray(payload[0])
+          assert.strictEqual(payload[0].length, 3)
+          assert.propertyVal(payload[0][0], 'name', 'express.request')
+          assert.propertyVal(payload[0][1], 'name', 'express.middleware')
+        })
+      }).timeout(50000)
+    }
   })
 })


### PR DESCRIPTION
### What does this PR do?
Fixes express v5 which was newly released. The main change is the new version does not contain any express routing code, and all routing is now handled by the routing package. To fix the integration, we don't wrap any router traced methods.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


