### PR TITLE
add package manager symlinks to denylist

### DIFF
--- a/.gitlab/requirements_block.json
+++ b/.gitlab/requirements_block.json
@@ -6,6 +6,9 @@
   {"name": "unsupported 2.x.x glibc x64","filepath": "/some/path", "args": [], "envars": [], "host": {"os": "linux", "arch": "arm64", "libc": "glibc:2.16.9"}},
   {"name": "unsupported 2.x.x glibc x86","filepath": "/some/path", "args": [], "envars": [], "host": {"os": "linux", "arch": "x86", "libc": "glibc:2.17"}},
   {"name": "npm","filepath": "/pathto/node", "args": ["/pathto/node", "/pathto/npm-cli.js"], "envars": [], "host": {"os": "linux", "arch": "x64", "libc": "glibc:2.40"}},
+  {"name": "npm-symlink","filepath": "/pathto/node", "args": ["/pathto/node", "/pathto/npm"], "envars": [], "host": {"os": "linux", "arch": "x64", "libc": "glibc:2.40"}},
   {"name": "yarn","filepath": "/pathto/node", "args": ["/pathto/node", "/pathto/yarn.js"], "envars": [], "host": {"os": "linux", "arch": "x64", "libc": "glibc:2.40"}},
-  {"name": "pnpm","filepath": "/pathto/node", "args": ["/pathto/node", "/pathto/pnpm.cjs"], "envars": [], "host": {"os": "linux", "arch": "x64", "libc": "glibc:2.40"}}
+  {"name": "yarn-symlink","filepath": "/pathto/node", "args": ["/pathto/node", "/pathto/yarn"], "envars": [], "host": {"os": "linux", "arch": "x64", "libc": "glibc:2.40"}},
+  {"name": "pnpm","filepath": "/pathto/node", "args": ["/pathto/node", "/pathto/pnpm.cjs"], "envars": [], "host": {"os": "linux", "arch": "x64", "libc": "glibc:2.40"}},
+  {"name": "pnpm-symlink","filepath": "/pathto/node", "args": ["/pathto/node", "/pathto/pnpm"], "envars": [], "host": {"os": "linux", "arch": "x64", "libc": "glibc:2.40"}}
 ]

--- a/requirements.json
+++ b/requirements.json
@@ -56,6 +56,19 @@
       "envars": null
     },
     {
+      "id": "npm_symlink",
+      "description": "Ignore the npm CLI",
+      "os": null,
+      "cmds": [
+        "**/node",
+        "**/nodejs",
+        "**/ts-node",
+        "**/ts-node-*"
+      ],
+      "args": [{ "args":  ["*/npm"], "position": 1}],
+      "envars": null
+    },
+    {
       "id": "yarn",
       "description": "Ignore the yarn CLI",
       "os": null,
@@ -69,6 +82,19 @@
       "envars": null
     },
     {
+      "id": "yarn_symlink",
+      "description": "Ignore the yarn CLI",
+      "os": null,
+      "cmds": [
+        "**/node",
+        "**/nodejs",
+        "**/ts-node",
+        "**/ts-node-*"
+      ],
+      "args": [{ "args":  ["*/yarn"], "position": 1}],
+      "envars": null
+    },
+    {
       "id": "pnpm",
       "description": "Ignore the pnpm CLI",
       "os": null,
@@ -79,6 +105,19 @@
         "**/ts-node-*"
       ],
       "args": [{ "args":  ["*/pnpm.cjs"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "pnpm_symlink",
+      "description": "Ignore the pnpm CLI",
+      "os": null,
+      "cmds": [
+        "**/node",
+        "**/nodejs",
+        "**/ts-node",
+        "**/ts-node-*"
+      ],
+      "args": [{ "args":  ["*/pnpm"], "position": 1}],
       "envars": null
     }
   ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
See title

### Motivation
<!-- What inspired you to submit this pull request? -->
Without this, denylists don't actually work for these package managers, as the symlinks aren't usually followed in arguments prior to invocation.


