### PR TITLE
Fix IAST standalone sampling priority propagation

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -17,9 +17,7 @@ let resetVulnerabilityCacheTimer
 let deduplicationEnabled = true
 
 function addVulnerability (iastContext, vulnerability) {
-  if (vulnerability?.evidence && vulnerability?.type &&
-    vulnerability?.location) {
-
+  if (vulnerability?.evidence && vulnerability?.type && vulnerability?.location) {
     if (deduplicationEnabled && isDuplicatedVulnerability(vulnerability)) return
 
     VULNERABILITY_HASHES.set(`${vulnerability.type}${vulnerability.hash}`, true)

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -22,14 +22,28 @@ function addVulnerability (iastContext, vulnerability) {
 
     VULNERABILITY_HASHES.set(`${vulnerability.type}${vulnerability.hash}`, true)
 
-    if (iastContext?.rootSpan) {
-      keepTrace(iastContext.rootSpan, SAMPLING_MECHANISM_APPSEC)
-      standalone.sample(iastContext.rootSpan)
+    let span = iastContext?.rootSpan
 
+    if (!span && tracer) {
+      span = tracer.startSpan('vulnerability', {
+        type: 'vulnerability'
+      })
+
+      vulnerability.location.spanId = span.context().toSpanId()
+
+      span.addTags({
+        [IAST_ENABLED_TAG_KEY]: 1
+      })
+    }
+
+    keepTrace(span, SAMPLING_MECHANISM_APPSEC)
+    standalone.sample(span)
+
+    if (iastContext?.rootSpan) {
       iastContext[VULNERABILITIES_KEY] = iastContext[VULNERABILITIES_KEY] || []
       iastContext[VULNERABILITIES_KEY].push(vulnerability)
     } else {
-      sendVulnerabilities([vulnerability])
+      sendVulnerabilities([vulnerability], span, false)
     }
   }
 }
@@ -40,24 +54,8 @@ function isValidVulnerability (vulnerability) {
     vulnerability.location && vulnerability.location.spanId
 }
 
-function sendVulnerabilities (vulnerabilities, rootSpan) {
+function sendVulnerabilities (vulnerabilities, span, isRootSpan = true) {
   if (vulnerabilities && vulnerabilities.length) {
-    let span = rootSpan
-    if (!span && tracer) {
-      span = tracer.startSpan('vulnerability', {
-        type: 'vulnerability'
-      })
-      vulnerabilities.forEach((vulnerability) => {
-        vulnerability.location.spanId = span.context().toSpanId()
-      })
-      span.addTags({
-        [IAST_ENABLED_TAG_KEY]: 1
-      })
-
-      keepTrace(span, SAMPLING_MECHANISM_APPSEC)
-      standalone.sample(span)
-    }
-
     if (span && span.addTags) {
       const validatedVulnerabilities = vulnerabilities.filter(isValidVulnerability)
       const jsonToSend = vulnerabilitiesFormatter.toJson(validatedVulnerabilities)
@@ -68,7 +66,7 @@ function sendVulnerabilities (vulnerabilities, rootSpan) {
         tags[IAST_JSON_TAG_KEY] = JSON.stringify(jsonToSend)
         span.addTags(tags)
 
-        if (!rootSpan) span.finish()
+        if (!isRootSpan) span.finish()
       }
     }
   }

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -43,7 +43,8 @@ function addVulnerability (iastContext, vulnerability) {
       iastContext[VULNERABILITIES_KEY] = iastContext[VULNERABILITIES_KEY] || []
       iastContext[VULNERABILITIES_KEY].push(vulnerability)
     } else {
-      sendVulnerabilities([vulnerability], span, false)
+      sendVulnerabilities([vulnerability], span)
+      span.finish()
     }
   }
 }
@@ -54,7 +55,7 @@ function isValidVulnerability (vulnerability) {
     vulnerability.location && vulnerability.location.spanId
 }
 
-function sendVulnerabilities (vulnerabilities, span, isRootSpan = true) {
+function sendVulnerabilities (vulnerabilities, span) {
   if (vulnerabilities && vulnerabilities.length) {
     if (span && span.addTags) {
       const validatedVulnerabilities = vulnerabilities.filter(isValidVulnerability)
@@ -65,8 +66,6 @@ function sendVulnerabilities (vulnerabilities, span, isRootSpan = true) {
         // TODO: Store this outside of the span and set the tag in the exporter.
         tags[IAST_JSON_TAG_KEY] = JSON.stringify(jsonToSend)
         span.addTags(tags)
-
-        if (!isRootSpan) span.finish()
       }
     }
   }

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -17,9 +17,17 @@ let resetVulnerabilityCacheTimer
 let deduplicationEnabled = true
 
 function addVulnerability (iastContext, vulnerability) {
-  if (vulnerability && vulnerability.evidence && vulnerability.type &&
-    vulnerability.location) {
-    if (iastContext && iastContext.rootSpan) {
+  if (vulnerability?.evidence && vulnerability?.type &&
+    vulnerability?.location) {
+
+    if (deduplicationEnabled && isDuplicatedVulnerability(vulnerability)) return
+
+    VULNERABILITY_HASHES.set(`${vulnerability.type}${vulnerability.hash}`, true)
+
+    if (iastContext?.rootSpan) {
+      keepTrace(iastContext.rootSpan, SAMPLING_MECHANISM_APPSEC)
+      standalone.sample(iastContext.rootSpan)
+
       iastContext[VULNERABILITIES_KEY] = iastContext[VULNERABILITIES_KEY] || []
       iastContext[VULNERABILITIES_KEY].push(vulnerability)
     } else {
@@ -47,21 +55,20 @@ function sendVulnerabilities (vulnerabilities, rootSpan) {
       span.addTags({
         [IAST_ENABLED_TAG_KEY]: 1
       })
+
+      keepTrace(span, SAMPLING_MECHANISM_APPSEC)
+      standalone.sample(span)
     }
 
     if (span && span.addTags) {
-      const validAndDedupVulnerabilities = deduplicateVulnerabilities(vulnerabilities).filter(isValidVulnerability)
-      const jsonToSend = vulnerabilitiesFormatter.toJson(validAndDedupVulnerabilities)
+      const validatedVulnerabilities = vulnerabilities.filter(isValidVulnerability)
+      const jsonToSend = vulnerabilitiesFormatter.toJson(validatedVulnerabilities)
 
       if (jsonToSend.vulnerabilities.length > 0) {
         const tags = {}
         // TODO: Store this outside of the span and set the tag in the exporter.
         tags[IAST_JSON_TAG_KEY] = JSON.stringify(jsonToSend)
         span.addTags(tags)
-
-        keepTrace(span, SAMPLING_MECHANISM_APPSEC)
-
-        standalone.sample(span)
 
         if (!rootSpan) span.finish()
       }
@@ -86,17 +93,8 @@ function stopClearCacheTimer () {
   }
 }
 
-function deduplicateVulnerabilities (vulnerabilities) {
-  if (!deduplicationEnabled) return vulnerabilities
-  const deduplicated = vulnerabilities.filter((vulnerability) => {
-    const key = `${vulnerability.type}${vulnerability.hash}`
-    if (!VULNERABILITY_HASHES.get(key)) {
-      VULNERABILITY_HASHES.set(key, true)
-      return true
-    }
-    return false
-  })
-  return deduplicated
+function isDuplicatedVulnerability (vulnerability) {
+  return VULNERABILITY_HASHES.get(`${vulnerability.type}${vulnerability.hash}`)
 }
 
 function start (config, _tracer) {

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -36,6 +36,8 @@ function addVulnerability (iastContext, vulnerability) {
       })
     }
 
+    if (!span) return
+
     keepTrace(span, SAMPLING_MECHANISM_APPSEC)
     standalone.sample(span)
 

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.spec.js
@@ -331,7 +331,8 @@ describe('Overhead controller', () => {
               iast: {
                 enabled: true,
                 requestSampling: 100,
-                maxConcurrentRequests: 2
+                maxConcurrentRequests: 2,
+                deduplicationEnabled: false
               }
             }
           })
@@ -365,7 +366,6 @@ describe('Overhead controller', () => {
             } else if (url === SECOND_REQUEST) {
               setImmediate(() => {
                 requestResolvers[FIRST_REQUEST]()
-                vulnerabilityReporter.clearCache()
               })
             }
           })
@@ -373,7 +373,6 @@ describe('Overhead controller', () => {
             if (url === FIRST_REQUEST) {
               setImmediate(() => {
                 requestResolvers[SECOND_REQUEST]()
-                vulnerabilityReporter.clearCache()
               })
             }
           })
@@ -388,7 +387,8 @@ describe('Overhead controller', () => {
               iast: {
                 enabled: true,
                 requestSampling: 100,
-                maxConcurrentRequests: 2
+                maxConcurrentRequests: 2,
+                deduplicationEnabled: false
               }
             }
           })
@@ -435,7 +435,6 @@ describe('Overhead controller', () => {
               requestResolvers[FIRST_REQUEST]()
             } else if (url === FIFTH_REQUEST) {
               requestResolvers[SECOND_REQUEST]()
-              vulnerabilityReporter.clearCache()
             }
           })
           testRequestEventEmitter.on(TEST_REQUEST_FINISHED, (url) => {
@@ -444,7 +443,6 @@ describe('Overhead controller', () => {
               axios.get(`http://localhost:${serverConfig.port}${FIFTH_REQUEST}`).then().catch(done)
             } else if (url === SECOND_REQUEST) {
               setImmediate(() => {
-                vulnerabilityReporter.clearCache()
                 requestResolvers[THIRD_REQUEST]()
                 requestResolvers[FOURTH_REQUEST]()
                 requestResolvers[FIFTH_REQUEST]()

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -375,7 +375,7 @@ describe('vulnerability-reporter', () => {
       expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
-    it('should not send duplicated vulnerabilities in multiple sends', () => {
+    it.skip('should not send duplicated vulnerabilities in multiple sends', () => {
       const iastContext = { rootSpan: span }
       addVulnerability(iastContext,
         vulnerabilityAnalyzer._createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -260,7 +260,10 @@ describe('vulnerability-reporter', () => {
           '[{"value":"SELECT id FROM u WHERE email = \'"},{"value":"joe@mail.com","source":1},{"value":"\';"}]},' +
           '"location":{"spanId":888,"path":"filename.js","line":99}}]}'
       })
-      expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+
+      expect(prioritySampler.setPriority).to.have.been.calledTwice
+      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should send multiple vulnerabilities with same tainted source', () => {
@@ -313,7 +316,10 @@ describe('vulnerability-reporter', () => {
           '[{"value":"UPDATE u SET name=\'"},{"value":"joe","source":0},{"value":"\' WHERE id=1;"}]},' +
           '"location":{"spanId":888,"path":"filename.js","line":99}}]}'
       })
-      expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+
+      expect(prioritySampler.setPriority).to.have.been.calledTwice
+      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should send once with multiple vulnerabilities', () => {
@@ -334,7 +340,10 @@ describe('vulnerability-reporter', () => {
           '{"type":"INSECURE_HASHING","hash":1755238473,"evidence":{"value":"md5"},' +
             '"location":{"spanId":-5,"path":"/path/to/file3.js","line":3}}]}'
       })
-      expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority).to.have.been.calledThrice
+      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.thirdCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should send once vulnerability with one vulnerability', () => {
@@ -401,7 +410,9 @@ describe('vulnerability-reporter', () => {
           '{"type":"INSECURE_HASHING","hash":3410512691,"evidence":{"value":"sha1"},"location":' +
           '{"spanId":888,"path":"filename.js","line":88}}]}'
       })
-      expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority).to.have.been.calledTwice
+      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should add _dd.p.appsec trace tag with standalone enabled', () => {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -382,23 +382,6 @@ describe('vulnerability-reporter', () => {
       expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
-    it.skip('should not send duplicated vulnerabilities in multiple sends', () => {
-      const iastContext = { rootSpan: span }
-      addVulnerability(iastContext,
-        vulnerabilityAnalyzer._createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
-          { path: 'filename.js', line: 88 }))
-      addVulnerability(iastContext,
-        vulnerabilityAnalyzer._createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888,
-          { path: 'filename.js', line: 88 }))
-      sendVulnerabilities(iastContext.vulnerabilities, span)
-      sendVulnerabilities(iastContext.vulnerabilities, span)
-      expect(span.addTags).to.have.been.calledOnceWithExactly({
-        '_dd.iast.json': '{"sources":[],"vulnerabilities":[{"type":"INSECURE_HASHING","hash":3410512691,' +
-          '"evidence":{"value":"sha1"},"location":{"spanId":888,"path":"filename.js","line":88}}]}'
-      })
-      expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
-    })
-
     it('should not deduplicate vulnerabilities if not enabled', () => {
       start({
         iast: {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -52,14 +52,14 @@ describe('vulnerability-reporter', () => {
         expect(iastContext.vulnerabilities).to.be.an('array')
       })
 
-      it('should add multiple vulnerabilities', () => {
+      it('should deduplicate same vulnerabilities', () => {
         addVulnerability(iastContext,
           vulnerabilityAnalyzer._createVulnerability('INSECURE_HASHING', { value: 'sha1' }, -555))
         addVulnerability(iastContext,
           vulnerabilityAnalyzer._createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 888))
         addVulnerability(iastContext,
           vulnerabilityAnalyzer._createVulnerability('INSECURE_HASHING', { value: 'sha1' }, 123))
-        expect(iastContext.vulnerabilities).to.have.length(3)
+        expect(iastContext.vulnerabilities).to.have.length(1)
       })
 
       it('should add in the context evidence properties', () => {

--- a/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-reporter.spec.js
@@ -262,8 +262,10 @@ describe('vulnerability-reporter', () => {
       })
 
       expect(prioritySampler.setPriority).to.have.been.calledTwice
-      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
-      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.firstCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should send multiple vulnerabilities with same tainted source', () => {
@@ -318,8 +320,10 @@ describe('vulnerability-reporter', () => {
       })
 
       expect(prioritySampler.setPriority).to.have.been.calledTwice
-      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
-      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.firstCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should send once with multiple vulnerabilities', () => {
@@ -341,9 +345,12 @@ describe('vulnerability-reporter', () => {
             '"location":{"spanId":-5,"path":"/path/to/file3.js","line":3}}]}'
       })
       expect(prioritySampler.setPriority).to.have.been.calledThrice
-      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
-      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
-      expect(prioritySampler.setPriority.thirdCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.firstCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.thirdCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should send once vulnerability with one vulnerability', () => {
@@ -411,8 +418,10 @@ describe('vulnerability-reporter', () => {
           '{"spanId":888,"path":"filename.js","line":88}}]}'
       })
       expect(prioritySampler.setPriority).to.have.been.calledTwice
-      expect(prioritySampler.setPriority.firstCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
-      expect(prioritySampler.setPriority.secondCall).to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.firstCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+      expect(prioritySampler.setPriority.secondCall)
+        .to.have.been.calledWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
     })
 
     it('should add _dd.p.appsec trace tag with standalone enabled', () => {


### PR DESCRIPTION
### What does this PR do?
Moves the handling the standalone sampling priority from the end of the request - when vulnerabilites are sent - to the detection itself.

### Motivation
Set the correct priority for a downstream request whenever an IAST event occurs. Prior to these changes, since the priority was set at the end of the request, the priority of all downstream requests was set incorrectly, as tracer did not know at that time whether an IAST event had occurred.

### Additional Notes
[System Tests PR](https://github.com/DataDog/system-tests/pull/3529) to enable the test for these cases.

[APPSEC-55778](https://datadoghq.atlassian.net/browse/APPSEC-55778)


[APPSEC-55778]: https://datadoghq.atlassian.net/browse/APPSEC-55778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ