### PR TITLE
repo: mandatory issue templates (AIDM-422)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,64 @@
+name: "Bug Report (Low Priority)"
+description: "Create a public Bug Report. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult."
+title: "[BUG]: "
+labels: bug
+body:
+  - type: input
+    attributes:
+      label: Tracer Version(s)
+      description: "Version(s) of the tracer affected by this bug"
+      placeholder: 1.2.3, 4.5.6
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Node.js Version(s)
+      description: "Version(s) of Node.js (`node --version`) that you've encountered this bug with"
+      placeholder: 20.1.1
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Bug Report
+      description: Please add a clear and concise description of the bug here
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction Code
+      description: Please add code here to help us reproduce the problem
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Error Logs
+      description: "Please provide any error logs from the tracer (`DD_TRACE_DEBUG=true` can help)"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Operating System
+      description: "Provide your operating system and version (e.g. `uname -a`)"
+      placeholder: Darwin Kernel Version 23.6.0
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: Bundling
+      description: "How is your application being bundled"
+      options:
+        - Unsure
+        - No Bundling
+        - ESBuild
+        - Webpack
+        - Next.js
+        - Vite
+        - Rollup
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Bug Report
+  - name: Bug Report (High Priority)
     url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:node
-    about: This option creates an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private. Please do not create a GitHub issue to report a bug.
-  - name: Feature Request
+    about: Create an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private. Please do not create a GitHub issue to report a bug.
+  - name: Feature Request (High Priority)
     url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:node&tf_1260825272270=pt_apm_category_feature_request
-    about: This option creates an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private. Please do not create a GitHub issue to request a feature.
-
+    about: Create an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private. Please do not create a GitHub issue to request a feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,50 @@
+name: Feature Request (Low Priority)
+description: Create a public Feature Request. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult.
+title: "[FEATURE]: "
+labels: feature-request
+body:
+  - type: input
+    attributes:
+      label: Package Name
+      description: "If your feature request is to add instrumentation support for an npm package please provide the name here"
+      placeholder: left-pad
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Package Version(s)
+      description: "If your feature request is to add instrumentation support for an npm package please provide the version you use"
+      placeholder: 1.2.3
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe the feature you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: |
+        Please add a clear and concise description of your problem.
+        E.g. I'm unable to instrument my database queries...
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here
+    validations:
+      required: false


### PR DESCRIPTION
### What does this PR do?
- makes it mandatory to create issues using a template
- creates a bug report template
- creates a feature request template

### Motivation
- creating a consistent issue reporting experience across all tracers
- here's a screenshot of what the create issue dialog will now look like

<img width="1172" alt="Screenshot 2024-12-16 at 16 03 42" src="https://github.com/user-attachments/assets/aa9070c9-64ec-429b-9471-f1db7a03e19f" />
