### PR TITLE
Upgrade `cross-spawn` to `v7.0.5` - patched ReDoS

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,9 +1733,9 @@ cross-argv@^1.0.0:
   integrity sha512-uAVe/bgNHlPdP1VE4Sk08u9pAJ7o1x/tVQtX77T5zlhYhuwOWtVkPBEtHdvF5cq48VzeCG5i1zN4dQc8pwLYrw==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.5.tgz#910aac880ff5243da96b728bc6521a5f6c2f2f82"
+  integrity sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
### What does this PR do?
Upgrade `cross-spawn` package to v7.0.5

### Motivation
Patch a ReDoS vulnerability. 
[GH Advisory](https://github.com/advisories/GHSA-3xgq-45jj-v275)

### Additional notes
`cross-spawn` is not a direct dependency, but a sub-dep of several packages.

```
$ yarn why cross-spawn -R                                      
yarn why v1.22.21
[1/4] 🤔  Why do we have the module "cross-spawn"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "cross-spawn@7.0.5"
info Reasons this module exists
   - "eslint" depends on it
   - Hoisted from "eslint#cross-spawn"
   - Hoisted from "nyc#foreground-child#cross-spawn"
   - Hoisted from "nyc#istanbul-lib-processinfo#cross-spawn"
info Disk size without dependencies: "60KB"
info Disk size with unique dependencies: "124KB"
info Disk size with transitive dependencies: "184KB"
info Number of shared dependencies: 4
✨  Done in 0.15s.
```

