### PR TITLE
Increase timeout on RASP integration test for windows

### DIFF
--- a/packages/dd-trace/test/appsec/rasp/command_injection.integration.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.integration.spec.js
@@ -10,7 +10,7 @@ describe('RASP - command_injection - integration', () => {
   let axios, sandbox, cwd, appPort, appFile, agent, proc
 
   before(async function () {
-    this.timeout(60000)
+    this.timeout(process.platform === 'win32' ? 90000 : 30000)
 
     sandbox = await createSandbox(
       ['express'],


### PR DESCRIPTION
### What does this PR do?
Increases timeout on RASP integration test for windows.

### Motivation
`createSandbox` method takes a long time when running on `windows`, but not on `ubuntu` and `macOS`. This makes the test flaky, hitting the timeout on `windows` from time to time.

The difference comes mainly from running `yarn add`, as can be seen [here for windows](https://github.com/DataDog/dd-trace-js/actions/runs/11893091045/job/33137330656#step:5:2275), and its counterparts on [ubuntu](https://github.com/DataDog/dd-trace-js/actions/runs/11893091045/job/33137322879#step:6:2275) and [macOS](https://github.com/DataDog/dd-trace-js/actions/runs/11893091045/job/33137321190#step:5:2275).
