### PR TITLE
Revert "fix aws-sdk invalid signature exception (#5127)"

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -59,11 +59,6 @@ class HttpClientPlugin extends ClientPlugin {
     }
 
     if (this.shouldInjectTraceHeaders(options, uri)) {
-      // Clone the headers object in case an upstream lib has a reference to the original headers
-      // Implemented due to aws-sdk issue where request signing is broken if we mutate the headers
-      // Explained further in:
-      // https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1609#issuecomment-1826167348
-      options.headers = Object.assign({}, options.headers)
       this.tracer.inject(span, HTTP_HEADERS, options.headers)
     }
 
@@ -77,6 +72,10 @@ class HttpClientPlugin extends ClientPlugin {
   }
 
   shouldInjectTraceHeaders (options, uri) {
+    if (hasAmazonSignature(options) && !this.config.enablePropagationWithAmazonHeaders) {
+      return false
+    }
+
     if (!this.config.propagationFilter(uri)) {
       return false
     }
@@ -213,6 +212,31 @@ function getHooks (config) {
   return { request }
 }
 
+function hasAmazonSignature (options) {
+  if (!options) {
+    return false
+  }
+
+  if (options.headers) {
+    const headers = Object.keys(options.headers)
+      .reduce((prev, next) => Object.assign(prev, {
+        [next.toLowerCase()]: options.headers[next]
+      }), {})
+
+    if (headers['x-amz-signature']) {
+      return true
+    }
+
+    if ([].concat(headers.authorization).some(startsWith('AWS4-HMAC-SHA256'))) {
+      return true
+    }
+  }
+
+  const search = options.search || options.path
+
+  return search && search.toLowerCase().indexOf('x-amz-signature=') !== -1
+}
+
 function extractSessionDetails (options) {
   if (typeof options === 'string') {
     return new URL(options).host
@@ -222,6 +246,10 @@ function extractSessionDetails (options) {
   const port = options.port
 
   return { host, port }
+}
+
+function startsWith (searchString) {
+  return value => String(value).startsWith(searchString)
 }
 
 module.exports = HttpClientPlugin

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -446,24 +446,13 @@ describe('Plugin', () => {
           })
         })
 
-        it('should inject tracing header into request without mutating the header', done => {
-          // ensures that the tracer clones request headers instead of mutating.
-          // Fixes aws-sdk InvalidSignatureException, more info:
-          // https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1609#issuecomment-1826167348
-
+        it('should skip injecting if the Authorization header contains an AWS signature', done => {
           const app = express()
-
-          const originalHeaders = {
-            Authorization: 'AWS4-HMAC-SHA256 ...'
-          }
 
           app.get('/', (req, res) => {
             try {
-              expect(req.get('x-datadog-trace-id')).to.be.a('string')
-              expect(req.get('x-datadog-parent-id')).to.be.a('string')
-
-              expect(originalHeaders['x-datadog-trace-id']).to.be.undefined
-              expect(originalHeaders['x-datadog-parent-id']).to.be.undefined
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
 
               res.status(200).send()
 
@@ -476,7 +465,91 @@ describe('Plugin', () => {
           appListener = server(app, port => {
             const req = http.request({
               port,
-              headers: originalHeaders
+              headers: {
+                Authorization: 'AWS4-HMAC-SHA256 ...'
+              }
+            })
+
+            req.end()
+          })
+        })
+
+        it('should skip injecting if one of the Authorization headers contains an AWS signature', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          appListener = server(app, port => {
+            const req = http.request({
+              port,
+              headers: {
+                Authorization: ['AWS4-HMAC-SHA256 ...']
+              }
+            })
+
+            req.end()
+          })
+        })
+
+        it('should skip injecting if the X-Amz-Signature header is set', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          appListener = server(app, port => {
+            const req = http.request({
+              port,
+              headers: {
+                'X-Amz-Signature': 'abc123'
+              }
+            })
+
+            req.end()
+          })
+        })
+
+        it('should skip injecting if the X-Amz-Signature query param is set', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.undefined
+              expect(req.get('x-datadog-parent-id')).to.be.undefined
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          appListener = server(app, port => {
+            const req = http.request({
+              port,
+              path: '/?X-Amz-Signature=abc123'
             })
 
             req.end()
@@ -1013,6 +1086,50 @@ describe('Plugin', () => {
           appListener = server(app, port => {
             const req = http.request(`${protocol}://localhost:${port}/user`, res => {
               res.on('data', () => {})
+            })
+
+            req.end()
+          })
+        })
+      })
+
+      describe('with config enablePropagationWithAmazonHeaders enabled', () => {
+        let config
+
+        beforeEach(() => {
+          config = {
+            enablePropagationWithAmazonHeaders: true
+          }
+
+          return agent.load('http', config)
+            .then(() => {
+              http = require(pluginToBeLoaded)
+              express = require('express')
+            })
+        })
+
+        it('should inject tracing header into AWS signed request', done => {
+          const app = express()
+
+          app.get('/', (req, res) => {
+            try {
+              expect(req.get('x-datadog-trace-id')).to.be.a('string')
+              expect(req.get('x-datadog-parent-id')).to.be.a('string')
+
+              res.status(200).send()
+
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+
+          appListener = server(app, port => {
+            const req = http.request({
+              port,
+              headers: {
+                Authorization: 'AWS4-HMAC-SHA256 ...'
+              }
             })
 
             req.end()


### PR DESCRIPTION
### What does this PR do?

This reverts the changes introduced by #5127 5 days ago.

The PR caused two tests to fail on `master`:

- [Plugins / fetch](https://github.com/DataDog/dd-trace-js/actions/runs/12886874414/job/35928441887)
- [Plugins / undici](https://github.com/DataDog/dd-trace-js/actions/runs/12886874414/job/35928462905)

For some reason there tests were not run in the PR CI.

For details see [this Slack thread](https://dd.slack.com/archives/C02LESJ9PQX/p1737537435408069).

### Motivation

Unblock `master`. Fixing the actual bug can happen off-branch.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


