### PR TITLE
[DI] Handle different casing in probe file paths

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -21,6 +21,8 @@ module.exports = {
   findScriptFromPartialPath (path) {
     if (!path) return null // This shouldn't happen, but better safe than sorry
 
+    path = path.toLowerCase()
+
     const bestMatch = new Array(3)
     let maxMatchLength = -1
 
@@ -33,7 +35,7 @@ module.exports = {
 
       // Compare characters from the end
       while (i >= 0 && j >= 0) {
-        const urlChar = url[i]
+        const urlChar = url[i].toLowerCase()
         const pathChar = path[j]
 
         // Check if both characters is a path boundary

--- a/packages/dd-trace/test/debugger/devtools_client/state.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/state.spec.js
@@ -63,6 +63,12 @@ describe('findScriptFromPartialPath', function () {
           it('prefixed with two unknown directories', testPath(`prefix1/prefix2/to/${filename}`))
         })
 
+        describe('case insensitive', function () {
+          it('should match if the path is in lowercase', testPath(filename.toLowerCase()))
+
+          it('should match if the path is in uppercase', testPath(filename.toUpperCase()))
+        })
+
         describe('non-matching paths', function () {
           it('should not match if only part of a directory matches (at boundary)',
             testPathNoMatch(`path/o/${filename}`))
@@ -73,8 +79,6 @@ describe('findScriptFromPartialPath', function () {
           it('should not match if only part of a directory matches (root)', testPathNoMatch(`o/${filename}`))
 
           it('should not match if only part of a file matches', testPathNoMatch(filename.slice(1)))
-
-          it('should not match if only difference is the letter casing', testPathNoMatch(filename.toUpperCase()))
         })
       })
 


### PR DESCRIPTION
### What does this PR do?

In case the file path provided by the user is a different casing than the one actually deployed, the tracer should still be able to match it and apply the probe.

### Motivation

Ensure higher chance of matching the user provided path with the files deployed.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


