### PR TITLE
Ignore elasticsearch 8.16.0 from esm tests

### DIFF
--- a/packages/datadog-instrumentations/src/elasticsearch.js
+++ b/packages/datadog-instrumentations/src/elasticsearch.js
@@ -13,7 +13,7 @@ addHook({ name: '@elastic/transport', file: 'lib/Transport.js', versions: ['>=8'
   return exports
 })
 
-addHook({ name: '@elastic/elasticsearch', file: 'lib/Transport.js', versions: ['>=5.6.16 <8', '>=8'] }, Transport => {
+addHook({ name: '@elastic/elasticsearch', file: 'lib/Transport.js', versions: ['>=5.6.16 <8', '>=8 <8.16.0'] }, Transport => {
   shimmer.wrap(Transport.prototype, 'request', createWrapRequest('elasticsearch'))
   shimmer.wrap(Transport.prototype, 'getConnection', createWrapGetConnection('elasticsearch'))
   return Transport

--- a/packages/datadog-instrumentations/src/elasticsearch.js
+++ b/packages/datadog-instrumentations/src/elasticsearch.js
@@ -13,7 +13,7 @@ addHook({ name: '@elastic/transport', file: 'lib/Transport.js', versions: ['>=8'
   return exports
 })
 
-addHook({ name: '@elastic/elasticsearch', file: 'lib/Transport.js', versions: ['>=5.6.16 <8', '>=8 <8.16.0'] }, Transport => {
+addHook({ name: '@elastic/elasticsearch', file: 'lib/Transport.js', versions: ['>=5.6.16 <8', '>=8'] }, Transport => {
   shimmer.wrap(Transport.prototype, 'request', createWrapRequest('elasticsearch'))
   shimmer.wrap(Transport.prototype, 'getConnection', createWrapGetConnection('elasticsearch'))
   return Transport

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -13,7 +13,8 @@ describe('esm', () => {
   let proc
   let sandbox
 
-  withVersions('elasticsearch', ['@elastic/elasticsearch'], version => {
+  // excluding 8.16.0 for esm tests, because it is not working: https://github.com/elastic/elasticsearch-js/issues/2466
+  withVersions('elasticsearch', ['@elastic/elasticsearch'], '<8.16.0 || >8.16.0', version => {
     before(async function () {
       this.timeout(20000)
       sandbox = await createSandbox([`'@elastic/elasticsearch@${version}'`], false, [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Ignores elasticsearch 8.16.0 from esm tests

### Motivation
<!-- What inspired you to submit this pull request? -->
An issue in @elastic/elasticsearch: https://github.com/elastic/elasticsearch-js/issues/2466

Our ESM tests were failing.




