### PR TITLE
Fix ESM instrumentation when importing only methods

### DIFF
--- a/integration-tests/esm.spec.js
+++ b/integration-tests/esm.spec.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { createSandbox, spawnProc } = require('./helpers')
+const path = require('path')
+const { assert } = require('chai')
+
+describe('Test ESM modules are instrumented as expected', () => {
+  let sandbox, cwd, proc
+  const execArgv = ['--import', 'dd-trace/initialize.mjs']
+
+  before(async () => {
+    sandbox = await createSandbox()
+    cwd = sandbox.folder
+  })
+
+  after(async () => {
+    await sandbox.remove()
+  })
+
+  afterEach(() => {
+    proc?.kill()
+  })
+
+  it('should instrument importing whole module', async () => {
+    let logs = ''
+    await spawnProc(path.join(cwd, 'esm/import-module.mjs'), {
+      cwd,
+      execArgv
+    }, (output) => {
+      logs += output.toString()
+    })
+
+    assert.include(logs, 'METHOD_INSTRUMENTED')
+  })
+
+  it('should instrument importing a method', async () => {
+    let logs = ''
+    await spawnProc(path.join(cwd, 'esm/import-method.mjs'), {
+      cwd,
+      execArgv
+    }, (output) => {
+      logs += output.toString()
+    })
+
+    assert.include(logs, 'METHOD_INSTRUMENTED')
+  })
+})

--- a/integration-tests/esm/import-method.mjs
+++ b/integration-tests/esm/import-method.mjs
@@ -1,0 +1,12 @@
+import dc from 'diagnostics_channel'
+import { execFileSync } from 'node:child_process'
+
+const tracingChannel = dc.tracingChannel('datadog:child_process:execution')
+tracingChannel.subscribe({
+  start: () => {
+    // eslint-disable-next-line no-console
+    console.log('METHOD_INSTRUMENTED')
+  }
+})
+
+execFileSync('ls')

--- a/integration-tests/esm/import-module.mjs
+++ b/integration-tests/esm/import-module.mjs
@@ -1,0 +1,12 @@
+import dc from 'diagnostics_channel'
+import childProcess from 'node:child_process'
+
+const tracingChannel = dc.tracingChannel('datadog:child_process:execution')
+tracingChannel.subscribe({
+  start: () => {
+    // eslint-disable-next-line no-console
+    console.log('METHOD_INSTRUMENTED')
+  }
+})
+
+childProcess.execFileSync('ls')

--- a/packages/datadog-instrumentations/src/child_process.js
+++ b/packages/datadog-instrumentations/src/child_process.js
@@ -17,7 +17,7 @@ const execAsyncMethods = ['execFile', 'spawn']
 const names = ['child_process', 'node:child_process']
 
 // child_process and node:child_process returns the same object instance, we only want to add hooks once
-let patched = false
+const patched = new WeakSet()
 
 function throwSyncError (error) {
   throw error
@@ -39,8 +39,8 @@ function returnSpawnSyncError (error, context) {
 
 names.forEach(name => {
   addHook({ name }, childProcess => {
-    if (!patched) {
-      patched = true
+    if (!patched.has(childProcess)) {
+      patched.add(childProcess)
       shimmer.massWrap(childProcess, execAsyncMethods, wrapChildProcessAsyncMethod(childProcess.ChildProcess))
       shimmer.wrap(childProcess, 'execSync', wrapChildProcessSyncMethod(throwSyncError, true))
       shimmer.wrap(childProcess, 'execFileSync', wrapChildProcessSyncMethod(throwSyncError))

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -29,6 +29,10 @@ function Hook (modules, hookOptions, onrequire) {
 
     this._patched[filename] = true
 
+    if (moduleExports?.default) {
+      moduleExports.default = onrequire(moduleExports.default, moduleName, moduleBaseDir, moduleVersion)
+    }
+
     return onrequire(moduleExports, moduleName, moduleBaseDir, moduleVersion)
   }
 
@@ -38,12 +42,7 @@ function Hook (modules, hookOptions, onrequire) {
     // modules and not ESM. In the meantime, all the modules we instrument are
     // CommonJS modules for which the default export is always moved to
     // `default` anyway.
-    if (moduleExports && moduleExports.default) {
-      moduleExports.default = safeHook(moduleExports.default, moduleName, moduleBaseDir)
-      return moduleExports
-    } else {
-      return safeHook(moduleExports, moduleName, moduleBaseDir)
-    }
+    return safeHook(moduleExports, moduleName, moduleBaseDir)
   })
 }
 

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -21,7 +21,7 @@ function Hook (modules, hookOptions, onrequire) {
 
   this._patched = Object.create(null)
 
-  const safeHook = (moduleExports, moduleName, moduleBaseDir, moduleVersion) => {
+  const safeHook = (moduleExports, moduleName, moduleBaseDir, moduleVersion, iitm = false) => {
     const parts = [moduleBaseDir, moduleName].filter(v => v)
     const filename = path.join(...parts)
 
@@ -29,7 +29,7 @@ function Hook (modules, hookOptions, onrequire) {
 
     this._patched[filename] = true
 
-    if (moduleExports?.default) {
+    if (iitm && moduleExports?.default) {
       moduleExports.default = onrequire(moduleExports.default, moduleName, moduleBaseDir, moduleVersion)
     }
 
@@ -42,7 +42,7 @@ function Hook (modules, hookOptions, onrequire) {
     // modules and not ESM. In the meantime, all the modules we instrument are
     // CommonJS modules for which the default export is always moved to
     // `default` anyway.
-    return safeHook(moduleExports, moduleName, moduleBaseDir)
+    return safeHook(moduleExports, moduleName, moduleBaseDir, undefined, true)
   })
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Instrument `default` and each exported method in esm modules.

### Motivation
<!-- What inspired you to submit this pull request? -->
`import-in-the-middle` exports a `default` object and a method/property by each exported method in the original library. If `default` is present, we are instrumenting only the default object, and the methods are not instrumented. 



