### PR TITLE
fix missing commands in denylist by allowing all

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -46,25 +46,15 @@
       "id": "npm",
       "description": "Ignore the npm CLI",
       "os": null,
-      "cmds": [
-        "**/node",
-        "**/nodejs",
-        "**/ts-node",
-        "**/ts-node-*"
-      ],
+      "cmds": [],
       "args": [{ "args":  ["*/npm-cli.js"], "position": 1}],
       "envars": null
     },
     {
       "id": "npm_symlink",
-      "description": "Ignore the npm CLI",
+      "description": "Ignore the npm CLI (symlink)",
       "os": null,
-      "cmds": [
-        "**/node",
-        "**/nodejs",
-        "**/ts-node",
-        "**/ts-node-*"
-      ],
+      "cmds": [],
       "args": [{ "args":  ["*/npm"], "position": 1}],
       "envars": null
     },
@@ -72,25 +62,15 @@
       "id": "yarn",
       "description": "Ignore the yarn CLI",
       "os": null,
-      "cmds": [
-        "**/node",
-        "**/nodejs",
-        "**/ts-node",
-        "**/ts-node-*"
-      ],
+      "cmds": [],
       "args": [{ "args":  ["*/yarn.js"], "position": 1}],
       "envars": null
     },
     {
       "id": "yarn_symlink",
-      "description": "Ignore the yarn CLI",
+      "description": "Ignore the yarn CLI (symlink)",
       "os": null,
-      "cmds": [
-        "**/node",
-        "**/nodejs",
-        "**/ts-node",
-        "**/ts-node-*"
-      ],
+      "cmds": [],
       "args": [{ "args":  ["*/yarn"], "position": 1}],
       "envars": null
     },
@@ -98,25 +78,15 @@
       "id": "pnpm",
       "description": "Ignore the pnpm CLI",
       "os": null,
-      "cmds": [
-        "**/node",
-        "**/nodejs",
-        "**/ts-node",
-        "**/ts-node-*"
-      ],
+      "cmds": [],
       "args": [{ "args":  ["*/pnpm.cjs"], "position": 1}],
       "envars": null
     },
     {
       "id": "pnpm_symlink",
-      "description": "Ignore the pnpm CLI",
+      "description": "Ignore the pnpm CLI (symlink)",
       "os": null,
-      "cmds": [
-        "**/node",
-        "**/nodejs",
-        "**/ts-node",
-        "**/ts-node-*"
-      ],
+      "cmds": [],
       "args": [{ "args":  ["*/pnpm"], "position": 1}],
       "envars": null
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing commands in denylist by allowing all.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `node` executable can have a lot of names depending on how it was installed. Since the injector already limits the list of commands that are supported, there is no need to repeat it here.