### PR TITLE
Ignore noop spans

### DIFF
--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -120,13 +120,15 @@ class PrioritySampler {
     if (!span || !this.validate(samplingPriority)) return
 
     const context = this._getContext(span)
+    const root = context._trace.started[0]
+
+    if (!root) return // noop span
 
     context._sampling.priority = samplingPriority
     context._sampling.mechanism = mechanism
 
-    const root = context._trace.started[0]
-
     log.trace(span, samplingPriority, mechanism)
+
     this._addDecisionMaker(root)
   }
 

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -490,6 +490,16 @@ describe('PrioritySampler', () => {
       expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_APPSEC)
       expect(context._trace.tags[DECISION_MAKER_KEY]).to.equal('-0')
     })
+
+    it('should ignore noop spans', () => {
+      context._trace.started[0] = undefined // noop
+
+      prioritySampler.setPriority(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+
+      expect(context._sampling.priority).to.undefined
+      expect(context._sampling.mechanism).to.undefined
+      expect(context._trace.tags[DECISION_MAKER_KEY]).to.undefined
+    })
   })
 
   describe('keepTrace', () => {


### PR DESCRIPTION
### What does this PR do?
do nothing if a noop span reaches `PrioritySampler.setPriority`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


