### PR TITLE
fix release notes always flagged as latest

### DIFF
--- a/scripts/release/notes.js
+++ b/scripts/release/notes.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
-const { capture, success, run } = require('./helpers/terminal')
+const { capture, run } = require('./helpers/terminal')
 const pkg = require('../../package.json')
 
 const version = pkg.version
@@ -15,9 +15,8 @@ const flags = []
 const folder = path.join(os.tmpdir(), 'release_notes')
 const file = path.join(folder, `${tag}.md`)
 
-if (args.includes('--latest')) {
-  flags.push('--latest')
-}
+// Default is to determine this automatically, so set it explicitly instead.
+flags.push(args.includes('--latest') ? '--latest' : '--latest=false')
 
 if (version.includes('-')) {
   flags.push('--prerelease')
@@ -27,5 +26,3 @@ fs.mkdirSync(folder, { recursive: true })
 fs.writeFileSync(file, body)
 
 run(`gh release create ${tag} --target v${major}.x --title ${version} -F ${file} ${flags.join(' ')}`)
-
-success(`Release notes published for ${version}.`)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix release notes always flagged as latest. I also removed the success message since `gh` already outputs on success, and the `success` helper was removed anyway.

### Motivation
<!-- What inspired you to submit this pull request? -->

Default is to determine whether a release is latest automatically, so we have to set it explicitly instead.


