### PR TITLE
Fix a crash in the profiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@datadog/native-iast-rewriter": "2.6.1",
     "@datadog/native-iast-taint-tracking": "3.2.0",
     "@datadog/native-metrics": "^3.1.0",
-    "@datadog/pprof": "5.5.0",
+    "@datadog/pprof": "5.5.1",
     "@datadog/sketches-js": "^2.1.0",
     "@isaacs/ttlcache": "^1.4.1",
     "@opentelemetry/api": ">=1.0.0 <1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,10 +436,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.5.0.tgz#48fff2d70c5d2975e1f7a2b00b45160d89cdeb06"
-  integrity sha512-+53v76BDLr6o9MWC8dj7FIhnUwNGeCxPwJcT2ZlioyKWHJqpbPQ0Pc92visXg/QI4s6Vpz7mZbThvD2kIe57Ng==
+"@datadog/pprof@5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.5.1.tgz#fba8124b6ad537e29326f5f15ed6e64b7a009e96"
+  integrity sha512-3pZVYqc5YkZJOj9Rc8kQ/wG4qlygcnnwFU/w0QKX6dEdJh+1+dWniuUu+GSEjy/H0jc14yhdT2eJJf/F2AnHNw==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
Updates profiler dependency from `5.5.0` to `5.5.1`.

### Motivation
Profiler library 5.5.0 has a frequent crash in signal handler in a code for a feature that is not yet used. We temporarily disabled the feature until we can better stabilize it.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

[PROF-11258]

[PROF-11258]: https://datadoghq.atlassian.net/browse/PROF-11258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ