### PR TITLE
Extended iast location fields 

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -75,12 +75,15 @@ class Analyzer extends SinkIastPlugin {
     if (locationFromSourceMap?.path) {
       originalLocation.path = locationFromSourceMap.path
     }
+
     if (locationFromSourceMap?.line) {
       originalLocation.line = locationFromSourceMap.line
     }
+
     if (locationFromSourceMap?.class_name) {
       originalLocation.class = locationFromSourceMap.class_name
     }
+
     if (locationFromSourceMap?.function) {
       originalLocation.method = locationFromSourceMap.function
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -80,12 +80,12 @@ class Analyzer extends SinkIastPlugin {
       originalLocation.line = locationFromSourceMap.line
     }
 
-    if (locationFromSourceMap?.class_name) {
-      originalLocation.class = locationFromSourceMap.class_name
+    if (location?.class_name) {
+      originalLocation.class = location.class_name
     }
 
-    if (locationFromSourceMap?.function) {
-      originalLocation.method = locationFromSourceMap.function
+    if (location?.function) {
+      originalLocation.method = location.function
     }
 
     return originalLocation

--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -78,8 +78,11 @@ class Analyzer extends SinkIastPlugin {
     if (locationFromSourceMap?.line) {
       originalLocation.line = locationFromSourceMap.line
     }
-    if (locationFromSourceMap?.column) {
-      originalLocation.column = locationFromSourceMap.column
+    if (locationFromSourceMap?.class_name) {
+      originalLocation.class = locationFromSourceMap.class_name
+    }
+    if (locationFromSourceMap?.function) {
+      originalLocation.method = locationFromSourceMap.function
     }
 
     return originalLocation

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
@@ -81,21 +81,16 @@ class VulnerabilityFormatter {
   }
 
   formatVulnerability (vulnerability, sourcesIndexes, sources) {
+    const { type, hash, stackId, evidence, location } = vulnerability
+
     const formattedVulnerability = {
-      type: vulnerability.type,
-      hash: vulnerability.hash,
-      stackId: vulnerability.stackId,
-      evidence: this.formatEvidence(vulnerability.type, vulnerability.evidence, sourcesIndexes, sources),
-      location: {
-        spanId: vulnerability.location.spanId
-      }
+      type,
+      hash,
+      stackId,
+      location,
+      evidence: this.formatEvidence(type, evidence, sourcesIndexes, sources)
     }
-    if (vulnerability.location.path) {
-      formattedVulnerability.location.path = vulnerability.location.path
-    }
-    if (vulnerability.location.line) {
-      formattedVulnerability.location.line = vulnerability.location.line
-    }
+
     return formattedVulnerability
   }
 

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
@@ -87,8 +87,8 @@ class VulnerabilityFormatter {
       type,
       hash,
       stackId,
-      location,
-      evidence: this.formatEvidence(type, evidence, sourcesIndexes, sources)
+      evidence: this.formatEvidence(type, evidence, sourcesIndexes, sources),
+      location
     }
 
     return formattedVulnerability

--- a/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerability-reporter.js
@@ -131,6 +131,7 @@ function replaceCallSiteFromSourceMap (callsite) {
     if (line) {
       callsite.line = line
     }
+    // We send the column in the stack trace but not in the vulnerability location
     if (column) {
       callsite.column = column
     }

--- a/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hsts-header-missing-analyzer.spec.js
@@ -27,7 +27,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence).to.be.undefined
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'text/html;charset=utf-8')
@@ -35,7 +35,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence).to.be.undefined
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'application/xhtml+xml')
@@ -43,7 +43,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence).to.be.undefined
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'text/html')
@@ -52,7 +52,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence.value).to.be.equal('max-age=-100')
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'text/html')
@@ -61,7 +61,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence.value).to.be.equal('max-age=-100; includeSubDomains')
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'text/html')
@@ -70,7 +70,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence.value).to.be.equal('invalid')
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', ['text/html'])
@@ -79,7 +79,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence.value).to.be.equal('invalid')
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', ['text/html'])
@@ -88,7 +88,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence).to.be.undefined
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', ['text/html'])
@@ -97,7 +97,7 @@ describe('hsts header missing analyzer', () => {
       }, HSTS_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence.value).to.be.equal(JSON.stringify(['invalid1', 'invalid2']))
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('HSTS_HEADER_MISSING:mocha'))
-      }, makeRequestWithXFordwardedProtoHeader)
+      }, makeRequestWithXFordwardedProtoHeader, undefined, false)
 
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('content-type', 'application/json')

--- a/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.spec.js
@@ -6,7 +6,7 @@ const proxyquire = require('proxyquire')
 describe('vulnerability-analyzer', () => {
   const VULNERABLE_VALUE = 'VULNERABLE_VALUE'
   const VULNERABILITY = 'VULNERABILITY'
-  const VULNERABILITY_LOCATION_FROM_SOURCEMAP = { path: 'VULNERABILITY_LOCATION_FROM_SOURCEMAP', line: 42, column: 21 }
+  const VULNERABILITY_LOCATION_FROM_SOURCEMAP = { path: 'VULNERABILITY_LOCATION_FROM_SOURCEMAP', line: 42 }
   const ANALYZER_TYPE = 'TEST_ANALYZER'
   const SPAN_ID = '123456'
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.spec.js
@@ -6,7 +6,9 @@ const proxyquire = require('proxyquire')
 describe('vulnerability-analyzer', () => {
   const VULNERABLE_VALUE = 'VULNERABLE_VALUE'
   const VULNERABILITY = 'VULNERABILITY'
-  const VULNERABILITY_LOCATION_FROM_SOURCEMAP = { path: 'VULNERABILITY_LOCATION_FROM_SOURCEMAP', line: 42 }
+  const VULNERABILITY_LOCATION_FROM_SOURCEMAP = {
+    path: 'VULNERABILITY_LOCATION_FROM_SOURCEMAP', line: 42, method: 'callFn'
+  }
   const ANALYZER_TYPE = 'TEST_ANALYZER'
   const SPAN_ID = '123456'
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/xcontenttype-header-missing-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/xcontenttype-header-missing-analyzer.spec.js
@@ -18,7 +18,7 @@ describe('xcontenttype header missing analyzer', () => {
       }, XCONTENTTYPE_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence).to.be.undefined
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('XCONTENTTYPE_HEADER_MISSING:mocha'))
-      })
+      }, undefined, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'text/html;charset=utf-8')
@@ -26,7 +26,7 @@ describe('xcontenttype header missing analyzer', () => {
       }, XCONTENTTYPE_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence).to.be.undefined
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('XCONTENTTYPE_HEADER_MISSING:mocha'))
-      })
+      }, undefined, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'application/xhtml+xml')
@@ -34,7 +34,7 @@ describe('xcontenttype header missing analyzer', () => {
       }, XCONTENTTYPE_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence).to.be.undefined
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('XCONTENTTYPE_HEADER_MISSING:mocha'))
-      })
+      }, undefined, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', 'text/html')
@@ -43,7 +43,7 @@ describe('xcontenttype header missing analyzer', () => {
       }, XCONTENTTYPE_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence.value).to.be.equal('whatever')
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('XCONTENTTYPE_HEADER_MISSING:mocha'))
-      })
+      }, undefined, undefined, false)
 
       testThatRequestHasVulnerability((req, res) => {
         res.setHeader('content-type', ['text/html'])
@@ -52,7 +52,7 @@ describe('xcontenttype header missing analyzer', () => {
       }, XCONTENTTYPE_HEADER_MISSING, 1, function (vulnerabilities) {
         expect(vulnerabilities[0].evidence.value).to.be.equal('whatever')
         expect(vulnerabilities[0].hash).to.be.equals(analyzer._createHash('XCONTENTTYPE_HEADER_MISSING:mocha'))
-      })
+      }, undefined, undefined, false)
 
       testThatRequestHasNoVulnerability((req, res) => {
         res.setHeader('content-type', 'application/json')

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/sql_row.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/sql_row.sequelize.plugin.spec.js
@@ -39,7 +39,7 @@ describe('db sources with sequelize', () => {
 
           res.end('OK')
         }, 'SQL_INJECTION', { occurrences: 1 }, null, null,
-        'Should have SQL_INJECTION using the first row of the result')
+        'Should have SQL_INJECTION using the first row of the result', false)
 
         testThatRequestHasNoVulnerability(async (req, res) => {
           const result = await sequelize.query('SELECT * from examples')
@@ -82,7 +82,7 @@ describe('db sources with sequelize', () => {
 
           res.end('OK')
         }, 'SQL_INJECTION', { occurrences: 1 }, null, null,
-        'Should have SQL_INJECTION using the first row of the result')
+        'Should have SQL_INJECTION using the first row of the result', false)
 
         testThatRequestHasNoVulnerability(async (req, res) => {
           const examples = await Example.findAll()

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { assert } = require('chai')
-const msgpack = require('msgpack-lite')
+const msgpack = require('@msgpack/msgpack')
 
 const agent = require('../../plugins/agent')
 const axios = require('axios')

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -395,7 +395,8 @@ function locationHasMatchingFrame (span, vulnerabilityType, vulnerabilities) {
           frame.line === location.line &&
           frame.class_name === location.class &&
           frame.function === location.method &&
-          frame.path === location.path
+          frame.path === location.path &&
+          !location.hasOwnProperty('column')
         ) {
           return true
         }

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
@@ -101,8 +101,7 @@ describe('Vulnerability formatter', () => {
         },
         location: {
           path: 'path',
-          line: 42,
-          column: 3
+          line: 42
         }
       }]
 

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/index.spec.js
@@ -93,9 +93,11 @@ describe('Vulnerability formatter', () => {
   })
 
   describe('toJson', () => {
-    it('should filter out column property from location', () => {
+    it('should format vulnerability correctly', () => {
       const vulnerabilities = [{
         type: 'test-vulnerability',
+        hash: 123456,
+        stackId: 1,
         evidence: {
           value: 'payload'
         },
@@ -105,8 +107,23 @@ describe('Vulnerability formatter', () => {
         }
       }]
 
-      const json = vulnerabilityFormatter.toJson(vulnerabilities)
-      expect(json.vulnerabilities[0].location.column).to.be.undefined
+      const result = vulnerabilityFormatter.toJson(vulnerabilities)
+
+      expect(result).to.deep.equal({
+        sources: [],
+        vulnerabilities: [{
+          type: 'test-vulnerability',
+          hash: 123456,
+          stackId: 1,
+          evidence: {
+            value: 'payload'
+          },
+          location: {
+            path: 'path',
+            line: 42
+          }
+        }]
+      })
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

[APPSEC-56392](https://datadoghq.atlassian.net/browse/APPSEC-56392)

- Extend IAST location fields
- Keep getting column but make sure we are not sending it
- Check the location is present in the stack trace with same fields/values for all vulns analyzers

### Motivation

Expanding vulnerability location in IAST

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js





[APPSEC-56392]: https://datadoghq.atlassian.net/browse/APPSEC-56392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ