### PR TITLE
Fix original url instanceOf url.URL

### DIFF
--- a/packages/datadog-instrumentations/src/url.js
+++ b/packages/datadog-instrumentations/src/url.js
@@ -59,6 +59,10 @@ addHook({ name: names }, function (url) {
           isURL: true
         })
       }
+
+      static [Symbol.hasInstance](instance) {
+        return instance instanceof URL;
+      }
     }
   })
 

--- a/packages/datadog-instrumentations/src/url.js
+++ b/packages/datadog-instrumentations/src/url.js
@@ -60,8 +60,8 @@ addHook({ name: names }, function (url) {
         })
       }
 
-      static [Symbol.hasInstance](instance) {
-        return instance instanceof URL;
+      static [Symbol.hasInstance] (instance) {
+        return instance instanceof URL
       }
     }
   })

--- a/packages/datadog-instrumentations/test/url.spec.js
+++ b/packages/datadog-instrumentations/test/url.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const agent = require('../../dd-trace/test/plugins/agent')
+const { assert } = require('chai')
 const { channel } = require('../src/helpers/instrument')
 const names = ['url', 'node:url']
 
@@ -66,6 +67,13 @@ names.forEach(name => {
             parsed: result,
             isURL: true
           }, sinon.match.any)
+        })
+
+        it('instanceof should work also for original instances', () => {
+          const OriginalUrl = url.URL.__proto__
+          const originalUrl = new OriginalUrl('https://www.datadoghq.com')
+
+          assert.isTrue(originalUrl instanceof url.URL)
         })
 
         ;['host', 'origin', 'hostname'].forEach(property => {

--- a/packages/datadog-instrumentations/test/url.spec.js
+++ b/packages/datadog-instrumentations/test/url.spec.js
@@ -70,7 +70,7 @@ names.forEach(name => {
         })
 
         it('instanceof should work also for original instances', () => {
-          const OriginalUrl = url.URL.__proto__
+          const OriginalUrl = Object.getPrototypeOf(url.URL)
           const originalUrl = new OriginalUrl('https://www.datadoghq.com')
 
           assert.isTrue(originalUrl instanceof url.URL)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Having an original instance of `URL`, `originalInstance instanceOf url.URL` should return true.

### Motivation
<!-- What inspired you to submit this pull request? -->
Issue: https://github.com/DataDog/dd-trace-js/issues/4896

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Thanks @benconnito for reporting the issue.
