### PR TITLE
inject cloned request headers for http requests

### DIFF
--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -9,7 +9,7 @@ class FetchPlugin extends HttpClientPlugin {
   bindStart (ctx) {
     const req = ctx.req
     const options = new URL(req.url)
-    const headers = options.headers = Object.fromEntries(req.headers.entries())
+    options.headers = Object.fromEntries(req.headers.entries())
 
     options.method = req.method
 
@@ -17,9 +17,9 @@ class FetchPlugin extends HttpClientPlugin {
 
     const store = super.bindStart(ctx)
 
-    for (const name in headers) {
+    for (const name in options.headers) {
       if (!req.headers.has(name)) {
-        req.headers.set(name, headers[name])
+        req.headers.set(name, options.headers[name])
       }
     }
 

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -14,7 +14,9 @@ const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 const SERVICE_NAME = DD_MAJOR < 3 ? 'test-http-client' : 'test'
 const describe = globalThis.fetch ? globalThis.describe : globalThis.describe.skip
 
-describe('Plugin', () => {
+describe('Plugin', function () {
+  this.timeout(0)
+
   let express
   let fetch
   let appListener
@@ -212,102 +214,6 @@ describe('Plugin', () => {
             .catch(done)
 
           fetch(`http://localhost:${port}/user?foo=bar`, { headers: { foo: 'bar' } })
-        })
-      })
-
-      it('should skip injecting if the Authorization header contains an AWS signature', done => {
-        const app = express()
-
-        app.get('/', (req, res) => {
-          try {
-            expect(req.get('x-datadog-trace-id')).to.be.undefined
-            expect(req.get('x-datadog-parent-id')).to.be.undefined
-
-            res.status(200).send()
-
-            done()
-          } catch (e) {
-            done(e)
-          }
-        })
-
-        appListener = server(app, port => {
-          fetch(`http://localhost:${port}/`, {
-            headers: {
-              Authorization: 'AWS4-HMAC-SHA256 ...'
-            }
-          })
-        })
-      })
-
-      it('should skip injecting if one of the Authorization headers contains an AWS signature', done => {
-        const app = express()
-
-        app.get('/', (req, res) => {
-          try {
-            expect(req.get('x-datadog-trace-id')).to.be.undefined
-            expect(req.get('x-datadog-parent-id')).to.be.undefined
-
-            res.status(200).send()
-
-            done()
-          } catch (e) {
-            done(e)
-          }
-        })
-
-        appListener = server(app, port => {
-          fetch(`http://localhost:${port}/`, {
-            headers: {
-              Authorization: ['AWS4-HMAC-SHA256 ...']
-            }
-          })
-        })
-      })
-
-      it('should skip injecting if the X-Amz-Signature header is set', done => {
-        const app = express()
-
-        app.get('/', (req, res) => {
-          try {
-            expect(req.get('x-datadog-trace-id')).to.be.undefined
-            expect(req.get('x-datadog-parent-id')).to.be.undefined
-
-            res.status(200).send()
-
-            done()
-          } catch (e) {
-            done(e)
-          }
-        })
-
-        appListener = server(app, port => {
-          fetch(`http://localhost:${port}/`, {
-            headers: {
-              'X-Amz-Signature': 'abc123'
-            }
-          })
-        })
-      })
-
-      it('should skip injecting if the X-Amz-Signature query param is set', done => {
-        const app = express()
-
-        app.get('/', (req, res) => {
-          try {
-            expect(req.get('x-datadog-trace-id')).to.be.undefined
-            expect(req.get('x-datadog-parent-id')).to.be.undefined
-
-            res.status(200).send()
-
-            done()
-          } catch (e) {
-            done(e)
-          }
-        })
-
-        appListener = server(app, port => {
-          fetch(`http://localhost:${port}/?X-Amz-Signature=abc123`)
         })
       })
 


### PR DESCRIPTION
### What does this PR do?
Fixes [this issue opened in the Datadog Lambda JS Serverless Layer ](https://github.com/DataDog/datadog-lambda-js/issues/596)
Header injection for distributed context was breaking AWS signed requests, specifically when requests were retried, and ended up being turned off for these requests. This PR fixes the problem and re-enables injection for signed requests. Instead of mutating request headers, we now clone them. AWS-SDK was regenerating request signatures based off the mutated headers (now with DD context data) during retries, causing signed requests to fail.

Solution based off [similar fix in Opentelemetry-js SDK](https://github.com/open-telemetry/opentelemetry-js/pull/4346)
[Deeper Explanation of issue](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1609#issuecomment-1826167348)

See #5127 #5141

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


