### PR TITLE
[DI] Probe file path matching algo should prefer shorter paths

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -43,8 +43,8 @@ module.exports = {
         // If both are boundaries, or if characters match exactly
         if (isBoundary || urlChar === pathChar) {
           if (isBoundary) {
-            lastBoundaryPos = matchLength
             atBoundary = true
+            lastBoundaryPos = matchLength
           } else {
             atBoundary = false
           }
@@ -71,7 +71,10 @@ module.exports = {
       }
 
       // If we found a valid match and it's better than our previous best
-      if (atBoundary && lastBoundaryPos !== -1 && lastBoundaryPos > maxMatchLength) {
+      if (atBoundary && (
+        lastBoundaryPos > maxMatchLength ||
+        (lastBoundaryPos === maxMatchLength && url.length < bestMatch[0].length) // Prefer shorter paths
+      )) {
         maxMatchLength = lastBoundaryPos
         bestMatch[0] = url
         bestMatch[1] = scriptId


### PR DESCRIPTION
### What does this PR do?

Improve the probe file path algorithm to prefer shorter paths if there's two matching paths where the mathing part are of equal length.

### Motivation

This fixes the case where two partial matches of equal length exist in the list of loaded files. For example if trying to apply a probe to the file path `utils/index.js` with the following loaded files, we want to pick the first one:

- `file:///app/utils/index.js`
- `file:///app/node_modules/some-module/utils/index.js`

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


