### PR TITLE
fix crashtracker not working with uds

### DIFF
--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -53,7 +53,7 @@ class Crashtracker {
         // TODO: Use the string directly when deserialization is fixed.
         url: {
           scheme: url.protocol.slice(0, -1),
-          authority: url.protocol === 'unix'
+          authority: url.protocol === 'unix:'
             ? Buffer.from(url.pathname).toString('hex')
             : url.host,
           path_and_query: ''

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -73,6 +73,15 @@ describe('crashtracking', () => {
 
         expect(() => crashtracker.start(config)).to.not.throw()
       })
+
+      it('should handle unix sockets', () => {
+        config.url = new URL('unix:///var/datadog/apm/test.socket')
+
+        crashtracker.start(config)
+
+        expect(binding.init).to.have.been.called
+        expect(log.error).to.not.have.been.called
+      })
     })
 
     describe('configure', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix crashtracker not working with UDS.

### Motivation
<!-- What inspired you to submit this pull request? -->

The crashtracker was incorrectly checking the protocol which was causing the initialization to fail.