### PR TITLE
v5.35.0 proposal

### DIFF
--- a/.github/workflows/instrumentations.yml
+++ b/.github/workflows/instrumentations.yml
@@ -36,6 +36,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/plugins/test
 
+  passport:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: passport
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/plugins/test
+
   passport-http:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -317,6 +317,14 @@ jobs:
           suffix: plugins-${{ github.job }}
       - uses: codecov/codecov-action@v5
 
+  dd-trace-api:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: dd-trace-api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/plugins/test
+
   dns:
     runs-on: ubuntu-latest
     env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.34.0",
+  "version": "5.35.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -40,6 +40,18 @@ function wrapRequest (send) {
   }
 }
 
+function wrapDeserialize (deserialize, channelSuffix) {
+  const headersCh = channel(`apm:aws:response:deserialize:${channelSuffix}`)
+
+  return function (response) {
+    if (headersCh.hasSubscribers) {
+      headersCh.publish({ headers: response.headers })
+    }
+
+    return deserialize.apply(this, arguments)
+  }
+}
+
 function wrapSmithySend (send) {
   return function (command, ...args) {
     const cb = args[args.length - 1]
@@ -60,6 +72,10 @@ function wrapSmithySend (send) {
     const completeChannel = channel(`apm:aws:request:complete:${channelSuffix}`)
     const responseStartChannel = channel(`apm:aws:response:start:${channelSuffix}`)
     const responseFinishChannel = channel(`apm:aws:response:finish:${channelSuffix}`)
+
+    if (typeof command.deserialize === 'function') {
+      shimmer.wrap(command, 'deserialize', deserialize => wrapDeserialize(deserialize, channelSuffix))
+    }
 
     return innerAr.runInAsyncScope(() => {
       startCh.publish({

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -102,6 +102,7 @@ module.exports = {
   oracledb: () => require('../oracledb'),
   openai: () => require('../openai'),
   paperplane: () => require('../paperplane'),
+  passport: () => require('../passport'),
   'passport-http': () => require('../passport-http'),
   'passport-local': () => require('../passport-local'),
   pg: () => require('../pg'),

--- a/packages/datadog-instrumentations/src/passport.js
+++ b/packages/datadog-instrumentations/src/passport.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const shimmer = require('../../datadog-shimmer')
+const { channel, addHook } = require('./helpers/instrument')
+
+const onPassportDeserializeUserChannel = channel('datadog:passport:deserializeUser:finish')
+
+function wrapDone (done) {
+  return function wrappedDone (err, user) {
+    if (!err && user) {
+      const abortController = new AbortController()
+
+      onPassportDeserializeUserChannel.publish({ user, abortController })
+
+      if (abortController.signal.aborted) return
+    }
+
+    return done.apply(this, arguments)
+  }
+}
+
+function wrapDeserializeUser (deserializeUser) {
+  return function wrappedDeserializeUser (fn, req, done) {
+    if (typeof fn === 'function') return deserializeUser.apply(this, arguments)
+
+    if (typeof req === 'function') {
+      done = req
+      arguments[1] = wrapDone(done)
+    } else {
+      arguments[2] = wrapDone(done)
+    }
+
+    return deserializeUser.apply(this, arguments)
+  }
+}
+
+addHook({
+  name: 'passport',
+  file: 'lib/authenticator.js',
+  versions: ['>=0.3.0']
+}, Authenticator => {
+  shimmer.wrap(Authenticator.prototype, 'deserializeUser', wrapDeserializeUser)
+
+  return Authenticator
+})

--- a/packages/datadog-instrumentations/test/passport.spec.js
+++ b/packages/datadog-instrumentations/test/passport.spec.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const { assert } = require('chai')
+const agent = require('../../dd-trace/test/plugins/agent')
+const axios = require('axios').create({ validateStatus: null })
+const dc = require('dc-polyfill')
+const { storage } = require('../../datadog-core')
+
+const users = [
+  {
+    id: 'error_user',
+    username: 'error',
+    password: '1234',
+    email: 'a@b.c'
+  }, {
+    id: 'notfound_user',
+    username: 'notfound',
+    password: '1234',
+    email: 'a@b.c'
+  }, {
+    id: 'uuid_42',
+    username: 'test',
+    password: '1234',
+    email: 'testuser@ddog.com'
+  }
+]
+
+withVersions('passport', 'passport', version => {
+  describe('passport instrumentation', () => {
+    const passportDeserializeUserChannel = dc.channel('datadog:passport:deserializeUser:finish')
+    let port, server, subscriberStub
+
+    before(() => {
+      return agent.load(['http'], { client: false })
+    })
+
+    before((done) => {
+      const express = require('../../../versions/express').get()
+      const expressSession = require('../../../versions/express-session').get()
+      const passport = require(`../../../versions/passport@${version}`).get()
+      const LocalStrategy = require('../../../versions/passport-local').get().Strategy
+
+      const app = express()
+
+      app.use(expressSession({
+        secret: 'secret',
+        resave: false,
+        rolling: true,
+        saveUninitialized: true
+      }))
+
+      app.use(passport.initialize())
+      app.use(passport.session())
+
+      passport.serializeUser((user, done) => {
+        done(null, user.id)
+      })
+
+      passport.deserializeUser((id, done) => {
+        if (id === 'error_user') {
+          return done('*MOCK* Cannot deserialize user')
+        }
+
+        if (id === 'notfound_user') {
+          return done(null, false)
+        }
+
+        const user = users.find((user) => user.id === id)
+
+        done(null, user)
+      })
+
+      passport.use(new LocalStrategy((username, password, done) => {
+        const user = users.find((user) => user.username === username && user.password === password)
+
+        return done(null, user)
+      }))
+
+      app.get('/login', passport.authenticate('local'))
+
+      app.get('/', (req, res) => {
+        res.send(req.user?.id)
+      })
+
+      server = app.listen(0, () => {
+        port = server.address().port
+        done()
+      })
+    })
+
+    beforeEach(() => {
+      subscriberStub = sinon.stub()
+
+      passportDeserializeUserChannel.subscribe(subscriberStub)
+    })
+
+    afterEach(() => {
+      passportDeserializeUserChannel.unsubscribe(subscriberStub)
+    })
+
+    after(() => {
+      server.close()
+      return agent.close({ ritmReset: false })
+    })
+
+    it('should not call subscriber when an error occurs', async () => {
+      const login = await axios.get(`http://localhost:${port}/login?username=error&password=1234`)
+      const cookie = login.headers['set-cookie'][0]
+
+      const res = await axios.get(`http://localhost:${port}/`, { headers: { cookie } })
+
+      assert.strictEqual(res.status, 500)
+      assert.include(res.data, '*MOCK* Cannot deserialize user')
+      sinon.assert.notCalled(subscriberStub)
+    })
+
+    it('should not call subscriber when no user is found', async () => {
+      const login = await axios.get(`http://localhost:${port}/login?username=notfound&password=1234`)
+      const cookie = login.headers['set-cookie'][0]
+
+      const res = await axios.get(`http://localhost:${port}/`, { headers: { cookie } })
+
+      assert.strictEqual(res.status, 200)
+      assert.strictEqual(res.data, '')
+      sinon.assert.notCalled(subscriberStub)
+    })
+
+    it('should call subscriber with proper arguments on user deserialize', async () => {
+      const login = await axios.get(`http://localhost:${port}/login?username=test&password=1234`)
+      const cookie = login.headers['set-cookie'][0]
+
+      const res = await axios.get(`http://localhost:${port}/`, { headers: { cookie } })
+
+      assert.strictEqual(res.status, 200)
+      assert.strictEqual(res.data, 'uuid_42')
+      sinon.assert.calledOnce(subscriberStub)
+      sinon.assert.calledWith(subscriberStub, {
+        user: { id: 'uuid_42', username: 'test', password: '1234', email: 'testuser@ddog.com' },
+        abortController: new AbortController()
+      })
+    })
+
+    it('should block when subscriber aborts', async () => {
+      const login = await axios.get(`http://localhost:${port}/login?username=test&password=1234`)
+      const cookie = login.headers['set-cookie'][0]
+
+      subscriberStub.callsFake(({ abortController }) => {
+        const res = storage.getStore().req.res
+        res.writeHead(403)
+        res.constructor.prototype.end.call(res, 'Blocked')
+        abortController.abort()
+      })
+
+      const res = await axios.get(`http://localhost:${port}/`, { headers: { cookie } })
+
+      const abortController = new AbortController()
+      abortController.abort()
+
+      assert.strictEqual(res.status, 403)
+      assert.strictEqual(res.data, 'Blocked')
+      sinon.assert.calledOnce(subscriberStub)
+      sinon.assert.calledWith(subscriberStub, {
+        user: { id: 'uuid_42', username: 'test', password: '1234', email: 'testuser@ddog.com' },
+        abortController
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
@@ -24,11 +24,23 @@ const PROVIDER = {
 }
 
 class Generation {
-  constructor ({ message = '', finishReason = '', choiceId = '' } = {}) {
+  constructor ({
+    message = '',
+    finishReason = '',
+    choiceId = '',
+    role,
+    inputTokens,
+    outputTokens
+  } = {}) {
     // stringify message as it could be a single generated message as well as a list of embeddings
     this.message = typeof message === 'string' ? message : JSON.stringify(message) || ''
     this.finishReason = finishReason || ''
     this.choiceId = choiceId || undefined
+    this.role = role
+    this.usage = {
+      inputTokens,
+      outputTokens
+    }
   }
 }
 
@@ -202,9 +214,12 @@ function extractTextAndResponseReason (response, provider, modelName) {
           if (generations.length > 0) {
             const generation = generations[0]
             return new Generation({
-              message: generation.message,
+              message: generation.message.content,
               finishReason: generation.finish_reason,
-              choiceId: shouldSetChoiceIds ? generation.id : undefined
+              choiceId: shouldSetChoiceIds ? generation.id : undefined,
+              role: generation.message.role,
+              inputTokens: body.usage?.prompt_tokens,
+              outputTokens: body.usage?.completion_tokens
             })
           }
         }
@@ -214,7 +229,9 @@ function extractTextAndResponseReason (response, provider, modelName) {
           return new Generation({
             message: completion.data?.text,
             finishReason: completion?.finishReason,
-            choiceId: shouldSetChoiceIds ? completion?.id : undefined
+            choiceId: shouldSetChoiceIds ? completion?.id : undefined,
+            inputTokens: body.usage?.prompt_tokens,
+            outputTokens: body.usage?.completion_tokens
           })
         }
         return new Generation()
@@ -226,7 +243,12 @@ function extractTextAndResponseReason (response, provider, modelName) {
         const results = body.results || []
         if (results.length > 0) {
           const result = results[0]
-          return new Generation({ message: result.outputText, finishReason: result.completionReason })
+          return new Generation({
+            message: result.outputText,
+            finishReason: result.completionReason,
+            inputTokens: body.inputTextTokenCount,
+            outputTokens: result.tokenCount
+          })
         }
         break
       }
@@ -252,7 +274,12 @@ function extractTextAndResponseReason (response, provider, modelName) {
         break
       }
       case PROVIDER.META: {
-        return new Generation({ message: body.generation, finishReason: body.stop_reason })
+        return new Generation({
+          message: body.generation,
+          finishReason: body.stop_reason,
+          inputTokens: body.prompt_token_count,
+          outputTokens: body.generation_token_count
+        })
       }
       case PROVIDER.MISTRAL: {
         const mistralGenerations = body.outputs || []

--- a/packages/datadog-plugin-aws-sdk/test/fixtures/bedrockruntime.js
+++ b/packages/datadog-plugin-aws-sdk/test/fixtures/bedrockruntime.js
@@ -32,19 +32,22 @@ bedrockruntime.models = [
     },
     response: {
       inputTextTokenCount: 7,
-      results: {
-        inputTextTokenCount: 7,
-        results: [
-          {
-            tokenCount: 35,
-            outputText: '\n' +
-                'Paris is the capital of France. France is a country that is located in Western Europe. ' +
-                'Paris is one of the most populous cities in the European Union. ',
-            completionReason: 'FINISH'
-          }
-        ]
-      }
-    }
+      results: [{
+        tokenCount: 35,
+        outputText: '\n' +
+            'Paris is the capital of France. France is a country that is located in Western Europe. ' +
+            'Paris is one of the most populous cities in the European Union. ',
+        completionReason: 'FINISH'
+      }]
+    },
+    usage: {
+      inputTokens: 7,
+      outputTokens: 35,
+      totalTokens: 42
+    },
+    output: '\n' +
+      'Paris is the capital of France. France is a country that is located in Western Europe. ' +
+      'Paris is one of the most populous cities in the European Union. '
   },
   {
     provider: PROVIDER.AI21,
@@ -79,7 +82,14 @@ bedrockruntime.models = [
         completion_tokens: 7,
         total_tokens: 17
       }
-    }
+    },
+    usage: {
+      inputTokens: 10,
+      outputTokens: 7,
+      totalTokens: 17
+    },
+    output: 'The capital of France is Paris.',
+    outputRole: 'assistant'
   },
   {
     provider: PROVIDER.ANTHROPIC,
@@ -97,7 +107,8 @@ bedrockruntime.models = [
       completion: ' Paris is the capital of France.',
       stop_reason: 'stop_sequence',
       stop: '\n\nHuman:'
-    }
+    },
+    output: ' Paris is the capital of France.'
   },
   {
     provider: PROVIDER.COHERE,
@@ -120,8 +131,8 @@ bedrockruntime.models = [
         }
       ],
       prompt: 'What is the capital of France?'
-    }
-
+    },
+    output: ' The capital of France is Paris. \n'
   },
   {
     provider: PROVIDER.META,
@@ -138,7 +149,13 @@ bedrockruntime.models = [
       prompt_token_count: 10,
       generation_token_count: 7,
       stop_reason: 'stop'
-    }
+    },
+    usage: {
+      inputTokens: 10,
+      outputTokens: 7,
+      totalTokens: 17
+    },
+    output: '\n\nThe capital of France is Paris.'
   },
   {
     provider: PROVIDER.MISTRAL,
@@ -158,7 +175,8 @@ bedrockruntime.models = [
           stop_reason: 'stop'
         }
       ]
-    }
+    },
+    output: 'The capital of France is Paris.'
   }
 ]
 bedrockruntime.modelConfig = {

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -1,0 +1,120 @@
+'use strict'
+
+const Plugin = require('../../dd-trace/src/plugins/plugin')
+const telemetryMetrics = require('../../dd-trace/src/telemetry/metrics')
+const apiMetrics = telemetryMetrics.manager.namespace('tracers')
+
+// api ==> here
+const objectMap = new WeakMap()
+
+const injectionEnabledTag =
+  `injection_enabled:${process.env.DD_INJECTION_ENABLED ? 'yes' : 'no'}`
+
+module.exports = class DdTraceApiPlugin extends Plugin {
+  static get id () {
+    return 'dd-trace-api'
+  }
+
+  constructor (...args) {
+    super(...args)
+
+    const tracer = this._tracer
+
+    this.addSub('datadog-api:v1:tracerinit', ({ proxy }) => {
+      const proxyVal = proxy()
+      objectMap.set(proxyVal, tracer)
+      objectMap.set(proxyVal.appsec, tracer.appsec)
+      objectMap.set(proxyVal.dogstatsd, tracer.dogstatsd)
+    })
+
+    const handleEvent = (name) => {
+      const counter = apiMetrics.count('dd_trace_api.called', [
+        `name:${name.replaceAll(':', '.')}`,
+        'api_version:v1',
+        injectionEnabledTag
+      ])
+
+      // For v1, APIs are 1:1 with their internal equivalents, so we can just
+      // call the internal method directly. That's what we do here unless we
+      // want to override. As the API evolves, this may change.
+      this.addSub(`datadog-api:v1:${name}`, ({ self, args, ret, proxy, revProxy }) => {
+        counter.inc()
+
+        if (name.includes(':')) {
+          name = name.split(':').pop()
+        }
+
+        if (objectMap.has(self)) {
+          self = objectMap.get(self)
+        }
+
+        for (let i = 0; i < args.length; i++) {
+          if (objectMap.has(args[i])) {
+            args[i] = objectMap.get(args[i])
+          }
+          if (typeof args[i] === 'function') {
+            const orig = args[i]
+            args[i] = (...fnArgs) => {
+              for (let j = 0; j < fnArgs.length; j++) {
+                if (revProxy && revProxy[j]) {
+                  const proxyVal = revProxy[j]()
+                  objectMap.set(proxyVal, fnArgs[j])
+                  fnArgs[j] = proxyVal
+                }
+              }
+              // TODO do we need to apply(this, ...) here?
+              return orig(...fnArgs)
+            }
+          }
+        }
+
+        try {
+          ret.value = self[name](...args)
+          if (proxy) {
+            const proxyVal = proxy()
+            objectMap.set(proxyVal, ret.value)
+            ret.value = proxyVal
+          } else if (ret.value && typeof ret.value === 'object') {
+            throw new TypeError(`Objects need proxies when returned via API (${name})`)
+          }
+        } catch (e) {
+          ret.error = e
+        }
+      })
+    }
+
+    // handleEvent('configure')
+    handleEvent('startSpan')
+    handleEvent('wrap')
+    handleEvent('trace')
+    handleEvent('inject')
+    handleEvent('extract')
+    handleEvent('getRumData')
+    handleEvent('profilerStarted')
+    handleEvent('context:toTraceId')
+    handleEvent('context:toSpanId')
+    handleEvent('context:toTraceparent')
+    handleEvent('span:context')
+    handleEvent('span:setTag')
+    handleEvent('span:addTags')
+    handleEvent('span:finish')
+    handleEvent('span:addLink')
+    handleEvent('scope')
+    handleEvent('scope:activate')
+    handleEvent('scope:active')
+    handleEvent('scope:bind')
+    handleEvent('appsec:blockRequest')
+    handleEvent('appsec:isUserBlocked')
+    handleEvent('appsec:setUser')
+    handleEvent('appsec:trackCustomEvent')
+    handleEvent('appsec:trackUserLoginFailureEvent')
+    handleEvent('appsec:trackUserLoginSuccessEvent')
+    handleEvent('dogstatsd:decrement')
+    handleEvent('dogstatsd:distribution')
+    handleEvent('dogstatsd:flush')
+    handleEvent('dogstatsd:gauge')
+    handleEvent('dogstatsd:histogram')
+    handleEvent('dogstatsd:increment')
+    handleEvent('use')
+  }
+}

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -1,0 +1,289 @@
+'use strict'
+
+const dc = require('dc-polyfill')
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const assert = require('assert')
+
+const SELF = Symbol('self')
+
+describe('Plugin', () => {
+  describe('dd-trace-api', () => {
+    let dummyTracer
+    let tracer
+
+    const allChannels = new Set()
+    const testedChannels = new Set()
+
+    before(async () => {
+      sinon.spy(dc, 'channel')
+
+      await agent.load('dd-trace-api')
+
+      tracer = require('../../dd-trace')
+
+      sinon.spy(tracer)
+      sinon.spy(tracer.appsec)
+      sinon.spy(tracer.dogstatsd)
+
+      for (let i = 0; i < dc.channel.callCount; i++) {
+        const call = dc.channel.getCall(i)
+        const channel = call.args[0]
+        if (channel.startsWith('datadog-api:v1:') && !channel.endsWith('tracerinit')) {
+          allChannels.add(channel)
+        }
+      }
+
+      dummyTracer = {
+        appsec: {},
+        dogstatsd: {}
+      }
+      const payload = {
+        proxy: () => dummyTracer,
+        args: []
+      }
+      dc.channel('datadog-api:v1:tracerinit').publish(payload)
+    })
+
+    after(() => agent.close({ ritmReset: false }))
+
+    describe('scope', () => {
+      let dummyScope
+      let scope
+
+      it('should call underlying api', () => {
+        dummyScope = {}
+        testChannel({
+          name: 'scope',
+          fn: tracer.scope,
+          ret: dummyScope
+        })
+      })
+
+      describe('scope:active', () => {
+        it('should call underlying api', () => {
+          scope = tracer.scope()
+          sinon.spy(scope, 'active')
+          testChannel({
+            name: 'scope:active',
+            fn: scope.active,
+            self: dummyScope,
+            ret: null
+          })
+          scope.active.restore()
+        })
+      })
+
+      describe('scope:activate', () => {
+        it('should call underlying api', () => {
+          scope = tracer.scope()
+          sinon.spy(scope, 'activate')
+          testChannel({
+            name: 'scope:activate',
+            fn: scope.activate,
+            self: dummyScope
+          })
+          scope.activate.restore()
+        })
+      })
+
+      describe('scope:bind', () => {
+        it('should call underlying api', () => {
+          scope = tracer.scope()
+          sinon.spy(scope, 'bind')
+          testChannel({
+            name: 'scope:bind',
+            fn: scope.bind,
+            self: dummyScope
+          })
+          scope.bind.restore()
+        })
+      })
+    })
+
+    describe('startSpan', () => {
+      let dummySpan
+      let dummySpanContext
+      let span
+      let spanContext
+
+      it('should call underlying api', () => {
+        dummySpan = {}
+        testChannel({
+          name: 'startSpan',
+          fn: tracer.startSpan,
+          ret: dummySpan
+        })
+        span = tracer.startSpan.getCall(0).returnValue
+        sinon.spy(span)
+      })
+
+      describe('span:context', () => {
+        const traceId = '1234567890abcdef'
+        const spanId = 'abcdef1234567890'
+        const traceparent = `00-${traceId}-${spanId}-01`
+
+        it('should call underlying api', () => {
+          dummySpanContext = {}
+          testChannel({
+            name: 'span:context',
+            fn: span.context,
+            self: dummySpan,
+            ret: dummySpanContext
+          })
+          spanContext = span.context.getCall(0).returnValue
+          sinon.stub(spanContext, 'toTraceId').callsFake(() => traceId)
+          sinon.stub(spanContext, 'toSpanId').callsFake(() => spanId)
+          sinon.stub(spanContext, 'toTraceparent').callsFake(() => traceparent)
+        })
+
+        describe('context:toTraceId', () => {
+          it('should call underlying api', () => {
+            testChannel({
+              name: 'context:toTraceId',
+              fn: spanContext.toTraceId,
+              self: dummySpanContext,
+              ret: traceId
+            })
+          })
+        })
+
+        describe('context:toSpanId', () => {
+          it('should call underlying api', () => {
+            testChannel({
+              name: 'context:toSpanId',
+              fn: spanContext.toSpanId,
+              self: dummySpanContext,
+              ret: spanId
+            })
+          })
+        })
+
+        describe('context:toTraceparent', () => {
+          it('should call underlying api', () => {
+            testChannel({
+              name: 'context:toTraceparent',
+              fn: spanContext.toTraceparent,
+              self: dummySpanContext,
+              ret: traceparent
+            })
+          })
+        })
+      })
+
+      describe('span:setTag', () => {
+        it('should call underlying api', () => {
+          testChannel({
+            name: 'span:setTag',
+            fn: span.setTag,
+            self: dummySpan,
+            ret: dummySpan
+          })
+        })
+      })
+
+      describe('span:addTags', () => {
+        it('should call underlying api', () => {
+          testChannel({
+            name: 'span:addTags',
+            fn: span.addTags,
+            self: dummySpan,
+            ret: dummySpan
+          })
+        })
+      })
+
+      describe('span:finish', () => {
+        it('should call underlying api', () => {
+          testChannel({
+            name: 'span:finish',
+            fn: span.finish,
+            self: dummySpan
+          })
+        })
+      })
+
+      describe('span:addLink', () => {
+        it('should call underlying api', () => {
+          testChannel({
+            name: 'span:addLink',
+            fn: span.addLink,
+            self: dummySpan,
+            ret: dummySpan,
+            args: [dummySpanContext]
+          })
+        })
+      })
+    })
+
+    describeMethod('inject')
+    describeMethod('extract', null)
+    describeMethod('getRumData', '')
+    describeMethod('trace')
+    describeMethod('wrap')
+    describeMethod('use', SELF)
+    describeMethod('profilerStarted', Promise.resolve(false))
+
+    describeSubsystem('appsec', 'blockRequest', false)
+    describeSubsystem('appsec', 'isUserBlocked', false)
+    describeSubsystem('appsec', 'setUser')
+    describeSubsystem('appsec', 'trackCustomEvent')
+    describeSubsystem('appsec', 'trackUserLoginFailureEvent')
+    describeSubsystem('appsec', 'trackUserLoginSuccessEvent')
+    describeSubsystem('dogstatsd', 'decrement')
+    describeSubsystem('dogstatsd', 'distribution')
+    describeSubsystem('dogstatsd', 'flush')
+    describeSubsystem('dogstatsd', 'gauge')
+    describeSubsystem('dogstatsd', 'histogram')
+    describeSubsystem('dogstatsd', 'increment')
+
+    after('dd-trace-api all events tested', () => {
+      assert.deepStrictEqual([...allChannels].sort(), [...testedChannels].sort())
+    })
+
+    function describeMethod (name, ret) {
+      describe(name, () => {
+        it('should call underlying api', () => {
+          if (ret === SELF) {
+            ret = dummyTracer
+          }
+          testChannel({ name, fn: tracer[name], ret })
+        })
+      })
+    }
+
+    function describeSubsystem (name, command, ret) {
+      describe(`${name}:${command}`, () => {
+        it('should call underlying api', () => {
+          const options = {
+            name: `${name}:${command}`,
+            fn: tracer[name][command],
+            self: tracer[name]
+          }
+          if (typeof ret !== 'undefined') {
+            options.ret = ret
+          }
+          testChannel(options)
+        })
+      })
+    }
+
+    function testChannel ({ name, fn, self = dummyTracer, ret = undefined, args = [] }) {
+      testedChannels.add('datadog-api:v1:' + name)
+      const ch = dc.channel('datadog-api:v1:' + name)
+      const payload = {
+        self,
+        args,
+        ret: {},
+        proxy: ret && typeof ret === 'object' ? () => ret : undefined,
+        revProxy: []
+      }
+      ch.publish(payload)
+      if (payload.ret.error) {
+        throw payload.ret.error
+      }
+      expect(payload.ret.value).to.equal(ret)
+      expect(fn).to.have.been.calledOnceWithExactly(...args)
+    }
+  })
+})

--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -115,7 +115,10 @@ function block (req, res, rootSpan, abortController, actionParameters = defaultB
     res.removeHeader(headerName)
   }
 
-  res.writeHead(statusCode, headers).end(body)
+  res.writeHead(statusCode, headers)
+
+  // this is needed to call the original end method, since express-session replaces it
+  res.constructor.prototype.end.call(res, body)
 
   responseBlockedSet.add(res)
 

--- a/packages/dd-trace/src/appsec/channels.js
+++ b/packages/dd-trace/src/appsec/channels.js
@@ -14,6 +14,7 @@ module.exports = {
   incomingHttpRequestStart: dc.channel('dd-trace:incomingHttpRequestStart'),
   incomingHttpRequestEnd: dc.channel('dd-trace:incomingHttpRequestEnd'),
   passportVerify: dc.channel('datadog:passport:verify:finish'),
+  passportUser: dc.channel('datadog:passport:deserializeUser:finish'),
   queryParser: dc.channel('datadog:query:read:finish'),
   setCookieChannel: dc.channel('datadog:iast:set-cookie'),
   nextBodyParsed: dc.channel('apm:next:body-parsed'),

--- a/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
@@ -22,7 +22,8 @@ const EXCLUDED_LOCATIONS = getNodeModulesPaths(
   'sqreen/lib/package-reader/index.js',
   'ws/lib/websocket-server.js',
   'google-gax/build/src/grpc.js',
-  'cookie-signature/index.js'
+  'cookie-signature/index.js',
+  'express-session/index.js'
 )
 
 const EXCLUDED_PATHS_FROM_STACK = [

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -10,6 +10,7 @@ const {
   incomingHttpRequestStart,
   incomingHttpRequestEnd,
   passportVerify,
+  passportUser,
   queryParser,
   nextBodyParsed,
   nextQueryParsed,
@@ -67,6 +68,7 @@ function enable (_config) {
     incomingHttpRequestStart.subscribe(incomingHttpStartTranslator)
     incomingHttpRequestEnd.subscribe(incomingHttpEndTranslator)
     passportVerify.subscribe(onPassportVerify) // possible optimization: only subscribe if collection mode is enabled
+    passportUser.subscribe(onPassportDeserializeUser)
     queryParser.subscribe(onRequestQueryParsed)
     nextBodyParsed.subscribe(onRequestBodyParsed)
     nextQueryParsed.subscribe(onRequestQueryParsed)
@@ -197,6 +199,20 @@ function onPassportVerify ({ framework, login, user, success, abortController })
   handleResults(results, store.req, store.req.res, rootSpan, abortController)
 }
 
+function onPassportDeserializeUser ({ user, abortController }) {
+  const store = storage.getStore()
+  const rootSpan = store?.req && web.root(store.req)
+
+  if (!rootSpan) {
+    log.warn('[ASM] No rootSpan found in onPassportDeserializeUser')
+    return
+  }
+
+  const results = UserTracking.trackUser(user, rootSpan)
+
+  handleResults(results, store.req, store.req.res, rootSpan, abortController)
+}
+
 function onRequestQueryParsed ({ req, res, query, abortController }) {
   if (!query || typeof query !== 'object') return
 
@@ -310,6 +326,7 @@ function disable () {
   if (incomingHttpRequestStart.hasSubscribers) incomingHttpRequestStart.unsubscribe(incomingHttpStartTranslator)
   if (incomingHttpRequestEnd.hasSubscribers) incomingHttpRequestEnd.unsubscribe(incomingHttpEndTranslator)
   if (passportVerify.hasSubscribers) passportVerify.unsubscribe(onPassportVerify)
+  if (passportUser.hasSubscribers) passportUser.unsubscribe(onPassportDeserializeUser)
   if (queryParser.hasSubscribers) queryParser.unsubscribe(onRequestQueryParsed)
   if (nextBodyParsed.hasSubscribers) nextBodyParsed.unsubscribe(onRequestBodyParsed)
   if (nextQueryParsed.hasSubscribers) nextQueryParsed.unsubscribe(onRequestQueryParsed)

--- a/packages/dd-trace/src/appsec/sdk/set_user.js
+++ b/packages/dd-trace/src/appsec/sdk/set_user.js
@@ -2,6 +2,8 @@
 
 const { getRootSpan } = require('./utils')
 const log = require('../../log')
+const waf = require('../waf')
+const addresses = require('../addresses')
 
 function setUserTags (user, rootSpan) {
   for (const k of Object.keys(user)) {
@@ -22,6 +24,13 @@ function setUser (tracer, user) {
   }
 
   setUserTags(user, rootSpan)
+  rootSpan.setTag('_dd.appsec.user.collection_mode', 'sdk')
+
+  waf.run({
+    persistent: {
+      [addresses.USER_ID]: '' + user.id
+    }
+  })
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -23,6 +23,7 @@ function checkUserAndSetUser (tracer, user) {
   if (rootSpan) {
     if (!rootSpan.context()._tags['usr.id']) {
       setUserTags(user, rootSpan)
+      rootSpan.setTag('_dd.appsec.user.collection_mode', 'sdk')
     }
   } else {
     log.warn('[ASM] Root span not available in isUserBlocked')

--- a/packages/dd-trace/src/appsec/telemetry.js
+++ b/packages/dd-trace/src/appsec/telemetry.js
@@ -186,6 +186,15 @@ function incrementMissingUserLoginMetric (framework, eventType) {
   }).inc()
 }
 
+function incrementMissingUserIdMetric (framework, eventType) {
+  if (!enabled) return
+
+  appsecMetrics.count('instrum.user_auth.missing_user_id', {
+    framework,
+    event_type: eventType
+  }).inc()
+}
+
 function getRequestMetrics (req) {
   if (req) {
     const store = getStore(req)
@@ -203,6 +212,7 @@ module.exports = {
   incrementWafUpdatesMetric,
   incrementWafRequestsMetric,
   incrementMissingUserLoginMetric,
+  incrementMissingUserIdMetric,
 
   getRequestMetrics
 }

--- a/packages/dd-trace/src/appsec/user_tracking.js
+++ b/packages/dd-trace/src/appsec/user_tracking.js
@@ -53,6 +53,8 @@ function obfuscateIfNeeded (str) {
 function getUserId (user) {
   if (!user) return
 
+  // should we iterate on user keys instead to be case insensitive ?
+  // but if we iterate over user then we're missing the inherited props ?
   for (const field of USER_ID_FIELDS) {
     let id = user[field]
 
@@ -72,11 +74,6 @@ function getUserId (user) {
 
 function trackLogin (framework, login, user, success, rootSpan) {
   if (!collectionMode || collectionMode === 'disabled') return
-
-  if (!rootSpan) {
-    log.error('[ASM] No rootSpan found in AppSec trackLogin')
-    return
-  }
 
   if (typeof login !== 'string') {
     log.error('[ASM] Invalid login provided to AppSec trackLogin')
@@ -162,7 +159,36 @@ function trackLogin (framework, login, user, success, rootSpan) {
   return waf.run({ persistent })
 }
 
+function trackUser (user, rootSpan) {
+  if (!collectionMode || collectionMode === 'disabled') return
+
+  const userId = getUserId(user)
+  if (!userId) {
+    log.error('[ASM] No valid user ID found in AppSec trackUser')
+    telemetry.incrementMissingUserIdMetric('passport', 'authenticated_request')
+    return
+  }
+
+  rootSpan.setTag('_dd.appsec.usr.id', userId)
+
+  const isSdkCalled = rootSpan.context()._tags['_dd.appsec.user.collection_mode'] === 'sdk'
+  // do not override SDK
+  if (!isSdkCalled) {
+    rootSpan.addTags({
+      'usr.id': userId,
+      '_dd.appsec.user.collection_mode': collectionMode
+    })
+
+    return waf.run({
+      persistent: {
+        [addresses.USER_ID]: userId
+      }
+    })
+  }
+}
+
 module.exports = {
   setCollectionMode,
-  trackLogin
+  trackLogin,
+  trackUser
 }

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -43,8 +43,8 @@ module.exports = {
         // If both are boundaries, or if characters match exactly
         if (isBoundary || urlChar === pathChar) {
           if (isBoundary) {
-            lastBoundaryPos = matchLength
             atBoundary = true
+            lastBoundaryPos = matchLength
           } else {
             atBoundary = false
           }
@@ -71,7 +71,10 @@ module.exports = {
       }
 
       // If we found a valid match and it's better than our previous best
-      if (atBoundary && lastBoundaryPos !== -1 && lastBoundaryPos > maxMatchLength) {
+      if (atBoundary && (
+        lastBoundaryPos > maxMatchLength ||
+        (lastBoundaryPos === maxMatchLength && url.length < bestMatch[0].length) // Prefer shorter paths
+      )) {
         maxMatchLength = lastBoundaryPos
         bestMatch[0] = url
         bestMatch[1] = scriptId

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -21,6 +21,8 @@ module.exports = {
   findScriptFromPartialPath (path) {
     if (!path) return null // This shouldn't happen, but better safe than sorry
 
+    path = path.toLowerCase()
+
     const bestMatch = new Array(3)
     let maxMatchLength = -1
 
@@ -33,7 +35,7 @@ module.exports = {
 
       // Compare characters from the end
       while (i >= 0 && j >= 0) {
-        const urlChar = url[i]
+        const urlChar = url[i].toLowerCase()
         const pathChar = path[j]
 
         // Check if both characters is a path boundary

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -8,7 +8,9 @@ const {
   parseModelId
 } = require('../../../../datadog-plugin-aws-sdk/src/services/bedrockruntime/utils')
 
-const enabledOperations = ['invokeModel']
+const ENABLED_OPERATIONS = ['invokeModel']
+
+const requestIdsToTokens = {}
 
 class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
   constructor () {
@@ -18,7 +20,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       const request = response.request
       const operation = request.operation
       // avoids instrumenting other non supported runtime operations
-      if (!enabledOperations.includes(operation)) {
+      if (!ENABLED_OPERATIONS.includes(operation)) {
         return
       }
       const { modelProvider, modelName } = parseModelId(request.params.modelId)
@@ -29,6 +31,17 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       }
       const span = storage.getStore()?.span
       this.setLLMObsTags({ request, span, response, modelProvider, modelName })
+    })
+
+    this.addSub('apm:aws:response:deserialize:bedrockruntime', ({ headers }) => {
+      const requestId = headers['x-amzn-requestid']
+      const inputTokenCount = headers['x-amzn-bedrock-input-token-count']
+      const outputTokenCount = headers['x-amzn-bedrock-output-token-count']
+
+      requestIdsToTokens[requestId] = {
+        inputTokensFromHeaders: inputTokenCount && parseInt(inputTokenCount),
+        outputTokensFromHeaders: outputTokenCount && parseInt(outputTokenCount)
+      }
     })
   }
 
@@ -52,7 +65,39 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
     })
 
     // add I/O tags
-    this._tagger.tagLLMIO(span, requestParams.prompt, textAndResponseReason.message)
+    this._tagger.tagLLMIO(
+      span,
+      requestParams.prompt,
+      [{ content: textAndResponseReason.message, role: textAndResponseReason.role }]
+    )
+
+    // add token metrics
+    const { inputTokens, outputTokens, totalTokens } = extractTokens({
+      requestId: response.$metadata.requestId,
+      usage: textAndResponseReason.usage
+    })
+    this._tagger.tagMetrics(span, {
+      inputTokens,
+      outputTokens,
+      totalTokens
+    })
+  }
+}
+
+function extractTokens ({ requestId, usage }) {
+  const {
+    inputTokensFromHeaders,
+    outputTokensFromHeaders
+  } = requestIdsToTokens[requestId] || {}
+  delete requestIdsToTokens[requestId]
+
+  const inputTokens = usage.inputTokens || inputTokensFromHeaders || 0
+  const outputTokens = usage.outputTokens || outputTokensFromHeaders || 0
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens
   }
 }
 

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -31,6 +31,9 @@ loadChannel.subscribe(({ name }) => {
 // Globals
 maybeEnable(require('../../datadog-plugin-fetch/src'))
 
+// Always enabled
+maybeEnable(require('../../datadog-plugin-dd-trace-api/src'))
+
 function maybeEnable (Plugin) {
   if (!Plugin || typeof Plugin !== 'function') return
   if (!pluginClasses[Plugin.id]) {

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -34,6 +34,7 @@ module.exports = {
   get couchbase () { return require('../../../datadog-plugin-couchbase/src') },
   get cypress () { return require('../../../datadog-plugin-cypress/src') },
   get dns () { return require('../../../datadog-plugin-dns/src') },
+  get 'dd-trace-api' () { return require('../../../datadog-plugin-dd-trace-api/src') },
   get elasticsearch () { return require('../../../datadog-plugin-elasticsearch/src') },
   get express () { return require('../../../datadog-plugin-express/src') },
   get fastify () { return require('../../../datadog-plugin-fastify/src') },

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -37,11 +37,14 @@ describe('blocking', () => {
     res = {
       setHeader: sinon.stub(),
       writeHead: sinon.stub(),
-      end: sinon.stub(),
       getHeaderNames: sinon.stub().returns([]),
-      removeHeader: sinon.stub()
+      removeHeader: sinon.stub(),
+      constructor: {
+        prototype: {
+          end: sinon.stub()
+        }
+      }
     }
-    res.writeHead.returns(res)
 
     rootSpan = {
       addTags: sinon.stub()
@@ -61,7 +64,7 @@ describe('blocking', () => {
         .calledOnceWithExactly('[ASM] Cannot send blocking response when headers have already been sent')
       expect(rootSpan.addTags).to.not.have.been.called
       expect(res.setHeader).to.not.have.been.called
-      expect(res.end).to.not.have.been.called
+      expect(res.constructor.prototype.end).to.not.have.been.called
     })
 
     it('should send blocking response with html type if present in the headers', () => {
@@ -73,7 +76,7 @@ describe('blocking', () => {
         'Content-Type': 'text/html; charset=utf-8',
         'Content-Length': 12
       })
-      expect(res.end).to.have.been.calledOnceWithExactly('htmlBodyéé')
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly('htmlBodyéé')
     })
 
     it('should send blocking response with json type if present in the headers in priority', () => {
@@ -85,7 +88,7 @@ describe('blocking', () => {
         'Content-Type': 'application/json',
         'Content-Length': 8
       })
-      expect(res.end).to.have.been.calledOnceWithExactly('jsonBody')
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly('jsonBody')
     })
 
     it('should send blocking response with json type if neither html or json is present in the headers', () => {
@@ -96,7 +99,7 @@ describe('blocking', () => {
         'Content-Type': 'application/json',
         'Content-Length': 8
       })
-      expect(res.end).to.have.been.calledOnceWithExactly('jsonBody')
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly('jsonBody')
     })
 
     it('should send blocking response and call abortController if passed in arguments', () => {
@@ -108,7 +111,7 @@ describe('blocking', () => {
         'Content-Type': 'application/json',
         'Content-Length': 8
       })
-      expect(res.end).to.have.been.calledOnceWithExactly('jsonBody')
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly('jsonBody')
       expect(abortController.signal.aborted).to.be.true
     })
 
@@ -125,7 +128,7 @@ describe('blocking', () => {
         'Content-Type': 'application/json',
         'Content-Length': 8
       })
-      expect(res.end).to.have.been.calledOnceWithExactly('jsonBody')
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly('jsonBody')
     })
   })
 
@@ -143,7 +146,7 @@ describe('blocking', () => {
 
       block(req, res, rootSpan)
 
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
     })
 
     it('should block with default json template', () => {
@@ -151,7 +154,7 @@ describe('blocking', () => {
 
       block(req, res, rootSpan)
 
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
     })
   })
 
@@ -174,7 +177,7 @@ describe('blocking', () => {
       block(req, res, rootSpan, null, actionParameters)
 
       expect(res.writeHead).to.have.been.calledOnceWith(401)
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
     })
 
     it('should block with default json template and custom status ' +
@@ -189,7 +192,7 @@ describe('blocking', () => {
       block(req, res, rootSpan, null, actionParameters)
 
       expect(res.writeHead).to.have.been.calledOnceWith(401)
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
     })
 
     it('should block with default html template and custom status ' +
@@ -204,7 +207,7 @@ describe('blocking', () => {
       block(req, res, rootSpan, null, actionParameters)
 
       expect(res.writeHead).to.have.been.calledOnceWith(401)
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
     })
 
     it('should block with default json template and custom status', () => {
@@ -217,7 +220,7 @@ describe('blocking', () => {
       block(req, res, rootSpan, null, actionParameters)
 
       expect(res.writeHead).to.have.been.calledOnceWith(401)
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
     })
 
     it('should block with default json template and custom status ' +
@@ -231,7 +234,7 @@ describe('blocking', () => {
       block(req, res, rootSpan, null, actionParameters)
 
       expect(res.writeHead).to.have.been.calledOnceWith(401)
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.json)
     })
 
     it('should block with default html template and custom status ' +
@@ -245,7 +248,7 @@ describe('blocking', () => {
       block(req, res, rootSpan, null, actionParameters)
 
       expect(res.writeHead).to.have.been.calledOnceWith(401)
-      expect(res.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
+      expect(res.constructor.prototype.end).to.have.been.calledOnceWithExactly(defaultBlockedTemplate.html)
     })
 
     it('should block with custom redirect', () => {
@@ -260,7 +263,7 @@ describe('blocking', () => {
       expect(res.writeHead).to.have.been.calledOnceWithExactly(301, {
         Location: '/you-have-been-blocked'
       })
-      expect(res.end).to.have.been.calledOnce
+      expect(res.constructor.prototype.end).to.have.been.calledOnce
     })
   })
 })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -11,6 +11,7 @@ const {
   incomingHttpRequestStart,
   incomingHttpRequestEnd,
   passportVerify,
+  passportUser,
   queryParser,
   nextBodyParsed,
   nextQueryParsed,
@@ -91,7 +92,8 @@ describe('AppSec Index', function () {
 
     UserTracking = {
       setCollectionMode: sinon.stub(),
-      trackLogin: sinon.stub()
+      trackLogin: sinon.stub(),
+      trackUser: sinon.stub()
     }
 
     log = {
@@ -176,6 +178,7 @@ describe('AppSec Index', function () {
       expect(bodyParser.hasSubscribers).to.be.false
       expect(cookieParser.hasSubscribers).to.be.false
       expect(passportVerify.hasSubscribers).to.be.false
+      expect(passportUser.hasSubscribers).to.be.false
       expect(queryParser.hasSubscribers).to.be.false
       expect(nextBodyParsed.hasSubscribers).to.be.false
       expect(nextQueryParsed.hasSubscribers).to.be.false
@@ -189,6 +192,7 @@ describe('AppSec Index', function () {
       expect(bodyParser.hasSubscribers).to.be.true
       expect(cookieParser.hasSubscribers).to.be.true
       expect(passportVerify.hasSubscribers).to.be.true
+      expect(passportUser.hasSubscribers).to.be.true
       expect(queryParser.hasSubscribers).to.be.true
       expect(nextBodyParsed.hasSubscribers).to.be.true
       expect(nextQueryParsed.hasSubscribers).to.be.true
@@ -271,6 +275,7 @@ describe('AppSec Index', function () {
       expect(bodyParser.hasSubscribers).to.be.false
       expect(cookieParser.hasSubscribers).to.be.false
       expect(passportVerify.hasSubscribers).to.be.false
+      expect(passportUser.hasSubscribers).to.be.false
       expect(queryParser.hasSubscribers).to.be.false
       expect(nextBodyParsed.hasSubscribers).to.be.false
       expect(nextQueryParsed.hasSubscribers).to.be.false
@@ -656,10 +661,13 @@ describe('AppSec Index', function () {
           'content-length': 42
         }),
         writeHead: sinon.stub(),
-        end: sinon.stub(),
-        getHeaderNames: sinon.stub().returns([])
+        getHeaderNames: sinon.stub().returns([]),
+        constructor: {
+          prototype: {
+            end: sinon.stub()
+          }
+        }
       }
-      res.writeHead.returns(res)
 
       req = {
         url: '/path',
@@ -687,7 +695,7 @@ describe('AppSec Index', function () {
 
         expect(waf.run).not.to.have.been.called
         expect(abortController.abort).not.to.have.been.called
-        expect(res.end).not.to.have.been.called
+        expect(res.constructor.prototype.end).not.to.have.been.called
       })
 
       it('Should not block with body by default', () => {
@@ -703,7 +711,7 @@ describe('AppSec Index', function () {
           }
         })
         expect(abortController.abort).not.to.have.been.called
-        expect(res.end).not.to.have.been.called
+        expect(res.constructor.prototype.end).not.to.have.been.called
       })
 
       it('Should block when it is detected as attack', () => {
@@ -719,7 +727,7 @@ describe('AppSec Index', function () {
           }
         })
         expect(abortController.abort).to.have.been.called
-        expect(res.end).to.have.been.called
+        expect(res.constructor.prototype.end).to.have.been.called
       })
     })
 
@@ -731,7 +739,7 @@ describe('AppSec Index', function () {
 
         expect(waf.run).not.to.have.been.called
         expect(abortController.abort).not.to.have.been.called
-        expect(res.end).not.to.have.been.called
+        expect(res.constructor.prototype.end).not.to.have.been.called
       })
 
       it('Should not block with cookie by default', () => {
@@ -746,7 +754,7 @@ describe('AppSec Index', function () {
           }
         })
         expect(abortController.abort).not.to.have.been.called
-        expect(res.end).not.to.have.been.called
+        expect(res.constructor.prototype.end).not.to.have.been.called
       })
 
       it('Should block when it is detected as attack', () => {
@@ -761,7 +769,7 @@ describe('AppSec Index', function () {
           }
         })
         expect(abortController.abort).to.have.been.called
-        expect(res.end).to.have.been.called
+        expect(res.constructor.prototype.end).to.have.been.called
       })
     })
 
@@ -773,7 +781,7 @@ describe('AppSec Index', function () {
 
         expect(waf.run).not.to.have.been.called
         expect(abortController.abort).not.to.have.been.called
-        expect(res.end).not.to.have.been.called
+        expect(res.constructor.prototype.end).not.to.have.been.called
       })
 
       it('Should not block with query by default', () => {
@@ -789,7 +797,7 @@ describe('AppSec Index', function () {
           }
         })
         expect(abortController.abort).not.to.have.been.called
-        expect(res.end).not.to.have.been.called
+        expect(res.constructor.prototype.end).not.to.have.been.called
       })
 
       it('Should block when it is detected as attack', () => {
@@ -805,7 +813,7 @@ describe('AppSec Index', function () {
           }
         })
         expect(abortController.abort).to.have.been.called
-        expect(res.end).to.have.been.called
+        expect(res.constructor.prototype.end).to.have.been.called
       })
     })
 
@@ -815,7 +823,7 @@ describe('AppSec Index', function () {
         sinon.stub(storage, 'getStore').returns({ req })
       })
 
-      it('should block when UserTracking.login() returns action', () => {
+      it('should block when UserTracking.trackLogin() returns action', () => {
         UserTracking.trackLogin.returns(resultActions)
 
         const abortController = new AbortController()
@@ -839,10 +847,10 @@ describe('AppSec Index', function () {
           rootSpan
         )
         expect(abortController.signal.aborted).to.be.true
-        expect(res.end).to.have.been.called
+        expect(res.constructor.prototype.end).to.have.been.called
       })
 
-      it('should not block when UserTracking.login() returns nothing', () => {
+      it('should not block when UserTracking.trackLogin() returns nothing', () => {
         UserTracking.trackLogin.returns(undefined)
 
         const abortController = new AbortController()
@@ -866,7 +874,7 @@ describe('AppSec Index', function () {
           rootSpan
         )
         expect(abortController.signal.aborted).to.be.false
-        expect(res.end).to.not.have.been.called
+        expect(res.constructor.prototype.end).to.not.have.been.called
       })
 
       it('should not block and call log if no rootSpan is found', () => {
@@ -887,7 +895,74 @@ describe('AppSec Index', function () {
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportVerify')
         expect(UserTracking.trackLogin).to.not.have.been.called
         expect(abortController.signal.aborted).to.be.false
-        expect(res.end).to.not.have.been.called
+        expect(res.constructor.prototype.end).to.not.have.been.called
+      })
+    })
+
+    describe('onPassportDeserializeUser', () => {
+      beforeEach(() => {
+        web.root.resetHistory()
+        sinon.stub(storage, 'getStore').returns({ req })
+      })
+
+      it('should block when UserTracking.trackUser() returns action', () => {
+        UserTracking.trackUser.returns(resultActions)
+
+        const abortController = new AbortController()
+        const payload = {
+          user: { _id: 1, username: 'test', password: '1234' },
+          abortController
+        }
+
+        passportUser.publish(payload)
+
+        expect(storage.getStore).to.have.been.calledOnce
+        expect(web.root).to.have.been.calledOnceWithExactly(req)
+        expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
+          payload.user,
+          rootSpan
+        )
+        expect(abortController.signal.aborted).to.be.true
+        expect(res.constructor.prototype.end).to.have.been.called
+      })
+
+      it('should not block when UserTracking.trackUser() returns nothing', () => {
+        UserTracking.trackUser.returns(undefined)
+
+        const abortController = new AbortController()
+        const payload = {
+          user: { _id: 1, username: 'test', password: '1234' },
+          abortController
+        }
+
+        passportUser.publish(payload)
+
+        expect(storage.getStore).to.have.been.calledOnce
+        expect(web.root).to.have.been.calledOnceWithExactly(req)
+        expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
+          payload.user,
+          rootSpan
+        )
+        expect(abortController.signal.aborted).to.be.false
+        expect(res.constructor.prototype.end).to.not.have.been.called
+      })
+
+      it('should not block and call log if no rootSpan is found', () => {
+        storage.getStore.returns(undefined)
+
+        const abortController = new AbortController()
+        const payload = {
+          user: { _id: 1, username: 'test', password: '1234' },
+          abortController
+        }
+
+        passportUser.publish(payload)
+
+        expect(storage.getStore).to.have.been.calledOnce
+        expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportDeserializeUser')
+        expect(UserTracking.trackUser).to.not.have.been.called
+        expect(abortController.signal.aborted).to.be.false
+        expect(res.constructor.prototype.end).to.not.have.been.called
       })
     })
 
@@ -913,7 +988,7 @@ describe('AppSec Index', function () {
           }
         }, req)
         expect(abortController.abort).to.have.been.calledOnce
-        expect(res.end).to.have.been.calledOnce
+        expect(res.constructor.prototype.end).to.have.been.calledOnce
 
         abortController.abort.resetHistory()
 
@@ -921,7 +996,7 @@ describe('AppSec Index', function () {
 
         expect(waf.run).to.have.been.calledOnce
         expect(abortController.abort).to.have.been.calledOnce
-        expect(res.end).to.have.been.calledOnce
+        expect(res.constructor.prototype.end).to.have.been.calledOnce
       })
 
       it('should not call the WAF if response was already analyzed', () => {
@@ -945,13 +1020,13 @@ describe('AppSec Index', function () {
           }
         }, req)
         expect(abortController.abort).to.have.not.been.called
-        expect(res.end).to.have.not.been.called
+        expect(res.constructor.prototype.end).to.have.not.been.called
 
         responseWriteHead.publish({ req, res, abortController, statusCode: 404, responseHeaders })
 
         expect(waf.run).to.have.been.calledOnce
         expect(abortController.abort).to.have.not.been.called
-        expect(res.end).to.have.not.been.called
+        expect(res.constructor.prototype.end).to.have.not.been.called
       })
 
       it('should not do anything without a root span', () => {
@@ -968,7 +1043,7 @@ describe('AppSec Index', function () {
 
         expect(waf.run).to.have.not.been.called
         expect(abortController.abort).to.have.not.been.called
-        expect(res.end).to.have.not.been.called
+        expect(res.constructor.prototype.end).to.have.not.been.called
       })
 
       it('should call the WAF with responde code and headers', () => {
@@ -992,7 +1067,7 @@ describe('AppSec Index', function () {
           }
         }, req)
         expect(abortController.abort).to.have.been.calledOnce
-        expect(res.end).to.have.been.calledOnce
+        expect(res.constructor.prototype.end).to.have.been.calledOnce
       })
     })
 

--- a/packages/dd-trace/test/appsec/sdk/set_user.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/set_user.spec.js
@@ -3,13 +3,16 @@
 const proxyquire = require('proxyquire')
 const agent = require('../../plugins/agent')
 const tracer = require('../../../../../index')
+const appsec = require('../../../src/appsec')
+const Config = require('../../../src/config')
 const axios = require('axios')
+const path = require('path')
 
 describe('set_user', () => {
   describe('Internal API', () => {
     const tracer = {}
 
-    let rootSpan, getRootSpan, log, setUser
+    let rootSpan, getRootSpan, log, waf, setUser
 
     beforeEach(() => {
       rootSpan = {
@@ -21,9 +24,14 @@ describe('set_user', () => {
         warn: sinon.stub()
       }
 
+      waf = {
+        run: sinon.stub()
+      }
+
       const setUserModule = proxyquire('../../../src/appsec/sdk/set_user', {
         './utils': { getRootSpan },
-        '../../log': log
+        '../../log': log,
+        '../waf': waf
       })
 
       setUser = setUserModule.setUser
@@ -34,6 +42,7 @@ describe('set_user', () => {
         setUser(tracer)
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Invalid user provided to setUser')
         expect(rootSpan.setTag).to.not.have.been.called
+        expect(waf.run).to.not.have.been.called
       })
 
       it('should not call setTag when user is empty', () => {
@@ -41,6 +50,7 @@ describe('set_user', () => {
         setUser(tracer, user)
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Invalid user provided to setUser')
         expect(rootSpan.setTag).to.not.have.been.called
+        expect(waf.run).to.not.have.been.called
       })
 
       it('should not call setTag when rootSpan is not available', () => {
@@ -50,6 +60,7 @@ describe('set_user', () => {
         expect(getRootSpan).to.be.calledOnceWithExactly(tracer)
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Root span not available in setUser')
         expect(rootSpan.setTag).to.not.have.been.called
+        expect(waf.run).to.not.have.been.called
       })
 
       it('should call setTag with every attribute', () => {
@@ -61,15 +72,28 @@ describe('set_user', () => {
 
         setUser(tracer, user)
         expect(log.warn).to.not.have.been.called
-        expect(rootSpan.setTag).to.have.been.calledThrice
-        expect(rootSpan.setTag.firstCall).to.have.been.calledWithExactly('usr.id', '123')
-        expect(rootSpan.setTag.secondCall).to.have.been.calledWithExactly('usr.email', 'a@b.c')
-        expect(rootSpan.setTag.thirdCall).to.have.been.calledWithExactly('usr.custom', 'hello')
+        expect(rootSpan.setTag.callCount).to.equal(4)
+        expect(rootSpan.setTag.getCall(0)).to.have.been.calledWithExactly('usr.id', '123')
+        expect(rootSpan.setTag.getCall(1)).to.have.been.calledWithExactly('usr.email', 'a@b.c')
+        expect(rootSpan.setTag.getCall(2)).to.have.been.calledWithExactly('usr.custom', 'hello')
+        expect(rootSpan.setTag.getCall(3)).to.have.been.calledWithExactly('_dd.appsec.user.collection_mode', 'sdk')
+        expect(waf.run).to.have.been.calledOnceWithExactly({
+          persistent: {
+            'usr.id': '123'
+          }
+        })
       })
     })
   })
 
   describe('Integration with the tracer', () => {
+    const config = new Config({
+      appsec: {
+        enabled: true,
+        rules: path.join(__dirname, './user_blocking_rules.json')
+      }
+    })
+
     let http
     let controller
     let appListener
@@ -93,9 +117,13 @@ describe('set_user', () => {
           port = appListener.address().port
           done()
         })
+
+      appsec.enable(config)
     })
 
     after(() => {
+      appsec.disable()
+
       appListener.close()
       return agent.close({ ritmReset: false })
     })
@@ -104,16 +132,20 @@ describe('set_user', () => {
       it('should set a proper user', (done) => {
         controller = (req, res) => {
           tracer.appsec.setUser({
-            id: 'testUser',
+            id: 'blockedUser',
             email: 'a@b.c',
             custom: 'hello'
           })
           res.end()
         }
         agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('usr.id', 'testUser')
+          expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
           expect(traces[0][0].meta).to.have.property('usr.email', 'a@b.c')
           expect(traces[0][0].meta).to.have.property('usr.custom', 'hello')
+          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
+          expect(traces[0][0].meta).to.have.property('appsec.event', 'true')
+          expect(traces[0][0].meta).to.not.have.property('appsec.blocked')
+          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
         }).then(done).catch(done)
         axios.get(`http://localhost:${port}/`)
       })
@@ -121,11 +153,15 @@ describe('set_user', () => {
       it('should override user on consecutive callings', (done) => {
         controller = (req, res) => {
           tracer.appsec.setUser({ id: 'testUser' })
-          tracer.appsec.setUser({ id: 'testUser2' })
+          tracer.appsec.setUser({ id: 'blockedUser' })
           res.end()
         }
         agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('usr.id', 'testUser2')
+          expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
+          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
+          expect(traces[0][0].meta).to.have.property('appsec.event', 'true')
+          expect(traces[0][0].meta).to.not.have.property('appsec.blocked')
+          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
         }).then(done).catch(done)
         axios.get(`http://localhost:${port}/`)
       })

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -77,7 +77,8 @@ describe('user_blocking', () => {
         const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
         expect(ret).to.be.true
         expect(getRootSpan).to.have.been.calledOnceWithExactly(tracer)
-        expect(rootSpan.setTag).to.have.been.calledOnceWithExactly('usr.id', 'user')
+        expect(rootSpan.setTag).to.have.been.calledWithExactly('usr.id', 'user')
+        expect(rootSpan.setTag).to.have.been.calledWithExactly('_dd.appsec.user.collection_mode', 'sdk')
       })
 
       it('should not override user when already set', () => {
@@ -104,7 +105,8 @@ describe('user_blocking', () => {
       it('should return false when received no results', () => {
         const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'gooduser' })
         expect(ret).to.be.false
-        expect(rootSpan.setTag).to.have.been.calledOnceWithExactly('usr.id', 'gooduser')
+        expect(rootSpan.setTag).to.have.been.calledWithExactly('usr.id', 'gooduser')
+        expect(rootSpan.setTag).to.have.been.calledWithExactly('_dd.appsec.user.collection_mode', 'sdk')
       })
     })
 
@@ -198,6 +200,7 @@ describe('user_blocking', () => {
         }
         agent.use(traces => {
           expect(traces[0][0].meta).to.have.property('usr.id', 'testUser3')
+          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
         }).then(done).catch(done)
         axios.get(`http://localhost:${port}/`)
       })
@@ -212,6 +215,7 @@ describe('user_blocking', () => {
         }
         agent.use(traces => {
           expect(traces[0][0].meta).to.have.property('usr.id', 'testUser')
+          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
         }).then(done).catch(done)
         axios.get(`http://localhost:${port}/`)
       })
@@ -224,6 +228,7 @@ describe('user_blocking', () => {
         }
         agent.use(traces => {
           expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
+          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
         }).then(done).catch(done)
         axios.get(`http://localhost:${port}/`)
       })

--- a/packages/dd-trace/test/appsec/telemetry.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry.spec.js
@@ -350,6 +350,17 @@ describe('Appsec Telemetry metrics', () => {
         })
       })
     })
+
+    describe('incrementMissingUserIdMetric', () => {
+      it('should increment instrum.user_auth.missing_user_id metric', () => {
+        appsecTelemetry.incrementMissingUserIdMetric('passport', 'authenticated_request')
+
+        expect(count).to.have.been.calledOnceWithExactly('instrum.user_auth.missing_user_id', {
+          framework: 'passport',
+          event_type: 'authenticated_request'
+        })
+      })
+    })
   })
 
   describe('if disabled', () => {

--- a/packages/dd-trace/test/appsec/user_tracking.spec.js
+++ b/packages/dd-trace/test/appsec/user_tracking.spec.js
@@ -15,9 +15,11 @@ describe('User Tracking', () => {
 
   let setCollectionMode
   let trackLogin
+  let trackUser
 
   beforeEach(() => {
     sinon.stub(telemetry, 'incrementMissingUserLoginMetric')
+    sinon.stub(telemetry, 'incrementMissingUserIdMetric')
     sinon.stub(standalone, 'sample')
     sinon.stub(waf, 'run').returns(['action1'])
 
@@ -25,7 +27,8 @@ describe('User Tracking', () => {
 
     rootSpan = {
       context: () => ({ _tags: currentTags }),
-      addTags: sinon.stub()
+      addTags: sinon.stub(),
+      setTag: sinon.stub()
     }
 
     log = {
@@ -42,6 +45,7 @@ describe('User Tracking', () => {
 
     setCollectionMode = UserTracking.setCollectionMode
     trackLogin = UserTracking.trackLogin
+    trackUser = UserTracking.trackUser
   })
 
   afterEach(() => {
@@ -168,21 +172,6 @@ describe('User Tracking', () => {
       assert.deepStrictEqual(results, undefined)
 
       sinon.assert.notCalled(log.error)
-      sinon.assert.notCalled(telemetry.incrementMissingUserLoginMetric)
-      sinon.assert.notCalled(keepTrace)
-      sinon.assert.notCalled(standalone.sample)
-      sinon.assert.notCalled(rootSpan.addTags)
-      sinon.assert.notCalled(waf.run)
-    })
-
-    it('should log error when rootSpan is not found', () => {
-      setCollectionMode('identification')
-
-      const results = trackLogin('passport-local', 'login', { id: '123', email: 'a@b.c' }, true)
-
-      assert.deepStrictEqual(results, undefined)
-
-      sinon.assert.calledOnceWithExactly(log.error, '[ASM] No rootSpan found in AppSec trackLogin')
       sinon.assert.notCalled(telemetry.incrementMissingUserLoginMetric)
       sinon.assert.notCalled(keepTrace)
       sinon.assert.notCalled(standalone.sample)
@@ -692,6 +681,134 @@ describe('User Tracking', () => {
         sinon.assert.notCalled(telemetry.incrementMissingUserLoginMetric)
         sinon.assert.notCalled(keepTrace)
         sinon.assert.notCalled(standalone.sample)
+        sinon.assert.notCalled(rootSpan.addTags)
+        sinon.assert.notCalled(waf.run)
+      })
+    })
+  })
+
+  describe('trackUser', () => {
+    it('should not do anything if collectionMode is empty or disabled', () => {
+      setCollectionMode('disabled')
+
+      const results = trackUser({ id: '123', email: 'a@b.c' }, rootSpan)
+
+      assert.deepStrictEqual(results, undefined)
+
+      sinon.assert.notCalled(log.error)
+      sinon.assert.notCalled(telemetry.incrementMissingUserIdMetric)
+      sinon.assert.notCalled(rootSpan.setTag)
+      sinon.assert.notCalled(rootSpan.addTags)
+      sinon.assert.notCalled(waf.run)
+    })
+
+    it('should log error and send telemetry when user ID is not found', () => {
+      setCollectionMode('identification')
+
+      const results = trackUser({ notAnId: 'bonjour' }, rootSpan)
+
+      assert.deepStrictEqual(results, undefined)
+
+      sinon.assert.calledOnceWithExactly(log.error, '[ASM] No valid user ID found in AppSec trackUser')
+      sinon.assert.calledOnceWithExactly(telemetry.incrementMissingUserIdMetric, 'passport', 'authenticated_request')
+      sinon.assert.notCalled(rootSpan.setTag)
+      sinon.assert.notCalled(rootSpan.addTags)
+      sinon.assert.notCalled(waf.run)
+    })
+
+    describe('when collectionMode is indentification', () => {
+      beforeEach(() => {
+        setCollectionMode('identification')
+      })
+
+      it('should write tags and call waf', () => {
+        const results = trackUser({ id: '123', email: 'a@b.c' }, rootSpan)
+
+        assert.deepStrictEqual(results, ['action1'])
+
+        sinon.assert.notCalled(log.error)
+        sinon.assert.notCalled(telemetry.incrementMissingUserIdMetric)
+
+        sinon.assert.calledOnceWithExactly(rootSpan.setTag, '_dd.appsec.usr.id', '123')
+        sinon.assert.calledOnceWithExactly(rootSpan.addTags, {
+          'usr.id': '123',
+          '_dd.appsec.user.collection_mode': 'identification'
+        })
+        sinon.assert.calledOnceWithExactly(waf.run, {
+          persistent: {
+            'usr.id': '123'
+          }
+        })
+      })
+
+      it('should not overwrite tags set by SDK', () => {
+        currentTags = {
+          'usr.id': 'sdk_id',
+          '_dd.appsec.user.collection_mode': 'sdk'
+        }
+
+        const results = trackUser({ id: '123', email: 'a@b.c' }, rootSpan)
+
+        assert.deepStrictEqual(results, undefined)
+
+        sinon.assert.notCalled(log.error)
+        sinon.assert.notCalled(telemetry.incrementMissingUserIdMetric)
+
+        sinon.assert.calledOnceWithExactly(rootSpan.setTag, '_dd.appsec.usr.id', '123')
+
+        sinon.assert.notCalled(rootSpan.addTags)
+        sinon.assert.notCalled(waf.run)
+      })
+    })
+
+    describe('when collectionMode is anonymization', () => {
+      beforeEach(() => {
+        setCollectionMode('anonymization')
+      })
+
+      it('should write tags and call waf', () => {
+        const results = trackUser({ id: '123', email: 'a@b.c' }, rootSpan)
+
+        assert.deepStrictEqual(results, ['action1'])
+
+        sinon.assert.notCalled(log.error)
+        sinon.assert.notCalled(telemetry.incrementMissingUserIdMetric)
+
+        sinon.assert.calledOnceWithExactly(
+          rootSpan.setTag,
+          '_dd.appsec.usr.id',
+          'anon_a665a45920422f9d417e4867efdc4fb8'
+        )
+        sinon.assert.calledOnceWithExactly(rootSpan.addTags, {
+          'usr.id': 'anon_a665a45920422f9d417e4867efdc4fb8',
+          '_dd.appsec.user.collection_mode': 'anonymization'
+        })
+        sinon.assert.calledOnceWithExactly(waf.run, {
+          persistent: {
+            'usr.id': 'anon_a665a45920422f9d417e4867efdc4fb8'
+          }
+        })
+      })
+
+      it('should not overwrite tags set by SDK', () => {
+        currentTags = {
+          'usr.id': 'sdk_id',
+          '_dd.appsec.user.collection_mode': 'sdk'
+        }
+
+        const results = trackUser({ id: '123', email: 'a@b.c' }, rootSpan)
+
+        assert.deepStrictEqual(results, undefined)
+
+        sinon.assert.notCalled(log.error)
+        sinon.assert.notCalled(telemetry.incrementMissingUserIdMetric)
+
+        sinon.assert.calledOnceWithExactly(
+          rootSpan.setTag,
+          '_dd.appsec.usr.id',
+          'anon_a665a45920422f9d417e4867efdc4fb8'
+        )
+
         sinon.assert.notCalled(rootSpan.addTags)
         sinon.assert.notCalled(waf.run)
       })

--- a/packages/dd-trace/test/debugger/devtools_client/state.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/state.spec.js
@@ -63,6 +63,12 @@ describe('findScriptFromPartialPath', function () {
           it('prefixed with two unknown directories', testPath(`prefix1/prefix2/to/${filename}`))
         })
 
+        describe('case insensitive', function () {
+          it('should match if the path is in lowercase', testPath(filename.toLowerCase()))
+
+          it('should match if the path is in uppercase', testPath(filename.toUpperCase()))
+        })
+
         describe('non-matching paths', function () {
           it('should not match if only part of a directory matches (at boundary)',
             testPathNoMatch(`path/o/${filename}`))
@@ -73,8 +79,6 @@ describe('findScriptFromPartialPath', function () {
           it('should not match if only part of a directory matches (root)', testPathNoMatch(`o/${filename}`))
 
           it('should not match if only part of a file matches', testPathNoMatch(filename.slice(1)))
-
-          it('should not match if only difference is the letter casing', testPathNoMatch(filename.toUpperCase()))
         })
       })
 

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -367,6 +367,20 @@
       "dep": true
     }
   ],
+  "passport": [
+    {
+      "name": "express",
+      "versions": [">=4.0.0"]
+    },
+    {
+      "name": "express-session",
+      "versions": [">=1.5.0"]
+    },
+    {
+      "name": "passport-local",
+      "versions": [">=1.0.0"]
+    }
+  ],
    "passport-http": [
      {
        "name": "passport",


### PR DESCRIPTION
* \[[`ee6dbec9bc`](https://github.com/DataDog/dd-trace-js/commit/ee6dbec9bc)] - **(SEMVER-PATCH)** \[DI] Handle different casing in probe file paths (Thomas Watson) [#5188](https://github.com/DataDog/dd-trace-js/pull/5188)
* \[[`dbe0b74bf4`](https://github.com/DataDog/dd-trace-js/commit/dbe0b74bf4)] - **(SEMVER-MINOR)** Automatic userID tracking and blocking (simon-id) [#4670](https://github.com/DataDog/dd-trace-js/pull/4670)
* \[[`bcdb068742`](https://github.com/DataDog/dd-trace-js/commit/bcdb068742)] - **(SEMVER-PATCH)** \[DI] Probe file path matching algo should prefer shorter paths (Thomas Watson) [#5186](https://github.com/DataDog/dd-trace-js/pull/5186)
* \[[`729972edff`](https://github.com/DataDog/dd-trace-js/commit/729972edff)] - **(SEMVER-MINOR)** Instrument dd-trace-api (Bryan English) [#5145](https://github.com/DataDog/dd-trace-js/pull/5145)
* \[[`f01d38594b`](https://github.com/DataDog/dd-trace-js/commit/f01d38594b)] - **(SEMVER-MINOR)** \[MLOB-2098] feat(llmobs): record bedrock token counts (Sam Brenner) [#5152](https://github.com/DataDog/dd-trace-js/pull/5152)

[MLOB-2098]: https://datadoghq.atlassian.net/browse/MLOB-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ