### PR TITLE
update native-metrics to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@datadog/native-appsec": "8.3.0",
     "@datadog/native-iast-rewriter": "2.6.1",
     "@datadog/native-iast-taint-tracking": "3.2.0",
-    "@datadog/native-metrics": "^3.0.1",
+    "@datadog/native-metrics": "^3.1.0",
     "@datadog/pprof": "5.4.1",
     "@datadog/sketches-js": "^2.1.0",
     "@isaacs/ttlcache": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3623,7 +3623,7 @@ mocha@^9:
     log-symbols "4.1.0"
     minimatch "4.2.1"
     ms "2.1.3"
-    nanoid "3.3.1"
+    nanoid "3.3.8"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,10 +428,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-metrics@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@datadog/native-metrics/-/native-metrics-3.0.1.tgz#dc276c93785c0377a048e316f23b7c8ff3acfa84"
-  integrity sha512-0GuMyYyXf+Qpb/F+Fcekz58f2mO37lit9U3jMbWY/m8kac44gCPABzL5q3gWbdH+hWgqYfQoEYsdNDGSrKfwoQ==
+"@datadog/native-metrics@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-metrics/-/native-metrics-3.1.0.tgz#c2378841accd9fdd6866d0e49bdf6e3d76e79f22"
+  integrity sha512-yOBi4x0OQRaGNPZ2bx9TGvDIgEdQ8fkudLTFAe7gEM1nAlvFmbE5YfpH8WenEtTSEBwojSau06m2q7axtEEmCg==
   dependencies:
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
@@ -3623,7 +3623,7 @@ mocha@^9:
     log-symbols "4.1.0"
     minimatch "4.2.1"
     ms "2.1.3"
-    nanoid "3.3.8"
+    nanoid "3.3.1"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update native-metrics to 3.1.0

### Motivation
<!-- What inspired you to submit this pull request? -->

This makes this option apply: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/runtime_metrics.js#L43