### PR TITLE
[DI] Clean up all logs emitted by the debugger

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -28,7 +28,10 @@ async function addBreakpoint (probe) {
   if (!script) throw new Error(`No loaded script found for ${file} (probe: ${probe.id}, version: ${probe.version})`)
   const [path, scriptId] = script
 
-  log.debug(`Adding breakpoint at ${path}:${line} (probe: ${probe.id}, version: ${probe.version})`)
+  log.debug(
+    '[debugger:devtools_client] Adding breakpoint at %s:%d (probe: %s, version: %d)',
+    path, line, probe.id, probe.version
+  )
 
   const { breakpointId } = await session.post('Debugger.setBreakpoint', {
     location: {

--- a/packages/dd-trace/src/debugger/devtools_client/config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/config.js
@@ -15,7 +15,9 @@ const config = module.exports = {
 updateUrl(parentConfig)
 
 configPort.on('message', updateUrl)
-configPort.on('messageerror', (err) => log.error('Debugger config messageerror', err))
+configPort.on('messageerror', (err) =>
+  log.error('[debugger:devtools_client] received "messageerror" on config port', err)
+)
 
 function updateUrl (updates) {
   config.url = updates.url || format({

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -54,7 +54,10 @@ session.on('Debugger.paused', async ({ params }) => {
   await session.post('Debugger.resume')
   const diff = process.hrtime.bigint() - start // TODO: Recored as telemetry (DEBUG-2858)
 
-  log.debug(`Finished processing breakpoints - main thread paused for: ${Number(diff) / 1000000} ms`)
+  log.debug(
+    '[debugger:devtools_client] Finished processing breakpoints - main thread paused for: %d ms',
+    Number(diff) / 1000000
+  )
 
   const logger = {
     // We can safely use `location.file` from the first probe in the array, since all probes hit by `hitBreakpoints`

--- a/packages/dd-trace/src/debugger/devtools_client/remote_config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/remote_config.js
@@ -41,10 +41,13 @@ rcPort.on('message', async ({ action, conf: probe, ackId }) => {
     ackError(err, probe)
   }
 })
-rcPort.on('messageerror', (err) => log.error('Debugger RC message error', err))
+rcPort.on('messageerror', (err) => log.error('[debugger:devtools_client] received "messageerror" on RC port', err))
 
 async function processMsg (action, probe) {
-  log.debug(`Received request to ${action} ${probe.type} probe (id: ${probe.id}, version: ${probe.version})`)
+  log.debug(
+    '[debugger:devtools_client] Received request to %s %s probe (id: %s, version: %d)',
+    action, probe.type, probe.id, probe.version
+  )
 
   if (action !== 'unapply') ackReceived(probe)
 

--- a/packages/dd-trace/src/debugger/devtools_client/status.js
+++ b/packages/dd-trace/src/debugger/devtools_client/status.js
@@ -55,7 +55,7 @@ function ackEmitting ({ id: probeId, version }) {
 }
 
 function ackError (err, { id: probeId, version }) {
-  log.error('Debugger ackError', err)
+  log.error('[debugger:devtools_client] ackError', err)
 
   onlyUniqueUpdates(STATUSES.ERROR, probeId, version, () => {
     const payload = statusPayload(probeId, version, STATUSES.ERROR)
@@ -87,7 +87,7 @@ function send (payload) {
   }
 
   request(form, options, (err) => {
-    if (err) log.error('Error sending debugger payload', err)
+    if (err) log.error('[debugger:devtools_client] Error sending debugger payload', err)
   })
 }
 


### PR DESCRIPTION
### What does this PR do?

They are now all prefixed with either `[debugger]` or `[debugger:devtools_client]` depending on their location. Template strings have been removed in favor of `%s`, `%d` etc.

This has been made possible thanks to #4932.

### Motivation

- Align on output format so it's easier to grep
- Don't use template strings to improve performance

