### PR TITLE
[DI] Improve path matching algorithm for probe file paths

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -12,16 +12,30 @@ module.exports = {
   /**
    * Find the matching script that can be inspected based on a partial path.
    *
-   * Algorithm: Find the sortest url that ends in the requested path.
+   * Algorithm:
    *
-   * Will identify the correct script as long as Node.js doesn't load a module from a `node_modules` folder outside the
-   * project root. If so, there's a risk that this path is shorter than the expected path inside the project root.
-   * Example of mismatch where path = `index.js`:
+   * 1. Find the sortest url that ends in the requested path
+   * 2. If no match, remove the base directory from the requested path and go to step 1
    *
-   * Expected match:       /www/code/my-projects/demo-project1/index.js
-   * Actual shorter match: /www/node_modules/dd-trace/index.js
+   * Risks of false positives:
    *
-   * To fix this, specify a more unique file path, e.g `demo-project1/index.js` instead of `index.js`
+   * 1. If Node.js loads a module from a `node_modules` folder outside the project root. If so, there's a risk that
+   *    this path is shorter than the expected path inside the project root.
+   *
+   *    Example of mismatch where path = `index.js`:
+   *
+   *    Expected match:       /www/code/my-projects/demo-project1/index.js
+   *    Actual shorter match: /www/node_modules/dd-trace/index.js
+   *
+   *    To fix this, specify a more unique file path, e.g `demo-project1/index.js` instead of `index.js`
+   *
+   * 2. If the requested path is unknown (e.g. if a directory is spelled incorrectly), base directories will be
+   *    removed and a shorter, incorrect match might be returned.
+   *
+   *    Requested path: `servr/index.js` (should have been `server/index.js`)
+   *
+   *    Expected match: server/index.js
+   *    Actual match:   index.js
    *
    * @param {string} path
    * @returns {[string, string, string | undefined] | undefined}

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -24,12 +24,23 @@ module.exports = {
    * To fix this, specify a more unique file path, e.g `demo-project1/index.js` instead of `index.js`
    *
    * @param {string} path
-   * @returns {[string, string] | undefined}
+   * @returns {[string, string, string | undefined] | undefined}
    */
   findScriptFromPartialPath (path) {
-    return scriptIds
-      .filter(([url]) => url.endsWith(path))
-      .sort(([a], [b]) => a.length - b.length)[0]
+    if (!path) return
+    do {
+      const result = scriptIds
+        .filter(([url]) => url.endsWith(path))
+        .sort(([a], [b]) => a.length - b.length)[0]
+
+      if (result === undefined) {
+        const index = path.indexOf('/')
+        if (index === -1) return
+        path = path.slice(index + 1)
+      } else {
+        return result
+      }
+    } while (true)
   },
 
   getStackFromCallFrames (callFrames) {

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -2,6 +2,8 @@
 
 const session = require('./session')
 
+const WINDOWS_DRIVE_LETTER_REGEX = /[a-zA-Z]/
+
 const scriptIds = []
 const scriptUrls = new Map()
 
@@ -10,51 +12,74 @@ module.exports = {
   breakpoints: new Map(),
 
   /**
-   * Find the matching script that can be inspected based on a partial path.
+   * Find the script to inspect based on a partial or absolute path. Handles both Windows and POSIX paths.
    *
-   * Algorithm:
-   *
-   * 1. Find the sortest url that ends in the requested path
-   * 2. If no match, remove the base directory from the requested path and go to step 1
-   *
-   * Risks of false positives:
-   *
-   * 1. If Node.js loads a module from a `node_modules` folder outside the project root. If so, there's a risk that
-   *    this path is shorter than the expected path inside the project root.
-   *
-   *    Example of mismatch where path = `index.js`:
-   *
-   *    Expected match:       /www/code/my-projects/demo-project1/index.js
-   *    Actual shorter match: /www/node_modules/dd-trace/index.js
-   *
-   *    To fix this, specify a more unique file path, e.g `demo-project1/index.js` instead of `index.js`
-   *
-   * 2. If the requested path is unknown (e.g. if a directory is spelled incorrectly), base directories will be
-   *    removed and a shorter, incorrect match might be returned.
-   *
-   *    Requested path: `servr/index.js` (should have been `server/index.js`)
-   *
-   *    Expected match: server/index.js
-   *    Actual match:   index.js
-   *
-   * @param {string} path
-   * @returns {[string, string, string | undefined] | undefined}
+   * @param {string} path - Partial or absolute path to match against loaded scripts
+   * @returns {[string, string, string | undefined] | null} - Array containing [url, scriptId, sourceMapURL]
+   *   or null if no match
    */
   findScriptFromPartialPath (path) {
-    if (!path) return
-    do {
-      const result = scriptIds
-        .filter(([url]) => url.endsWith(path))
-        .sort(([a], [b]) => a.length - b.length)[0]
+    if (!path) return null // This shouldn't happen, but better safe than sorry
 
-      if (result === undefined) {
-        const index = path.indexOf('/')
-        if (index === -1) return
-        path = path.slice(index + 1)
-      } else {
-        return result
+    const bestMatch = new Array(3)
+    let maxMatchLength = -1
+
+    for (const [url, scriptId, sourceMapURL] of scriptIds) {
+      let i = url.length - 1
+      let j = path.length - 1
+      let matchLength = 0
+      let lastBoundaryPos = -1
+      let atBoundary = false
+
+      // Compare characters from the end
+      while (i >= 0 && j >= 0) {
+        const urlChar = url[i]
+        const pathChar = path[j]
+
+        // Check if both characters is a path boundary
+        const isBoundary = (urlChar === '/' || urlChar === '\\') && (pathChar === '/' || pathChar === '\\' ||
+          (j === 1 && pathChar === ':' && WINDOWS_DRIVE_LETTER_REGEX.test(path[0])))
+
+        // If both are boundaries, or if characters match exactly
+        if (isBoundary || urlChar === pathChar) {
+          if (isBoundary) {
+            lastBoundaryPos = matchLength
+            atBoundary = true
+          } else {
+            atBoundary = false
+          }
+          matchLength++
+          i--
+          j--
+        } else {
+          break
+        }
       }
-    } while (true)
+
+      // If we've matched the entire path pattern, ensure it starts at a path boundary
+      if (j === -1) {
+        if (i >= 0) {
+          // If there are more characters in the URL, the next one must be a slash
+          if (url[i] === '/' || url[i] === '\\') {
+            atBoundary = true
+            lastBoundaryPos = matchLength
+          }
+        } else {
+          atBoundary = true
+          lastBoundaryPos = matchLength
+        }
+      }
+
+      // If we found a valid match and it's better than our previous best
+      if (atBoundary && lastBoundaryPos !== -1 && lastBoundaryPos > maxMatchLength) {
+        maxMatchLength = lastBoundaryPos
+        bestMatch[0] = url
+        bestMatch[1] = scriptId
+        bestMatch[2] = sourceMapURL
+      }
+    }
+
+    return maxMatchLength > -1 ? bestMatch : null
   },
 
   getStackFromCallFrames (callFrames) {

--- a/packages/dd-trace/test/debugger/devtools_client/state.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/state.spec.js
@@ -21,6 +21,10 @@ describe('findScriptFromPartialPath', function () {
             cases.forEach(([url, scriptId]) => {
               listener({ params: { scriptId, url } })
             })
+
+            // Test case for when there's multiple partial matches
+            listener({ params: { scriptId: 'should-match', url: 'file:///server/index.js' } })
+            listener({ params: { scriptId: 'should-not-match', url: 'file:///index.js' } })
           }
         }
       }
@@ -107,6 +111,13 @@ describe('findScriptFromPartialPath', function () {
       }
     }
   }
+
+  describe('multiple partial matches', function () {
+    it('should match the longest partial match', function () {
+      const result = state.findScriptFromPartialPath('server/index.js')
+      expect(result).to.deep.equal(['file:///server/index.js', 'should-match', undefined])
+    })
+  })
 
   describe('circuit breakers', function () {
     it('should abort if the path is unknown', testPathNoMatch('this/path/does/not/exist.js'))

--- a/packages/dd-trace/test/debugger/devtools_client/state.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/state.spec.js
@@ -5,60 +5,121 @@ require('../../setup/mocha')
 describe('findScriptFromPartialPath', function () {
   let state
 
+  const cases = [
+    ['file:///path/to/foo.js', 'script-id-posix'],
+    ['file:///C:/path/to/bar.js', 'script-id-win-slash'],
+    // We have no evidence that Chrome DevTools Protocol uses backslashes in paths, but test in case it changes
+    ['file:///C:\\path\\to\\baz.js', 'script-id-win-backslash']
+  ]
+
   before(function () {
     state = proxyquire('../src/debugger/devtools_client/state', {
       './session': {
         '@noCallThru': true,
         on (event, listener) {
           if (event === 'Debugger.scriptParsed') {
-            listener({ params: { scriptId: 'script-id', url: 'file:///path/to/foo.js' } })
+            cases.forEach(([url, scriptId]) => {
+              listener({ params: { scriptId, url } })
+            })
           }
         }
       }
     })
   })
 
-  describe('full path matches', function () {
-    it('with a "file:" protocol', testPath('file:///path/to/foo.js'))
+  for (const [url, scriptId] of cases) {
+    const filename = url.includes('\\') ? url.split('\\').pop() : url.split('/').pop()
 
-    it('with a root slash', testPath('/path/to/foo.js'))
+    describe(`targeting ${url}`, function () {
+      describe('POSIX paths', function () {
+        describe('full path matches', function () {
+          it('with a "file:" protocol', testPath(`file:///path/to/${filename}`))
 
-    it('without a root slash', testPath('path/to/foo.js'))
-  })
+          it('with a root slash', testPath(`/path/to/${filename}`))
 
-  describe('partial path matches', function () {
-    it('fewer directories', testPath('to/foo.js'))
+          it('without a root slash', testPath(`path/to/${filename}`))
+        })
 
-    it('no directories', testPath('foo.js'))
-  })
+        describe('partial path matches', function () {
+          it('fewer directories', testPath(`to/${filename}`))
 
-  describe('path contains directory prefix', function () {
-    it('prefixed with unknown directory', testPath('prefix/to/foo.js'))
+          it('no directories', testPath(filename))
+        })
 
-    it('prefixed with two unknown directories', testPath('prefix1/prefix2/to/foo.js'))
-  })
+        describe('path contains directory prefix', function () {
+          it('prefixed with unknown directory', testPath(`prefix/to/${filename}`))
+
+          it('prefixed with two unknown directories', testPath(`prefix1/prefix2/to/${filename}`))
+        })
+
+        describe('non-matching paths', function () {
+          it('should not match if only part of a directory matches (at boundary)',
+            testPathNoMatch(`path/o/${filename}`))
+
+          it('should not match if only part of a directory matches (not at boundary)',
+            testPathNoMatch(`path/no/${filename}`))
+
+          it('should not match if only part of a directory matches (root)', testPathNoMatch(`o/${filename}`))
+
+          it('should not match if only part of a file matches', testPathNoMatch(filename.slice(1)))
+
+          it('should not match if only difference is the letter casing', testPathNoMatch(filename.toUpperCase()))
+        })
+      })
+
+      describe('Windows paths', function () {
+        describe('with backslashes', function () {
+          describe('full path matches', function () {
+            it('with a "file:" protocol', testPath(`file:///C|\\path\\to\\${filename}`))
+
+            it('with a drive letter', testPath(`C:\\path\\to\\${filename}`))
+
+            it('without a drive slash', testPath(`C:path\\to\\${filename}`))
+          })
+
+          describe('partial path matches', function () {
+            it('fewer directories', testPath(`to\\${filename}`))
+          })
+
+          describe('path contains directory prefix', function () {
+            it('prefixed with unknown directory', testPath(`prefix\\to\\${filename}`))
+
+            it('prefixed with two unknown directories', testPath(`prefix1\\prefix2\\to\\${filename}`))
+          })
+        })
+
+        describe('with forward slashes', function () {
+          describe('full path matches', function () {
+            it('with a "file:" protocol', testPath(`file:///C|/path/to/${filename}`))
+
+            it('with a drive letter', testPath(`C:/path/to/${filename}`))
+
+            it('without a drive slash', testPath(`C:path/to/${filename}`))
+          })
+        })
+      })
+    })
+
+    function testPath (path) {
+      return function () {
+        const result = state.findScriptFromPartialPath(path)
+        expect(result).to.deep.equal([url, scriptId, undefined])
+      }
+    }
+  }
 
   describe('circuit breakers', function () {
-    it('should abort if the path is unknown', function () {
-      const result = state.findScriptFromPartialPath('this/path/does/not/exist.js')
-      expect(result).to.be.undefined
-    })
+    it('should abort if the path is unknown', testPathNoMatch('this/path/does/not/exist.js'))
 
-    it('should abort if the path is undefined', function () {
-      const result = state.findScriptFromPartialPath(undefined)
-      expect(result).to.be.undefined
-    })
+    it('should abort if the path is undefined', testPathNoMatch(undefined))
 
-    it('should abort if the path is an empty string', function () {
-      const result = state.findScriptFromPartialPath('')
-      expect(result).to.be.undefined
-    })
+    it('should abort if the path is an empty string', testPathNoMatch(''))
   })
 
-  function testPath (path) {
+  function testPathNoMatch (path) {
     return function () {
       const result = state.findScriptFromPartialPath(path)
-      expect(result).to.deep.equal(['file:///path/to/foo.js', 'script-id', undefined])
+      expect(result).to.be.null
     }
   }
 })

--- a/packages/dd-trace/test/debugger/devtools_client/state.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/state.spec.js
@@ -1,0 +1,64 @@
+'use strict'
+
+require('../../setup/mocha')
+
+describe('findScriptFromPartialPath', function () {
+  let state
+
+  before(function () {
+    state = proxyquire('../src/debugger/devtools_client/state', {
+      './session': {
+        '@noCallThru': true,
+        on (event, listener) {
+          if (event === 'Debugger.scriptParsed') {
+            listener({ params: { scriptId: 'script-id', url: 'file:///path/to/foo.js' } })
+          }
+        }
+      }
+    })
+  })
+
+  describe('full path matches', function () {
+    it('with a "file:" protocol', testPath('file:///path/to/foo.js'))
+
+    it('with a root slash', testPath('/path/to/foo.js'))
+
+    it('without a root slash', testPath('path/to/foo.js'))
+  })
+
+  describe('partial path matches', function () {
+    it('fewer directories', testPath('to/foo.js'))
+
+    it('no directories', testPath('foo.js'))
+  })
+
+  describe('path contains directory prefix', function () {
+    it('prefixed with unknown directory', testPath('prefix/to/foo.js'))
+
+    it('prefixed with two unknown directories', testPath('prefix1/prefix2/to/foo.js'))
+  })
+
+  describe('circuit breakers', function () {
+    it('should abort if the path is unknown', function () {
+      const result = state.findScriptFromPartialPath('this/path/does/not/exist.js')
+      expect(result).to.be.undefined
+    })
+
+    it('should abort if the path is undefined', function () {
+      const result = state.findScriptFromPartialPath(undefined)
+      expect(result).to.be.undefined
+    })
+
+    it('should abort if the path is an empty string', function () {
+      const result = state.findScriptFromPartialPath('')
+      expect(result).to.be.undefined
+    })
+  })
+
+  function testPath (path) {
+    return function () {
+      const result = state.findScriptFromPartialPath(path)
+      expect(result).to.deep.equal(['file:///path/to/foo.js', 'script-id', undefined])
+    }
+  }
+})


### PR DESCRIPTION
### What does this PR do?

Change the path matching algorithm used to match a probe file path against the list of loaded module paths. The new algorithm supports Windows paths and path prefixes and has fewer false positives.
    
### Motivation

Ensure there's a higher chance of a match given the file path provided via RC.

The problem with path prefixes can occur if the user-provided file path contains a base directory, but this directory isn't part of the deployed code base. This would for example be the case if the files are stored in a sub-directory in the git repo (which is common for mono-repos), but deployed into a different directory in production. Or it can occur if the user copy-pastes the full local path from their development machine.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js