### PR TITLE
Send tags, including git metadata, to RC endpoint

### DIFF
--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -9,6 +9,7 @@ const log = require('../../log')
 const { getExtraServices } = require('../../service-naming/extra-services')
 const { UNACKNOWLEDGED, ACKNOWLEDGED, ERROR } = require('./apply_states')
 const Scheduler = require('./scheduler')
+const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../../plugins/util/tags')
 
 const clientId = uuid()
 
@@ -32,6 +33,14 @@ class RemoteConfigManager extends EventEmitter {
       hostname: config.hostname || 'localhost',
       port: config.port
     }))
+
+    const tags = config.repositoryUrl
+      ? {
+          ...config.tags,
+          [GIT_REPOSITORY_URL]: config.repositoryUrl,
+          [GIT_COMMIT_SHA]: config.commitSHA
+        }
+      : config.tags
 
     this._handlers = new Map()
     const appliedConfigs = this.appliedConfigs = new Map()
@@ -67,7 +76,8 @@ class RemoteConfigManager extends EventEmitter {
           service: config.service,
           env: config.env,
           app_version: config.version,
-          extra_services: []
+          extra_services: [],
+          tags: Object.entries(tags).map((pair) => pair.join(':'))
         },
         capabilities: DEFAULT_CAPABILITY // updated by `updateCapabilities()`
       },

--- a/packages/dd-trace/test/appsec/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/manager.spec.js
@@ -98,7 +98,8 @@ describe('RemoteConfigManager', () => {
           service: config.service,
           env: config.env,
           app_version: config.version,
-          extra_services: []
+          extra_services: [],
+          tags: ['runtime-id:runtimeId']
         },
         capabilities: 'AA=='
       },
@@ -106,6 +107,20 @@ describe('RemoteConfigManager', () => {
     })
 
     expect(rc.appliedConfigs).to.be.an.instanceOf(Map)
+  })
+
+  it('should add git metadata to tags if present', () => {
+    const configWithGit = {
+      ...config,
+      repositoryUrl: 'https://github.com/DataDog/dd-trace-js',
+      commitSHA: '1234567890'
+    }
+    const rc = new RemoteConfigManager(configWithGit)
+    expect(rc.state.client.client_tracer.tags).to.deep.equal([
+      'runtime-id:runtimeId',
+      'git.repository_url:https://github.com/DataDog/dd-trace-js',
+      'git.commit.sha:1234567890'
+    ])
   })
 
   describe('updateCapabilities', () => {


### PR DESCRIPTION
### What does this PR do?

Adds DD tags to the JSON data sent to the `/v0.7/config` endpoint used by Remote Config. The tags include git metadata: Repository and commit SHA of the service being instrumented.

### Motivation

The git metadata is needed by DI to show the source code of a running service in the UI if source code integration is enabled.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


