### PR TITLE
fix invalid output for log.trace

### DIFF
--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -67,7 +67,7 @@ const log = {
       const params = args.map(a => {
         return a && a.hasOwnProperty('toString') && typeof a.toString === 'function'
           ? a.toString()
-          : inspect(a, { depth: 5, breakLength: Infinity, compact: true })
+          : inspect(a, { depth: 3, breakLength: Infinity, compact: true })
       }).join(', ')
       const formatted = logRecord.stack.replace('Error: ', `Trace: ${fn}(${params})`)
 

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -59,9 +59,14 @@ const log = {
   trace (...args) {
     if (traceChannel.hasSubscribers) {
       const logRecord = {}
+
       Error.captureStackTrace(logRecord, this.trace)
-      const stack = logRecord.stack.split('\n')[1].replace(/^\s+at ([^\s]) .+/, '$1')
-      traceChannel.publish(Log.parse('Trace', args, { stack }))
+
+      const fn = logRecord.stack.split('\n')[1].replace(/^\s+at ([^\s]+) .+/, '$1')
+      const params = args.map(a => JSON.stringify(a)).join(', ')
+      const formatted = logRecord.stack.replace('Error: ', `Trace: ${fn}(${params})`)
+
+      traceChannel.publish(Log.parse(formatted))
     }
     return this
   },

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const coalesce = require('koalas')
+const { inspect } = require('util')
 const { isTrue } = require('../util')
 const { traceChannel, debugChannel, infoChannel, warnChannel, errorChannel } = require('./channels')
 const logWriter = require('./writer')
@@ -63,7 +64,11 @@ const log = {
       Error.captureStackTrace(logRecord, this.trace)
 
       const fn = logRecord.stack.split('\n')[1].replace(/^\s+at ([^\s]+) .+/, '$1')
-      const params = args.map(a => JSON.stringify(a)).join(', ')
+      const params = args.map(a => {
+        return a && a.hasOwnProperty('toString') && typeof a.toString === 'function'
+          ? a.toString()
+          : inspect(a, { depth: 5, breakLength: Infinity, compact: true })
+      }).join(', ')
       const formatted = logRecord.stack.replace('Error: ', `Trace: ${fn}(${params})`)
 
       traceChannel.publish(Log.parse(formatted))

--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -4,7 +4,6 @@ const { storage } = require('../../../datadog-core')
 const { LogChannel } = require('./channels')
 const { Log } = require('./log')
 const defaultLogger = {
-  trace: msg => console.trace(msg), /* eslint-disable-line no-console */
   debug: msg => console.debug(msg), /* eslint-disable-line no-console */
   info: msg => console.info(msg), /* eslint-disable-line no-console */
   warn: msg => console.warn(msg), /* eslint-disable-line no-console */
@@ -91,8 +90,10 @@ function onDebug (log) {
 
 function onTrace (log) {
   const { formatted, cause } = getErrorLog(log)
-  if (formatted) withNoop(() => logger.trace(formatted))
-  if (cause) withNoop(() => logger.trace(cause))
+  // Using logger.debug() because not all loggers have trace level,
+  // and console.trace() has a completely different meaning.
+  if (formatted) withNoop(() => logger.debug(formatted))
+  if (cause) withNoop(() => logger.debug(cause))
 }
 
 function error (...args) {

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -107,7 +107,7 @@ class DatadogSpan {
 
   toString () {
     const spanContext = this.context()
-    const resourceName = spanContext._tags['resource.name']
+    const resourceName = spanContext._tags['resource.name'] || ''
     const resource = resourceName.length > 100
       ? `${resourceName.substring(0, 97)}...`
       : resourceName

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -57,7 +57,7 @@ class PrioritySampler {
 
   isSampled (span) {
     const priority = this._getPriorityFromAuto(span)
-    log.trace(span)
+    log.trace(span.toString())
     return priority === USER_KEEP || priority === AUTO_KEEP
   }
 
@@ -71,7 +71,7 @@ class PrioritySampler {
     if (context._sampling.priority !== undefined) return
     if (!root) return // noop span
 
-    log.trace(span, auto)
+    log.trace(span.toString(), auto)
 
     const tag = this._getPriorityFromTags(context._tags, context)
 
@@ -126,7 +126,7 @@ class PrioritySampler {
 
     const root = context._trace.started[0]
 
-    log.trace(span, samplingPriority, mechanism)
+    log.trace(span.toString(), samplingPriority, mechanism)
     this._addDecisionMaker(root)
   }
 

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -57,7 +57,7 @@ class PrioritySampler {
 
   isSampled (span) {
     const priority = this._getPriorityFromAuto(span)
-    log.trace(span.toString())
+    log.trace(span)
     return priority === USER_KEEP || priority === AUTO_KEEP
   }
 
@@ -71,7 +71,7 @@ class PrioritySampler {
     if (context._sampling.priority !== undefined) return
     if (!root) return // noop span
 
-    log.trace(span.toString(), auto)
+    log.trace(span, auto)
 
     const tag = this._getPriorityFromTags(context._tags, context)
 
@@ -126,7 +126,7 @@ class PrioritySampler {
 
     const root = context._trace.started[0]
 
-    log.trace(span.toString(), samplingPriority, mechanism)
+    log.trace(span, samplingPriority, mechanism)
     this._addDecisionMaker(root)
   }
 

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -148,10 +148,14 @@ describe('log', () => {
 
       it('should log to console after setting log level to trace', function foo () {
         log.toggle(true, 'trace')
-        log.trace('argument', { hello: 'world' })
+        log.trace('argument', { hello: 'world' }, {
+          toString: () => 'string'
+        }, { foo: 'bar' })
 
         expect(console.debug).to.have.been.calledOnce
-        expect(console.debug.firstCall.args[0]).to.match(/^Trace: Test.foo\("argument", {"hello":"world"}\)/)
+        expect(console.debug.firstCall.args[0]).to.match(
+          /^Trace: Test.foo\('argument', { hello: 'world' }, string, { foo: 'bar' }\)/
+        )
         expect(console.debug.firstCall.args[0].split('\n').length).to.be.gte(3)
       })
     })

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -86,7 +86,6 @@ describe('log', () => {
       sinon.stub(console, 'error')
       sinon.stub(console, 'warn')
       sinon.stub(console, 'debug')
-      sinon.stub(console, 'trace')
 
       error = new Error()
 
@@ -105,7 +104,6 @@ describe('log', () => {
       console.error.restore()
       console.warn.restore()
       console.debug.restore()
-      console.trace.restore()
     })
 
     it('should support chaining', () => {
@@ -145,14 +143,16 @@ describe('log', () => {
       it('should not log to console by default', () => {
         log.trace('trace')
 
-        expect(console.trace).to.not.have.been.called
+        expect(console.debug).to.not.have.been.called
       })
 
-      it('should log to console after setting log level to trace', () => {
+      it('should log to console after setting log level to trace', function foo () {
         log.toggle(true, 'trace')
-        log.trace('argument')
+        log.trace('argument', { hello: 'world' })
 
-        expect(console.trace).to.have.been.calledTwice
+        expect(console.debug).to.have.been.calledOnce
+        expect(console.debug.firstCall.args[0]).to.match(/^Trace: Test.foo\("argument", {"hello":"world"}\)/)
+        expect(console.debug.firstCall.args[0].split('\n').length).to.be.gte(3)
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix invalid output for `log.trace`.

### Motivation
<!-- What inspired you to submit this pull request? -->

There were a few major issues with the previous implementation:

1) It only contained the first line of the stack trace instead of the entire stack trace.
2) It didn't format objects explicitly, which would result in `[Object object]`.
3) It split the trace output in two separate entries.
4) It used `logger.trace()` which is not guaranteed to be present or correct on the user-provided logger, for example `console.trace()` is not a log method.