### PR TITLE
chore(llmobs): use namespaced storage from core

### DIFF
--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -2,8 +2,8 @@
 
 const log = require('../log')
 const { PROPAGATED_PARENT_ID_KEY } = require('./constants/tags')
-const { storage } = require('../../../datadog-core')
-const llmobsStorage = storage('llmobs')
+const core = require('../../../datadog-core')
+const storage = core.storage('llmobs')
 
 const LLMObsSpanProcessor = require('./span_processor')
 
@@ -64,7 +64,7 @@ function disable () {
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propogate the parent id.
 function handleLLMObsParentIdInjection ({ carrier }) {
-  const parent = llmobsStorage.getStore()?.span
+  const parent = storage.getStore()?.span
   if (!parent) return
 
   const parentId = parent?.context().toSpanId()

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -2,7 +2,8 @@
 
 const log = require('../log')
 const { PROPAGATED_PARENT_ID_KEY } = require('./constants/tags')
-const { storage } = require('./storage')
+const { storage } = require('../../../datadog-core')
+const llmobsStorage = storage('llmobs')
 
 const LLMObsSpanProcessor = require('./span_processor')
 
@@ -63,7 +64,7 @@ function disable () {
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propogate the parent id.
 function handleLLMObsParentIdInjection ({ carrier }) {
-  const parent = storage.getStore()?.span
+  const parent = llmobsStorage.getStore()?.span
   if (!parent) return
 
   const parentId = parent?.context().toSpanId()

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const log = require('../../log')
-const { storage } = require('../../../../datadog-core')
-const llmobsStorage = storage('llmobs')
+const core = require('../../../../datadog-core')
+const storage = core.storage('llmobs')
 
 const TracingPlugin = require('../../plugins/tracing')
 const LLMObsTagger = require('../tagger')
@@ -26,7 +26,7 @@ class LLMObsPlugin extends TracingPlugin {
   }
 
   start (ctx) {
-    const oldStore = llmobsStorage.getStore()
+    const oldStore = storage.getStore()
     const parent = oldStore?.span
     const span = ctx.currentStore?.span
 

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const log = require('../../log')
-const { storage } = require('../storage')
+const { storage } = require('../../../../datadog-core')
+const llmobsStorage = storage('llmobs')
 
 const TracingPlugin = require('../../plugins/tracing')
 const LLMObsTagger = require('../tagger')
@@ -25,7 +26,7 @@ class LLMObsPlugin extends TracingPlugin {
   }
 
   start (ctx) {
-    const oldStore = storage.getStore()
+    const oldStore = llmobsStorage.getStore()
     const parent = oldStore?.span
     const span = ctx.currentStore?.span
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -8,8 +8,8 @@ const {
 } = require('./util')
 const { isTrue } = require('../util')
 
-const { storage } = require('../../../datadog-core')
-const llmobsStorage = storage('llmobs')
+const core = require('../../../datadog-core')
+const storage = core.storage('llmobs')
 
 const Span = require('../opentracing/span')
 
@@ -335,13 +335,13 @@ class LLMObs extends NoopLLMObs {
   }
 
   _active () {
-    const store = llmobsStorage.getStore()
+    const store = storage.getStore()
     return store?.span
   }
 
   _activate (span, { kind, options } = {}, fn) {
     const parent = this._active()
-    if (this.enabled) llmobsStorage.enterWith({ span })
+    if (this.enabled) storage.enterWith({ span })
 
     this._tagger.registerLLMObsSpan(span, {
       ...options,
@@ -352,7 +352,7 @@ class LLMObs extends NoopLLMObs {
     try {
       return fn()
     } finally {
-      if (this.enabled) llmobsStorage.enterWith({ span: parent })
+      if (this.enabled) storage.enterWith({ span: parent })
     }
   }
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -8,7 +8,8 @@ const {
 } = require('./util')
 const { isTrue } = require('../util')
 
-const { storage } = require('./storage')
+const { storage } = require('../../../datadog-core')
+const llmobsStorage = storage('llmobs')
 
 const Span = require('../opentracing/span')
 
@@ -334,13 +335,13 @@ class LLMObs extends NoopLLMObs {
   }
 
   _active () {
-    const store = storage.getStore()
+    const store = llmobsStorage.getStore()
     return store?.span
   }
 
   _activate (span, { kind, options } = {}, fn) {
     const parent = this._active()
-    if (this.enabled) storage.enterWith({ span })
+    if (this.enabled) llmobsStorage.enterWith({ span })
 
     this._tagger.registerLLMObsSpan(span, {
       ...options,
@@ -351,7 +352,7 @@ class LLMObs extends NoopLLMObs {
     try {
       return fn()
     } finally {
-      if (this.enabled) storage.enterWith({ span: parent })
+      if (this.enabled) llmobsStorage.enterWith({ span: parent })
     }
   }
 

--- a/packages/dd-trace/src/llmobs/storage.js
+++ b/packages/dd-trace/src/llmobs/storage.js
@@ -1,7 +1,0 @@
-'use strict'
-
-// TODO: remove this and use namespaced storage once available
-const { AsyncLocalStorage } = require('async_hooks')
-const storage = new AsyncLocalStorage()
-
-module.exports = { storage }

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -43,10 +43,12 @@ describe('module', () => {
       '../log': logger,
       './writers/spans/agentless': LLMObsAgentlessSpanWriter,
       './writers/spans/agentProxy': LLMObsAgentProxySpanWriter,
-      './storage': {
-        storage: {
-          getStore () {
-            return store
+      '../../../datadog-core': {
+        storage: function () {
+          return {
+            getStore () {
+              return store
+            }
           }
         }
       }


### PR DESCRIPTION
### What does this PR do?
Switches from our duplicated `storage` implementation using `AsyncLocalStorage` to the new namespaced helper that was merged via #4775.

The storage object is used as context management for LLMObs span parentage across async contexts.

### Motivation
Removes some code duplication in the repo.