### PR TITLE
[test optimization] [SDTEST-1272] Detect new tests regardless of Early Flake Detection

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -884,7 +884,7 @@ versions.forEach(version => {
                 )
                 assert.equal(retriedTests.length, NUM_RETRIES_EFD)
                 retriedTests.forEach(test => {
-                  test.meta[TEST_RETRY_REASON] = 'efd'
+                  assert.propertyVal(test.meta, TEST_RETRY_REASON, 'efd')
                 })
                 // Test name does not change
                 newTests.forEach(test => {
@@ -1187,12 +1187,9 @@ versions.forEach(version => {
                 // no new tests detected
                 const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
                 assert.equal(newTests.length, 0)
+                // no retries
                 const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
                 assert.equal(retriedTests.length, 0)
-                // Test name does not change
-                newTests.forEach(test => {
-                  assert.equal(test.meta[TEST_NAME], 'Say whatever')
-                })
               })
 
             childProcess = exec(

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -30,6 +30,7 @@ const {
   TEST_NAME,
   JEST_DISPLAY_NAME,
   TEST_EARLY_FLAKE_ABORT_REASON,
+  TEST_RETRY_REASON,
   TEST_SOURCE_START,
   TEST_CODE_OWNERS,
   TEST_SESSION_NAME,
@@ -1609,16 +1610,14 @@ describe('jest CommonJS', () => {
       })
       const NUM_RETRIES_EFD = 3
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
@@ -1652,6 +1651,9 @@ describe('jest CommonJS', () => {
             retriedTests.length
           )
           assert.equal(retriedTests.length, NUM_RETRIES_EFD)
+          retriedTests.forEach(test => {
+            assert.propertyVal(test.meta, TEST_RETRY_REASON, 'efd')
+          })
           // Test name does not change
           newTests.forEach(test => {
             assert.equal(test.meta[TEST_NAME], 'ci visibility 2 can report tests 2')
@@ -1682,16 +1684,14 @@ describe('jest CommonJS', () => {
         }
       })
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': 3
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const parameterizedTestFile = 'test-parameterized.js'
@@ -1757,16 +1757,14 @@ describe('jest CommonJS', () => {
         }
       })
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': 3
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -1779,8 +1777,12 @@ describe('jest CommonJS', () => {
           const newTests = tests.filter(test =>
             test.meta[TEST_IS_NEW] === 'true'
           )
-          // new tests are not detected
-          assert.equal(newTests.length, 0)
+          // new tests are detected but not retried
+          assert.equal(newTests.length, 1)
+          const retriedTests = tests.filter(test =>
+            test.meta[TEST_IS_RETRY] === 'true'
+          )
+          assert.equal(retriedTests.length, 0)
         })
 
       childProcess = exec(
@@ -1809,16 +1811,14 @@ describe('jest CommonJS', () => {
 
       const NUM_RETRIES_EFD = 5
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -1875,16 +1875,14 @@ describe('jest CommonJS', () => {
 
       const NUM_RETRIES_EFD = 5
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -1931,16 +1929,14 @@ describe('jest CommonJS', () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
 
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': 3
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
       // Tests from ci-visibility/test/skipped-and-todo-test will be considered new
       receiver.setKnownTests({
@@ -1999,16 +1995,14 @@ describe('jest CommonJS', () => {
 
       const NUM_RETRIES_EFD = 5
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -2051,16 +2045,14 @@ describe('jest CommonJS', () => {
 
       const NUM_RETRIES_EFD = 3
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -2127,16 +2119,14 @@ describe('jest CommonJS', () => {
 
       const NUM_RETRIES_EFD = 3
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -2183,16 +2173,14 @@ describe('jest CommonJS', () => {
 
       const NUM_RETRIES_EFD = 3
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 1
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -2235,16 +2223,14 @@ describe('jest CommonJS', () => {
       })
       const NUM_RETRIES_EFD = 3
       receiver.setSettings({
-        itr_enabled: false,
-        code_coverage: false,
-        tests_skipping: false,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
             '5s': NUM_RETRIES_EFD
           },
           faulty_session_threshold: 100
-        }
+        },
+        known_tests_enabled: true
       })
 
       const eventsPromise = receiver
@@ -2292,6 +2278,65 @@ describe('jest CommonJS', () => {
             DD_TRACE_DEBUG: 1,
             DD_TRACE_LOG_LEVEL: 'warn'
           },
+          stdio: 'inherit'
+        }
+      )
+      childProcess.on('exit', () => {
+        eventsPromise.then(() => {
+          done()
+        }).catch(done)
+      })
+    })
+
+    it('disables early flake detection if known tests should not be requested', (done) => {
+      receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
+      // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
+      receiver.setKnownTests({
+        jest: {
+          'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests']
+        }
+      })
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': 3
+          },
+          faulty_session_threshold: 100
+        },
+        known_tests_enabled: false
+      })
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
+
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+          const oldTests = tests.filter(test =>
+            test.meta[TEST_SUITE] === 'ci-visibility/test/ci-visibility-test.js'
+          )
+          oldTests.forEach(test => {
+            assert.notProperty(test.meta, TEST_IS_NEW)
+          })
+          assert.equal(oldTests.length, 1)
+          const newTests = tests.filter(test =>
+            test.meta[TEST_SUITE] === 'ci-visibility/test/ci-visibility-test-2.js'
+          )
+          newTests.forEach(test => {
+            assert.notProperty(test.meta, TEST_IS_NEW)
+          })
+          const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          assert.equal(retriedTests.length, 0)
+        })
+
+      childProcess = exec(
+        runTestsWithCoverageCommand,
+        {
+          cwd,
+          env: { ...getCiVisEvpProxyConfig(receiver.port), TESTS_TO_RUN: 'test/ci-visibility-test' },
           stdio: 'inherit'
         }
       )
@@ -2792,6 +2837,72 @@ describe('jest CommonJS', () => {
       childProcess.on('exit', (code) => {
         eventsPromise.then(() => {
           assert.equal(code, 0)
+          done()
+        }).catch(done)
+      })
+    })
+  })
+
+  context('known tests without early flake detection', () => {
+    it('detects new tests without retrying them', (done) => {
+      receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
+      // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
+      receiver.setKnownTests({
+        jest: {
+          'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests']
+        }
+      })
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: false
+        },
+        known_tests_enabled: true
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
+
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+          // no other tests are considered new
+          const oldTests = tests.filter(test =>
+            test.meta[TEST_SUITE] === 'ci-visibility/test/ci-visibility-test.js'
+          )
+          oldTests.forEach(test => {
+            assert.notProperty(test.meta, TEST_IS_NEW)
+          })
+          assert.equal(oldTests.length, 1)
+
+          const newTests = tests.filter(test =>
+            test.meta[TEST_SUITE] === 'ci-visibility/test/ci-visibility-test-2.js'
+          )
+          newTests.forEach(test => {
+            assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+          })
+          const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          // no test has been retried
+          assert.equal(retriedTests.length, 0)
+          // Test name does not change
+          newTests.forEach(test => {
+            assert.equal(test.meta[TEST_NAME], 'ci visibility 2 can report tests 2')
+          })
+        })
+
+      childProcess = exec(
+        runTestsWithCoverageCommand,
+        {
+          cwd,
+          env: { ...getCiVisEvpProxyConfig(receiver.port), TESTS_TO_RUN: 'test/ci-visibility-test' },
+          stdio: 'inherit'
+        }
+      )
+
+      childProcess.on('exit', () => {
+        eventsPromise.then(() => {
           done()
         }).catch(done)
       })

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -2289,6 +2289,16 @@ describe('jest CommonJS', () => {
     })
 
     it('disables early flake detection if known tests should not be requested', (done) => {
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': 3
+          }
+        },
+        known_tests_enabled: false
+      })
+
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
       receiver.setKnownTests({
@@ -2296,16 +2306,7 @@ describe('jest CommonJS', () => {
           'ci-visibility/test/ci-visibility-test.js': ['ci visibility can report tests']
         }
       })
-      receiver.setSettings({
-        early_flake_detection: {
-          enabled: true,
-          slow_test_retries: {
-            '5s': 3
-          },
-          faulty_session_threshold: 100
-        },
-        known_tests_enabled: false
-      })
+
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
@@ -2886,10 +2887,6 @@ describe('jest CommonJS', () => {
           const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
           // no test has been retried
           assert.equal(retriedTests.length, 0)
-          // Test name does not change
-          newTests.forEach(test => {
-            assert.equal(test.meta[TEST_NAME], 'ci visibility 2 can report tests 2')
-          })
         })
 
       childProcess = exec(

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -367,12 +367,12 @@ versions.forEach((version) => {
               const newTests = tests.filter(test =>
                 test.resource.endsWith('should work with passing tests')
               )
+              // new tests are detected but not retried
               newTests.forEach(test => {
                 assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
               })
 
               const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-
               assert.equal(retriedTests.length, 0)
             })
 
@@ -561,7 +561,6 @@ versions.forEach((version) => {
               })
 
               const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-
               assert.equal(retriedTests.length, 0)
             })
 
@@ -822,6 +821,7 @@ versions.forEach((version) => {
               const newTests = tests.filter(test =>
                 test.resource.endsWith('should work with passing tests')
               )
+              // new tests detected but no retries
               newTests.forEach(test => {
                 assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
               })

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -30,7 +30,7 @@ const {
   DI_DEBUG_ERROR_FILE_SUFFIX,
   DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX,
   DI_DEBUG_ERROR_LINE_SUFFIX,
-  TEST_RETRY_REASON // TODO: missing this tag!
+  TEST_RETRY_REASON
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 
@@ -944,7 +944,7 @@ versions.forEach((version) => {
               'early flake detection does not retry if the test is skipped'
             ])
 
-            // new tests are not detected
+            // new tests are not detected and not retried
             const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
             assert.equal(newTests.length, 0)
 

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -29,7 +29,8 @@ const {
   DI_DEBUG_ERROR_PREFIX,
   DI_DEBUG_ERROR_FILE_SUFFIX,
   DI_DEBUG_ERROR_SNAPSHOT_ID_SUFFIX,
-  DI_DEBUG_ERROR_LINE_SUFFIX
+  DI_DEBUG_ERROR_LINE_SUFFIX,
+  TEST_RETRY_REASON // TODO: missing this tag!
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -421,15 +421,13 @@ versions.forEach((version) => {
     context('early flake detection', () => {
       it('retries new tests', (done) => {
         receiver.setSettings({
-          itr_enabled: false,
-          code_coverage: false,
-          tests_skipping: false,
           early_flake_detection: {
             enabled: true,
             slow_test_retries: {
               '5s': NUM_RETRIES_EFD
             }
-          }
+          },
+          known_tests_enabled: true
         })
 
         receiver.setKnownTests({
@@ -469,10 +467,11 @@ versions.forEach((version) => {
               'early flake detection does not retry if the test is skipped'
             ])
             const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.equal(newTests.length, 12) // 4 executions of the three new tests
+            // 4 executions of the 3 new tests + 1 new skipped test (not retried)
+            assert.equal(newTests.length, 13)
 
             const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 9) // 3 retries of the three new tests
+            assert.equal(retriedTests.length, 9) // 3 retries of the 3 new tests
 
             // exit code should be 0 and test session should be reported as passed,
             // even though there are some failing executions
@@ -507,15 +506,13 @@ versions.forEach((version) => {
 
       it('fails if all the attempts fail', (done) => {
         receiver.setSettings({
-          itr_enabled: false,
-          code_coverage: false,
-          tests_skipping: false,
           early_flake_detection: {
             enabled: true,
             slow_test_retries: {
               '5s': NUM_RETRIES_EFD
             }
-          }
+          },
+          known_tests_enabled: true
         })
 
         receiver.setKnownTests({
@@ -550,10 +547,11 @@ versions.forEach((version) => {
               'early flake detection does not retry if the test is skipped'
             ])
             const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.equal(newTests.length, 8) // 4 executions of the two new tests
+            // 4 executions of the 2 new tests + 1 new skipped test (not retried)
+            assert.equal(newTests.length, 9)
 
             const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 6) // 3 retries of the two new tests
+            assert.equal(retriedTests.length, 6) // 3 retries of the 2 new tests
 
             // the multiple attempts did not result in a single pass,
             // so the test session should be reported as failed
@@ -588,16 +586,14 @@ versions.forEach((version) => {
 
       it('bails out of EFD if the percentage of new tests is too high', (done) => {
         receiver.setSettings({
-          itr_enabled: false,
-          code_coverage: false,
-          tests_skipping: false,
           early_flake_detection: {
             enabled: true,
             slow_test_retries: {
               '5s': NUM_RETRIES_EFD
             },
             faulty_session_threshold: 0
-          }
+          },
+          known_tests_enabled: true
         })
 
         receiver.setKnownTests({
@@ -628,9 +624,7 @@ versions.forEach((version) => {
             env: {
               ...getCiVisAgentlessConfig(receiver.port),
               TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
-              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
-              DD_TRACE_DEBUG: '1',
-              DD_TRACE_LOG_LEVEL: 'error'
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init'
             },
             stdio: 'pipe'
           }
@@ -646,15 +640,13 @@ versions.forEach((version) => {
 
       it('is disabled if DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED is false', (done) => {
         receiver.setSettings({
-          itr_enabled: false,
-          code_coverage: false,
-          tests_skipping: false,
           early_flake_detection: {
             enabled: true,
             slow_test_retries: {
               '5s': NUM_RETRIES_EFD
             }
-          }
+          },
+          known_tests_enabled: true
         })
 
         receiver.setKnownTests({
@@ -662,7 +654,7 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/early-flake-detection.mjs': [
               // 'early flake detection can retry tests that eventually pass', // will be considered new
               // 'early flake detection can retry tests that always pass', // will be considered new
-              // 'early flake detection does not retry if the test is skipped', // skipped so not retried
+              // 'early flake detection does not retry if the test is skipped', // will be considered new
               'early flake detection does not retry if it is not new'
             ]
           }
@@ -682,8 +674,10 @@ versions.forEach((version) => {
               'early flake detection does not retry if it is not new',
               'early flake detection does not retry if the test is skipped'
             ])
+
+            // new tests are detected but not retried
             const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.equal(newTests.length, 0)
+            assert.equal(newTests.length, 3)
 
             const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
             assert.equal(retriedTests.length, 0)
@@ -718,15 +712,13 @@ versions.forEach((version) => {
 
       it('does not run EFD if the known tests request fails', (done) => {
         receiver.setSettings({
-          itr_enabled: false,
-          code_coverage: false,
-          tests_skipping: false,
           early_flake_detection: {
             enabled: true,
             slow_test_retries: {
               '5s': NUM_RETRIES_EFD
             }
-          }
+          },
+          known_tests_enabled: true
         })
 
         receiver.setKnownTestsResponseCode(500)
@@ -781,15 +773,13 @@ versions.forEach((version) => {
 
       it('works when the cwd is not the repository root', (done) => {
         receiver.setSettings({
-          itr_enabled: false,
-          code_coverage: false,
-          tests_skipping: false,
           early_flake_detection: {
             enabled: true,
             slow_test_retries: {
               '5s': NUM_RETRIES_EFD
             }
-          }
+          },
+          known_tests_enabled: true
         })
 
         receiver.setKnownTests({
@@ -837,11 +827,21 @@ versions.forEach((version) => {
 
       it('works with repeats config when EFD is disabled', (done) => {
         receiver.setSettings({
-          itr_enabled: false,
-          code_coverage: false,
-          tests_skipping: false,
           early_flake_detection: {
             enabled: false
+          },
+          known_tests_enabled: true
+        })
+
+        receiver.setKnownTests({
+          vitest: {
+            'ci-visibility/vitest-tests/early-flake-detection.mjs': [
+              // 'early flake detection can retry tests that eventually pass', // will be considered new
+              // 'early flake detection can retry tests that always pass', // will be considered new
+              // 'early flake detection can retry tests that eventually fail', // will be considered new
+              // 'early flake detection does not retry if the test is skipped', // will be considered new
+              'early flake detection does not retry if it is not new'
+            ]
           }
         })
 
@@ -864,13 +864,14 @@ versions.forEach((version) => {
               'early flake detection does not retry if the test is skipped'
             ])
             const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.equal(newTests.length, 0) // no new test detected
+            // all but one are considered new
+            assert.equal(newTests.length, 7)
 
             const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
             assert.equal(retriedTests.length, 4) // 2 repetitions on 2 tests
 
             // vitest reports the test as failed if any of the repetitions fail, so we'll follow that
-            // TODO: we might want to improve htis
+            // TODO: we might want to improve this
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.equal(failedTests.length, 3)
 
@@ -888,6 +889,77 @@ versions.forEach((version) => {
               TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
               NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
               SHOULD_REPEAT: '1'
+            },
+            stdio: 'pipe'
+          }
+        )
+
+        childProcess.on('exit', (exitCode) => {
+          eventsPromise.then(() => {
+            assert.equal(exitCode, 1)
+            done()
+          }).catch(done)
+        })
+      })
+
+      it('disables early flake detection if known tests should not be requested', (done) => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD
+            }
+          },
+          known_tests_enabled: false
+        })
+
+        receiver.setKnownTests({
+          vitest: {
+            'ci-visibility/vitest-tests/early-flake-detection.mjs': [
+              // 'early flake detection can retry tests that eventually pass', // will be considered new
+              // 'early flake detection can retry tests that always pass', // will be considered new
+              // 'early flake detection does not retry if the test is skipped', // will be considered new
+              'early flake detection does not retry if it is not new'
+            ]
+          }
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const tests = events.filter(event => event.type === 'test').map(test => test.content)
+
+            assert.equal(tests.length, 4)
+
+            assert.includeMembers(tests.map(test => test.meta[TEST_NAME]), [
+              'early flake detection can retry tests that eventually pass',
+              'early flake detection can retry tests that always pass',
+              'early flake detection does not retry if it is not new',
+              'early flake detection does not retry if the test is skipped'
+            ])
+
+            // new tests are not detected
+            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+            assert.equal(newTests.length, 0)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.equal(retriedTests.length, 0)
+
+            const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+            assert.equal(failedTests.length, 1)
+            const testSessionEvent = events.find(event => event.type === 'test_session_end').content
+            assert.equal(testSessionEvent.meta[TEST_STATUS], 'fail')
+          })
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init'
             },
             stdio: 'pipe'
           }
@@ -1150,5 +1222,76 @@ versions.forEach((version) => {
         })
       })
     }
+
+    context('known tests without early flake detection', () => {
+      it('detects new tests without retrying them', (done) => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: false
+          },
+          known_tests_enabled: true
+        })
+
+        receiver.setKnownTests({
+          vitest: {
+            'ci-visibility/vitest-tests/early-flake-detection.mjs': [
+              // 'early flake detection can retry tests that eventually pass', // will be considered new
+              // 'early flake detection can retry tests that always pass', // will be considered new
+              // 'early flake detection does not retry if the test is skipped', // will be considered new
+              'early flake detection does not retry if it is not new'
+            ]
+          }
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const tests = events.filter(event => event.type === 'test').map(test => test.content)
+
+            assert.equal(tests.length, 4)
+
+            assert.includeMembers(tests.map(test => test.meta[TEST_NAME]), [
+              'early flake detection can retry tests that eventually pass',
+              'early flake detection can retry tests that always pass',
+              'early flake detection does not retry if it is not new',
+              'early flake detection does not retry if the test is skipped'
+            ])
+            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+            // all but one are considered new
+            assert.equal(newTests.length, 3)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.equal(retriedTests.length, 0)
+
+            const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+            assert.equal(failedTests.length, 1)
+
+            const testSessionEvent = events.find(event => event.type === 'test_session_end').content
+            assert.propertyVal(testSessionEvent.meta, TEST_STATUS, 'fail')
+            assert.notProperty(testSessionEvent.meta, TEST_EARLY_FLAKE_ENABLED)
+          })
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init'
+            },
+            stdio: 'pipe'
+          }
+        )
+
+        childProcess.on('exit', (exitCode) => {
+          eventsPromise.then(() => {
+            assert.equal(exitCode, 1)
+            done()
+          }).catch(done)
+        })
+      })
+    })
   })
 })

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -474,6 +474,10 @@ versions.forEach((version) => {
             const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
             assert.equal(retriedTests.length, 9) // 3 retries of the 3 new tests
 
+            retriedTests.forEach(test => {
+              assert.equal(test.meta[TEST_RETRY_REASON], 'efd')
+            })
+
             // exit code should be 0 and test session should be reported as passed,
             // even though there are some failing executions
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -70,6 +70,7 @@ let earlyFlakeDetectionNumRetries = 0
 let earlyFlakeDetectionFaultyThreshold = 0
 let isEarlyFlakeDetectionFaulty = false
 let isFlakyTestRetriesEnabled = false
+let isKnownTestsEnabled = false
 let numTestRetries = 0
 let knownTests = []
 let skippedSuites = []
@@ -292,7 +293,7 @@ function wrapRun (pl, isLatestVersion) {
         }
         let isNew = false
         let isEfdRetry = false
-        if (isEarlyFlakeDetectionEnabled && status !== 'skip') {
+        if (isKnownTestsEnabled && status !== 'skip') {
           const numRetries = numRetriesByPickleId.get(this.pickle.id)
 
           isNew = numRetries !== undefined
@@ -394,13 +395,15 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
     isSuitesSkippingEnabled = configurationResponse.libraryConfig?.isSuitesSkippingEnabled
     isFlakyTestRetriesEnabled = configurationResponse.libraryConfig?.isFlakyTestRetriesEnabled
     numTestRetries = configurationResponse.libraryConfig?.flakyTestRetriesCount
+    isKnownTestsEnabled = configurationResponse.libraryConfig?.isKnownTestsEnabled
 
-    if (isEarlyFlakeDetectionEnabled) {
+    if (isKnownTestsEnabled) {
       const knownTestsResponse = await getChannelPromise(knownTestsCh)
       if (!knownTestsResponse.err) {
         knownTests = knownTestsResponse.knownTests
       } else {
         isEarlyFlakeDetectionEnabled = false
+        isKnownTestsEnabled = false
       }
     }
 
@@ -437,7 +440,7 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
 
     pickleByFile = isCoordinator ? getPickleByFileNew(this) : getPickleByFile(this)
 
-    if (isEarlyFlakeDetectionEnabled) {
+    if (isKnownTestsEnabled) {
       const isFaulty = getIsFaultyEarlyFlakeDetection(
         Object.keys(pickleByFile),
         knownTests.cucumber || {},
@@ -445,6 +448,7 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
       )
       if (isFaulty) {
         isEarlyFlakeDetectionEnabled = false
+        isKnownTestsEnabled = false
         isEarlyFlakeDetectionFaulty = true
       }
     }
@@ -533,7 +537,7 @@ function getWrappedRunTestCase (runTestCaseFunction, isNewerCucumberVersion = fa
 
     let isNew = false
 
-    if (isEarlyFlakeDetectionEnabled) {
+    if (isKnownTestsEnabled) {
       isNew = isNewTest(testSuitePath, pickle.name)
       if (isNew) {
         numRetriesByPickleId.set(pickle.id, 0)
@@ -678,14 +682,14 @@ function getWrappedParseWorkerMessage (parseWorkerMessageFunction, isNewVersion)
       const { status } = getStatusFromResultLatest(worstTestStepResult)
       let isNew = false
 
-      if (isEarlyFlakeDetectionEnabled) {
+      if (isKnownTestsEnabled) {
         isNew = isNewTest(pickle.uri, pickle.name)
       }
 
       const testFileAbsolutePath = pickle.uri
       const finished = pickleResultByFile[testFileAbsolutePath]
 
-      if (isNew) {
+      if (isEarlyFlakeDetectionEnabled && isNew) {
         const testFullname = `${pickle.uri}:${pickle.name}`
         let testStatuses = newTestsByTestFullname.get(testFullname)
         if (!testStatuses) {
@@ -839,7 +843,8 @@ addHook({
   )
   // EFD in parallel mode only supported in >=11.0.0
   shimmer.wrap(adapterPackage.ChildProcessAdapter.prototype, 'startWorker', startWorker => function () {
-    if (isEarlyFlakeDetectionEnabled) {
+    if (isKnownTestsEnabled) {
+      this.options.worldParameters._ddIsEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
       this.options.worldParameters._ddKnownTests = knownTests
       this.options.worldParameters._ddEarlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
     }
@@ -862,9 +867,12 @@ addHook({
     'initialize',
     initialize => async function () {
       await initialize.apply(this, arguments)
-      isEarlyFlakeDetectionEnabled = !!this.options.worldParameters._ddKnownTests
-      if (isEarlyFlakeDetectionEnabled) {
+      isKnownTestsEnabled = !!this.options.worldParameters._ddKnownTests
+      if (isKnownTestsEnabled) {
         knownTests = this.options.worldParameters._ddKnownTests
+      }
+      isEarlyFlakeDetectionEnabled = !!this.options.worldParameters._ddIsEarlyFlakeDetectionEnabled
+      if (isEarlyFlakeDetectionEnabled) {
         earlyFlakeDetectionNumRetries = this.options.worldParameters._ddEarlyFlakeDetectionNumRetries
       }
     }

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -140,9 +140,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       this.flakyTestRetriesCount = this.testEnvironmentOptions._ddFlakyTestRetriesCount
       this.isDiEnabled = this.testEnvironmentOptions._ddIsDiEnabled
       this.isKnownTestsEnabled = this.testEnvironmentOptions._ddIsKnownTestsEnabled
-      this.shouldDetectNewTests = this.isEarlyFlakeDetectionEnabled || this.isKnownTestsEnabled
 
-      if (this.shouldDetectNewTests) {
+      if (this.isKnownTestsEnabled) {
         try {
           const hasKnownTests = !!knownTests.jest
           earlyFlakeDetectionNumRetries = this.testEnvironmentOptions._ddEarlyFlakeDetectionNumRetries
@@ -153,7 +152,6 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           // If there has been an error parsing the tests, we'll disable Early Flake Deteciton
           this.isEarlyFlakeDetectionEnabled = false
           this.isKnownTestsEnabled = false
-          this.shouldDetectNewTests = false
         }
       }
 
@@ -233,7 +231,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         asyncResources.set(event.test, asyncResource)
         const testName = getJestTestName(event.test)
 
-        if (this.shouldDetectNewTests) {
+        if (this.isKnownTestsEnabled) {
           const originalTestName = removeEfdStringFromTestName(testName)
           isNewTest = retriedTestsToNumAttempts.has(originalTestName)
           if (isNewTest) {
@@ -293,7 +291,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         event.test.fn = originalTestFns.get(event.test)
 
         // We'll store the test statuses of the retries
-        if (this.shouldDetectNewTests) {
+        if (this.isKnownTestsEnabled) {
           const testName = getJestTestName(event.test)
           const originalTestName = removeEfdStringFromTestName(testName)
           const isNewTest = retriedTestsToNumAttempts.has(originalTestName)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -69,6 +69,7 @@ let earlyFlakeDetectionNumRetries = 0
 let earlyFlakeDetectionFaultyThreshold = 30
 let isEarlyFlakeDetectionFaulty = false
 let hasFilteredSkippableSuites = false
+let isKnownTestsEnabled = false
 
 const sessionAsyncResource = new AsyncResource('bound-anonymous-fn')
 
@@ -138,17 +139,21 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       this.isFlakyTestRetriesEnabled = this.testEnvironmentOptions._ddIsFlakyTestRetriesEnabled
       this.flakyTestRetriesCount = this.testEnvironmentOptions._ddFlakyTestRetriesCount
       this.isDiEnabled = this.testEnvironmentOptions._ddIsDiEnabled
+      this.isKnownTestsEnabled = this.testEnvironmentOptions._ddIsKnownTestsEnabled
+      this.shouldDetectNewTests = this.isEarlyFlakeDetectionEnabled || this.isKnownTestsEnabled
 
-      if (this.isEarlyFlakeDetectionEnabled) {
-        const hasKnownTests = !!knownTests.jest
-        earlyFlakeDetectionNumRetries = this.testEnvironmentOptions._ddEarlyFlakeDetectionNumRetries
+      if (this.shouldDetectNewTests) {
         try {
+          const hasKnownTests = !!knownTests.jest
+          earlyFlakeDetectionNumRetries = this.testEnvironmentOptions._ddEarlyFlakeDetectionNumRetries
           this.knownTestsForThisSuite = hasKnownTests
             ? (knownTests.jest[this.testSuite] || [])
             : this.getKnownTestsForSuite(this.testEnvironmentOptions._ddKnownTests)
         } catch (e) {
           // If there has been an error parsing the tests, we'll disable Early Flake Deteciton
           this.isEarlyFlakeDetectionEnabled = false
+          this.isKnownTestsEnabled = false
+          this.shouldDetectNewTests = false
         }
       }
 
@@ -228,7 +233,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         asyncResources.set(event.test, asyncResource)
         const testName = getJestTestName(event.test)
 
-        if (this.isEarlyFlakeDetectionEnabled) {
+        if (this.shouldDetectNewTests) {
           const originalTestName = removeEfdStringFromTestName(testName)
           isNewTest = retriedTestsToNumAttempts.has(originalTestName)
           if (isNewTest) {
@@ -254,24 +259,26 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         })
       }
       if (event.name === 'add_test') {
-        if (this.isEarlyFlakeDetectionEnabled) {
+        if (this.isKnownTestsEnabled) {
           const testName = this.getTestNameFromAddTestEvent(event, state)
           const isNew = !this.knownTestsForThisSuite?.includes(testName)
           const isSkipped = event.mode === 'todo' || event.mode === 'skip'
           if (isNew && !isSkipped && !retriedTestsToNumAttempts.has(testName)) {
             retriedTestsToNumAttempts.set(testName, 0)
-            // Retrying snapshots has proven to be problematic, so we'll skip them for now
-            // We'll still detect new tests, but we won't retry them.
-            // TODO: do not bail out of EFD with the whole test suite
-            if (this.getHasSnapshotTests()) {
-              log.warn('Early flake detection is disabled for suites with snapshots')
-              return
-            }
-            for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
-              if (this.global.test) {
-                this.global.test(addEfdStringToTestName(event.testName, retryIndex), event.fn, event.timeout)
-              } else {
-                log.error('Early flake detection could not retry test because global.test is undefined')
+            if (this.isEarlyFlakeDetectionEnabled) {
+              // Retrying snapshots has proven to be problematic, so we'll skip them for now
+              // We'll still detect new tests, but we won't retry them.
+              // TODO: do not bail out of EFD with the whole test suite
+              if (this.getHasSnapshotTests()) {
+                log.warn('Early flake detection is disabled for suites with snapshots')
+                return
+              }
+              for (let retryIndex = 0; retryIndex < earlyFlakeDetectionNumRetries; retryIndex++) {
+                if (this.global.test) {
+                  this.global.test(addEfdStringToTestName(event.testName, retryIndex), event.fn, event.timeout)
+                } else {
+                  log.error('Early flake detection could not retry test because global.test is undefined')
+                }
               }
             }
           }
@@ -286,7 +293,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         event.test.fn = originalTestFns.get(event.test)
 
         // We'll store the test statuses of the retries
-        if (this.isEarlyFlakeDetectionEnabled) {
+        if (this.shouldDetectNewTests) {
           const testName = getJestTestName(event.test)
           const originalTestName = removeEfdStringFromTestName(testName)
           const isNewTest = retriedTestsToNumAttempts.has(originalTestName)
@@ -483,12 +490,13 @@ function cliWrapper (cli, jestVersion) {
         isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
         earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
         earlyFlakeDetectionFaultyThreshold = libraryConfig.earlyFlakeDetectionFaultyThreshold
+        isKnownTestsEnabled = libraryConfig.isKnownTestsEnabled
       }
     } catch (err) {
       log.error('Jest library configuration error', err)
     }
 
-    if (isEarlyFlakeDetectionEnabled) {
+    if (isKnownTestsEnabled) {
       const knownTestsPromise = new Promise((resolve) => {
         onDone = resolve
       })
@@ -504,6 +512,7 @@ function cliWrapper (cli, jestVersion) {
         } else {
           // We disable EFD if there has been an error in the known tests request
           isEarlyFlakeDetectionEnabled = false
+          isKnownTestsEnabled = false
         }
       } catch (err) {
         log.error('Jest known tests error', err)
@@ -821,6 +830,7 @@ addHook({
       _ddIsFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount,
       _ddIsDiEnabled,
+      _ddIsKnownTestsEnabled,
       ...restOfTestEnvironmentOptions
     } = testEnvironmentOptions
 
@@ -848,17 +858,19 @@ addHook({
     const testPaths = await getTestPaths.apply(this, arguments)
     const [{ rootDir, shard }] = arguments
 
-    if (isEarlyFlakeDetectionEnabled) {
+    if (isKnownTestsEnabled) {
       const projectSuites = testPaths.tests.map(test => getTestSuitePath(test.path, test.context.config.rootDir))
       const isFaulty =
         getIsFaultyEarlyFlakeDetection(projectSuites, knownTests.jest || {}, earlyFlakeDetectionFaultyThreshold)
       if (isFaulty) {
         log.error('Early flake detection is disabled because the number of new suites is too high.')
         isEarlyFlakeDetectionEnabled = false
+        isKnownTestsEnabled = false
         const testEnvironmentOptions = testPaths.tests[0]?.context?.config?.testEnvironmentOptions
         // Project config is shared among all tests, so we can modify it here
         if (testEnvironmentOptions) {
           testEnvironmentOptions._ddIsEarlyFlakeDetectionEnabled = false
+          testEnvironmentOptions._ddIsKnownTestsEnabled = false
         }
         isEarlyFlakeDetectionFaulty = true
       }
@@ -929,6 +941,11 @@ addHook({
   return runtimePackage
 })
 
+/*
+* This hook does two things:
+* - Pass known tests to the workers.
+* - Receive trace, coverage and logs payloads from the workers.
+*/
 addHook({
   name: 'jest-worker',
   versions: ['>=24.9.0'],
@@ -936,7 +953,7 @@ addHook({
 }, (childProcessWorker) => {
   const ChildProcessWorker = childProcessWorker.default
   shimmer.wrap(ChildProcessWorker.prototype, 'send', send => function (request) {
-    if (!isEarlyFlakeDetectionEnabled) {
+    if (!isKnownTestsEnabled) {
       return send.apply(this, arguments)
     }
     const [type] = request

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -349,12 +349,14 @@ function getOnPendingHandler () {
 // Hook to add retries to tests if EFD is enabled
 function getRunTestsWrapper (runTests, config) {
   return function (suite, fn) {
-    if (config.isEarlyFlakeDetectionEnabled) {
+    if (config.isKnownTestsEnabled) {
       // by the time we reach `this.on('test')`, it is too late. We need to add retries here
       suite.tests.forEach(test => {
         if (!test.isPending() && isNewTest(test, config.knownTests)) {
           test._ddIsNew = true
-          retryTest(test, config.earlyFlakeDetectionNumRetries)
+          if (config.isEarlyFlakeDetectionEnabled) {
+            retryTest(test, config.earlyFlakeDetectionNumRetries)
+          }
         }
       })
     }

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -25,10 +25,12 @@ addHook({
 }, (Mocha) => {
   shimmer.wrap(Mocha.prototype, 'run', run => function () {
     if (this.options._ddKnownTests) {
-      // EFD is enabled if there's a list of known tests
-      config.isEarlyFlakeDetectionEnabled = true
+      // If there are known tests, it means isKnownTestsEnabled should be true
+      config.isKnownTestsEnabled = true
+      config.isEarlyFlakeDetectionEnabled = this.options._ddIsEfdEnabled
       config.knownTests = this.options._ddKnownTests
       config.earlyFlakeDetectionNumRetries = this.options._ddEfdNumRetries
+      delete this.options._ddIsEfdEnabled
       delete this.options._ddKnownTests
       delete this.options._ddEfdNumRetries
     }

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -25,6 +25,7 @@ const isEarlyFlakeDetectionFaultyCh = channel('ci:vitest:is-early-flake-detectio
 const taskToAsync = new WeakMap()
 const taskToStatuses = new WeakMap()
 const newTasks = new WeakSet()
+let isRetryReasonEfd = false
 const switchedStatuses = new WeakSet()
 const sessionAsyncResource = new AsyncResource('bound-anonymous-fn')
 
@@ -316,6 +317,7 @@ addHook({
         onDone: (isNew) => {
           if (isNew) {
             if (isEarlyFlakeDetectionEnabled) {
+              isRetryReasonEfd = task.repeats !== numRepeats
               task.repeats = numRepeats
             }
             newTasks.add(task)
@@ -444,6 +446,7 @@ addHook({
         testName,
         testSuiteAbsolutePath: task.file.filepath,
         isRetry: numAttempt > 0 || numRepetition > 0,
+        isRetryReasonEfd,
         isNew,
         mightHitProbe: isDiEnabled && numAttempt > 0
       })

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -26,7 +26,8 @@ const {
   TEST_MODULE,
   TEST_MODULE_ID,
   TEST_SUITE,
-  CUCUMBER_IS_PARALLEL
+  CUCUMBER_IS_PARALLEL,
+  TEST_RETRY_REASON
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -321,6 +322,7 @@ class CucumberPlugin extends CiPlugin {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
           span.setTag(TEST_IS_RETRY, 'true')
+          span.setTag(TEST_RETRY_REASON, 'efd')
         }
       }
 

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -31,7 +31,8 @@ const {
   TEST_EARLY_FLAKE_ENABLED,
   getTestSessionName,
   TEST_SESSION_NAME,
-  TEST_LEVEL_EVENT_TYPES
+  TEST_LEVEL_EVENT_TYPES,
+  TEST_RETRY_REASON
 } = require('../../dd-trace/src/plugins/util/test')
 const { isMarkedAsUnskippable } = require('../../datadog-plugin-jest/src/util')
 const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
@@ -112,7 +113,7 @@ function getCypressCommand (details) {
 function getLibraryConfiguration (tracer, testConfiguration) {
   return new Promise(resolve => {
     if (!tracer._tracer._exporter?.getLibraryConfiguration) {
-      return resolve({ err: new Error('CI Visibility was not initialized correctly') })
+      return resolve({ err: new Error('Test Optimization was not initialized correctly') })
     }
 
     tracer._tracer._exporter.getLibraryConfiguration(testConfiguration, (err, libraryConfig) => {
@@ -124,7 +125,7 @@ function getLibraryConfiguration (tracer, testConfiguration) {
 function getSkippableTests (tracer, testConfiguration) {
   return new Promise(resolve => {
     if (!tracer._tracer._exporter?.getSkippableSuites) {
-      return resolve({ err: new Error('CI Visibility was not initialized correctly') })
+      return resolve({ err: new Error('Test Optimization was not initialized correctly') })
     }
     tracer._tracer._exporter.getSkippableSuites(testConfiguration, (err, skippableTests, correlationId) => {
       resolve({
@@ -139,7 +140,7 @@ function getSkippableTests (tracer, testConfiguration) {
 function getKnownTests (tracer, testConfiguration) {
   return new Promise(resolve => {
     if (!tracer._tracer._exporter?.getKnownTests) {
-      return resolve({ err: new Error('CI Visibility was not initialized correctly') })
+      return resolve({ err: new Error('Test Optimization was not initialized correctly') })
     }
     tracer._tracer._exporter.getKnownTests(testConfiguration, (err, knownTests) => {
       resolve({
@@ -203,6 +204,7 @@ class CypressPlugin {
     this.isSuitesSkippingEnabled = false
     this.isCodeCoverageEnabled = false
     this.isEarlyFlakeDetectionEnabled = false
+    this.isKnownTestsEnabled = false
     this.earlyFlakeDetectionNumRetries = 0
     this.testsToSkip = []
     this.skippedTests = []
@@ -232,13 +234,15 @@ class CypressPlugin {
               isEarlyFlakeDetectionEnabled,
               earlyFlakeDetectionNumRetries,
               isFlakyTestRetriesEnabled,
-              flakyTestRetriesCount
+              flakyTestRetriesCount,
+              isKnownTestsEnabled
             }
           } = libraryConfigurationResponse
           this.isSuitesSkippingEnabled = isSuitesSkippingEnabled
           this.isCodeCoverageEnabled = isCodeCoverageEnabled
           this.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
           this.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
+          this.isKnownTestsEnabled = isKnownTestsEnabled
           if (isFlakyTestRetriesEnabled) {
             this.cypressConfig.retries.runMode = flakyTestRetriesCount
           }
@@ -354,7 +358,7 @@ class CypressPlugin {
     this.frameworkVersion = getCypressVersion(details)
     this.rootDir = getRootDir(details)
 
-    if (this.isEarlyFlakeDetectionEnabled) {
+    if (this.isKnownTestsEnabled) {
       const knownTestsResponse = await getKnownTests(
         this.tracer,
         this.testConfiguration
@@ -362,6 +366,7 @@ class CypressPlugin {
       if (knownTestsResponse.err) {
         log.error('Cypress known tests response error', knownTestsResponse.err)
         this.isEarlyFlakeDetectionEnabled = false
+        this.isKnownTestsEnabled = false
       } else {
         // We use TEST_FRAMEWORK_NAME for the name of the module
         this.knownTestsByTestSuite = knownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]
@@ -567,6 +572,9 @@ class CypressPlugin {
           cypressTestStatus = CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.attempts[attemptIndex].state]
           if (attemptIndex > 0) {
             finishedTest.testSpan.setTag(TEST_IS_RETRY, 'true')
+            if (finishedTest.isEfdRetry) {
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'efd')
+            }
           }
         }
         if (cypressTest.displayError) {
@@ -618,7 +626,8 @@ class CypressPlugin {
         const suitePayload = {
           isEarlyFlakeDetectionEnabled: this.isEarlyFlakeDetectionEnabled,
           knownTestsForSuite: this.knownTestsByTestSuite?.[testSuite] || [],
-          earlyFlakeDetectionNumRetries: this.earlyFlakeDetectionNumRetries
+          earlyFlakeDetectionNumRetries: this.earlyFlakeDetectionNumRetries,
+          isKnownTestsEnabled: this.isKnownTestsEnabled
         }
 
         if (this.testSuiteSpan) {
@@ -703,13 +712,15 @@ class CypressPlugin {
           this.activeTestSpan.setTag(TEST_IS_NEW, 'true')
           if (isEfdRetry) {
             this.activeTestSpan.setTag(TEST_IS_RETRY, 'true')
+            this.activeTestSpan.setTag(TEST_RETRY_REASON, 'efd')
           }
         }
         const finishedTest = {
           testName,
           testStatus,
           finishTime: this.activeTestSpan._getTime(), // we store the finish time here
-          testSpan: this.activeTestSpan
+          testSpan: this.activeTestSpan,
+          isEfdRetry
         }
         if (this.finishedTestsByFile[testSuite]) {
           this.finishedTestsByFile[testSuite].push(finishedTest)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -23,7 +23,8 @@ const {
   JEST_DISPLAY_NAME,
   TEST_IS_RUM_ACTIVE,
   TEST_BROWSER_DRIVER,
-  getFormattedError
+  getFormattedError,
+  TEST_RETRY_REASON
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -167,6 +168,7 @@ class JestPlugin extends CiPlugin {
         config._ddIsFlakyTestRetriesEnabled = this.libraryConfig?.isFlakyTestRetriesEnabled ?? false
         config._ddFlakyTestRetriesCount = this.libraryConfig?.flakyTestRetriesCount
         config._ddIsDiEnabled = this.libraryConfig?.isDiEnabled ?? false
+        config._ddIsKnownTestsEnabled = this.libraryConfig?.isKnownTestsEnabled ?? false
       })
     })
 
@@ -410,6 +412,7 @@ class JestPlugin extends CiPlugin {
       extraTags[TEST_IS_NEW] = 'true'
       if (isEfdRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
+        extraTags[TEST_RETRY_REASON] = 'efd'
       }
     }
 

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -30,7 +30,8 @@ const {
   TEST_SUITE,
   MOCHA_IS_PARALLEL,
   TEST_IS_RUM_ACTIVE,
-  TEST_BROWSER_DRIVER
+  TEST_BROWSER_DRIVER,
+  TEST_RETRY_REASON
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -421,6 +422,7 @@ class MochaPlugin extends CiPlugin {
       extraTags[TEST_IS_NEW] = 'true'
       if (isEfdRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
+        extraTags[TEST_RETRY_REASON] = 'efd'
       }
     }
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -15,7 +15,8 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
-  TELEMETRY_TEST_SESSION
+  TELEMETRY_TEST_SESSION,
+  TEST_RETRY_REASON
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -144,6 +145,7 @@ class PlaywrightPlugin extends CiPlugin {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
           span.setTag(TEST_IS_RETRY, 'true')
+          span.setTag(TEST_RETRY_REASON, 'efd')
         }
       }
       if (isRetry) {

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -147,7 +147,7 @@ class VitestPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:vitest:test:skip', ({ testName, testSuiteAbsolutePath }) => {
+    this.addSub('ci:vitest:test:skip', ({ testName, testSuiteAbsolutePath, isNew }) => {
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const testSpan = this.startTestSpan(
         testName,
@@ -156,7 +156,8 @@ class VitestPlugin extends CiPlugin {
         {
           [TEST_SOURCE_FILE]: testSuite,
           [TEST_SOURCE_START]: 1, // we can't get the proper start line in vitest
-          [TEST_STATUS]: 'skip'
+          [TEST_STATUS]: 'skip',
+          ...(isNew ? { [TEST_IS_NEW]: 'true' } : {})
         }
       )
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'test', {

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -87,9 +87,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
 
   shouldRequestKnownTests () {
     return !!(
-      this._config.isEarlyFlakeDetectionEnabled &&
       this._canUseCiVisProtocol &&
-      this._libraryConfig?.isEarlyFlakeDetectionEnabled
+      this._libraryConfig?.isKnownTestsEnabled
     )
   }
 
@@ -197,7 +196,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
       earlyFlakeDetectionNumRetries,
       earlyFlakeDetectionFaultyThreshold,
       isFlakyTestRetriesEnabled,
-      isDiEnabled
+      isDiEnabled,
+      isKnownTestsEnabled
     } = remoteConfiguration
     return {
       isCodeCoverageEnabled,
@@ -209,7 +209,8 @@ class CiVisibilityExporter extends AgentInfoExporter {
       earlyFlakeDetectionFaultyThreshold,
       isFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled && this._config.isFlakyTestRetriesEnabled,
       flakyTestRetriesCount: this._config.flakyTestRetriesCount,
-      isDiEnabled: isDiEnabled && this._config.isTestDynamicInstrumentationEnabled
+      isDiEnabled: isDiEnabled && this._config.isTestDynamicInstrumentationEnabled,
+      isKnownTestsEnabled
     }
   }
 

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -93,7 +93,8 @@ function getLibraryConfiguration ({
               require_git: requireGit,
               early_flake_detection: earlyFlakeDetectionConfig,
               flaky_test_retries_enabled: isFlakyTestRetriesEnabled,
-              di_enabled: isDiEnabled
+              di_enabled: isDiEnabled,
+              known_tests_enabled: isKnownTestsEnabled
             }
           }
         } = JSON.parse(res)
@@ -103,13 +104,14 @@ function getLibraryConfiguration ({
           isSuitesSkippingEnabled,
           isItrEnabled,
           requireGit,
-          isEarlyFlakeDetectionEnabled: earlyFlakeDetectionConfig?.enabled ?? false,
+          isEarlyFlakeDetectionEnabled: isKnownTestsEnabled && (earlyFlakeDetectionConfig?.enabled ?? false),
           earlyFlakeDetectionNumRetries:
             earlyFlakeDetectionConfig?.slow_test_retries?.['5s'] || DEFAULT_EARLY_FLAKE_DETECTION_NUM_RETRIES,
           earlyFlakeDetectionFaultyThreshold:
             earlyFlakeDetectionConfig?.faulty_session_threshold ?? DEFAULT_EARLY_FLAKE_DETECTION_ERROR_THRESHOLD,
           isFlakyTestRetriesEnabled,
-          isDiEnabled: isDiEnabled && isFlakyTestRetriesEnabled
+          isDiEnabled: isDiEnabled && isFlakyTestRetriesEnabled,
+          isKnownTestsEnabled
         }
 
         log.debug(() => `Remote settings: ${JSON.stringify(settings)}`)

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -158,6 +158,7 @@ module.exports = class CiPlugin extends Plugin {
         if (err) {
           log.error('Known tests could not be fetched. %s', err.message)
           this.libraryConfig.isEarlyFlakeDetectionEnabled = false
+          this.libraryConfig.isKnownTestsEnabled = false
         }
         onDone({ err, knownTests })
       })

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -59,6 +59,7 @@ const TEST_IS_NEW = 'test.is_new'
 const TEST_IS_RETRY = 'test.is_retry'
 const TEST_EARLY_FLAKE_ENABLED = 'test.early_flake.enabled'
 const TEST_EARLY_FLAKE_ABORT_REASON = 'test.early_flake.abort_reason'
+const TEST_RETRY_REASON = 'test.retry_reason'
 
 const CI_APP_ORIGIN = 'ciapp-test'
 
@@ -145,6 +146,7 @@ module.exports = {
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
   TEST_EARLY_FLAKE_ABORT_REASON,
+  TEST_RETRY_REASON,
   getTestEnvironmentMetadata,
   getTestParametersString,
   finishAllTraceSpans,


### PR DESCRIPTION
### What does this PR do?

* Always request known tests if `known_tests_enabled` is responded by the backend. 
* Always set `test.is_new: true` tag to new tests.
* Set `test.retry_reason: 'efd'` if tests are retried with early flake detection.

### Motivation

* Detecting new tests adds value regardless of whether you want to detect flakiness on them or not.

### Plugin Checklist

- [x] Unit tests.
