### PR TITLE
[DI] Associate probe results with active span

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -13,6 +13,12 @@ const { version } = require('../../../../../package.json')
 
 require('./remote_config')
 
+// Expression to run on a call frame of the paused thread to get its active trace and span id.
+const expression = `
+  const context = global.require('dd-trace').scope().active()?.context();
+  ({ trace_id: context?.toTraceId(), span_id: context?.toSpanId() })
+`
+
 // There doesn't seem to be an official standard for the content of these fields, so we're just populating them with
 // something that should be useful to a Node.js developer.
 const threadId = parentThreadId === 0 ? `pid:${process.pid}` : `pid:${process.pid};tid:${parentThreadId}`
@@ -59,6 +65,7 @@ session.on('Debugger.paused', async ({ params }) => {
   }
 
   const timestamp = Date.now()
+  const dd = await getDD(params.callFrames[0].callFrameId)
 
   let processLocalState
   if (captureSnapshotForProbe !== null) {
@@ -122,7 +129,7 @@ session.on('Debugger.paused', async ({ params }) => {
     }
 
     // TODO: Process template (DEBUG-2628)
-    send(probe.template, logger, snapshot, (err) => {
+    send(probe.template, logger, dd, snapshot, (err) => {
       if (err) log.error('Debugger error', err)
       else ackEmitting(probe)
     })
@@ -131,4 +138,22 @@ session.on('Debugger.paused', async ({ params }) => {
 
 function highestOrUndefined (num, max) {
   return num === undefined ? max : Math.max(num, max ?? 0)
+}
+
+async function getDD (callFrameId) {
+  const { result } = await session.post('Debugger.evaluateOnCallFrame', {
+    callFrameId,
+    expression,
+    returnByValue: true,
+    includeCommandLineAPI: true
+  })
+
+  if (result?.value?.trace_id === undefined) {
+    if (result?.subtype === 'error') {
+      log.error('[debugger:devtools_client] Error getting trace/span id:', result.description)
+    }
+    return
+  }
+
+  return result.value
 }

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -22,7 +22,7 @@ const ddtags = [
 
 const path = `/debugger/v1/input?${stringify({ ddtags })}`
 
-function send (message, logger, snapshot, cb) {
+function send (message, logger, dd, snapshot, cb) {
   const opts = {
     method: 'POST',
     url: config.url,
@@ -36,6 +36,7 @@ function send (message, logger, snapshot, cb) {
     service,
     message,
     logger,
+    dd,
     'debugger.snapshot': snapshot
   }
 


### PR DESCRIPTION
### What does this PR do?

Adds trace and span id if available to the probe payload before sending it to the agent.

### Motivation

This allows the user to correlate a given probe result with the active trace.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

This is achived by executing a code-snippet on the top call frame of the paused thread when a breakpoint is hit. This code finds the current span context and fetches the trace- and span-id from it and returns it to the monitoring thread.

This comes with a significant performance overhead, but currently I haven't found a better solution.
As long as the probe isn't in a hot code-path, it's not a huge issue.
We can work on improving this algorithm later.

