### PR TITLE
add concurrency group to all-green ci job

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   all-green:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add concurrency group to `all-green` ci job.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise it fails instead of being cancelled when a newer commit is merged on the branch.