### PR TITLE
Upgrade @datadog/pprof to 5.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@datadog/native-iast-rewriter": "2.6.1",
     "@datadog/native-iast-taint-tracking": "3.2.0",
     "@datadog/native-metrics": "^3.1.0",
-    "@datadog/pprof": "5.4.1",
+    "@datadog/pprof": "5.5.0",
     "@datadog/sketches-js": "^2.1.0",
     "@isaacs/ttlcache": "^1.4.1",
     "@opentelemetry/api": ">=1.0.0 <1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,10 +436,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.4.1.tgz#08c9bcf5d8efb2eeafdfc9f5bb5402f79fb41266"
-  integrity sha512-IvpL96e/cuh8ugP5O8Czdup7XQOLHeIDgM5pac5W7Lc1YzGe5zTtebKFpitvb1CPw1YY+1qFx0pWGgKP2kOfHg==
+"@datadog/pprof@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.5.0.tgz#48fff2d70c5d2975e1f7a2b00b45160d89cdeb06"
+  integrity sha512-+53v76BDLr6o9MWC8dj7FIhnUwNGeCxPwJcT2ZlioyKWHJqpbPQ0Pc92visXg/QI4s6Vpz7mZbThvD2kIe57Ng==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
Upgrades `@datadog/pprof` dependency to 5.5.0

### Motivation
Version 5.5.0 brings significant improvements to the profiler, see https://github.com/DataDog/pprof-nodejs/pull/192 for details.
