### PR TITLE
[DI] Clean up snapshot integration test

### DIFF
--- a/integration-tests/debugger/snapshot.spec.js
+++ b/integration-tests/debugger/snapshot.spec.js
@@ -16,10 +16,10 @@ describe('Dynamic Instrumentation', function () {
           assert.deepEqual(Object.keys(captures.lines), [String(t.breakpoint.line)])
 
           const { locals } = captures.lines[t.breakpoint.line]
-          const { request, fastify, getSomeData } = locals
+          const { request, fastify, getUndefined } = locals
           delete locals.request
           delete locals.fastify
-          delete locals.getSomeData
+          delete locals.getUndefined
 
           // from block scope
           assert.deepEqual(locals, {
@@ -67,18 +67,18 @@ describe('Dynamic Instrumentation', function () {
               }
             },
             emptyObj: { type: 'Object', fields: {} },
-            fn: {
-              type: 'Function',
-              fields: {
-                length: { type: 'number', value: '0' },
-                name: { type: 'string', value: 'fn' }
-              }
-            },
             p: {
               type: 'Promise',
               fields: {
                 '[[PromiseState]]': { type: 'string', value: 'fulfilled' },
                 '[[PromiseResult]]': { type: 'undefined' }
+              }
+            },
+            arrowFn: {
+              type: 'Function',
+              fields: {
+                length: { type: 'number', value: '0' },
+                name: { type: 'string', value: 'arrowFn' }
               }
             }
           })
@@ -99,11 +99,11 @@ describe('Dynamic Instrumentation', function () {
           assert.equal(fastify.type, 'Object')
           assert.typeOf(fastify.fields, 'Object')
 
-          assert.deepEqual(getSomeData, {
+          assert.deepEqual(getUndefined, {
             type: 'Function',
             fields: {
               length: { type: 'number', value: '0' },
-              name: { type: 'string', value: 'getSomeData' }
+              name: { type: 'string', value: 'getUndefined' }
             }
           })
 
@@ -118,7 +118,7 @@ describe('Dynamic Instrumentation', function () {
           const { locals } = captures.lines[t.breakpoint.line]
           delete locals.request
           delete locals.fastify
-          delete locals.getSomeData
+          delete locals.getUndefined
 
           assert.deepEqual(locals, {
             nil: { type: 'null', isNull: true },
@@ -139,8 +139,8 @@ describe('Dynamic Instrumentation', function () {
             arr: { type: 'Array', notCapturedReason: 'depth' },
             obj: { type: 'Object', notCapturedReason: 'depth' },
             emptyObj: { type: 'Object', notCapturedReason: 'depth' },
-            fn: { type: 'Function', notCapturedReason: 'depth' },
-            p: { type: 'Promise', notCapturedReason: 'depth' }
+            p: { type: 'Promise', notCapturedReason: 'depth' },
+            arrowFn: { type: 'Function', notCapturedReason: 'depth' }
           })
 
           done()
@@ -212,7 +212,7 @@ describe('Dynamic Instrumentation', function () {
             // Up to 3 properties from the local scope
             'request', 'nil', 'undef',
             // Up to 3 properties from the closure scope
-            'fastify', 'getSomeData'
+            'fastify', 'getUndefined'
           ])
 
           assert.strictEqual(locals.request.type, 'Request')

--- a/integration-tests/debugger/target-app/snapshot.js
+++ b/integration-tests/debugger/target-app/snapshot.js
@@ -5,12 +5,33 @@ const Fastify = require('fastify')
 
 const fastify = Fastify()
 
-// Since line probes have hardcoded line numbers, we want to try and keep the line numbers from changing within the
-// `handler` function below when making changes to this file. This is achieved by calling `getSomeData` and keeping all
-// variable names on the same line as much as possible.
 fastify.get('/:name', function handler (request) {
-  // eslint-disable-next-line no-unused-vars
-  const { nil, undef, bool, num, bigint, str, lstr, sym, regex, arr, obj, emptyObj, fn, p } = getSomeData()
+  /* eslint-disable no-unused-vars */
+  const nil = null
+  const undef = getUndefined()
+  const bool = true
+  const num = 42
+  const bigint = 42n
+  const str = 'foo'
+  // eslint-disable-next-line @stylistic/js/max-len
+  const lstr = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+  const sym = Symbol('foo')
+  const regex = /bar/i
+  const arr = [1, 2, 3, 4, 5]
+  const obj = {
+    foo: {
+      baz: 42,
+      nil: null,
+      undef: undefined,
+      deep: { nested: { obj: { that: { goes: { on: { forever: true } } } } } }
+    },
+    bar: true
+  }
+  const emptyObj = {}
+  const p = Promise.resolve()
+  const arrowFn = () => {}
+  /* eslint-enable no-unused-vars */
+
   return { hello: request.params.name } // BREAKPOINT: /foo
 })
 
@@ -22,30 +43,4 @@ fastify.listen({ port: process.env.APP_PORT }, (err) => {
   process.send({ port: process.env.APP_PORT })
 })
 
-function getSomeData () {
-  return {
-    nil: null,
-    undef: undefined,
-    bool: true,
-    num: 42,
-    bigint: 42n,
-    str: 'foo',
-    // eslint-disable-next-line @stylistic/js/max-len
-    lstr: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-    sym: Symbol('foo'),
-    regex: /bar/i,
-    arr: [1, 2, 3, 4, 5],
-    obj: {
-      foo: {
-        baz: 42,
-        nil: null,
-        undef: undefined,
-        deep: { nested: { obj: { that: { goes: { on: { forever: true } } } } } }
-      },
-      bar: true
-    },
-    emptyObj: {},
-    fn: () => {},
-    p: Promise.resolve()
-  }
-}
+function getUndefined () {}


### PR DESCRIPTION
### What does this PR do?

The comment about the breakpoint line number being hardcoded is no longer true. Since this is no longer the case, this PR removes the hack used to avoid changing the line number when adding new variables to the captured snapshot.

### Motivation

Out of date comments are bad. Readable code is good.
