### PR TITLE
[DI] Improve trace/span-id probe results tests

### DIFF
--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -18,7 +18,7 @@ module.exports = {
   setup
 }
 
-function setup () {
+function setup (env) {
   let sandbox, cwd, appPort
   const breakpoints = getBreakpointInfo(1) // `1` to disregard the `setup` function
   const t = {
@@ -91,7 +91,8 @@ function setup () {
         DD_DYNAMIC_INSTRUMENTATION_ENABLED: true,
         DD_TRACE_AGENT_PORT: t.agent.port,
         DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
-        DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: pollInterval
+        DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: pollInterval,
+        ...env
       }
     })
     t.axios = Axios.create({


### PR DESCRIPTION
### What does this PR do?

Add test that checks if everything works as expected even if tracing is disabled.

### Motivation

There's no trace/span-id if tracing is disabled, so having a test that checks everything still works as expected is a good idea.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


