### PR TITLE
[test optimization] Fix `cy.window` for multi origin tests

### DIFF
--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -4,7 +4,7 @@ import cypress from 'cypress'
 async function runCypress () {
   await cypress.run({
     config: {
-      defaultCommandTimeout: 100,
+      defaultCommandTimeout: 1000,
       e2e: {
         setupNodeEvents (on, config) {
           if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -4,7 +4,7 @@ const cypressFailFast = require('cypress-fail-fast/plugin')
 const ddTracePlugin = require('dd-trace/ci/cypress/plugin')
 
 module.exports = {
-  defaultCommandTimeout: 100,
+  defaultCommandTimeout: 1000,
   e2e: {
     setupNodeEvents (on, config) {
       if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -75,7 +75,7 @@ moduleTypes.forEach(({
   describe(`cypress@${version} ${type}`, function () {
     this.retries(2)
     this.timeout(60000)
-    let sandbox, cwd, receiver, childProcess, webAppPort
+    let sandbox, cwd, receiver, childProcess, webAppPort, secondWebAppServer
 
     if (type === 'commonJS') {
       testCommand = testCommand(version)
@@ -92,6 +92,9 @@ moduleTypes.forEach(({
     after(async () => {
       await sandbox.remove()
       await new Promise(resolve => webAppServer.close(resolve))
+      if (secondWebAppServer) {
+        await new Promise(resolve => secondWebAppServer.close(resolve))
+      }
     })
 
     beforeEach(async function () {
@@ -1638,52 +1641,55 @@ moduleTypes.forEach(({
       })
     })
 
-    it('does not crash for multi origin tests', async () => {
-      const {
-        NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
-        ...restEnvVars
-      } = getCiVisEvpProxyConfig(receiver.port)
+    // cy.origin is not available in old versions of Cypress
+    if (version === 'latest') {
+      it('does not crash for multi origin tests', async () => {
+        const {
+          NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
+          ...restEnvVars
+        } = getCiVisEvpProxyConfig(receiver.port)
 
-      const secondWebAppPort = await getPort()
+        const secondWebAppPort = await getPort()
 
-      const secondWebAppServer = http.createServer((req, res) => {
-        res.setHeader('Content-Type', 'text/html')
-        res.writeHead(200)
-        res.end(`
-          <!DOCTYPE html>
-          <html>
-            <div class="hella-world">Hella World</div>
-          </html>
-        `)
-      })
-
-      secondWebAppServer.listen(secondWebAppPort)
-
-      const specToRun = 'cypress/e2e/multi-origin.js'
-
-      childProcess = exec(
-        version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
-        {
-          cwd,
-          env: {
-            ...restEnvVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-            CYPRESS_BASE_URL_SECOND: `http://localhost:${secondWebAppPort}`,
-            SPEC_PATTERN: specToRun
-          },
-          stdio: 'pipe'
-        }
-      )
-
-      await receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-          assert.equal(events.length, 4)
-
-          const test = events.find(event => event.type === 'test').content
-          assert.equal(test.resource, 'cypress/e2e/multi-origin.js.tests multiple origins')
-          assert.equal(test.meta[TEST_STATUS], 'pass')
+        secondWebAppServer = http.createServer((req, res) => {
+          res.setHeader('Content-Type', 'text/html')
+          res.writeHead(200)
+          res.end(`
+            <!DOCTYPE html>
+            <html>
+              <div class="hella-world">Hella World</div>
+            </html>
+          `)
         })
-    })
+
+        secondWebAppServer.listen(secondWebAppPort)
+
+        const specToRun = 'cypress/e2e/multi-origin.js'
+
+        childProcess = exec(
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+          {
+            cwd,
+            env: {
+              ...restEnvVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL_SECOND: `http://localhost:${secondWebAppPort}`,
+              SPEC_PATTERN: specToRun
+            },
+            stdio: 'pipe'
+          }
+        )
+
+        await receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            assert.equal(events.length, 4)
+
+            const test = events.find(event => event.type === 'test').content
+            assert.equal(test.resource, 'cypress/e2e/multi-origin.js.tests multiple origins')
+            assert.equal(test.meta[TEST_STATUS], 'pass')
+          })
+      })
+    }
   })
 })

--- a/integration-tests/cypress/e2e/multi-origin.js
+++ b/integration-tests/cypress/e2e/multi-origin.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+
+it('tests multiple origins', () => {
+  // Visit first site
+  cy.visit('/');
+  cy.get('.hello-world')
+    .should('have.text', 'Hello World')
+
+  // Visit second site
+  cy.origin(Cypress.env('BASE_URL_SECOND'), () => {
+    cy.visit('/')
+    cy.get('.hella-world').should('have.text', 'Hella World')
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Make it so that `dd-trace` does not crash cypress tests that do multi origin testing.

### Motivation
Tests that do multi origin testing, such as (got from [cypress blog](https://www.cypress.io/blog/cypress-9-6-0-easily-test-multi-domain-workflows-with-cy-origin)):

```javascript
it('navigates', () => {
  cy.visit('/')
  cy.get('h1').contains('My Homepage')
  cy.origin('www.acme.com', () => {
  cy.visit('/history/founder')
    cy.get('h1').contains('About our Founder, Marvin Acme') // 👍
  })
})
```

can't safely access `cy.window()` on `after` hooks. 

This change makes it so that we try to grab the first's origin window. Additionally, we `try / catch` the reading of `window` so that it's safer. There's no way to `try / catch` the `cy.window()` operation, so this is what we're left with.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
