### PR TITLE
[DI] Reduce time it takes to run benchmarks

### DIFF
--- a/benchmark/sirun/debugger/app.js
+++ b/benchmark/sirun/debugger/app.js
@@ -14,7 +14,7 @@ setTimeout(doSomeWork, 250)
 function doSomeWork (arg1 = 1, arg2 = 2) {
   const data = getSomeData()
   data.n = n
-  if (++n <= 500) {
+  if (++n <= 250) {
     setTimeout(doSomeWork, 1)
   }
 }


### PR DESCRIPTION
### What does this PR do?

Reduce the number of iterations the Dynamic Instrumentation benchmarks run from `500` to `250`.

### Motivation

The `line-probe-with-snapshot-default` benchmark took 6 minutes to run, which could make it flaky (because of timeout). Reducing it to 3 minutes should get us well below the threshold.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


