### PR TITLE
refactor custom metrics to be self-contained

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -190,6 +190,14 @@ class CustomMetrics {
   constructor (config) {
     const clientConfig = DogStatsDClient.generateClientConfig(config)
     this.dogstatsd = new DogStatsDClient(clientConfig)
+
+    this._boundFlush = this.flush.bind(this)
+
+    // TODO(bengl) this magic number should be configurable
+    this._flushInterval = setInterval(this._boundFlush, 10 * 1000)
+    this._flushInterval.unref()
+
+    process.once('beforeExit', this._boundFlush)
   }
 
   increment (stat, value = 1, tags) {

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -67,16 +67,7 @@ class Tracer extends NoopProxy {
       telemetry.start(config, this._pluginManager)
 
       if (config.dogstatsd) {
-        // Custom Metrics
         this.dogstatsd = new dogstatsd.CustomMetrics(config)
-
-        setInterval(() => {
-          this.dogstatsd.flush()
-        }, 10 * 1000).unref()
-
-        process.once('beforeExit', () => {
-          this.dogstatsd.flush()
-        })
       }
 
       if (config.spanLeakDebug > 0) {

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -431,5 +431,20 @@ describe('dogstatsd', () => {
       expect(udp4.send).to.have.been.called
       expect(udp4.send.firstCall.args[0].toString()).to.equal('test.histogram:10|h\n')
     })
+
+    it('should flush via interval', () => {
+      const clock = sinon.useFakeTimers()
+
+      client = new CustomMetrics({ dogstatsd: {} })
+
+      client.gauge('test.avg', 10, { foo: 'bar' })
+
+      expect(udp4.send).not.to.have.been.called
+
+      clock.tick(10 * 1000)
+
+      expect(udp4.send).to.have.been.called
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.avg:10|g|#foo:bar\n')
+    })
   })
 })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -401,28 +401,6 @@ describe('TracerProxy', () => {
         proxy.dogstatsd.increment('foo')
       })
 
-      it('should call custom metrics flush via interval', () => {
-        const clock = sinon.useFakeTimers()
-
-        config.dogstatsd = {
-          hostname: 'localhost',
-          port: 9876
-        }
-        config.tags = {
-          service: 'photos',
-          env: 'prod',
-          version: '1.2.3'
-        }
-
-        proxy.init()
-
-        expect(dogStatsD._flushes()).to.equal(0)
-
-        clock.tick(10000)
-
-        expect(dogStatsD._flushes()).to.equal(1)
-      })
-
       it('should expose real metrics methods after init when configured', () => {
         config.dogstatsd = {
           hostname: 'localhost',


### PR DESCRIPTION
This had no real business being in `Proxy#init()`, so I moved it to where it makes more sense. 


