### PR TITLE
update crashtracker timeout to 5 seconds

### DIFF
--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -60,7 +60,7 @@ class Crashtracker {
         },
         timeout_ms: 3000
       },
-      timeout_ms: 0,
+      timeout_ms: 5000,
       // TODO: Use `EnabledWithSymbolsInReceiver` instead for Linux when fixed.
       resolve_frames: 'EnabledWithInprocessSymbols'
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update crashtracker timeout to 5 seconds.

### Motivation
<!-- What inspired you to submit this pull request? -->

The code in libdatadog defaults to not timing out if the value is `0` but for some reason it seems to instantly timeout instead. I was only able to reproduce this in system tests.