### PR TITLE
install plugin modules without npm view

### DIFF
--- a/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
@@ -67,22 +67,14 @@ const testCases = [
   }
 ]
 
-// a bit of devex to show the version we're actually testing
-// so we don't need to know ahead of time
-function getLatestVersion (range) {
-  const command = `npm show typescript@${range} version`
-  const output = execSync(command, { encoding: 'utf-8' }).trim()
-  const versions = output.split('\n').map(line => line.split(' ')[1].replace(/'/g, ''))
-  return versions[versions.length - 1]
-}
-
 describe('typescript', () => {
   let agent
   let proc
   let sandbox
 
   for (const version of testVersions) {
-    context(`with version ${getLatestVersion(version)}`, () => {
+    // TODO: Figure out the real version without using `npm show` as it's broken.
+    context(`with version ${version}`, () => {
       before(async function () {
         this.timeout(20000)
         sandbox = await createSandbox(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Install plugin modules without `npm view`.

### Motivation
<!-- What inspired you to submit this pull request? -->

For some reason, `npm view` has been extremely unreliable since yesterday. This PR attempts to get rid of it.