### PR TITLE
stop using native metrics for newer node versions

### DIFF
--- a/packages/dd-trace/src/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics.js
@@ -13,7 +13,7 @@ const { NODE_MAJOR, NODE_MINOR } = require('../../../version')
 const INTERVAL = 10 * 1000
 
 const allMetricsAvailable = NODE_MAJOR > 22 ||
-  (NODE_MAJOR === 22 && NODE_MAJOR >= 8) ||
+  (NODE_MAJOR === 22 && NODE_MINOR >= 8) ||
   (NODE_MAJOR === 20 && NODE_MINOR >= 18)
 
 let nativeMetrics = null


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop using native metrics for newer Node versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

All the runtime metrics we need are now available out of the box from Node, so loading a native extension is no longer necessary to capture them.