### PR TITLE
add runtime version to crash report metadata

### DIFF
--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -79,6 +79,7 @@ class Crashtracker {
         'language:javascript',
         `library_version:${pkg.version}`,
         'runtime:nodejs',
+        `runtime_version:${process.versions.node}`,
         'severity:crash'
       ]
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add runtime version to crash report metadata.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is currently missing from crash reports which makes it difficult to quickly validate if a crash is from a Node issue.