### PR TITLE
consolidate instances of `loadInst`, so code isn't repeated

### DIFF
--- a/packages/dd-trace/test/setup/helpers/load-inst.js
+++ b/packages/dd-trace/test/setup/helpers/load-inst.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const proxyquire = require('proxyquire')
+
+function loadInstFile (file, instrumentations) {
+  const instrument = {
+    addHook (instrumentation) {
+      instrumentations.push(instrumentation)
+    }
+  }
+
+  const instPath = path.join(__dirname, `../../../../datadog-instrumentations/src/${file}`)
+
+  proxyquire.noPreserveCache()(instPath, {
+    './helpers/instrument': instrument,
+    '../helpers/instrument': instrument
+  })
+}
+
+function loadOneInst (name) {
+  const instrumentations = []
+
+  try {
+    loadInstFile(`${name}/server.js`, instrumentations)
+    loadInstFile(`${name}/client.js`, instrumentations)
+  } catch (e) {
+    try {
+      loadInstFile(`${name}/main.js`, instrumentations)
+    } catch (e) {
+      loadInstFile(`${name}.js`, instrumentations)
+    }
+  }
+
+  return instrumentations
+}
+
+function getAllInstrumentations () {
+  const names = fs.readdirSync(path.join(__dirname, '../../../../', 'datadog-instrumentations', 'src'))
+    .filter(file => file.endsWith('.js'))
+    .map(file => file.slice(0, -3))
+
+  const instrumentations = names.reduce((acc, key) => {
+    const name = key
+    let instrumentations = loadOneInst(name)
+
+    instrumentations = instrumentations.filter(i => i.versions)
+    if (instrumentations.length) {
+      acc[key] = instrumentations
+    }
+
+    return acc
+  }, {})
+
+  return instrumentations
+}
+
+module.exports = {
+  getInstrumentation: loadOneInst,
+  getAllInstrumentations
+}

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -11,6 +11,7 @@ const agent = require('../plugins/agent')
 const Nomenclature = require('../../src/service-naming')
 const { storage } = require('../../../datadog-core')
 const { schemaDefinitions } = require('../../src/service-naming/schemas')
+const { getInstrumentation } = require('./helpers/load-inst')
 
 global.withVersions = withVersions
 global.withExports = withExports
@@ -18,38 +19,6 @@ global.withNamingSchema = withNamingSchema
 global.withPeerService = withPeerService
 
 const testedPlugins = agent.testedPlugins
-
-function loadInst (plugin) {
-  const instrumentations = []
-
-  try {
-    loadInstFile(`${plugin}/server.js`, instrumentations)
-    loadInstFile(`${plugin}/client.js`, instrumentations)
-  } catch (e) {
-    try {
-      loadInstFile(`${plugin}/main.js`, instrumentations)
-    } catch (e) {
-      loadInstFile(`${plugin}.js`, instrumentations)
-    }
-  }
-
-  return instrumentations
-}
-
-function loadInstFile (file, instrumentations) {
-  const instrument = {
-    addHook (instrumentation) {
-      instrumentations.push(instrumentation)
-    }
-  }
-
-  const instPath = path.join(__dirname, `../../../datadog-instrumentations/src/${file}`)
-
-  proxyquire.noPreserveCache()(instPath, {
-    './helpers/instrument': instrument,
-    '../helpers/instrument': instrument
-  })
-}
 
 function withNamingSchema (
   spanProducerFn,
@@ -174,7 +143,7 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
 }
 
 function withVersions (plugin, modules, range, cb) {
-  const instrumentations = typeof plugin === 'string' ? loadInst(plugin) : [].concat(plugin)
+  const instrumentations = typeof plugin === 'string' ? getInstrumentation(plugin) : [].concat(plugin)
   const names = instrumentations.map(instrumentation => instrumentation.name)
 
   modules = [].concat(modules)

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -5,10 +5,10 @@ const os = require('os')
 const path = require('path')
 const crypto = require('crypto')
 const semver = require('semver')
-const proxyquire = require('proxyquire')
 const exec = require('./helpers/exec')
 const childProcess = require('child_process')
 const externals = require('../packages/dd-trace/test/plugins/externals')
+const { getInstrumentation } = require('../packages/dd-trace/test/setup/helpers/load-inst')
 
 const requirePackageJsonPath = require.resolve('../packages/dd-trace/src/require-package-json')
 
@@ -47,19 +47,7 @@ async function run () {
 
 async function assertVersions () {
   const internals = names
-    .map(key => {
-      const instrumentations = []
-      const name = key
-
-      try {
-        loadInstFile(`${name}/server.js`, instrumentations)
-        loadInstFile(`${name}/client.js`, instrumentations)
-      } catch (e) {
-        loadInstFile(`${name}.js`, instrumentations)
-      }
-
-      return instrumentations
-    })
+    .map(getInstrumentation)
     .reduce((prev, next) => prev.concat(next), [])
 
   for (const inst of internals) {
@@ -117,10 +105,10 @@ function assertFolder (name, version) {
   }
 }
 
-async function assertPackage (name, version, dependency, external) {
-  const dependencies = { [name]: dependency }
+async function assertPackage (name, version, dependencyVersionRange, external) {
+  const dependencies = { [name]: dependencyVersionRange }
   if (deps[name]) {
-    await addDependencies(dependencies, name, dependency)
+    await addDependencies(dependencies, name, dependencyVersionRange)
   }
   const pkg = {
     name: [name, sha1(name).substr(0, 8), sha1(version)].filter(val => val).join('-'),
@@ -239,19 +227,4 @@ function sha1 (str) {
   const shasum = crypto.createHash('sha1')
   shasum.update(str)
   return shasum.digest('hex')
-}
-
-function loadInstFile (file, instrumentations) {
-  const instrument = {
-    addHook (instrumentation) {
-      instrumentations.push(instrumentation)
-    }
-  }
-
-  const instPath = path.join(__dirname, `../packages/datadog-instrumentations/src/${file}`)
-
-  proxyquire.noPreserveCache()(instPath, {
-    './helpers/instrument': instrument,
-    '../helpers/instrument': instrument
-  })
 }


### PR DESCRIPTION
### What does this PR do?
The `loadInst` function has been copied and pasted several places. This consolidates them, preventing code rot. 
### Motivation
Any later refactors of `withVersions` are going to depend on a single source of truth in terms of how we load instrumentation data without loading the code.



