### PR TITLE
Update Azure Functions operation name to azure.functions.invoke

### DIFF
--- a/packages/datadog-instrumentations/src/azure-functions.js
+++ b/packages/datadog-instrumentations/src/azure-functions.js
@@ -6,7 +6,7 @@ const {
 const shimmer = require('../../datadog-shimmer')
 const dc = require('dc-polyfill')
 
-const azureFunctionsChannel = dc.tracingChannel('datadog:azure-functions:invoke')
+const azureFunctionsChannel = dc.tracingChannel('datadog:azure:functions:invoke')
 
 addHook({ name: '@azure/functions', versions: ['>=4'] }, azureFunction => {
   const { app } = azureFunction

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -20,7 +20,7 @@ class AzureFunctionsPlugin extends TracingPlugin {
   static get kind () { return 'server' }
   static get type () { return 'serverless' }
 
-  static get prefix () { return 'tracing:datadog:azure-functions:invoke' }
+  static get prefix () { return 'tracing:datadog:azure:functions:invoke' }
 
   bindStart (ctx) {
     const { functionName, methodName } = ctx

--- a/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
@@ -47,7 +47,7 @@ describe('esm', () => {
         assert.strictEqual(payload.length, 1)
         assert.isArray(payload[0])
         assert.strictEqual(payload[0].length, 1)
-        assert.propertyVal(payload[0][0], 'name', 'azure-functions.invoke')
+        assert.propertyVal(payload[0][0], 'name', 'azure.functions.invoke')
       })
     }).timeout(50000)
   })

--- a/packages/dd-trace/src/service-naming/schemas/v0/serverless.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/serverless.js
@@ -3,7 +3,7 @@ const { identityService } = require('../util')
 const serverless = {
   server: {
     'azure-functions': {
-      opName: () => 'azure-functions.invoke',
+      opName: () => 'azure.functions.invoke',
       serviceName: identityService
     }
   }

--- a/packages/dd-trace/src/service-naming/schemas/v1/serverless.js
+++ b/packages/dd-trace/src/service-naming/schemas/v1/serverless.js
@@ -3,7 +3,7 @@ const { identityService } = require('../util')
 const serverless = {
   server: {
     'azure-functions': {
-      opName: () => 'azure-functions.invoke',
+      opName: () => 'azure.functions.invoke',
       serviceName: identityService
     }
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update Azure Functions operation name to `azure.functions.invoke`.

### Motivation
<!-- What inspired you to submit this pull request? -->

* Consistent Azure Functions instrumentation operation name across runtimes 
* Consistent operation name schema across clouds `<cloud_provider>.<cloud_service>.*`

https://datadoghq.atlassian.net/browse/SVLS-5995

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Schema in Python: https://github.com/DataDog/dd-trace-py/blob/0c1953cd0c0915cc88cebd5a86133d4b6caffce4/ddtrace/internal/schema/span_attribute_schema.py#L57

While this is a breaking change, we are in contact with the handful of customers that are using it as part of the beta. We will be notifying them of the change in operation name.

