### PR TITLE
[test optimization] [SDTEST-1332] Fetch `di_enabled` flag

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -1545,12 +1545,7 @@ versions.forEach(version => {
           context('dynamic instrumentation', () => {
             it('does not activate if DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED is not set', (done) => {
               receiver.setSettings({
-                itr_enabled: false,
-                code_coverage: false,
-                tests_skipping: false,
-                early_flake_detection: {
-                  enabled: false
-                },
+                flaky_test_retries_enabled: true,
                 di_enabled: true
               })
 
@@ -1594,12 +1589,7 @@ versions.forEach(version => {
 
             it('does not activate dynamic instrumentation if remote settings are disabled', (done) => {
               receiver.setSettings({
-                itr_enabled: false,
-                code_coverage: false,
-                tests_skipping: false,
-                early_flake_detection: {
-                  enabled: false
-                },
+                flaky_test_retries_enabled: true,
                 di_enabled: false
               })
 
@@ -1646,13 +1636,7 @@ versions.forEach(version => {
 
             it('runs retries with dynamic instrumentation', (done) => {
               receiver.setSettings({
-                itr_enabled: false,
-                code_coverage: false,
-                tests_skipping: false,
-                early_flake_detection: {
-                  enabled: false
-                },
-                flaky_test_retries_enabled: false,
+                flaky_test_retries_enabled: true,
                 di_enabled: true
               })
 
@@ -1735,13 +1719,7 @@ versions.forEach(version => {
 
             it('does not crash if the retry does not hit the breakpoint', (done) => {
               receiver.setSettings({
-                itr_enabled: false,
-                code_coverage: false,
-                tests_skipping: false,
-                early_flake_detection: {
-                  enabled: false
-                },
-                flaky_test_retries_enabled: false,
+                flaky_test_retries_enabled: true,
                 di_enabled: true
               })
 

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -2413,13 +2413,7 @@ describe('jest CommonJS', () => {
   context('dynamic instrumentation', () => {
     it('does not activate dynamic instrumentation if DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED is not set', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: true
       })
       const eventsPromise = receiver
@@ -2465,13 +2459,7 @@ describe('jest CommonJS', () => {
 
     it('does not activate dynamic instrumentation if remote settings are disabled', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: false
       })
       const eventsPromise = receiver
@@ -2518,13 +2506,7 @@ describe('jest CommonJS', () => {
 
     it('runs retries with dynamic instrumentation', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: true
       })
       let snapshotIdByTest, snapshotIdByLog
@@ -2608,13 +2590,7 @@ describe('jest CommonJS', () => {
 
     it('does not crash if the retry does not hit the breakpoint', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: true
       })
       const eventsPromise = receiver

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -2419,8 +2419,8 @@ describe('jest CommonJS', () => {
         flaky_test_retries_enabled: false,
         early_flake_detection: {
           enabled: false
-        }
-        // di_enabled: true // TODO
+        },
+        di_enabled: true
       })
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
@@ -2463,6 +2463,59 @@ describe('jest CommonJS', () => {
       })
     })
 
+    it('does not activate dynamic instrumentation if remote settings are disabled', (done) => {
+      receiver.setSettings({
+        itr_enabled: false,
+        code_coverage: false,
+        tests_skipping: false,
+        flaky_test_retries_enabled: false,
+        early_flake_detection: {
+          enabled: false
+        },
+        di_enabled: false
+      })
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+
+          assert.equal(retriedTests.length, 1)
+          const [retriedTest] = retriedTests
+
+          assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
+          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
+          assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
+          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+        })
+      const logsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/logs'), (payloads) => {
+          if (payloads.length > 0) {
+            throw new Error('Unexpected logs')
+          }
+        }, 5000)
+
+      childProcess = exec(runTestsWithCoverageCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: 'dynamic-instrumentation/test-hit-breakpoint',
+            DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED: 'true'
+          },
+          stdio: 'inherit'
+        }
+      )
+
+      childProcess.on('exit', (code) => {
+        Promise.all([eventsPromise, logsPromise]).then(() => {
+          assert.equal(code, 0)
+          done()
+        }).catch(done)
+      })
+    })
+
     it('runs retries with dynamic instrumentation', (done) => {
       receiver.setSettings({
         itr_enabled: false,
@@ -2471,8 +2524,8 @@ describe('jest CommonJS', () => {
         flaky_test_retries_enabled: false,
         early_flake_detection: {
           enabled: false
-        }
-        // di_enabled: true // TODO
+        },
+        di_enabled: true
       })
       let snapshotIdByTest, snapshotIdByLog
       let spanIdByTest, spanIdByLog, traceIdByTest, traceIdByLog
@@ -2561,8 +2614,8 @@ describe('jest CommonJS', () => {
         flaky_test_retries_enabled: false,
         early_flake_detection: {
           enabled: false
-        }
-        // di_enabled: true // TODO
+        },
+        di_enabled: true
       })
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -2152,13 +2152,7 @@ describe('mocha CommonJS', function () {
   context('dynamic instrumentation', () => {
     it('does not activate dynamic instrumentation if DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED is not set', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: true
       })
 
@@ -2209,13 +2203,7 @@ describe('mocha CommonJS', function () {
 
     it('does not activate dynamic instrumentation if remote settings are disabled', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: false
       })
 
@@ -2267,13 +2255,7 @@ describe('mocha CommonJS', function () {
 
     it('runs retries with dynamic instrumentation', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: true
       })
 
@@ -2362,13 +2344,7 @@ describe('mocha CommonJS', function () {
 
     it('does not crash if the retry does not hit the breakpoint', (done) => {
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
-        flaky_test_retries_enabled: false,
-        early_flake_detection: {
-          enabled: false
-        },
+        flaky_test_retries_enabled: true,
         di_enabled: true
       })
 

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -909,7 +909,8 @@ versions.forEach((version) => {
             itr_enabled: false,
             code_coverage: false,
             tests_skipping: false,
-            flaky_test_retries_enabled: false
+            flaky_test_retries_enabled: false,
+            di_enabled: true
           })
 
           const eventsPromise = receiver
@@ -955,6 +956,59 @@ versions.forEach((version) => {
           })
         })
 
+        it('does not activate dynamic instrumentation if remote settings are disabled', (done) => {
+          receiver.setSettings({
+            itr_enabled: false,
+            code_coverage: false,
+            tests_skipping: false,
+            flaky_test_retries_enabled: false,
+            di_enabled: true
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+
+              assert.equal(retriedTests.length, 1)
+              const [retriedTest] = retriedTests
+
+              assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
+              assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
+              assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
+              assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+            })
+
+          const logsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/logs'), (payloads) => {
+              if (payloads.length > 0) {
+                throw new Error('Unexpected logs')
+              }
+            }, 5000)
+
+          childProcess = exec(
+            './node_modules/.bin/vitest run --retry=1',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                TEST_DIR: 'ci-visibility/vitest-tests/dynamic-instrumentation*',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+                DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED: '1'
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            Promise.all([eventsPromise, logsPromise]).then(() => {
+              done()
+            }).catch(done)
+          })
+        })
+
         it('runs retries with dynamic instrumentation', (done) => {
           receiver.setSettings({
             itr_enabled: false,
@@ -963,8 +1017,8 @@ versions.forEach((version) => {
             flaky_test_retries_enabled: false,
             early_flake_detection: {
               enabled: false
-            }
-            // di_enabled: true // TODO
+            },
+            di_enabled: true
           })
 
           let snapshotIdByTest, snapshotIdByLog
@@ -1050,6 +1104,17 @@ versions.forEach((version) => {
         })
 
         it('does not crash if the retry does not hit the breakpoint', (done) => {
+          receiver.setSettings({
+            itr_enabled: false,
+            code_coverage: false,
+            tests_skipping: false,
+            flaky_test_retries_enabled: false,
+            early_flake_detection: {
+              enabled: false
+            },
+            di_enabled: true
+          })
+
           const eventsPromise = receiver
             .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
               const events = payloads.flatMap(({ payload }) => payload.events)

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -906,10 +906,7 @@ versions.forEach((version) => {
       context('dynamic instrumentation', () => {
         it('does not activate it if DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED is not set', (done) => {
           receiver.setSettings({
-            itr_enabled: false,
-            code_coverage: false,
-            tests_skipping: false,
-            flaky_test_retries_enabled: false,
+            flaky_test_retries_enabled: true,
             di_enabled: true
           })
 
@@ -958,11 +955,8 @@ versions.forEach((version) => {
 
         it('does not activate dynamic instrumentation if remote settings are disabled', (done) => {
           receiver.setSettings({
-            itr_enabled: false,
-            code_coverage: false,
-            tests_skipping: false,
-            flaky_test_retries_enabled: false,
-            di_enabled: true
+            flaky_test_retries_enabled: true,
+            di_enabled: false
           })
 
           const eventsPromise = receiver
@@ -1011,13 +1005,7 @@ versions.forEach((version) => {
 
         it('runs retries with dynamic instrumentation', (done) => {
           receiver.setSettings({
-            itr_enabled: false,
-            code_coverage: false,
-            tests_skipping: false,
-            flaky_test_retries_enabled: false,
-            early_flake_detection: {
-              enabled: false
-            },
+            flaky_test_retries_enabled: true,
             di_enabled: true
           })
 
@@ -1105,13 +1093,7 @@ versions.forEach((version) => {
 
         it('does not crash if the retry does not hit the breakpoint', (done) => {
           receiver.setSettings({
-            itr_enabled: false,
-            code_coverage: false,
-            tests_skipping: false,
-            flaky_test_retries_enabled: false,
-            early_flake_detection: {
-              enabled: false
-            },
+            flaky_test_retries_enabled: true,
             di_enabled: true
           })
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -133,6 +133,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       this.isEarlyFlakeDetectionEnabled = this.testEnvironmentOptions._ddIsEarlyFlakeDetectionEnabled
       this.isFlakyTestRetriesEnabled = this.testEnvironmentOptions._ddIsFlakyTestRetriesEnabled
       this.flakyTestRetriesCount = this.testEnvironmentOptions._ddFlakyTestRetriesCount
+      this.isDiEnabled = this.testEnvironmentOptions._ddIsDiEnabled
 
       if (this.isEarlyFlakeDetectionEnabled) {
         const hasKnownTests = !!knownTests.jest
@@ -284,7 +285,12 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             const willBeRetried = numRetries > 0 && numTestExecutions - 1 < numRetries
 
             const error = formatJestError(event.test.errors[0])
-            testErrCh.publish({ error, willBeRetried, probe, numTestExecutions })
+            testErrCh.publish({
+              error,
+              willBeRetried,
+              probe,
+              isDiEnabled: this.isDiEnabled
+            })
           }
           testRunFinishCh.publish({
             status,
@@ -786,6 +792,7 @@ addHook({
       _ddRepositoryRoot,
       _ddIsFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount,
+      _ddIsDiEnabled,
       ...restOfTestEnvironmentOptions
     } = testEnvironmentOptions
 

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -255,7 +255,7 @@ class CucumberPlugin extends CiPlugin {
         span.setTag(TEST_IS_RETRY, 'true')
       }
       span.setTag('error', error)
-      if (this.di && error) {
+      if (this.di && error && this.libraryConfig?.isDiEnabled) {
         const testName = span.context()._tags[TEST_NAME]
         const debuggerParameters = this.addDiProbe(error)
         debuggerParameterPerTest.set(testName, debuggerParameters)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -161,6 +161,7 @@ class JestPlugin extends CiPlugin {
         config._ddRepositoryRoot = this.repositoryRoot
         config._ddIsFlakyTestRetriesEnabled = this.libraryConfig?.isFlakyTestRetriesEnabled ?? false
         config._ddFlakyTestRetriesCount = this.libraryConfig?.flakyTestRetriesCount
+        config._ddIsDiEnabled = this.libraryConfig?.isDiEnabled ?? false
       })
     })
 
@@ -355,14 +356,14 @@ class JestPlugin extends CiPlugin {
       finishAllTraceSpans(span)
     })
 
-    this.addSub('ci:jest:test:err', ({ error, willBeRetried, probe }) => {
+    this.addSub('ci:jest:test:err', ({ error, willBeRetried, probe, isDiEnabled }) => {
       if (error) {
         const store = storage.getStore()
         if (store && store.span) {
           const span = store.span
           span.setTag(TEST_STATUS, 'fail')
           span.setTag('error', error)
-          if (willBeRetried && this.di) {
+          if (willBeRetried && this.di && isDiEnabled) {
             // if we use numTestExecutions, we have to remove the breakpoint after each execution
             const testName = span.context()._tags[TEST_NAME]
             const debuggerParameters = this.addDiProbe(error, probe)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -294,7 +294,7 @@ class MochaPlugin extends CiPlugin {
             browserDriver: spanTags[TEST_BROWSER_DRIVER]
           }
         )
-        if (willBeRetried && this.di) {
+        if (willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
           const testName = span.context()._tags[TEST_NAME]
           const debuggerParameters = this.addDiProbe(err)
           debuggerParameterPerTest.set(testName, debuggerParameters)

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -137,12 +137,12 @@ class VitestPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:vitest:test:error', ({ duration, error, willBeRetried, probe }) => {
+    this.addSub('ci:vitest:test:error', ({ duration, error, willBeRetried, probe, isDiEnabled }) => {
       const store = storage.getStore()
       const span = store?.span
 
       if (span) {
-        if (willBeRetried && this.di) {
+        if (willBeRetried && this.di && isDiEnabled) {
           const testName = span.context()._tags[TEST_NAME]
           const debuggerParameters = this.addDiProbe(error, probe)
           debuggerParameterPerTest.set(testName, debuggerParameters)

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -196,7 +196,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
       isEarlyFlakeDetectionEnabled,
       earlyFlakeDetectionNumRetries,
       earlyFlakeDetectionFaultyThreshold,
-      isFlakyTestRetriesEnabled
+      isFlakyTestRetriesEnabled,
+      isDiEnabled
     } = remoteConfiguration
     return {
       isCodeCoverageEnabled,
@@ -207,7 +208,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
       earlyFlakeDetectionNumRetries,
       earlyFlakeDetectionFaultyThreshold,
       isFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled && this._config.isFlakyTestRetriesEnabled,
-      flakyTestRetriesCount: this._config.flakyTestRetriesCount
+      flakyTestRetriesCount: this._config.flakyTestRetriesCount,
+      isDiEnabled: isDiEnabled && this._config.isTestDynamicInstrumentationEnabled
     }
   }
 

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -92,7 +92,8 @@ function getLibraryConfiguration ({
               itr_enabled: isItrEnabled,
               require_git: requireGit,
               early_flake_detection: earlyFlakeDetectionConfig,
-              flaky_test_retries_enabled: isFlakyTestRetriesEnabled
+              flaky_test_retries_enabled: isFlakyTestRetriesEnabled,
+              di_enabled: isDiEnabled
             }
           }
         } = JSON.parse(res)
@@ -107,7 +108,8 @@ function getLibraryConfiguration ({
             earlyFlakeDetectionConfig?.slow_test_retries?.['5s'] || DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES,
           earlyFlakeDetectionFaultyThreshold:
             earlyFlakeDetectionConfig?.faulty_session_threshold ?? DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD,
-          isFlakyTestRetriesEnabled
+          isFlakyTestRetriesEnabled,
+          isDiEnabled: isDiEnabled && isFlakyTestRetriesEnabled
         }
 
         log.debug(() => `Remote settings: ${JSON.stringify(settings)}`)


### PR DESCRIPTION
### What does this PR do?
Fetch the new `di_enabled` backend flag to determine whether Dynamic Instrumentation on retries is enabled. 

### Motivation
Allow customers to use the feature by controlling a toggle in our UI, rather than by an environment variable.

### Plugin Checklist

- [x] Unit tests.
