### PR TITLE
Remove `x-forwarded` from ipHeaderList

### DIFF
--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -32,6 +32,7 @@ const contentHeaderList = [
 
 const EVENT_HEADERS_MAP = mapHeaderAndTags([
   ...ipHeaderList,
+  'x-forwarded',
   'forwarded',
   'via',
   ...contentHeaderList,

--- a/packages/dd-trace/src/plugins/util/ip_extractor.js
+++ b/packages/dd-trace/src/plugins/util/ip_extractor.js
@@ -8,7 +8,6 @@ const ipHeaderList = [
   'x-real-ip',
   'true-client-ip',
   'x-client-ip',
-  'x-forwarded',
   'forwarded-for',
   'x-cluster-client-ip',
   'fastly-client-ip',

--- a/packages/dd-trace/test/plugins/util/ip_extractor.spec.js
+++ b/packages/dd-trace/test/plugins/util/ip_extractor.spec.js
@@ -34,7 +34,6 @@ describe('ip extractor', () => {
     'x-real-ip',
     'true-client-ip',
     'x-client-ip',
-    'x-forwarded',
     'forwarded-for',
     'x-cluster-client-ip',
     'fastly-client-ip',


### PR DESCRIPTION
### What does this PR do?
Remove the `x-forwarded` header from the IP collection list, but keep it in the tags collection.
