### PR TITLE
fix tracer flare log

### DIFF
--- a/packages/dd-trace/src/flare/index.js
+++ b/packages/dd-trace/src/flare/index.js
@@ -92,6 +92,9 @@ const flare = {
 function recordLog (msg) {
   if (tracerLogs.length > MAX_LOG_SIZE) return
 
+  if (msg && typeof msg === 'object') {
+    msg = JSON.stringify(msg)
+  }
   tracerLogs.write(`${msg}\n`) // TODO: gzip
 }
 

--- a/packages/dd-trace/test/flare.spec.js
+++ b/packages/dd-trace/test/flare.spec.js
@@ -155,7 +155,7 @@ describe('Flare', () => {
 
     debugChannel.publish('foo')
     debugChannel.publish('bar')
-    debugChannel.publish({foo: 'bar'})
+    debugChannel.publish({ foo: 'bar' })
 
     flare.send(task)
   })

--- a/packages/dd-trace/test/flare.spec.js
+++ b/packages/dd-trace/test/flare.spec.js
@@ -142,7 +142,7 @@ describe('Flare', () => {
 
         const content = file.buffer.toString()
 
-        expect(content).to.equal('foo\nbar\n')
+        expect(content).to.equal('foo\nbar\n{"foo":"bar"}\n')
 
         done()
       } catch (e) {
@@ -155,6 +155,7 @@ describe('Flare', () => {
 
     debugChannel.publish('foo')
     debugChannel.publish('bar')
+    debugChannel.publish({foo: 'bar'})
 
     flare.send(task)
   })


### PR DESCRIPTION
Our log messages are all objects, so without this, we were getting nothing but `[object Object]` in flare logs.

