### PR TITLE
update package size job to node 20

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - run: yarn
       - name: Compute module size tree and report
         uses: qard/heaviest-objects-in-the-universe@v1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update package size job to Node 20.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some of our dependencies now require Node 18 to run which fails this job as it uses Node 16 on the v4.x release line. It's possible to ignore engines, but there isn't really any reason to do that since this job doesn't use our code, so we can instead just bump Node as suggested in https://github.com/DataDog/dd-trace-js/pull/5033#discussion_r1889786789