### PR TITLE
disable merge queue

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,4 @@
+---
+schema-version: v1
+kind: mergequeue
+enable: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Disables the devflow/merge automation.

### Motivation
<!-- What inspired you to submit this pull request? -->
We've had several PRs where folks have attempted to use devflow's merge queue, which doesn't work on this repo because it creates a chicken-and-egg situation with all-green. The easiest thing to do at this point is to opt out of it, though we may revisit this in the future.


