### PR TITLE
Rename `Tracer` to `NoopProxy` in `noop/proxy.js`

### DIFF
--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -10,7 +10,7 @@ const noopAppsec = new NoopAppsecSdk()
 const noopDogStatsDClient = new NoopDogStatsDClient()
 const noopLLMObs = new NoopLLMObsSDK(noop)
 
-class Tracer {
+class NoopProxy {
   constructor () {
     this._tracer = noop
     this.appsec = noopAppsec
@@ -91,4 +91,4 @@ class Tracer {
   }
 }
 
-module.exports = Tracer
+module.exports = NoopProxy


### PR DESCRIPTION
### What does this PR do?
Rename `Tracer` to `NoopProxy` in `noop/proxy.js`

### Motivation
It always caused me great confusion because it was named `Tracer` in the definition, but `NoopProxy` where it was used.
https://github.com/DataDog/dd-trace-js/blob/12f24185e76af18d18b41a7e53f360ae7de04c8a/packages/dd-trace/src/proxy.js#L2