### PR TITLE
[bench] exit if results.ndjson is empty

### DIFF
--- a/benchmark/sirun/strip-unwanted-results.js
+++ b/benchmark/sirun/strip-unwanted-results.js
@@ -17,6 +17,11 @@ const lines = fs
   .trim()
   .split('\n')
 
+if (lines.length === 1 && lines[0] === '') {
+  console.log('The file "results.ndjson" is empty! Aborting...')
+  process.exit(1)
+}
+
 const results = []
 
 for (const line of lines) {

--- a/benchmark/sirun/strip-unwanted-results.js
+++ b/benchmark/sirun/strip-unwanted-results.js
@@ -18,7 +18,7 @@ const lines = fs
   .split('\n')
 
 if (lines.length === 1 && lines[0] === '') {
-  console.log('The file "results.ndjson" is empty! Aborting...')
+  console.log('The file "results.ndjson" is empty! Aborting...') // eslint-disable-line no-console
   process.exit(1)
 }
 


### PR DESCRIPTION
### What does this PR do?

Log a nicer error message in case a benchmark didn't produce any output.

### Motivation

Previously it would be difficult to debug as running these scripts isn't normally possible on dev laptops.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


