### PR TITLE
Add support for endpoint_counts

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -106,7 +106,7 @@ class AgentExporter {
     this._activation = activation || 'unknown'
   }
 
-  export ({ profiles, start, end, tags }) {
+  export ({ profiles, start, end, tags, endpointCounts }) {
     const fields = []
 
     function typeToFile (type) {
@@ -130,6 +130,7 @@ class AgentExporter {
         'format:pprof',
         ...Object.entries(tags).map(([key, value]) => `${key}:${value}`)
       ].join(','),
+      endpoint_counts: endpointCounts,
       info: {
         application: {
           env: this._env,

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -3,13 +3,13 @@
 const retry = require('retry')
 const { request: httpRequest } = require('http')
 const { request: httpsRequest } = require('https')
+const { EventSerializer } = require('./event_serializer')
 
 // TODO: avoid using dd-trace internals. Make this a separate module?
 const docker = require('../../exporters/common/docker')
 const FormData = require('../../exporters/common/form-data')
 const { storage } = require('../../../../datadog-core')
 const version = require('../../../../../package.json').version
-const os = require('os')
 const { urlToHttpOptions } = require('url')
 const perf = require('perf_hooks').performance
 
@@ -89,8 +89,10 @@ function computeRetries (uploadTimeout) {
   return [tries, Math.floor(uploadTimeout)]
 }
 
-class AgentExporter {
-  constructor ({ url, logger, uploadTimeout, env, host, service, version, libraryInjected, activation } = {}) {
+class AgentExporter extends EventSerializer {
+  constructor (config = {}) {
+    super(config)
+    const { url, logger, uploadTimeout } = config
     this._url = url
     this._logger = logger
 
@@ -98,75 +100,13 @@ class AgentExporter {
 
     this._backoffTime = backoffTime
     this._backoffTries = backoffTries
-    this._env = env
-    this._host = host
-    this._service = service
-    this._appVersion = version
-    this._libraryInjected = !!libraryInjected
-    this._activation = activation || 'unknown'
   }
 
-  export ({ profiles, start, end, tags, endpointCounts }) {
+  export (exportSpec) {
+    const { profiles } = exportSpec
     const fields = []
 
-    function typeToFile (type) {
-      return `${type}.pprof`
-    }
-
-    const event = JSON.stringify({
-      attachments: Object.keys(profiles).map(typeToFile),
-      start: start.toISOString(),
-      end: end.toISOString(),
-      family: 'node',
-      version: '4',
-      tags_profiler: [
-        'language:javascript',
-        'runtime:nodejs',
-        `runtime_arch:${process.arch}`,
-        `runtime_os:${process.platform}`,
-        `runtime_version:${process.version}`,
-        `process_id:${process.pid}`,
-        `profiler_version:${version}`,
-        'format:pprof',
-        ...Object.entries(tags).map(([key, value]) => `${key}:${value}`)
-      ].join(','),
-      endpoint_counts: endpointCounts,
-      info: {
-        application: {
-          env: this._env,
-          service: this._service,
-          start_time: new Date(perf.nodeTiming.nodeStart + perf.timeOrigin).toISOString(),
-          version: this._appVersion
-        },
-        platform: {
-          hostname: this._host,
-          kernel_name: os.type(),
-          kernel_release: os.release(),
-          kernel_version: os.version()
-        },
-        profiler: {
-          activation: this._activation,
-          ssi: {
-            mechanism: this._libraryInjected ? 'injected_agent' : 'none'
-          },
-          version
-        },
-        runtime: {
-          // Using `nodejs` for consistency with the existing `runtime` tag.
-          // Note that the event `family` property uses `node`, as that's what's
-          // proscribed by the Intake API, but that's an internal enum and is
-          // not customer visible.
-          engine: 'nodejs',
-          // strip off leading 'v'. This makes the format consistent with other
-          // runtimes (e.g. Ruby) but not with the existing `runtime_version` tag.
-          // We'll keep it like this as we want cross-engine consistency. We
-          // also aren't changing the format of the existing tag as we don't want
-          // to break it.
-          version: process.version.substring(1)
-        }
-      }
-    })
-
+    const event = this.getEventJSON(exportSpec)
     fields.push(['event', event, {
       filename: 'event.json',
       contentType: 'application/json'
@@ -182,7 +122,7 @@ class AgentExporter {
         return `Adding ${type} profile to agent export: ` + bytes
       })
 
-      const filename = typeToFile(type)
+      const filename = this.typeToFile(type)
       fields.push([filename, buffer, {
         filename,
         contentType: 'application/octet-stream'

--- a/packages/dd-trace/src/profiling/exporters/event_serializer.js
+++ b/packages/dd-trace/src/profiling/exporters/event_serializer.js
@@ -1,0 +1,76 @@
+const os = require('os')
+const perf = require('perf_hooks').performance
+const version = require('../../../../../package.json').version
+
+class EventSerializer {
+  constructor ({ env, host, service, version, libraryInjected, activation } = {}) {
+    this._env = env
+    this._host = host
+    this._service = service
+    this._appVersion = version
+    this._libraryInjected = !!libraryInjected
+    this._activation = activation || 'unknown'
+  }
+
+  typeToFile (type) {
+    return `${type}.pprof`
+  }
+
+  getEventJSON ({ profiles, start, end, tags = {}, endpointCounts }) {
+    return JSON.stringify({
+      attachments: Object.keys(profiles).map(t => this.typeToFile(t)),
+      start: start && start.toISOString(),
+      end: end.toISOString(),
+      family: 'node',
+      version: '4',
+      tags_profiler: [
+        'language:javascript',
+        'runtime:nodejs',
+        `runtime_arch:${process.arch}`,
+        `runtime_os:${process.platform}`,
+        `runtime_version:${process.version}`,
+        `process_id:${process.pid}`,
+        `profiler_version:${version}`,
+        'format:pprof',
+        ...Object.entries(tags).map(([key, value]) => `${key}:${value}`)
+      ].join(','),
+      endpoint_counts: endpointCounts,
+      info: {
+        application: {
+          env: this._env,
+          service: this._service,
+          start_time: new Date(perf.nodeTiming.nodeStart + perf.timeOrigin).toISOString(),
+          version: this._appVersion
+        },
+        platform: {
+          hostname: this._host,
+          kernel_name: os.type(),
+          kernel_release: os.release(),
+          kernel_version: os.version()
+        },
+        profiler: {
+          activation: this._activation,
+          ssi: {
+            mechanism: this._libraryInjected ? 'injected_agent' : 'none'
+          },
+          version
+        },
+        runtime: {
+          // Using `nodejs` for consistency with the existing `runtime` tag.
+          // Note that the event `family` property uses `node`, as that's what's
+          // proscribed by the Intake API, but that's an internal enum and is
+          // not customer visible.
+          engine: 'nodejs',
+          // strip off leading 'v'. This makes the format consistent with other
+          // runtimes (e.g. Ruby) but not with the existing `runtime_version` tag.
+          // We'll keep it like this as we want cross-engine consistency. We
+          // also aren't changing the format of the existing tag as we don't want
+          // to break it.
+          version: process.version.substring(1)
+        }
+      }
+    })
+  }
+}
+
+module.exports = { EventSerializer }

--- a/packages/dd-trace/src/profiling/exporters/event_serializer.js
+++ b/packages/dd-trace/src/profiling/exporters/event_serializer.js
@@ -19,7 +19,7 @@ class EventSerializer {
   getEventJSON ({ profiles, start, end, tags = {}, endpointCounts }) {
     return JSON.stringify({
       attachments: Object.keys(profiles).map(t => this.typeToFile(t)),
-      start: start && start.toISOString(),
+      start: start.toISOString(),
       end: end.toISOString(),
       family: 'node',
       version: '4',

--- a/packages/dd-trace/src/profiling/exporters/file.js
+++ b/packages/dd-trace/src/profiling/exporters/file.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const { promisify } = require('util')
 const { threadId } = require('worker_threads')
 const writeFile = promisify(fs.writeFile)
+const { EventSerializer } = require('./event_serializer')
 
 function formatDateTime (t) {
   const pad = (n) => String(n).padStart(2, '0')
@@ -11,18 +12,21 @@ function formatDateTime (t) {
          `T${pad(t.getUTCHours())}${pad(t.getUTCMinutes())}${pad(t.getUTCSeconds())}Z`
 }
 
-class FileExporter {
-  constructor ({ pprofPrefix } = {}) {
+class FileExporter extends EventSerializer {
+  constructor (config = {}) {
+    super(config)
+    const { pprofPrefix } = config
     this._pprofPrefix = pprofPrefix || ''
   }
 
-  export ({ profiles, end }) {
+  export (exportSpec) {
+    const { profiles, end } = exportSpec
     const types = Object.keys(profiles)
     const dateStr = formatDateTime(end)
     const tasks = types.map(type => {
       return writeFile(`${this._pprofPrefix}${type}_worker_${threadId}_${dateStr}.pprof`, profiles[type])
     })
-
+    tasks.push(writeFile(`event_worker_${threadId}_${dateStr}.json`, this.getEventJSON(exportSpec)))
     return Promise.all(tasks)
   }
 }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -223,7 +223,6 @@ class Profiler extends EventEmitter {
 
   _submit (profiles, start, end, snapshotKind) {
     const { tags } = this._config
-    const tasks = []
 
     // Flatten endpoint counts
     const endpointCounts = {}
@@ -233,15 +232,14 @@ class Profiler extends EventEmitter {
     this.endpointCounts.clear()
 
     tags.snapshot = snapshotKind
-    for (const exporter of this._config.exporters) {
-      const task = exporter.export({ profiles, start, end, tags, endpointCounts })
-        .catch(err => {
-          if (this._logger) {
-            this._logger.warn(err)
-          }
-        })
-      tasks.push(task)
-    }
+    const exportSpec = { profiles, start, end, tags, endpointCounts }
+    const tasks = this._config.exporters.map(exporter =>
+      exporter.export(exportSpec).catch(err => {
+        if (this._logger) {
+          this._logger.warn(err)
+        }
+      })
+    )
 
     return Promise.all(tasks)
   }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -85,8 +85,10 @@ class Profiler extends EventEmitter {
         this._logger.debug(`Started ${profiler.type} profiler in ${threadNamePrefix} thread`)
       }
 
-      this._spanFinishListener = this._onSpanFinish.bind(this)
-      spanFinishedChannel.subscribe(this._spanFinishListener)
+      if (config.endpointCollectionEnabled) {
+        this._spanFinishListener = this._onSpanFinish.bind(this)
+        spanFinishedChannel.subscribe(this._spanFinishListener)
+      }
 
       this._capture(this._timeoutInterval, start)
       return true
@@ -123,8 +125,10 @@ class Profiler extends EventEmitter {
 
     this._enabled = false
 
-    spanFinishedChannel.unsubscribe(this._spanFinishListener)
-    this._spanFinishListener = undefined
+    if (this._spanFinishListener !== undefined) {
+      spanFinishedChannel.unsubscribe(this._spanFinishListener)
+      this._spanFinishListener = undefined
+    }
 
     for (const profiler of this._config.profilers) {
       profiler.stop()

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -13,7 +13,7 @@ const {
   getThreadLabels
 } = require('./shared')
 
-const { isWebServerSpan, endpointNameFromTags } = require('../webspan-utils')
+const { isWebServerSpan, endpointNameFromTags, getStartedSpans } = require('../webspan-utils')
 
 const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
@@ -27,10 +27,6 @@ let kSampleCount
 function getActiveSpan () {
   const store = storage.getStore()
   return store && store.span
-}
-
-function getStartedSpans (context) {
-  return context._trace.started
 }
 
 let channelsActivated = false

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -3,8 +3,6 @@
 const { storage } = require('../../../../datadog-core')
 
 const dc = require('dc-polyfill')
-const { HTTP_METHOD, HTTP_ROUTE, RESOURCE_NAME, SPAN_TYPE } = require('../../../../../ext/tags')
-const { WEB } = require('../../../../../ext/types')
 const runtimeMetrics = require('../../runtime_metrics')
 const telemetryMetrics = require('../../telemetry/metrics')
 const {
@@ -14,6 +12,8 @@ const {
   getNonJSThreadsLabels,
   getThreadLabels
 } = require('./shared')
+
+const { isWebServerSpan, endpointNameFromTags } = require('../webspan-utils')
 
 const beforeCh = dc.channel('dd-trace:storage:before')
 const enterCh = dc.channel('dd-trace:storage:enter')
@@ -31,17 +31,6 @@ function getActiveSpan () {
 
 function getStartedSpans (context) {
   return context._trace.started
-}
-
-function isWebServerSpan (tags) {
-  return tags[SPAN_TYPE] === WEB
-}
-
-function endpointNameFromTags (tags) {
-  return tags[RESOURCE_NAME] || [
-    tags[HTTP_METHOD],
-    tags[HTTP_ROUTE]
-  ].filter(v => v).join(' ')
 }
 
 let channelsActivated = false

--- a/packages/dd-trace/src/profiling/webspan-utils.js
+++ b/packages/dd-trace/src/profiling/webspan-utils.js
@@ -1,0 +1,18 @@
+const { HTTP_METHOD, HTTP_ROUTE, RESOURCE_NAME, SPAN_TYPE } = require('../../../../ext/tags')
+const { WEB } = require('../../../../ext/types')
+
+function isWebServerSpan (tags) {
+  return tags[SPAN_TYPE] === WEB
+}
+
+function endpointNameFromTags (tags) {
+  return tags[RESOURCE_NAME] || [
+    tags[HTTP_METHOD],
+    tags[HTTP_ROUTE]
+  ].filter(v => v).join(' ')
+}
+
+module.exports = {
+  isWebServerSpan,
+  endpointNameFromTags
+}

--- a/packages/dd-trace/src/profiling/webspan-utils.js
+++ b/packages/dd-trace/src/profiling/webspan-utils.js
@@ -12,7 +12,12 @@ function endpointNameFromTags (tags) {
   ].filter(v => v).join(' ')
 }
 
+function getStartedSpans (context) {
+  return context._trace.started
+}
+
 module.exports = {
   isWebServerSpan,
-  endpointNameFromTags
+  endpointNameFromTags,
+  getStartedSpans
 }

--- a/packages/dd-trace/test/profiling/exporters/file.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/file.spec.js
@@ -27,7 +27,7 @@ describe('exporters/file', () => {
     }
     await exporter.export({ profiles, end: new Date('2023-02-10T21:03:05Z') })
 
-    sinon.assert.calledOnce(fs.writeFile)
+    sinon.assert.calledTwice(fs.writeFile)
     sinon.assert.calledWith(fs.writeFile, 'test_worker_0_20230210T210305Z.pprof', buffer)
   })
 
@@ -39,7 +39,7 @@ describe('exporters/file', () => {
     }
     await exporter.export({ profiles, end: new Date('2023-02-10T21:03:05Z') })
 
-    sinon.assert.calledOnce(fs.writeFile)
+    sinon.assert.calledTwice(fs.writeFile)
     sinon.assert.calledWith(fs.writeFile, 'myprefix_test_worker_0_20230210T210305Z.pprof', buffer)
   })
 })

--- a/packages/dd-trace/test/profiling/exporters/file.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/file.spec.js
@@ -25,7 +25,11 @@ describe('exporters/file', () => {
     const profiles = {
       test: buffer
     }
-    await exporter.export({ profiles, end: new Date('2023-02-10T21:03:05Z') })
+    await exporter.export({
+      profiles,
+      start: new Date('2023-02-10T21:02:05Z'),
+      end: new Date('2023-02-10T21:03:05Z')
+    })
 
     sinon.assert.calledTwice(fs.writeFile)
     sinon.assert.calledWith(fs.writeFile, 'test_worker_0_20230210T210305Z.pprof', buffer)
@@ -37,7 +41,11 @@ describe('exporters/file', () => {
     const profiles = {
       test: buffer
     }
-    await exporter.export({ profiles, end: new Date('2023-02-10T21:03:05Z') })
+    await exporter.export({
+      profiles,
+      start: new Date('2023-02-10T21:02:05Z'),
+      end: new Date('2023-02-10T21:03:05Z')
+    })
 
     sinon.assert.calledTwice(fs.writeFile)
     sinon.assert.calledWith(fs.writeFile, 'myprefix_test_worker_0_20230210T210305Z.pprof', buffer)


### PR DESCRIPTION
### What does this PR do?
The profiling UI can show a `CPU - Average Time Per Call For Top Endpoints` if it is given an `endpoint_counts` JSON property in the uploaded `event.json`. We now add this property.

### Motivation
We want to get the Node.js functionality to match https://docs.datadoghq.com/profiler/guide/isolate-outliers-in-monolithic-services as much as possible.

### Additional Notes
This will also need a change in `logs_backend` before it starts showing up.

JIRA: [PROF-11013]



[PROF-11013]: https://datadoghq.atlassian.net/browse/PROF-11013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ