### PR TITLE
fix langchain tests trying to run on unsupported node

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -567,7 +567,18 @@ jobs:
       PLUGINS: langchain
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/plugins/test
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/install
+      - uses: ./.github/actions/node/18 # langchain doesn't support Node 16
+      - run: yarn test:plugins:ci
+        shell: bash
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:plugins:ci
+        shell: bash
+      - uses: codecov/codecov-action@v3
+      - if: always()
+        uses: ./.github/actions/testagent/logs
 
   limitd-client:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix langchain tests trying to run on unsupported Node.

### Motivation
<!-- What inspired you to submit this pull request? -->

Tests were failing on v4.x release line since langchain errors out on Node 16.
