### PR TITLE
Increase Sirun benchmark SPLITS from 3 to 4

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -65,20 +65,26 @@ benchmark:
         GROUP: 2
       - MAJOR_VERSION: 18
         GROUP: 3
+      - MAJOR_VERSION: 18
+        GROUP: 4
       - MAJOR_VERSION: 20
         GROUP: 1
       - MAJOR_VERSION: 20
         GROUP: 2
       - MAJOR_VERSION: 20
         GROUP: 3
+      - MAJOR_VERSION: 20
+        GROUP: 4
       - MAJOR_VERSION: 22
         GROUP: 1
       - MAJOR_VERSION: 22
         GROUP: 2
       - MAJOR_VERSION: 22
         GROUP: 3
+      - MAJOR_VERSION: 22
+        GROUP: 4
   variables:
-    SPLITS: 3
+    SPLITS: 4
 
 benchmark-serverless:
   stage: benchmarks

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -4,10 +4,11 @@ set -e # Exit on error, so errors don't go unnoticed
 set -x # Print commands and their arguments as they are executed (easier debugging in case of error)
 
 DIRS=($(ls -d */ | sed 's:/$::')) # Array of subdirectories
+CWD=$(pwd)
 
 function cleanup {
   for D in "${DIRS[@]}"; do
-    rm -f "${D}/meta-temp.json"
+    rm -f "${CWD}/${D}/meta-temp.json"
   done
 }
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 
+set -e # Exit on error, so errors don't go unnoticed
+set -x # Print commands and their arguments as they are executed (easier debugging in case of error)
+
 # Temporary until merged to master
 wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-musl.tar.gz \
 	&& tar -xzf sirun.tar.gz \
 	&& rm sirun.tar.gz \
 	&& mv sirun /usr/bin/sirun
 
+set +x
 if test -f ~/.nvm/nvm.sh; then
   source ~/.nvm/nvm.sh
 else
   source /usr/local/nvm/nvm.sh
 fi
+set -x
 
 nvm use 18
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -87,7 +87,7 @@ wait # waits until all tests are complete before continuing
 # TODO: cleanup even when something fails
 for D in *; do
   if [ -d "${D}" ]; then
-    unlink "${D}/meta-temp.json" 2>/dev/null
+    rm -f "${D}/meta-temp.json"
   fi
 done
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -3,6 +3,16 @@
 set -e # Exit on error, so errors don't go unnoticed
 set -x # Print commands and their arguments as they are executed (easier debugging in case of error)
 
+function cleanup {
+  for D in *; do
+    if [ -d "${D}" ]; then
+      rm -f "${D}/meta-temp.json"
+    fi
+  done
+}
+
+trap cleanup EXIT
+
 # Temporary until merged to master
 wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-musl.tar.gz \
 	&& tar -xzf sirun.tar.gz \
@@ -83,13 +93,6 @@ for D in *; do
 done
 
 wait # waits until all tests are complete before continuing
-
-# TODO: cleanup even when something fails
-for D in *; do
-  if [ -d "${D}" ]; then
-    rm -f "${D}/meta-temp.json"
-  fi
-done
 
 node ./strip-unwanted-results.js
 

--- a/benchmark/sirun/strip-unwanted-results.js
+++ b/benchmark/sirun/strip-unwanted-results.js
@@ -17,6 +17,11 @@ const lines = fs
   .trim()
   .split('\n')
 
+if (lines.length === 1 && lines[0] === '') {
+  console.log('The file "results.ndjson" is empty! Aborting...')
+  process.exit(1)
+}
+
 const results = []
 
 for (const line of lines) {


### PR DESCRIPTION
### What does this PR do?

Increase the `SPLITS` variable used for running Sirun benchmarks from `3` to `4` to ensure there's room to run all out benchmarks.

### Motivation

After merging https://github.com/DataDog/dd-trace-js/pull/5004 that adds one more benchmark, it was discovered that one of the other benchmarks stopped running. Hopefully this fixes it.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


