### PR TITLE
Test aerospike node 16 with ubuntu-22.04 (#5017)

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -21,7 +21,7 @@ jobs:
         node-version: [16]
         range: ['>=4.0.0 <5.2.0']
         aerospike-image: [ce-5.7.0.15]
-        test-image: [ubuntu-latest]
+        test-image: [ubuntu-22.04]
         include:
           - node-version: 18
             range: '>=5.2.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the runner for aerospike tests in node 16. It is not working with ubuntu-24.04, but it works on ubuntu-22.04.

### Motivation
<!-- What inspired you to submit this pull request? -->
Fix the CI


