### PR TITLE
fix race condition in initialization file on latest node

### DIFF
--- a/initialize.mjs
+++ b/initialize.mjs
@@ -51,8 +51,9 @@ export async function getSource (...args) {
 if (isMainThread) {
   // Need this IIFE for versions of Node.js without top-level await.
   (async () => {
-    await import('./init.js')
-    const { register } = await import('node:module')
+    const { register, createRequire } = await import('node:module')
+    const require = createRequire(import.meta.url)
+    require('./init.js')
     if (register) {
       register('./loader-hook.mjs', import.meta.url)
     }

--- a/initialize.mjs
+++ b/initialize.mjs
@@ -12,6 +12,7 @@
 
 import { isMainThread } from 'worker_threads'
 
+import * as Module from 'node:module'
 import { fileURLToPath } from 'node:url'
 import {
   load as origLoad,
@@ -49,13 +50,9 @@ export async function getSource (...args) {
 }
 
 if (isMainThread) {
-  // Need this IIFE for versions of Node.js without top-level await.
-  (async () => {
-    const { register, createRequire } = await import('node:module')
-    const require = createRequire(import.meta.url)
-    require('./init.js')
-    if (register) {
-      register('./loader-hook.mjs', import.meta.url)
-    }
-  })()
+  const require = Module.createRequire(import.meta.url)
+  require('./init.js')
+  if (Module.register) {
+    Module.register('./loader-hook.mjs', import.meta.url)
+  }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix race condition in initialization file on latest Node.

### Motivation
<!-- What inspired you to submit this pull request? -->

In Node 23, sometimes the tracer was getting initialized and sometimes not. It seems to be a bug in Node where there is a race condition when using `await import`, so we use `require` instead to do it synchronously and avoid the issue.