### PR TITLE
add guardrail to completely bail out in very old versions

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -34,7 +34,7 @@ jobs:
   integration-guardrails:
     strategy:
       matrix:
-        version: [12, 14, 16]
+        version: [10, 12, 14, 16]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -34,7 +34,7 @@ jobs:
   integration-guardrails:
     strategy:
       matrix:
-        version: [10, 12, 14, 16]
+        version: [12, 14, 16]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -44,6 +44,20 @@ jobs:
       - uses: ./.github/actions/install
       - run: node node_modules/.bin/mocha --colors --timeout 30000 integration-tests/init.spec.js
 
+  integration-guardrails-unsupported:
+    strategy:
+      matrix:
+        version: ['0.10', '4', '6', '8', '10']
+    runs-on: ubuntu-latest
+    env:
+      DD_INJECTION_ENABLED: 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - run: node ./init
+
   integration-ci:
     strategy:
       matrix:

--- a/init.js
+++ b/init.js
@@ -51,7 +51,7 @@ if (NODE_MAJOR >= 12) {
           { name: 'abort.runtime', tags: [] }
         ])
         log.info('Aborting application instrumentation due to incompatible_runtime.')
-        log.info(`Found incompatible runtime nodejs ${version}, Supported runtimes: nodejs ${engines.node}.`)
+        log.info('Found incompatible runtime nodejs ' + version + ', Supported runtimes: nodejs ' + engines.node + '.')
         if (forced) {
           log.info('DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.')
         }
@@ -63,7 +63,7 @@ if (NODE_MAJOR >= 12) {
     var tracer = require('.')
     tracer.init()
     module.exports = tracer
-    telemetry('complete', [`injection_forced:${forced && initBailout ? 'true' : 'false'}`])
+    telemetry('complete', ['injection_forced:' + forced && initBailout ? 'true' : 'false'])
     log.info('Application instrumentation bootstrapping complete')
   }
 }

--- a/init.js
+++ b/init.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-const NODE_MAJOR = require('./version').NODE_MAJOR
+var NODE_MAJOR = require('./version').NODE_MAJOR
 
 // We use several things that are not supported by older versions of Node:
 // - AsyncLocalStorage
@@ -10,30 +10,30 @@ const NODE_MAJOR = require('./version').NODE_MAJOR
 // and probably others.
 // TODO: Remove all these dependencies so that we can report telemetry.
 if (NODE_MAJOR >= 12) {
-  const path = require('path')
-  const Module = require('module')
-  const semver = require('semver')
-  const log = require('./packages/dd-trace/src/log')
-  const isTrue = require('./packages/dd-trace/src/util').isTrue
-  const telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
+  var path = require('path')
+  var Module = require('module')
+  var semver = require('semver')
+  var log = require('./packages/dd-trace/src/log')
+  var isTrue = require('./packages/dd-trace/src/util').isTrue
+  var telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
 
-  let initBailout = false
-  let clobberBailout = false
-  const forced = isTrue(process.env.DD_INJECT_FORCE)
+  var initBailout = false
+  var clobberBailout = false
+  var forced = isTrue(process.env.DD_INJECT_FORCE)
 
   if (process.env.DD_INJECTION_ENABLED) {
     // If we're running via single-step install, and we're not in the app's
     // node_modules, then we should not initialize the tracer. This prevents
     // single-step-installed tracer from clobbering the manually-installed tracer.
-    let resolvedInApp
-    const entrypoint = process.argv[1]
+    var resolvedInApp
+    var entrypoint = process.argv[1]
     try {
       resolvedInApp = Module.createRequire(entrypoint).resolve('dd-trace')
     } catch (e) {
       // Ignore. If we can't resolve the module, we assume it's not in the app.
     }
     if (resolvedInApp) {
-      const ourselves = path.join(__dirname, 'index.js')
+      var ourselves = path.join(__dirname, 'index.js')
       if (ourselves !== resolvedInApp) {
         clobberBailout = true
       }
@@ -42,8 +42,8 @@ if (NODE_MAJOR >= 12) {
     // If we're running via single-step install, and the runtime doesn't match
     // the engines field in package.json, then we should not initialize the tracer.
     if (!clobberBailout) {
-      const engines = require('./package.json').engines
-      const version = process.versions.node
+      var engines = require('./package.json').engines
+      var version = process.versions.node
       if (!semver.satisfies(version, engines.node)) {
         initBailout = true
         telemetry([
@@ -60,7 +60,7 @@ if (NODE_MAJOR >= 12) {
   }
 
   if (!clobberBailout && (!initBailout || forced)) {
-    const tracer = require('.')
+    var tracer = require('.')
     tracer.init()
     module.exports = tracer
     telemetry('complete', [`injection_forced:${forced && initBailout ? 'true' : 'false'}`])

--- a/init.js
+++ b/init.js
@@ -1,4 +1,6 @@
-/* eslint-disable */
+'use strict'
+
+/* eslint-disable no-var */
 
 var NODE_MAJOR = require('./version').NODE_MAJOR
 

--- a/init.js
+++ b/init.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint-disable */
+
 const { NODE_MAJOR } = require('./version')
 
 // We use several things that are not supported by older versions of Node:
@@ -9,63 +11,61 @@ const { NODE_MAJOR } = require('./version')
 // - Mocha (for testing)
 // and probably others.
 // TODO: Remove all these dependencies so that we can report telemetry.
-if (NODE_MAJOR < 12) {
-  process.exit(0)
-}
+if (NODE_MAJOR >= 12) {
+  const path = require('path')
+  const Module = require('module')
+  const semver = require('semver')
+  const log = require('./packages/dd-trace/src/log')
+  const { isTrue } = require('./packages/dd-trace/src/util')
+  const telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
 
-const path = require('path')
-const Module = require('module')
-const semver = require('semver')
-const log = require('./packages/dd-trace/src/log')
-const { isTrue } = require('./packages/dd-trace/src/util')
-const telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
+  let initBailout = false
+  let clobberBailout = false
+  const forced = isTrue(process.env.DD_INJECT_FORCE)
 
-let initBailout = false
-let clobberBailout = false
-const forced = isTrue(process.env.DD_INJECT_FORCE)
-
-if (process.env.DD_INJECTION_ENABLED) {
-  // If we're running via single-step install, and we're not in the app's
-  // node_modules, then we should not initialize the tracer. This prevents
-  // single-step-installed tracer from clobbering the manually-installed tracer.
-  let resolvedInApp
-  const entrypoint = process.argv[1]
-  try {
-    resolvedInApp = Module.createRequire(entrypoint).resolve('dd-trace')
-  } catch (e) {
-    // Ignore. If we can't resolve the module, we assume it's not in the app.
-  }
-  if (resolvedInApp) {
-    const ourselves = path.join(__dirname, 'index.js')
-    if (ourselves !== resolvedInApp) {
-      clobberBailout = true
+  if (process.env.DD_INJECTION_ENABLED) {
+    // If we're running via single-step install, and we're not in the app's
+    // node_modules, then we should not initialize the tracer. This prevents
+    // single-step-installed tracer from clobbering the manually-installed tracer.
+    let resolvedInApp
+    const entrypoint = process.argv[1]
+    try {
+      resolvedInApp = Module.createRequire(entrypoint).resolve('dd-trace')
+    } catch (e) {
+      // Ignore. If we can't resolve the module, we assume it's not in the app.
     }
-  }
+    if (resolvedInApp) {
+      const ourselves = path.join(__dirname, 'index.js')
+      if (ourselves !== resolvedInApp) {
+        clobberBailout = true
+      }
+    }
 
-  // If we're running via single-step install, and the runtime doesn't match
-  // the engines field in package.json, then we should not initialize the tracer.
-  if (!clobberBailout) {
-    const { engines } = require('./package.json')
-    const version = process.versions.node
-    if (!semver.satisfies(version, engines.node)) {
-      initBailout = true
-      telemetry([
-        { name: 'abort', tags: ['reason:incompatible_runtime'] },
-        { name: 'abort.runtime', tags: [] }
-      ])
-      log.info('Aborting application instrumentation due to incompatible_runtime.')
-      log.info(`Found incompatible runtime nodejs ${version}, Supported runtimes: nodejs ${engines.node}.`)
-      if (forced) {
-        log.info('DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.')
+    // If we're running via single-step install, and the runtime doesn't match
+    // the engines field in package.json, then we should not initialize the tracer.
+    if (!clobberBailout) {
+      const { engines } = require('./package.json')
+      const version = process.versions.node
+      if (!semver.satisfies(version, engines.node)) {
+        initBailout = true
+        telemetry([
+          { name: 'abort', tags: ['reason:incompatible_runtime'] },
+          { name: 'abort.runtime', tags: [] }
+        ])
+        log.info('Aborting application instrumentation due to incompatible_runtime.')
+        log.info(`Found incompatible runtime nodejs ${version}, Supported runtimes: nodejs ${engines.node}.`)
+        if (forced) {
+          log.info('DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.')
+        }
       }
     }
   }
-}
 
-if (!clobberBailout && (!initBailout || forced)) {
-  const tracer = require('.')
-  tracer.init()
-  module.exports = tracer
-  telemetry('complete', [`injection_forced:${forced && initBailout ? 'true' : 'false'}`])
-  log.info('Application instrumentation bootstrapping complete')
+  if (!clobberBailout && (!initBailout || forced)) {
+    const tracer = require('.')
+    tracer.init()
+    module.exports = tracer
+    telemetry('complete', [`injection_forced:${forced && initBailout ? 'true' : 'false'}`])
+    log.info('Application instrumentation bootstrapping complete')
+  }
 }

--- a/init.js
+++ b/init.js
@@ -1,5 +1,18 @@
 'use strict'
 
+const { NODE_MAJOR } = require('./version')
+
+// We use several things that are not supported by older versions of Node:
+// - AsyncLocalStorage
+// - The `semver` module
+// - dc-polyfill
+// - Mocha (for testing)
+// and probably others.
+// TODO: Remove all these dependencies so that we can report telemetry.
+if (NODE_MAJOR < 12) {
+  process.exit(0)
+}
+
 const path = require('path')
 const Module = require('module')
 const semver = require('semver')

--- a/init.js
+++ b/init.js
@@ -65,7 +65,7 @@ if (NODE_MAJOR >= 12) {
     var tracer = require('.')
     tracer.init()
     module.exports = tracer
-    telemetry('complete', ['injection_forced:' + forced && initBailout ? 'true' : 'false'])
+    telemetry('complete', ['injection_forced:' + (forced && initBailout ? 'true' : 'false')])
     log.info('Application instrumentation bootstrapping complete')
   }
 }

--- a/init.js
+++ b/init.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-const { NODE_MAJOR } = require('./version')
+const NODE_MAJOR = require('./version').NODE_MAJOR
 
 // We use several things that are not supported by older versions of Node:
 // - AsyncLocalStorage
@@ -14,7 +14,7 @@ if (NODE_MAJOR >= 12) {
   const Module = require('module')
   const semver = require('semver')
   const log = require('./packages/dd-trace/src/log')
-  const { isTrue } = require('./packages/dd-trace/src/util')
+  const isTrue = require('./packages/dd-trace/src/util').isTrue
   const telemetry = require('./packages/dd-trace/src/telemetry/init-telemetry')
 
   let initBailout = false
@@ -42,7 +42,7 @@ if (NODE_MAJOR >= 12) {
     // If we're running via single-step install, and the runtime doesn't match
     // the engines field in package.json, then we should not initialize the tracer.
     if (!clobberBailout) {
-      const { engines } = require('./package.json')
+      const engines = require('./package.json').engines
       const version = process.versions.node
       if (!semver.satisfies(version, engines.node)) {
         initBailout = true

--- a/init.js
+++ b/init.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /* eslint-disable */
 
 const { NODE_MAJOR } = require('./version')

--- a/version.js
+++ b/version.js
@@ -1,7 +1,9 @@
 'use strict'
 
-const ddMatches = require('./package.json').version.match(/^(\d+)\.(\d+)\.(\d+)/)
-const nodeMatches = process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/)
+/* eslint-disable no-var */
+
+var ddMatches = require('./package.json').version.match(/^(\d+)\.(\d+)\.(\d+)/)
+var nodeMatches = process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/)
 
 module.exports = {
   DD_MAJOR: parseInt(ddMatches[1]),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add guardrail to completely bail out in very old versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise these versions could error out, and preventing that would require significant changes to telemetry, logging and tests, so for now this PR focuses on at least making sure we are not loading at all.