### PR TITLE
Fix numbers stated in benchmark README.md

### DIFF
--- a/benchmark/sirun/appsec-iast/README.md
+++ b/benchmark/sirun/appsec-iast/README.md
@@ -1,4 +1,4 @@
-This creates 150 HTTP requests from client to server.
+This benchmarks HTTP requests from client to server.
 
 The variants are:
 - control tracer with non vulnerable endpoint without iast 

--- a/benchmark/sirun/appsec/README.md
+++ b/benchmark/sirun/appsec/README.md
@@ -1,4 +1,4 @@
-This creates 1,000 HTTP requests from client to server.
+This benchmarks HTTP requests from client to server.
 
 The variants are:
 - control tracer without appsec

--- a/benchmark/sirun/encoding/README.md
+++ b/benchmark/sirun/encoding/README.md
@@ -1,4 +1,4 @@
-This test sends a single trace 10000 times to the encoder. Each trace is
+This test sends a single trace many times to the encoder. Each trace is
 pre-formatted (as the encoder requires) and consists of 30 spans with the same
 content in each of them. The IDs are all randomized. A null writer is provided
 to the encoder, so writing operations are not included here.

--- a/benchmark/sirun/exporting-pipeline/README.md
+++ b/benchmark/sirun/exporting-pipeline/README.md
@@ -2,6 +2,6 @@ This test creates a 30 span trace (of similar format to the encoding test).
 These spans are then passed through the formatting, encoding, and writing steps
 in our pipeline, and sent to a dummy agent. Once a span (i.e. a trace) is added
 to the exporter, we then proceed to the next iteration via `setImmediate`, and
-run for 25000 iterations.
+run for many iterations.
 
 There's a variant for each of our encodings/endpoints.

--- a/benchmark/sirun/log/README.md
+++ b/benchmark/sirun/log/README.md
@@ -1,4 +1,4 @@
-This test calls the internal logger on various log levels for 1000 iterations.
+This test calls the internal logger on various log levels for many iterations.
 
 * `without-log` is the baseline that has logging disabled completely.
 * `skip-log` has logs enabled but uses a log level that isn't so that the handler doesn't run.

--- a/benchmark/sirun/plugin-bluebird/README.md
+++ b/benchmark/sirun/plugin-bluebird/README.md
@@ -1,3 +1,3 @@
-This creates 50000 promises in a chain using the latest version of `bluebird`.
+This creates a lot of promises in a chain using the latest version of `bluebird`.
 
 The variants are with the tracer and without it.

--- a/benchmark/sirun/plugin-dns/README.md
+++ b/benchmark/sirun/plugin-dns/README.md
@@ -1,2 +1,2 @@
-Runs `dns.lookup('localhost', cb)` 10000 times. In the `with-tracer` variant,
+Runs `dns.lookup('localhost', cb)` many times. In the `with-tracer` variant,
 tracing is enabled. Iteration count is set to 10.

--- a/benchmark/sirun/plugin-http/README.md
+++ b/benchmark/sirun/plugin-http/README.md
@@ -1,4 +1,4 @@
-This creates 1,000 HTTP requests from client to server.
+This benchmarks HTTP requests from client to server.
 
 The variants are with the tracer and without it, and instrumenting on the server
 and the client separately.

--- a/benchmark/sirun/plugin-net/README.md
+++ b/benchmark/sirun/plugin-net/README.md
@@ -1,3 +1,3 @@
-Creates 1000 connections between a net server and net client, doing a simple
+Benchmarks connections between a net server and net client, doing a simple
 echo request. Since we only instrument client-side net connections, our variants
 are having the client with and without the tracer.

--- a/benchmark/sirun/plugin-q/README.md
+++ b/benchmark/sirun/plugin-q/README.md
@@ -1,3 +1,3 @@
-This creates 50000 promises in a chain using the latest version of `q`.
+This benchmarks promises in a chain using the latest version of `q`.
 
 The variants are with the tracer and without it.

--- a/benchmark/sirun/spans/README.md
+++ b/benchmark/sirun/spans/README.md
@@ -1,5 +1,5 @@
 This test initializes a tracer with the no-op scope manager. It then creates
-100000 spans, and depending on the variant, either finishes all of them as they
+many spans, and depending on the variant, either finishes all of them as they
 are created, or later on once they're all created. Prior to creating any spans,
 it modifies the processor instance so that no span processing (or exporting) is
 done, and it simply stops storing the spans.


### PR DESCRIPTION
### What does this PR do?

These numbers have drifted over time as the benchmarks have been tweaked. The number stated in the `README.md` files are therefore no longer correct. Instead of trying to keep these in sync, this commit just removes any mention of iterations from the `README.md` files.

### Motivation

Remove need to keep files in sync to lessen maintenance burden.

