### PR TITLE
set node types minimum version to oldest

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.11.1",
     "@stylistic/eslint-plugin-js": "^2.8.0",
-    "@types/node": "^16.18.103",
+    "@types/node": "^16.0.0",
     "autocannon": "^4.5.2",
     "aws-sdk": "^2.1446.0",
     "axios": "^1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,10 +956,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^16.18.103":
-  version "16.18.103"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.103.tgz#5557c7c32a766fddbec4b933b1d5c365f89b20a4"
-  integrity sha512-gOAcUSik1nR/CRC3BsK8kr6tbmNIOTpvb1sT+v5Nmmys+Ho8YtnIHP90wEsVK4hTcHndOqPVIlehEGEA5y31bA==
+"@types/node@^16.0.0":
+  version "16.18.122"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.122.tgz#54948ddbe2ddef8144ee16b37f160e3f99c32397"
+  integrity sha512-rF6rUBS80n4oK16EW8nE75U+9fw0SSUgoPtWSvHhPXdT7itbvmS7UjB/jyM8i3AkvI6yeSM5qCwo+xN0npGDHg==
 
 "@types/prop-types@*":
   version "15.7.5"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set node types minimum version to oldest.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now this differs in 4.x and 5.x release lines, which makes no sense because both use Node 16 for this, so it just results in constant conflicts for no reason.