### PR TITLE
use weakmap to avoid references from node to datadog stores

### DIFF
--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -2,20 +2,36 @@
 
 const { AsyncLocalStorage } = require('async_hooks')
 
+class DatadogStorage {
+  constructor () {
+    this._storage = new AsyncLocalStorage()
+  }
+
+  enterWith (store) {
+    const handle = {}
+    stores.set(handle, store)
+    this._storage.enterWith(handle)
+  }
+
+  getStore () {
+    const handle = this._storage.getStore()
+    return stores.get(handle)
+  }
+}
+
 const storages = Object.create(null)
-const legacyStorage = new AsyncLocalStorage()
+const legacyStorage = new DatadogStorage()
 
 const storage = function (namespace) {
   if (!storages[namespace]) {
-    storages[namespace] = new AsyncLocalStorage()
+    storages[namespace] = new DatadogStorage()
   }
   return storages[namespace]
 }
 
-storage.disable = legacyStorage.disable.bind(legacyStorage)
 storage.enterWith = legacyStorage.enterWith.bind(legacyStorage)
-storage.exit = legacyStorage.exit.bind(legacyStorage)
 storage.getStore = legacyStorage.getStore.bind(legacyStorage)
-storage.run = legacyStorage.run.bind(legacyStorage)
+
+const stores = new WeakMap()
 
 module.exports = storage

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -24,7 +24,7 @@ class DatadogStorage {
     try {
       return Reflect.apply(fn, null, args)
     } finally {
-      this.enterWith(prior)
+      this._storage.enterWith(prior)
     }
   }
 }

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -17,6 +17,16 @@ class DatadogStorage {
     const handle = this._storage.getStore()
     return stores.get(handle)
   }
+
+  run (store, fn, ...args) {
+    const prior = this._storage.getStore()
+    this.enterWith(store)
+    try {
+      return Reflect.apply(fn, null, args)
+    } finally {
+      this.enterWith(prior)
+    }
+  }
 }
 
 const storages = Object.create(null)
@@ -31,6 +41,7 @@ const storage = function (namespace) {
 
 storage.enterWith = legacyStorage.enterWith.bind(legacyStorage)
 storage.getStore = legacyStorage.getStore.bind(legacyStorage)
+storage.run = legacyStorage.run.bind(legacyStorage)
 
 const stores = new WeakMap()
 

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -7,10 +7,18 @@ class DatadogStorage {
     this._storage = new AsyncLocalStorage()
   }
 
+  disable () {
+    this._storage.disable()
+  }
+
   enterWith (store) {
     const handle = {}
     stores.set(handle, store)
     this._storage.enterWith(handle)
+  }
+
+  exit (callback, ...args) {
+    this._storage.exit(callback, ...args)
   }
 
   getStore () {
@@ -39,7 +47,9 @@ const storage = function (namespace) {
   return storages[namespace]
 }
 
+storage.disable = legacyStorage.disable.bind(legacyStorage)
 storage.enterWith = legacyStorage.enterWith.bind(legacyStorage)
+storage.exit = legacyStorage.exit.bind(legacyStorage)
 storage.getStore = legacyStorage.getStore.bind(legacyStorage)
 storage.run = legacyStorage.run.bind(legacyStorage)
 

--- a/packages/dd-trace/src/llmobs/storage.js
+++ b/packages/dd-trace/src/llmobs/storage.js
@@ -1,7 +1,6 @@
 'use strict'
 
-// TODO: remove this and use namespaced storage once available
-const { AsyncLocalStorage } = require('async_hooks')
-const storage = new AsyncLocalStorage()
+const { storage: createStorage } = require('../../../datadog-core')
+const storage = createStorage('llmobs')
 
 module.exports = { storage }

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { AsyncLocalStorage } = require('async_hooks')
+const { storage } = require('../../../datadog-core')
 const { trace, ROOT_CONTEXT } = require('@opentelemetry/api')
 const DataDogSpanContext = require('../opentracing/span_context')
 
@@ -9,7 +9,7 @@ const tracer = require('../../')
 
 class ContextManager {
   constructor () {
-    this._store = new AsyncLocalStorage()
+    this._store = storage('opentelemetry')
   }
 
   active () {

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -1,4 +1,4 @@
-const { AsyncLocalStorage } = require('async_hooks')
+const { storage } = require('../../../../../datadog-core')
 const TracingPlugin = require('../../../plugins/tracing')
 const { performance } = require('perf_hooks')
 
@@ -8,7 +8,7 @@ class EventPlugin extends TracingPlugin {
   constructor (eventHandler) {
     super()
     this.eventHandler = eventHandler
-    this.store = new AsyncLocalStorage()
+    this.store = storage('profiling')
     this.entryType = this.constructor.entryType
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use WeakMap to avoid references from Node to Datadog stores.

### Motivation
<!-- What inspired you to submit this pull request? -->

When using AsyncLocalStorage, it attaches the store to the underlying resource directly. This means that if the resource is cloned, everything in all stores referenced by that resource will also be cloned, and some objects that may be referenced like sockets cannot be cloned, resulting in an error at best, and a segmentation fault at worst. Using a WeakMap makes it so that it's the map that references both a handle that is used as the store, and the real store stored in the map so that the store is no longer cloned.

This is an issue with `AsyncLocalStorage` and not with dd-trace so it should be fixed in Node, but for now we need to at least fix the immediate issue in the library.