### PR TITLE
make SSI not crash on node 12.0.0, 18.0.0, et.c

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -34,7 +34,7 @@ jobs:
   integration-guardrails:
     strategy:
       matrix:
-        version: [12, 14, 16]
+        version: [12.0.0, 12, 14, 16]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,7 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [18.0.0, 18.1.0, 18, 20.0.0, 20, 22.0.0, 22, latest]
+        version: [18, 20, 22, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
   integration-guardrails:
     strategy:
       matrix:
-        version: [12.0.0, 12, 14.0.0, 14, 16.0.0, 16]
+        version: [12.0.0, 12, 14.0.0, 14, 16.0.0, 16, 18.0.0, 18.1.0, 20.0.0, 22.0.0]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,7 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [18, 20, latest]
+        version: [18.0.0, 18.1.0, 18, 20.0.0, 20, 22.0.0, 22, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
   integration-guardrails:
     strategy:
       matrix:
-        version: [12.0.0, 12, 14, 16]
+        version: [12.0.0, 12, 14.0.0, 14, 16.0.0, 16]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/init.js
+++ b/init.js
@@ -2,7 +2,9 @@
 
 /* eslint-disable no-var */
 
-var NODE_MAJOR = require('./version').NODE_MAJOR
+var nodeVersion = require('./version')
+var NODE_MAJOR = nodeVersion.NODE_MAJOR
+var NODE_MINOR = nodeVersion.NODE_MINOR
 
 // We use several things that are not supported by older versions of Node:
 // - AsyncLocalStorage
@@ -11,7 +13,7 @@ var NODE_MAJOR = require('./version').NODE_MAJOR
 // - Mocha (for testing)
 // and probably others.
 // TODO: Remove all these dependencies so that we can report telemetry.
-if (NODE_MAJOR >= 12) {
+if ((NODE_MAJOR === 12 && NODE_MINOR >= 17) || NODE_MAJOR > 12) {
   var path = require('path')
   var Module = require('module')
   var semver = require('semver')

--- a/initialize.mjs
+++ b/initialize.mjs
@@ -31,11 +31,16 @@ ${result.source}`
   return result
 }
 
+const [NODE_MAJOR, NODE_MINOR] = process.versions.node.split('.').map(x => +x)
+
+const brokenLoaders = NODE_MAJOR === 18 && NODE_MINOR === 0
+
 export async function load (...args) {
-  return insertInit(await origLoad(...args))
+  const loadHook = brokenLoaders ? args[args.length - 1] : origLoad
+  return insertInit(await loadHook(...args))
 }
 
-export const resolve = origResolve
+export const resolve = brokenLoaders ? undefined : origResolve
 
 export const getFormat = origGetFormat
 

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -193,15 +193,15 @@ describe('init.js', () => {
 // or on 18.0.0 in particular.
 if (
   semver.satisfies(process.versions.node, '>=12.17.0') &&
-  semver.satisfies(process.versions.node, '>=14.13.1') &&
-  !semver.satisfies(process.versions.node, '18.0.0')
+  semver.satisfies(process.versions.node, '>=14.13.1')
 ) {
   describe('initialize.mjs', () => {
     useSandbox()
     stubTracerIfNeeded()
 
     context('as --loader', () => {
-      testInjectionScenarios('loader', 'initialize.mjs', true)
+      testInjectionScenarios('loader', 'initialize.mjs',
+        process.versions.node !== '18.0.0')
       testRuntimeVersionChecks('loader', 'initialize.mjs')
     })
     if (semver.satisfies(process.versions.node, '>=20.6.0')) {

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -189,8 +189,13 @@ describe('init.js', () => {
   testRuntimeVersionChecks('require', 'init.js')
 })
 
-// ESM is not supportable prior to Node.js 12.17.0
-if (semver.satisfies(process.versions.node, '>=12.17.0')) {
+// ESM is not supportable prior to Node.js 12.17.0, 14.13.1 on the 14.x line,
+// or on 18.0.0 in particular.
+if (
+  semver.satisfies(process.versions.node, '>=12.17.0') &&
+  semver.satisfies(process.versions.node, '>=14.13.1') &&
+  !semver.satisfies(process.versions.node, '18.0.0')
+) {
   describe('initialize.mjs', () => {
     useSandbox()
     stubTracerIfNeeded()
@@ -199,7 +204,7 @@ if (semver.satisfies(process.versions.node, '>=12.17.0')) {
       testInjectionScenarios('loader', 'initialize.mjs', true)
       testRuntimeVersionChecks('loader', 'initialize.mjs')
     })
-    if (Number(process.versions.node.split('.')[0]) >= 18) {
+    if (semver.satisfies(process.versions.node, '>=20.6.0')) {
       context('as --import', () => {
         testInjectionScenarios('import', 'initialize.mjs', true)
         testRuntimeVersionChecks('loader', 'initialize.mjs')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Put appropriate guardrails in place on ESM initialization so that it doesn't crash on buggy, unsupported versions of Node.js
* Do a proper bailout on versions of Node.js v12 that don't have AsyncLocalStorage.

### Motivation
<!-- What inspired you to submit this pull request? -->
Folks might use these `X.0.0` versions, and while some features might not work, apps should not crash.


