### PR TITLE
fix oracledb ci job using a node version incompatible with container

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -837,6 +837,10 @@ jobs:
           curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
           tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: '16'
       - uses: ./.github/actions/install
       - run: which node
       - run: yarn config set ignore-engines true

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -842,7 +842,6 @@ jobs:
           cache: yarn
           node-version: '16'
       - uses: ./.github/actions/install
-      - run: which node
       - run: yarn config set ignore-engines true
       - run: yarn services --ignore-engines
       - run: yarn test:plugins --ignore-engines

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -802,7 +802,11 @@ jobs:
   # TODO: Figure out why nyc stopped working with EACCESS errors.
   oracledb:
     runs-on: ubuntu-latest
-    container: bengl/node-12-with-oracle-client
+    container:
+      image: bengl/node-12-with-oracle-client
+      volumes:
+        - /node20217:/node20217:rw,rshared
+        - /node20217:/__e/node20:ro,rshared
     services:
       oracledb:
         image: gvenzl/oracle-xe:18-slim
@@ -827,7 +831,11 @@ jobs:
       # Needed to fix issue with `actions/checkout@v3: https://github.com/actions/checkout/issues/1590
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-      - run: which node
+      # https://github.com/actions/runner/issues/2906#issuecomment-2109514798
+      - name: Install Node for runner (with glibc 2.17 compatibility)
+        run: |
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
+          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install
       - run: which node

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -828,10 +828,6 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          cache: yarn
-          node-version: '16'
       - uses: ./.github/actions/install
       - run: yarn config set ignore-engines true
       - run: yarn services --ignore-engines

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -827,8 +827,10 @@ jobs:
       # Needed to fix issue with `actions/checkout@v3: https://github.com/actions/checkout/issues/1590
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
+      - run: which node
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install
+      - run: which node
       - run: yarn config set ignore-engines true
       - run: yarn services --ignore-engines
       - run: yarn test:plugins --ignore-engines


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix oracledb ci job using a Node version incompatible with container.

### Motivation
<!-- What inspired you to submit this pull request? -->

GitHub Actions now forces all actions to use Node 20, but Node 20 is not compatible with glibc 2.25 that is needed by the container we use to test oracledb. This can be worked around by overwriting the GHA Node version with an unofficial build that support older glibc.