### PR TITLE
[bench] minor code-cleanup in the benchmarking script

### DIFF
--- a/benchmark/sirun/run-all-variants.js
+++ b/benchmark/sirun/run-all-variants.js
@@ -4,7 +4,7 @@
 
 const fs = require('fs')
 const path = require('path')
-const { exec, getStdio } = require('./run-util')
+const { exec, stdio } = require('./run-util')
 
 process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
 
@@ -18,10 +18,10 @@ const env = Object.assign({}, process.env, { DD_TRACE_STARTUP_LOGS: 'false' })
     const variants = metaJson.variants
     for (const variant in variants) {
       const variantEnv = Object.assign({}, env, { SIRUN_VARIANT: variant })
-      await exec('sirun', ['meta-temp.json'], { env: variantEnv, stdio: getStdio() })
+      await exec('sirun', ['meta-temp.json'], { env: variantEnv, stdio })
     }
   } else {
-    await exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })
+    await exec('sirun', ['meta-temp.json'], { env, stdio })
   }
 
   try {

--- a/benchmark/sirun/run-one-variant.js
+++ b/benchmark/sirun/run-one-variant.js
@@ -2,10 +2,10 @@
 
 'use strict'
 
-const { exec, getStdio } = require('./run-util')
+const { exec, stdio } = require('./run-util')
 
 process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
 
 const env = Object.assign({}, process.env, { DD_TRACE_STARTUP_LOGS: 'false' })
 
-exec('sirun', ['meta-temp.json'], { env, stdio: getStdio() })
+exec('sirun', ['meta-temp.json'], { env, stdio })

--- a/benchmark/sirun/run-util.js
+++ b/benchmark/sirun/run-util.js
@@ -18,10 +18,6 @@ function exec (...args) {
   })
 }
 
-function getStdio () {
-  return ['inherit', 'pipe', 'inherit']
-}
-
 function streamAddVersion (input) {
   input.rl = readline.createInterface({ input })
   input.rl.on('line', function (line) {
@@ -39,6 +35,6 @@ function streamAddVersion (input) {
 
 module.exports = {
   exec,
-  getStdio,
+  stdio: ['inherit', 'pipe', 'inherit'],
   streamAddVersion
 }


### PR DESCRIPTION
### What does this PR do?

Don't wrap static data behind a function call when we can just expose the static data directly.

### Motivation

Just make the code simpler.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


