### PR TITLE
fix runtime metrics test not waiting for gc observer to run

### DIFF
--- a/packages/dd-trace/src/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics.js
@@ -361,7 +361,7 @@ function startGCObserver () {
 
   gcObserver = new PerformanceObserver(list => {
     for (const entry of list.getEntries()) {
-      const type = gcType(entry.kind)
+      const type = gcType(entry.detail?.kind || entry.kind)
 
       runtimeMetrics.histogram('runtime.node.gc.pause.by.type', entry.duration, `gc_type:${type}`)
       runtimeMetrics.histogram('runtime.node.gc.pause', entry.duration)

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -13,6 +13,7 @@ suiteDescribe('runtimeMetrics', () => {
   let runtimeMetrics
   let config
   let clock
+  let setImmediate
   let client
   let Client
 
@@ -50,6 +51,7 @@ suiteDescribe('runtimeMetrics', () => {
       }
     }
 
+    setImmediate = globalThis.setImmediate
     clock = sinon.useFakeTimers()
 
     runtimeMetrics.start(config)
@@ -91,71 +93,79 @@ suiteDescribe('runtimeMetrics', () => {
       })
     })
 
-    it('should start collecting runtimeMetrics every 10 seconds', () => {
+    it('should start collecting runtimeMetrics every 10 seconds', (done) => {
       runtimeMetrics.stop()
       runtimeMetrics.start(config)
 
       global.gc()
 
-      clock.tick(10000)
+      setImmediate(() => setImmediate(() => { // Wait for GC observer to trigger.
+        clock.tick(10000)
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.cpu.user')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.cpu.system')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.cpu.total')
+        try {
+          expect(client.gauge).to.have.been.calledWith('runtime.node.cpu.user')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.cpu.system')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.cpu.total')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.mem.rss')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.mem.heap_total')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.mem.heap_used')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.mem.rss')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.mem.heap_total')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.mem.heap_used')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.process.uptime')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.process.uptime')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_heap_size')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_heap_size_executable')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_physical_size')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_available_size')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_heap_size')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.heap_size_limit')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_heap_size')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_heap_size_executable')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_physical_size')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_available_size')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.total_heap_size')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.heap_size_limit')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.malloced_memory')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.peak_malloced_memory')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.malloced_memory')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.peak_malloced_memory')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.max')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.min')
-      expect(client.increment).to.have.been.calledWith('runtime.node.event_loop.delay.sum')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.avg')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.median')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.95percentile')
-      expect(client.increment).to.have.been.calledWith('runtime.node.event_loop.delay.count')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.max')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.min')
+          expect(client.increment).to.have.been.calledWith('runtime.node.event_loop.delay.sum')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.avg')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.median')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.delay.95percentile')
+          expect(client.increment).to.have.been.calledWith('runtime.node.event_loop.delay.count')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.utilization')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.event_loop.utilization')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.max')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.min')
-      expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.sum')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.avg')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.median')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.95percentile')
-      expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.count')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.max')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.min')
+          expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.sum')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.avg')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.median')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.95percentile')
+          expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.count')
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.max')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.min')
-      expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.by.type.sum')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.avg')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.median')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.95percentile')
-      expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.by.type.count')
-      expect(client.increment).to.have.been.calledWith(
-        'runtime.node.gc.pause.by.type.count', sinon.match.any, sinon.match(val => {
-          return val && /^gc_type:[a-z_]+$/.test(val[0])
-        })
-      )
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.max')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.min')
+          expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.by.type.sum')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.avg')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.median')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.gc.pause.by.type.95percentile')
+          expect(client.increment).to.have.been.calledWith('runtime.node.gc.pause.by.type.count')
+          expect(client.increment).to.have.been.calledWith(
+            'runtime.node.gc.pause.by.type.count', sinon.match.any, sinon.match(val => {
+              return val && /^gc_type:[a-z_]+$/.test(val[0])
+            })
+          )
 
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.size.by.space')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.used_size.by.space')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.available_size.by.space')
-      expect(client.gauge).to.have.been.calledWith('runtime.node.heap.physical_size.by.space')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.size.by.space')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.used_size.by.space')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.available_size.by.space')
+          expect(client.gauge).to.have.been.calledWith('runtime.node.heap.physical_size.by.space')
 
-      expect(client.flush).to.have.been.called
+          expect(client.flush).to.have.been.called
+
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }))
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix runtime metrics test not waiting for GC observer to run.

### Motivation
<!-- What inspired you to submit this pull request? -->

Sinon fake timers can replace user-land timers but not built-in ones and thus ends up changing the order of operation since fake timers are synchronous and always execute before real asynchronous timers.