### PR TITLE
fix startup benchmark

### DIFF
--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -7,11 +7,15 @@ if (Number(process.env.USE_TRACER)) {
 if (Number(process.env.EVERYTHING)) {
   const json = require('../../../package.json')
   for (const pkg in json.dependencies) {
-    require(pkg)
+    try {
+      require(pkg)
+    } catch {}
   }
   for (const devPkg in json.devDependencies) {
     if (devPkg !== '@types/node') {
-      require(devPkg)
+      try {
+        require(devPkg)
+      } catch {}
     }
   }
 }


### PR DESCRIPTION
Some dependencies don't work correctly with `require` anymore.



