### PR TITLE
[DI] Adhere to diagnostics JSON schema (version -> probeVersion)

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -24,15 +24,15 @@ describe('Dynamic Instrumentation', function () {
       const expectedPayloads = [{
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 0, status: 'RECEIVED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 0, status: 'RECEIVED' } }
       }, {
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 0, status: 'INSTALLED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 0, status: 'INSTALLED' } }
       }, {
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 0, status: 'EMITTING' } }
+        debugger: { diagnostics: { probeId, probeVersion: 0, status: 'EMITTING' } }
       }]
 
       t.agent.on('remote-config-ack-update', (id, version, state, error) => {
@@ -75,19 +75,19 @@ describe('Dynamic Instrumentation', function () {
       const expectedPayloads = [{
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 0, status: 'RECEIVED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 0, status: 'RECEIVED' } }
       }, {
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 0, status: 'INSTALLED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 0, status: 'INSTALLED' } }
       }, {
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 1, status: 'RECEIVED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 1, status: 'RECEIVED' } }
       }, {
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 1, status: 'INSTALLED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 1, status: 'INSTALLED' } }
       }]
       const triggers = [
         () => {
@@ -128,11 +128,11 @@ describe('Dynamic Instrumentation', function () {
       const expectedPayloads = [{
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 0, status: 'RECEIVED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 0, status: 'RECEIVED' } }
       }, {
         ddsource: 'dd_debugger',
         service: 'node',
-        debugger: { diagnostics: { probeId, version: 0, status: 'INSTALLED' } }
+        debugger: { diagnostics: { probeId, probeVersion: 0, status: 'INSTALLED' } }
       }]
 
       t.agent.on('remote-config-ack-update', (id, version, state, error) => {

--- a/packages/dd-trace/src/debugger/devtools_client/status.js
+++ b/packages/dd-trace/src/debugger/devtools_client/status.js
@@ -91,12 +91,12 @@ function send (payload) {
   })
 }
 
-function statusPayload (probeId, version, status) {
+function statusPayload (probeId, probeVersion, status) {
   return {
     ddsource,
     service,
     debugger: {
-      diagnostics: { probeId, runtimeId, version, status }
+      diagnostics: { probeId, runtimeId, probeVersion, status }
     }
   }
 }

--- a/packages/dd-trace/test/debugger/devtools_client/status.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/status.spec.js
@@ -79,7 +79,7 @@ describe('diagnostic message http request caching', function () {
 
 function assertRequestData (request, { probeId, version, status, exception }) {
   const payload = getFormPayload(request)
-  const diagnostics = { probeId, runtimeId, version, status }
+  const diagnostics = { probeId, runtimeId, probeVersion: version, status }
 
   // Error requests will also contain an `exception` property
   if (exception) diagnostics.exception = exception


### PR DESCRIPTION
Rename the `debugger.diagnostics.version` field to `debugger.diagnostics.probeVersion` for the JSON sent to the `/debugger/v1/diagnostics` endpoint.

This is in line with what the other tracers does, but was incorrectly named in the RFC.
