### PR TITLE
copy prototypes in shimmer where necessary

### DIFF
--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -6,6 +6,12 @@ const log = require('../../dd-trace/src/log')
 const unwrappers = new WeakMap()
 
 function copyProperties (original, wrapped) {
+  // TODO getPrototypeOf is not fast. Should we instead do this in specific
+  // instrumentations where needed?
+  const proto = Object.getPrototypeOf(original)
+  if (proto !== Function.prototype) {
+    Object.setPrototypeOf(wrapped, proto)
+  }
   const props = Object.getOwnPropertyDescriptors(original)
   const keys = Reflect.ownKeys(props)
 


### PR DESCRIPTION
It's necessary to copy function prototypes when their prototype isn't `Function.prototype`. Otherwise `router` and other integrations are broken.