### PR TITLE
[test optimization] Do not init on package managers

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -71,8 +71,6 @@ if (shouldInit) {
   tracer.init(options)
   tracer.use('fs', false)
   tracer.use('child_process', false)
-} else {
-  console.log('not init')
 }
 
 module.exports = tracer

--- a/ci/init.js
+++ b/ci/init.js
@@ -1,10 +1,21 @@
 /* eslint-disable no-console */
 const tracer = require('../packages/dd-trace')
 const { isTrue } = require('../packages/dd-trace/src/util')
+const log = require('../packages/dd-trace/src/log')
 
 const isJestWorker = !!process.env.JEST_WORKER_ID
 const isCucumberWorker = !!process.env.CUCUMBER_WORKER_ID
 const isMochaWorker = !!process.env.MOCHA_WORKER_ID
+
+const packageManagers = [
+  'npm',
+  'yarn',
+  'pnpm'
+]
+
+const isPackageManager = () => {
+  return packageManagers.some(packageManager => process.argv[1]?.includes(`bin/${packageManager}`))
+}
 
 const options = {
   startupLogs: false,
@@ -13,6 +24,11 @@ const options = {
 }
 
 let shouldInit = true
+
+if (isPackageManager()) {
+  log.debug('dd-trace is not initialized in a package manager.')
+  shouldInit = false
+}
 
 const isAgentlessEnabled = isTrue(process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED)
 
@@ -55,6 +71,8 @@ if (shouldInit) {
   tracer.init(options)
   tracer.use('fs', false)
   tracer.use('child_process', false)
+} else {
+  console.log('not init')
 }
 
 module.exports = tracer

--- a/integration-tests/test-api-manual.spec.js
+++ b/integration-tests/test-api-manual.spec.js
@@ -10,24 +10,20 @@ const {
   getCiVisAgentlessConfig
 } = require('./helpers')
 const { FakeCiVisIntake } = require('./ci-visibility-intake')
-const webAppServer = require('./ci-visibility/web-app-server')
 const {
   TEST_STATUS
 } = require('../packages/dd-trace/src/plugins/util/test')
 
 describe('test-api-manual', () => {
-  let sandbox, cwd, receiver, childProcess, webAppPort
+  let sandbox, cwd, receiver, childProcess
 
   before(async () => {
     sandbox = await createSandbox([], true)
     cwd = sandbox.folder
-    webAppPort = await getPort()
-    webAppServer.listen(webAppPort)
   })
 
   after(async () => {
     await sandbox.remove()
-    await new Promise(resolve => webAppServer.close(resolve))
   })
 
   beforeEach(async function () {

--- a/integration-tests/test-optimization-startup.spec.js
+++ b/integration-tests/test-optimization-startup.spec.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const { exec } = require('child_process')
+
+const getPort = require('get-port')
+const { assert } = require('chai')
+
+const { createSandbox } = require('./helpers')
+const { FakeCiVisIntake } = require('./ci-visibility-intake')
+
+describe('test optimization startup', () => {
+  let sandbox, cwd, receiver, childProcess
+
+  before(async () => {
+    sandbox = await createSandbox(['yarn', 'npm', 'pnpm'], true)
+    cwd = sandbox.folder
+  })
+
+  after(async () => {
+    await sandbox.remove()
+  })
+
+  beforeEach(async function () {
+    const port = await getPort()
+    receiver = await new FakeCiVisIntake(port).start()
+  })
+
+  afterEach(async () => {
+    childProcess.kill()
+    await receiver.stop()
+  })
+
+  it('skips initialization for yarn', (done) => {
+    let testOutput
+
+    childProcess = exec('node ./node_modules/.bin/yarn -v',
+      {
+        cwd,
+        env: {
+          ...process.env,
+          NODE_OPTIONS: '-r dd-trace/ci/init',
+          DD_TRACE_DEBUG: '1'
+        },
+        stdio: 'pipe'
+      }
+    )
+
+    childProcess.stdout.on('data', (chunk) => {
+      testOutput += chunk.toString()
+    })
+
+    childProcess.on('exit', () => {
+      assert.include(testOutput, 'dd-trace is not initialized in a package manager')
+      done()
+    })
+  })
+
+  it('skips initialization for npm', (done) => {
+    let testOutput
+
+    childProcess = exec('node ./node_modules/.bin/npm -v',
+      {
+        cwd,
+        env: {
+          ...process.env,
+          NODE_OPTIONS: '-r dd-trace/ci/init',
+          DD_TRACE_DEBUG: '1'
+        },
+        stdio: 'pipe'
+      }
+    )
+
+    childProcess.stdout.on('data', (chunk) => {
+      testOutput += chunk.toString()
+    })
+
+    childProcess.on('exit', () => {
+      assert.include(testOutput, 'dd-trace is not initialized in a package manager')
+      done()
+    })
+  })
+
+  it('skips initialization for pnpm', (done) => {
+    let testOutput
+
+    childProcess = exec('node ./node_modules/.bin/pnpm -v',
+      {
+        cwd,
+        env: {
+          ...process.env,
+          NODE_OPTIONS: '-r dd-trace/ci/init',
+          DD_TRACE_DEBUG: '1'
+        },
+        stdio: 'pipe'
+      }
+    )
+
+    childProcess.stdout.on('data', (chunk) => {
+      testOutput += chunk.toString()
+    })
+
+    childProcess.on('exit', () => {
+      assert.include(testOutput, 'dd-trace is not initialized in a package manager')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Do not initialize test optimization (FKA test visibility) if the running process is a package manager, such as `yarn` or `npm`. 

So for example if you run your tests like this:

```json
  "scripts": {
    "test": "jest"
  }
```
```
yarn test
```

`yarn` actually spawns a _new_ process for `jest`, meaning that at least two `dd-trace` initializations happen.

### Motivation
We recommend initializing test optimization with `NODE_OPTIONS='-r dd-trace/ci/init'`. This means that _every_ node process will initialize the tracer. This is usually safe, but it leads to unnecessary code being run. By avoiding the most commonly used processes, that is, package managers, we already save a bunch of initializations.

### Plugin Checklist

- [x] Unit tests.
