### PR TITLE
[test optimization][SDTEST-1355] Fix ATR + DI 

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -343,7 +343,9 @@ should set probe: ${shouldSetProbe}
 
         const shouldRemoveProbe = this.isDiEnabled && !willBeRetried
         asyncResource.runInAsyncScope(() => {
-          log.warn(`shouldRemoveProbe: ${shouldRemoveProbe}`)
+          if (shouldRemoveProbe) {
+            log.warn(`shouldRemoveProbe for: ${getJestTestName(event.test)}`)
+          }
           testFinishCh.publish({
             status,
             testStartLine: getTestLineStart(event.test.asyncError, this.testSuite),

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -313,6 +313,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         const asyncResource = asyncResources.get(event.test)
 
         if (status === 'fail') {
+          log.warn('Setting probe because test failed')
           asyncResource.runInAsyncScope(() => {
             testErrCh.publish({
               error: formatJestError(event.test.errors[0]),

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -314,14 +314,6 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 
         if (status === 'fail') {
           const shouldSetProbe = this.isDiEnabled && willBeRetried && numTestExecutions === 1
-          log.warn(
-            `Setting probe because test failed: ${getJestTestName(event.test)},
-num test executions: ${numTestExecutions}
-will be retried: ${willBeRetried}
-is di enabled: ${this.isDiEnabled}
-should set probe: ${shouldSetProbe}
-`
-          )
           asyncResource.runInAsyncScope(() => {
             testErrCh.publish({
               error: formatJestError(event.test.errors[0]),
@@ -341,25 +333,16 @@ should set probe: ${shouldSetProbe}
           })
         }
 
-        const shouldRemoveProbe = this.isDiEnabled && !willBeRetried
         asyncResource.runInAsyncScope(() => {
-          if (shouldRemoveProbe) {
-            log.warn(`shouldRemoveProbe for: ${getJestTestName(event.test)}`)
-          }
           testFinishCh.publish({
             status,
             testStartLine: getTestLineStart(event.test.asyncError, this.testSuite),
-            promises,
-            shouldRemoveProbe: this.isDiEnabled && !willBeRetried
+            promises
           })
         })
 
         if (promises.isProbeReady) {
           await promises.isProbeReady
-        }
-
-        if (promises.isProbeRemoved) {
-          await promises.isProbeRemoved
         }
       }
       if (event.name === 'test_skip' || event.name === 'test_todo') {

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -231,7 +231,7 @@ class CucumberPlugin extends CiPlugin {
 
       this.activeTestSpan = testSpan
       // Time we give the breakpoint to be hit
-      if (promises && this.runningTestProbeId) {
+      if (promises && this.runningTestProbe) {
         promises.hitBreakpointPromise = new Promise((resolve) => {
           setTimeout(resolve, BREAKPOINT_HIT_GRACE_PERIOD_MS)
         })
@@ -248,8 +248,8 @@ class CucumberPlugin extends CiPlugin {
       if (isFirstAttempt && this.di && error && this.libraryConfig?.isDiEnabled) {
         const probeInformation = this.addDiProbe(error)
         if (probeInformation) {
-          const { probeId, stackIndex } = probeInformation
-          this.runningTestProbeId = probeId
+          const { file, line, stackIndex } = probeInformation
+          this.runningTestProbe = { file, line }
           this.testErrorStackIndex = stackIndex
           // TODO: we're not waiting for setProbePromise to be resolved, so there might be race conditions
         }
@@ -359,9 +359,9 @@ class CucumberPlugin extends CiPlugin {
           this.tracer._exporter.flush()
         }
         this.activeTestSpan = null
-        if (this.runningTestProbeId) {
-          this.removeDiProbe(this.runningTestProbeId)
-          this.runningTestProbeId = null
+        if (this.runningTestProbe) {
+          this.removeDiProbe(this.runningTestProbe)
+          this.runningTestProbe = null
         }
       }
     })

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -39,6 +39,7 @@ const {
   TELEMETRY_CODE_COVERAGE_NUM_FILES,
   TELEMETRY_TEST_SESSION
 } = require('../../dd-trace/src/ci-visibility/telemetry')
+const log = require('../../dd-trace/src/log')
 
 const isJestWorker = !!process.env.JEST_WORKER_ID
 
@@ -363,9 +364,12 @@ class JestPlugin extends CiPlugin {
             const probeInformation = this.addDiProbe(error)
             if (probeInformation) {
               const { probeId, setProbePromise, stackIndex } = probeInformation
+              log.warn(`Setting probe for test error stackIndex:${stackIndex}`)
               this.runningTestProbeId = probeId
               this.testErrorStackIndex = stackIndex
               promises.isProbeReady = withTimeout(setProbePromise, 2000)
+            } else {
+              log.warn('no probeInformation')
             }
           }
         }

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -348,10 +348,10 @@ class JestPlugin extends CiPlugin {
       span.finish()
       finishAllTraceSpans(span)
       this.activeTestSpan = null
-      if (shouldRemoveProbe && this.runningTestProbeId) {
+      if (shouldRemoveProbe && this.runningTestProbe) {
         log.warn(`ci:jest:test:finish removing probe ${spanTags[TEST_NAME]}`)
-        promises.isProbeRemoved = withTimeout(this.removeDiProbe(this.runningTestProbeId), 2000)
-        this.runningTestProbeId = null
+        promises.isProbeRemoved = withTimeout(this.removeDiProbe(this.runningTestProbe), 2000)
+        this.runningTestProbe = null
       }
     })
 
@@ -365,9 +365,9 @@ class JestPlugin extends CiPlugin {
           if (shouldSetProbe) {
             const probeInformation = this.addDiProbe(error)
             if (probeInformation) {
-              const { probeId, setProbePromise, stackIndex } = probeInformation
+              const { file, line, setProbePromise, stackIndex } = probeInformation
               log.warn(`Setting probe for test error stackIndex:${stackIndex}`)
-              this.runningTestProbeId = probeId
+              this.runningTestProbe = { file, line }
               this.testErrorStackIndex = stackIndex
               promises.isProbeReady = withTimeout(setProbePromise, 2000)
             } else {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -24,7 +24,8 @@ const {
   TEST_IS_RUM_ACTIVE,
   TEST_BROWSER_DRIVER,
   getFormattedError,
-  TEST_RETRY_REASON
+  TEST_RETRY_REASON,
+  TEST_NAME
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -348,6 +349,7 @@ class JestPlugin extends CiPlugin {
       finishAllTraceSpans(span)
       this.activeTestSpan = null
       if (shouldRemoveProbe && this.runningTestProbeId) {
+        log.warn(`ci:jest:test:finish removing probe ${spanTags[TEST_NAME]}`)
         promises.isProbeRemoved = withTimeout(this.removeDiProbe(this.runningTestProbeId), 2000)
         this.runningTestProbeId = null
       }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -219,9 +219,9 @@ class MochaPlugin extends CiPlugin {
         span.finish()
         finishAllTraceSpans(span)
         this.activeTestSpan = null
-        if (this.di && this.libraryConfig?.isDiEnabled && this.runningTestProbeId && isLastRetry) {
-          this.removeDiProbe(this.runningTestProbeId)
-          this.runningTestProbeId = null
+        if (this.di && this.libraryConfig?.isDiEnabled && this.runningTestProbe && isLastRetry) {
+          this.removeDiProbe(this.runningTestProbe)
+          this.runningTestProbe = null
         }
       }
     })
@@ -275,8 +275,8 @@ class MochaPlugin extends CiPlugin {
         if (isFirstAttempt && willBeRetried && this.di && this.libraryConfig?.isDiEnabled) {
           const probeInformation = this.addDiProbe(err)
           if (probeInformation) {
-            const { probeId, stackIndex } = probeInformation
-            this.runningTestProbeId = probeId
+            const { file, line, stackIndex } = probeInformation
+            this.runningTestProbe = { file, line }
             this.testErrorStackIndex = stackIndex
             test._ddShouldWaitForHitProbe = true
             // TODO: we're not waiting for setProbePromise to be resolved, so there might be race conditions

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -135,8 +135,8 @@ class VitestPlugin extends CiPlugin {
         if (shouldSetProbe && this.di) {
           const probeInformation = this.addDiProbe(error)
           if (probeInformation) {
-            const { probeId, stackIndex, setProbePromise } = probeInformation
-            this.runningTestProbeId = probeId
+            const { file, line, stackIndex, setProbePromise } = probeInformation
+            this.runningTestProbe = { file, line }
             this.testErrorStackIndex = stackIndex
             promises.setProbePromise = setProbePromise
           }
@@ -237,8 +237,8 @@ class VitestPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       // TODO: too frequent flush - find for method in worker to decrease frequency
       this.tracer._exporter.flush(onFinish)
-      if (this.runningTestProbeId) {
-        this.removeDiProbe(this.runningTestProbeId)
+      if (this.runningTestProbe) {
+        this.removeDiProbe(this.runningTestProbe)
       }
     })
 

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -119,6 +119,8 @@ class TestVisDynamicInstrumentation {
       const onHit = this.onHitBreakpointByProbeId.get(probeId)
       if (onHit) {
         onHit({ snapshot })
+      } else {
+        log.warn('Received a breakpoint hit for an unknown probe')
       }
     }).unref()
 

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
@@ -93,11 +93,14 @@ async function addBreakpoint (probe) {
   probe.location = { file, lines: [String(line)] }
 
   const script = findScriptFromPartialPath(file)
-  if (!script) throw new Error(`No loaded script found for ${file}`)
+  if (!script) {
+    log.error(`No loaded script found for ${file}`)
+    throw new Error(`No loaded script found for ${file}`)
+  }
 
   const [path, scriptId, sourceMapURL] = script
 
-  log.debug(`Adding breakpoint at ${path}:${line}`)
+  log.warn(`Adding breakpoint at ${path}:${line}`)
 
   let lineNumber = line
 

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/worker/index.js
@@ -109,15 +109,19 @@ async function addBreakpoint (probe) {
     }
   }
 
-  const { breakpointId } = await session.post('Debugger.setBreakpoint', {
-    location: {
-      scriptId,
-      lineNumber: lineNumber - 1
-    }
-  })
+  try {
+    const { breakpointId } = await session.post('Debugger.setBreakpoint', {
+      location: {
+        scriptId,
+        lineNumber: lineNumber - 1
+      }
+    })
 
-  breakpointIdToProbe.set(breakpointId, probe)
-  probeIdToBreakpointId.set(probe.id, breakpointId)
+    breakpointIdToProbe.set(breakpointId, probe)
+    probeIdToBreakpointId.set(probe.id, breakpointId)
+  } catch (e) {
+    log.error(`Error setting breakpoint at ${path}:${line}:`, e)
+  }
 }
 
 function start () {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -337,6 +337,7 @@ module.exports = class CiPlugin extends Plugin {
   }
 
   removeDiProbe ({ file, line }) {
+    return Promise.resolve()
     // TODO: we should probably only call this after the test suite has finished just to be sure
     // return
     // const probeId = this.fileLineToProbeId.get(`${file}:${line}`)

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -346,6 +346,7 @@ module.exports = class CiPlugin extends Plugin {
       log.warn('Could not add breakpoint for dynamic instrumentation')
       return
     }
+    log.debug('Adding breakpoint for Dynamic Instrumentation')
 
     const [probeId, setProbePromise] = this.di.addLineProbe({ file, line }, this.onDiBreakpointHit.bind(this))
 

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -337,10 +337,12 @@ module.exports = class CiPlugin extends Plugin {
   }
 
   removeDiProbe ({ file, line }) {
-    const probeId = this.fileLineToProbeId.get(`${file}:${line}`)
-    log.warn(`Removing probe from ${file}:${line}, with probe id: ${probeId}`)
-    this.fileLineToProbeId.delete(probeId)
-    return this.di.removeProbe(probeId)
+    // TODO: we should probably only call this after the test suite has finished just to be sure
+    // return
+    // const probeId = this.fileLineToProbeId.get(`${file}:${line}`)
+    // log.warn(`Removing probe from ${file}:${line}, with probe id: ${probeId}`)
+    // this.fileLineToProbeId.delete(probeId)
+    // return this.di.removeProbe(probeId)
   }
 
   addDiProbe (err) {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -368,6 +368,8 @@ module.exports = class CiPlugin extends Plugin {
 
     const [probeId, setProbePromise] = this.di.addLineProbe({ file, line }, this.onDiBreakpointHit.bind(this))
 
+    this.fileLineToProbeId.set(activeProbeKey, probeId)
+
     return {
       probeId,
       setProbePromise,

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -336,14 +336,20 @@ module.exports = class CiPlugin extends Plugin {
     })
   }
 
+  removeAllDiProbes () {
+    log.debug('Removing all DI probes')
+    return Promise.all(Array.from(this.fileLineToProbeId.keys())
+      .map((fileLine) => {
+        const [file, line] = fileLine.split(':')
+        return this.removeDiProbe({ file, line })
+      }))
+  }
+
   removeDiProbe ({ file, line }) {
-    return Promise.resolve()
-    // TODO: we should probably only call this after the test suite has finished just to be sure
-    // return
-    // const probeId = this.fileLineToProbeId.get(`${file}:${line}`)
-    // log.warn(`Removing probe from ${file}:${line}, with probe id: ${probeId}`)
-    // this.fileLineToProbeId.delete(probeId)
-    // return this.di.removeProbe(probeId)
+    const probeId = this.fileLineToProbeId.get(`${file}:${line}`)
+    log.warn(`Removing probe from ${file}:${line}, with probe id: ${probeId}`)
+    this.fileLineToProbeId.delete(probeId)
+    return this.di.removeProbe(probeId)
   }
 
   addDiProbe (err) {
@@ -355,6 +361,7 @@ module.exports = class CiPlugin extends Plugin {
     }
     log.debug('Adding breakpoint for Dynamic Instrumentation')
 
+    this.testErrorStackIndex = stackIndex
     const activeProbeKey = `${file}:${line}`
 
     if (this.fileLineToProbeId.has(activeProbeKey)) {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -337,7 +337,10 @@ module.exports = class CiPlugin extends Plugin {
   }
 
   removeAllDiProbes () {
-    log.debug('Removing all DI probes')
+    if (this.fileLineToProbeId.size === 0) {
+      return Promise.resolve()
+    }
+    log.debug('Removing all Dynamic Instrumentation probes')
     return Promise.all(Array.from(this.fileLineToProbeId.keys())
       .map((fileLine) => {
         const [file, line] = fileLine.split(':')
@@ -347,7 +350,7 @@ module.exports = class CiPlugin extends Plugin {
 
   removeDiProbe ({ file, line }) {
     const probeId = this.fileLineToProbeId.get(`${file}:${line}`)
-    log.warn(`Removing probe from ${file}:${line}, with probe id: ${probeId}`)
+    log.warn(`Removing probe from ${file}:${line}, with id: ${probeId}`)
     this.fileLineToProbeId.delete(probeId)
     return this.di.removeProbe(probeId)
   }


### PR DESCRIPTION
### What does this PR do?

* Add extra useful logs for debugging
* Don't crash the worker thread of the breakpoint already exists
* Store active probes in a `Map`
* Add function to remove all DI probes
* Do not remove DI probes on test finish in `jest`, as retries are deferred to the end of the test file execution, not executed immediately after the first attempt fails: this makes the assumption that tests run sequentially wrong. 
* Remove DI probes on `jest`'s test suite finish (test file)


### Motivation
Try to understand why DI info is sometimes missing.

### Plugin Checklist

Since this is a refactor, just the already present tests should be enough. 