### PR TITLE
v5.31.0 proposal

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -35,6 +35,10 @@ jobs:
             range: '>=5.12.1'
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
+          - node-version: 22
+            range: '>=6.0.0'
+            aerospike-image: ce-6.4.0.3
+            test-image: ubuntu-latest
     runs-on: ${{ matrix.test-image }}
     services:
       aerospike:

--- a/benchmark/sirun/run-all-variants.js
+++ b/benchmark/sirun/run-all-variants.js
@@ -14,25 +14,19 @@ const metaJson = require(path.join(process.cwd(), 'meta.json'))
 const env = Object.assign({}, process.env, { DD_TRACE_STARTUP_LOGS: 'false' })
 
 ;(async () => {
-  try {
-    if (metaJson.variants) {
-      const variants = metaJson.variants
-      for (const variant in variants) {
-        const variantEnv = Object.assign({}, env, { SIRUN_VARIANT: variant })
-        await exec('sirun', ['meta-temp.json'], { env: variantEnv, stdio: getStdio() })
-      }
-    } else {
-      await exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })
+  if (metaJson.variants) {
+    const variants = metaJson.variants
+    for (const variant in variants) {
+      const variantEnv = Object.assign({}, env, { SIRUN_VARIANT: variant })
+      await exec('sirun', ['meta-temp.json'], { env: variantEnv, stdio: getStdio() })
     }
+  } else {
+    await exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })
+  }
 
-    try {
-      fs.unlinkSync(path.join(process.cwd(), 'meta-temp.json'))
-    } catch (e) {
-      // it's ok if we can't delete a temp file
-    }
+  try {
+    fs.unlinkSync(path.join(process.cwd(), 'meta-temp.json'))
   } catch (e) {
-    setImmediate(() => {
-      throw e // Older Node versions don't fail on uncaught promise rejections.
-    })
+    // it's ok if we can't delete a temp file
   }
 })()

--- a/benchmark/sirun/run-one-variant.js
+++ b/benchmark/sirun/run-one-variant.js
@@ -8,12 +8,4 @@ process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
 
 const env = Object.assign({}, process.env, { DD_TRACE_STARTUP_LOGS: 'false' })
 
-;(async () => {
-  try {
-    await exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })
-  } catch (e) {
-    setImmediate(() => {
-      throw e // Older Node versions don't fail on uncaught promise rejections.
-    })
-  }
-})()
+exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })

--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -428,7 +428,7 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=true', function () {
-    const t = setup({ DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: true })
+    const t = setup({ env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: true } })
 
     describe('input messages', function () {
       it(
@@ -439,7 +439,7 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=false', function () {
-    const t = setup({ DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: false })
+    const t = setup({ env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: false } })
 
     describe('input messages', function () {
       it(
@@ -450,7 +450,7 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=false', function () {
-    const t = setup({ DD_TRACING_ENABLED: false })
+    const t = setup({ env: { DD_TRACING_ENABLED: false } })
 
     describe('input messages', function () {
       it(

--- a/integration-tests/debugger/ddtags.spec.js
+++ b/integration-tests/debugger/ddtags.spec.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const os = require('os')
+
+const { assert } = require('chai')
+const { setup } = require('./utils')
+const { version } = require('../../package.json')
+
+describe('Dynamic Instrumentation', function () {
+  describe('ddtags', function () {
+    const t = setup({
+      env: {
+        DD_ENV: 'test-env',
+        DD_VERSION: 'test-version',
+        DD_GIT_COMMIT_SHA: 'test-commit-sha',
+        DD_GIT_REPOSITORY_URL: 'test-repository-url'
+      },
+      testApp: 'target-app/basic.js'
+    })
+
+    it('should add the expected ddtags as a query param to /debugger/v1/input', function (done) {
+      t.triggerBreakpoint()
+
+      t.agent.on('debugger-input', ({ query }) => {
+        assert.property(query, 'ddtags')
+
+        // Before: "a:b,c:d"
+        // After: { a: 'b', c: 'd' }
+        const ddtags = query.ddtags
+          .split(',')
+          .map((tag) => tag.split(':'))
+          .reduce((acc, [k, v]) => { acc[k] = v; return acc }, {})
+
+        assert.hasAllKeys(ddtags, [
+          'env',
+          'version',
+          'debugger_version',
+          'host_name',
+          'git.commit.sha',
+          'git.repository_url'
+        ])
+
+        assert.strictEqual(ddtags.env, 'test-env')
+        assert.strictEqual(ddtags.version, 'test-version')
+        assert.strictEqual(ddtags.debugger_version, version)
+        assert.strictEqual(ddtags.host_name, os.hostname())
+        assert.strictEqual(ddtags['git.commit.sha'], 'test-commit-sha')
+        assert.strictEqual(ddtags['git.repository_url'], 'test-repository-url')
+
+        done()
+      })
+
+      t.agent.addRemoteConfig(t.rcConfig)
+    })
+  })
+})

--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -11,7 +11,7 @@ describe('Dynamic Instrumentation', function () {
       beforeEach(t.triggerBreakpoint)
 
       it('should prune snapshot if payload is too large', function (done) {
-        t.agent.on('debugger-input', ({ payload }) => {
+        t.agent.on('debugger-input', ({ payload: [payload] }) => {
           assert.isBelow(Buffer.byteLength(JSON.stringify(payload)), 1024 * 1024) // 1MB
           assert.deepEqual(payload['debugger.snapshot'].captures, {
             lines: {

--- a/integration-tests/debugger/snapshot.spec.js
+++ b/integration-tests/debugger/snapshot.spec.js
@@ -16,10 +16,10 @@ describe('Dynamic Instrumentation', function () {
           assert.deepEqual(Object.keys(captures.lines), [String(t.breakpoint.line)])
 
           const { locals } = captures.lines[t.breakpoint.line]
-          const { request, fastify, getSomeData } = locals
+          const { request, fastify, getUndefined } = locals
           delete locals.request
           delete locals.fastify
-          delete locals.getSomeData
+          delete locals.getUndefined
 
           // from block scope
           assert.deepEqual(locals, {
@@ -67,18 +67,18 @@ describe('Dynamic Instrumentation', function () {
               }
             },
             emptyObj: { type: 'Object', fields: {} },
-            fn: {
-              type: 'Function',
-              fields: {
-                length: { type: 'number', value: '0' },
-                name: { type: 'string', value: 'fn' }
-              }
-            },
             p: {
               type: 'Promise',
               fields: {
                 '[[PromiseState]]': { type: 'string', value: 'fulfilled' },
                 '[[PromiseResult]]': { type: 'undefined' }
+              }
+            },
+            arrowFn: {
+              type: 'Function',
+              fields: {
+                length: { type: 'number', value: '0' },
+                name: { type: 'string', value: 'arrowFn' }
               }
             }
           })
@@ -99,11 +99,11 @@ describe('Dynamic Instrumentation', function () {
           assert.equal(fastify.type, 'Object')
           assert.typeOf(fastify.fields, 'Object')
 
-          assert.deepEqual(getSomeData, {
+          assert.deepEqual(getUndefined, {
             type: 'Function',
             fields: {
               length: { type: 'number', value: '0' },
-              name: { type: 'string', value: 'getSomeData' }
+              name: { type: 'string', value: 'getUndefined' }
             }
           })
 
@@ -118,7 +118,7 @@ describe('Dynamic Instrumentation', function () {
           const { locals } = captures.lines[t.breakpoint.line]
           delete locals.request
           delete locals.fastify
-          delete locals.getSomeData
+          delete locals.getUndefined
 
           assert.deepEqual(locals, {
             nil: { type: 'null', isNull: true },
@@ -139,8 +139,8 @@ describe('Dynamic Instrumentation', function () {
             arr: { type: 'Array', notCapturedReason: 'depth' },
             obj: { type: 'Object', notCapturedReason: 'depth' },
             emptyObj: { type: 'Object', notCapturedReason: 'depth' },
-            fn: { type: 'Function', notCapturedReason: 'depth' },
-            p: { type: 'Promise', notCapturedReason: 'depth' }
+            p: { type: 'Promise', notCapturedReason: 'depth' },
+            arrowFn: { type: 'Function', notCapturedReason: 'depth' }
           })
 
           done()
@@ -212,7 +212,7 @@ describe('Dynamic Instrumentation', function () {
             // Up to 3 properties from the local scope
             'request', 'nil', 'undef',
             // Up to 3 properties from the closure scope
-            'fastify', 'getSomeData'
+            'fastify', 'getUndefined'
           ])
 
           assert.strictEqual(locals.request.type, 'Request')

--- a/integration-tests/debugger/snapshot.spec.js
+++ b/integration-tests/debugger/snapshot.spec.js
@@ -11,7 +11,7 @@ describe('Dynamic Instrumentation', function () {
       beforeEach(t.triggerBreakpoint)
 
       it('should capture a snapshot', function (done) {
-        t.agent.on('debugger-input', ({ payload: { 'debugger.snapshot': { captures } } }) => {
+        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
           assert.deepEqual(Object.keys(captures), ['lines'])
           assert.deepEqual(Object.keys(captures.lines), [String(t.breakpoint.line)])
 
@@ -114,7 +114,7 @@ describe('Dynamic Instrumentation', function () {
       })
 
       it('should respect maxReferenceDepth', function (done) {
-        t.agent.on('debugger-input', ({ payload: { 'debugger.snapshot': { captures } } }) => {
+        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
           delete locals.request
           delete locals.fastify
@@ -150,7 +150,7 @@ describe('Dynamic Instrumentation', function () {
       })
 
       it('should respect maxLength', function (done) {
-        t.agent.on('debugger-input', ({ payload: { 'debugger.snapshot': { captures } } }) => {
+        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
 
           assert.deepEqual(locals.lstr, {
@@ -167,7 +167,7 @@ describe('Dynamic Instrumentation', function () {
       })
 
       it('should respect maxCollectionSize', function (done) {
-        t.agent.on('debugger-input', ({ payload: { 'debugger.snapshot': { captures } } }) => {
+        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
 
           assert.deepEqual(locals.arr, {
@@ -205,7 +205,7 @@ describe('Dynamic Instrumentation', function () {
           }
         }
 
-        t.agent.on('debugger-input', ({ payload: { 'debugger.snapshot': { captures } } }) => {
+        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
 
           assert.deepEqual(Object.keys(locals), [

--- a/integration-tests/debugger/target-app/snapshot.js
+++ b/integration-tests/debugger/target-app/snapshot.js
@@ -5,12 +5,33 @@ const Fastify = require('fastify')
 
 const fastify = Fastify()
 
-// Since line probes have hardcoded line numbers, we want to try and keep the line numbers from changing within the
-// `handler` function below when making changes to this file. This is achieved by calling `getSomeData` and keeping all
-// variable names on the same line as much as possible.
 fastify.get('/:name', function handler (request) {
-  // eslint-disable-next-line no-unused-vars
-  const { nil, undef, bool, num, bigint, str, lstr, sym, regex, arr, obj, emptyObj, fn, p } = getSomeData()
+  /* eslint-disable no-unused-vars */
+  const nil = null
+  const undef = getUndefined()
+  const bool = true
+  const num = 42
+  const bigint = 42n
+  const str = 'foo'
+  // eslint-disable-next-line @stylistic/js/max-len
+  const lstr = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+  const sym = Symbol('foo')
+  const regex = /bar/i
+  const arr = [1, 2, 3, 4, 5]
+  const obj = {
+    foo: {
+      baz: 42,
+      nil: null,
+      undef: undefined,
+      deep: { nested: { obj: { that: { goes: { on: { forever: true } } } } } }
+    },
+    bar: true
+  }
+  const emptyObj = {}
+  const p = Promise.resolve()
+  const arrowFn = () => {}
+  /* eslint-enable no-unused-vars */
+
   return { hello: request.params.name } // BREAKPOINT: /foo
 })
 
@@ -22,30 +43,4 @@ fastify.listen({ port: process.env.APP_PORT }, (err) => {
   process.send({ port: process.env.APP_PORT })
 })
 
-function getSomeData () {
-  return {
-    nil: null,
-    undef: undefined,
-    bool: true,
-    num: 42,
-    bigint: 42n,
-    str: 'foo',
-    // eslint-disable-next-line @stylistic/js/max-len
-    lstr: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-    sym: Symbol('foo'),
-    regex: /bar/i,
-    arr: [1, 2, 3, 4, 5],
-    obj: {
-      foo: {
-        baz: 42,
-        nil: null,
-        undef: undefined,
-        deep: { nested: { obj: { that: { goes: { on: { forever: true } } } } } }
-      },
-      bar: true
-    },
-    emptyObj: {},
-    fn: () => {},
-    p: Promise.resolve()
-  }
-}
+function getUndefined () {}

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -50,9 +50,11 @@ function setup ({ env, testApp } = {}) {
   function triggerBreakpoint (url) {
     // Trigger the breakpoint once probe is successfully installed
     t.agent.on('debugger-diagnostics', ({ payload }) => {
-      if (payload.debugger.diagnostics.status === 'INSTALLED') {
-        t.axios.get(url)
-      }
+      payload.forEach((event) => {
+        if (event.debugger.diagnostics.status === 'INSTALLED') {
+          t.axios.get(url)
+        }
+      })
     })
   }
 

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -18,9 +18,9 @@ module.exports = {
   setup
 }
 
-function setup (env) {
+function setup ({ env, testApp } = {}) {
   let sandbox, cwd, appPort
-  const breakpoints = getBreakpointInfo(1) // `1` to disregard the `setup` function
+  const breakpoints = getBreakpointInfo({ file: testApp, stackIndex: 1 }) // `1` to disregard the `setup` function
   const t = {
     breakpoint: breakpoints[0],
     breakpoints,
@@ -108,16 +108,18 @@ function setup (env) {
   return t
 }
 
-function getBreakpointInfo (stackIndex = 0) {
-  // First, get the filename of file that called this function
-  const testFile = new Error().stack
-    .split('\n')[stackIndex + 2] // +2 to skip this function + the first line, which is the error message
-    .split(' (')[1]
-    .slice(0, -1)
-    .split(':')[0]
+function getBreakpointInfo ({ file, stackIndex = 0 }) {
+  if (!file) {
+    // First, get the filename of file that called this function
+    const testFile = new Error().stack
+      .split('\n')[stackIndex + 2] // +2 to skip this function + the first line, which is the error message
+      .split(' (')[1]
+      .slice(0, -1)
+      .split(':')[0]
 
-  // Then, find the corresponding file in which the breakpoint(s) exists
-  const file = join('target-app', basename(testFile).replace('.spec', ''))
+    // Then, find the corresponding file in which the breakpoint(s) exists
+    file = join('target-app', basename(testFile).replace('.spec', ''))
+  }
 
   // Finally, find the line number(s) of the breakpoint(s)
   const lines = readFileSync(join(__dirname, file), 'utf8').split('\n')

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -326,6 +326,7 @@ function buildExpressServer (agent) {
     res.status(200).send()
     agent.emit('debugger-input', {
       headers: req.headers,
+      query: req.query,
       payload: req.body
     })
   })

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "jszip": "^3.5.0",
     "knex": "^2.4.2",
     "mkdirp": "^3.0.1",
-    "mocha": "^9",
+    "mocha": "^10",
     "msgpack-lite": "^0.1.26",
     "multer": "^1.4.5-lts.1",
     "nock": "^11.3.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@datadog/libdatadog": "^0.3.0",
-    "@datadog/native-appsec": "8.3.0",
+    "@datadog/native-appsec": "8.4.0",
     "@datadog/native-iast-rewriter": "2.6.1",
     "@datadog/native-iast-taint-tracking": "3.2.0",
     "@datadog/native-metrics": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.30.0",
+  "version": "5.31.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -21,8 +21,16 @@ class DatadogStorage {
     this._storage.exit(callback, ...args)
   }
 
-  getStore () {
-    const handle = this._storage.getStore()
+  // TODO: Refactor the Scope class to use a span-only store and remove this.
+  getHandle () {
+    return this._storage.getStore()
+  }
+
+  getStore (handle) {
+    if (!handle) {
+      handle = this._storage.getStore()
+    }
+
     return stores.get(handle)
   }
 
@@ -50,6 +58,7 @@ const storage = function (namespace) {
 storage.disable = legacyStorage.disable.bind(legacyStorage)
 storage.enterWith = legacyStorage.enterWith.bind(legacyStorage)
 storage.exit = legacyStorage.exit.bind(legacyStorage)
+storage.getHandle = legacyStorage.getHandle.bind(legacyStorage)
 storage.getStore = legacyStorage.getStore.bind(legacyStorage)
 storage.run = legacyStorage.run.bind(legacyStorage)
 

--- a/packages/datadog-instrumentations/src/aerospike.js
+++ b/packages/datadog-instrumentations/src/aerospike.js
@@ -40,7 +40,7 @@ function wrapProcess (process) {
 addHook({
   name: 'aerospike',
   file: 'lib/commands/command.js',
-  versions: ['4', '5']
+  versions: ['4', '5', '6']
 },
 commandFactory => {
   return shimmer.wrapFunction(commandFactory, f => wrapCreateCommand(f))

--- a/packages/dd-trace/src/appsec/remote_config/manager.js
+++ b/packages/dd-trace/src/appsec/remote_config/manager.js
@@ -9,6 +9,7 @@ const log = require('../../log')
 const { getExtraServices } = require('../../service-naming/extra-services')
 const { UNACKNOWLEDGED, ACKNOWLEDGED, ERROR } = require('./apply_states')
 const Scheduler = require('./scheduler')
+const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../../plugins/util/tags')
 
 const clientId = uuid()
 
@@ -32,6 +33,14 @@ class RemoteConfigManager extends EventEmitter {
       hostname: config.hostname || 'localhost',
       port: config.port
     }))
+
+    const tags = config.repositoryUrl
+      ? {
+          ...config.tags,
+          [GIT_REPOSITORY_URL]: config.repositoryUrl,
+          [GIT_COMMIT_SHA]: config.commitSHA
+        }
+      : config.tags
 
     this._handlers = new Map()
     const appliedConfigs = this.appliedConfigs = new Map()
@@ -67,7 +76,8 @@ class RemoteConfigManager extends EventEmitter {
           service: config.service,
           env: config.env,
           app_version: config.version,
-          extra_services: []
+          extra_services: [],
+          tags: Object.entries(tags).map((pair) => pair.join(':'))
         },
         capabilities: DEFAULT_CAPABILITY // updated by `updateCapabilities()`
       },

--- a/packages/dd-trace/src/debugger/devtools_client/config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/config.js
@@ -9,7 +9,8 @@ const config = module.exports = {
   service: parentConfig.service,
   commitSHA: parentConfig.commitSHA,
   repositoryUrl: parentConfig.repositoryUrl,
-  parentThreadId
+  parentThreadId,
+  maxTotalPayloadSize: 5 * 1024 * 1024 // 5MB
 }
 
 updateUrl(parentConfig)

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -129,9 +129,8 @@ session.on('Debugger.paused', async ({ params }) => {
     }
 
     // TODO: Process template (DEBUG-2628)
-    send(probe.template, logger, dd, snapshot, (err) => {
-      if (err) log.error('Debugger error', err)
-      else ackEmitting(probe)
+    send(probe.template, logger, dd, snapshot, () => {
+      ackEmitting(probe)
     })
   }
 })

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -141,6 +141,8 @@ function highestOrUndefined (num, max) {
 }
 
 async function getDD (callFrameId) {
+  // TODO: Consider if an `objectGroup` should be used, so it can be explicitly released using
+  // `Runtime.releaseObjectGroup`
   const { result } = await session.post('Debugger.evaluateOnCallFrame', {
     callFrameId,
     expression,

--- a/packages/dd-trace/src/debugger/devtools_client/json-buffer.js
+++ b/packages/dd-trace/src/debugger/devtools_client/json-buffer.js
@@ -1,0 +1,36 @@
+'use strict'
+
+class JSONBuffer {
+  constructor ({ size, timeout, onFlush }) {
+    this._maxSize = size
+    this._timeout = timeout
+    this._onFlush = onFlush
+    this._reset()
+  }
+
+  _reset () {
+    clearTimeout(this._timer)
+    this._timer = null
+    this._partialJson = null
+  }
+
+  _flush () {
+    const json = `${this._partialJson}]`
+    this._reset()
+    this._onFlush(json)
+  }
+
+  write (str, size = Buffer.byteLength(str)) {
+    if (this._timer === null) {
+      this._partialJson = `[${str}`
+      this._timer = setTimeout(() => this._flush(), this._timeout)
+    } else if (Buffer.byteLength(this._partialJson) + size + 2 > this._maxSize) {
+      this._flush()
+      this.write(str, size)
+    } else {
+      this._partialJson += `,${str}`
+    }
+  }
+}
+
+module.exports = JSONBuffer

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -6,6 +6,7 @@ const { stringify } = require('querystring')
 const config = require('./config')
 const request = require('../../exporters/common/request')
 const { GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('../../plugins/util/tags')
+const { version } = require('../../../../../package.json')
 
 module.exports = send
 
@@ -16,6 +17,10 @@ const hostname = getHostname()
 const service = config.service
 
 const ddtags = [
+  ['env', process.env.DD_ENV],
+  ['version', process.env.DD_VERSION],
+  ['debugger_version', version],
+  ['host_name', hostname],
   [GIT_COMMIT_SHA, config.commitSHA],
   [GIT_REPOSITORY_URL, config.repositoryUrl]
 ].map((pair) => pair.join(':')).join(',')

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -4,13 +4,15 @@ const { hostname: getHostname } = require('os')
 const { stringify } = require('querystring')
 
 const config = require('./config')
+const JSONBuffer = require('./json-buffer')
 const request = require('../../exporters/common/request')
 const { GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('../../plugins/util/tags')
+const log = require('../../log')
 const { version } = require('../../../../../package.json')
 
 module.exports = send
 
-const MAX_PAYLOAD_SIZE = 1024 * 1024 // 1MB
+const MAX_LOG_PAYLOAD_SIZE = 1024 * 1024 // 1MB
 
 const ddsource = 'dd_debugger'
 const hostname = getHostname()
@@ -27,14 +29,10 @@ const ddtags = [
 
 const path = `/debugger/v1/input?${stringify({ ddtags })}`
 
-function send (message, logger, dd, snapshot, cb) {
-  const opts = {
-    method: 'POST',
-    url: config.url,
-    path,
-    headers: { 'Content-Type': 'application/json; charset=utf-8' }
-  }
+let callbacks = []
+const jsonBuffer = new JSONBuffer({ size: config.maxTotalPayloadSize, timeout: 1000, onFlush })
 
+function send (message, logger, dd, snapshot, cb) {
   const payload = {
     ddsource,
     hostname,
@@ -46,8 +44,9 @@ function send (message, logger, dd, snapshot, cb) {
   }
 
   let json = JSON.stringify(payload)
+  let size = Buffer.byteLength(json)
 
-  if (Buffer.byteLength(json) > MAX_PAYLOAD_SIZE) {
+  if (size > MAX_LOG_PAYLOAD_SIZE) {
     // TODO: This is a very crude way to handle large payloads. Proper pruning will be implemented later (DEBUG-2624)
     const line = Object.values(payload['debugger.snapshot'].captures.lines)[0]
     line.locals = {
@@ -55,7 +54,26 @@ function send (message, logger, dd, snapshot, cb) {
       size: Object.keys(line.locals).length
     }
     json = JSON.stringify(payload)
+    size = Buffer.byteLength(json)
   }
 
-  request(json, opts, cb)
+  jsonBuffer.write(json, size)
+  callbacks.push(cb)
+}
+
+function onFlush (payload) {
+  const opts = {
+    method: 'POST',
+    url: config.url,
+    path,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' }
+  }
+
+  const _callbacks = callbacks
+  callbacks = []
+
+  request(payload, opts, (err) => {
+    if (err) log.error('Could not send debugger payload', err)
+    else _callbacks.forEach(cb => cb())
+  })
 }

--- a/packages/dd-trace/src/debugger/devtools_client/status.js
+++ b/packages/dd-trace/src/debugger/devtools_client/status.js
@@ -2,6 +2,7 @@
 
 const LRUCache = require('lru-cache')
 const config = require('./config')
+const JSONBuffer = require('./json-buffer')
 const request = require('../../exporters/common/request')
 const FormData = require('../../exporters/common/form-data')
 const log = require('../../log')
@@ -24,6 +25,8 @@ const cache = new LRUCache({
   // TODO: Consider alternative as this is NOT performant :(
   ttlAutopurge: true
 })
+
+const jsonBuffer = new JSONBuffer({ size: config.maxTotalPayloadSize, timeout: 1000, onFlush })
 
 const STATUSES = {
   RECEIVED: 'RECEIVED',
@@ -71,11 +74,15 @@ function ackError (err, { id: probeId, version }) {
 }
 
 function send (payload) {
+  jsonBuffer.write(JSON.stringify(payload))
+}
+
+function onFlush (payload) {
   const form = new FormData()
 
   form.append(
     'event',
-    JSON.stringify(payload),
+    payload,
     { filename: 'event.json', contentType: 'application/json; charset=utf-8' }
   )
 
@@ -87,7 +94,7 @@ function send (payload) {
   }
 
   request(form, options, (err) => {
-    if (err) log.error('[debugger:devtools_client] Error sending debugger payload', err)
+    if (err) log.error('[debugger:devtools_client] Error sending probe payload', err)
   })
 }
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { SPAN_KIND, OUTPUT_VALUE } = require('./constants/tags')
+const { SPAN_KIND, OUTPUT_VALUE, INPUT_VALUE } = require('./constants/tags')
 
 const {
   getFunctionArguments,
   validateKind
 } = require('./util')
-const { isTrue } = require('../util')
+const { isTrue, isError } = require('../util')
 
 const { storage } = require('./storage')
 
@@ -134,29 +134,63 @@ class LLMObs extends NoopLLMObs {
 
     function wrapped () {
       const span = llmobs._tracer.scope().active()
+      const fnArgs = arguments
 
-      const result = llmobs._activate(span, { kind, options: llmobsOptions }, () => {
-        if (!['llm', 'embedding'].includes(kind)) {
-          llmobs.annotate(span, { inputData: getFunctionArguments(fn, arguments) })
+      const lastArgId = fnArgs.length - 1
+      const cb = fnArgs[lastArgId]
+      const hasCallback = typeof cb === 'function'
+
+      if (hasCallback) {
+        const scopeBoundCb = llmobs._bind(cb)
+        fnArgs[lastArgId] = function () {
+          // it is standard practice to follow the callback signature (err, result)
+          // however, we try to parse the arguments to determine if the first argument is an error
+          // if it is not, and is not undefined, we will use that for the output value
+          const maybeError = arguments[0]
+          const maybeResult = arguments[1]
+
+          llmobs._autoAnnotate(
+            span,
+            kind,
+            getFunctionArguments(fn, fnArgs),
+            isError(maybeError) || maybeError == null ? maybeResult : maybeError
+          )
+
+          return scopeBoundCb.apply(this, arguments)
+        }
+      }
+
+      try {
+        const result = llmobs._activate(span, { kind, options: llmobsOptions }, () => fn.apply(this, fnArgs))
+
+        if (result && typeof result.then === 'function') {
+          return result.then(
+            value => {
+              if (!hasCallback) {
+                llmobs._autoAnnotate(span, kind, getFunctionArguments(fn, fnArgs), value)
+              }
+              return value
+            },
+            err => {
+              llmobs._autoAnnotate(span, kind, getFunctionArguments(fn, fnArgs))
+              throw err
+            }
+          )
         }
 
-        return fn.apply(this, arguments)
-      })
+        // it is possible to return a value and have a callback
+        // however, since the span finishes when the callback is called, it is possible that
+        // the callback is called before the function returns (although unlikely)
+        // we do not want to throw for "annotating a finished span" in this case
+        if (!hasCallback) {
+          llmobs._autoAnnotate(span, kind, getFunctionArguments(fn, fnArgs), result)
+        }
 
-      if (result && typeof result.then === 'function') {
-        return result.then(value => {
-          if (value && !['llm', 'retrieval'].includes(kind) && !LLMObsTagger.tagMap.get(span)?.[OUTPUT_VALUE]) {
-            llmobs.annotate(span, { outputData: value })
-          }
-          return value
-        })
+        return result
+      } catch (e) {
+        llmobs._autoAnnotate(span, kind, getFunctionArguments(fn, fnArgs))
+        throw e
       }
-
-      if (result && !['llm', 'retrieval'].includes(kind) && !LLMObsTagger.tagMap.get(span)?.[OUTPUT_VALUE]) {
-        llmobs.annotate(span, { outputData: result })
-      }
-
-      return result
     }
 
     return this._tracer.wrap(name, spanOptions, wrapped)
@@ -333,26 +367,56 @@ class LLMObs extends NoopLLMObs {
     flushCh.publish()
   }
 
+  _autoAnnotate (span, kind, input, output) {
+    const annotations = {}
+    if (input && !['llm', 'embedding'].includes(kind) && !LLMObsTagger.tagMap.get(span)?.[INPUT_VALUE]) {
+      annotations.inputData = input
+    }
+
+    if (output && !['llm', 'retrieval'].includes(kind) && !LLMObsTagger.tagMap.get(span)?.[OUTPUT_VALUE]) {
+      annotations.outputData = output
+    }
+
+    this.annotate(span, annotations)
+  }
+
   _active () {
     const store = storage.getStore()
     return store?.span
   }
 
-  _activate (span, { kind, options } = {}, fn) {
+  _activate (span, options, fn) {
     const parent = this._active()
     if (this.enabled) storage.enterWith({ span })
 
-    this._tagger.registerLLMObsSpan(span, {
-      ...options,
-      parent,
-      kind
-    })
+    if (options) {
+      this._tagger.registerLLMObsSpan(span, {
+        ...options,
+        parent
+      })
+    }
 
     try {
       return fn()
     } finally {
       if (this.enabled) storage.enterWith({ span: parent })
     }
+  }
+
+  // bind function to active LLMObs span
+  _bind (fn) {
+    if (typeof fn !== 'function') return fn
+
+    const llmobs = this
+    const activeSpan = llmobs._active()
+
+    const bound = function () {
+      return llmobs._activate(activeSpan, null, () => {
+        return fn.apply(this, arguments)
+      })
+    }
+
+    return bound
   }
 
   _extractOptions (options) {

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -63,15 +63,17 @@ const log = {
 
       Error.captureStackTrace(logRecord, this.trace)
 
-      const fn = logRecord.stack.split('\n')[1].replace(/^\s+at ([^\s]+) .+/, '$1')
+      const stack = logRecord.stack.split('\n')
+      const fn = stack[1].replace(/^\s+at ([^\s]+) .+/, '$1')
       const params = args.map(a => {
         return a && a.hasOwnProperty('toString') && typeof a.toString === 'function'
           ? a.toString()
           : inspect(a, { depth: 3, breakLength: Infinity, compact: true })
       }).join(', ')
-      const formatted = logRecord.stack.replace('Error: ', `Trace: ${fn}(${params})`)
 
-      traceChannel.publish(Log.parse(formatted))
+      stack[0] = `Trace: ${fn}(${params})`
+
+      traceChannel.publish(Log.parse(stack.join('\n')))
     }
     return this
   },

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -65,11 +65,8 @@ const log = {
 
       const stack = logRecord.stack.split('\n')
       const fn = stack[1].replace(/^\s+at ([^\s]+) .+/, '$1')
-      const params = args.map(a => {
-        return a && a.hasOwnProperty('toString') && typeof a.toString === 'function'
-          ? a.toString()
-          : inspect(a, { depth: 3, breakLength: Infinity, compact: true })
-      }).join(', ')
+      const options = { depth: 2, breakLength: Infinity, compact: true, maxArrayLength: Infinity }
+      const params = args.map(a => inspect(a, options)).join(', ')
 
       stack[0] = `Trace: ${fn}(${params})`
 

--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -10,7 +10,7 @@ const noopAppsec = new NoopAppsecSdk()
 const noopDogStatsDClient = new NoopDogStatsDClient()
 const noopLLMObs = new NoopLLMObsSDK(noop)
 
-class Tracer {
+class NoopProxy {
   constructor () {
     this._tracer = noop
     this.appsec = noopAppsec
@@ -91,4 +91,4 @@ class Tracer {
   }
 }
 
-module.exports = Tracer
+module.exports = NoopProxy

--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -6,7 +6,7 @@ const { storage } = require('../../../datadog-core') // TODO: noop storage?
 
 class NoopSpan {
   constructor (tracer, parent) {
-    this._store = storage.getStore()
+    this._store = storage.getHandle()
     this._noopTracer = tracer
     this._noopContext = this._createContext(parent)
   }

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -14,6 +14,7 @@ const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../telemetry/metrics')
 const { channel } = require('dc-polyfill')
 const spanleak = require('../spanleak')
+const util = require('util')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
 
@@ -64,7 +65,7 @@ class DatadogSpan {
     this._debug = debug
     this._processor = processor
     this._prioritySampler = prioritySampler
-    this._store = storage.getStore()
+    this._store = storage.getHandle()
     this._duration = undefined
 
     this._events = []
@@ -102,6 +103,15 @@ class DatadogSpan {
 
     if (startCh.hasSubscribers) {
       startCh.publish({ span: this, fields })
+    }
+  }
+
+  [util.inspect.custom] () {
+    return {
+      ...this,
+      _parentTracer: `[${this._parentTracer.constructor.name}]`,
+      _prioritySampler: `[${this._prioritySampler.constructor.name}]`,
+      _processor: `[${this._processor.constructor.name}]`
     }
   }
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const util = require('util')
 const { AUTO_KEEP } = require('../../../../ext/priority')
 
 // the lowercase, hex encoded upper 64 bits of a 128-bit trace id, if present
@@ -29,6 +30,17 @@ class DatadogSpanContext {
       tags: {}
     }
     this._otelSpanContext = undefined
+  }
+
+  [util.inspect.custom] () {
+    return {
+      ...this,
+      _trace: {
+        ...this._trace,
+        started: '[Array]',
+        finished: '[Array]'
+      }
+    }
   }
 
   toTraceId (get128bitId = false) {

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -120,13 +120,15 @@ class PrioritySampler {
     if (!span || !this.validate(samplingPriority)) return
 
     const context = this._getContext(span)
+    const root = context._trace.started[0]
+
+    if (!root) return // noop span
 
     context._sampling.priority = samplingPriority
     context._sampling.mechanism = mechanism
 
-    const root = context._trace.started[0]
-
     log.trace(span, samplingPriority, mechanism)
+
     this._addDecisionMaker(root)
   }
 

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -17,7 +17,7 @@ class Scope {
     if (typeof callback !== 'function') return callback
 
     const oldStore = storage.getStore()
-    const newStore = span ? span._store : oldStore
+    const newStore = span ? storage.getStore(span._store) : oldStore
 
     storage.enterWith({ ...newStore, span })
 

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -307,6 +307,8 @@ function updateConfig (changes, config) {
   if (!config.telemetry.enabled) return
   if (changes.length === 0) return
 
+  logger.trace(changes)
+
   const application = createAppObject(config)
   const host = createHostObject()
 

--- a/packages/dd-trace/test/appsec/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/appsec/remote_config/manager.spec.js
@@ -98,7 +98,8 @@ describe('RemoteConfigManager', () => {
           service: config.service,
           env: config.env,
           app_version: config.version,
-          extra_services: []
+          extra_services: [],
+          tags: ['runtime-id:runtimeId']
         },
         capabilities: 'AA=='
       },
@@ -106,6 +107,20 @@ describe('RemoteConfigManager', () => {
     })
 
     expect(rc.appliedConfigs).to.be.an.instanceOf(Map)
+  })
+
+  it('should add git metadata to tags if present', () => {
+    const configWithGit = {
+      ...config,
+      repositoryUrl: 'https://github.com/DataDog/dd-trace-js',
+      commitSHA: '1234567890'
+    }
+    const rc = new RemoteConfigManager(configWithGit)
+    expect(rc.state.client.client_tracer.tags).to.deep.equal([
+      'runtime-id:runtimeId',
+      'git.repository_url:https://github.com/DataDog/dd-trace-js',
+      'git.commit.sha:1234567890'
+    ])
   })
 
   describe('updateCapabilities', () => {

--- a/packages/dd-trace/test/debugger/devtools_client/json-buffer.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/json-buffer.spec.js
@@ -1,0 +1,45 @@
+'use strict'
+
+require('../../setup/mocha')
+
+const JSONBuffer = require('../../../src/debugger/devtools_client/json-buffer')
+
+const MAX_SAFE_SIGNED_INTEGER = 2 ** 31 - 1
+
+describe('JSONBuffer', () => {
+  it('should call onFlush with the expected payload when the timeout is reached', function (done) {
+    const onFlush = (json) => {
+      const diff = Date.now() - start
+      expect(json).to.equal('[{"message":1},{"message":2},{"message":3}]')
+      expect(diff).to.be.within(95, 110)
+      done()
+    }
+
+    const jsonBuffer = new JSONBuffer({ size: Infinity, timeout: 100, onFlush })
+
+    const start = Date.now()
+    jsonBuffer.write(JSON.stringify({ message: 1 }))
+    jsonBuffer.write(JSON.stringify({ message: 2 }))
+    jsonBuffer.write(JSON.stringify({ message: 3 }))
+  })
+
+  it('should call onFlush with the expected payload when the size is reached', function (done) {
+    const expectedPayloads = [
+      '[{"message":1},{"message":2}]',
+      '[{"message":3},{"message":4}]'
+    ]
+
+    const onFlush = (json) => {
+      expect(json).to.equal(expectedPayloads.shift())
+      if (expectedPayloads.length === 0) done()
+    }
+
+    const jsonBuffer = new JSONBuffer({ size: 30, timeout: MAX_SAFE_SIGNED_INTEGER, onFlush })
+
+    jsonBuffer.write(JSON.stringify({ message: 1 })) // size: 15
+    jsonBuffer.write(JSON.stringify({ message: 2 })) // size: 29
+    jsonBuffer.write(JSON.stringify({ message: 3 })) // size: 15 (flushed, and re-added)
+    jsonBuffer.write(JSON.stringify({ message: 4 })) // size: 29
+    jsonBuffer.write(JSON.stringify({ message: 5 })) // size: 15 (flushed, and re-added)
+  })
+})

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -1,0 +1,111 @@
+'use strict'
+
+require('../../setup/mocha')
+
+const { hostname: getHostname } = require('os')
+const { expectWithin, getRequestOptions } = require('./utils')
+const JSONBuffer = require('../../../src/debugger/devtools_client/json-buffer')
+const { version } = require('../../../../../package.json')
+
+process.env.DD_ENV = 'my-env'
+process.env.DD_VERSION = 'my-version'
+const service = 'my-service'
+const commitSHA = 'my-commit-sha'
+const repositoryUrl = 'my-repository-url'
+const url = 'my-url'
+const ddsource = 'dd_debugger'
+const hostname = getHostname()
+const message = { message: true }
+const logger = { logger: true }
+const dd = { dd: true }
+const snapshot = { snapshot: true }
+
+describe('input message http requests', function () {
+  let send, request, jsonBuffer
+
+  beforeEach(function () {
+    request = sinon.spy()
+    request['@noCallThru'] = true
+
+    class JSONBufferSpy extends JSONBuffer {
+      constructor (...args) {
+        super(...args)
+        jsonBuffer = this
+        sinon.spy(this, 'write')
+      }
+    }
+
+    send = proxyquire('../src/debugger/devtools_client/send', {
+      './config': { service, commitSHA, repositoryUrl, url, '@noCallThru': true },
+      './json-buffer': JSONBufferSpy,
+      '../../exporters/common/request': request
+    })
+  })
+
+  it('should buffer instead of calling request directly', function () {
+    const callback = sinon.spy()
+
+    send(message, logger, dd, snapshot, callback)
+    expect(request).to.not.have.been.called
+    expect(jsonBuffer.write).to.have.been.calledOnceWith(
+      JSON.stringify(getPayload())
+    )
+    expect(callback).to.not.have.been.called
+  })
+
+  it('should call request with the expected payload once the buffer is flushed', function (done) {
+    const callback1 = sinon.spy()
+    const callback2 = sinon.spy()
+    const callback3 = sinon.spy()
+
+    send({ message: 1 }, logger, dd, snapshot, callback1)
+    send({ message: 2 }, logger, dd, snapshot, callback2)
+    send({ message: 3 }, logger, dd, snapshot, callback3)
+    expect(request).to.not.have.been.called
+
+    expectWithin(1200, () => {
+      expect(request).to.have.been.calledOnceWith(JSON.stringify([
+        getPayload({ message: 1 }),
+        getPayload({ message: 2 }),
+        getPayload({ message: 3 })
+      ]))
+
+      const opts = getRequestOptions(request)
+      expect(opts).to.have.property('method', 'POST')
+      expect(opts).to.have.property(
+        'path',
+        '/debugger/v1/input?ddtags=' +
+          `env%3A${process.env.DD_ENV}%2C` +
+          `version%3A${process.env.DD_VERSION}%2C` +
+          `debugger_version%3A${version}%2C` +
+          `host_name%3A${hostname}%2C` +
+          `git.commit.sha%3A${commitSHA}%2C` +
+          `git.repository_url%3A${repositoryUrl}`
+      )
+
+      expect(callback1).to.not.have.been.calledOnce
+      expect(callback2).to.not.have.been.calledOnce
+      expect(callback3).to.not.have.been.calledOnce
+
+      request.firstCall.callback()
+
+      expect(callback1).to.have.been.calledOnce
+      expect(callback2).to.have.been.calledOnce
+      expect(callback3).to.have.been.calledOnce
+
+      done()
+    })
+  })
+})
+
+function getPayload (_message = message) {
+  return {
+    ddsource,
+    hostname,
+    service,
+    message: _message,
+    logger,
+    dd,
+    'debugger.snapshot': snapshot
+  }
+}

--- a/packages/dd-trace/test/debugger/devtools_client/status.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/status.spec.js
@@ -2,12 +2,15 @@
 
 require('../../setup/mocha')
 
+const { expectWithin, getRequestOptions } = require('./utils')
+const JSONBuffer = require('../../../src/debugger/devtools_client/json-buffer')
+
 const ddsource = 'dd_debugger'
 const service = 'my-service'
 const runtimeId = 'my-runtime-id'
 
-describe('diagnostic message http request caching', function () {
-  let statusproxy, request
+describe('diagnostic message http requests', function () {
+  let statusproxy, request, jsonBuffer
 
   const acks = [
     ['ackReceived', 'RECEIVED'],
@@ -20,8 +23,17 @@ describe('diagnostic message http request caching', function () {
     request = sinon.spy()
     request['@noCallThru'] = true
 
+    class JSONBufferSpy extends JSONBuffer {
+      constructor (...args) {
+        super(...args)
+        jsonBuffer = this
+        sinon.spy(this, 'write')
+      }
+    }
+
     statusproxy = proxyquire('../src/debugger/devtools_client/status', {
       './config': { service, runtimeId, '@noCallThru': true },
+      './json-buffer': JSONBufferSpy,
       '../../exporters/common/request': request
     })
   })
@@ -45,54 +57,85 @@ describe('diagnostic message http request caching', function () {
         }
       })
 
-      it('should only call once if no change', function () {
+      it('should buffer instead of calling request directly', function () {
         ackFn({ id: 'foo', version: 0 })
-        expect(request).to.have.been.calledOnce
-        assertRequestData(request, { probeId: 'foo', version: 0, status, exception })
-
-        ackFn({ id: 'foo', version: 0 })
-        expect(request).to.have.been.calledOnce
+        expect(request).to.not.have.been.called
+        expect(jsonBuffer.write).to.have.been.calledOnceWith(
+          JSON.stringify(formatAsDiagnosticsEvent({ probeId: 'foo', version: 0, status, exception }))
+        )
       })
 
-      it('should call again if version changes', function () {
+      it('should only add to buffer once if no change', function () {
         ackFn({ id: 'foo', version: 0 })
-        expect(request).to.have.been.calledOnce
-        assertRequestData(request, { probeId: 'foo', version: 0, status, exception })
+        expect(jsonBuffer.write).to.have.been.calledOnceWith(
+          JSON.stringify(formatAsDiagnosticsEvent({ probeId: 'foo', version: 0, status, exception }))
+        )
+
+        ackFn({ id: 'foo', version: 0 })
+        expect(jsonBuffer.write).to.have.been.calledOnce
+      })
+
+      it('should add to buffer again if version changes', function () {
+        ackFn({ id: 'foo', version: 0 })
+        expect(jsonBuffer.write).to.have.been.calledOnceWith(
+          JSON.stringify(formatAsDiagnosticsEvent({ probeId: 'foo', version: 0, status, exception }))
+        )
 
         ackFn({ id: 'foo', version: 1 })
-        expect(request).to.have.been.calledTwice
-        assertRequestData(request, { probeId: 'foo', version: 1, status, exception })
+        expect(jsonBuffer.write).to.have.been.calledTwice
+        expect(jsonBuffer.write.lastCall).to.have.been.calledWith(
+          JSON.stringify(formatAsDiagnosticsEvent({ probeId: 'foo', version: 1, status, exception }))
+        )
       })
 
-      it('should call again if probeId changes', function () {
+      it('should add to buffer again if probeId changes', function () {
         ackFn({ id: 'foo', version: 0 })
-        expect(request).to.have.been.calledOnce
-        assertRequestData(request, { probeId: 'foo', version: 0, status, exception })
+        expect(jsonBuffer.write).to.have.been.calledOnceWith(
+          JSON.stringify(formatAsDiagnosticsEvent({ probeId: 'foo', version: 0, status, exception }))
+        )
 
         ackFn({ id: 'bar', version: 0 })
-        expect(request).to.have.been.calledTwice
-        assertRequestData(request, { probeId: 'bar', version: 0, status, exception })
+        expect(jsonBuffer.write).to.have.been.calledTwice
+        expect(jsonBuffer.write.lastCall).to.have.been.calledWith(
+          JSON.stringify(formatAsDiagnosticsEvent({ probeId: 'bar', version: 0, status, exception }))
+        )
+      })
+
+      it('should call request with the expected payload once the buffer is flushed', function (done) {
+        ackFn({ id: 'foo', version: 0 })
+        ackFn({ id: 'foo', version: 1 })
+        ackFn({ id: 'bar', version: 0 })
+        expect(request).to.not.have.been.called
+
+        expectWithin(1200, () => {
+          expect(request).to.have.been.calledOnce
+
+          const payload = getFormPayload(request)
+
+          expect(payload).to.deep.equal([
+            formatAsDiagnosticsEvent({ probeId: 'foo', version: 0, status, exception }),
+            formatAsDiagnosticsEvent({ probeId: 'foo', version: 1, status, exception }),
+            formatAsDiagnosticsEvent({ probeId: 'bar', version: 0, status, exception })
+          ])
+
+          const opts = getRequestOptions(request)
+          expect(opts).to.have.property('method', 'POST')
+          expect(opts).to.have.property('path', '/debugger/v1/diagnostics')
+
+          done()
+        })
       })
     })
   }
 })
 
-function assertRequestData (request, { probeId, version, status, exception }) {
-  const payload = getFormPayload(request)
+function formatAsDiagnosticsEvent ({ probeId, version, status, exception }) {
   const diagnostics = { probeId, runtimeId, probeVersion: version, status }
 
   // Error requests will also contain an `exception` property
   if (exception) diagnostics.exception = exception
 
-  expect(payload).to.deep.equal({ ddsource, service, debugger: { diagnostics } })
-
-  const opts = getRequestOptions(request)
-  expect(opts).to.have.property('method', 'POST')
-  expect(opts).to.have.property('path', '/debugger/v1/diagnostics')
-}
-
-function getRequestOptions (request) {
-  return request.lastCall.args[1]
+  return { ddsource, service, debugger: { diagnostics } }
 }
 
 function getFormPayload (request) {

--- a/packages/dd-trace/test/debugger/devtools_client/utils.js
+++ b/packages/dd-trace/test/debugger/devtools_client/utils.js
@@ -3,7 +3,21 @@
 const { randomUUID } = require('node:crypto')
 
 module.exports = {
-  generateProbeConfig
+  expectWithin,
+  generateProbeConfig,
+  getRequestOptions
+}
+
+function expectWithin (timeout, fn, start = Date.now(), backoff = 1) {
+  try {
+    fn()
+  } catch (e) {
+    if (Date.now() - start > timeout) {
+      throw e
+    } else {
+      setTimeout(expectWithin, backoff, timeout, fn, start, backoff < 128 ? backoff * 2 : backoff)
+    }
+  }
 }
 
 function generateProbeConfig (breakpoint, overrides = {}) {
@@ -22,4 +36,8 @@ function generateProbeConfig (breakpoint, overrides = {}) {
     evaluateAt: 'EXIT',
     ...overrides
   }
+}
+
+function getRequestOptions (request) {
+  return request.lastCall.args[1]
 }

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -147,14 +147,18 @@ describe('log', () => {
       })
 
       it('should log to console after setting log level to trace', function foo () {
+        class Foo {
+          constructor () {
+            this.bar = 'baz'
+          }
+        }
+
         log.toggle(true, 'trace')
-        log.trace('argument', { hello: 'world' }, {
-          toString: () => 'string'
-        }, { foo: 'bar' })
+        log.trace('argument', { hello: 'world' }, new Foo())
 
         expect(console.debug).to.have.been.calledOnce
         expect(console.debug.firstCall.args[0]).to.match(
-          /^Trace: Test.foo\('argument', { hello: 'world' }, string, { foo: 'bar' }\)/
+          /^Trace: Test.foo\('argument', { hello: 'world' }, Foo { bar: 'baz' }\)/
         )
         expect(console.debug.firstCall.args[0].split('\n').length).to.be.gte(3)
       })

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -490,6 +490,16 @@ describe('PrioritySampler', () => {
       expect(context._sampling.mechanism).to.equal(SAMPLING_MECHANISM_APPSEC)
       expect(context._trace.tags[DECISION_MAKER_KEY]).to.equal('-0')
     })
+
+    it('should ignore noop spans', () => {
+      context._trace.started[0] = undefined // noop
+
+      prioritySampler.setPriority(span, USER_KEEP, SAMPLING_MECHANISM_APPSEC)
+
+      expect(context._sampling.priority).to.undefined
+      expect(context._sampling.mechanism).to.undefined
+      expect(context._trace.tags[DECISION_MAKER_KEY]).to.undefined
+    })
   })
 
   describe('keepTrace', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,11 +1012,6 @@
   resolved "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz"
   integrity sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==
 
-"@ungap/promise-all-settled@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
-  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
-
 "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
@@ -1063,10 +1058,10 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-colors@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+ansi-colors@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -1355,6 +1350,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -1362,9 +1364,9 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browser-stdout@1.3.1:
+browser-stdout@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
 browserslist@^4.21.9:
@@ -1533,10 +1535,25 @@ checksum@^1.0.0:
   dependencies:
     optimist "~0.3.5"
 
-chokidar@3.5.3, chokidar@^3.3.0:
+chokidar@^3.3.0:
   version "3.5.3"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@^3.5.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -1818,13 +1835,6 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  dependencies:
-    ms "2.1.2"
-
 debug@4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
@@ -1845,6 +1855,13 @@ debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
   dependencies:
     ms "2.1.2"
+
+debug@^4.3.5:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1918,17 +1935,12 @@ detect-newline@^3.0.0:
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
   integrity "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE= sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
 
-diff@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
-
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-diff@^5.1.0:
+diff@^5.1.0, diff@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
   integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
@@ -2116,11 +2128,6 @@ escape-html@~1.0.3:
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
@@ -2130,6 +2137,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-compat-utils@^0.5.1:
   version "0.5.1"
@@ -2471,20 +2483,20 @@ find-cache-dir@^3.2.0:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-up@5.0.0, find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 findit@^2.0.0:
@@ -2674,18 +2686,6 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.0.5, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.3:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
@@ -2697,6 +2697,17 @@ glob@^7.0.5, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -2751,11 +2762,6 @@ graphql@0.13.2:
   integrity sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==
   dependencies:
     iterall "^1.2.1"
-
-growl@1.10.5:
-  version "1.10.5"
-  resolved "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz"
-  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 has-async-hooks@^1.0.0:
   version "1.0.0"
@@ -2831,9 +2837,9 @@ hdr-histogram-percentiles-obj@^2.0.0:
   dependencies:
     hdr-histogram-js "^1.0.0"
 
-he@1.2.0:
+he@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 html-escaper@^2.0.0:
@@ -3292,13 +3298,6 @@ jmespath@0.16.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
-
 js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
@@ -3306,6 +3305,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -3457,7 +3463,7 @@ lodash@^4.17.13, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@4.1.0:
+log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -3560,19 +3566,19 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-4.2.1.tgz#40d9d511a46bdc4e563c22c3080cde9c0d8299b4"
-  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1, minimatch@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.7"
@@ -3603,35 +3609,31 @@ mkdirp@^3.0.1:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz"
   integrity "sha1-5E5MVgf7J5wWgkFxPMbg/qmty1A= sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
 
-mocha@^9:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.2.tgz#d70db46bdb93ca57402c809333e5a84977a88fb9"
-  integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
+mocha@^10:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.8.2.tgz#8d8342d016ed411b12a429eb731b825f961afb96"
+  integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==
   dependencies:
-    "@ungap/promise-all-settled" "1.1.2"
-    ansi-colors "4.1.1"
-    browser-stdout "1.3.1"
-    chokidar "3.5.3"
-    debug "4.3.3"
-    diff "5.0.0"
-    escape-string-regexp "4.0.0"
-    find-up "5.0.0"
-    glob "7.2.0"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "4.1.0"
-    log-symbols "4.1.0"
-    minimatch "4.2.1"
-    ms "2.1.3"
-    nanoid "3.3.8"
-    serialize-javascript "6.0.0"
-    strip-json-comments "3.1.1"
-    supports-color "8.1.1"
-    which "2.0.2"
-    workerpool "6.2.0"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
-    yargs-unparser "2.0.0"
+    ansi-colors "^4.1.3"
+    browser-stdout "^1.3.1"
+    chokidar "^3.5.3"
+    debug "^4.3.5"
+    diff "^5.2.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^8.1.0"
+    he "^1.2.0"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^5.1.6"
+    ms "^2.1.3"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^6.5.1"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.9"
+    yargs-unparser "^2.0.0"
 
 module-details-from-path@^1.0.3:
   version "1.0.3"
@@ -3653,7 +3655,7 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1, ms@^2.1.2:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.2, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -3680,11 +3682,6 @@ multer@^1.4.5-lts.1:
     object-assign "^4.1.1"
     type-is "^1.6.4"
     xtend "^4.0.0"
-
-nanoid@3.3.8:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
-  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4438,10 +4435,10 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
 
@@ -4695,17 +4692,10 @@ strip-bom@^4.0.0:
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
-strip-json-comments@3.1.1, strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-supports-color@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -4718,6 +4708,13 @@ supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -5142,7 +5139,7 @@ which-typed-array@^1.1.14, which-typed-array@^1.1.15, which-typed-array@^1.1.2:
     gopd "^1.0.1"
     has-tostringtag "^1.0.2"
 
-which@2.0.2, which@^2.0.1, which@^2.0.2:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -5166,10 +5163,10 @@ wordwrap@~0.0.2:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
   integrity sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==
 
-workerpool@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
-  integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
+workerpool@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
+  integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
@@ -5257,11 +5254,6 @@ yaml@^2.5.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.5.0.tgz#c6165a721cf8000e91c36490a41d7be25176cf5d"
   integrity sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==
 
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz"
@@ -5270,33 +5262,20 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-unparser@2.0.0:
+yargs-unparser@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
   integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
   dependencies:
     camelcase "^6.0.0"
     decamelize "^4.0.0"
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
-
-yargs@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
 
 yargs@^15.0.2:
   version "15.4.1"
@@ -5314,6 +5293,19 @@ yargs@^15.0.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,10 +406,10 @@
   resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.3.0.tgz#2fc1e2695872840bc8c356f66acf675da428d6f0"
   integrity sha512-TbP8+WyXfh285T17FnLeLUOPl4SbkRYMqKgcmknID2mXHNrbt5XJgW9bnDgsrrtu31Q7FjWWw2WolgRLWyzLRA==
 
-"@datadog/native-appsec@8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-8.3.0.tgz#91afd89d18d386be4da8a1b0e04500f2f8b5eb66"
-  integrity sha512-RYHbSJ/MwJcJaLzaCaZvUyNLUKFbMshayIiv4ckpFpQJDiq1T8t9iM2k7008s75g1vRuXfsRNX7MaLn4aoFuWA==
+"@datadog/native-appsec@8.4.0":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-appsec/-/native-appsec-8.4.0.tgz#5c44d949ff8f40a94c334554db79c1c470653bae"
+  integrity sha512-LC47AnpVLpQFEUOP/nIIs+i0wLb8XYO+et3ACaJlHa2YJM3asR4KZTqQjDQNy08PTAUbVvYWKwfSR1qVsU/BeA==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
* \[[`34b751db6d`](https://github.com/DataDog/dd-trace-js/commit/34b751db6d)] - **(SEMVER-PATCH)** improve logging of spans in trace log level (Roch Devost) [#5074](https://github.com/DataDog/dd-trace-js/pull/5074)
* \[[`c7648a7b8f`](https://github.com/DataDog/dd-trace-js/commit/c7648a7b8f)] - **(SEMVER-PATCH)** fix trace log level not adding parameters to output (Roch Devost) [#5069](https://github.com/DataDog/dd-trace-js/pull/5069)
* \[[`daf7030eb7`](https://github.com/DataDog/dd-trace-js/commit/daf7030eb7)] - **(SEMVER-PATCH)** add trace level logging when updating config (Roch Devost) [#5071](https://github.com/DataDog/dd-trace-js/pull/5071)
* \[[`317c7a9e09`](https://github.com/DataDog/dd-trace-js/commit/317c7a9e09)] - **(SEMVER-PATCH)** rename Tracer to NoopProxy in noop/proxy.js (simon-id) [#5068](https://github.com/DataDog/dd-trace-js/pull/5068)
* \[[`7378bff190`](https://github.com/DataDog/dd-trace-js/commit/7378bff190)] - **(SEMVER-PATCH)** **Benchmarks**: No need to guard against unhandled promise rejections (Thomas Watson) [#5025](https://github.com/DataDog/dd-trace-js/pull/5025)
* \[[`b4f99e80d7`](https://github.com/DataDog/dd-trace-js/commit/b4f99e80d7)] - **(SEMVER-PATCH)** \[DI] Batch outgoing http requests (Thomas Watson) [#5007](https://github.com/DataDog/dd-trace-js/pull/5007)
* \[[`1e7622373a`](https://github.com/DataDog/dd-trace-js/commit/1e7622373a)] - **(SEMVER-PATCH)** Send tags, including git metadata, to RC endpoint (Thomas Watson) [#5070](https://github.com/DataDog/dd-trace-js/pull/5070)
* \[[`86c8e26b6f`](https://github.com/DataDog/dd-trace-js/commit/86c8e26b6f)] - **(SEMVER-PATCH)** ignore noop spans (Igor Unanua) [#5063](https://github.com/DataDog/dd-trace-js/pull/5063)
* \[[`12f24185e7`](https://github.com/DataDog/dd-trace-js/commit/12f24185e7)] - **(SEMVER-MINOR)** Update native-appsec to 8.4.0 (ishabi) [#5064](https://github.com/DataDog/dd-trace-js/pull/5064)
* \[[`f813f43d20`](https://github.com/DataDog/dd-trace-js/commit/f813f43d20)] - **(SEMVER-PATCH)** upgrade mocha\@9 to mocha\@10 (ishabi) [#5065](https://github.com/DataDog/dd-trace-js/pull/5065)
* \[[`8981beb6c7`](https://github.com/DataDog/dd-trace-js/commit/8981beb6c7)] - **(SEMVER-PATCH)** \[DI] Add TODO comment (Thomas Watson) [#5054](https://github.com/DataDog/dd-trace-js/pull/5054)
* \[[`330e973219`](https://github.com/DataDog/dd-trace-js/commit/330e973219)] - **(SEMVER-PATCH)** \[DI] Clean up snapshot integration test (Thomas Watson) [#5050](https://github.com/DataDog/dd-trace-js/pull/5050)
* \[[`4d6a8e3fe8`](https://github.com/DataDog/dd-trace-js/commit/4d6a8e3fe8)] - **(SEMVER-MINOR)** support aerospike 6 (ishabi) [#5057](https://github.com/DataDog/dd-trace-js/pull/5057)
* \[[`98ceacfd84`](https://github.com/DataDog/dd-trace-js/commit/98ceacfd84)] - **(SEMVER-PATCH)** \[MLOB-1942] fix(llmobs): auto-annotations for wrapped functions happen after manual annotations (Sam Brenner) [#4960](https://github.com/DataDog/dd-trace-js/pull/4960)
* \[[`3798033eba`](https://github.com/DataDog/dd-trace-js/commit/3798033eba)] - **(SEMVER-MINOR)** \[DI] Attach ddtags to probe results (Thomas Watson) [#5042](https://github.com/DataDog/dd-trace-js/pull/5042)

[MLOB-1942]: https://datadoghq.atlassian.net/browse/MLOB-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ