### PR TITLE
automate release notes from github actions

### DIFF
--- a/.github/workflows/release-4.yml
+++ b/.github/workflows/release-4.yml
@@ -18,6 +18,7 @@ jobs:
       contents: write
       pull-requests: read
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-4.yml
+++ b/.github/workflows/release-4.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: read
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
@@ -31,3 +32,4 @@ jobs:
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
+      - run: node scripts/release/notes

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: read
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     outputs:
@@ -33,6 +34,7 @@ jobs:
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
+      - run: node scripts/release/notes --latest
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -18,6 +18,7 @@ jobs:
       contents: write
       pull-requests: read
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     outputs:
       pkgjson: ${{ steps.pkg.outputs.json }}

--- a/scripts/release/notes.js
+++ b/scripts/release/notes.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { capture, success, run } = require('./helpers/terminal')
+const pkg = require('../../package.json')
+
+const version = pkg.version
+const tag = `v${version}`
+const major = version.split('.')[0]
+const body = capture(`gh pr view ${tag}-proposal --json body --jq '.body'`)
+const args = process.argv.slice(2)
+const flags = []
+const folder = path.join(os.tmpdir(), 'release_notes')
+const file = path.join(folder, `${tag}.md`)
+
+if (args.includes('--latest')) {
+  flags.push('--latest')
+}
+
+if (version.includes('-')) {
+  flags.push('--prerelease')
+}
+
+fs.mkdirSync(folder, { recursive: true })
+fs.writeFileSync(file, body)
+
+run(`gh release create ${tag} --target v${major}.x --title ${version} -F ${file} ${flags.join(' ')}`)
+
+success(`Release notes published for ${version}.`)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Automate release notes from GitHub actions.

### Motivation
<!-- What inspired you to submit this pull request? -->

Now that #4880 has landed, the release notes should always be in the PR body, so instead of having to copy that manually to a new GitHub release, this does it automatically as part of the release workflow.

