### PR TITLE
[ASM] Discard inferred spans when resolving the root span of a trace

### DIFF
--- a/packages/dd-trace/src/appsec/sdk/utils.js
+++ b/packages/dd-trace/src/appsec/sdk/utils.js
@@ -1,8 +1,27 @@
 'use strict'
 
 function getRootSpan (tracer) {
-  const span = tracer.scope().active()
-  return span && span.context()._trace.started[0]
+  let span = tracer.scope().active()
+  if (!span) return
+
+  const context = span.context()
+  const started = context._trace.started
+
+  let parentId = context._parentId
+  while (parentId) {
+    const parent = started.find(s => s.context()._spanId === parentId)
+    const pContext = parent?.context()
+
+    if (pContext) {
+      parentId = pContext._parentId
+
+      if (!pContext._tags?._inferred_span) {
+        span = parent
+      }
+    }
+  }
+
+  return span
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/sdk/utils.js
+++ b/packages/dd-trace/src/appsec/sdk/utils.js
@@ -18,6 +18,8 @@ function getRootSpan (tracer) {
       if (!pContext._tags?._inferred_span) {
         span = parent
       }
+    } else {
+      break
     }
   }
 

--- a/packages/dd-trace/src/appsec/sdk/utils.js
+++ b/packages/dd-trace/src/appsec/sdk/utils.js
@@ -12,14 +12,12 @@ function getRootSpan (tracer) {
     const parent = started.find(s => s.context()._spanId === parentId)
     const pContext = parent?.context()
 
-    if (pContext) {
-      parentId = pContext._parentId
+    if (!pContext) break
 
-      if (!pContext._tags?._inferred_span) {
-        span = parent
-      }
-    } else {
-      break
+    parentId = pContext._parentId
+
+    if (!pContext._tags?._inferred_span) {
+      span = parent
     }
   }
 

--- a/packages/dd-trace/test/appsec/sdk/utils.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/utils.spec.js
@@ -3,17 +3,16 @@
 const { assert } = require('chai')
 
 const { getRootSpan } = require('../../../src/appsec/sdk/utils')
-const Tracer = require('../../../src/proxy')
+const DatadogTracer = require('../../../src/tracer')
 const Config = require('../../../src/config')
 
 describe('Appsec SDK utils', () => {
   let tracer
 
   before(() => {
-    tracer = new Tracer(new Config({
+    tracer = new DatadogTracer(new Config({
       enabled: true
     }))
-    tracer.init()
   })
 
   describe('getRootSpan', () => {

--- a/packages/dd-trace/test/appsec/sdk/utils.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/utils.spec.js
@@ -1,0 +1,155 @@
+'use strict'
+
+const { assert } = require('chai')
+
+const { getRootSpan } = require('../../../src/appsec/sdk/utils')
+const Tracer = require('../../../src/proxy')
+const Config = require('../../../src/config')
+
+describe('Appsec SDK utils', () => {
+  let tracer
+
+  before(() => {
+    tracer = new Tracer(new Config({
+      enabled: true
+    }))
+    tracer.init()
+  })
+
+  describe('getRootSpan', () => {
+    it('should return root span if there are no childs', () => {
+      tracer.trace('parent', { }, parent => {
+        const root = getRootSpan(tracer)
+
+        assert.equal(parent, root)
+      })
+    })
+
+    it('should return root span of single child', () => {
+      const childOf = tracer.startSpan('parent')
+
+      tracer.trace('child1', { childOf }, child1 => {
+        const root = getRootSpan(tracer)
+
+        assert.equal(childOf, root)
+      })
+    })
+
+    it('should return root span of multiple child', () => {
+      const childOf = tracer.startSpan('parent')
+
+      tracer.trace('child1.1', { childOf }, child11 => {
+        tracer.trace('child1.1.2', { childOf: child11 }, child112 => {})
+      })
+      tracer.trace('child1.2', { childOf }, child12 => {
+        const root = getRootSpan(tracer)
+
+        assert.equal(childOf, root)
+      })
+    })
+
+    it('should return root span of single child discarding inferred spans', () => {
+      const childOf = tracer.startSpan('parent')
+      childOf.setTag('_inferred_span', {})
+
+      tracer.trace('child1', { childOf }, child1 => {
+        const root = getRootSpan(tracer)
+
+        assert.equal(child1, root)
+      })
+    })
+
+    it('should return root span of an inferred span', () => {
+      const childOf = tracer.startSpan('parent')
+
+      tracer.trace('child1', { childOf }, child1 => {
+        child1.setTag('_inferred_span', {})
+
+        const root = getRootSpan(tracer)
+
+        assert.equal(childOf, root)
+      })
+    })
+
+    it('should return root span of an inferred span with inferred parent', () => {
+      const childOf = tracer.startSpan('parent')
+      childOf.setTag('_inferred_span', {})
+
+      tracer.trace('child1', { childOf }, child1 => {
+        child1.setTag('_inferred_span', {})
+
+        const root = getRootSpan(tracer)
+
+        assert.equal(child1, root)
+      })
+    })
+
+    it('should return root span discarding inferred spans (mutiple childs)', () => {
+      const childOf = tracer.startSpan('parent')
+      childOf.setTag('_inferred_span', {})
+
+      tracer.trace('child1.1', { childOf }, child11 => {})
+      tracer.trace('child1.2', { childOf }, child12 => {
+        tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
+          const root = getRootSpan(tracer)
+
+          assert.equal(child12, root)
+        })
+      })
+    })
+
+    it('should return root span discarding inferred spans if it is direct parent (mutiple childs)', () => {
+      const childOf = tracer.startSpan('parent')
+
+      tracer.trace('child1.1', { childOf }, child11 => {})
+      tracer.trace('child1.2', { childOf }, child12 => {
+        child12.setTag('_inferred_span', {})
+
+        tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
+          const root = getRootSpan(tracer)
+
+          assert.equal(childOf, root)
+        })
+      })
+    })
+
+    it('should return root span discarding multiple inferred spans', () => {
+      const childOf = tracer.startSpan('parent')
+
+      tracer.trace('child1.1', { childOf }, child11 => {})
+      tracer.trace('child1.2', { childOf }, child12 => {
+        child12.setTag('_inferred_span', {})
+
+        tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
+          child121.setTag('_inferred_span', {})
+
+          tracer.trace('child1.2.1.1', { childOf: child121 }, child1211 => {
+            const root = getRootSpan(tracer)
+
+            assert.equal(childOf, root)
+          })
+        })
+      })
+    })
+
+    it('should return itself as root span if all are inferred spans', () => {
+      const childOf = tracer.startSpan('parent')
+      childOf.setTag('_inferred_span', {})
+
+      tracer.trace('child1.1', { childOf }, child11 => {})
+      tracer.trace('child1.2', { childOf }, child12 => {
+        child12.setTag('_inferred_span', {})
+
+        tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
+          child121.setTag('_inferred_span', {})
+
+          tracer.trace('child1.2.1.1', { childOf: child121 }, child1211 => {
+            const root = getRootSpan(tracer)
+
+            assert.equal(child1211, root)
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/sdk/utils.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/utils.spec.js
@@ -5,6 +5,7 @@ const { assert } = require('chai')
 const { getRootSpan } = require('../../../src/appsec/sdk/utils')
 const DatadogTracer = require('../../../src/tracer')
 const Config = require('../../../src/config')
+const id = require('../../../src/id')
 
 describe('Appsec SDK utils', () => {
   let tracer
@@ -26,6 +27,17 @@ describe('Appsec SDK utils', () => {
 
     it('should return root span of single child', () => {
       const childOf = tracer.startSpan('parent')
+
+      tracer.trace('child1', { childOf }, child1 => {
+        const root = getRootSpan(tracer)
+
+        assert.equal(childOf, root)
+      })
+    })
+
+    it('should return root span of single child from unknown parent', () => {
+      const childOf = tracer.startSpan('parent')
+      childOf.context()._parentId = id()
 
       tracer.trace('child1', { childOf }, child1 => {
         const root = getRootSpan(tracer)

--- a/packages/dd-trace/test/appsec/sdk/utils.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/utils.spec.js
@@ -21,7 +21,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('parent', { }, parent => {
         const root = getRootSpan(tracer)
 
-        assert.equal(parent, root)
+        assert.equal(root, parent)
       })
     })
 
@@ -31,7 +31,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('child1', { childOf }, child1 => {
         const root = getRootSpan(tracer)
 
-        assert.equal(childOf, root)
+        assert.equal(root, childOf)
       })
     })
 
@@ -42,7 +42,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('child1', { childOf }, child1 => {
         const root = getRootSpan(tracer)
 
-        assert.equal(childOf, root)
+        assert.equal(root, childOf)
       })
     })
 
@@ -55,7 +55,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('child1.2', { childOf }, child12 => {
         const root = getRootSpan(tracer)
 
-        assert.equal(childOf, root)
+        assert.equal(root, childOf)
       })
     })
 
@@ -66,7 +66,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('child1', { childOf }, child1 => {
         const root = getRootSpan(tracer)
 
-        assert.equal(child1, root)
+        assert.equal(root, child1)
       })
     })
 
@@ -78,7 +78,7 @@ describe('Appsec SDK utils', () => {
 
         const root = getRootSpan(tracer)
 
-        assert.equal(childOf, root)
+        assert.equal(root, childOf)
       })
     })
 
@@ -91,7 +91,7 @@ describe('Appsec SDK utils', () => {
 
         const root = getRootSpan(tracer)
 
-        assert.equal(child1, root)
+        assert.equal(root, child1)
       })
     })
 
@@ -104,7 +104,7 @@ describe('Appsec SDK utils', () => {
         tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
           const root = getRootSpan(tracer)
 
-          assert.equal(child12, root)
+          assert.equal(root, child12)
         })
       })
     })
@@ -119,7 +119,7 @@ describe('Appsec SDK utils', () => {
         tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
           const root = getRootSpan(tracer)
 
-          assert.equal(childOf, root)
+          assert.equal(root, childOf)
         })
       })
     })
@@ -137,7 +137,7 @@ describe('Appsec SDK utils', () => {
           tracer.trace('child1.2.1.1', { childOf: child121 }, child1211 => {
             const root = getRootSpan(tracer)
 
-            assert.equal(childOf, root)
+            assert.equal(root, childOf)
           })
         })
       })
@@ -157,7 +157,7 @@ describe('Appsec SDK utils', () => {
           tracer.trace('child1.2.1.1', { childOf: child121 }, child1211 => {
             const root = getRootSpan(tracer)
 
-            assert.equal(child1211, root)
+            assert.equal(root, child1211)
           })
         })
       })


### PR DESCRIPTION
### What does this PR do?
Visit upwards parent spans in order to discard possible inferred spans based on the `_inferred_span` tag

### Motivation
Fix an Appsec SDK `trackEvent` method problem in serverless environments. SDK root span resolution differs from that of the tracer and tags added by the SDK may be lost if they are added in a inferred span.



### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


