### PR TITLE
[DI] Ensure probe EMITTING status is sent correctly

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -146,10 +146,9 @@ session.on('Debugger.paused', async ({ params }) => {
       }
     }
 
+    ackEmitting(probe)
     // TODO: Process template (DEBUG-2628)
-    send(probe.template, logger, dd, snapshot, () => {
-      ackEmitting(probe)
-    })
+    send(probe.template, logger, dd, snapshot)
   }
 })
 

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -29,10 +29,9 @@ const ddtags = [
 
 const path = `/debugger/v1/input?${stringify({ ddtags })}`
 
-let callbacks = []
 const jsonBuffer = new JSONBuffer({ size: config.maxTotalPayloadSize, timeout: 1000, onFlush })
 
-function send (message, logger, dd, snapshot, cb) {
+function send (message, logger, dd, snapshot) {
   const payload = {
     ddsource,
     hostname,
@@ -58,7 +57,6 @@ function send (message, logger, dd, snapshot, cb) {
   }
 
   jsonBuffer.write(json, size)
-  callbacks.push(cb)
 }
 
 function onFlush (payload) {
@@ -69,11 +67,7 @@ function onFlush (payload) {
     headers: { 'Content-Type': 'application/json; charset=utf-8' }
   }
 
-  const _callbacks = callbacks
-  callbacks = []
-
   request(payload, opts, (err) => {
     if (err) log.error('[debugger:devtools_client] Error sending probe payload', err)
-    else _callbacks.forEach(cb => cb())
   })
 }

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -54,13 +54,9 @@ describe('input message http requests', function () {
   })
 
   it('should call request with the expected payload once the buffer is flushed', function (done) {
-    const callback1 = sinon.spy()
-    const callback2 = sinon.spy()
-    const callback3 = sinon.spy()
-
-    send({ message: 1 }, logger, dd, snapshot, callback1)
-    send({ message: 2 }, logger, dd, snapshot, callback2)
-    send({ message: 3 }, logger, dd, snapshot, callback3)
+    send({ message: 1 }, logger, dd, snapshot)
+    send({ message: 2 }, logger, dd, snapshot)
+    send({ message: 3 }, logger, dd, snapshot)
     expect(request).to.not.have.been.called
 
     expectWithin(1200, () => {
@@ -82,16 +78,6 @@ describe('input message http requests', function () {
           `git.commit.sha%3A${commitSHA}%2C` +
           `git.repository_url%3A${repositoryUrl}`
       )
-
-      expect(callback1).to.not.have.been.calledOnce
-      expect(callback2).to.not.have.been.calledOnce
-      expect(callback3).to.not.have.been.calledOnce
-
-      request.firstCall.callback()
-
-      expect(callback1).to.have.been.calledOnce
-      expect(callback2).to.have.been.calledOnce
-      expect(callback3).to.have.been.calledOnce
 
       done()
     })


### PR DESCRIPTION
### What does this PR do?

Queue the probe `EMITTING` status before trying to queue the probe payload.

### Motivation

Before, the `EMITTING` status was only emitted if the probe payload was successfully received by the agnet. If the agent didn't return a HTTP 2xx status code, the `EMITTING` status would never be sent.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


