### PR TITLE
Instrument dd-trace-api

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -317,6 +317,14 @@ jobs:
           suffix: plugins-${{ github.job }}
       - uses: codecov/codecov-action@v5
 
+  dd-trace-api:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: dd-trace-api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/plugins/test
+
   dns:
     runs-on: ubuntu-latest
     env:

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -76,23 +76,35 @@ module.exports = class DdTraceApiPlugin extends Plugin {
       })
     }
 
-    handleEvent('init')
-    // TODO(bengl) for API calls like this one that return an object created
-    // internally, care needs to be taken to ensure we're not breaking the
-    // calling API. We don't expect spans to change much, but if they do, this
-    // needs to be taken into account.
+    // handleEvent('configure')
     handleEvent('startSpan')
     handleEvent('wrap')
     handleEvent('trace')
     handleEvent('inject')
     handleEvent('extract')
     handleEvent('getRumData')
-    handleEvent('setUser')
     handleEvent('profilerStarted')
     handleEvent('span:context')
     handleEvent('span:setTag')
     handleEvent('span:addTags')
     handleEvent('span:finish')
     handleEvent('span:addLink')
+    handleEvent('scope')
+    handleEvent('scope:activate')
+    handleEvent('scope:active')
+    handleEvent('scope:bind')
+    handleEvent('appsec:blockRequest')
+    handleEvent('appsec:isUserBlocked')
+    handleEvent('appsec:setUser')
+    handleEvent('appsec:tracerCustomEvent')
+    handleEvent('appsec:trackUserLoginFailureEvent')
+    handleEvent('appsec:trackUserLoginSuccessEvent')
+    handleEvent('dogstatsd:decrement')
+    handleEvent('dogstatsd:distribution')
+    handleEvent('dogstatsd:flush')
+    handleEvent('dogstatsd:gauge')
+    handleEvent('dogstatsd:histogram')
+    handleEvent('dogstatsd:increment')
+    handleEvent('use')
   }
 }

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const Plugin = require('../../dd-trace/src/plugins/plugin')
+
+const objectMap = new WeakMap()
+
+class DdTraceApiPlugin extends Plugin {
+  static get id () {
+    return 'dd-trace-api'
+  }
+
+  constructor (...args) {
+    super(...args)
+
+    const tracer = this._tracer
+
+    const handleEvent = (name, fn) => {
+      // For v1, APIs are 1:1 with their internal equivalents, so we can just
+      // call the internal method directly. That's what we do here unless we
+      // want to override. As the API evolves, this may change.
+      this.addSub(`datadog-api:v1:${name}`, ({ self, args, ret, dummy }) => {
+        if (!fn && name.includes(':')) {
+          name = name.split(':').pop()
+        }
+
+        try {
+          ret.value = fn ? fn(args, self) : self[name](...args)
+          if (dummy) {
+            objectMap.set(dummy, ret.value)
+            ret.value = dummy
+          }
+        } catch (e) {
+          ret.error = e
+        }
+      })
+    }
+
+    handleEvent('init')
+    // TODO(bengl) for API calls like this one that return an object created
+    // internally, care needs to be taken to ensure we're not breaking the
+    // calling API. We don't expect spans to change much, but if they do, this
+    // needs to be taken into account.
+    handleEvent('startSpan')
+    handleEvent('inject')
+    handleEvent('extract')
+    handleEvent('getRumData')
+    handleEvent('setUser')
+    handleEvent('profilerStarted')
+  }
+}

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -88,7 +88,9 @@ module.exports = class DdTraceApiPlugin extends Plugin {
     handleEvent('extract')
     handleEvent('getRumData')
     handleEvent('profilerStarted')
-    // TODO does context need to be wrapped/proxied?
+    handleEvent('context:toTraceId')
+    handleEvent('context:toSpanId')
+    handleEvent('context:toTraceparent')
     handleEvent('span:context')
     handleEvent('span:setTag')
     handleEvent('span:addTags')

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -7,6 +7,9 @@ const apiMetrics = telemetryMetrics.manager.namespace('tracers')
 // api ==> here
 const objectMap = new WeakMap()
 
+const injectionEnabledTag =
+  `injection_enabled:${process.env.DD_INJECTION_ENABLED ? 'yes' : 'no'}`
+
 module.exports = class DdTraceApiPlugin extends Plugin {
   static get id () {
     return 'dd-trace-api'
@@ -28,7 +31,7 @@ module.exports = class DdTraceApiPlugin extends Plugin {
       const counter = apiMetrics.count('dd_trace_api.called', [
         `name:${name.replace(':', '.')}`,
         'api_version:v1',
-        `injection_enabled:${process.env.DD_INJECTION_ENABLED ? 'yes' : 'no'}`
+        injectionEnabledTag
       ])
 
       // For v1, APIs are 1:1 with their internal equivalents, so we can just

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -72,7 +72,7 @@ module.exports = class DdTraceApiPlugin extends Plugin {
             objectMap.set(proxyVal, ret.value)
             ret.value = proxyVal
           } else if (ret.value && typeof ret.value === 'object') {
-            throw new TypeError('Objects need proxies when returned via API')
+            throw new TypeError(`Objects need proxies when returned via API (${name})`)
           }
         } catch (e) {
           ret.error = e

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -29,7 +29,7 @@ module.exports = class DdTraceApiPlugin extends Plugin {
 
     const handleEvent = (name) => {
       const counter = apiMetrics.count('dd_trace_api.called', [
-        `name:${name.replace(':', '.')}`,
+        `name:${name.replaceAll(':', '.')}`,
         'api_version:v1',
         injectionEnabledTag
       ])

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const dc = require('dc-polyfill')
+
+const Plugin = require('../src')
+const NoopProxy = require('../../dd-trace/src/noop/proxy')
+const assert = require('assert')
+
+describe('Plugin', () => {
+  describe('dd-trace-api', () => {
+    let dummyTracer
+    let plugin
+    let tracer
+    let scope
+
+    const allChannels = new Set()
+    const testedChannels = new Set()
+
+    function test({name, fn, self = dummyTracer, ret = undefined, args = []}) {
+      testedChannels.add('datadog-api:v1:' + name)
+      const ch = dc.channel('datadog-api:v1:' + name)
+      const payload = {
+        self,
+        args: [],
+        ret: {},
+        proxy: () => ret,
+        revProxy: []
+      }
+      ch.publish(payload)
+      expect(payload.ret.value).to.equal(ret)
+      expect(fn).to.have.been.calledOnceWithExactly(...args)
+    }
+
+    before(() => {
+      sinon.spy(dc, 'channel')
+
+      tracer = new NoopProxy()
+      scope = tracer._tracer._scope
+      sinon.spy(scope)
+      sinon.spy(tracer)
+      plugin = new Plugin(tracer, {})
+      plugin.configure(true)
+
+      for (let i = 0; i < dc.channel.callCount; i++) {
+        const call = dc.channel.getCall(i)
+        const channel = call.args[0]
+        allChannels.add(channel)
+      }
+
+      dummyTracer = {}
+      const payload = {
+        proxy: () => dummyTracer,
+        args: []
+      }
+      dc.channel('datadog-api:v1:tracerinit').publish(payload)
+    })
+
+    describe('scope', () => {
+      let dummyScope
+      it('should call underlying api', () => {
+        dummyScope = {}
+        test({name: 'scope', fn: tracer.scope, ret: dummyScope})
+      })
+
+//       describe('scope:active', () => {
+//         it('should call underlying api', () => {
+//           const scope = tracer.scope()
+//           test({name: 'scope:active', fn: tracer._scope.active, self: scope, ret: null})
+//         })
+//       })
+//
+//       describe('scope:activate', () => {
+//         it('should call underlying api', () => {
+//           const scope = tracer.scope()
+//           test({name: 'scope:activate', fn: tracer._scope.active, self: scope})
+//         })
+//       })
+//
+//       describe('scope:bind', () => {
+//         it('should call underlying api', () => {
+//           const dummyScope = tracer.scope()
+//           test({name: 'scope:bind', fn: tracer._scope.active, self: scope})
+//         })
+//       })
+
+    })
+
+
+    after('dd-trace-api all events tested', () => {
+      // TODO uncomment next line when all are tested
+      // assert.deepStrictEqual([...allChannels].sort(), [...testedChannels].sort())
+    })
+  })
+})
+

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -98,11 +98,35 @@ describe('Plugin', () => {
       })
 
       describe('span:context', () => {
+        let traceId = '1234567890abcdef'
+        let spanId = 'abcdef1234567890'
+        let traceparent= `00-${traceId}-${spanId}-01`
+
         it('should call underlying api', () => {
           dummySpanContext = {}
           testChannel({ name: 'span:context', fn: span.context, self: dummySpan, ret: dummySpanContext })
           spanContext = span.context.getCall(0).returnValue
-          sinon.spy(spanContext)
+          sinon.stub(spanContext, 'toTraceId').callsFake(() => traceId)
+          sinon.stub(spanContext, 'toSpanId').callsFake(() => spanId)
+          sinon.stub(spanContext, 'toTraceparent').callsFake(() => traceparent)
+        })
+
+        describe('context:toTraceId', () => {
+          it('should call underlying api', () => {
+            testChannel({ name: 'context:toTraceId', fn: spanContext.toTraceId, self: dummySpanContext, ret: traceId })
+          })
+        })
+
+        describe('context:toSpanId', () => {
+          it('should call underlying api', () => {
+            testChannel({ name: 'context:toSpanId', fn: spanContext.toSpanId, self: dummySpanContext, ret: spanId })
+          })
+        })
+
+        describe('context:toTraceparent', () => {
+          it('should call underlying api', () => {
+            testChannel({ name: 'context:toTraceparent', fn: spanContext.toTraceparent, self: dummySpanContext, ret: traceparent })
+          })
         })
       })
 

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -53,14 +53,23 @@ describe('Plugin', () => {
 
       it('should call underlying api', () => {
         dummyScope = {}
-        testChannel({ name: 'scope', fn: tracer.scope, ret: dummyScope })
+        testChannel({
+          name: 'scope',
+          fn: tracer.scope,
+          ret: dummyScope
+        })
       })
 
       describe('scope:active', () => {
         it('should call underlying api', () => {
           scope = tracer.scope()
           sinon.spy(scope, 'active')
-          testChannel({ name: 'scope:active', fn: scope.active, self: dummyScope, ret: null })
+          testChannel({
+            name: 'scope:active',
+            fn: scope.active,
+            self: dummyScope,
+            ret: null
+          })
           scope.active.restore()
         })
       })
@@ -69,7 +78,11 @@ describe('Plugin', () => {
         it('should call underlying api', () => {
           scope = tracer.scope()
           sinon.spy(scope, 'activate')
-          testChannel({ name: 'scope:activate', fn: scope.activate, self: dummyScope })
+          testChannel({
+            name: 'scope:activate',
+            fn: scope.activate,
+            self: dummyScope
+          })
           scope.activate.restore()
         })
       })
@@ -78,7 +91,11 @@ describe('Plugin', () => {
         it('should call underlying api', () => {
           scope = tracer.scope()
           sinon.spy(scope, 'bind')
-          testChannel({ name: 'scope:bind', fn: scope.bind, self: dummyScope })
+          testChannel({
+            name: 'scope:bind',
+            fn: scope.bind,
+            self: dummyScope
+          })
           scope.bind.restore()
         })
       })
@@ -92,19 +109,28 @@ describe('Plugin', () => {
 
       it('should call underlying api', () => {
         dummySpan = {}
-        testChannel({ name: 'startSpan', fn: tracer.startSpan, ret: dummySpan })
+        testChannel({
+          name: 'startSpan',
+          fn: tracer.startSpan,
+          ret: dummySpan
+        })
         span = tracer.startSpan.getCall(0).returnValue
         sinon.spy(span)
       })
 
       describe('span:context', () => {
-        let traceId = '1234567890abcdef'
-        let spanId = 'abcdef1234567890'
-        let traceparent= `00-${traceId}-${spanId}-01`
+        const traceId = '1234567890abcdef'
+        const spanId = 'abcdef1234567890'
+        const traceparent = `00-${traceId}-${spanId}-01`
 
         it('should call underlying api', () => {
           dummySpanContext = {}
-          testChannel({ name: 'span:context', fn: span.context, self: dummySpan, ret: dummySpanContext })
+          testChannel({
+            name: 'span:context',
+            fn: span.context,
+            self: dummySpan,
+            ret: dummySpanContext
+          })
           spanContext = span.context.getCall(0).returnValue
           sinon.stub(spanContext, 'toTraceId').callsFake(() => traceId)
           sinon.stub(spanContext, 'toSpanId').callsFake(() => spanId)
@@ -113,38 +139,67 @@ describe('Plugin', () => {
 
         describe('context:toTraceId', () => {
           it('should call underlying api', () => {
-            testChannel({ name: 'context:toTraceId', fn: spanContext.toTraceId, self: dummySpanContext, ret: traceId })
+            testChannel({
+              name: 'context:toTraceId',
+              fn: spanContext.toTraceId,
+              self: dummySpanContext,
+              ret: traceId
+            })
           })
         })
 
         describe('context:toSpanId', () => {
           it('should call underlying api', () => {
-            testChannel({ name: 'context:toSpanId', fn: spanContext.toSpanId, self: dummySpanContext, ret: spanId })
+            testChannel({
+              name: 'context:toSpanId',
+              fn: spanContext.toSpanId,
+              self: dummySpanContext,
+              ret: spanId
+            })
           })
         })
 
         describe('context:toTraceparent', () => {
           it('should call underlying api', () => {
-            testChannel({ name: 'context:toTraceparent', fn: spanContext.toTraceparent, self: dummySpanContext, ret: traceparent })
+            testChannel({
+              name: 'context:toTraceparent',
+              fn: spanContext.toTraceparent,
+              self: dummySpanContext,
+              ret: traceparent
+            })
           })
         })
       })
 
       describe('span:setTag', () => {
         it('should call underlying api', () => {
-          testChannel({ name: 'span:setTag', fn: span.setTag, self: dummySpan, ret: dummySpan })
+          testChannel({
+            name: 'span:setTag',
+            fn: span.setTag,
+            self: dummySpan,
+            ret: dummySpan
+          })
         })
       })
 
       describe('span:addTags', () => {
         it('should call underlying api', () => {
-          testChannel({ name: 'span:addTags', fn: span.addTags, self: dummySpan, ret: dummySpan })
+          testChannel({
+            name: 'span:addTags',
+            fn: span.addTags,
+            self: dummySpan,
+            ret: dummySpan
+          })
         })
       })
 
       describe('span:finish', () => {
         it('should call underlying api', () => {
-          testChannel({ name: 'span:finish', fn: span.finish, self: dummySpan })
+          testChannel({
+            name: 'span:finish',
+            fn: span.finish,
+            self: dummySpan
+          })
         })
       })
 
@@ -186,7 +241,7 @@ describe('Plugin', () => {
       assert.deepStrictEqual([...allChannels].sort(), [...testedChannels].sort())
     })
 
-    function describeMethod(name, ret) {
+    function describeMethod (name, ret) {
       describe(name, () => {
         it('should call underlying api', () => {
           if (ret === SELF) {
@@ -197,7 +252,7 @@ describe('Plugin', () => {
       })
     }
 
-    function describeSubsystem(name, command, ret) {
+    function describeSubsystem (name, command, ret) {
       describe(`${name}:${command}`, () => {
         it('should call underlying api', () => {
           const options = {

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -2,52 +2,58 @@
 
 const dc = require('dc-polyfill')
 
-const Plugin = require('../src')
-const NoopProxy = require('../../dd-trace/src/noop/proxy')
+const agent = require('../../dd-trace/test/plugins/agent')
 const assert = require('assert')
 
 describe('Plugin', () => {
   describe('dd-trace-api', () => {
     let dummyTracer
-    let plugin
     let tracer
-    let scope
 
     const allChannels = new Set()
     const testedChannels = new Set()
 
-    function test({name, fn, self = dummyTracer, ret = undefined, args = []}) {
+    function testChannel ({ name, fn, self = dummyTracer, ret = undefined, args = [] }) {
       testedChannels.add('datadog-api:v1:' + name)
       const ch = dc.channel('datadog-api:v1:' + name)
       const payload = {
         self,
-        args: [],
+        args,
         ret: {},
-        proxy: () => ret,
+        proxy: ret && typeof ret === 'object' ? () => ret : undefined,
         revProxy: []
       }
       ch.publish(payload)
+      if (payload.ret.error) {
+        throw payload.ret.error
+      }
       expect(payload.ret.value).to.equal(ret)
       expect(fn).to.have.been.calledOnceWithExactly(...args)
     }
 
-    before(() => {
+    before(async () => {
       sinon.spy(dc, 'channel')
 
-      tracer = new NoopProxy()
-      scope = tracer._tracer._scope
-      sinon.spy(scope)
+      await agent.load('dd-trace-api')
+
+      tracer = require('../../dd-trace')
+
       sinon.spy(tracer)
-      plugin = new Plugin(tracer, {})
-      plugin.configure(true)
+      sinon.spy(tracer.appsec)
+      sinon.spy(tracer.dogstatsd)
 
       for (let i = 0; i < dc.channel.callCount; i++) {
         const call = dc.channel.getCall(i)
         const channel = call.args[0]
-        allChannels.add(channel)
+        if (channel.startsWith('datadog-api:v1:') && !channel.endsWith('tracerinit')) {
+          allChannels.add(channel)
+        }
       }
 
-      dummyTracer = {}
+      dummyTracer = {
+        appsec: {},
+        dogstatsd: {}
+      }
       const payload = {
         proxy: () => dummyTracer,
         args: []
@@ -55,41 +61,264 @@ describe('Plugin', () => {
       dc.channel('datadog-api:v1:tracerinit').publish(payload)
     })
 
+    after(() => agent.close({ ritmReset: false }))
+
     describe('scope', () => {
       let dummyScope
+      let scope
+
       it('should call underlying api', () => {
         dummyScope = {}
-        test({name: 'scope', fn: tracer.scope, ret: dummyScope})
+        testChannel({ name: 'scope', fn: tracer.scope, ret: dummyScope })
       })
 
-//       describe('scope:active', () => {
-//         it('should call underlying api', () => {
-//           const scope = tracer.scope()
-//           test({name: 'scope:active', fn: tracer._scope.active, self: scope, ret: null})
-//         })
-//       })
-//
-//       describe('scope:activate', () => {
-//         it('should call underlying api', () => {
-//           const scope = tracer.scope()
-//           test({name: 'scope:activate', fn: tracer._scope.active, self: scope})
-//         })
-//       })
-//
-//       describe('scope:bind', () => {
-//         it('should call underlying api', () => {
-//           const dummyScope = tracer.scope()
-//           test({name: 'scope:bind', fn: tracer._scope.active, self: scope})
-//         })
-//       })
+      describe('scope:active', () => {
+        it('should call underlying api', () => {
+          scope = tracer.scope()
+          sinon.spy(scope, 'active')
+          testChannel({ name: 'scope:active', fn: scope.active, self: dummyScope, ret: null })
+          scope.active.restore()
+        })
+      })
 
+      describe('scope:activate', () => {
+        it('should call underlying api', () => {
+          scope = tracer.scope()
+          sinon.spy(scope, 'activate')
+          testChannel({ name: 'scope:activate', fn: scope.activate, self: dummyScope })
+          scope.activate.restore()
+        })
+      })
+
+      describe('scope:bind', () => {
+        it('should call underlying api', () => {
+          scope = tracer.scope()
+          sinon.spy(scope, 'bind')
+          testChannel({ name: 'scope:bind', fn: scope.bind, self: dummyScope })
+          scope.bind.restore()
+        })
+      })
     })
 
+    describe('inject', () => {
+      it('should call underlying api', () => {
+        testChannel({ name: 'inject', fn: tracer.inject })
+      })
+    })
+
+    describe('extract', () => {
+      it('should call underlying api', () => {
+        testChannel({ name: 'extract', fn: tracer.extract, ret: null })
+      })
+    })
+
+    describe('getRumData', () => {
+      it('should call underlying api', () => {
+        testChannel({ name: 'getRumData', fn: tracer.getRumData, ret: '' })
+      })
+    })
+
+    describe('trace', () => {
+      it('should call underlying api', () => {
+        testChannel({ name: 'trace', fn: tracer.trace })
+      })
+    })
+
+    describe('wrap', () => {
+      it('should call underlying api', () => {
+        testChannel({ name: 'wrap', fn: tracer.wrap })
+      })
+    })
+
+    describe('use', () => {
+      it('should call underlying api', () => {
+        testChannel({ name: 'use', fn: tracer.use, ret: dummyTracer })
+      })
+    })
+
+    describe('profilerStarted', () => {
+      it('should call underlying api', () => {
+        testChannel({ name: 'profilerStarted', fn: tracer.profilerStarted, ret: Promise.resolve(false) })
+      })
+    })
+
+    describe('startSpan', () => {
+      let dummySpan
+      let dummySpanContext
+      let span
+      let spanContext
+
+      it('should call underlying api', () => {
+        dummySpan = {}
+        testChannel({ name: 'startSpan', fn: tracer.startSpan, ret: dummySpan })
+        span = tracer.startSpan.getCall(0).returnValue
+        sinon.spy(span)
+      })
+
+      describe('span:context', () => {
+        it('should call underlying api', () => {
+          dummySpanContext = {}
+          testChannel({ name: 'span:context', fn: span.context, self: dummySpan, ret: dummySpanContext })
+          spanContext = span.context.getCall(0).returnValue
+          sinon.spy(spanContext)
+        })
+      })
+
+      describe('span:setTag', () => {
+        it('should call underlying api', () => {
+          testChannel({ name: 'span:setTag', fn: span.setTag, self: dummySpan, ret: dummySpan })
+        })
+      })
+
+      describe('span:addTags', () => {
+        it('should call underlying api', () => {
+          testChannel({ name: 'span:addTags', fn: span.addTags, self: dummySpan, ret: dummySpan })
+        })
+      })
+
+      describe('span:finish', () => {
+        it('should call underlying api', () => {
+          testChannel({ name: 'span:finish', fn: span.finish, self: dummySpan })
+        })
+      })
+
+      describe('span:addLink', () => {
+        it('should call underlying api', () => {
+          testChannel({
+            name: 'span:addLink',
+            fn: span.addLink,
+            self: dummySpan,
+            ret: dummySpan,
+            args: [dummySpanContext]
+          })
+        })
+      })
+    })
+
+    describe('appsec:blockRequest', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'appsec:blockRequest',
+          fn: tracer.appsec.blockRequest,
+          self: tracer.appsec,
+          ret: false
+        })
+      })
+    })
+
+    describe('appsec:isUserBlocked', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'appsec:isUserBlocked',
+          fn: tracer.appsec.isUserBlocked,
+          self: tracer.appsec,
+          ret: false
+        })
+      })
+    })
+
+    describe('appsec:setUser', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'appsec:setUser',
+          fn: tracer.appsec.setUser,
+          self: tracer.appsec
+        })
+      })
+    })
+
+    describe('appsec:trackCustomEvent', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'appsec:trackCustomEvent',
+          fn: tracer.appsec.trackCustomEvent,
+          self: tracer.appsec
+        })
+      })
+    })
+
+    describe('appsec:trackUserLoginFailureEvent', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'appsec:trackUserLoginFailureEvent',
+          fn: tracer.appsec.trackUserLoginFailureEvent,
+          self: tracer.appsec
+        })
+      })
+    })
+
+    describe('appsec:trackUserLoginSuccessEvent', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'appsec:trackUserLoginSuccessEvent',
+          fn: tracer.appsec.trackUserLoginSuccessEvent,
+          self: tracer.appsec
+        })
+      })
+    })
+
+    describe('dogstatsd:decrement', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'dogstatsd:decrement',
+          fn: tracer.dogstatsd.decrement,
+          self: tracer.dogstatsd
+        })
+      })
+    })
+
+    describe('dogstatsd:distribution', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'dogstatsd:distribution',
+          fn: tracer.dogstatsd.distribution,
+          self: tracer.dogstatsd
+        })
+      })
+    })
+
+    describe('dogstatsd:flush', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'dogstatsd:flush',
+          fn: tracer.dogstatsd.flush,
+          self: tracer.dogstatsd
+        })
+      })
+    })
+
+    describe('dogstatsd:gauge', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'dogstatsd:gauge',
+          fn: tracer.dogstatsd.gauge,
+          self: tracer.dogstatsd
+        })
+      })
+    })
+
+    describe('dogstatsd:histogram', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'dogstatsd:histogram',
+          fn: tracer.dogstatsd.histogram,
+          self: tracer.dogstatsd
+        })
+      })
+    })
+
+    describe('dogstatsd:increment', () => {
+      it('should call underlying api', () => {
+        testChannel({
+          name: 'dogstatsd:increment',
+          fn: tracer.dogstatsd.increment,
+          self: tracer.dogstatsd
+        })
+      })
+    })
 
     after('dd-trace-api all events tested', () => {
-      // TODO uncomment next line when all are tested
-      // assert.deepStrictEqual([...allChannels].sort(), [...testedChannels].sort())
+      assert.deepStrictEqual([...allChannels].sort(), [...testedChannels].sort())
     })
   })
 })
-

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -31,6 +31,9 @@ loadChannel.subscribe(({ name }) => {
 // Globals
 maybeEnable(require('../../datadog-plugin-fetch/src'))
 
+// Always enabled
+maybeEnable(require('../../datadog-plugin-dd-trace-api/src'))
+
 function maybeEnable (Plugin) {
   if (!Plugin || typeof Plugin !== 'function') return
   if (!pluginClasses[Plugin.id]) {

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -34,6 +34,7 @@ module.exports = {
   get couchbase () { return require('../../../datadog-plugin-couchbase/src') },
   get cypress () { return require('../../../datadog-plugin-cypress/src') },
   get dns () { return require('../../../datadog-plugin-dns/src') },
+  get 'dd-trace-api' () { return require('../../../datadog-plugin-dd-trace-api/src') },
   get elasticsearch () { return require('../../../datadog-plugin-elasticsearch/src') },
   get express () { return require('../../../datadog-plugin-express/src') },
   get fastify () { return require('../../../datadog-plugin-fastify/src') },


### PR DESCRIPTION
This is the initial PR that adds support for the (soon to be released) `dd-trace-api` module.

The `dd-trace-api` module works by sending all API calls through diagnostics channels, including the name of the function being called, all the arguments, and the `this` object. appropriate functions are passed through for any return values that need to be proxied.

What's proxying? Here, it refers to having a facade object presented by `dd-trace-api` that corresponds to a "real" object created by `dd-trace`. The facade allows `dd-trace-api` to never expose an internal object to the caller.

Testing is done primarily by checking that diagnostics channels map correctly to the internal function calls. Additional testing will take place in `dd-trace-api` to ensure the whole system works end-to-end.


