### PR TITLE
[DI] Ensure probes without a 'sampling' property is parsed correctly

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -23,10 +23,10 @@ async function addBreakpoint (probe) {
   delete probe.where
 
   // Optimize for fast calculations when probe is hit
-  const snapshotsPerSecond = probe.sampling.snapshotsPerSecond ?? (probe.captureSnapshot
+  const snapshotsPerSecond = probe.sampling?.snapshotsPerSecond ?? (probe.captureSnapshot
     ? MAX_SNAPSHOTS_PER_SECOND_PER_PROBE
     : MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE)
-  probe.sampling.nsBetweenSampling = BigInt(1 / snapshotsPerSecond * 1e9)
+  probe.nsBetweenSampling = BigInt(1 / snapshotsPerSecond * 1e9)
   probe.lastCaptureNs = 0n
 
   // TODO: Inbetween `await session.post('Debugger.enable')` and here, the scripts are parsed and cached.

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -42,7 +42,7 @@ session.on('Debugger.paused', async ({ params }) => {
     const id = params.hitBreakpoints[i]
     const probe = breakpoints.get(id)
 
-    if (start - probe.lastCaptureNs < probe.sampling.nsBetweenSampling) {
+    if (start - probe.lastCaptureNs < probe.nsBetweenSampling) {
       continue
     }
 


### PR DESCRIPTION
### What does this PR do?

Ensure a missing `probe.sampling` property doesn't crash the DI worker thread.

### Motivation

Even though, the `probe.sampling` property is currently always present, it might not always be. So better prepare for the eventuality that it's not. Otherwise, an exception would have been thrown.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


