### PR TITLE
make DatadogSpanContext.toTraceId and DatadogSpanContext.toSpanId more defensive

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -325,6 +325,7 @@ class TextMapPropagator {
       if (context === null) {
         context = extractedContext
         if (this._config.tracePropagationExtractFirst) {
+          if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) this._extractBaggageItems(carrier, context)
           return context
         }
       } else {

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -325,7 +325,9 @@ class TextMapPropagator {
       if (context === null) {
         context = extractedContext
         if (this._config.tracePropagationExtractFirst) {
-          if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) this._extractBaggageItems(carrier, context)
+          if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) {
+            this._extractBaggageItems(carrier, context)
+          }
           return context
         }
       } else {

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -49,14 +49,14 @@ class DatadogSpanContext {
         ? this._trace.tags[TRACE_ID_128] + this._traceId.toString(16).padStart(16, '0')
         : this._traceId.toString(16).padStart(32, '0')
     }
-    return this._traceId.toString(10)
+    return this._traceId?.toString(10)
   }
 
   toSpanId (get128bitId = false) {
     if (get128bitId) {
       return this._spanId.toString(16).padStart(16, '0')
     }
-    return this._spanId.toString(10)
+    return this._spanId?.toString(10)
   }
 
   toTraceparent () {


### PR DESCRIPTION
### What does this PR do?
Add handling for the cases _traceId or _spanId is undefined as a possible fix for this [issue](https://github.com/DataDog/dd-trace-js/issues/4987)

### Motivation
[This line](https://github.com/DataDog/dd-trace-js/blob/c28765a66d5d7d2b2f97fc0cbcf179344926b71a/packages/dd-trace/src/opentracing/propagation/text_map.js#L348) technically makes it possible to have a DatadogSpanContext object with no _traceId or _spanId, even though I'm not sure when this case will be reached, other than when the only propagation style is `baggage` in the [tracer config object](https://github.com/DataDog/dd-trace-js/blob/c28765a66d5d7d2b2f97fc0cbcf179344926b71a/packages/dd-trace/src/config.js#L564-L565). Some customers reported they started seeing crashes due to this issue after their services have been running for a while, so I think there is probably some edge cases that are currently unaccounted for. This PR is an attempt at remedying this.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


