### PR TITLE
Do not init the tracer by default in Worker threads

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -2,6 +2,7 @@
 const tracer = require('../packages/dd-trace')
 const { isTrue } = require('../packages/dd-trace/src/util')
 const log = require('../packages/dd-trace/src/log')
+const { isMainThread } = require('worker_threads')
 
 const isJestWorker = !!process.env.JEST_WORKER_ID
 const isCucumberWorker = !!process.env.CUCUMBER_WORKER_ID
@@ -65,6 +66,10 @@ if (isMochaWorker) {
   options.experimental = {
     exporter: 'mocha_worker'
   }
+}
+
+if (!isMainThread) {
+  shouldInit = false
 }
 
 if (shouldInit) {

--- a/packages/dd-trace/src/guardrails/index.js
+++ b/packages/dd-trace/src/guardrails/index.js
@@ -53,6 +53,18 @@ function guard (fn) {
     }
   }
 
+  // If is a worker do not init
+  if (!clobberBailout) {
+    try {
+      var workerThreads = require('worker_threads')
+      if (!workerThreads.isMainThread) {
+        clobberBailout = true
+      }
+    } catch (e) {
+      // ignore, in theory it cannot happen
+    }
+  }
+
   if (!clobberBailout && (!initBailout || forced)) {
     var result = fn()
     telemetry('complete', ['injection_forced:' + (forced && initBailout ? 'true' : 'false')])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Prevent the tracer init in Worker threads by default. 

### Motivation
<!-- What inspired you to submit this pull request? -->
- Can cause unexpected and untested behaviours: Two tracers with the same service name but different ids
-  In `initialize.mjs` we are initializing the tracer only in the main thread: https://github.com/DataDog/dd-trace-js/blob/master/initialize.mjs#L52

### Additional Notes
<!-- Anything else we should know when reviewing? -->


