### PR TITLE
Mark crashes that happen during collecting profiles as `profiler_serializing:1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@datadog/libdatadog": "^0.3.0",
+    "@datadog/libdatadog": "^0.4.0",
     "@datadog/native-appsec": "8.4.0",
     "@datadog/native-iast-rewriter": "2.6.1",
     "@datadog/native-iast-taint-tracking": "3.2.0",

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -40,6 +40,15 @@ class Crashtracker {
     }
   }
 
+  withProfilerSerializing (f) {
+    binding.beginProfilerSerializing()
+    try {
+      return f()
+    } finally {
+      binding.endProfilerSerializing()
+    }
+  }
+
   // TODO: Send only configured values when defaults are fixed.
   _getConfig (config) {
     const { hostname = '127.0.0.1', port = 8126 } = config

--- a/packages/dd-trace/src/crashtracking/noop.js
+++ b/packages/dd-trace/src/crashtracking/noop.js
@@ -3,6 +3,9 @@
 class NoopCrashtracker {
   configure () {}
   start () {}
+  withProfilerSerializing (f) {
+    return f()
+  }
 }
 
 module.exports = new NoopCrashtracker()


### PR DESCRIPTION
### What does this PR do?
libdatadog has several OpTypes for annotating crashes with information on what the profiler was doing at the time. ProfilerSerializing is relevant to most crashes we observe with Node.js – setting it would add “profiler_serializing:1” tag to the crashes.

### Motivation
It will make it easier to filter profiling-related crashes.

### Additional Notes

Requires release of https://github.com/DataDog/libdatadog-nodejs/pull/45 first.
JIRA: [PROF-11108]

[PROF-11108]: https://datadoghq.atlassian.net/browse/PROF-11108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ