### PR TITLE
[test optimization] Fix vitest latest release

### DIFF
--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -35,7 +35,7 @@ const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/
 
 const NUM_RETRIES_EFD = 3
 
-const versions = ['2.1.8'] // was previously 'latest', but v3 breaks this test
+const versions = ['1.6.0', 'latest']
 
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -179,7 +179,9 @@ function getSortWrapper (sort) {
       const knownTestsResponse = await getChannelPromise(knownTestsCh)
       if (!knownTestsResponse.err) {
         knownTests = knownTestsResponse.knownTests
-        const testFilepaths = await this.ctx.getTestFilepaths()
+        const getFilePaths = this.ctx.getTestFilepaths || this.ctx._globTestFilepaths
+
+        const testFilepaths = await getFilePaths.call(this.ctx)
 
         isEarlyFlakeDetectionFaultyCh.publish({
           knownTests: knownTests.vitest || {},

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -494,15 +494,6 @@ addHook({
 
 addHook({
   name: 'vitest',
-  versions: ['>=2.1.0'],
-  filePattern: 'dist/chunks/RandomSequencer.*'
-}, (randomSequencerPackage) => {
-  shimmer.wrap(randomSequencerPackage.B.prototype, 'sort', getSortWrapper)
-  return randomSequencerPackage
-})
-
-addHook({
-  name: 'vitest',
   versions: ['>=2.0.5 <2.1.0'],
   filePattern: 'dist/chunks/index.*'
 }, (vitestPackage) => {
@@ -511,6 +502,24 @@ addHook({
   }
 
   return vitestPackage
+})
+
+addHook({
+  name: 'vitest',
+  versions: ['>=2.1.0 <3.0.0'],
+  filePattern: 'dist/chunks/RandomSequencer.*'
+}, (randomSequencerPackage) => {
+  shimmer.wrap(randomSequencerPackage.B.prototype, 'sort', getSortWrapper)
+  return randomSequencerPackage
+})
+
+addHook({
+  name: 'vitest',
+  versions: ['>=3.0.0'],
+  filePattern: 'dist/chunks/resolveConfig.*'
+}, (randomSequencerPackage) => {
+  shimmer.wrap(randomSequencerPackage.B.prototype, 'sort', getSortWrapper)
+  return randomSequencerPackage
 })
 
 // Can't specify file because compiled vitest includes hashes in their files
@@ -533,15 +542,17 @@ addHook({
   versions: ['>=1.6.0'],
   file: 'dist/index.js'
 }, (vitestPackage, frameworkVersion) => {
-  shimmer.wrap(vitestPackage, 'startTests', startTests => async function (testPath) {
+  shimmer.wrap(vitestPackage, 'startTests', startTests => async function (testPaths) {
     let testSuiteError = null
     if (!testSuiteStartCh.hasSubscribers) {
       return startTests.apply(this, arguments)
     }
+    // From >=3.0.1, the first arguments changes from a string to an object containing the filepath
+    const testSuiteAbsolutePath = testPaths[0]?.filepath || testPaths[0]
 
     const testSuiteAsyncResource = new AsyncResource('bound-anonymous-fn')
     testSuiteAsyncResource.runInAsyncScope(() => {
-      testSuiteStartCh.publish({ testSuiteAbsolutePath: testPath[0], frameworkVersion })
+      testSuiteStartCh.publish({ testSuiteAbsolutePath, frameworkVersion })
     })
     const startTestsResponse = await startTests.apply(this, arguments)
 

--- a/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
@@ -13,7 +13,7 @@ class TestApiManualPlugin extends CiPlugin {
 
   constructor (...args) {
     super(...args)
-    this._isConfigured = false
+    this._isEnvDataCalcualted = false
     this.sourceRoot = process.cwd()
 
     this.unconfiguredAddSub('dd-trace:ci:manual:test:start', ({ testName, testSuite }) => {
@@ -43,19 +43,20 @@ class TestApiManualPlugin extends CiPlugin {
     })
   }
 
-  // To lazily configure to avoid unnecessary setup time.
+  // To lazily calculate env data.
   unconfiguredAddSub (channelName, handler) {
     this.addSub(channelName, (...args) => {
-      if (!this._isConfigured) {
-        this._isConfigured = true
-        this.configure(this._config)
+      if (!this._isEnvDataCalcualted) {
+        this._isEnvDataCalcualted = true
+        this.configure(this._config, true)
       }
       return handler(...args)
     })
   }
 
-  setConfig (config) {
+  configure (config, shouldGetEnvironmentData) {
     this._config = config
+    super.configure(config, shouldGetEnvironmentData)
   }
 }
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -184,12 +184,16 @@ module.exports = class CiPlugin extends Plugin {
     }
   }
 
-  configure (config) {
+  configure (config, shouldGetEnvironmentData = true) {
     super.configure(config)
 
-    if (config.isTestDynamicInstrumentationEnabled) {
+    if (config.isTestDynamicInstrumentationEnabled && !this.di) {
       const testVisibilityDynamicInstrumentation = require('../ci-visibility/dynamic-instrumentation')
       this.di = testVisibilityDynamicInstrumentation
+    }
+
+    if (!shouldGetEnvironmentData) {
+      return
     }
 
     this.testEnvironmentMetadata = getTestEnvironmentMetadata(this.constructor.id, this.config)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -166,7 +166,10 @@ class Tracer extends NoopProxy {
         if (config.isManualApiEnabled) {
           const TestApiManualPlugin = require('./ci-visibility/test-api-manual/test-api-manual-plugin')
           this._testApiManualPlugin = new TestApiManualPlugin(this)
-          this._testApiManualPlugin.configure({ ...config, enabled: true })
+          // `shouldGetEnvironmentData` is passed as false so that we only lazily calculate it
+          // This is the only place where we need to do this because the rest of the plugins
+          // are lazily configured when the library is imported.
+          this._testApiManualPlugin.configure({ ...config, enabled: true }, false)
         }
       }
       if (config.ciVisAgentlessLogSubmissionEnabled) {


### PR DESCRIPTION
### What does this PR do?
* Add new hooks for new version of vitest.
* Lazily load env data calculation for the manual API plugin

### Motivation
* Fix instrumentation for latest vitest release: https://github.com/vitest-dev/vitest/releases/tag/v3.0.2
* Speed up setup of manual API (so the calculation of env data is lazy)

### Plugin Checklist
No need to add new extra tests. Just check that the ones we had work.