### PR TITLE
[DSM] Fix an issue where RabbitMQ producers when producing a message to the default exchange were setting checkpoints that didn't work in DSM

### DIFF
--- a/packages/datadog-plugin-amqplib/src/producer.js
+++ b/packages/datadog-plugin-amqplib/src/producer.js
@@ -36,9 +36,17 @@ class AmqplibProducerPlugin extends ProducerPlugin {
     if (this.config.dsmEnabled) {
       const hasRoutingKey = fields.routingKey != null
       const payloadSize = getAmqpMessageSize({ content: message, headers: fields.headers })
+
+      // there are two ways to send messages in RabbitMQ:
+      // 1. using an exchange and a routing key in which DSM connects via the exchange
+      // 2. using an unnamed exchange and a routing key in which DSM connects via the topic
+      const exchangeOrTopicTag = hasRoutingKey && !fields.exchange
+        ? `topic:${fields.routingKey}`
+        : `exchange:${fields.exchange}`
+
       const dataStreamsContext = this.tracer
         .setCheckpoint(
-          ['direction:out', `exchange:${fields.exchange}`, `has_routing_key:${hasRoutingKey}`, 'type:rabbitmq']
+          ['direction:out', exchangeOrTopicTag, `has_routing_key:${hasRoutingKey}`, 'type:rabbitmq']
           , span, payloadSize)
       DsmPathwayCodec.encode(dataStreamsContext, fields.headers)
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The RabbitMQ DSM integration is built with the idea that users will always have an exchange. The Producer plugin sends a checkpoint with the exchange (and no topic). However, there is an API in RabbitMQ where instead of publishing to an exchange w/ a routing key, you send either [directly to a queue](https://amqp-node.github.io/amqplib/channel_api.html#channel_sendToQueue) or you publish to either an undefined or empty string exchange and then the routing key is the queue and the exchange is the default exchange ([link, see second sentence of the first bullet](https://amqp-node.github.io/amqplib/channel_api.html#channel_publish)). In this case we are unable to show the connection between producer and consumer because we are only sending a checkpoint w/ the exchange which is blank and then the consumer has the topic and the exchange (still blank) and thus we aren't able to correlate them. This is happening w/ a client (unnamed)

see:
debug endpoint w/ checkpoints
![checkpoints-with-blur](https://github.com/user-attachments/assets/ae877cd3-dffb-4df4-be57-62dc699f903b)


trace on producer where we can see that the producer is sending only a routingKey and not an exchange
![trace-with-blur](https://github.com/user-attachments/assets/b68fe684-c31b-4fae-b76d-347c01f5fce8)


what the map ends up looking like
![map-with-blur](https://github.com/user-attachments/assets/5b317829-3267-4dba-b75c-8735733b3fb4)


To test that this works, I made an experiment using this branch of the tracer on staging w/ the data-streams-dev and sent a message from the producer w/ no exchange. [you can see that here](https://ddstaging.datadoghq.com/data-streams/map?query=service%3Arabbitmq-nodejs-producer%20queue%3Anodejs-rabbitmq-default-exchange&collapse_pipeline=true&mapPreferences=qson%3A%28data%3A%28shouldShowLoops%3A%21f%2CshouldShowGrpcOrHttp%3A%21f%2CshouldShowUsmTraffic%3A%21f%2CshouldRemoveS3%3A%21t%2CshouldUseBoxPackingLayout%3A%21t%2CshouldHideExchanges%3A%21f%2CshouldShowConnectors%3A%21f%29%2Cversion%3A%210%29&remove_pipelines=true)

#### why conditionally send the topic? why not always send the topic?
This fix is for **only this case**, in a case where we have an exchange, we still want to correlate via the exchange and get the difference between the queue and the routing key (so we only send the topic on the producer if there is a routing key and an empty exchange), otherwise we'd have a connection between two services that looked like this: 
![CleanShot 2025-01-23 at 11 08 12](https://github.com/user-attachments/assets/745f9be5-5531-4664-be4d-990a63cccf26)


### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


