### PR TITLE
Explain why keeping query in http end translator

### DIFF
--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -163,7 +163,7 @@ function incomingHttpEndTranslator ({ req, res }) {
     persistent[addresses.HTTP_INCOMING_COOKIES] = req.cookies
   }
 
-  // we need to keeo this to support nextjs
+  // we need to keep this to support nextjs
   if (req.query !== null && typeof req.query === 'object') {
     persistent[addresses.HTTP_INCOMING_QUERY] = req.query
   }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -163,6 +163,11 @@ function incomingHttpEndTranslator ({ req, res }) {
     persistent[addresses.HTTP_INCOMING_COOKIES] = req.cookies
   }
 
+  // we need to keeo this to support nextjs
+  if (req.query !== null && typeof req.query === 'object') {
+    persistent[addresses.HTTP_INCOMING_QUERY] = req.query
+  }
+
   if (apiSecuritySampler.sampleRequest(req, res, true)) {
     persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }
   }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -163,10 +163,6 @@ function incomingHttpEndTranslator ({ req, res }) {
     persistent[addresses.HTTP_INCOMING_COOKIES] = req.cookies
   }
 
-  if (req.query !== null && typeof req.query === 'object') {
-    persistent[addresses.HTTP_INCOMING_QUERY] = req.query
-  }
-
   if (apiSecuritySampler.sampleRequest(req, res, true)) {
     persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }
   }

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -431,9 +431,6 @@ describe('AppSec Index', function () {
         body: {
           a: '1'
         },
-        query: {
-          b: '2'
-        },
         route: {
           path: '/path/:c'
         },
@@ -458,8 +455,7 @@ describe('AppSec Index', function () {
       expect(waf.run).to.have.been.calledOnceWithExactly({
         persistent: {
           'server.request.body': { a: '1' },
-          'server.request.cookies': { d: '4', e: '5' },
-          'server.request.query': { b: '2' }
+          'server.request.cookies': { d: '4', e: '5' }
         }
       }, req)
       expect(Reporter.finishRequest).to.have.been.calledOnceWithExactly(req, res)
@@ -501,9 +497,6 @@ describe('AppSec Index', function () {
         body: {
           a: '1'
         },
-        query: {
-          b: '2'
-        },
         route: {
           path: '/path/:c'
         }
@@ -523,8 +516,7 @@ describe('AppSec Index', function () {
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
         persistent: {
-          'server.request.body': { a: '1' },
-          'server.request.query': { b: '2' }
+          'server.request.body': { a: '1' }
         }
       }, req)
     })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -431,6 +431,9 @@ describe('AppSec Index', function () {
         body: {
           a: '1'
         },
+        query: {
+          b: '2'
+        },
         route: {
           path: '/path/:c'
         },
@@ -455,7 +458,8 @@ describe('AppSec Index', function () {
       expect(waf.run).to.have.been.calledOnceWithExactly({
         persistent: {
           'server.request.body': { a: '1' },
-          'server.request.cookies': { d: '4', e: '5' }
+          'server.request.cookies': { d: '4', e: '5' },
+          'server.request.query': { b: '2' }
         }
       }, req)
       expect(Reporter.finishRequest).to.have.been.calledOnceWithExactly(req, res)
@@ -497,6 +501,9 @@ describe('AppSec Index', function () {
         body: {
           a: '1'
         },
+        query: {
+          b: '2'
+        },
         route: {
           path: '/path/:c'
         }
@@ -516,7 +523,8 @@ describe('AppSec Index', function () {
 
       expect(waf.run).to.have.been.calledOnceWithExactly({
         persistent: {
-          'server.request.body': { a: '1' }
+          'server.request.body': { a: '1' },
+          'server.request.query': { b: '2' }
         }
       }, req)
     })


### PR DESCRIPTION
### What does this PR do?
Explain why sending query to the WAF at the HTTP end request translator, used for nextjs
### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


