### PR TITLE
[bench] clean up temp files even in case of error

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+function cleanup {
+  for D in *; do
+    if [ -d "${D}" ]; then
+      rm -f "${D}/meta-temp.json"
+    fi
+  done
+}
+
+trap cleanup EXIT
+
 # Temporary until merged to master
 wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-musl.tar.gz \
 	&& tar -xzf sirun.tar.gz \
@@ -84,13 +94,6 @@ for D in *; do
 done
 
 wait # waits until all tests are complete before continuing
-
-# TODO: cleanup even when something fails
-for D in *; do
-  if [ -d "${D}" ]; then
-    rm -f "${D}/meta-temp.json"
-  fi
-done
 
 node ./strip-unwanted-results.js
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -2,11 +2,11 @@
 
 set -e
 
+DIRS=($(ls -d */ | sed 's:/$::')) # Array of subdirectories
+
 function cleanup {
-  for D in *; do
-    if [ -d "${D}" ]; then
-      rm -f "${D}/meta-temp.json"
-    fi
+  for D in "${DIRS[@]}"; do
+    rm -f "${D}/meta-temp.json"
   done
 }
 
@@ -49,13 +49,11 @@ SPLITS=${SPLITS:-1}
 GROUP=${GROUP:-1}
 
 BENCH_COUNT=0
-for D in *; do
-  if [ -d "${D}" ]; then
-    cd "${D}"
-    variants="$(node ../get-variants.js)"
-    for V in $variants; do BENCH_COUNT=$(($BENCH_COUNT+1)); done
-    cd ..
-  fi
+for D in "${DIRS[@]}"; do
+  cd "${D}"
+  variants="$(node ../get-variants.js)"
+  for V in $variants; do BENCH_COUNT=$(($BENCH_COUNT+1)); done
+  cd ..
 done
 
 GROUP_SIZE=$(($(($BENCH_COUNT+$SPLITS-1))/$SPLITS)) # round up
@@ -69,28 +67,26 @@ if [[ ${GROUP_SIZE} -gt 24 ]]; then
   exit 1
 fi
 
-for D in *; do
-  if [ -d "${D}" ]; then
-    cd "${D}"
-    variants="$(node ../get-variants.js)"
+for D in "${DIRS[@]}"; do
+  cd "${D}"
+  variants="$(node ../get-variants.js)"
 
-    node ../squash-affinity.js
+  node ../squash-affinity.js
 
-    for V in $variants; do
-      if [[ ${BENCH_INDEX} -ge ${BENCH_START} && ${BENCH_INDEX} -lt ${BENCH_END} ]]; then
-        echo "running $((BENCH_INDEX+1)) out of ${BENCH_COUNT}, ${D}/${V} in background, pinned to core ${CPU_AFFINITY}..."
+  for V in $variants; do
+    if [[ ${BENCH_INDEX} -ge ${BENCH_START} && ${BENCH_INDEX} -lt ${BENCH_END} ]]; then
+      echo "running $((BENCH_INDEX+1)) out of ${BENCH_COUNT}, ${D}/${V} in background, pinned to core ${CPU_AFFINITY}..."
 
-        export SIRUN_VARIANT=$V
+      export SIRUN_VARIANT=$V
 
-        (time node ../run-one-variant.js >> ../results.ndjson && echo "${D}/${V} finished.") &
-        ((CPU_AFFINITY=CPU_AFFINITY+1))
-      fi
+      (time node ../run-one-variant.js >> ../results.ndjson && echo "${D}/${V} finished.") &
+      ((CPU_AFFINITY=CPU_AFFINITY+1))
+    fi
 
-      BENCH_INDEX=$(($BENCH_INDEX+1))
-    done
+    BENCH_INDEX=$(($BENCH_INDEX+1))
+  done
 
-    cd ..
-  fi
+  cd ..
 done
 
 wait # waits until all tests are complete before continuing

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -3,10 +3,11 @@
 set -e
 
 DIRS=($(ls -d */ | sed 's:/$::')) # Array of subdirectories
+CWD=$(pwd)
 
 function cleanup {
   for D in "${DIRS[@]}"; do
-    rm -f "${D}/meta-temp.json"
+    rm -f "${CWD}/${D}/meta-temp.json"
   done
 }
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -88,7 +88,7 @@ wait # waits until all tests are complete before continuing
 # TODO: cleanup even when something fails
 for D in *; do
   if [ -d "${D}" ]; then
-    unlink "${D}/meta-temp.json" 2>/dev/null
+    rm -f "${D}/meta-temp.json"
   fi
 done
 


### PR DESCRIPTION
### What does this PR do?

Ensure the clean up of temp files are performed as expected even if an error occurs during script execution.

Also use `rm -f` instead of `unlink` to remove the need to surpress errors with a redirect.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

Tip: Ignore whitespace when reviewing for a better experience.

