### PR TITLE
DNS Lookup event hostname is sometimes not a string

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -14,7 +14,23 @@ const pprofValueUnit = 'nanoseconds'
 const dateOffset = BigInt(Math.round(performance.timeOrigin * MS_TO_NS))
 
 function labelFromStr (stringTable, key, valStr) {
-  return new Label({ key, str: stringTable.dedup(String(valStr)) })
+  return new Label({ key, str: stringTable.dedup(safeToString(valStr)) })
+}
+
+// We don't want to invoke toString for objects and functions, rather we'll
+// provide dummy values. These values are not meant to emulate built-in toString
+// behavior.
+function safeToString (val) {
+  switch (typeof val) {
+    case 'string':
+      return val
+    case 'object':
+      return '[object]'
+    case 'function':
+      return '[function]'
+    default:
+      return String(val)
+  }
 }
 
 function labelFromStrStr (stringTable, keyStr, valStr) {

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -14,7 +14,7 @@ const pprofValueUnit = 'nanoseconds'
 const dateOffset = BigInt(Math.round(performance.timeOrigin * MS_TO_NS))
 
 function labelFromStr (stringTable, key, valStr) {
-  return new Label({ key, str: stringTable.dedup(valStr) })
+  return new Label({ key, str: stringTable.dedup(String(valStr)) })
 }
 
 function labelFromStrStr (stringTable, keyStr, valStr) {


### PR DESCRIPTION
### What does this PR do?
Ensures that values of event details we want to encode as labels are always coerced to string because sometimes they aren't strings. (Possibly: null or undefined?)

### Motivation
A low cardinality occurrence of the following error in our telemetry logs:
```
Error : redacted
TypeError: redacted
    at labelFromStr (dd-trace/src/profiling/profilers/events.js:17:44)
    at addLabel (dd-trace/src/profiling/profilers/events.js:88:19)
    at DNSDecorator.decorateSample (dd-trace/src/profiling/profilers/events.js:95:9)
    at EventSerializer.addEvent (dd-trace/src/profiling/profilers/events.js:200:15)
    at DNSLookupPlugin.eventHandler (dd-trace/src/profiling/profilers/events.js:336:56)
    at DNSLookupPlugin.finish (dd-trace/src/profiling/profilers/event_plugins/event.js:54:10)
    ...
```

JIRA: [PROF-11087]


[PROF-11087]: https://datadoghq.atlassian.net/browse/PROF-11087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ