### PR TITLE
[DI] Add more debug logs related to queuing and flushing payloads

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -62,6 +62,8 @@ function send (message, logger, dd, snapshot, cb) {
 }
 
 function onFlush (payload) {
+  log.debug('[debugger:devtools_client] Flushing probe payload buffer')
+
   const opts = {
     method: 'POST',
     url: config.url,

--- a/packages/dd-trace/src/debugger/devtools_client/status.js
+++ b/packages/dd-trace/src/debugger/devtools_client/status.js
@@ -37,6 +37,8 @@ const STATUSES = {
 }
 
 function ackReceived ({ id: probeId, version }) {
+  log.debug('[debugger:devtools_client] Queueing RECEIVED status for probe %s (version: %d)', probeId, version)
+
   onlyUniqueUpdates(
     STATUSES.RECEIVED, probeId, version,
     () => send(statusPayload(probeId, version, STATUSES.RECEIVED))
@@ -44,6 +46,8 @@ function ackReceived ({ id: probeId, version }) {
 }
 
 function ackInstalled ({ id: probeId, version }) {
+  log.debug('[debugger:devtools_client] Queueing INSTALLED status for probe %s (version: %d)', probeId, version)
+
   onlyUniqueUpdates(
     STATUSES.INSTALLED, probeId, version,
     () => send(statusPayload(probeId, version, STATUSES.INSTALLED))
@@ -51,6 +55,8 @@ function ackInstalled ({ id: probeId, version }) {
 }
 
 function ackEmitting ({ id: probeId, version }) {
+  log.debug('[debugger:devtools_client] Queueing EMITTING status for probe %s (version: %d)', probeId, version)
+
   onlyUniqueUpdates(
     STATUSES.EMITTING, probeId, version,
     () => send(statusPayload(probeId, version, STATUSES.EMITTING))
@@ -78,6 +84,8 @@ function send (payload) {
 }
 
 function onFlush (payload) {
+  log.debug('[debugger:devtools_client] Flushing diagnostics payload buffer')
+
   const form = new FormData()
 
   form.append(


### PR DESCRIPTION
### What does this PR do?

What the PR title says...

### Motivation

Makes debugging easier. Most recently we're investigating an issue where these logs could help: https://github.com/DataDog/system-tests/pull/3823

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


