### PR TITLE
(fix) Verifying span id is nonzero during extraction

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -497,7 +497,7 @@ class TextMapPropagator {
 
   _extractGenericContext (carrier, traceKey, spanKey, radix) {
     if (carrier[traceKey] && carrier[spanKey]) {
-      if (invalidSegment.test(carrier[traceKey])) return null
+      if (invalidSegment.test(carrier[traceKey]) || invalidSegment.test(carrier[spanKey])) return null
 
       return new DatadogSpanContext({
         traceId: id(carrier[traceKey], radix),


### PR DESCRIPTION
### What does this PR do?
Adds a check to ensure that Span Links are only created in compound header extraction when the `SpanID` is valid. 
### Motivation
This system-tests [PR](https://github.com/DataDog/system-tests/pull/3499/files#diff-2f9154dbb913f2bbd44191a5bcaeea03cb0ed080ab29fe2ca76e1fcef1b26044R123-R144) introduces a test to ensure that all libraries only create span links in distributed tracing header extraction when the `SpanID` is valid. This PR aims to implement this check in dd-trace-js.
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


