### PR TITLE
[test optimization] Fix logic to bypass jest's require cache

### DIFF
--- a/integration-tests/ci-visibility/office-addin-mock/dependency.js
+++ b/integration-tests/ci-visibility/office-addin-mock/dependency.js
@@ -1,0 +1,7 @@
+require('office-addin-mock')
+
+function sum (a, b) {
+  return a + b
+}
+
+module.exports = sum

--- a/integration-tests/ci-visibility/office-addin-mock/test.js
+++ b/integration-tests/ci-visibility/office-addin-mock/test.js
@@ -1,0 +1,6 @@
+const sum = require('./dependency')
+const { expect } = require('chai')
+
+test('can sum', () => {
+  expect(sum(1, 2)).to.equal(3)
+})

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -866,7 +866,7 @@ const LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE = [
 
 function shouldBypassJestRequireEngine (moduleName) {
   return (
-    LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.some(library => moduleName.includes(library))
+    LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.some(library => moduleName === library)
   )
 }
 


### PR DESCRIPTION
### What does this PR do?
`moduleName.includes` is bad logic: a module being `winston-but-not-winston-library` would bypass jest's require cache, which is not what we want.

### Motivation
Fixes https://github.com/DataDog/dd-trace-js/issues/4915

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
