### PR TITLE
[MLOB-1981] fix(llmobs): `childOf` applies to LLM Observability spans

### DIFF
--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -102,19 +102,19 @@ class LLMObs extends NoopLLMObs {
 
     if (fn.length > 1) {
       return this._tracer.trace(name, spanOptions, (span, cb) =>
-        this._activate(span, { 
-          kind, 
-          options: llmobsOptions, 
-          childOf: spanOptions?.childOf 
+        this._activate(span, {
+          kind,
+          options: llmobsOptions,
+          childOf: spanOptions?.childOf
         }, () => fn(span, cb))
       )
     }
 
     return this._tracer.trace(name, spanOptions, span =>
-      this._activate(span, { 
-        kind, 
-        options: llmobsOptions, 
-        childOf: spanOptions?.childOf 
+      this._activate(span, {
+        kind,
+        options: llmobsOptions,
+        childOf: spanOptions?.childOf
       }, () => fn(span))
     )
   }
@@ -143,10 +143,10 @@ class LLMObs extends NoopLLMObs {
     function wrapped () {
       const span = llmobs._tracer.scope().active()
 
-      const result = llmobs._activate(span, { 
-        kind, 
-        options: llmobsOptions, 
-        childOf: spanOptions?.childOf 
+      const result = llmobs._activate(span, {
+        kind,
+        options: llmobsOptions,
+        childOf: spanOptions?.childOf
       }, () => {
         if (!['llm', 'embedding'].includes(kind)) {
           llmobs.annotate(span, { inputData: getFunctionArguments(fn, arguments) })
@@ -351,12 +351,12 @@ class LLMObs extends NoopLLMObs {
   }
 
   _activate (span, { kind, options, childOf } = {}, fn) {
-    const parent = childOf instanceof Span && LLMObsTagger.tagMap.has(childOf) ? childOf : this._active()
+    const parent = this._active()
     if (this.enabled) storage.enterWith({ span })
 
     this._tagger.registerLLMObsSpan(span, {
       ...options,
-      parent,
+      parent: this._getParent(parent, childOf),
       kind
     })
 
@@ -365,6 +365,10 @@ class LLMObs extends NoopLLMObs {
     } finally {
       if (this.enabled) storage.enterWith({ span: parent })
     }
+  }
+
+  _getParent (parent, childOf) {
+    return childOf instanceof Span && LLMObsTagger.tagMap.has(childOf) ? childOf : parent
   }
 
   _extractOptions (options) {


### PR DESCRIPTION
### What does this PR do?
Has the LLMObs SDK respect the `childOf` option when instrumenting spans with LLM Observability. If `childOf` is specified, we will activate the function in the context of that span if it is an LLM Observability span, otherwise activate it in the scope of the current active LLMObs span. 

This is useful for cases where you might want to have a callback run in the same scope as the function that invoked it:

```javascript
let llmSpan

function myLlm () {
  setTimeout(myTask, 200)
  llmobs.trace({ ... }, span => { 
    llmSpan = span 
    // some other task that keeps this span alive for more than 200ms
  })
}

function myTask () {
  llmobs.trace({ ..., childOf: llmSpan }, () => ...)
}
```

as we do not have a way of currently activating `myTask` in the scope of the traced function, since the function is not called before the scope of the `llmobs.trace` in `myLlm` closes. Respecting the `childOf` argument helps with this.

### Motivation
Fixes parentage in cases of manual instrumentation.


