### PR TITLE
[test optimization] [SDTEST-1355] Fix DI issues with auto test retries

### DIFF
--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -2530,9 +2530,11 @@ describe('jest CommonJS', () => {
               .endsWith('ci-visibility/dynamic-instrumentation/dependency.js')
           )
           assert.equal(retriedTest.metrics[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_LINE_SUFFIX}`], 4)
-          assert.exists(retriedTest.meta[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX}`])
 
-          snapshotIdByTest = retriedTest.meta[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX}`]
+          const snapshotIdKey = `${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX}`
+          assert.exists(retriedTest.meta[snapshotIdKey])
+
+          snapshotIdByTest = retriedTest.meta[snapshotIdKey]
           spanIdByTest = retriedTest.span_id.toString()
           traceIdByTest = retriedTest.trace_id.toString()
 

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -35,9 +35,10 @@ const {
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES,
   DI_ERROR_DEBUG_INFO_CAPTURED,
-  DI_DEBUG_ERROR_FILE,
-  DI_DEBUG_ERROR_SNAPSHOT_ID,
-  DI_DEBUG_ERROR_LINE
+  DI_DEBUG_ERROR_PREFIX,
+  DI_DEBUG_ERROR_FILE_SUFFIX,
+  DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX,
+  DI_DEBUG_ERROR_LINE_SUFFIX
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -2426,11 +2427,12 @@ describe('jest CommonJS', () => {
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
 
-          assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
-          assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+          const hasDebugTags = Object.keys(retriedTest.meta)
+            .some(property => property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED)
+
+          assert.isFalse(hasDebugTags)
         })
+
       const logsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/logs'), (payloads) => {
           if (payloads.length > 0) {
@@ -2472,10 +2474,10 @@ describe('jest CommonJS', () => {
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
 
-          assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
-          assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+          const hasDebugTags = Object.keys(retriedTest.meta)
+            .some(property => property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED)
+
+          assert.isFalse(hasDebugTags)
         })
       const logsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/logs'), (payloads) => {
@@ -2522,15 +2524,15 @@ describe('jest CommonJS', () => {
           const [retriedTest] = retriedTests
 
           assert.propertyVal(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-          assert.propertyVal(
-            retriedTest.meta,
-            DI_DEBUG_ERROR_FILE,
-            'ci-visibility/dynamic-instrumentation/dependency.js'
-          )
-          assert.equal(retriedTest.metrics[DI_DEBUG_ERROR_LINE], 4)
-          assert.exists(retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID])
 
-          snapshotIdByTest = retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID]
+          assert.isTrue(
+            retriedTest.meta[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_FILE_SUFFIX}`]
+              .endsWith('ci-visibility/dynamic-instrumentation/dependency.js')
+          )
+          assert.equal(retriedTest.metrics[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_LINE_SUFFIX}`], 4)
+          assert.exists(retriedTest.meta[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX}`])
+
+          snapshotIdByTest = retriedTest.meta[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX}`]
           spanIdByTest = retriedTest.span_id.toString()
           traceIdByTest = retriedTest.trace_id.toString()
 
@@ -2603,14 +2605,10 @@ describe('jest CommonJS', () => {
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
 
-          assert.propertyVal(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-          assert.propertyVal(
-            retriedTest.meta,
-            DI_DEBUG_ERROR_FILE,
-            'ci-visibility/dynamic-instrumentation/dependency.js'
-          )
-          assert.equal(retriedTest.metrics[DI_DEBUG_ERROR_LINE], 4)
-          assert.exists(retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID])
+          const hasDebugTags = Object.keys(retriedTest.meta)
+            .some(property => property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED)
+
+          assert.isFalse(hasDebugTags)
         })
       const logsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/logs'), (payloads) => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -37,9 +37,10 @@ const {
   TEST_LEVEL_EVENT_TYPES,
   TEST_EARLY_FLAKE_ABORT_REASON,
   DI_ERROR_DEBUG_INFO_CAPTURED,
-  DI_DEBUG_ERROR_FILE,
-  DI_DEBUG_ERROR_SNAPSHOT_ID,
-  DI_DEBUG_ERROR_LINE
+  DI_DEBUG_ERROR_PREFIX,
+  DI_DEBUG_ERROR_FILE_SUFFIX,
+  DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX,
+  DI_DEBUG_ERROR_LINE_SUFFIX
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -2166,10 +2167,10 @@ describe('mocha CommonJS', function () {
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
 
-          assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
-          assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+          const hasDebugTags = Object.keys(retriedTest.meta)
+            .some(property => property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED)
+
+          assert.isFalse(hasDebugTags)
         })
 
       const logsPromise = receiver
@@ -2217,10 +2218,10 @@ describe('mocha CommonJS', function () {
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
 
-          assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
-          assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
-          assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+          const hasDebugTags = Object.keys(retriedTest.meta)
+            .some(property => property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED)
+
+          assert.isFalse(hasDebugTags)
         })
 
       const logsPromise = receiver
@@ -2273,15 +2274,17 @@ describe('mocha CommonJS', function () {
           const [retriedTest] = retriedTests
 
           assert.propertyVal(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-          assert.propertyVal(
-            retriedTest.meta,
-            DI_DEBUG_ERROR_FILE,
-            'ci-visibility/dynamic-instrumentation/dependency.js'
+          assert.isTrue(
+            retriedTest.meta[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_FILE_SUFFIX}`]
+              .endsWith('ci-visibility/dynamic-instrumentation/dependency.js')
           )
-          assert.equal(retriedTest.metrics[DI_DEBUG_ERROR_LINE], 4)
-          assert.exists(retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID])
+          assert.equal(retriedTest.metrics[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_LINE_SUFFIX}`], 4)
 
-          snapshotIdByTest = retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID]
+          const snapshotIdKey = `${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX}`
+
+          assert.exists(retriedTest.meta[snapshotIdKey])
+
+          snapshotIdByTest = retriedTest.meta[snapshotIdKey]
           spanIdByTest = retriedTest.span_id.toString()
           traceIdByTest = retriedTest.trace_id.toString()
 
@@ -2358,14 +2361,10 @@ describe('mocha CommonJS', function () {
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
 
-          assert.propertyVal(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-          assert.propertyVal(
-            retriedTest.meta,
-            DI_DEBUG_ERROR_FILE,
-            'ci-visibility/dynamic-instrumentation/dependency.js'
-          )
-          assert.equal(retriedTest.metrics[DI_DEBUG_ERROR_LINE], 4)
-          assert.exists(retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID])
+          const hasDebugTags = Object.keys(retriedTest.meta)
+            .some(property => property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED)
+
+          assert.isFalse(hasDebugTags)
         })
       const logsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/logs'), (payloads) => {

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -904,7 +904,7 @@ versions.forEach((version) => {
 
     // dynamic instrumentation only supported from >=2.0.0
     if (version === 'latest') {
-      context.only('dynamic instrumentation', () => {
+      context('dynamic instrumentation', () => {
         it('does not activate it if DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED is not set', (done) => {
           receiver.setSettings({
             flaky_test_retries_enabled: true,
@@ -1007,7 +1007,7 @@ versions.forEach((version) => {
           })
         })
 
-        it.only('runs retries with dynamic instrumentation', (done) => {
+        it('runs retries with dynamic instrumentation', (done) => {
           receiver.setSettings({
             flaky_test_retries_enabled: true,
             di_enabled: true
@@ -1086,9 +1086,6 @@ versions.forEach((version) => {
               stdio: 'pipe'
             }
           )
-
-          childProcess.stdout.pipe(process.stdout)
-          childProcess.stderr.pipe(process.stderr)
 
           childProcess.on('exit', () => {
             Promise.all([eventsPromise, logsPromise]).then(() => {

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -26,15 +26,16 @@ const {
   TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_SUITE,
   DI_ERROR_DEBUG_INFO_CAPTURED,
-  DI_DEBUG_ERROR_FILE,
-  DI_DEBUG_ERROR_LINE,
-  DI_DEBUG_ERROR_SNAPSHOT_ID
+  DI_DEBUG_ERROR_PREFIX,
+  DI_DEBUG_ERROR_FILE_SUFFIX,
+  DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX,
+  DI_DEBUG_ERROR_LINE_SUFFIX
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 
 const NUM_RETRIES_EFD = 3
 
-const versions = ['1.6.0', 'latest']
+const versions = ['latest']
 
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 
@@ -903,7 +904,7 @@ versions.forEach((version) => {
 
     // dynamic instrumentation only supported from >=2.0.0
     if (version === 'latest') {
-      context('dynamic instrumentation', () => {
+      context.only('dynamic instrumentation', () => {
         it('does not activate it if DD_TEST_DYNAMIC_INSTRUMENTATION_ENABLED is not set', (done) => {
           receiver.setSettings({
             flaky_test_retries_enabled: true,
@@ -920,10 +921,12 @@ versions.forEach((version) => {
               assert.equal(retriedTests.length, 1)
               const [retriedTest] = retriedTests
 
-              assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
-              assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
-              assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
-              assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+              const hasDebugTags = Object.keys(retriedTest.meta)
+                .some(property =>
+                  property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED
+                )
+
+              assert.isFalse(hasDebugTags)
             })
 
           const logsPromise = receiver
@@ -968,11 +971,12 @@ versions.forEach((version) => {
 
               assert.equal(retriedTests.length, 1)
               const [retriedTest] = retriedTests
+              const hasDebugTags = Object.keys(retriedTest.meta)
+                .some(property =>
+                  property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED
+                )
 
-              assert.notProperty(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED)
-              assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_FILE)
-              assert.notProperty(retriedTest.metrics, DI_DEBUG_ERROR_LINE)
-              assert.notProperty(retriedTest.meta, DI_DEBUG_ERROR_SNAPSHOT_ID)
+              assert.isFalse(hasDebugTags)
             })
 
           const logsPromise = receiver
@@ -1003,7 +1007,7 @@ versions.forEach((version) => {
           })
         })
 
-        it('runs retries with dynamic instrumentation', (done) => {
+        it.only('runs retries with dynamic instrumentation', (done) => {
           receiver.setSettings({
             flaky_test_retries_enabled: true,
             di_enabled: true
@@ -1023,15 +1027,17 @@ versions.forEach((version) => {
               const [retriedTest] = retriedTests
 
               assert.propertyVal(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-              assert.propertyVal(
-                retriedTest.meta,
-                DI_DEBUG_ERROR_FILE,
-                'ci-visibility/vitest-tests/bad-sum.mjs'
-              )
-              assert.equal(retriedTest.metrics[DI_DEBUG_ERROR_LINE], 4)
-              assert.exists(retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID])
 
-              snapshotIdByTest = retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID]
+              assert.isTrue(
+                retriedTest.meta[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_FILE_SUFFIX}`]
+                  .endsWith('ci-visibility/vitest-tests/bad-sum.mjs')
+              )
+              assert.equal(retriedTest.metrics[`${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_LINE_SUFFIX}`], 4)
+
+              const snapshotIdKey = `${DI_DEBUG_ERROR_PREFIX}.0.${DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX}`
+              assert.exists(retriedTest.meta[snapshotIdKey])
+
+              snapshotIdByTest = retriedTest.meta[snapshotIdKey]
               spanIdByTest = retriedTest.span_id.toString()
               traceIdByTest = retriedTest.trace_id.toString()
 
@@ -1081,6 +1087,9 @@ versions.forEach((version) => {
             }
           )
 
+          childProcess.stdout.pipe(process.stdout)
+          childProcess.stderr.pipe(process.stderr)
+
           childProcess.on('exit', () => {
             Promise.all([eventsPromise, logsPromise]).then(() => {
               assert.equal(snapshotIdByTest, snapshotIdByLog)
@@ -1107,14 +1116,12 @@ versions.forEach((version) => {
               assert.equal(retriedTests.length, 1)
               const [retriedTest] = retriedTests
 
-              assert.propertyVal(retriedTest.meta, DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-              assert.propertyVal(
-                retriedTest.meta,
-                DI_DEBUG_ERROR_FILE,
-                'ci-visibility/vitest-tests/bad-sum.mjs'
-              )
-              assert.equal(retriedTest.metrics[DI_DEBUG_ERROR_LINE], 4)
-              assert.exists(retriedTest.meta[DI_DEBUG_ERROR_SNAPSHOT_ID])
+              const hasDebugTags = Object.keys(retriedTest.meta)
+                .some(property =>
+                  property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED
+                )
+
+              assert.isFalse(hasDebugTags)
             })
 
           const logsPromise = receiver

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -238,8 +238,9 @@ function wrapRun (pl, isLatestVersion) {
     asyncResource.runInAsyncScope(() => {
       testStartCh.publish(testStartPayload)
     })
+    const promises = {}
     try {
-      this.eventBroadcaster.on('envelope', shimmer.wrapFunction(null, () => (testCase) => {
+      this.eventBroadcaster.on('envelope', shimmer.wrapFunction(null, () => async (testCase) => {
         // Only supported from >=8.0.0
         if (testCase?.testCaseFinished) {
           const { testCaseFinished: { willBeRetried } } = testCase
@@ -254,6 +255,11 @@ function wrapRun (pl, isLatestVersion) {
 
             const failedAttemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
             const isRetry = numAttempt++ > 0
+
+            if (promises.hitBreakpointPromise) {
+              await promises.hitBreakpointPromise
+            }
+
             failedAttemptAsyncResource.runInAsyncScope(() => {
               // the current span will be finished and a new one will be created
               testRetryCh.publish({ isRetry, error })
@@ -263,7 +269,7 @@ function wrapRun (pl, isLatestVersion) {
             numAttemptToAsyncResource.set(numAttempt, newAsyncResource)
 
             newAsyncResource.runInAsyncScope(() => {
-              testStartCh.publish(testStartPayload) // a new span will be created
+              testStartCh.publish({ ...testStartPayload, promises }) // a new span will be created
             })
           }
         }
@@ -273,7 +279,7 @@ function wrapRun (pl, isLatestVersion) {
       asyncResource.runInAsyncScope(() => {
         promise = run.apply(this, arguments)
       })
-      promise.finally(() => {
+      promise.finally(async () => {
         const result = this.getWorstStepResult()
         const { status, skipReason } = isLatestVersion
           ? getStatusFromResultLatest(result)
@@ -296,6 +302,9 @@ function wrapRun (pl, isLatestVersion) {
 
         const error = getErrorFromCucumberResult(result)
 
+        if (promises.hitBreakpointPromise) {
+          await promises.hitBreakpointPromise
+        }
         attemptAsyncResource.runInAsyncScope(() => {
           testFinishCh.publish({ status, skipReason, error, isNew, isEfdRetry, isFlakyRetry: numAttempt > 0 })
         })

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -253,8 +253,8 @@ function wrapRun (pl, isLatestVersion) {
               // ignore error
             }
 
-            const isFirstAttempt = numAttempt++ === 0
             const failedAttemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
+            const isFirstAttempt = numAttempt++ === 0
 
             if (promises.hitBreakpointPromise) {
               await promises.hitBreakpointPromise

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -253,8 +253,8 @@ function wrapRun (pl, isLatestVersion) {
               // ignore error
             }
 
+            const isFirstAttempt = numAttempt++ === 0
             const failedAttemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
-            const isRetry = numAttempt++ > 0
 
             if (promises.hitBreakpointPromise) {
               await promises.hitBreakpointPromise
@@ -262,7 +262,7 @@ function wrapRun (pl, isLatestVersion) {
 
             failedAttemptAsyncResource.runInAsyncScope(() => {
               // the current span will be finished and a new one will be created
-              testRetryCh.publish({ isRetry, error })
+              testRetryCh.publish({ isFirstAttempt, error })
             })
 
             const newAsyncResource = new AsyncResource('bound-anonymous-fn')

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -75,7 +75,7 @@ const originalTestFns = new WeakMap()
 const retriedTestsToNumAttempts = new Map()
 const newTestsTestStatuses = new Map()
 
-const BREAKPOINT_HIT_GRACE_PERIOD_MS = 500
+const BREAKPOINT_HIT_GRACE_PERIOD_MS = 200
 
 // based on https://github.com/facebook/jest/blob/main/packages/jest-circus/src/formatNodeAssertErrors.ts#L41
 function formatJestError (errors) {
@@ -316,8 +316,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         }
 
         // After finishing it might take a bit for the snapshot to be handled.
-        // We'll give 500ms for the snapshot to be handled.
-        // This means that tests retried with DI are 500ms slower at least.
+        // This means that tests retried with DI are BREAKPOINT_HIT_GRACE_PERIOD_MS slower at least.
         if (mightHitBreakpoint) {
           await new Promise(resolve => {
             setTimeout(() => {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -28,6 +28,42 @@ const newTasks = new WeakSet()
 const switchedStatuses = new WeakSet()
 const sessionAsyncResource = new AsyncResource('bound-anonymous-fn')
 
+const BREAKPOINT_HIT_GRACE_PERIOD_MS = 400
+
+function waitForHitProbe () {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve()
+    }, BREAKPOINT_HIT_GRACE_PERIOD_MS)
+  })
+}
+
+function getProvidedContext () {
+  try {
+    const {
+      _ddIsEarlyFlakeDetectionEnabled,
+      _ddIsDiEnabled,
+      _ddKnownTests: knownTests,
+      _ddEarlyFlakeDetectionNumRetries: numRepeats
+    } = globalThis.__vitest_worker__.providedContext
+
+    return {
+      isDiEnabled: _ddIsDiEnabled,
+      isEarlyFlakeDetectionEnabled: _ddIsEarlyFlakeDetectionEnabled,
+      knownTests,
+      numRepeats
+    }
+  } catch (e) {
+    log.error('Vitest workers could not parse provided context, so some features will not work.')
+    return {
+      isDiEnabled: false,
+      isEarlyFlakeDetectionEnabled: false,
+      knownTests: {},
+      numRepeats: 0
+    }
+  }
+}
+
 function isReporterPackage (vitestPackage) {
   return vitestPackage.B?.name === 'BaseSequencer'
 }
@@ -253,29 +289,26 @@ addHook({
   // `onBeforeRunTask` is run before any repetition or attempt is run
   shimmer.wrap(VitestTestRunner.prototype, 'onBeforeRunTask', onBeforeRunTask => async function (task) {
     const testName = getTestName(task)
-    try {
-      const {
-        _ddKnownTests: knownTests,
-        _ddIsEarlyFlakeDetectionEnabled: isEarlyFlakeDetectionEnabled,
-        _ddEarlyFlakeDetectionNumRetries: numRepeats
-      } = globalThis.__vitest_worker__.providedContext
 
-      if (isEarlyFlakeDetectionEnabled) {
-        isNewTestCh.publish({
-          knownTests,
-          testSuiteAbsolutePath: task.file.filepath,
-          testName,
-          onDone: (isNew) => {
-            if (isNew) {
-              task.repeats = numRepeats
-              newTasks.add(task)
-              taskToStatuses.set(task, [])
-            }
+    const {
+      _ddKnownTests: knownTests,
+      _ddIsEarlyFlakeDetectionEnabled: isEarlyFlakeDetectionEnabled,
+      _ddEarlyFlakeDetectionNumRetries: numRepeats
+    } = getProvidedContext()
+
+    if (isEarlyFlakeDetectionEnabled) {
+      isNewTestCh.publish({
+        knownTests,
+        testSuiteAbsolutePath: task.file.filepath,
+        testName,
+        onDone: (isNew) => {
+          if (isNew) {
+            task.repeats = numRepeats
+            newTasks.add(task)
+            taskToStatuses.set(task, [])
           }
-        })
-      }
-    } catch (e) {
-      log.error('Vitest workers could not parse known tests, so Early Flake Detection will not work.')
+        }
+      })
     }
 
     return onBeforeRunTask.apply(this, arguments)
@@ -283,9 +316,7 @@ addHook({
 
   // `onAfterRunTask` is run after all repetitions or attempts are run
   shimmer.wrap(VitestTestRunner.prototype, 'onAfterRunTask', onAfterRunTask => async function (task) {
-    const {
-      _ddIsEarlyFlakeDetectionEnabled: isEarlyFlakeDetectionEnabled
-    } = globalThis.__vitest_worker__.providedContext
+    const { isEarlyFlakeDetectionEnabled } = getProvidedContext()
 
     if (isEarlyFlakeDetectionEnabled && taskToStatuses.has(task)) {
       const statuses = taskToStatuses.get(task)
@@ -309,43 +340,40 @@ addHook({
     }
     const testName = getTestName(task)
     let isNew = false
-    let isEarlyFlakeDetectionEnabled = false
-    let isDiEnabled = false
 
-    try {
-      const {
-        _ddIsEarlyFlakeDetectionEnabled,
-        _ddIsDiEnabled
-      } = globalThis.__vitest_worker__.providedContext
+    const {
+      isEarlyFlakeDetectionEnabled,
+      isDiEnabled
+    } = getProvidedContext()
 
-      isEarlyFlakeDetectionEnabled = _ddIsEarlyFlakeDetectionEnabled
-      isDiEnabled = _ddIsDiEnabled
-
-      if (isEarlyFlakeDetectionEnabled) {
-        isNew = newTasks.has(task)
-      }
-    } catch (e) {
-      log.error('Vitest workers could not parse known tests, so Early Flake Detection will not work.')
+    if (isEarlyFlakeDetectionEnabled) {
+      isNew = newTasks.has(task)
     }
+
     const { retry: numAttempt, repeats: numRepetition } = retryInfo
 
     // We finish the previous test here because we know it has failed already
     if (numAttempt > 0) {
-      const probe = {}
+      const shouldWaitForHitProbe = isDiEnabled && numAttempt > 1
+      if (shouldWaitForHitProbe) {
+        await waitForHitProbe()
+      }
+
+      const promises = {}
+      const shouldSetProbe = isDiEnabled && numAttempt === 1
       const asyncResource = taskToAsync.get(task)
       const testError = task.result?.errors?.[0]
       if (asyncResource) {
         asyncResource.runInAsyncScope(() => {
           testErrorCh.publish({
             error: testError,
-            willBeRetried: true,
-            probe,
-            isDiEnabled
+            shouldSetProbe,
+            promises
           })
         })
         // We wait for the probe to be set
-        if (probe.setProbePromise) {
-          await probe.setProbePromise
+        if (promises.setProbePromise) {
+          await promises.setProbePromise
         }
       }
     }
@@ -401,7 +429,8 @@ addHook({
         testName,
         testSuiteAbsolutePath: task.file.filepath,
         isRetry: numAttempt > 0 || numRepetition > 0,
-        isNew
+        isNew,
+        mightHitProbe: isDiEnabled && numAttempt > 0
       })
     })
     return onBeforeTryTask.apply(this, arguments)
@@ -417,6 +446,12 @@ addHook({
 
       const status = getVitestTestStatus(task, retryCount)
       const asyncResource = taskToAsync.get(task)
+
+      const { isDiEnabled } = getProvidedContext()
+
+      if (isDiEnabled && retryCount > 1) {
+        await waitForHitProbe()
+      }
 
       if (asyncResource) {
         // We don't finish here because the test might fail in a later hook (afterEach)

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -291,9 +291,9 @@ addHook({
     const testName = getTestName(task)
 
     const {
-      _ddKnownTests: knownTests,
-      _ddIsEarlyFlakeDetectionEnabled: isEarlyFlakeDetectionEnabled,
-      _ddEarlyFlakeDetectionNumRetries: numRepeats
+      knownTests,
+      isEarlyFlakeDetectionEnabled,
+      numRepeats
     } = getProvidedContext()
 
     if (isEarlyFlakeDetectionEnabled) {

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -244,6 +244,7 @@ class CucumberPlugin extends CiPlugin {
         span.setTag(TEST_IS_RETRY, 'true')
       }
       span.setTag('error', error)
+      // TODO: PROBE SHOULD ONLY BE ADDED IN THE FIRST TRY!
       if (this.di && error && this.libraryConfig?.isDiEnabled) {
         const probeInformation = this.addDiProbe(error)
         if (probeInformation) {

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -26,12 +26,7 @@ const {
   TEST_MODULE,
   TEST_MODULE_ID,
   TEST_SUITE,
-  CUCUMBER_IS_PARALLEL,
-  TEST_NAME,
-  DI_ERROR_DEBUG_INFO_CAPTURED,
-  DI_DEBUG_ERROR_SNAPSHOT_ID,
-  DI_DEBUG_ERROR_FILE,
-  DI_DEBUG_ERROR_LINE
+  CUCUMBER_IS_PARALLEL
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -50,8 +45,8 @@ const {
 } = require('../../dd-trace/src/ci-visibility/telemetry')
 const id = require('../../dd-trace/src/id')
 
+const BREAKPOINT_HIT_GRACE_PERIOD_MS = 200
 const isCucumberWorker = !!process.env.CUCUMBER_WORKER_ID
-const debuggerParameterPerTest = new Map()
 
 function getTestSuiteTags (testSuiteSpan) {
   const suiteTags = {
@@ -210,7 +205,13 @@ class CucumberPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_FINISHED, 'suite', { library: 'istanbul' })
     })
 
-    this.addSub('ci:cucumber:test:start', ({ testName, testFileAbsolutePath, testSourceLine, isParallel }) => {
+    this.addSub('ci:cucumber:test:start', ({
+      testName,
+      testFileAbsolutePath,
+      testSourceLine,
+      isParallel,
+      promises
+    }) => {
       const store = storage.getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
@@ -227,24 +228,12 @@ class CucumberPlugin extends CiPlugin {
 
       this.enter(testSpan, store)
 
-      const debuggerParameters = debuggerParameterPerTest.get(testName)
-
-      if (debuggerParameters) {
-        const spanContext = testSpan.context()
-
-        // TODO: handle race conditions with this.retriedTestIds
-        this.retriedTestIds = {
-          spanId: spanContext.toSpanId(),
-          traceId: spanContext.toTraceId()
-        }
-        const { snapshotId, file, line } = debuggerParameters
-
-        // TODO: should these be added on test:end if and only if the probe is hit?
-        // Sync issues: `hitProbePromise` might be resolved after the test ends
-        testSpan.setTag(DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-        testSpan.setTag(DI_DEBUG_ERROR_SNAPSHOT_ID, snapshotId)
-        testSpan.setTag(DI_DEBUG_ERROR_FILE, file)
-        testSpan.setTag(DI_DEBUG_ERROR_LINE, line)
+      this.activeTestSpan = testSpan
+      // Time we give the breakpoint to be hit
+      if (promises && this.runningTestProbeId) {
+        promises.hitBreakpointPromise = new Promise((resolve) => {
+          setTimeout(resolve, BREAKPOINT_HIT_GRACE_PERIOD_MS)
+        })
       }
     })
 
@@ -256,9 +245,13 @@ class CucumberPlugin extends CiPlugin {
       }
       span.setTag('error', error)
       if (this.di && error && this.libraryConfig?.isDiEnabled) {
-        const testName = span.context()._tags[TEST_NAME]
-        const debuggerParameters = this.addDiProbe(error)
-        debuggerParameterPerTest.set(testName, debuggerParameters)
+        const probeInformation = this.addDiProbe(error)
+        if (probeInformation) {
+          const { probeId, stackIndex } = probeInformation
+          this.runningTestProbeId = probeId
+          this.testErrorStackIndex = stackIndex
+          // TODO: we're not waiting for setProbePromise to be resolved, so there might be race conditions
+        }
       }
       span.setTag(TEST_STATUS, 'fail')
       span.finish()
@@ -363,6 +356,7 @@ class CucumberPlugin extends CiPlugin {
         if (isCucumberWorker) {
           this.tracer._exporter.flush()
         }
+        this.activeTestSpan = null
       }
     })
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -27,7 +27,7 @@ const {
   DI_DEBUG_ERROR_SNAPSHOT_ID,
   DI_DEBUG_ERROR_FILE,
   DI_DEBUG_ERROR_LINE,
-  TEST_NAME
+  getFormattedError
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -44,10 +44,19 @@ const {
 } = require('../../dd-trace/src/ci-visibility/telemetry')
 
 const isJestWorker = !!process.env.JEST_WORKER_ID
-const debuggerParameterPerTest = new Map()
 
 // https://github.com/facebook/jest/blob/d6ad15b0f88a05816c2fe034dd6900d28315d570/packages/jest-worker/src/types.ts#L38
 const CHILD_MESSAGE_END = 2
+
+function withTimeout (promise, timeoutMs) {
+  return new Promise(resolve => {
+    // Set a timeout to resolve after 1s
+    setTimeout(resolve, timeoutMs)
+
+    // Also resolve if the original promise resolves
+    promise.then(resolve)
+  })
+}
 
 class JestPlugin extends CiPlugin {
   static get id () {
@@ -308,32 +317,10 @@ class JestPlugin extends CiPlugin {
       const span = this.startTestSpan(test)
 
       this.enter(span, store)
-
-      const { name: testName } = test
-
-      const debuggerParameters = debuggerParameterPerTest.get(testName)
-
-      // If we have a debugger probe, we need to add the snapshot id to the span
-      if (debuggerParameters) {
-        const spanContext = span.context()
-
-        // TODO: handle race conditions with this.retriedTestIds
-        this.retriedTestIds = {
-          spanId: spanContext.toSpanId(),
-          traceId: spanContext.toTraceId()
-        }
-        const { snapshotId, file, line } = debuggerParameters
-
-        // TODO: should these be added on test:end if and only if the probe is hit?
-        // Sync issues: `hitProbePromise` might be resolved after the test ends
-        span.setTag(DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-        span.setTag(DI_DEBUG_ERROR_SNAPSHOT_ID, snapshotId)
-        span.setTag(DI_DEBUG_ERROR_FILE, file)
-        span.setTag(DI_DEBUG_ERROR_LINE, line)
-      }
+      this.activeTestSpan = span
     })
 
-    this.addSub('ci:jest:test:finish', ({ status, testStartLine }) => {
+    this.addSub('ci:jest:test:finish', ({ status, testStartLine, promises, shouldRemoveProbe }) => {
       const span = storage.getStore().span
       span.setTag(TEST_STATUS, status)
       if (testStartLine) {
@@ -354,20 +341,24 @@ class JestPlugin extends CiPlugin {
 
       span.finish()
       finishAllTraceSpans(span)
+      this.activeTestSpan = null
+      if (shouldRemoveProbe) {
+        promises.isProbeRemoved = withTimeout(this.removeDiProbe(this.runningTestProbeId), 2000)
+        this.runningTestProbeId = null
+      }
     })
 
-    this.addSub('ci:jest:test:err', ({ error, willBeRetried, probe, isDiEnabled }) => {
+    this.addSub('ci:jest:test:err', ({ error, shouldSetProbe, promises }) => {
       if (error) {
         const store = storage.getStore()
         if (store && store.span) {
           const span = store.span
           span.setTag(TEST_STATUS, 'fail')
-          span.setTag('error', error)
-          if (willBeRetried && this.di && isDiEnabled) {
-            // if we use numTestExecutions, we have to remove the breakpoint after each execution
-            const testName = span.context()._tags[TEST_NAME]
-            const debuggerParameters = this.addDiProbe(error, probe)
-            debuggerParameterPerTest.set(testName, debuggerParameters)
+          span.setTag('error', getFormattedError(error, this.repositoryRoot))
+          if (shouldSetProbe) {
+            const [probeId, setProbePromise] = this.addDiProbe(error, this.onDiBreakpointHit.bind(this))
+            this.runningTestProbeId = probeId
+            promises.isProbeReady = withTimeout(setProbePromise, 2000)
           }
         }
       }
@@ -377,6 +368,32 @@ class JestPlugin extends CiPlugin {
       const span = this.startTestSpan(test)
       span.setTag(TEST_STATUS, 'skip')
       span.finish()
+    })
+  }
+
+  onDiBreakpointHit ({ snapshot }) {
+    if (!this.activeTestSpan || this.activeTestSpan.context()._isFinished) {
+      console.log('active span is null or finished', this.activeTestSpan)
+      // this is unexpected
+      return
+    }
+
+    // TODO: WHERE TO GET THE STACK INDEX FROM????
+    const stackIndex = 3
+
+    this.activeTestSpan.setTag(DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
+    // TODO: replace DI_DEBUG_ERROR tags by just their prefix
+    this.activeTestSpan.setTag(DI_DEBUG_ERROR_SNAPSHOT_ID.replace('0', stackIndex), snapshot.id)
+    this.activeTestSpan.setTag(DI_DEBUG_ERROR_FILE.replace('0', stackIndex), snapshot.probe.location.file)
+    this.activeTestSpan.setTag(DI_DEBUG_ERROR_LINE.replace('0', stackIndex), snapshot.probe.location.lines[0])
+
+    const activeTestSpanContext = this.activeTestSpan.context()
+    this.tracer._exporter.exportDiLogs(this.testEnvironmentMetadata, {
+      debugger: { snapshot },
+      dd: {
+        trace_id: activeTestSpanContext.toTraceId(),
+        span_id: activeTestSpanContext.toSpanId()
+      }
     })
   }
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -352,7 +352,7 @@ class JestPlugin extends CiPlugin {
           span.setTag(TEST_STATUS, 'fail')
           span.setTag('error', getFormattedError(error, this.repositoryRoot))
           if (shouldSetProbe) {
-            const probeInformation = this.addDiProbe(error, this.onDiBreakpointHit.bind(this))
+            const probeInformation = this.addDiProbe(error)
             if (probeInformation) {
               const { probeId, setProbePromise, stackIndex } = probeInformation
               this.runningTestProbeId = probeId

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -397,7 +397,7 @@ class JestPlugin extends CiPlugin {
     )
     this.activeTestSpan.setTag(
       `${DI_DEBUG_ERROR_PREFIX}.${stackIndex}.${DI_DEBUG_ERROR_LINE_SUFFIX}`,
-      snapshot.probe.location.lines[0]
+      Number(snapshot.probe.location.lines[0])
     )
 
     const activeTestSpanContext = this.activeTestSpan.context()

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -52,8 +52,6 @@ const {
 const id = require('../../dd-trace/src/id')
 const log = require('../../dd-trace/src/log')
 
-const debuggerParameterPerTest = new Map()
-
 function getTestSuiteLevelVisibilityTags (testSuiteSpan) {
   const testSuiteSpanContext = testSuiteSpan.context()
   const suiteTags = {
@@ -192,36 +190,15 @@ class MochaPlugin extends CiPlugin {
       const store = storage.getStore()
       const span = this.startTestSpan(testInfo)
 
-      const { testName } = testInfo
-
-      const debuggerParameters = debuggerParameterPerTest.get(testName)
-
-      if (debuggerParameters) {
-        const spanContext = span.context()
-
-        // TODO: handle race conditions with this.retriedTestIds
-        this.retriedTestIds = {
-          spanId: spanContext.toSpanId(),
-          traceId: spanContext.toTraceId()
-        }
-        const { snapshotId, file, line } = debuggerParameters
-
-        // TODO: should these be added on test:end if and only if the probe is hit?
-        // Sync issues: `hitProbePromise` might be resolved after the test ends
-        span.setTag(DI_ERROR_DEBUG_INFO_CAPTURED, 'true')
-        span.setTag(DI_DEBUG_ERROR_SNAPSHOT_ID, snapshotId)
-        span.setTag(DI_DEBUG_ERROR_FILE, file)
-        span.setTag(DI_DEBUG_ERROR_LINE, line)
-      }
-
       this.enter(span, store)
+      this.activeTestSpan = span
     })
 
     this.addSub('ci:mocha:worker:finish', () => {
       this.tracer._exporter.flush()
     })
 
-    this.addSub('ci:mocha:test:finish', ({ status, hasBeenRetried }) => {
+    this.addSub('ci:mocha:test:finish', ({ status, hasBeenRetried, isLastRetry }) => {
       const store = storage.getStore()
       const span = store?.span
 
@@ -245,6 +222,11 @@ class MochaPlugin extends CiPlugin {
 
         span.finish()
         finishAllTraceSpans(span)
+        this.activeTestSpan = null
+        if (this.di && this.libraryConfig?.isDiEnabled && this.runningTestProbeId && isLastRetry) {
+          this.removeDiProbe(this.runningTestProbeId)
+          this.runningTestProbeId = null
+        }
       }
     })
 
@@ -271,7 +253,7 @@ class MochaPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:mocha:test:retry', ({ isFirstAttempt, willBeRetried, err }) => {
+    this.addSub('ci:mocha:test:retry', ({ isFirstAttempt, willBeRetried, err, test }) => {
       const store = storage.getStore()
       const span = store?.span
       if (span) {
@@ -295,9 +277,14 @@ class MochaPlugin extends CiPlugin {
           }
         )
         if (willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
-          const testName = span.context()._tags[TEST_NAME]
-          const debuggerParameters = this.addDiProbe(err)
-          debuggerParameterPerTest.set(testName, debuggerParameters)
+          const probeInformation = this.addDiProbe(err, this.onDiBreakpointHit.bind(this))
+          if (probeInformation) {
+            const { probeId, stackIndex } = probeInformation
+            this.runningTestProbeId = probeId
+            this.testErrorStackIndex = stackIndex
+            test._ddShouldWaitForHitProbe = true
+            // TODO: we're not waiting for setProbePromise to be resolved, so there might be race conditions
+          }
         }
 
         span.finish()

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -271,8 +271,7 @@ class MochaPlugin extends CiPlugin {
             browserDriver: spanTags[TEST_BROWSER_DRIVER]
           }
         )
-        // TODO: PROBE SHOULD ONLY BE ADDED IN THE FIRST TRY!
-        if (willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
+        if (isFirstAttempt && willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
           const probeInformation = this.addDiProbe(err)
           if (probeInformation) {
             const { probeId, stackIndex } = probeInformation

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -30,12 +30,7 @@ const {
   TEST_SUITE,
   MOCHA_IS_PARALLEL,
   TEST_IS_RUM_ACTIVE,
-  TEST_BROWSER_DRIVER,
-  TEST_NAME,
-  DI_ERROR_DEBUG_INFO_CAPTURED,
-  DI_DEBUG_ERROR_SNAPSHOT_ID,
-  DI_DEBUG_ERROR_FILE,
-  DI_DEBUG_ERROR_LINE
+  TEST_BROWSER_DRIVER
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -277,7 +272,7 @@ class MochaPlugin extends CiPlugin {
           }
         )
         if (willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
-          const probeInformation = this.addDiProbe(err, this.onDiBreakpointHit.bind(this))
+          const probeInformation = this.addDiProbe(err)
           if (probeInformation) {
             const { probeId, stackIndex } = probeInformation
             this.runningTestProbeId = probeId

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -271,6 +271,7 @@ class MochaPlugin extends CiPlugin {
             browserDriver: spanTags[TEST_BROWSER_DRIVER]
           }
         )
+        // TODO: PROBE SHOULD ONLY BE ADDED IN THE FIRST TRY!
         if (willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
           const probeInformation = this.addDiProbe(err)
           if (probeInformation) {

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -225,6 +225,9 @@ class VitestPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       // TODO: too frequent flush - find for method in worker to decrease frequency
       this.tracer._exporter.flush(onFinish)
+      if (this.runningTestProbeId) {
+        this.removeDiProbe(this.runningTestProbeId)
+      }
     })
 
     this.addSub('ci:vitest:test-suite:error', ({ error }) => {

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -21,7 +21,6 @@ class TestVisDynamicInstrumentation {
   }
 
   removeProbe (probeId) {
-    // breakpointRemoveChannel
     return new Promise(resolve => {
       this.breakpointRemoveChannel.port2.postMessage(probeId)
 
@@ -29,10 +28,9 @@ class TestVisDynamicInstrumentation {
     })
   }
 
-  // Return 3 elements:
-  // 1. Snapshot ID
+  // Return 2 elements:
+  // 1. Probe ID
   // 2. Promise that's resolved when the breakpoint is set
-  // 3. Promise that's resolved when the breakpoint is hit
   addLineProbe ({ file, line }, onHitBreakpoint) {
     const probeId = randomUUID()
 

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -124,12 +124,6 @@ class TestVisDynamicInstrumentation {
         probeIdToResolveBreakpointRemove.delete(probeId)
       }
     }).unref()
-
-    this.worker.on('error', (err) => log.error('Test Visibility - Dynamic Instrumentation worker error', err))
-    this.worker.on(
-      'messageerror',
-      (err) => log.error('Test Visibility - Dynamic Instrumentation worker messageerror', err)
-    )
   }
 }
 

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
@@ -105,7 +105,7 @@ async function addBreakpoint (probe) {
     try {
       lineNumber = await processScriptWithInlineSourceMap({ file, line, sourceMapURL })
     } catch (err) {
-      log.error('Error processing script with inline source map')
+      log.error('Error processing script with inline source map', err)
     }
   }
 

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
@@ -140,13 +140,13 @@ async function processScriptWithInlineSourceMap (params) {
   let generatedPosition
 
   // Map to the generated position. We'll attempt with the full file path first, then with the basename.
-  try {
-    generatedPosition = consumer.generatedPositionFor({
-      source: file,
-      line,
-      column: 0
-    })
-  } catch (e) {
+  // TODO: figure out why sometimes the full path doesn't work
+  generatedPosition = consumer.generatedPositionFor({
+    source: file,
+    line,
+    column: 0
+  })
+  if (generatedPosition.line === null) {
     generatedPosition = consumer.generatedPositionFor({
       source: path.basename(file),
       line,
@@ -155,6 +155,12 @@ async function processScriptWithInlineSourceMap (params) {
   }
 
   consumer.destroy()
+
+  // If we can't find the line, just return the original line
+  if (generatedPosition.line === null) {
+    log.error(`Could not find generated position for ${file}:${line}`)
+    return line
+  }
 
   return generatedPosition.line
 }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -298,7 +298,7 @@ module.exports = class CiPlugin extends Plugin {
   addDiProbe (err, onHitBreakpoint) {
     const [file, line, stackIndex] = getFileAndLineNumberFromError(err, this.repositoryRoot)
 
-    if (!file || !line || !stackIndex) {
+    if (!file || !Number.isInteger(line)) {
       log.warn('Could not add breakpoint for dynamic instrumentation')
       return
     }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -303,6 +303,14 @@ module.exports = class CiPlugin extends Plugin {
       return
     }
 
-    return this.di.addLineProbe({ file, line }, onHitBreakpoint)
+    const [probeId, setProbePromise] = this.di.addLineProbe({ file, line }, onHitBreakpoint)
+
+    return {
+      probeId,
+      setProbePromise,
+      stackIndex,
+      file,
+      line
+    }
   }
 }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -295,7 +295,6 @@ module.exports = class CiPlugin extends Plugin {
     return this.di.removeProbe(probeId)
   }
 
-  // TODO: If the test finishes and the probe is not hit, we should remove the breakpoint
   addDiProbe (err, onHitBreakpoint) {
     const [file, line, stackIndex] = getFileAndLineNumberFromError(err, this.repositoryRoot)
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -333,7 +333,7 @@ module.exports = class CiPlugin extends Plugin {
     return this.di.removeProbe(probeId)
   }
 
-  addDiProbe (err, onHitBreakpoint) {
+  addDiProbe (err) {
     const [file, line, stackIndex] = getFileAndLineNumberFromError(err, this.repositoryRoot)
 
     if (!file || !Number.isInteger(line)) {
@@ -341,7 +341,7 @@ module.exports = class CiPlugin extends Plugin {
       return
     }
 
-    const [probeId, setProbePromise] = this.di.addLineProbe({ file, line }, onHitBreakpoint)
+    const [probeId, setProbePromise] = this.di.addLineProbe({ file, line }, this.onDiBreakpointHit.bind(this))
 
     return {
       probeId,

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -108,10 +108,10 @@ const TEST_LEVEL_EVENT_TYPES = [
 
 // Dynamic instrumentation - Test optimization integration tags
 const DI_ERROR_DEBUG_INFO_CAPTURED = 'error.debug_info_captured'
-// TODO: for the moment we'll only use a single snapshot id, so `0` is hardcoded
-const DI_DEBUG_ERROR_SNAPSHOT_ID = '_dd.debug.error.0.snapshot_id'
-const DI_DEBUG_ERROR_FILE = '_dd.debug.error.0.file'
-const DI_DEBUG_ERROR_LINE = '_dd.debug.error.0.line'
+const DI_DEBUG_ERROR_PREFIX = '_dd.debug.error'
+const DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX = 'snapshot_id'
+const DI_DEBUG_ERROR_FILE_SUFFIX = 'file'
+const DI_DEBUG_ERROR_LINE_SUFFIX = 'line'
 
 module.exports = {
   TEST_CODE_OWNERS,
@@ -191,9 +191,10 @@ module.exports = {
   getNumFromKnownTests,
   getFileAndLineNumberFromError,
   DI_ERROR_DEBUG_INFO_CAPTURED,
-  DI_DEBUG_ERROR_SNAPSHOT_ID,
-  DI_DEBUG_ERROR_FILE,
-  DI_DEBUG_ERROR_LINE,
+  DI_DEBUG_ERROR_PREFIX,
+  DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX,
+  DI_DEBUG_ERROR_FILE_SUFFIX,
+  DI_DEBUG_ERROR_LINE_SUFFIX,
   getFormattedError
 }
 

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/dynamic-instrumentation.spec.js
@@ -23,8 +23,8 @@ describe('test visibility with dynamic instrumentation', () => {
   it('can grab local variables', (done) => {
     childProcess = fork(path.join(__dirname, 'target-app', 'test-visibility-dynamic-instrumentation-script.js'))
 
-    childProcess.on('message', ({ snapshot: { language, stack, probe, captures }, snapshotId }) => {
-      assert.exists(snapshotId)
+    childProcess.on('message', ({ snapshot: { language, stack, probe, captures }, probeId }) => {
+      assert.exists(probeId)
       assert.exists(probe)
       assert.exists(stack)
       assert.equal(language, 'javascript')

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/target-app/test-visibility-dynamic-instrumentation-script.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/target-app/test-visibility-dynamic-instrumentation-script.js
@@ -11,17 +11,15 @@ const intervalId = setInterval(() => {}, 5000)
 tvDynamicInstrumentation.start(new Config())
 
 tvDynamicInstrumentation.isReady().then(() => {
-  const [
-    snapshotId,
-    breakpointSetPromise,
-    breakpointHitPromise
-  ] = tvDynamicInstrumentation.addLineProbe({ file: path.join(__dirname, 'di-dependency.js'), line: 9 })
-
-  breakpointHitPromise.then(({ snapshot }) => {
-    // once the breakpoint is hit, we can grab the snapshot and send it to the parent process
-    process.send({ snapshot, snapshotId })
-    clearInterval(intervalId)
-  })
+  const file = path.join(__dirname, 'di-dependency.js')
+  const [probeId, breakpointSetPromise] = tvDynamicInstrumentation.addLineProbe(
+    { file, line: 9 },
+    ({ snapshot }) => {
+      // once the breakpoint is hit, we can grab the snapshot and send it to the parent process
+      process.send({ snapshot, probeId })
+      clearInterval(intervalId)
+    }
+  )
 
   // We run the code once the breakpoint is set
   breakpointSetPromise.then(() => {


### PR DESCRIPTION
### What does this PR do?

Fix different issues with the integration between Dynamic Instrumentation and Test Optimization.

### Motivation

* Line probes were not cleaned up after the test finished. This caused an issue where we tried to add a line probe that was already there.
* We did not wait for hit probes to return their information to the main process. This caused a race condition where we assigned the snapshot to the wrong test. 
* We were working under the assumption that the line probe would always be located at the top of the test error stack trace. This is not true since the user code might be at a different place.

Unrelated to this PR: I fixed the way we reported `TestingLibraryElementError`. Instead of showing the error message in the stack, we clean up the stack. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
