### PR TITLE
Updating where extracted header span links get passed to startSpan

### DIFF
--- a/packages/datadog-plugin-amqplib/src/consumer.js
+++ b/packages/datadog-plugin-amqplib/src/consumer.js
@@ -26,8 +26,7 @@ class AmqplibConsumerPlugin extends ConsumerPlugin {
         'amqp.consumerTag': fields.consumerTag,
         'amqp.source': fields.source,
         'amqp.destination': fields.destination
-      },
-      extractedLinks: childOf?._links
+      }
     })
 
     if (

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -42,8 +42,7 @@ class Kinesis extends BaseAwsSdkPlugin {
               {},
               this.requestTags.get(request) || {},
               { 'span.kind': 'server' }
-            ),
-            extractedLinks: responseExtraction.maybeChildOf._links
+            )
           }
           span = plugin.tracer.startSpan('aws.response', options)
           this.enter(span, store)

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -33,8 +33,7 @@ class Sqs extends BaseAwsSdkPlugin {
             {},
             this.requestTags.get(request) || {},
             { 'span.kind': 'server' }
-          ),
-          extractedLinks: contextExtraction.datadogContext._links
+          )
         }
         parsedMessageAttributes = contextExtraction.parsedAttributes
         span = plugin.tracer.startSpan('aws.response', options)

--- a/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
@@ -22,8 +22,7 @@ class GoogleCloudPubsubConsumerPlugin extends ConsumerPlugin {
       },
       metrics: {
         'pubsub.ack': 0
-      },
-      extractedLinks: childOf?._links
+      }
     })
     if (this.config.dsmEnabled && message?.attributes) {
       const payloadSize = getMessageSize(message)

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -48,8 +48,7 @@ class GrpcServerPlugin extends ServerPlugin {
       },
       metrics: {
         'grpc.status.code': 0
-      },
-      extractedLinks: childOf?._links
+      }
     })
 
     addMetadataTags(span, metadata, metadataFilter, 'request')

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -219,8 +219,7 @@ class JestPlugin extends CiPlugin {
           [COMPONENT]: this.constructor.id,
           ...this.testEnvironmentMetadata,
           ...testSuiteMetadata
-        },
-        extractedLinks: testSessionSpanContext?._links
+        }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
       if (_ddTestCodeCoverageEnabled) {

--- a/packages/datadog-plugin-kafkajs/src/consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/consumer.js
@@ -76,8 +76,7 @@ class KafkajsConsumerPlugin extends ConsumerPlugin {
       },
       metrics: {
         'kafka.partition': partition
-      },
-      extractedLinks: childOf?._links
+      }
     })
     if (this.config.dsmEnabled && message?.headers) {
       const payloadSize = getMessageSize(message)

--- a/packages/datadog-plugin-moleculer/src/server.js
+++ b/packages/datadog-plugin-moleculer/src/server.js
@@ -18,8 +18,7 @@ class MoleculerServerPlugin extends ServerPlugin {
       meta: {
         'resource.name': action.name,
         ...moleculerTags(broker, ctx, this.config)
-      },
-      extractedLinks: followsFrom?._links
+      }
     })
   }
 }

--- a/packages/datadog-plugin-rhea/src/consumer.js
+++ b/packages/datadog-plugin-rhea/src/consumer.js
@@ -28,8 +28,7 @@ class RheaConsumerPlugin extends ConsumerPlugin {
         component: 'rhea',
         'amqp.link.source.address': name,
         'amqp.link.role': 'receiver'
-      },
-      extractedLinks: childOf?._links
+      }
     })
 
     if (

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -191,8 +191,7 @@ class VitestPlugin extends CiPlugin {
           [COMPONENT]: this.constructor.id,
           ...this.testEnvironmentMetadata,
           ...testSuiteMetadata
-        },
-        extractedLinks: testSessionSpanContext?._links
+        }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
       const store = storage.getStore()

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -101,7 +101,7 @@ class TracingPlugin extends Plugin {
     }
   }
 
-  startSpan (name, { childOf, kind, meta, metrics, service, resource, type, extractedLinks } = {}, enter = true) {
+  startSpan (name, { childOf, kind, meta, metrics, service, resource, type } = {}, enter = true) {
     const store = storage.getStore()
     if (store && childOf === undefined) {
       childOf = store.span
@@ -119,7 +119,7 @@ class TracingPlugin extends Plugin {
         ...metrics
       },
       integrationName: type,
-      links: extractedLinks
+      links: childOf?.links
     })
 
     analyticsSampler.sample(span, this.config.measured)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -267,7 +267,7 @@ const web = {
       }
     }
 
-    const span = tracer.startSpan(name, { childOf, extractedLinks: childOf?.links })
+    const span = tracer.startSpan(name, { childOf, links: childOf?.links })
 
     return span
   },

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -267,7 +267,7 @@ const web = {
       }
     }
 
-    const span = tracer.startSpan(name, { childOf, links: childOf?.links })
+    const span = tracer.startSpan(name, { childOf, links: childOf?._links })
 
     return span
   },


### PR DESCRIPTION
### What does this PR do?
This PR abstracts the process of passing extracted header span links to `startSpan` from individual plugins to the base level plugin `startSpan` functions. Furthermore, a quick fix is made to fix a bug with the call to `startSpan` from `web.js`

### Motivation
Currently, all plugins that extract headers must pass in the extracted span links to its respective call to `startSpan`. This PR removes the need to do that by checking for extracted span links in the base level plugin `startSpan` functions. Additionally, this PR makes a quick fix to the `web.js` call to `startSpan`, as it was previously incorrectly passing in span links.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


