### PR TITLE
[bench] Don't force Node.js 18 for npm/yarn install

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -14,9 +14,6 @@ else
   source /usr/local/nvm/nvm.sh
 fi
 
-nvm use 18
-
-# using Node.js v18 for the global yarn package
 (
   cd ../../ &&
   npm install --global yarn \


### PR DESCRIPTION
### What does this PR do?

Remove forced usage of Node.js 18 when running `npm install`/`yarn install` and `yarn services`.

### Motivation

I think this is no longer needed. It was proably added at a point when Node.js 18 was the newest version and where we required that version at a minimum. Now Node.js 18 is the oldest version we support, so it shouldn't be nessecary.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


