### PR TITLE
[bench] detect number of CPU cores dynamically

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -27,13 +27,14 @@ nvm use 18
 # run each test in parallel for a given version of Node.js
 # once all of the tests have complete move on to the next version
 
-export CPU_AFFINITY="${CPU_START_ID:-24}" # Benchmarking Platform convention
+TOTAL_CPU_CORES=$(nproc:-24)
+export CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # Benchmarking Platform convention
 
 nvm use $MAJOR_VERSION # provided by each benchmark stage
 export VERSION=`nvm current`
 export ENABLE_AFFINITY=true
 echo "using Node.js ${VERSION}"
-CPU_AFFINITY="${CPU_START_ID:-24}" # reset for each node.js version
+CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # reset for each node.js version
 SPLITS=${SPLITS:-1}
 GROUP=${GROUP:-1}
 
@@ -54,7 +55,7 @@ BENCH_END=$(($GROUP_SIZE*$GROUP))
 BENCH_START=$(($BENCH_END-$GROUP_SIZE))
 
 if [[ ${GROUP_SIZE} -gt 24 ]]; then
-  echo "Group size ${GROUP_SIZE} is larger than available number of CPU cores on Benchmarking Platform machines (24 cores)"
+  echo "Group size ${GROUP_SIZE} is larger than available number of CPU cores on Benchmarking Platform machines (${TOTAL_CPU_CORES} cores)"
   exit 1
 fi
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -27,7 +27,7 @@ nvm use 18
 # run each test in parallel for a given version of Node.js
 # once all of the tests have complete move on to the next version
 
-TOTAL_CPU_CORES=$(nproc:-24)
+TOTAL_CPU_CORES=$(nproc 2>/dev/null || echo "24")
 export CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # Benchmarking Platform convention
 
 nvm use $MAJOR_VERSION # provided by each benchmark stage


### PR DESCRIPTION
### What does this PR do?

The benchmark script needs to know how many CPU cores are available on the system running the benchmarks. This PR changes the script to use `nproc` to detect the number of CPU cores instead of hardcoding it to 24.

### Motivation

Makes the script more dynamic in case this number changes in the future or the script otherwise is being run in a different environment (e.g. a developer machine).

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


