### PR TITLE
[DI] Attach ddtags to probe results

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -428,7 +428,7 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=true', function () {
-    const t = setup({ DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: true })
+    const t = setup({ env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: true } })
 
     describe('input messages', function () {
       it(
@@ -439,7 +439,7 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=false', function () {
-    const t = setup({ DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: false })
+    const t = setup({ env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: false } })
 
     describe('input messages', function () {
       it(
@@ -450,7 +450,7 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=false', function () {
-    const t = setup({ DD_TRACING_ENABLED: false })
+    const t = setup({ env: { DD_TRACING_ENABLED: false } })
 
     describe('input messages', function () {
       it(

--- a/integration-tests/debugger/ddtags.spec.js
+++ b/integration-tests/debugger/ddtags.spec.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const os = require('os')
+
+const { assert } = require('chai')
+const { setup } = require('./utils')
+const { version } = require('../../package.json')
+
+describe('Dynamic Instrumentation', function () {
+  describe('ddtags', function () {
+    const t = setup({
+      env: {
+        DD_ENV: 'test-env',
+        DD_VERSION: 'test-version',
+        DD_GIT_COMMIT_SHA: 'test-commit-sha',
+        DD_GIT_REPOSITORY_URL: 'test-repository-url'
+      },
+      testApp: 'target-app/basic.js'
+    })
+
+    it('should add the expected ddtags as a query param to /debugger/v1/input', function (done) {
+      t.triggerBreakpoint()
+
+      t.agent.on('debugger-input', ({ query }) => {
+        assert.property(query, 'ddtags')
+
+        // Before: "a:b,c:d"
+        // After: { a: 'b', c: 'd' }
+        const ddtags = query.ddtags
+          .split(',')
+          .map((tag) => tag.split(':'))
+          .reduce((acc, [k, v]) => { acc[k] = v; return acc }, {})
+
+        assert.hasAllKeys(ddtags, [
+          'env',
+          'version',
+          'debugger_version',
+          'host_name',
+          'git.commit.sha',
+          'git.repository_url'
+        ])
+
+        assert.strictEqual(ddtags.env, 'test-env')
+        assert.strictEqual(ddtags.version, 'test-version')
+        assert.strictEqual(ddtags.debugger_version, version)
+        assert.strictEqual(ddtags.host_name, os.hostname())
+        assert.strictEqual(ddtags['git.commit.sha'], 'test-commit-sha')
+        assert.strictEqual(ddtags['git.repository_url'], 'test-repository-url')
+
+        done()
+      })
+
+      t.agent.addRemoteConfig(t.rcConfig)
+    })
+  })
+})

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -18,9 +18,9 @@ module.exports = {
   setup
 }
 
-function setup (env) {
+function setup ({ env, testApp } = {}) {
   let sandbox, cwd, appPort
-  const breakpoints = getBreakpointInfo(1) // `1` to disregard the `setup` function
+  const breakpoints = getBreakpointInfo({ file: testApp, stackIndex: 1 }) // `1` to disregard the `setup` function
   const t = {
     breakpoint: breakpoints[0],
     breakpoints,
@@ -108,16 +108,18 @@ function setup (env) {
   return t
 }
 
-function getBreakpointInfo (stackIndex = 0) {
-  // First, get the filename of file that called this function
-  const testFile = new Error().stack
-    .split('\n')[stackIndex + 2] // +2 to skip this function + the first line, which is the error message
-    .split(' (')[1]
-    .slice(0, -1)
-    .split(':')[0]
+function getBreakpointInfo ({ file, stackIndex = 0 }) {
+  if (!file) {
+    // First, get the filename of file that called this function
+    const testFile = new Error().stack
+      .split('\n')[stackIndex + 2] // +2 to skip this function + the first line, which is the error message
+      .split(' (')[1]
+      .slice(0, -1)
+      .split(':')[0]
 
-  // Then, find the corresponding file in which the breakpoint(s) exists
-  const file = join('target-app', basename(testFile).replace('.spec', ''))
+    // Then, find the corresponding file in which the breakpoint(s) exists
+    file = join('target-app', basename(testFile).replace('.spec', ''))
+  }
 
   // Finally, find the line number(s) of the breakpoint(s)
   const lines = readFileSync(join(__dirname, file), 'utf8').split('\n')

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -326,6 +326,7 @@ function buildExpressServer (agent) {
     res.status(200).send()
     agent.emit('debugger-input', {
       headers: req.headers,
+      query: req.query,
       payload: req.body
     })
   })

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -6,6 +6,7 @@ const { stringify } = require('querystring')
 const config = require('./config')
 const request = require('../../exporters/common/request')
 const { GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('../../plugins/util/tags')
+const { version } = require('../../../../../package.json')
 
 module.exports = send
 
@@ -16,6 +17,10 @@ const hostname = getHostname()
 const service = config.service
 
 const ddtags = [
+  ['env', process.env.DD_ENV],
+  ['version', process.env.DD_VERSION],
+  ['debugger_version', version],
+  ['host_name', hostname],
   [GIT_COMMIT_SHA, config.commitSHA],
   [GIT_REPOSITORY_URL, config.repositoryUrl]
 ].map((pair) => pair.join(':')).join(',')


### PR DESCRIPTION
The following extra information is added to each probe result:
    
- `env` - From the `DD_ENV` environment variable
- `version` - From the `DD_VERSION` environment variable
- `debugger_version` - The version of the tracing lib
- `host_name` - The hostname that application is running on
    
The `agent_version` is not added in this PR, but will be come later.
