### PR TITLE
ignore engines for package size job

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '18'
-      - run: yarn
+      - run: yarn --ignore-engines
       - name: Compute module size tree and report
         uses: qard/heaviest-objects-in-the-universe@v1
         with:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Ignore engines for package size job.

### Motivation
<!-- What inspired you to submit this pull request? -->

It fails on Node 16 otherwise because the new eslint dependencies don't support it.