### PR TITLE
fix next test using an incompatible version of react

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -152,12 +152,10 @@ async function addDependencies (dependencies, name, versionRange) {
     for (const section of ['devDependencies', 'peerDependencies']) {
       if (pkgJson[section] && dep in pkgJson[section]) {
         if (pkgJson[section][dep].includes('||')) {
-          dependencies[dep] = pkgJson[section][dep].split('||')
-            .map(v => v.trim())
-            .filter(v => !/[a-z]/.test(v)) // Ignore prereleases.
-            .join(' || ')
+          // Use the first version in the list (as npm does by default)
+          dependencies[dep] = pkgJson[section][dep].split('||')[0].trim()
         } else {
-          // Only one version available so use that even if it is a prerelease.
+          // Only one version available so use that.
           dependencies[dep] = pkgJson[section][dep]
         }
         break


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix Next test using an incompatible version of React.

### Motivation
<!-- What inspired you to submit this pull request? -->

Next 15.0.4 has now switched their peer dependency to either React 18 or 19. Previously they were using a prerelease, so I added code to prefer non-prerelease version to install for tests, but now they are using the stable version which doesn't work, so I changed the logic to use the first entry in the list, which seems to also be what npm does by default.