### PR TITLE
Protect req.socket.remoteAddress in appsec reporter

### DIFF
--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -148,7 +148,9 @@ function reportAttack (attackData) {
     newTags['_dd.appsec.json'] = '{"triggers":' + attackData + '}'
   }
 
-  newTags['network.client.ip'] = req.socket.remoteAddress
+  if (req.socket) {
+    newTags['network.client.ip'] = req.socket.remoteAddress
+  }
 
   rootSpan.addTags(newTags)
 }

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -223,6 +223,20 @@ describe('reporter', () => {
       storage.disable()
     })
 
+    it('should add tags to request span when socket is not there', () => {
+      delete req.socket
+      const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]')
+      expect(result).to.not.be.false
+      expect(web.root).to.have.been.calledOnceWith(req)
+
+      expect(span.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.event': 'true',
+        '_dd.origin': 'appsec',
+        '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}'
+      })
+      expect(prioritySampler.setPriority).to.have.been.calledOnceWithExactly(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+    })
+
     it('should add tags to request span', () => {
       const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]')
       expect(result).to.not.be.false

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -225,7 +225,9 @@ describe('reporter', () => {
 
     it('should add tags to request span when socket is not there', () => {
       delete req.socket
+
       const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]')
+
       expect(result).to.not.be.false
       expect(web.root).to.have.been.calledOnceWith(req)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Protect `req.socket.remoteAddress` for the use cases when `req.socket` is empty.

### Motivation
<!-- What inspired you to submit this pull request? -->
Detected logs with the failure.


