### PR TITLE
fix guardrail on node version outside of ssi

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -295,7 +295,6 @@ jobs:
       SERVICES: couchbase
       PACKAGE_VERSION_RANGE: ${{ matrix.range }}
       DD_INJECT_FORCE: 'true'
-      DD_TRACE_DEBUG: 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -294,6 +294,7 @@ jobs:
       PLUGINS: couchbase
       SERVICES: couchbase
       PACKAGE_VERSION_RANGE: ${{ matrix.range }}
+      DD_INJECT_FORCE: 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start
@@ -828,6 +829,7 @@ jobs:
       PLUGINS: oracledb
       SERVICES: oracledb
       DD_TEST_AGENT_URL: http://testagent:9126
+      DD_INJECT_FORCE: 'true'
       # Needed to fix issue with `actions/checkout@v3: https://github.com/actions/checkout/issues/1590
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -295,6 +295,7 @@ jobs:
       SERVICES: couchbase
       PACKAGE_VERSION_RANGE: ${{ matrix.range }}
       DD_INJECT_FORCE: 'true'
+      DD_TRACE_DEBUG: 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/testagent/start

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -49,14 +49,15 @@ jobs:
       matrix:
         version: ['0.8', '0.10', '0.12', '4', '6', '8', '10', '12.0.0']
     runs-on: ubuntu-latest
-    env:
-      DD_INJECTION_ENABLED: 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
       - run: node ./init
+      - run: node ./init
+        env:
+          DD_INJECTION_ENABLED: 'true'
 
   integration-ci:
     strategy:

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -105,7 +105,7 @@ async function runAndCheckWithTelemetry (filename, expectedOut, ...expectedTelem
 }
 
 function spawnProc (filename, options = {}, stdioHandler, stderrHandler) {
-  const proc = fork(filename, { ...options, stdio: 'pipe', env: { ...process.env, ...options.env } })
+  const proc = fork(filename, { ...options, stdio: 'pipe' })
   return new Promise((resolve, reject) => {
     proc
       .on('message', ({ port }) => {
@@ -306,7 +306,7 @@ async function spawnPluginIntegrationTestProc (cwd, serverFile, agentPort, stdio
     NODE_OPTIONS: `--loader=${hookFile}`,
     DD_TRACE_AGENT_PORT: agentPort
   }
-  env = { ...env, ...additionalEnvArgs }
+  env = { ...process.env, ...env, ...additionalEnvArgs }
   return spawnProc(path.join(cwd, serverFile), {
     cwd,
     env

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -105,7 +105,7 @@ async function runAndCheckWithTelemetry (filename, expectedOut, ...expectedTelem
 }
 
 function spawnProc (filename, options = {}, stdioHandler, stderrHandler) {
-  const proc = fork(filename, { ...options, stdio: 'pipe' })
+  const proc = fork(filename, { ...options, stdio: 'pipe', env: { ...process.env, ...options.env } })
   return new Promise((resolve, reject) => {
     proc
       .on('message', ({ port }) => {

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -34,12 +34,14 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
       const NODE_OPTIONS = `--no-warnings --${arg} ${path.join(__dirname, '..', filename)}`
       useEnv({ NODE_OPTIONS })
 
-      context('without DD_INJECTION_ENABLED', () => {
-        it('should initialize the tracer', () => doTest('init/trace.js', 'true\n'))
-        it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n'))
-        it(`should ${esmWorks ? '' : 'not '}initialize ESM instrumentation`, () =>
-          doTest('init/instrument.mjs', `${esmWorks}\n`))
-      })
+      if (currentVersionIsSupported) {
+        context('without DD_INJECTION_ENABLED', () => {
+          it('should initialize the tracer', () => doTest('init/trace.js', 'true\n'))
+          it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n'))
+          it(`should ${esmWorks ? '' : 'not '}initialize ESM instrumentation`, () =>
+            doTest('init/instrument.mjs', `${esmWorks}\n`))
+        })
+      }
       context('with DD_INJECTION_ENABLED', () => {
         useEnv({ DD_INJECTION_ENABLED })
 
@@ -87,8 +89,8 @@ function testRuntimeVersionChecks (arg, filename) {
       context('when node version is less than engines field', () => {
         useEnv({ NODE_OPTIONS })
 
-        it('should initialize the tracer, if no DD_INJECTION_ENABLED', () =>
-          doTest('true\n'))
+        it('should not initialize the tracer', () =>
+          doTest('false\n'))
         context('with DD_INJECTION_ENABLED', () => {
           useEnv({ DD_INJECTION_ENABLED })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix guardrail on Node version outside of SSI.

### Motivation
<!-- What inspired you to submit this pull request? -->

When a version of Node is not supported, we should bailout regardless of SSI as we can otherwise cause errors and segmentation faults. This is not something that should happen outside of a user error, but it can happen, for example attempting to upgrade dd-trace without upgrading Node and without reading the release notes.