### PR TITLE
fix(langchain): do not throw when result is undefined

### DIFF
--- a/packages/datadog-plugin-langchain/src/handlers/language_models/chat_model.js
+++ b/packages/datadog-plugin-langchain/src/handlers/language_models/chat_model.js
@@ -46,7 +46,7 @@ class LangChainChatModelHandler extends LangChainLanguageModelHandler {
 
     this.extractTokenMetrics(ctx.currentStore?.span, result)
 
-    for (const messageSetIdx in result.generations) {
+    for (const messageSetIdx in result?.generations) {
       const messageSet = result.generations[messageSetIdx]
 
       for (const chatCompletionIdx in messageSet) {

--- a/packages/datadog-plugin-langchain/src/handlers/language_models/llm.js
+++ b/packages/datadog-plugin-langchain/src/handlers/language_models/llm.js
@@ -37,7 +37,7 @@ class LangChainLLMHandler extends LangChainLanguageModelHandler {
 
     this.extractTokenMetrics(ctx.currentStore?.span, result)
 
-    for (const completionIdx in result.generations) {
+    for (const completionIdx in result?.generations) {
       const completion = result.generations[completionIdx]
       if (this.isPromptCompletionSampled()) {
         tags[`langchain.response.completions.${completionIdx}.text`] = this.normalize(completion[0].text) || ''

--- a/packages/datadog-plugin-langchain/test/index.spec.js
+++ b/packages/datadog-plugin-langchain/test/index.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { expect } = require('chai')
 const { useEnv } = require('../../../integration-tests/helpers')
 const agent = require('../../dd-trace/test/plugins/agent')
 


### PR DESCRIPTION
### What does this PR do?
Fixes cases when the underlying chain (llm call, chat model call, embedding, or some other chain operation) results in the output of the chain or part of the chain being undefined. This only happens for LLMs and chat model calls, as the embedding handler returns early if the result is not an array (`undefined` isn't), and the chain handler first array-ifys the result, and since we normalize `undefined` to `undefined`, the tag never gets added to the span.

The fix adds optional chaining to the iteration over `result.generations`. Iterating over `undefined` does nothing, and since that is our only operation in `getSpanEndTags` for both LLMs and chat models, we return early.

Despite chain and embedding handlers not having this bug, I added regression tests to be safe.

### Motivation
We do not want to throw from plugins.


