### PR TITLE
Add summary.json to the benchmark .gitignore file

### DIFF
--- a/benchmark/sirun/.gitignore
+++ b/benchmark/sirun/.gitignore
@@ -1,2 +1,3 @@
 *.ndjson
 meta-temp.json
+summary.json


### PR DESCRIPTION
When using Sirun, it's normal to generate a `summary.json` file after running a benchmark. These should not be added to git.
