### PR TITLE
Lazy load AppSec SDK on first method use

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -220,7 +220,7 @@ class Tracer extends NoopProxy {
         if (config._isInServerlessEnvironment()) {
           // lazy load if we're in serverless to save on startup time
           this.appsec = new Proxy(this.appsec, {
-            get (target, key) {
+            get: (target, key) => {
               const AppsecSdk = require('./appsec/sdk')
               this.appsec = new AppsecSdk(this._tracer, config)
               return this.appsec[key]

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -230,6 +230,7 @@ class Tracer extends NoopProxy {
           const AppsecSdk = require('./appsec/sdk')
           this.appsec = new AppsecSdk(this._tracer, config)
         }
+
         this.llmobs = new LLMObsSDK(this._tracer, this._modules.llmobs, config)
         this._tracingInitialized = true
       }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


