### PR TITLE
[test optimization] Fix test name extraction in playwright

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests/landing-page-test.js
+++ b/integration-tests/ci-visibility/playwright-tests/landing-page-test.js
@@ -4,29 +4,34 @@ test.beforeEach(async ({ page }) => {
   await page.goto(process.env.PW_BASE_URL)
 })
 
-test.describe('playwright', () => {
-  test('should work with passing tests', async ({ page }) => {
-    await expect(page.locator('.hello-world')).toHaveText([
-      'Hello World'
-    ])
-  })
-  test.skip('should work with skipped tests', async ({ page }) => {
-    await expect(page.locator('.hello-world')).toHaveText([
-      'Hello World'
-    ])
-  })
-  test.fixme('should work with fixme', async ({ page }) => {
-    await expect(page.locator('.hello-world')).toHaveText([
-      'Hello Warld'
-    ])
-  })
-  test('should work with annotated tests', async ({ page }) => {
-    test.info().annotations.push({ type: 'DD_TAGS[test.memory.usage]', description: 'low' })
-    test.info().annotations.push({ type: 'DD_TAGS[test.memory.allocations]', description: 16 })
-    // this is malformed and should be ignored
-    test.info().annotations.push({ type: 'DD_TAGS[test.invalid', description: 'high' })
-    await expect(page.locator('.hello-world')).toHaveText([
-      'Hello World'
-    ])
+test.describe('highest-level-describe', () => {
+  test.describe(' leading and trailing spaces ', () => {
+    // even empty describe blocks should be allowed
+    test.describe(' ', () => {
+      test('should work with passing tests', async ({ page }) => {
+        await expect(page.locator('.hello-world')).toHaveText([
+          'Hello World'
+        ])
+      })
+      test.skip('should work with skipped tests', async ({ page }) => {
+        await expect(page.locator('.hello-world')).toHaveText([
+          'Hello World'
+        ])
+      })
+      test.fixme('should work with fixme', async ({ page }) => {
+        await expect(page.locator('.hello-world')).toHaveText([
+          'Hello Warld'
+        ])
+      })
+      test('should work with annotated tests', async ({ page }) => {
+        test.info().annotations.push({ type: 'DD_TAGS[test.memory.usage]', description: 'low' })
+        test.info().annotations.push({ type: 'DD_TAGS[test.memory.allocations]', description: 16 })
+        // this is malformed and should be ignored
+        test.info().annotations.push({ type: 'DD_TAGS[test.invalid', description: 'high' })
+        await expect(page.locator('.hello-world')).toHaveText([
+          'Hello World'
+        ])
+      })
+    })
   })
 })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -123,10 +123,14 @@ versions.forEach((version) => {
             })
 
             assert.includeMembers(testEvents.map(test => test.content.resource), [
-              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with passing tests',
-              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with skipped tests',
-              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with fixme',
-              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with annotated tests',
+              'landing-page-test.js.highest-level-describe' +
+              '  leading and trailing spaces    should work with passing tests',
+              'landing-page-test.js.highest-level-describe' +
+              '  leading and trailing spaces    should work with skipped tests',
+              'landing-page-test.js.highest-level-describe' +
+              '  leading and trailing spaces    should work with fixme',
+              'landing-page-test.js.highest-level-describe' +
+              '  leading and trailing spaces    should work with annotated tests',
               'todo-list-page-test.js.playwright should work with failing tests',
               'todo-list-page-test.js.should work with fixme root'
             ])
@@ -263,10 +267,11 @@ versions.forEach((version) => {
             {
               playwright: {
                 'landing-page-test.js': [
-                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests', // it will be considered new
+                  // it will be considered new
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
                   'highest-level-describe  leading and trailing spaces    should work with skipped tests',
                   'highest-level-describe  leading and trailing spaces    should work with fixme',
-                  'highest-level-describe  leading and trailing spaces    should work with annotated tests',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
                 ],
                 'skipped-suite-test.js': [
                   'should work with fixme root'
@@ -336,10 +341,11 @@ versions.forEach((version) => {
             {
               playwright: {
                 'landing-page-test.js': [
-                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests', // it will be considered new
+                  // it will be considered new
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
                   'highest-level-describe  leading and trailing spaces    should work with skipped tests',
                   'highest-level-describe  leading and trailing spaces    should work with fixme',
-                  'highest-level-describe  leading and trailing spaces    should work with annotated tests',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
                 ],
                 'skipped-suite-test.js': [
                   'should work with fixme root'
@@ -409,7 +415,7 @@ versions.forEach((version) => {
                   // 'highest-level-describe  leading and trailing spaces    should work with skipped tests',
                   // new but not retried because it's skipped
                   // 'highest-level-describe  leading and trailing spaces    should work with fixme',
-                  'highest-level-describe  leading and trailing spaces    should work with annotated tests',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
                 ],
                 'skipped-suite-test.js': [
                   'should work with fixme root'

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -123,11 +123,11 @@ versions.forEach((version) => {
             })
 
             assert.includeMembers(testEvents.map(test => test.content.resource), [
-              'landing-page-test.js.should work with passing tests',
-              'landing-page-test.js.should work with skipped tests',
-              'landing-page-test.js.should work with fixme',
-              'landing-page-test.js.should work with annotated tests',
-              'todo-list-page-test.js.should work with failing tests',
+              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with passing tests',
+              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with skipped tests',
+              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with fixme',
+              'landing-page-test.js.highest-level-describe  leading and trailing spaces    should work with annotated tests',
+              'todo-list-page-test.js.playwright should work with failing tests',
               'todo-list-page-test.js.should work with fixme root'
             ])
 
@@ -155,7 +155,7 @@ versions.forEach((version) => {
               assert.property(stepEvent.content.meta, 'playwright.step')
             })
             const annotatedTest = testEvents.find(test =>
-              test.content.resource === 'landing-page-test.js.should work with annotated tests'
+              test.content.resource.endsWith('should work with annotated tests')
             )
 
             assert.propertyVal(annotatedTest.content.meta, 'test.memory.usage', 'low')
@@ -187,8 +187,8 @@ versions.forEach((version) => {
         const events = payloads.flatMap(({ payload }) => payload.events)
         const testEvents = events.filter(event => event.type === 'test')
         assert.includeMembers(testEvents.map(test => test.content.resource), [
-          'playwright-tests-ts/one-test.js.should work with passing tests',
-          'playwright-tests-ts/one-test.js.should work with skipped tests'
+          'playwright-tests-ts/one-test.js.playwright should work with passing tests',
+          'playwright-tests-ts/one-test.js.playwright should work with skipped tests'
         ])
         assert.include(testOutput, '1 passed')
         assert.include(testOutput, '1 skipped')
@@ -263,16 +263,16 @@ versions.forEach((version) => {
             {
               playwright: {
                 'landing-page-test.js': [
-                  // 'should work with passing tests', // it will be considered new
-                  'should work with skipped tests',
-                  'should work with fixme',
-                  'should work with annotated tests'
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests', // it will be considered new
+                  'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests',
                 ],
                 'skipped-suite-test.js': [
                   'should work with fixme root'
                 ],
                 'todo-list-page-test.js': [
-                  'should work with failing tests',
+                  'playwright should work with failing tests',
                   'should work with fixme root'
                 ]
               }
@@ -288,8 +288,7 @@ versions.forEach((version) => {
 
               const tests = events.filter(event => event.type === 'test').map(event => event.content)
               const newTests = tests.filter(test =>
-                test.resource ===
-                  'landing-page-test.js.should work with passing tests'
+                test.resource.endsWith('should work with passing tests')
               )
               newTests.forEach(test => {
                 assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
@@ -337,16 +336,16 @@ versions.forEach((version) => {
             {
               playwright: {
                 'landing-page-test.js': [
-                  // 'should work with passing tests', // it will be considered new
-                  'should work with skipped tests',
-                  'should work with fixme',
-                  'should work with annotated tests'
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests', // it will be considered new
+                  'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests',
                 ],
                 'skipped-suite-test.js': [
                   'should work with fixme root'
                 ],
                 'todo-list-page-test.js': [
-                  'should work with failing tests',
+                  'playwright should work with failing tests',
                   'should work with fixme root'
                 ]
               }
@@ -359,8 +358,7 @@ versions.forEach((version) => {
               const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
               const newTests = tests.filter(test =>
-                test.resource ===
-                  'landing-page-test.js.should work with passing tests'
+                test.resource.endsWith('should work with passing tests')
               )
               newTests.forEach(test => {
                 assert.notProperty(test.meta, TEST_IS_NEW)
@@ -406,16 +404,18 @@ versions.forEach((version) => {
             {
               playwright: {
                 'landing-page-test.js': [
-                  'should work with passing tests',
-                  // 'should work with skipped tests', // new but not retried because it's skipped
-                  // 'should work with fixme', // new but not retried because it's skipped
-                  'should work with annotated tests'
+                  'highest-level-describe  leading and trailing spaces    should work with passing tests',
+                  // new but not retried because it's skipped
+                  // 'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  // new but not retried because it's skipped
+                  // 'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests',
                 ],
                 'skipped-suite-test.js': [
                   'should work with fixme root'
                 ],
                 'todo-list-page-test.js': [
-                  'should work with failing tests',
+                  'playwright should work with failing tests',
                   'should work with fixme root'
                 ]
               }
@@ -428,9 +428,8 @@ versions.forEach((version) => {
               const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
               const newTests = tests.filter(test =>
-                test.resource ===
-                  'landing-page-test.js.should work with skipped tests' ||
-                test.resource === 'landing-page-test.js.should work with fixme'
+                test.resource.endsWith('should work with skipped tests') ||
+                test.resource.endsWith('should work with fixme')
               )
               // no retries
               assert.equal(newTests.length, 2)

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -47,7 +47,7 @@ function isNewTest (test) {
   const testSuite = getTestSuitePath(test._requireFile, rootDir)
   const testsForSuite = knownTests?.playwright?.[testSuite] || []
 
-  return !testsForSuite.includes(test.title)
+  return !testsForSuite.includes(getTestFullname(test))
 }
 
 function getSuiteType (test, type) {
@@ -227,7 +227,7 @@ function testWillRetry (test, testStatus) {
 function getTestFullname (test) {
   let parent = test.parent
   const names = [test.title]
-  while (parent?._type === 'describe') {
+  while (parent?._type === 'describe' || parent?._isDescribe) {
     if (parent.title) {
       names.unshift(parent.title)
     }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -224,10 +224,21 @@ function testWillRetry (test, testStatus) {
   return testStatus === 'fail' && test.results.length <= test.retries
 }
 
+function getTestFullname (test) {
+  let parent = test.parent
+  const names = [test.title]
+  while (parent?._type === 'describe') {
+    if (parent.title) {
+      names.unshift(parent.title)
+    }
+    parent = parent.parent
+  }
+  return names.join(' ')
+}
+
 function testBeginHandler (test, browserName) {
   const {
     _requireFile: testSuiteAbsolutePath,
-    title: testName,
     _type,
     location: {
       line: testSourceLine
@@ -237,6 +248,8 @@ function testBeginHandler (test, browserName) {
   if (_type === 'beforeAll' || _type === 'afterAll') {
     return
   }
+
+  const testName = getTestFullname(test)
 
   const isNewTestSuite = !startedSuites.includes(testSuiteAbsolutePath)
 


### PR DESCRIPTION
### What does this PR do?
Test names in playwright do not take into account surrounding `describe` blocks, as described in #4976. This PR fixes this.

### Motivation
Fixes #4976

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
