### PR TITLE
fix next esm tests installing wrong version of react

### DIFF
--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -30,7 +30,7 @@ describe('esm', () => {
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(120 * 1000)
-      sandbox = await createSandbox([`'next@${version}'`, 'react', 'react-dom'],
+      sandbox = await createSandbox([`'next@${version}'`, 'react@^18.2.0', 'react-dom@^18.2.0'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'],
         BUILD_COMMAND)
     })

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -151,7 +151,15 @@ async function addDependencies (dependencies, name, versionRange) {
   for (const dep of deps[name]) {
     for (const section of ['devDependencies', 'peerDependencies']) {
       if (pkgJson[section] && dep in pkgJson[section]) {
-        dependencies[dep] = pkgJson[section][dep]
+        if (pkgJson[section][dep].includes('||')) {
+          dependencies[dep] = pkgJson[section][dep].split('||')
+            .map(v => v.trim())
+            .filter(v => !/[a-z]/.test(v)) // Ignore prereleases.
+            .join(' || ')
+        } else {
+          // Only one version available so use that even if it is a prerelease.
+          dependencies[dep] = pkgJson[section][dep]
+        }
         break
       }
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix Next.js ESM tests installing wrong version of `react` and `react-dom` by hardcoding their versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

React just released version 19 which is incompatible with Next.js. For our regular tests, this is installed as we use the version range from the `peerDependency` of the library, but this logic was never added to ESM tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This is a temporary workaround and the correct solution would be to install the version as defined in the peer dependencies, but that will require more effort to rework how ESM tests work.
