### PR TITLE
telemetry: increment .count when deduping telemetry logs

### DIFF
--- a/packages/dd-trace/src/telemetry/logs/log-collector.js
+++ b/packages/dd-trace/src/telemetry/logs/log-collector.js
@@ -3,7 +3,7 @@
 const log = require('../../log')
 const { calculateDDBasePath } = require('../../util')
 
-const logs = new Map()
+const logs = new Map() // hash -> log
 
 // NOTE: Is this a reasonable number?
 let maxEntries = 10000
@@ -73,8 +73,10 @@ const logCollector = {
       }
       const hash = createHash(logEntry)
       if (!logs.has(hash)) {
-        logs.set(hash, logEntry)
+        logs.set(hash, errorCopy(logEntry))
         return true
+      } else {
+        logs.get(hash).count++
       }
     } catch (e) {
       log.error('Unable to add log to logCollector: %s', e.message)
@@ -112,6 +114,19 @@ const logCollector = {
       maxEntries = max
     }
   }
+}
+
+// clone an Error object to later serialize and transmit
+// { ...error } doesn't work
+// also users can add arbitrary fields to an error
+function errorCopy (error) {
+  const keys = Object.getOwnPropertyNames(error)
+  const obj = {}
+  for (const key of keys) {
+    obj[key] = error[key]
+  }
+  obj.count = 1
+  return obj
 }
 
 logCollector.reset()

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -66,6 +66,8 @@ function globMatch (pattern, subject) {
   return true
 }
 
+// TODO: this adds stack traces relative to packages/
+// shouldn't paths be relative to the root of dd-trace?
 function calculateDDBasePath (dirname) {
   const dirSteps = dirname.split(path.sep)
   const packagesIndex = dirSteps.lastIndexOf('packages')

--- a/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
+++ b/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
@@ -104,5 +104,24 @@ describe('telemetry log collector', () => {
       expect(logs.length).to.be.equal(4)
       expect(logs[3]).to.deep.eq({ message: 'Omitted 2 entries due to overflowing', level: 'ERROR' })
     })
+
+    it('duplicated errors should send incremented count values', () => {
+      const err1 = new Error('oh no')
+      err1.level = 'ERROR'
+
+      const err2 = new Error('foo buzz')
+      err2.level = 'ERROR'
+
+      logCollector.add(err1)
+      logCollector.add(err2)
+      logCollector.add(err1)
+      logCollector.add(err2)
+      logCollector.add(err1)
+
+      const drainedErrors = logCollector.drain()
+      expect(drainedErrors.length).to.be.equal(2)
+      expect(drainedErrors[0].count).to.be.equal(3)
+      expect(drainedErrors[1].count).to.be.equal(2)
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
- we currently deduplicate telemetry logs
- however we don't track when this deduplicaiton happens
- this change modifies telemetry logs to have a .count field which increments each time this happens

### Motivation
- AIDM-391
- this way we'll know if a message happens once or a thousand times

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


