### PR TITLE
aws: add DD_TRACE_FORCE_AWS_PROPAGATION env var

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -169,13 +169,16 @@ function normalizeClientConfig (config) {
   const propagationFilter = getFilter({ blocklist: config.propagationBlocklist })
   const headers = getHeaders(config)
   const hooks = getHooks(config)
+  const enablePropagationWithAmazonHeaders = config.enablePropagationWithAmazonHeaders ||
+    process.env.DD_TRACE_FORCE_AWS_PROPAGATION === 'true'
 
   return Object.assign({}, config, {
     validateStatus,
     filter,
     propagationFilter,
     headers,
-    hooks
+    hooks,
+    enablePropagationWithAmazonHeaders
   })
 }
 


### PR DESCRIPTION
### What does this PR do?
- adds a new DD_TRACE_FORCE_AWS_PROPAGATION=true env var
- this forces the insertion of propagation headers into outbound signed AWS requests

### Motivation
- requested by a user