### PR TITLE
fix release script hanging on applying new changes

### DIFF
--- a/scripts/release/helpers/terminal.js
+++ b/scripts/release/helpers/terminal.js
@@ -17,7 +17,7 @@ const RESET = '\x1b[0m'
 
 const print = (...msgs) => msgs.forEach(msg => process.stdout.write(msg))
 const log = (...msgs) => msgs.forEach(msg => print(`${msg}\n`))
-const fatal = (...msgs) => log(...msgs) || process.exit(1)
+const fatal = (...msgs) => fail() || log(...msgs) || process.exit(1)
 
 let timer
 let current
@@ -115,7 +115,9 @@ function fail (err) {
 
   current = undefined
 
-  throw err
+  if (err) {
+    throw err
+  }
 }
 
 // Parse CLI arguments into parameters and flags.

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -100,7 +100,10 @@ try {
     .replace(/\n/g, ' ').trim()
 
   if (proposalDiff) {
-    pass(`${proposalDiff.split(' ').length} new`)
+    // Get new changes since last commit of the proposal branch.
+    const newChanges = capture(`${diffCmd} v${newVersion}-proposal master`)
+
+    pass(`\n\n${newChanges}\n`)
 
     start('Apply changes from the main branch')
 
@@ -109,14 +112,11 @@ try {
       run('git reset --hard HEAD~1')
     }
 
-    // Output new changes since last commit of the proposal branch.
-    const newChanges = capture(`${diffCmd} v${newVersion}-proposal master`)
-
-    log(`\n${newChanges}\n`)
-
     // Cherry pick all new commits to the proposal branch.
     try {
       run(`echo "${proposalDiff}" | xargs git cherry-pick`)
+
+      pass()
     } catch (err) {
       fatal(
         'Cherry-pick failed. Resolve the conflicts and run `git cherry-pick --continue` to continue.',

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -103,7 +103,7 @@ try {
     // Get new changes since last commit of the proposal branch.
     const newChanges = capture(`${diffCmd} v${newVersion}-proposal master`)
 
-    pass(`\n\n${newChanges}\n`)
+    pass(`\n${newChanges}`)
 
     start('Apply changes from the main branch')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix release script hanging on applying new changes.

### Motivation
<!-- What inspired you to submit this pull request? -->

The script was hanging because `pass` wasn't called after applying changes, which led to a timer that was getting overridden and never cleared. The output also got slightly corrupted because steps are expected to always pass or fail before the next step starts.

### Additional Notes

Working example:

<img width="714" alt="image" src="https://github.com/user-attachments/assets/da3ee269-1d8e-4037-88f1-e270b90c68eb">
