### PR TITLE
chore(llmobs): tracer version tagging

### DIFF
--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -291,7 +291,7 @@ class LLMObs extends NoopLLMObs {
     }
 
     const evaluationTags = {
-      'dd-trace.version': tracerVersion,
+      'ddtrace.version': tracerVersion,
       ml_app: mlApp
     }
 

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -179,7 +179,7 @@ class LLMObsSpanProcessor {
       service: this._config.service,
       source: 'integration',
       ml_app: mlApp,
-      'dd-trace.version': tracerVersion,
+      'ddtrace.version': tracerVersion,
       error: Number(!!error) || 0,
       language: 'javascript'
     }

--- a/packages/dd-trace/src/llmobs/writers/spans/base.js
+++ b/packages/dd-trace/src/llmobs/writers/spans/base.js
@@ -6,6 +6,8 @@ const { DROPPED_IO_COLLECTION_ERROR } = require('../../constants/tags')
 const BaseWriter = require('../base')
 const logger = require('../../../log')
 
+const tracerVersion = require('../../../../../../package.json').version
+
 class LLMObsSpanWriter extends BaseWriter {
   constructor (options) {
     super({
@@ -32,6 +34,7 @@ class LLMObsSpanWriter extends BaseWriter {
   makePayload (events) {
     return {
       '_dd.stage': 'raw',
+      '_dd.tracer_version': tracerVersion,
       event_type: this._eventType,
       spans: events
     }

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -952,7 +952,7 @@ describe('sdk', () => {
         label: 'test',
         metric_type: 'score',
         score_value: 0.6,
-        tags: [`dd-trace.version:${tracerVersion}`, 'ml_app:test', 'host:localhost']
+        tags: [`ddtrace.version:${tracerVersion}`, 'ml_app:test', 'host:localhost']
       })
     })
 

--- a/packages/dd-trace/test/llmobs/sdk/integration.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/integration.spec.js
@@ -245,7 +245,7 @@ describe('end to end sdk integration tests', () => {
         categorical_value: 'bar',
         ml_app: 'test',
         timestamp_ms: 1234567890,
-        tags: [`dd-trace.version:${tracerVersion}`, 'ml_app:test']
+        tags: [`ddtrace.version:${tracerVersion}`, 'ml_app:test']
       }
     ]
 

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -85,7 +85,7 @@ describe('span processor', () => {
           'service:',
           'source:integration',
           'ml_app:myApp',
-          'dd-trace.version:x.y.z',
+          'ddtrace.version:x.y.z',
           'error:0',
           'language:javascript'
         ],

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -164,7 +164,7 @@ function expectedLLMObsTags ({
     `service:${service ?? ''}`,
     'source:integration',
     `ml_app:${tags.ml_app}`,
-    `dd-trace.version:${tracerVersion}`
+    `ddtrace.version:${tracerVersion}`
   ]
 
   if (sessionId) spanTags.push(`session_id:${sessionId}`)


### PR DESCRIPTION
### What does this PR do?
Adds `_dd.tracer_version` as a top-level entry on the span event payload.

Additionally, standardizes `ddtrace.version` tag (was previously `dd-trace.version`).

### Motivation
Both of these are to match internal changes for the LLMObs team.


