### PR TITLE
Use literals for creating BigInts when possible

### DIFF
--- a/packages/dd-trace/src/datastreams/fnv.js
+++ b/packages/dd-trace/src/datastreams/fnv.js
@@ -15,7 +15,7 @@ function fnv64 (data) {
     data = Buffer.from(data, 'utf-8')
   }
   const byteArray = new Uint8Array(data)
-  return fnv(byteArray, FNV1_64_INIT, FNV_64_PRIME, BigInt(2) ** BigInt(64))
+  return fnv(byteArray, FNV1_64_INIT, FNV_64_PRIME, 2n ** 64n)
 }
 
 module.exports = {

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -25,8 +25,8 @@ const expression = `
 const threadId = parentThreadId === 0 ? `pid:${process.pid}` : `pid:${process.pid};tid:${parentThreadId}`
 const threadName = parentThreadId === 0 ? 'MainThread' : `WorkerThread:${parentThreadId}`
 
-const oneSecondNs = BigInt(1_000_000_000)
-let globalSnapshotSamplingRateWindowStart = BigInt(0)
+const oneSecondNs = 1_000_000_000n
+let globalSnapshotSamplingRateWindowStart = 0n
 let snapshotsSampledWithinTheLastSecond = 0
 
 // WARNING: The code above the line `await session.post('Debugger.resume')` is highly optimized. Please edit with care!

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -119,7 +119,7 @@ describe('span processor', () => {
     it('removes problematic fields from the metadata', () => {
       // problematic fields are circular references or bigints
       const metadata = {
-        bigint: BigInt(1),
+        bigint: 1n,
         deep: {
           foo: 'bar'
         },


### PR DESCRIPTION
### What does this PR do?

Change `BigInt(42)` to `42n`

### Motivation

https://github.com/DataDog/dd-trace-js/pull/5081#discussion_r1910546396

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


