### PR TITLE
remove test-agent plugin logs from test output and save to artifact file instead

### DIFF
--- a/.github/actions/plugins/test/action.yml
+++ b/.github/actions/plugins/test/action.yml
@@ -13,8 +13,7 @@ runs:
     - run: yarn test:plugins:ci
       shell: bash
     - uses: codecov/codecov-action@v5
-    # uncomment to get test-agent logs within github actions output
-    # - if: always()
-    #   uses: ./.github/actions/testagent/logs
-    #   with:
-    #     suffix: test-${{ github.job }}
+    - if: always()
+      uses: ./.github/actions/testagent/logs
+      with:
+        suffix: test-${{ github.job }}

--- a/.github/actions/plugins/test/action.yml
+++ b/.github/actions/plugins/test/action.yml
@@ -13,7 +13,8 @@ runs:
     - run: yarn test:plugins:ci
       shell: bash
     - uses: codecov/codecov-action@v5
-    - if: always()
-      uses: ./.github/actions/testagent/logs
-      with:
-        suffix: test-${{ github.job }}
+    # uncomment to get test-agent logs within github actions output
+    # - if: always()
+    #   uses: ./.github/actions/testagent/logs
+    #   with:
+    #     suffix: test-${{ github.job }}

--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -17,13 +17,18 @@ runs:
         mkdir -p "./artifacts/supported-integrations"
       shell: bash
     - name: Save Test Agent Logs
+      id: save_logs
+      env:
+        SUFFIX: ${{ inputs.suffix }}
       run: |
         # Clean the suffix to derive the plugin name
-        plugin="${{ inputs.suffix }}"
+        plugin="${SUFFIX}"
         plugin="${plugin/test-and-upstream-/}"
         plugin="${plugin/test-/}"
         plugin="${plugin/plugins-/}"
         plugin="${plugin/upstream-/}"
+
+        echo "PLUGIN_NAME=${plugin}" >> $GITHUB_ENV
 
         if [ -n "${{inputs.container-id}}" ]; then
           docker logs "${{inputs.container-id}}" > "artifacts/logs/test_agent_logs_${plugin}.txt"
@@ -34,7 +39,7 @@ runs:
     - name: Archive Test Agent Logs
       uses: actions/upload-artifact@v4
       with:
-        name: "test_agent_logs_${plugin}"
+        name: "test_agent_logs_${{ env.PLUGIN_NAME }}"
         path: "./artifacts/logs"
     - name: Get Tested Integrations from Test Agent
       run: |
@@ -54,5 +59,5 @@ runs:
     - name: Archive Test Agent Tested Versions Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: "supported-integrations-${{ inputs.suffix }}"
+        name: "supported-integrations-${{ env.PLUGIN_NAME }}"
         path: "./artifacts/supported-integrations"

--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -11,21 +11,25 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v2
+    - name: Create Artifacts Directory
+      run: mkdir -p "./artifacts"
+      shell: bash
     - name: Save Test Agent Logs
       run: |
+        # Remove "test-and-upstream-" from the suffix
+        plugin="${{ inputs.suffix }}"
+        plugin="${plugin/test-and-upstream-/}"
+
         if [ -n "${{inputs.container-id}}" ]; then
-          docker logs "${{inputs.container-id}}" > "artifacts/test_agent_logs_${{inputs.suffix}}.txt"
+          docker logs "${{inputs.container-id}}" > "artifacts/test_agent_logs_${plugin}.txt"
         else
-          docker compose logs testagent > "artifacts/test_agent_logs_${{inputs.suffix}}.txt"
+          docker compose logs testagent > "artifacts/test_agent_logs_${plugin}.txt"
         fi
       shell: bash
     - name: Get Tested Integrations from Test Agent
       run: |
         # make temporary files to save response data to
         response=$(mktemp) && headers=$(mktemp)
-
-        # create artifacts directory if it doesn't exist
-        mkdir -p "./artifacts"
 
         # get tested integrations
         curl -o "$response" -D "$headers" http://127.0.0.1:9126/test/integrations/tested_versions

--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -11,8 +11,10 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v2
-    - name: Create Artifacts Directory
-      run: mkdir -p "./artifacts"
+    - name: Create Artifacts Directories
+      run: |
+        mkdir -p "./artifacts/logs"
+        mkdir -p "./artifacts/supported-integrations"
       shell: bash
     - name: Save Test Agent Logs
       run: |
@@ -21,11 +23,16 @@ runs:
         plugin="${plugin/test-and-upstream-/}"
 
         if [ -n "${{inputs.container-id}}" ]; then
-          docker logs "${{inputs.container-id}}" > "artifacts/test_agent_logs_${plugin}.txt"
+          docker logs "${{inputs.container-id}}" > "artifacts/logs/test_agent_logs_${plugin}.txt"
         else
-          docker compose logs testagent > "artifacts/test_agent_logs_${plugin}.txt"
+          docker compose logs testagent > "artifacts/logs/test_agent_logs_${plugin}.txt"
         fi
       shell: bash
+    - name: Archive Test Agent Logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-agent-logs-${{inputs.suffix}}
+        path: "./artifacts/logs"
     - name: Get Tested Integrations from Test Agent
       run: |
         # make temporary files to save response data to
@@ -38,11 +45,11 @@ runs:
         filename=$(awk -F': ' '/file-name/{print $2}' "$headers" | tr -d '\r\n')
 
         # copy data to final file and remove temp files
-        mv "$response" "artifacts/${filename}_supported_versions.csv"
+        mv "$response" "artifacts/supported-integrations/${filename}_supported_versions.csv"
         rm "$headers"
       shell: bash
-    - name: Archive Test Agent Artifacts
+    - name: Archive Test Agent Tested Versions Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: supported-integrations-${{inputs.suffix}}
-        path: ./artifacts
+        path: "./artifacts/supported-integrations"

--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -19,29 +19,18 @@ runs:
     - name: Save Test Agent Logs
       id: save_logs
       if:  runner.debug == '1' # only create test agent log artifacts if the github action has been re-run with debug mode
-      env:
-        SUFFIX: ${{ inputs.suffix }}
       run: |
-        # Clean the suffix to derive the plugin name
-        plugin="${SUFFIX}"
-        plugin="${plugin/test-and-upstream-/}"
-        plugin="${plugin/test-/}"
-        plugin="${plugin/plugins-/}"
-        plugin="${plugin/upstream-/}"
-
-        echo "PLUGIN_NAME=${plugin}" >> $GITHUB_ENV
-
         if [ -n "${{inputs.container-id}}" ]; then
-          docker logs "${{inputs.container-id}}" > "artifacts/logs/test_agent_logs_${plugin}.txt"
+          docker logs "${{inputs.container-id}}" > "artifacts/logs/test_agent_logs_${{ inputs.suffix }}.txt"
         else
-          docker compose logs testagent > "artifacts/logs/test_agent_logs_${plugin}.txt"
+          docker compose logs testagent > "artifacts/logs/test_agent_logs_${{ inputs.suffix }}.txt"
         fi
       shell: bash
     - name: Archive Test Agent Logs
       if:  runner.debug == '1' # only create test agent log artifacts if the github action has been re-run with debug mode
       uses: actions/upload-artifact@v4
       with:
-        name: "test_agent_logs_${{ env.PLUGIN_NAME }}"
+        name: "test_agent_logs_${{ inputs.suffix }}"
         path: "./artifacts/logs"
     - name: Get Tested Integrations from Test Agent
       run: |
@@ -61,5 +50,5 @@ runs:
     - name: Archive Test Agent Tested Versions Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: "supported-integrations-${{ env.PLUGIN_NAME }}"
-        path: "./artifacts/supported-integrations"
+        name: supported-integrations-${{ inputs.suffix }}
+        path: ./artifacts

--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -18,9 +18,12 @@ runs:
       shell: bash
     - name: Save Test Agent Logs
       run: |
-        # Remove "test-and-upstream-" from the suffix
+        # Clean the suffix to derive the plugin name
         plugin="${{ inputs.suffix }}"
         plugin="${plugin/test-and-upstream-/}"
+        plugin="${plugin/test-/}"
+        plugin="${plugin/plugins-/}"
+        plugin="${plugin/upstream-/}"
 
         if [ -n "${{inputs.container-id}}" ]; then
           docker logs "${{inputs.container-id}}" > "artifacts/logs/test_agent_logs_${plugin}.txt"
@@ -31,7 +34,7 @@ runs:
     - name: Archive Test Agent Logs
       uses: actions/upload-artifact@v4
       with:
-        name: test-agent-logs-${{inputs.suffix}}
+        name: "test_agent_logs_${plugin}"
         path: "./artifacts/logs"
     - name: Get Tested Integrations from Test Agent
       run: |
@@ -51,5 +54,5 @@ runs:
     - name: Archive Test Agent Tested Versions Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: supported-integrations-${{inputs.suffix}}
+        name: "supported-integrations-${{ inputs.suffix }}"
         path: "./artifacts/supported-integrations"

--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -18,6 +18,7 @@ runs:
       shell: bash
     - name: Save Test Agent Logs
       id: save_logs
+      if:  runner.debug == '1' # only create test agent log artifacts if the github action has been re-run with debug mode
       env:
         SUFFIX: ${{ inputs.suffix }}
       run: |
@@ -37,6 +38,7 @@ runs:
         fi
       shell: bash
     - name: Archive Test Agent Logs
+      if:  runner.debug == '1' # only create test agent log artifacts if the github action has been re-run with debug mode
       uses: actions/upload-artifact@v4
       with:
         name: "test_agent_logs_${{ env.PLUGIN_NAME }}"

--- a/.github/actions/testagent/logs/action.yml
+++ b/.github/actions/testagent/logs/action.yml
@@ -11,11 +11,12 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v2
-    - run: |
+    - name: Save Test Agent Logs
+      run: |
         if [ -n "${{inputs.container-id}}" ]; then
-          docker logs ${{inputs.container-id}}
+          docker logs "${{inputs.container-id}}" > "artifacts/test_agent_logs_${{inputs.suffix}}.txt"
         else
-          docker compose logs testagent
+          docker compose logs testagent > "artifacts/test_agent_logs_${{inputs.suffix}}.txt"
         fi
       shell: bash
     - name: Get Tested Integrations from Test Agent


### PR DESCRIPTION
### What does this PR do?
disable test-agent plugin logs

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


