### PR TITLE
use gc observer for gc runtime metrics when available

### DIFF
--- a/packages/dd-trace/src/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics.js
@@ -341,6 +341,11 @@ function captureNativeMetrics () {
 function histogram (name, stats, tags) {
   tags = [].concat(tags)
 
+  // Stats can contain garbage data when a value was never recorded.
+  if (stats.count === 0) {
+    stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0 }
+  }
+
   client.gauge(`${name}.min`, stats.min, tags)
   client.gauge(`${name}.max`, stats.max, tags)
   client.increment(`${name}.sum`, stats.sum, tags)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use `gc` observer for GC runtime metrics when available.

### Motivation
<!-- What inspired you to submit this pull request? -->

Node provides this out of the box since Node 16, so we shouldn't use our own native implementation.