### PR TITLE
simplify wrap and trace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,10 +85,6 @@ interface Tracer extends opentracing.Tracer {
    * span will finish when that callback is called.
    * * The function doesn't accept a callback and doesn't return a promise, in
    * which case the span will finish at the end of the function execution.
-   *
-   * If the `orphanable` option is set to false, the function will not be traced
-   * unless there is already an active span or `childOf` option. Note that this
-   * option is deprecated and has been removed in version 4.0.
    */
   trace<T> (name: string, fn: (span: tracer.Span) => T): T;
   trace<T> (name: string, fn: (span: tracer.Span, done: (error?: Error) => void) => T): T;
@@ -659,13 +655,13 @@ declare namespace tracer {
          * *  'anonymous': will hash user IDs and user logins before collecting them
          * *  'anon': alias for 'anonymous'
          * *  'safe': deprecated alias for 'anonymous'
-         * 
+         *
          * *  'identification': will collect user IDs and logins without redaction
          * *  'ident': alias for 'identification'
          * *  'extended': deprecated alias for 'identification'
-         * 
+         *
          * *  'disabled': will not collect user IDs and logins
-         * 
+         *
          * Unknown values will be considered as 'disabled'
          * @default 'identification'
          */

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -3,20 +3,16 @@
 require('./setup/tap')
 
 const Span = require('../src/opentracing/span')
-const { storage } = require('../../datadog-core')
 const Config = require('../src/config')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { DD_MAJOR } = require('../../../version')
 
 const SPAN_TYPE = tags.SPAN_TYPE
 const RESOURCE_NAME = tags.RESOURCE_NAME
 const SERVICE_NAME = tags.SERVICE_NAME
 const EXPORT_SERVICE_NAME = 'service'
 const BASE_SERVICE = tags.BASE_SERVICE
-
-const describeOrphanable = DD_MAJOR < 4 ? describe : describe.skip
 
 describe('Tracer', () => {
   let Tracer
@@ -283,64 +279,6 @@ describe('Tracer', () => {
         })
       })
     })
-
-    describeOrphanable('when there is no parent span', () => {
-      it('should not trace if `orphanable: false`', () => {
-        sinon.spy(tracer, 'startSpan')
-
-        tracer.trace('name', { orphanable: false }, () => {})
-
-        expect(tracer.startSpan).to.have.not.been.called
-      })
-
-      it('should trace if `orphanable: true`', () => {
-        sinon.spy(tracer, 'startSpan')
-
-        tracer.trace('name', { orhpanable: true }, () => {})
-
-        expect(tracer.startSpan).to.have.been.called
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        sinon.spy(tracer, 'startSpan')
-
-        tracer.trace('name', {}, () => {})
-
-        expect(tracer.startSpan).to.have.been.called
-      })
-    })
-
-    describeOrphanable('when there is a parent span', () => {
-      it('should trace if `orphanable: false`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          sinon.spy(tracer, 'startSpan')
-
-          tracer.trace('name', { orhpanable: false }, () => {})
-
-          expect(tracer.startSpan).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: true`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          sinon.spy(tracer, 'startSpan')
-
-          tracer.trace('name', { orphanable: true }, () => {})
-
-          expect(tracer.startSpan).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          sinon.spy(tracer, 'startSpan')
-
-          tracer.trace('name', {}, () => {})
-
-          expect(tracer.startSpan).to.have.been.called
-        })
-      })
-    })
   })
 
   describe('getRumData', () => {
@@ -468,88 +406,6 @@ describe('Tracer', () => {
 
       expect(tracer.trace).to.have.been.calledWith('name', {
         tags: { sometag: 'somevalue', invocations: 2 }
-      })
-    })
-
-    it('should not trace in a noop context', () => {
-      const fn = tracer.wrap('name', {}, () => {})
-
-      sinon.spy(tracer, 'trace')
-
-      storage.enterWith({ noop: true })
-      fn()
-      storage.enterWith(null)
-
-      expect(tracer.trace).to.have.not.been.called
-    })
-
-    describeOrphanable('when there is no parent span', () => {
-      it('should not trace if `orphanable: false`', () => {
-        const fn = tracer.wrap('name', { orphanable: false }, () => {})
-
-        sinon.spy(tracer, 'trace')
-
-        fn()
-
-        expect(tracer.trace).to.have.not.been.called
-      })
-
-      it('should trace if `orphanable: true`', () => {
-        const fn = tracer.wrap('name', { orhpanable: true }, () => {})
-
-        sinon.spy(tracer, 'trace')
-
-        fn()
-
-        expect(tracer.trace).to.have.been.called
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        const fn = tracer.wrap('name', {}, () => {})
-
-        sinon.spy(tracer, 'trace')
-
-        fn()
-
-        expect(tracer.trace).to.have.been.called
-      })
-    })
-
-    describeOrphanable('when there is a parent span', () => {
-      it('should trace if `orphanable: false`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          const fn = tracer.wrap('name', { orhpanable: false }, () => {})
-
-          sinon.spy(tracer, 'trace')
-
-          fn()
-
-          expect(tracer.trace).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: true`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          const fn = tracer.wrap('name', { orphanable: true }, () => {})
-
-          sinon.spy(tracer, 'trace')
-
-          fn()
-
-          expect(tracer.trace).to.have.been.called
-        })
-      })
-
-      it('should trace if `orphanable: undefined`', () => {
-        tracer.scope().activate(tracer.startSpan('parent'), () => {
-          const fn = tracer.wrap('name', {}, () => {})
-
-          sinon.spy(tracer, 'trace')
-
-          fn()
-
-          expect(tracer.trace).to.have.been.called
-        })
       })
     })
   })


### PR DESCRIPTION
* Remove orphanable option from wrap and trace. They were deprecated in v4, meaning they no longer work in supported versions anyway.
* Remove noop check from wrap. The noop check is for internal use only, and we no longer use wrap internally, so it's unneeded in wrap.

