### PR TITLE
fix(llmobs): use `config.url` for agent proxy

### DIFF
--- a/packages/dd-trace/src/llmobs/writers/spans/agentProxy.js
+++ b/packages/dd-trace/src/llmobs/writers/spans/agentProxy.js
@@ -10,10 +10,10 @@ const LLMObsBaseSpanWriter = require('./base')
 class LLMObsAgentProxySpanWriter extends LLMObsBaseSpanWriter {
   constructor (config) {
     super({
-      intake: config.hostname || 'localhost',
-      protocol: 'http:',
+      intake: config.url?.hostname || config.hostname || 'localhost',
+      protocol: config.url?.protocol || 'http:',
       endpoint: EVP_PROXY_AGENT_ENDPOINT,
-      port: config.port
+      port: config.url?.port || config.port
     })
 
     this._headers[EVP_SUBDOMAIN_HEADER_NAME] = EVP_SUBDOMAIN_HEADER_VALUE

--- a/packages/dd-trace/test/llmobs/writers/spans/agentProxy.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/spans/agentProxy.spec.js
@@ -25,4 +25,12 @@ describe('LLMObsAgentProxySpanWriter', () => {
 
     expect(writer._url.href).to.equal('http://localhost:8126/evp_proxy/v2/api/v2/llmobs')
   })
+
+  it('uses the url property if provided on the config', () => {
+    writer = new LLMObsAgentProxySpanWriter({
+      url: new URL('http://test-agent:12345')
+    })
+
+    expect(writer._url.href).to.equal('http://test-agent:12345/evp_proxy/v2/api/v2/llmobs')
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Lets the agent proxy writer use `config.url` (set from `DD_TRACE_AGENT_URL`) if provided.

### Motivation
No reported issues yet. I noticed this when working on some shared testing. This change needs to be released in order for those tests to run.