### PR TITLE
[DI] Record thread paused telemetry when breakpoint is hit

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/telemetry.js
+++ b/packages/dd-trace/src/debugger/devtools_client/telemetry.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { workerData: { telemetryPort } } = require('node:worker_threads')
+
+module.exports = {
+  threadPausedMsMetric (ms) {
+    telemetryPort.postMessage({ type: 'gauge', metric: 'thread_paused.ms', value: ms })
+  }
+}

--- a/packages/dd-trace/src/debugger/telemetry.js
+++ b/packages/dd-trace/src/debugger/telemetry.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const telemetryMetrics = require('../telemetry/metrics')
+
+const debuggerNamespace = telemetryMetrics.manager.namespace('live_debugger')
+
+module.exports = {
+  onTelemetryMessage ({ type, metric, value, tags = [] }) {
+    debuggerNamespace[type](metric, tags).track(value)
+  }
+}

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -74,7 +74,7 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
 
   const data = JSON.stringify({
     api_version: 'v2',
-    naming_schema_version: config.spanAttributeSchema ? config.spanAttributeSchema : '',
+    naming_schema_version: config.spanAttributeSchema,
     request_type: reqType,
     tracer_time: Math.floor(Date.now() / 1000),
     runtime_id: config.tags['runtime-id'],

--- a/packages/dd-trace/src/telemetry/telemetry.js
+++ b/packages/dd-trace/src/telemetry/telemetry.js
@@ -219,7 +219,6 @@ function heartbeat (config, application, host) {
     sendData(config, application, host, reqType, payload, updateRetryData)
     heartbeat(config, application, host)
   }, heartbeatInterval).unref()
-  return heartbeatTimeout
 }
 
 function extendedHeartbeat (config) {
@@ -232,7 +231,6 @@ function extendedHeartbeat (config) {
     sendData(config, application, host, 'app-extended-heartbeat', payload)
     Object.keys(extendedHeartbeatPayload).forEach(key => delete extendedHeartbeatPayload[key])
   }, 1000 * 60 * 60 * 24).unref()
-  return extendedInterval
 }
 
 function start (aConfig, thePluginManager) {

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -56,6 +56,7 @@ describe('onPause', function () {
       './session': session,
       './send': send,
       './status': { ackReceived },
+      './telemetry': { threadPausedMsMetric: sinon.spy(), '@noCallThru': true },
       './remote_config': { '@noCallThru': true }
     })
 


### PR DESCRIPTION
### What does this PR do?

The target thread is paused for some amount of time when ever a breakpoint is hit. Record the amount of time in milliseconds as telemetry.

### Motivation

It's important to track how big of an impact using breakpoints has on the instrumented application. We can't know this simply from benchmarks, as each customer application is unique. So getting some real world data is important.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


