### PR TITLE
[DSM] Add a wait for active stream to the putTestRecords function which was flaking when the stream was inactive

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis_helpers.js
@@ -55,23 +55,25 @@ function putTestRecord (kinesis, streamName, data, cb) {
 }
 
 function putTestRecords (kinesis, streamName, cb) {
-  kinesis.putRecords({
-    Records: [
-      {
-        PartitionKey: id().toString(),
-        Data: dataBufferCustom(1)
-      },
-      {
-        PartitionKey: id().toString(),
-        Data: dataBufferCustom(2)
-      },
-      {
-        PartitionKey: id().toString(),
-        Data: dataBufferCustom(3)
-      }
-    ],
-    StreamName: streamName
-  }, cb)
+  waitForActiveStream(kinesis, streamName, () => {
+    kinesis.putRecords({
+      Records: [
+        {
+          PartitionKey: id().toString(),
+          Data: dataBufferCustom(1)
+        },
+        {
+          PartitionKey: id().toString(),
+          Data: dataBufferCustom(2)
+        },
+        {
+          PartitionKey: id().toString(),
+          Data: dataBufferCustom(3)
+        }
+      ],
+      StreamName: streamName
+    }, cb)
+  })
 }
 
 function waitForActiveStream (kinesis, streamName, cb) {


### PR DESCRIPTION
### What does this PR do?
This should fix a [flaky test](https://github.com/DataDog/dd-trace-js/actions/runs/12981775934/job/36200668701)

The test fails when its run and the stream is not in an active state:
![CleanShot 2025-02-04 at 12 48 56@2x](https://github.com/user-attachments/assets/504da6a5-c5dd-4e4c-a6bf-d42968a2ed6e)

Its not entirely clear why that is happening as `waitForActiveStream` is called in the before action of the test, however, in recreation, it happened a little less than 1% of the time and always on the same test. So in that particular test (the only one using the `helpers.putTestRecords` method, I added a second waitForActiveStream. I ran the Kinesis suite ~300 times and didn't get a recurrence with this second wait.

I added it to the helper instead of directly on the flakey test in case a second test is written using the helper so as to prevent recurrence

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


