### PR TITLE
telemetry: make count logic faster

### DIFF
--- a/packages/dd-trace/src/telemetry/logs/index.js
+++ b/packages/dd-trace/src/telemetry/logs/index.js
@@ -40,6 +40,7 @@ function onErrorLog (msg) {
 
   const telLog = {
     level: 'ERROR',
+    count: 1,
 
     // existing log.error(err) without message will be reported as 'Generic Error'
     message: message ?? 'Generic Error'

--- a/packages/dd-trace/src/telemetry/logs/log-collector.js
+++ b/packages/dd-trace/src/telemetry/logs/log-collector.js
@@ -79,7 +79,7 @@ const logCollector = {
       }
       const hash = createHash(logEntry)
       if (!logs.has(hash)) {
-        logs.set(hash, errorCopy(logEntry))
+        logs.set(hash, logEntry)
         return true
       } else {
         logs.get(hash).count++
@@ -120,19 +120,6 @@ const logCollector = {
       maxEntries = max
     }
   }
-}
-
-// clone an Error object to later serialize and transmit
-// { ...error } doesn't work
-// also users can add arbitrary fields to an error
-function errorCopy (error) {
-  const keys = Object.getOwnPropertyNames(error)
-  const obj = {}
-  for (const key of keys) {
-    obj[key] = error[key]
-  }
-  obj.count = 1
-  return obj
 }
 
 logCollector.reset()

--- a/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
+++ b/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
@@ -128,11 +128,9 @@ describe('telemetry log collector', () => {
     })
 
     it('duplicated errors should send incremented count values', () => {
-      const err1 = new Error('oh no')
-      err1.level = 'ERROR'
+      const err1 = { message: 'oh no', level: 'ERROR', count: 1 }
 
-      const err2 = new Error('foo buzz')
-      err2.level = 'ERROR'
+      const err2 = { message: 'foo buzz', level: 'ERROR', count: 1 }
 
       logCollector.add(err1)
       logCollector.add(err2)


### PR DESCRIPTION
### What does this PR do?
- remove an unnecessary object duplication

### Motivation
- see comment on #5001