### PR TITLE
Improve benchmarks runner to abort if not enough CPU cores

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -46,6 +46,12 @@ done
 BENCH_COUNT=$(($BENCH_COUNT+$BENCH_COUNT%$SPLITS))
 GROUP_SIZE=$(($BENCH_COUNT/$SPLITS))
 
+if [ ${GROUP_SIZE} -gt ${CPU_AFFINITY} ]; then
+  echo "Not enough CPU cores available to run benchmarks, aborting..."
+  echo "Consider increasing the number of groups/splits or decreasing the number of benchmarks."
+  exit 1
+fi
+
 run_all_variants () {
   local variants="$(node ../get-variants.js)"
 


### PR DESCRIPTION
### What does this PR do?

Aborts running benchmarks in CI if there's not enough CPU cores available for the current amount of groups/splits.

### Motivation

After merging https://github.com/DataDog/dd-trace-js/pull/5004 that adds one more benchmark, it was discovered that one of the other benchmarks stopped running. The changes included in this PR would have caught that.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


